### PR TITLE
[Rust Server] Rust 1.39 compatibility

### DIFF
--- a/modules/openapi-generator/src/main/resources/rust-server/Cargo.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/Cargo.mustache
@@ -18,7 +18,7 @@ conversion = ["frunk", "frunk_derives", "frunk_core", "frunk-enum-core", "frunk-
 chrono = { version = "0.4", features = ["serde"] }
 futures = "0.1"
 swagger = "2"
-lazy_static = "0.2"
+lazy_static = "1.4"
 log = "0.3.0"
 mime = "0.2.6"
 multipart = "0.13.3"

--- a/modules/openapi-generator/src/main/resources/rust-server/client-mod.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/client-mod.mustache
@@ -86,7 +86,7 @@ fn into_base_path(input: &str, correct_scheme: Option<&'static str>) -> Result<S
 /// A client that implements the API by making HTTP calls out to a server.
 pub struct Client<F> where
   F: Future<Item=hyper::Response, Error=hyper::Error> + 'static {
-    client_service: Arc<Box<hyper::client::Service<Request=hyper::Request<hyper::Body>, Response=hyper::Response, Error=hyper::Error, Future=F>>>,
+    client_service: Arc<Box<dyn hyper::client::Service<Request=hyper::Request<hyper::Body>, Response=hyper::Response, Error=hyper::Error, Future=F>>>,
     base_path: String,
 }
 
@@ -197,7 +197,7 @@ impl Client<hyper::client::FutureResponse> {
         handle: Handle,
         base_path: &str,
         protocol: Option<&'static str>,
-        connector_fn: Box<Fn(&Handle) -> C + Send + Sync>,
+        connector_fn: Box<dyn Fn(&Handle) -> C + Send + Sync>,
     ) -> Result<Client<hyper::client::FutureResponse>, ClientInitError>
     where
         C: hyper::client::Connect + hyper::client::Service,
@@ -224,7 +224,7 @@ impl Client<hyper::client::FutureResponse> {
     /// should be mentioned here.
     #[deprecated(note="Use try_new_with_client_service instead")]
     pub fn try_new_with_hyper_client(
-        hyper_client: Arc<Box<hyper::client::Service<Request=hyper::Request<hyper::Body>, Response=hyper::Response, Error=hyper::Error, Future=hyper::client::FutureResponse>>>,
+        hyper_client: Arc<Box<dyn hyper::client::Service<Request=hyper::Request<hyper::Body>, Response=hyper::Response, Error=hyper::Error, Future=hyper::client::FutureResponse>>>,
         handle: Handle,
         base_path: &str
     ) -> Result<Client<hyper::client::FutureResponse>, ClientInitError>
@@ -242,7 +242,7 @@ impl<F> Client<F> where
     /// Constructor for creating a `Client` by passing in a pre-made `hyper` client Service.
     ///
     /// This allows adding custom wrappers around the underlying transport, for example for logging.
-    pub fn try_new_with_client_service(client_service: Arc<Box<hyper::client::Service<Request=hyper::Request<hyper::Body>, Response=hyper::Response, Error=hyper::Error, Future=F>>>,
+    pub fn try_new_with_client_service(client_service: Arc<Box<dyn hyper::client::Service<Request=hyper::Request<hyper::Body>, Response=hyper::Response, Error=hyper::Error, Future=F>>>,
                                        handle: Handle,
                                        base_path: &str)
                                     -> Result<Client<F>, ClientInitError>
@@ -258,7 +258,7 @@ impl<F, C> Api<C> for Client<F> where
     F: Future<Item=hyper::Response, Error=hyper::Error>  + 'static,
     C: Has<XSpanIdString> {{#hasAuthMethods}}+ Has<Option<AuthData>>{{/hasAuthMethods}}{
 {{#apiInfo}}{{#apis}}{{#operations}}{{#operation}}
-    fn {{#vendorExtensions}}{{{operation_id}}}{{/vendorExtensions}}(&self{{#allParams}}, param_{{{paramName}}}: {{^required}}Option<{{/required}}{{#isListContainer}}&{{/isListContainer}}{{{dataType}}}{{^required}}>{{/required}}{{/allParams}}, context: &C) -> Box<Future<Item={{{operationId}}}Response, Error=ApiError>> {
+    fn {{#vendorExtensions}}{{{operation_id}}}{{/vendorExtensions}}(&self{{#allParams}}, param_{{{paramName}}}: {{^required}}Option<{{/required}}{{#isListContainer}}&{{/isListContainer}}{{{dataType}}}{{^required}}>{{/required}}{{/allParams}}, context: &C) -> Box<dyn Future<Item={{{operationId}}}Response, Error=ApiError>> {
         let mut uri = format!(
             "{}{{{basePathWithoutHost}}}{{path}}",
             self.base_path{{#pathParams}}, {{{baseName}}}=utf8_percent_encode(&param_{{{paramName}}}.to_string(), ID_ENCODE_SET){{/pathParams}}
@@ -269,7 +269,7 @@ impl<F, C> Api<C> for Client<F> where
 {{^required}}        if let Some({{{paramName}}}) = param_{{{paramName}}} {
             query_string.append_pair("{{{baseName}}}", &{{{paramName}}}{{#isListContainer}}.join(","){{/isListContainer}}{{^isListContainer}}.to_string(){{/isListContainer}});
         }{{/required}}{{/queryParams}}
-{{#authMethods}}{{#isApiKey}}{{#isKeyInQuery}}        if let Some(auth_data) = (context as &Has<Option<AuthData>>).get().as_ref() {
+{{#authMethods}}{{#isApiKey}}{{#isKeyInQuery}}        if let Some(auth_data) = (context as &dyn Has<Option<AuthData>>).get().as_ref() {
             if let AuthData::ApiKey(ref api_key) = *auth_data {
                 query_string.append_pair("{{keyParamName}}", api_key);
             }
@@ -416,10 +416,10 @@ impl<F, C> Api<C> for Client<F> where
   {{/consumesMultipart}}
 {{/vendorExtensions}}
 
-        request.headers_mut().set(XSpanId((context as &Has<XSpanIdString>).get().0.clone()));
+        request.headers_mut().set(XSpanId((context as &dyn Has<XSpanIdString>).get().0.clone()));
 {{#vendorExtensions.hasHeaderAuthMethods}}
 
-        (context as &Has<Option<AuthData>>).get().as_ref().map(|auth_data| {
+        (context as &dyn Has<Option<AuthData>>).get().as_ref().map(|auth_data| {
             // Currently only authentication with Basic, API Key, and Bearer are supported
             match auth_data {
             {{#authMethods}}
@@ -480,7 +480,7 @@ impl<F, C> Api<C> for Client<F> where
 {{#headers}}                    header! { (Response{{{nameInCamelCase}}}, "{{{baseName}}}") => [{{{datatype}}}] }
                     let response_{{{name}}} = match response.headers().get::<Response{{{nameInCamelCase}}}>() {
                         Some(response_{{{name}}}) => response_{{{name}}}.0.clone(),
-                        None => return Box::new(future::err(ApiError(String::from("Required response header {{{baseName}}} for response {{{code}}} was not found.")))) as Box<Future<Item=_, Error=_>>,
+                        None => return Box::new(future::err(ApiError(String::from("Required response header {{{baseName}}} for response {{{code}}} was not found.")))) as Box<dyn Future<Item=_, Error=_>>,
                     };
 {{/headers}}
                     let body = response.body();
@@ -532,7 +532,7 @@ impl<F, C> Api<C> for Client<F> where
 {{/headers}}
                         )
 {{/dataType}}
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 },
 {{/responses}}
                 code => {
@@ -552,7 +552,7 @@ impl<F, C> Api<C> for Client<F> where
                                         Err(e) => Cow::from(format!("<Failed to read body: {}>", e)),
                                     })))
                             )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 }
             }
         }))
@@ -583,7 +583,7 @@ impl From<openssl::error::ErrorStack> for ClientInitError {
 
 impl fmt::Display for ClientInitError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        (self as &fmt::Debug).fmt(f)
+        (self as &dyn fmt::Debug).fmt(f)
     }
 }
 

--- a/modules/openapi-generator/src/main/resources/rust-server/example-client.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/example-client.mustache
@@ -72,7 +72,7 @@ fn main() {
         {{#vendorExtensions}}{{#noClientExample}}// Disabled because there's no example.
         // {{/noClientExample}}Some("{{{operationId}}}") => {
         {{#noClientExample}}// {{/noClientExample}}    let result = core.run(client.{{{operation_id}}}{{/vendorExtensions}}({{#allParams}}{{^-first}}, {{/-first}}{{#vendorExtensions}}{{{example}}}{{/vendorExtensions}}{{/allParams}}));
-        {{#vendorExtensions}}{{#noClientExample}}// {{/noClientExample}}{{/vendorExtensions}}    println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+        {{#vendorExtensions}}{{#noClientExample}}// {{/noClientExample}}{{/vendorExtensions}}    println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         {{#vendorExtensions}}{{#noClientExample}}// {{/noClientExample}}{{/vendorExtensions}} },
 {{/operation}}{{/operations}}{{/apis}}{{/apiInfo}}
         _ => {

--- a/modules/openapi-generator/src/main/resources/rust-server/example-server_server.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/example-server_server.mustache
@@ -31,7 +31,7 @@ impl<C> Server<C> {
 impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
 {{#apiInfo}}{{#apis}}{{#operations}}{{#operation}}
 {{#summary}}    /// {{{summary}}}{{/summary}}
-    fn {{#vendorExtensions}}{{{operation_id}}}{{/vendorExtensions}}(&self{{#allParams}}, {{{paramName}}}: {{^required}}Option<{{/required}}{{#isListContainer}}&{{/isListContainer}}{{{dataType}}}{{^required}}>{{/required}}{{/allParams}}, context: &C) -> Box<Future<Item={{{operationId}}}Response, Error=ApiError>> {
+    fn {{#vendorExtensions}}{{{operation_id}}}{{/vendorExtensions}}(&self{{#allParams}}, {{{paramName}}}: {{^required}}Option<{{/required}}{{#isListContainer}}&{{/isListContainer}}{{{dataType}}}{{^required}}>{{/required}}{{/allParams}}, context: &C) -> Box<dyn Future<Item={{{operationId}}}Response, Error=ApiError>> {
         let context = context.clone();
         println!("{{#vendorExtensions}}{{{operation_id}}}{{/vendorExtensions}}({{#allParams}}{{#vendorExtensions}}{{{formatString}}}{{/vendorExtensions}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) - X-Span-ID: {:?}"{{#allParams}}, {{{paramName}}}{{/allParams}}, context.get().0.clone());{{#allParams}}{{/allParams}}
         Box::new(futures::failed("Generic failure".into()))

--- a/modules/openapi-generator/src/main/resources/rust-server/lib.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/lib.mustache
@@ -92,7 +92,7 @@ pub enum {{{operationId}}}Response {
 pub trait Api<C> {
 {{#apiInfo}}{{#apis}}{{#operations}}{{#operation}}
 {{#summary}}    /// {{{summary}}}{{/summary}}
-    fn {{#vendorExtensions}}{{{operation_id}}}{{/vendorExtensions}}(&self{{#allParams}}, {{{paramName}}}: {{^required}}Option<{{/required}}{{#isListContainer}}&{{/isListContainer}}{{{dataType}}}{{^required}}>{{/required}}{{/allParams}}, context: &C) -> Box<Future<Item={{{operationId}}}Response, Error=ApiError>>;
+    fn {{#vendorExtensions}}{{{operation_id}}}{{/vendorExtensions}}(&self{{#allParams}}, {{{paramName}}}: {{^required}}Option<{{/required}}{{#isListContainer}}&{{/isListContainer}}{{{dataType}}}{{^required}}>{{/required}}{{/allParams}}, context: &C) -> Box<dyn Future<Item={{{operationId}}}Response, Error=ApiError>>;
 {{/operation}}{{/operations}}{{/apis}}{{/apiInfo}}
 }
 
@@ -100,7 +100,7 @@ pub trait Api<C> {
 pub trait ApiNoContext {
 {{#apiInfo}}{{#apis}}{{#operations}}{{#operation}}
 {{#summary}}    /// {{{summary}}}{{/summary}}
-    fn {{#vendorExtensions}}{{{operation_id}}}{{/vendorExtensions}}(&self{{#allParams}}, {{{paramName}}}: {{^required}}Option<{{/required}}{{#isListContainer}}&{{/isListContainer}}{{{dataType}}}{{^required}}>{{/required}}{{/allParams}}) -> Box<Future<Item={{{operationId}}}Response, Error=ApiError>>;
+    fn {{#vendorExtensions}}{{{operation_id}}}{{/vendorExtensions}}(&self{{#allParams}}, {{{paramName}}}: {{^required}}Option<{{/required}}{{#isListContainer}}&{{/isListContainer}}{{{dataType}}}{{^required}}>{{/required}}{{/allParams}}) -> Box<dyn Future<Item={{{operationId}}}Response, Error=ApiError>>;
 {{/operation}}{{/operations}}{{/apis}}{{/apiInfo}}
 }
 
@@ -119,7 +119,7 @@ impl<'a, T: Api<C> + Sized, C> ContextWrapperExt<'a, C> for T {
 impl<'a, T: Api<C>, C> ApiNoContext for ContextWrapper<'a, T, C> {
 {{#apiInfo}}{{#apis}}{{#operations}}{{#operation}}
 {{#summary}}    /// {{{summary}}}{{/summary}}
-    fn {{#vendorExtensions}}{{{operation_id}}}{{/vendorExtensions}}(&self{{#allParams}}, {{{paramName}}}: {{^required}}Option<{{/required}}{{#isListContainer}}&{{/isListContainer}}{{{dataType}}}{{^required}}>{{/required}}{{/allParams}}) -> Box<Future<Item={{{operationId}}}Response, Error=ApiError>> {
+    fn {{#vendorExtensions}}{{{operation_id}}}{{/vendorExtensions}}(&self{{#allParams}}, {{{paramName}}}: {{^required}}Option<{{/required}}{{#isListContainer}}&{{/isListContainer}}{{{dataType}}}{{^required}}>{{/required}}{{/allParams}}) -> Box<dyn Future<Item={{{operationId}}}Response, Error=ApiError>> {
         self.api().{{#vendorExtensions}}{{{operation_id}}}{{/vendorExtensions}}({{#allParams}}{{{paramName}}}, {{/allParams}}&self.context())
     }
 {{/operation}}{{/operations}}{{/apis}}{{/apiInfo}}

--- a/modules/openapi-generator/src/main/resources/rust-server/server-mod.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/server-mod.mustache
@@ -128,7 +128,7 @@ where
     type Request = (Request, C);
     type Response = Response;
     type Error = Error;
-    type Future = Box<Future<Item=Response, Error=Error>>;
+    type Future = Box<dyn Future<Item=Response, Error=Error>>;
 
     fn call(&self, (req, mut context): Self::Request) -> Self::Future {
         let api_impl = self.api_impl.clone();
@@ -143,7 +143,7 @@ where
             &hyper::Method::{{vendorExtensions.HttpMethod}} if path.matched(paths::ID_{{vendorExtensions.PATH_ID}}) => {
 {{#hasAuthMethods}}
                 {
-                    let authorization = match (&context as &Has<Option<Authorization>>).get() {
+                    let authorization = match (&context as &dyn Has<Option<Authorization>>).get() {
                         &Some(ref authorization) => authorization,
                         &None => return Box::new(future::ok(Response::new()
                                                 .with_status(StatusCode::Forbidden)
@@ -257,7 +257,7 @@ where
                 // values, rather than causing a 400 response). Produce warning header and logs for
                 // any unused fields.
                 Box::new(body.concat2()
-                    .then(move |result| -> Box<Future<Item=Response, Error=Error>> {
+                    .then(move |result| -> Box<dyn Future<Item=Response, Error=Error>> {
                         match result {
                             Ok(body) => {
         {{#vendorExtensions}}
@@ -313,7 +313,7 @@ where
                 // values, rather than causing a 400 response). Produce warning header and logs for
                 // any unused fields.
                 Box::new(body.concat2()
-                    .then(move |result| -> Box<Future<Item=Response, Error=Error>> {
+                    .then(move |result| -> Box<dyn Future<Item=Response, Error=Error>> {
                         match result {
                             Ok(body) => {
                                 // Read Form Parameters from body
@@ -404,7 +404,7 @@ where
                                 Box::new(api_impl.{{#vendorExtensions}}{{{operation_id}}}{{/vendorExtensions}}({{#allParams}}param_{{{paramName}}}{{#isListContainer}}.as_ref(){{/isListContainer}}, {{/allParams}}&context)
                                     .then(move |result| {
                                         let mut response = Response::new();
-                                        response.headers_mut().set(XSpanId((&context as &Has<XSpanIdString>).get().0.to_string()));
+                                        response.headers_mut().set(XSpanId((&context as &dyn Has<XSpanIdString>).get().0.to_string()));
 {{#bodyParams}}{{#vendorExtensions}}{{^consumesPlainText}}
                                         if !unused_elements.is_empty() {
                                             response.headers_mut().set(Warning(format!("Ignoring unknown fields in body: {:?}", unused_elements)));
@@ -486,7 +486,7 @@ where
   {{^consumesMultipart}}
     {{^bodyParams}}
                         }}
-                }) as Box<Future<Item=Response, Error=Error>>
+                }) as Box<dyn Future<Item=Response, Error=Error>>
     {{/bodyParams}}
   {{/consumesMultipart}}
 {{/vendorExtensions}}
@@ -496,13 +496,13 @@ where
                             Err(e) => Box::new(future::ok(Response::new().with_status(StatusCode::BadRequest).with_body(format!("Couldn't read body parameter {{{baseName}}}: {}", e)))),
                         }
                     })
-                ) as Box<Future<Item=Response, Error=Error>>
+                ) as Box<dyn Future<Item=Response, Error=Error>>
   {{/-first}}
 {{/bodyParams}}
 {{#vendorExtensions}}
   {{#consumesMultipart}}
     {{^bodyParams}}
-                                as Box<Future<Item=Response, Error=Error>>
+                                as Box<dyn Future<Item=Response, Error=Error>>
                             },
                             Err(e) => Box::new(future::ok(Response::new().with_status(StatusCode::BadRequest).with_body(format!("Couldn't read multipart body")))),
                         }
@@ -513,7 +513,7 @@ where
 {{/vendorExtensions}}
             },
 {{/operation}}{{/operations}}{{/apis}}{{/apiInfo}}
-            _ => Box::new(future::ok(Response::new().with_status(StatusCode::NotFound))) as Box<Future<Item=Response, Error=Error>>,
+            _ => Box::new(future::ok(Response::new().with_status(StatusCode::NotFound))) as Box<dyn Future<Item=Response, Error=Error>>,
         }
     }
 }

--- a/samples/server/petstore/rust-server/output/multipart-v3/Cargo.toml
+++ b/samples/server/petstore/rust-server/output/multipart-v3/Cargo.toml
@@ -16,7 +16,7 @@ conversion = ["frunk", "frunk_derives", "frunk_core", "frunk-enum-core", "frunk-
 chrono = { version = "0.4", features = ["serde"] }
 futures = "0.1"
 swagger = "2"
-lazy_static = "0.2"
+lazy_static = "1.4"
 log = "0.3.0"
 mime = "0.2.6"
 multipart = "0.13.3"

--- a/samples/server/petstore/rust-server/output/multipart-v3/examples/client.rs
+++ b/samples/server/petstore/rust-server/output/multipart-v3/examples/client.rs
@@ -71,7 +71,7 @@ fn main() {
 
         Some("MultipartRequestPost") => {
             let result = core.run(client.multipart_request_post("string_field_example".to_string(), swagger::ByteArray(Vec::from("BYTE_ARRAY_DATA_HERE")), Some("optional_string_field_example".to_string()), None));
-            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
          },
 
         _ => {

--- a/samples/server/petstore/rust-server/output/multipart-v3/examples/server_lib/server.rs
+++ b/samples/server/petstore/rust-server/output/multipart-v3/examples/server_lib/server.rs
@@ -28,7 +28,7 @@ impl<C> Server<C> {
 impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
 
 
-    fn multipart_request_post(&self, string_field: String, binary_field: swagger::ByteArray, optional_string_field: Option<String>, object_field: Option<models::MultipartRequestObjectField>, context: &C) -> Box<Future<Item=MultipartRequestPostResponse, Error=ApiError>> {
+    fn multipart_request_post(&self, string_field: String, binary_field: swagger::ByteArray, optional_string_field: Option<String>, object_field: Option<models::MultipartRequestObjectField>, context: &C) -> Box<dyn Future<Item=MultipartRequestPostResponse, Error=ApiError>> {
         let context = context.clone();
         println!("multipart_request_post(\"{}\", {:?}, {:?}, {:?}) - X-Span-ID: {:?}", string_field, binary_field, optional_string_field, object_field, context.get().0.clone());
         Box::new(futures::failed("Generic failure".into()))

--- a/samples/server/petstore/rust-server/output/multipart-v3/src/client/mod.rs
+++ b/samples/server/petstore/rust-server/output/multipart-v3/src/client/mod.rs
@@ -73,7 +73,7 @@ fn into_base_path(input: &str, correct_scheme: Option<&'static str>) -> Result<S
 /// A client that implements the API by making HTTP calls out to a server.
 pub struct Client<F> where
   F: Future<Item=hyper::Response, Error=hyper::Error> + 'static {
-    client_service: Arc<Box<hyper::client::Service<Request=hyper::Request<hyper::Body>, Response=hyper::Response, Error=hyper::Error, Future=F>>>,
+    client_service: Arc<Box<dyn hyper::client::Service<Request=hyper::Request<hyper::Body>, Response=hyper::Response, Error=hyper::Error, Future=F>>>,
     base_path: String,
 }
 
@@ -184,7 +184,7 @@ impl Client<hyper::client::FutureResponse> {
         handle: Handle,
         base_path: &str,
         protocol: Option<&'static str>,
-        connector_fn: Box<Fn(&Handle) -> C + Send + Sync>,
+        connector_fn: Box<dyn Fn(&Handle) -> C + Send + Sync>,
     ) -> Result<Client<hyper::client::FutureResponse>, ClientInitError>
     where
         C: hyper::client::Connect + hyper::client::Service,
@@ -211,7 +211,7 @@ impl Client<hyper::client::FutureResponse> {
     /// should be mentioned here.
     #[deprecated(note="Use try_new_with_client_service instead")]
     pub fn try_new_with_hyper_client(
-        hyper_client: Arc<Box<hyper::client::Service<Request=hyper::Request<hyper::Body>, Response=hyper::Response, Error=hyper::Error, Future=hyper::client::FutureResponse>>>,
+        hyper_client: Arc<Box<dyn hyper::client::Service<Request=hyper::Request<hyper::Body>, Response=hyper::Response, Error=hyper::Error, Future=hyper::client::FutureResponse>>>,
         handle: Handle,
         base_path: &str
     ) -> Result<Client<hyper::client::FutureResponse>, ClientInitError>
@@ -229,7 +229,7 @@ impl<F> Client<F> where
     /// Constructor for creating a `Client` by passing in a pre-made `hyper` client Service.
     ///
     /// This allows adding custom wrappers around the underlying transport, for example for logging.
-    pub fn try_new_with_client_service(client_service: Arc<Box<hyper::client::Service<Request=hyper::Request<hyper::Body>, Response=hyper::Response, Error=hyper::Error, Future=F>>>,
+    pub fn try_new_with_client_service(client_service: Arc<Box<dyn hyper::client::Service<Request=hyper::Request<hyper::Body>, Response=hyper::Response, Error=hyper::Error, Future=F>>>,
                                        handle: Handle,
                                        base_path: &str)
                                     -> Result<Client<F>, ClientInitError>
@@ -245,7 +245,7 @@ impl<F, C> Api<C> for Client<F> where
     F: Future<Item=hyper::Response, Error=hyper::Error>  + 'static,
     C: Has<XSpanIdString> {
 
-    fn multipart_request_post(&self, param_string_field: String, param_binary_field: swagger::ByteArray, param_optional_string_field: Option<String>, param_object_field: Option<models::MultipartRequestObjectField>, context: &C) -> Box<Future<Item=MultipartRequestPostResponse, Error=ApiError>> {
+    fn multipart_request_post(&self, param_string_field: String, param_binary_field: swagger::ByteArray, param_optional_string_field: Option<String>, param_object_field: Option<models::MultipartRequestObjectField>, context: &C) -> Box<dyn Future<Item=MultipartRequestPostResponse, Error=ApiError>> {
         let mut uri = format!(
             "{}/multipart_request",
             self.base_path
@@ -344,7 +344,7 @@ impl<F, C> Api<C> for Client<F> where
         request.headers_mut().set(ContentType(multipart_header));
 
 
-        request.headers_mut().set(XSpanId((context as &Has<XSpanIdString>).get().0.clone()));
+        request.headers_mut().set(XSpanId((context as &dyn Has<XSpanIdString>).get().0.clone()));
         Box::new(self.client_service.call(request)
                              .map_err(|e| ApiError(format!("No response received: {}", e)))
                              .and_then(|mut response| {
@@ -356,7 +356,7 @@ impl<F, C> Api<C> for Client<F> where
                         future::ok(
                             MultipartRequestPostResponse::OK
                         )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 },
                 code => {
                     let headers = response.headers().clone();
@@ -375,7 +375,7 @@ impl<F, C> Api<C> for Client<F> where
                                         Err(e) => Cow::from(format!("<Failed to read body: {}>", e)),
                                     })))
                             )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 }
             }
         }))
@@ -406,7 +406,7 @@ impl From<openssl::error::ErrorStack> for ClientInitError {
 
 impl fmt::Display for ClientInitError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        (self as &fmt::Debug).fmt(f)
+        (self as &dyn fmt::Debug).fmt(f)
     }
 }
 

--- a/samples/server/petstore/rust-server/output/multipart-v3/src/lib.rs
+++ b/samples/server/petstore/rust-server/output/multipart-v3/src/lib.rs
@@ -61,7 +61,7 @@ pub enum MultipartRequestPostResponse {
 pub trait Api<C> {
 
 
-    fn multipart_request_post(&self, string_field: String, binary_field: swagger::ByteArray, optional_string_field: Option<String>, object_field: Option<models::MultipartRequestObjectField>, context: &C) -> Box<Future<Item=MultipartRequestPostResponse, Error=ApiError>>;
+    fn multipart_request_post(&self, string_field: String, binary_field: swagger::ByteArray, optional_string_field: Option<String>, object_field: Option<models::MultipartRequestObjectField>, context: &C) -> Box<dyn Future<Item=MultipartRequestPostResponse, Error=ApiError>>;
 
 }
 
@@ -69,7 +69,7 @@ pub trait Api<C> {
 pub trait ApiNoContext {
 
 
-    fn multipart_request_post(&self, string_field: String, binary_field: swagger::ByteArray, optional_string_field: Option<String>, object_field: Option<models::MultipartRequestObjectField>) -> Box<Future<Item=MultipartRequestPostResponse, Error=ApiError>>;
+    fn multipart_request_post(&self, string_field: String, binary_field: swagger::ByteArray, optional_string_field: Option<String>, object_field: Option<models::MultipartRequestObjectField>) -> Box<dyn Future<Item=MultipartRequestPostResponse, Error=ApiError>>;
 
 }
 
@@ -88,7 +88,7 @@ impl<'a, T: Api<C> + Sized, C> ContextWrapperExt<'a, C> for T {
 impl<'a, T: Api<C>, C> ApiNoContext for ContextWrapper<'a, T, C> {
 
 
-    fn multipart_request_post(&self, string_field: String, binary_field: swagger::ByteArray, optional_string_field: Option<String>, object_field: Option<models::MultipartRequestObjectField>) -> Box<Future<Item=MultipartRequestPostResponse, Error=ApiError>> {
+    fn multipart_request_post(&self, string_field: String, binary_field: swagger::ByteArray, optional_string_field: Option<String>, object_field: Option<models::MultipartRequestObjectField>) -> Box<dyn Future<Item=MultipartRequestPostResponse, Error=ApiError>> {
         self.api().multipart_request_post(string_field, binary_field, optional_string_field, object_field, &self.context())
     }
 

--- a/samples/server/petstore/rust-server/output/openapi-v3/Cargo.toml
+++ b/samples/server/petstore/rust-server/output/openapi-v3/Cargo.toml
@@ -16,7 +16,7 @@ conversion = ["frunk", "frunk_derives", "frunk_core", "frunk-enum-core", "frunk-
 chrono = { version = "0.4", features = ["serde"] }
 futures = "0.1"
 swagger = "2"
-lazy_static = "0.2"
+lazy_static = "1.4"
 log = "0.3.0"
 mime = "0.2.6"
 multipart = "0.13.3"

--- a/samples/server/petstore/rust-server/output/openapi-v3/examples/client.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/examples/client.rs
@@ -91,57 +91,57 @@ fn main() {
 
         Some("MultigetGet") => {
             let result = core.run(client.multiget_get());
-            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
          },
 
         Some("MultipleAuthSchemeGet") => {
             let result = core.run(client.multiple_auth_scheme_get());
-            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
          },
 
         Some("ReadonlyAuthSchemeGet") => {
             let result = core.run(client.readonly_auth_scheme_get());
-            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
          },
 
         Some("RequiredOctetStreamPut") => {
             let result = core.run(client.required_octet_stream_put(swagger::ByteArray(Vec::from("BYTE_ARRAY_DATA_HERE"))));
-            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
          },
 
         Some("ResponsesWithHeadersGet") => {
             let result = core.run(client.responses_with_headers_get());
-            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
          },
 
         Some("UuidGet") => {
             let result = core.run(client.uuid_get());
-            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
          },
 
         Some("XmlExtraPost") => {
             let result = core.run(client.xml_extra_post(None));
-            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
          },
 
         Some("XmlOtherPost") => {
             let result = core.run(client.xml_other_post(None));
-            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
          },
 
         Some("XmlOtherPut") => {
             let result = core.run(client.xml_other_put(None));
-            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
          },
 
         Some("XmlPost") => {
             let result = core.run(client.xml_post(None));
-            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
          },
 
         Some("XmlPut") => {
             let result = core.run(client.xml_put(None));
-            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
          },
 
         _ => {

--- a/samples/server/petstore/rust-server/output/openapi-v3/examples/server_lib/server.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/examples/server_lib/server.rs
@@ -39,77 +39,77 @@ impl<C> Server<C> {
 impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
 
     /// Get some stuff.
-    fn multiget_get(&self, context: &C) -> Box<Future<Item=MultigetGetResponse, Error=ApiError>> {
+    fn multiget_get(&self, context: &C) -> Box<dyn Future<Item=MultigetGetResponse, Error=ApiError>> {
         let context = context.clone();
         println!("multiget_get() - X-Span-ID: {:?}", context.get().0.clone());
         Box::new(futures::failed("Generic failure".into()))
     }
 
 
-    fn multiple_auth_scheme_get(&self, context: &C) -> Box<Future<Item=MultipleAuthSchemeGetResponse, Error=ApiError>> {
+    fn multiple_auth_scheme_get(&self, context: &C) -> Box<dyn Future<Item=MultipleAuthSchemeGetResponse, Error=ApiError>> {
         let context = context.clone();
         println!("multiple_auth_scheme_get() - X-Span-ID: {:?}", context.get().0.clone());
         Box::new(futures::failed("Generic failure".into()))
     }
 
 
-    fn readonly_auth_scheme_get(&self, context: &C) -> Box<Future<Item=ReadonlyAuthSchemeGetResponse, Error=ApiError>> {
+    fn readonly_auth_scheme_get(&self, context: &C) -> Box<dyn Future<Item=ReadonlyAuthSchemeGetResponse, Error=ApiError>> {
         let context = context.clone();
         println!("readonly_auth_scheme_get() - X-Span-ID: {:?}", context.get().0.clone());
         Box::new(futures::failed("Generic failure".into()))
     }
 
 
-    fn required_octet_stream_put(&self, body: swagger::ByteArray, context: &C) -> Box<Future<Item=RequiredOctetStreamPutResponse, Error=ApiError>> {
+    fn required_octet_stream_put(&self, body: swagger::ByteArray, context: &C) -> Box<dyn Future<Item=RequiredOctetStreamPutResponse, Error=ApiError>> {
         let context = context.clone();
         println!("required_octet_stream_put({:?}) - X-Span-ID: {:?}", body, context.get().0.clone());
         Box::new(futures::failed("Generic failure".into()))
     }
 
 
-    fn responses_with_headers_get(&self, context: &C) -> Box<Future<Item=ResponsesWithHeadersGetResponse, Error=ApiError>> {
+    fn responses_with_headers_get(&self, context: &C) -> Box<dyn Future<Item=ResponsesWithHeadersGetResponse, Error=ApiError>> {
         let context = context.clone();
         println!("responses_with_headers_get() - X-Span-ID: {:?}", context.get().0.clone());
         Box::new(futures::failed("Generic failure".into()))
     }
 
 
-    fn uuid_get(&self, context: &C) -> Box<Future<Item=UuidGetResponse, Error=ApiError>> {
+    fn uuid_get(&self, context: &C) -> Box<dyn Future<Item=UuidGetResponse, Error=ApiError>> {
         let context = context.clone();
         println!("uuid_get() - X-Span-ID: {:?}", context.get().0.clone());
         Box::new(futures::failed("Generic failure".into()))
     }
 
 
-    fn xml_extra_post(&self, duplicate_xml_object: Option<models::DuplicateXmlObject>, context: &C) -> Box<Future<Item=XmlExtraPostResponse, Error=ApiError>> {
+    fn xml_extra_post(&self, duplicate_xml_object: Option<models::DuplicateXmlObject>, context: &C) -> Box<dyn Future<Item=XmlExtraPostResponse, Error=ApiError>> {
         let context = context.clone();
         println!("xml_extra_post({:?}) - X-Span-ID: {:?}", duplicate_xml_object, context.get().0.clone());
         Box::new(futures::failed("Generic failure".into()))
     }
 
 
-    fn xml_other_post(&self, another_xml_object: Option<models::AnotherXmlObject>, context: &C) -> Box<Future<Item=XmlOtherPostResponse, Error=ApiError>> {
+    fn xml_other_post(&self, another_xml_object: Option<models::AnotherXmlObject>, context: &C) -> Box<dyn Future<Item=XmlOtherPostResponse, Error=ApiError>> {
         let context = context.clone();
         println!("xml_other_post({:?}) - X-Span-ID: {:?}", another_xml_object, context.get().0.clone());
         Box::new(futures::failed("Generic failure".into()))
     }
 
 
-    fn xml_other_put(&self, string: Option<models::AnotherXmlArray>, context: &C) -> Box<Future<Item=XmlOtherPutResponse, Error=ApiError>> {
+    fn xml_other_put(&self, string: Option<models::AnotherXmlArray>, context: &C) -> Box<dyn Future<Item=XmlOtherPutResponse, Error=ApiError>> {
         let context = context.clone();
         println!("xml_other_put({:?}) - X-Span-ID: {:?}", string, context.get().0.clone());
         Box::new(futures::failed("Generic failure".into()))
     }
 
     /// Post an array
-    fn xml_post(&self, string: Option<models::XmlArray>, context: &C) -> Box<Future<Item=XmlPostResponse, Error=ApiError>> {
+    fn xml_post(&self, string: Option<models::XmlArray>, context: &C) -> Box<dyn Future<Item=XmlPostResponse, Error=ApiError>> {
         let context = context.clone();
         println!("xml_post({:?}) - X-Span-ID: {:?}", string, context.get().0.clone());
         Box::new(futures::failed("Generic failure".into()))
     }
 
 
-    fn xml_put(&self, xml_object: Option<models::XmlObject>, context: &C) -> Box<Future<Item=XmlPutResponse, Error=ApiError>> {
+    fn xml_put(&self, xml_object: Option<models::XmlObject>, context: &C) -> Box<dyn Future<Item=XmlPutResponse, Error=ApiError>> {
         let context = context.clone();
         println!("xml_put({:?}) - X-Span-ID: {:?}", xml_object, context.get().0.clone());
         Box::new(futures::failed("Generic failure".into()))

--- a/samples/server/petstore/rust-server/output/openapi-v3/src/lib.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/src/lib.rs
@@ -174,37 +174,37 @@ pub enum XmlPutResponse {
 pub trait Api<C> {
 
     /// Get some stuff.
-    fn multiget_get(&self, context: &C) -> Box<Future<Item=MultigetGetResponse, Error=ApiError>>;
+    fn multiget_get(&self, context: &C) -> Box<dyn Future<Item=MultigetGetResponse, Error=ApiError>>;
 
 
-    fn multiple_auth_scheme_get(&self, context: &C) -> Box<Future<Item=MultipleAuthSchemeGetResponse, Error=ApiError>>;
+    fn multiple_auth_scheme_get(&self, context: &C) -> Box<dyn Future<Item=MultipleAuthSchemeGetResponse, Error=ApiError>>;
 
 
-    fn readonly_auth_scheme_get(&self, context: &C) -> Box<Future<Item=ReadonlyAuthSchemeGetResponse, Error=ApiError>>;
+    fn readonly_auth_scheme_get(&self, context: &C) -> Box<dyn Future<Item=ReadonlyAuthSchemeGetResponse, Error=ApiError>>;
 
 
-    fn required_octet_stream_put(&self, body: swagger::ByteArray, context: &C) -> Box<Future<Item=RequiredOctetStreamPutResponse, Error=ApiError>>;
+    fn required_octet_stream_put(&self, body: swagger::ByteArray, context: &C) -> Box<dyn Future<Item=RequiredOctetStreamPutResponse, Error=ApiError>>;
 
 
-    fn responses_with_headers_get(&self, context: &C) -> Box<Future<Item=ResponsesWithHeadersGetResponse, Error=ApiError>>;
+    fn responses_with_headers_get(&self, context: &C) -> Box<dyn Future<Item=ResponsesWithHeadersGetResponse, Error=ApiError>>;
 
 
-    fn uuid_get(&self, context: &C) -> Box<Future<Item=UuidGetResponse, Error=ApiError>>;
+    fn uuid_get(&self, context: &C) -> Box<dyn Future<Item=UuidGetResponse, Error=ApiError>>;
 
 
-    fn xml_extra_post(&self, duplicate_xml_object: Option<models::DuplicateXmlObject>, context: &C) -> Box<Future<Item=XmlExtraPostResponse, Error=ApiError>>;
+    fn xml_extra_post(&self, duplicate_xml_object: Option<models::DuplicateXmlObject>, context: &C) -> Box<dyn Future<Item=XmlExtraPostResponse, Error=ApiError>>;
 
 
-    fn xml_other_post(&self, another_xml_object: Option<models::AnotherXmlObject>, context: &C) -> Box<Future<Item=XmlOtherPostResponse, Error=ApiError>>;
+    fn xml_other_post(&self, another_xml_object: Option<models::AnotherXmlObject>, context: &C) -> Box<dyn Future<Item=XmlOtherPostResponse, Error=ApiError>>;
 
 
-    fn xml_other_put(&self, string: Option<models::AnotherXmlArray>, context: &C) -> Box<Future<Item=XmlOtherPutResponse, Error=ApiError>>;
+    fn xml_other_put(&self, string: Option<models::AnotherXmlArray>, context: &C) -> Box<dyn Future<Item=XmlOtherPutResponse, Error=ApiError>>;
 
     /// Post an array
-    fn xml_post(&self, string: Option<models::XmlArray>, context: &C) -> Box<Future<Item=XmlPostResponse, Error=ApiError>>;
+    fn xml_post(&self, string: Option<models::XmlArray>, context: &C) -> Box<dyn Future<Item=XmlPostResponse, Error=ApiError>>;
 
 
-    fn xml_put(&self, xml_object: Option<models::XmlObject>, context: &C) -> Box<Future<Item=XmlPutResponse, Error=ApiError>>;
+    fn xml_put(&self, xml_object: Option<models::XmlObject>, context: &C) -> Box<dyn Future<Item=XmlPutResponse, Error=ApiError>>;
 
 }
 
@@ -212,37 +212,37 @@ pub trait Api<C> {
 pub trait ApiNoContext {
 
     /// Get some stuff.
-    fn multiget_get(&self) -> Box<Future<Item=MultigetGetResponse, Error=ApiError>>;
+    fn multiget_get(&self) -> Box<dyn Future<Item=MultigetGetResponse, Error=ApiError>>;
 
 
-    fn multiple_auth_scheme_get(&self) -> Box<Future<Item=MultipleAuthSchemeGetResponse, Error=ApiError>>;
+    fn multiple_auth_scheme_get(&self) -> Box<dyn Future<Item=MultipleAuthSchemeGetResponse, Error=ApiError>>;
 
 
-    fn readonly_auth_scheme_get(&self) -> Box<Future<Item=ReadonlyAuthSchemeGetResponse, Error=ApiError>>;
+    fn readonly_auth_scheme_get(&self) -> Box<dyn Future<Item=ReadonlyAuthSchemeGetResponse, Error=ApiError>>;
 
 
-    fn required_octet_stream_put(&self, body: swagger::ByteArray) -> Box<Future<Item=RequiredOctetStreamPutResponse, Error=ApiError>>;
+    fn required_octet_stream_put(&self, body: swagger::ByteArray) -> Box<dyn Future<Item=RequiredOctetStreamPutResponse, Error=ApiError>>;
 
 
-    fn responses_with_headers_get(&self) -> Box<Future<Item=ResponsesWithHeadersGetResponse, Error=ApiError>>;
+    fn responses_with_headers_get(&self) -> Box<dyn Future<Item=ResponsesWithHeadersGetResponse, Error=ApiError>>;
 
 
-    fn uuid_get(&self) -> Box<Future<Item=UuidGetResponse, Error=ApiError>>;
+    fn uuid_get(&self) -> Box<dyn Future<Item=UuidGetResponse, Error=ApiError>>;
 
 
-    fn xml_extra_post(&self, duplicate_xml_object: Option<models::DuplicateXmlObject>) -> Box<Future<Item=XmlExtraPostResponse, Error=ApiError>>;
+    fn xml_extra_post(&self, duplicate_xml_object: Option<models::DuplicateXmlObject>) -> Box<dyn Future<Item=XmlExtraPostResponse, Error=ApiError>>;
 
 
-    fn xml_other_post(&self, another_xml_object: Option<models::AnotherXmlObject>) -> Box<Future<Item=XmlOtherPostResponse, Error=ApiError>>;
+    fn xml_other_post(&self, another_xml_object: Option<models::AnotherXmlObject>) -> Box<dyn Future<Item=XmlOtherPostResponse, Error=ApiError>>;
 
 
-    fn xml_other_put(&self, string: Option<models::AnotherXmlArray>) -> Box<Future<Item=XmlOtherPutResponse, Error=ApiError>>;
+    fn xml_other_put(&self, string: Option<models::AnotherXmlArray>) -> Box<dyn Future<Item=XmlOtherPutResponse, Error=ApiError>>;
 
     /// Post an array
-    fn xml_post(&self, string: Option<models::XmlArray>) -> Box<Future<Item=XmlPostResponse, Error=ApiError>>;
+    fn xml_post(&self, string: Option<models::XmlArray>) -> Box<dyn Future<Item=XmlPostResponse, Error=ApiError>>;
 
 
-    fn xml_put(&self, xml_object: Option<models::XmlObject>) -> Box<Future<Item=XmlPutResponse, Error=ApiError>>;
+    fn xml_put(&self, xml_object: Option<models::XmlObject>) -> Box<dyn Future<Item=XmlPutResponse, Error=ApiError>>;
 
 }
 
@@ -261,57 +261,57 @@ impl<'a, T: Api<C> + Sized, C> ContextWrapperExt<'a, C> for T {
 impl<'a, T: Api<C>, C> ApiNoContext for ContextWrapper<'a, T, C> {
 
     /// Get some stuff.
-    fn multiget_get(&self) -> Box<Future<Item=MultigetGetResponse, Error=ApiError>> {
+    fn multiget_get(&self) -> Box<dyn Future<Item=MultigetGetResponse, Error=ApiError>> {
         self.api().multiget_get(&self.context())
     }
 
 
-    fn multiple_auth_scheme_get(&self) -> Box<Future<Item=MultipleAuthSchemeGetResponse, Error=ApiError>> {
+    fn multiple_auth_scheme_get(&self) -> Box<dyn Future<Item=MultipleAuthSchemeGetResponse, Error=ApiError>> {
         self.api().multiple_auth_scheme_get(&self.context())
     }
 
 
-    fn readonly_auth_scheme_get(&self) -> Box<Future<Item=ReadonlyAuthSchemeGetResponse, Error=ApiError>> {
+    fn readonly_auth_scheme_get(&self) -> Box<dyn Future<Item=ReadonlyAuthSchemeGetResponse, Error=ApiError>> {
         self.api().readonly_auth_scheme_get(&self.context())
     }
 
 
-    fn required_octet_stream_put(&self, body: swagger::ByteArray) -> Box<Future<Item=RequiredOctetStreamPutResponse, Error=ApiError>> {
+    fn required_octet_stream_put(&self, body: swagger::ByteArray) -> Box<dyn Future<Item=RequiredOctetStreamPutResponse, Error=ApiError>> {
         self.api().required_octet_stream_put(body, &self.context())
     }
 
 
-    fn responses_with_headers_get(&self) -> Box<Future<Item=ResponsesWithHeadersGetResponse, Error=ApiError>> {
+    fn responses_with_headers_get(&self) -> Box<dyn Future<Item=ResponsesWithHeadersGetResponse, Error=ApiError>> {
         self.api().responses_with_headers_get(&self.context())
     }
 
 
-    fn uuid_get(&self) -> Box<Future<Item=UuidGetResponse, Error=ApiError>> {
+    fn uuid_get(&self) -> Box<dyn Future<Item=UuidGetResponse, Error=ApiError>> {
         self.api().uuid_get(&self.context())
     }
 
 
-    fn xml_extra_post(&self, duplicate_xml_object: Option<models::DuplicateXmlObject>) -> Box<Future<Item=XmlExtraPostResponse, Error=ApiError>> {
+    fn xml_extra_post(&self, duplicate_xml_object: Option<models::DuplicateXmlObject>) -> Box<dyn Future<Item=XmlExtraPostResponse, Error=ApiError>> {
         self.api().xml_extra_post(duplicate_xml_object, &self.context())
     }
 
 
-    fn xml_other_post(&self, another_xml_object: Option<models::AnotherXmlObject>) -> Box<Future<Item=XmlOtherPostResponse, Error=ApiError>> {
+    fn xml_other_post(&self, another_xml_object: Option<models::AnotherXmlObject>) -> Box<dyn Future<Item=XmlOtherPostResponse, Error=ApiError>> {
         self.api().xml_other_post(another_xml_object, &self.context())
     }
 
 
-    fn xml_other_put(&self, string: Option<models::AnotherXmlArray>) -> Box<Future<Item=XmlOtherPutResponse, Error=ApiError>> {
+    fn xml_other_put(&self, string: Option<models::AnotherXmlArray>) -> Box<dyn Future<Item=XmlOtherPutResponse, Error=ApiError>> {
         self.api().xml_other_put(string, &self.context())
     }
 
     /// Post an array
-    fn xml_post(&self, string: Option<models::XmlArray>) -> Box<Future<Item=XmlPostResponse, Error=ApiError>> {
+    fn xml_post(&self, string: Option<models::XmlArray>) -> Box<dyn Future<Item=XmlPostResponse, Error=ApiError>> {
         self.api().xml_post(string, &self.context())
     }
 
 
-    fn xml_put(&self, xml_object: Option<models::XmlObject>) -> Box<Future<Item=XmlPutResponse, Error=ApiError>> {
+    fn xml_put(&self, xml_object: Option<models::XmlObject>) -> Box<dyn Future<Item=XmlPutResponse, Error=ApiError>> {
         self.api().xml_put(xml_object, &self.context())
     }
 

--- a/samples/server/petstore/rust-server/output/openapi-v3/src/server/mod.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/src/server/mod.rs
@@ -133,7 +133,7 @@ where
     type Request = (Request, C);
     type Response = Response;
     type Error = Error;
-    type Future = Box<Future<Item=Response, Error=Error>>;
+    type Future = Box<dyn Future<Item=Response, Error=Error>>;
 
     fn call(&self, (req, mut context): Self::Request) -> Self::Future {
         let api_impl = self.api_impl.clone();
@@ -151,7 +151,7 @@ where
                                 Box::new(api_impl.multiget_get(&context)
                                     .then(move |result| {
                                         let mut response = Response::new();
-                                        response.headers_mut().set(XSpanId((&context as &Has<XSpanIdString>).get().0.to_string()));
+                                        response.headers_mut().set(XSpanId((&context as &dyn Has<XSpanIdString>).get().0.to_string()));
 
                                         match result {
                                             Ok(rsp) => match rsp {
@@ -259,13 +259,13 @@ where
                                     }
                                 ))
                         }}
-                }) as Box<Future<Item=Response, Error=Error>>
+                }) as Box<dyn Future<Item=Response, Error=Error>>
             },
 
             // MultipleAuthSchemeGet - GET /multiple_auth_scheme
             &hyper::Method::Get if path.matched(paths::ID_MULTIPLE_AUTH_SCHEME) => {
                 {
-                    let authorization = match (&context as &Has<Option<Authorization>>).get() {
+                    let authorization = match (&context as &dyn Has<Option<Authorization>>).get() {
                         &Some(ref authorization) => authorization,
                         &None => return Box::new(future::ok(Response::new()
                                                 .with_status(StatusCode::Forbidden)
@@ -296,7 +296,7 @@ where
                                 Box::new(api_impl.multiple_auth_scheme_get(&context)
                                     .then(move |result| {
                                         let mut response = Response::new();
-                                        response.headers_mut().set(XSpanId((&context as &Has<XSpanIdString>).get().0.to_string()));
+                                        response.headers_mut().set(XSpanId((&context as &dyn Has<XSpanIdString>).get().0.to_string()));
 
                                         match result {
                                             Ok(rsp) => match rsp {
@@ -320,13 +320,13 @@ where
                                     }
                                 ))
                         }}
-                }) as Box<Future<Item=Response, Error=Error>>
+                }) as Box<dyn Future<Item=Response, Error=Error>>
             },
 
             // ReadonlyAuthSchemeGet - GET /readonly_auth_scheme
             &hyper::Method::Get if path.matched(paths::ID_READONLY_AUTH_SCHEME) => {
                 {
-                    let authorization = match (&context as &Has<Option<Authorization>>).get() {
+                    let authorization = match (&context as &dyn Has<Option<Authorization>>).get() {
                         &Some(ref authorization) => authorization,
                         &None => return Box::new(future::ok(Response::new()
                                                 .with_status(StatusCode::Forbidden)
@@ -356,7 +356,7 @@ where
                                 Box::new(api_impl.readonly_auth_scheme_get(&context)
                                     .then(move |result| {
                                         let mut response = Response::new();
-                                        response.headers_mut().set(XSpanId((&context as &Has<XSpanIdString>).get().0.to_string()));
+                                        response.headers_mut().set(XSpanId((&context as &dyn Has<XSpanIdString>).get().0.to_string()));
 
                                         match result {
                                             Ok(rsp) => match rsp {
@@ -380,7 +380,7 @@ where
                                     }
                                 ))
                         }}
-                }) as Box<Future<Item=Response, Error=Error>>
+                }) as Box<dyn Future<Item=Response, Error=Error>>
             },
 
             // RequiredOctetStreamPut - PUT /required_octet_stream
@@ -389,7 +389,7 @@ where
                 // values, rather than causing a 400 response). Produce warning header and logs for
                 // any unused fields.
                 Box::new(body.concat2()
-                    .then(move |result| -> Box<Future<Item=Response, Error=Error>> {
+                    .then(move |result| -> Box<dyn Future<Item=Response, Error=Error>> {
                         match result {
                             Ok(body) => {
                                 let param_body: Option<swagger::ByteArray> = if !body.is_empty() {
@@ -404,7 +404,7 @@ where
                                 Box::new(api_impl.required_octet_stream_put(param_body, &context)
                                     .then(move |result| {
                                         let mut response = Response::new();
-                                        response.headers_mut().set(XSpanId((&context as &Has<XSpanIdString>).get().0.to_string()));
+                                        response.headers_mut().set(XSpanId((&context as &dyn Has<XSpanIdString>).get().0.to_string()));
 
                                         match result {
                                             Ok(rsp) => match rsp {
@@ -431,7 +431,7 @@ where
                             Err(e) => Box::new(future::ok(Response::new().with_status(StatusCode::BadRequest).with_body(format!("Couldn't read body parameter body: {}", e)))),
                         }
                     })
-                ) as Box<Future<Item=Response, Error=Error>>
+                ) as Box<dyn Future<Item=Response, Error=Error>>
             },
 
             // ResponsesWithHeadersGet - GET /responses_with_headers
@@ -441,7 +441,7 @@ where
                                 Box::new(api_impl.responses_with_headers_get(&context)
                                     .then(move |result| {
                                         let mut response = Response::new();
-                                        response.headers_mut().set(XSpanId((&context as &Has<XSpanIdString>).get().0.to_string()));
+                                        response.headers_mut().set(XSpanId((&context as &dyn Has<XSpanIdString>).get().0.to_string()));
 
                                         match result {
                                             Ok(rsp) => match rsp {
@@ -492,7 +492,7 @@ where
                                     }
                                 ))
                         }}
-                }) as Box<Future<Item=Response, Error=Error>>
+                }) as Box<dyn Future<Item=Response, Error=Error>>
             },
 
             // UuidGet - GET /uuid
@@ -502,7 +502,7 @@ where
                                 Box::new(api_impl.uuid_get(&context)
                                     .then(move |result| {
                                         let mut response = Response::new();
-                                        response.headers_mut().set(XSpanId((&context as &Has<XSpanIdString>).get().0.to_string()));
+                                        response.headers_mut().set(XSpanId((&context as &dyn Has<XSpanIdString>).get().0.to_string()));
 
                                         match result {
                                             Ok(rsp) => match rsp {
@@ -532,7 +532,7 @@ where
                                     }
                                 ))
                         }}
-                }) as Box<Future<Item=Response, Error=Error>>
+                }) as Box<dyn Future<Item=Response, Error=Error>>
             },
 
             // XmlExtraPost - POST /xml_extra
@@ -541,7 +541,7 @@ where
                 // values, rather than causing a 400 response). Produce warning header and logs for
                 // any unused fields.
                 Box::new(body.concat2()
-                    .then(move |result| -> Box<Future<Item=Response, Error=Error>> {
+                    .then(move |result| -> Box<dyn Future<Item=Response, Error=Error>> {
                         match result {
                             Ok(body) => {
                                 let mut unused_elements = Vec::new();
@@ -560,7 +560,7 @@ where
                                 Box::new(api_impl.xml_extra_post(param_duplicate_xml_object, &context)
                                     .then(move |result| {
                                         let mut response = Response::new();
-                                        response.headers_mut().set(XSpanId((&context as &Has<XSpanIdString>).get().0.to_string()));
+                                        response.headers_mut().set(XSpanId((&context as &dyn Has<XSpanIdString>).get().0.to_string()));
 
                                         if !unused_elements.is_empty() {
                                             response.headers_mut().set(Warning(format!("Ignoring unknown fields in body: {:?}", unused_elements)));
@@ -598,7 +598,7 @@ where
                             Err(e) => Box::new(future::ok(Response::new().with_status(StatusCode::BadRequest).with_body(format!("Couldn't read body parameter DuplicateXmlObject: {}", e)))),
                         }
                     })
-                ) as Box<Future<Item=Response, Error=Error>>
+                ) as Box<dyn Future<Item=Response, Error=Error>>
             },
 
             // XmlOtherPost - POST /xml_other
@@ -607,7 +607,7 @@ where
                 // values, rather than causing a 400 response). Produce warning header and logs for
                 // any unused fields.
                 Box::new(body.concat2()
-                    .then(move |result| -> Box<Future<Item=Response, Error=Error>> {
+                    .then(move |result| -> Box<dyn Future<Item=Response, Error=Error>> {
                         match result {
                             Ok(body) => {
                                 let mut unused_elements = Vec::new();
@@ -626,7 +626,7 @@ where
                                 Box::new(api_impl.xml_other_post(param_another_xml_object, &context)
                                     .then(move |result| {
                                         let mut response = Response::new();
-                                        response.headers_mut().set(XSpanId((&context as &Has<XSpanIdString>).get().0.to_string()));
+                                        response.headers_mut().set(XSpanId((&context as &dyn Has<XSpanIdString>).get().0.to_string()));
 
                                         if !unused_elements.is_empty() {
                                             response.headers_mut().set(Warning(format!("Ignoring unknown fields in body: {:?}", unused_elements)));
@@ -664,7 +664,7 @@ where
                             Err(e) => Box::new(future::ok(Response::new().with_status(StatusCode::BadRequest).with_body(format!("Couldn't read body parameter AnotherXmlObject: {}", e)))),
                         }
                     })
-                ) as Box<Future<Item=Response, Error=Error>>
+                ) as Box<dyn Future<Item=Response, Error=Error>>
             },
 
             // XmlOtherPut - PUT /xml_other
@@ -673,7 +673,7 @@ where
                 // values, rather than causing a 400 response). Produce warning header and logs for
                 // any unused fields.
                 Box::new(body.concat2()
-                    .then(move |result| -> Box<Future<Item=Response, Error=Error>> {
+                    .then(move |result| -> Box<dyn Future<Item=Response, Error=Error>> {
                         match result {
                             Ok(body) => {
                                 let mut unused_elements = Vec::new();
@@ -692,7 +692,7 @@ where
                                 Box::new(api_impl.xml_other_put(param_string, &context)
                                     .then(move |result| {
                                         let mut response = Response::new();
-                                        response.headers_mut().set(XSpanId((&context as &Has<XSpanIdString>).get().0.to_string()));
+                                        response.headers_mut().set(XSpanId((&context as &dyn Has<XSpanIdString>).get().0.to_string()));
 
                                         if !unused_elements.is_empty() {
                                             response.headers_mut().set(Warning(format!("Ignoring unknown fields in body: {:?}", unused_elements)));
@@ -730,7 +730,7 @@ where
                             Err(e) => Box::new(future::ok(Response::new().with_status(StatusCode::BadRequest).with_body(format!("Couldn't read body parameter string: {}", e)))),
                         }
                     })
-                ) as Box<Future<Item=Response, Error=Error>>
+                ) as Box<dyn Future<Item=Response, Error=Error>>
             },
 
             // XmlPost - POST /xml
@@ -739,7 +739,7 @@ where
                 // values, rather than causing a 400 response). Produce warning header and logs for
                 // any unused fields.
                 Box::new(body.concat2()
-                    .then(move |result| -> Box<Future<Item=Response, Error=Error>> {
+                    .then(move |result| -> Box<dyn Future<Item=Response, Error=Error>> {
                         match result {
                             Ok(body) => {
                                 let mut unused_elements = Vec::new();
@@ -758,7 +758,7 @@ where
                                 Box::new(api_impl.xml_post(param_string, &context)
                                     .then(move |result| {
                                         let mut response = Response::new();
-                                        response.headers_mut().set(XSpanId((&context as &Has<XSpanIdString>).get().0.to_string()));
+                                        response.headers_mut().set(XSpanId((&context as &dyn Has<XSpanIdString>).get().0.to_string()));
 
                                         if !unused_elements.is_empty() {
                                             response.headers_mut().set(Warning(format!("Ignoring unknown fields in body: {:?}", unused_elements)));
@@ -796,7 +796,7 @@ where
                             Err(e) => Box::new(future::ok(Response::new().with_status(StatusCode::BadRequest).with_body(format!("Couldn't read body parameter string: {}", e)))),
                         }
                     })
-                ) as Box<Future<Item=Response, Error=Error>>
+                ) as Box<dyn Future<Item=Response, Error=Error>>
             },
 
             // XmlPut - PUT /xml
@@ -805,7 +805,7 @@ where
                 // values, rather than causing a 400 response). Produce warning header and logs for
                 // any unused fields.
                 Box::new(body.concat2()
-                    .then(move |result| -> Box<Future<Item=Response, Error=Error>> {
+                    .then(move |result| -> Box<dyn Future<Item=Response, Error=Error>> {
                         match result {
                             Ok(body) => {
                                 let mut unused_elements = Vec::new();
@@ -824,7 +824,7 @@ where
                                 Box::new(api_impl.xml_put(param_xml_object, &context)
                                     .then(move |result| {
                                         let mut response = Response::new();
-                                        response.headers_mut().set(XSpanId((&context as &Has<XSpanIdString>).get().0.to_string()));
+                                        response.headers_mut().set(XSpanId((&context as &dyn Has<XSpanIdString>).get().0.to_string()));
 
                                         if !unused_elements.is_empty() {
                                             response.headers_mut().set(Warning(format!("Ignoring unknown fields in body: {:?}", unused_elements)));
@@ -862,10 +862,10 @@ where
                             Err(e) => Box::new(future::ok(Response::new().with_status(StatusCode::BadRequest).with_body(format!("Couldn't read body parameter XmlObject: {}", e)))),
                         }
                     })
-                ) as Box<Future<Item=Response, Error=Error>>
+                ) as Box<dyn Future<Item=Response, Error=Error>>
             },
 
-            _ => Box::new(future::ok(Response::new().with_status(StatusCode::NotFound))) as Box<Future<Item=Response, Error=Error>>,
+            _ => Box::new(future::ok(Response::new().with_status(StatusCode::NotFound))) as Box<dyn Future<Item=Response, Error=Error>>,
         }
     }
 }

--- a/samples/server/petstore/rust-server/output/ops-v3/Cargo.toml
+++ b/samples/server/petstore/rust-server/output/ops-v3/Cargo.toml
@@ -16,7 +16,7 @@ conversion = ["frunk", "frunk_derives", "frunk_core", "frunk-enum-core", "frunk-
 chrono = { version = "0.4", features = ["serde"] }
 futures = "0.1"
 swagger = "2"
-lazy_static = "0.2"
+lazy_static = "1.4"
 log = "0.3.0"
 mime = "0.2.6"
 multipart = "0.13.3"

--- a/samples/server/petstore/rust-server/output/ops-v3/examples/client.rs
+++ b/samples/server/petstore/rust-server/output/ops-v3/examples/client.rs
@@ -143,187 +143,187 @@ fn main() {
 
         Some("Op10Get") => {
             let result = core.run(client.op10_get());
-            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
          },
 
         Some("Op11Get") => {
             let result = core.run(client.op11_get());
-            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
          },
 
         Some("Op12Get") => {
             let result = core.run(client.op12_get());
-            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
          },
 
         Some("Op13Get") => {
             let result = core.run(client.op13_get());
-            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
          },
 
         Some("Op14Get") => {
             let result = core.run(client.op14_get());
-            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
          },
 
         Some("Op15Get") => {
             let result = core.run(client.op15_get());
-            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
          },
 
         Some("Op16Get") => {
             let result = core.run(client.op16_get());
-            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
          },
 
         Some("Op17Get") => {
             let result = core.run(client.op17_get());
-            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
          },
 
         Some("Op18Get") => {
             let result = core.run(client.op18_get());
-            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
          },
 
         Some("Op19Get") => {
             let result = core.run(client.op19_get());
-            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
          },
 
         Some("Op1Get") => {
             let result = core.run(client.op1_get());
-            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
          },
 
         Some("Op20Get") => {
             let result = core.run(client.op20_get());
-            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
          },
 
         Some("Op21Get") => {
             let result = core.run(client.op21_get());
-            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
          },
 
         Some("Op22Get") => {
             let result = core.run(client.op22_get());
-            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
          },
 
         Some("Op23Get") => {
             let result = core.run(client.op23_get());
-            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
          },
 
         Some("Op24Get") => {
             let result = core.run(client.op24_get());
-            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
          },
 
         Some("Op25Get") => {
             let result = core.run(client.op25_get());
-            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
          },
 
         Some("Op26Get") => {
             let result = core.run(client.op26_get());
-            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
          },
 
         Some("Op27Get") => {
             let result = core.run(client.op27_get());
-            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
          },
 
         Some("Op28Get") => {
             let result = core.run(client.op28_get());
-            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
          },
 
         Some("Op29Get") => {
             let result = core.run(client.op29_get());
-            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
          },
 
         Some("Op2Get") => {
             let result = core.run(client.op2_get());
-            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
          },
 
         Some("Op30Get") => {
             let result = core.run(client.op30_get());
-            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
          },
 
         Some("Op31Get") => {
             let result = core.run(client.op31_get());
-            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
          },
 
         Some("Op32Get") => {
             let result = core.run(client.op32_get());
-            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
          },
 
         Some("Op33Get") => {
             let result = core.run(client.op33_get());
-            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
          },
 
         Some("Op34Get") => {
             let result = core.run(client.op34_get());
-            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
          },
 
         Some("Op35Get") => {
             let result = core.run(client.op35_get());
-            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
          },
 
         Some("Op36Get") => {
             let result = core.run(client.op36_get());
-            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
          },
 
         Some("Op37Get") => {
             let result = core.run(client.op37_get());
-            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
          },
 
         Some("Op3Get") => {
             let result = core.run(client.op3_get());
-            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
          },
 
         Some("Op4Get") => {
             let result = core.run(client.op4_get());
-            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
          },
 
         Some("Op5Get") => {
             let result = core.run(client.op5_get());
-            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
          },
 
         Some("Op6Get") => {
             let result = core.run(client.op6_get());
-            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
          },
 
         Some("Op7Get") => {
             let result = core.run(client.op7_get());
-            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
          },
 
         Some("Op8Get") => {
             let result = core.run(client.op8_get());
-            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
          },
 
         Some("Op9Get") => {
             let result = core.run(client.op9_get());
-            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
          },
 
         _ => {

--- a/samples/server/petstore/rust-server/output/ops-v3/examples/server_lib/server.rs
+++ b/samples/server/petstore/rust-server/output/ops-v3/examples/server_lib/server.rs
@@ -64,259 +64,259 @@ impl<C> Server<C> {
 impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
 
 
-    fn op10_get(&self, context: &C) -> Box<Future<Item=Op10GetResponse, Error=ApiError>> {
+    fn op10_get(&self, context: &C) -> Box<dyn Future<Item=Op10GetResponse, Error=ApiError>> {
         let context = context.clone();
         println!("op10_get() - X-Span-ID: {:?}", context.get().0.clone());
         Box::new(futures::failed("Generic failure".into()))
     }
 
 
-    fn op11_get(&self, context: &C) -> Box<Future<Item=Op11GetResponse, Error=ApiError>> {
+    fn op11_get(&self, context: &C) -> Box<dyn Future<Item=Op11GetResponse, Error=ApiError>> {
         let context = context.clone();
         println!("op11_get() - X-Span-ID: {:?}", context.get().0.clone());
         Box::new(futures::failed("Generic failure".into()))
     }
 
 
-    fn op12_get(&self, context: &C) -> Box<Future<Item=Op12GetResponse, Error=ApiError>> {
+    fn op12_get(&self, context: &C) -> Box<dyn Future<Item=Op12GetResponse, Error=ApiError>> {
         let context = context.clone();
         println!("op12_get() - X-Span-ID: {:?}", context.get().0.clone());
         Box::new(futures::failed("Generic failure".into()))
     }
 
 
-    fn op13_get(&self, context: &C) -> Box<Future<Item=Op13GetResponse, Error=ApiError>> {
+    fn op13_get(&self, context: &C) -> Box<dyn Future<Item=Op13GetResponse, Error=ApiError>> {
         let context = context.clone();
         println!("op13_get() - X-Span-ID: {:?}", context.get().0.clone());
         Box::new(futures::failed("Generic failure".into()))
     }
 
 
-    fn op14_get(&self, context: &C) -> Box<Future<Item=Op14GetResponse, Error=ApiError>> {
+    fn op14_get(&self, context: &C) -> Box<dyn Future<Item=Op14GetResponse, Error=ApiError>> {
         let context = context.clone();
         println!("op14_get() - X-Span-ID: {:?}", context.get().0.clone());
         Box::new(futures::failed("Generic failure".into()))
     }
 
 
-    fn op15_get(&self, context: &C) -> Box<Future<Item=Op15GetResponse, Error=ApiError>> {
+    fn op15_get(&self, context: &C) -> Box<dyn Future<Item=Op15GetResponse, Error=ApiError>> {
         let context = context.clone();
         println!("op15_get() - X-Span-ID: {:?}", context.get().0.clone());
         Box::new(futures::failed("Generic failure".into()))
     }
 
 
-    fn op16_get(&self, context: &C) -> Box<Future<Item=Op16GetResponse, Error=ApiError>> {
+    fn op16_get(&self, context: &C) -> Box<dyn Future<Item=Op16GetResponse, Error=ApiError>> {
         let context = context.clone();
         println!("op16_get() - X-Span-ID: {:?}", context.get().0.clone());
         Box::new(futures::failed("Generic failure".into()))
     }
 
 
-    fn op17_get(&self, context: &C) -> Box<Future<Item=Op17GetResponse, Error=ApiError>> {
+    fn op17_get(&self, context: &C) -> Box<dyn Future<Item=Op17GetResponse, Error=ApiError>> {
         let context = context.clone();
         println!("op17_get() - X-Span-ID: {:?}", context.get().0.clone());
         Box::new(futures::failed("Generic failure".into()))
     }
 
 
-    fn op18_get(&self, context: &C) -> Box<Future<Item=Op18GetResponse, Error=ApiError>> {
+    fn op18_get(&self, context: &C) -> Box<dyn Future<Item=Op18GetResponse, Error=ApiError>> {
         let context = context.clone();
         println!("op18_get() - X-Span-ID: {:?}", context.get().0.clone());
         Box::new(futures::failed("Generic failure".into()))
     }
 
 
-    fn op19_get(&self, context: &C) -> Box<Future<Item=Op19GetResponse, Error=ApiError>> {
+    fn op19_get(&self, context: &C) -> Box<dyn Future<Item=Op19GetResponse, Error=ApiError>> {
         let context = context.clone();
         println!("op19_get() - X-Span-ID: {:?}", context.get().0.clone());
         Box::new(futures::failed("Generic failure".into()))
     }
 
 
-    fn op1_get(&self, context: &C) -> Box<Future<Item=Op1GetResponse, Error=ApiError>> {
+    fn op1_get(&self, context: &C) -> Box<dyn Future<Item=Op1GetResponse, Error=ApiError>> {
         let context = context.clone();
         println!("op1_get() - X-Span-ID: {:?}", context.get().0.clone());
         Box::new(futures::failed("Generic failure".into()))
     }
 
 
-    fn op20_get(&self, context: &C) -> Box<Future<Item=Op20GetResponse, Error=ApiError>> {
+    fn op20_get(&self, context: &C) -> Box<dyn Future<Item=Op20GetResponse, Error=ApiError>> {
         let context = context.clone();
         println!("op20_get() - X-Span-ID: {:?}", context.get().0.clone());
         Box::new(futures::failed("Generic failure".into()))
     }
 
 
-    fn op21_get(&self, context: &C) -> Box<Future<Item=Op21GetResponse, Error=ApiError>> {
+    fn op21_get(&self, context: &C) -> Box<dyn Future<Item=Op21GetResponse, Error=ApiError>> {
         let context = context.clone();
         println!("op21_get() - X-Span-ID: {:?}", context.get().0.clone());
         Box::new(futures::failed("Generic failure".into()))
     }
 
 
-    fn op22_get(&self, context: &C) -> Box<Future<Item=Op22GetResponse, Error=ApiError>> {
+    fn op22_get(&self, context: &C) -> Box<dyn Future<Item=Op22GetResponse, Error=ApiError>> {
         let context = context.clone();
         println!("op22_get() - X-Span-ID: {:?}", context.get().0.clone());
         Box::new(futures::failed("Generic failure".into()))
     }
 
 
-    fn op23_get(&self, context: &C) -> Box<Future<Item=Op23GetResponse, Error=ApiError>> {
+    fn op23_get(&self, context: &C) -> Box<dyn Future<Item=Op23GetResponse, Error=ApiError>> {
         let context = context.clone();
         println!("op23_get() - X-Span-ID: {:?}", context.get().0.clone());
         Box::new(futures::failed("Generic failure".into()))
     }
 
 
-    fn op24_get(&self, context: &C) -> Box<Future<Item=Op24GetResponse, Error=ApiError>> {
+    fn op24_get(&self, context: &C) -> Box<dyn Future<Item=Op24GetResponse, Error=ApiError>> {
         let context = context.clone();
         println!("op24_get() - X-Span-ID: {:?}", context.get().0.clone());
         Box::new(futures::failed("Generic failure".into()))
     }
 
 
-    fn op25_get(&self, context: &C) -> Box<Future<Item=Op25GetResponse, Error=ApiError>> {
+    fn op25_get(&self, context: &C) -> Box<dyn Future<Item=Op25GetResponse, Error=ApiError>> {
         let context = context.clone();
         println!("op25_get() - X-Span-ID: {:?}", context.get().0.clone());
         Box::new(futures::failed("Generic failure".into()))
     }
 
 
-    fn op26_get(&self, context: &C) -> Box<Future<Item=Op26GetResponse, Error=ApiError>> {
+    fn op26_get(&self, context: &C) -> Box<dyn Future<Item=Op26GetResponse, Error=ApiError>> {
         let context = context.clone();
         println!("op26_get() - X-Span-ID: {:?}", context.get().0.clone());
         Box::new(futures::failed("Generic failure".into()))
     }
 
 
-    fn op27_get(&self, context: &C) -> Box<Future<Item=Op27GetResponse, Error=ApiError>> {
+    fn op27_get(&self, context: &C) -> Box<dyn Future<Item=Op27GetResponse, Error=ApiError>> {
         let context = context.clone();
         println!("op27_get() - X-Span-ID: {:?}", context.get().0.clone());
         Box::new(futures::failed("Generic failure".into()))
     }
 
 
-    fn op28_get(&self, context: &C) -> Box<Future<Item=Op28GetResponse, Error=ApiError>> {
+    fn op28_get(&self, context: &C) -> Box<dyn Future<Item=Op28GetResponse, Error=ApiError>> {
         let context = context.clone();
         println!("op28_get() - X-Span-ID: {:?}", context.get().0.clone());
         Box::new(futures::failed("Generic failure".into()))
     }
 
 
-    fn op29_get(&self, context: &C) -> Box<Future<Item=Op29GetResponse, Error=ApiError>> {
+    fn op29_get(&self, context: &C) -> Box<dyn Future<Item=Op29GetResponse, Error=ApiError>> {
         let context = context.clone();
         println!("op29_get() - X-Span-ID: {:?}", context.get().0.clone());
         Box::new(futures::failed("Generic failure".into()))
     }
 
 
-    fn op2_get(&self, context: &C) -> Box<Future<Item=Op2GetResponse, Error=ApiError>> {
+    fn op2_get(&self, context: &C) -> Box<dyn Future<Item=Op2GetResponse, Error=ApiError>> {
         let context = context.clone();
         println!("op2_get() - X-Span-ID: {:?}", context.get().0.clone());
         Box::new(futures::failed("Generic failure".into()))
     }
 
 
-    fn op30_get(&self, context: &C) -> Box<Future<Item=Op30GetResponse, Error=ApiError>> {
+    fn op30_get(&self, context: &C) -> Box<dyn Future<Item=Op30GetResponse, Error=ApiError>> {
         let context = context.clone();
         println!("op30_get() - X-Span-ID: {:?}", context.get().0.clone());
         Box::new(futures::failed("Generic failure".into()))
     }
 
 
-    fn op31_get(&self, context: &C) -> Box<Future<Item=Op31GetResponse, Error=ApiError>> {
+    fn op31_get(&self, context: &C) -> Box<dyn Future<Item=Op31GetResponse, Error=ApiError>> {
         let context = context.clone();
         println!("op31_get() - X-Span-ID: {:?}", context.get().0.clone());
         Box::new(futures::failed("Generic failure".into()))
     }
 
 
-    fn op32_get(&self, context: &C) -> Box<Future<Item=Op32GetResponse, Error=ApiError>> {
+    fn op32_get(&self, context: &C) -> Box<dyn Future<Item=Op32GetResponse, Error=ApiError>> {
         let context = context.clone();
         println!("op32_get() - X-Span-ID: {:?}", context.get().0.clone());
         Box::new(futures::failed("Generic failure".into()))
     }
 
 
-    fn op33_get(&self, context: &C) -> Box<Future<Item=Op33GetResponse, Error=ApiError>> {
+    fn op33_get(&self, context: &C) -> Box<dyn Future<Item=Op33GetResponse, Error=ApiError>> {
         let context = context.clone();
         println!("op33_get() - X-Span-ID: {:?}", context.get().0.clone());
         Box::new(futures::failed("Generic failure".into()))
     }
 
 
-    fn op34_get(&self, context: &C) -> Box<Future<Item=Op34GetResponse, Error=ApiError>> {
+    fn op34_get(&self, context: &C) -> Box<dyn Future<Item=Op34GetResponse, Error=ApiError>> {
         let context = context.clone();
         println!("op34_get() - X-Span-ID: {:?}", context.get().0.clone());
         Box::new(futures::failed("Generic failure".into()))
     }
 
 
-    fn op35_get(&self, context: &C) -> Box<Future<Item=Op35GetResponse, Error=ApiError>> {
+    fn op35_get(&self, context: &C) -> Box<dyn Future<Item=Op35GetResponse, Error=ApiError>> {
         let context = context.clone();
         println!("op35_get() - X-Span-ID: {:?}", context.get().0.clone());
         Box::new(futures::failed("Generic failure".into()))
     }
 
 
-    fn op36_get(&self, context: &C) -> Box<Future<Item=Op36GetResponse, Error=ApiError>> {
+    fn op36_get(&self, context: &C) -> Box<dyn Future<Item=Op36GetResponse, Error=ApiError>> {
         let context = context.clone();
         println!("op36_get() - X-Span-ID: {:?}", context.get().0.clone());
         Box::new(futures::failed("Generic failure".into()))
     }
 
 
-    fn op37_get(&self, context: &C) -> Box<Future<Item=Op37GetResponse, Error=ApiError>> {
+    fn op37_get(&self, context: &C) -> Box<dyn Future<Item=Op37GetResponse, Error=ApiError>> {
         let context = context.clone();
         println!("op37_get() - X-Span-ID: {:?}", context.get().0.clone());
         Box::new(futures::failed("Generic failure".into()))
     }
 
 
-    fn op3_get(&self, context: &C) -> Box<Future<Item=Op3GetResponse, Error=ApiError>> {
+    fn op3_get(&self, context: &C) -> Box<dyn Future<Item=Op3GetResponse, Error=ApiError>> {
         let context = context.clone();
         println!("op3_get() - X-Span-ID: {:?}", context.get().0.clone());
         Box::new(futures::failed("Generic failure".into()))
     }
 
 
-    fn op4_get(&self, context: &C) -> Box<Future<Item=Op4GetResponse, Error=ApiError>> {
+    fn op4_get(&self, context: &C) -> Box<dyn Future<Item=Op4GetResponse, Error=ApiError>> {
         let context = context.clone();
         println!("op4_get() - X-Span-ID: {:?}", context.get().0.clone());
         Box::new(futures::failed("Generic failure".into()))
     }
 
 
-    fn op5_get(&self, context: &C) -> Box<Future<Item=Op5GetResponse, Error=ApiError>> {
+    fn op5_get(&self, context: &C) -> Box<dyn Future<Item=Op5GetResponse, Error=ApiError>> {
         let context = context.clone();
         println!("op5_get() - X-Span-ID: {:?}", context.get().0.clone());
         Box::new(futures::failed("Generic failure".into()))
     }
 
 
-    fn op6_get(&self, context: &C) -> Box<Future<Item=Op6GetResponse, Error=ApiError>> {
+    fn op6_get(&self, context: &C) -> Box<dyn Future<Item=Op6GetResponse, Error=ApiError>> {
         let context = context.clone();
         println!("op6_get() - X-Span-ID: {:?}", context.get().0.clone());
         Box::new(futures::failed("Generic failure".into()))
     }
 
 
-    fn op7_get(&self, context: &C) -> Box<Future<Item=Op7GetResponse, Error=ApiError>> {
+    fn op7_get(&self, context: &C) -> Box<dyn Future<Item=Op7GetResponse, Error=ApiError>> {
         let context = context.clone();
         println!("op7_get() - X-Span-ID: {:?}", context.get().0.clone());
         Box::new(futures::failed("Generic failure".into()))
     }
 
 
-    fn op8_get(&self, context: &C) -> Box<Future<Item=Op8GetResponse, Error=ApiError>> {
+    fn op8_get(&self, context: &C) -> Box<dyn Future<Item=Op8GetResponse, Error=ApiError>> {
         let context = context.clone();
         println!("op8_get() - X-Span-ID: {:?}", context.get().0.clone());
         Box::new(futures::failed("Generic failure".into()))
     }
 
 
-    fn op9_get(&self, context: &C) -> Box<Future<Item=Op9GetResponse, Error=ApiError>> {
+    fn op9_get(&self, context: &C) -> Box<dyn Future<Item=Op9GetResponse, Error=ApiError>> {
         let context = context.clone();
         println!("op9_get() - X-Span-ID: {:?}", context.get().0.clone());
         Box::new(futures::failed("Generic failure".into()))

--- a/samples/server/petstore/rust-server/output/ops-v3/src/client/mod.rs
+++ b/samples/server/petstore/rust-server/output/ops-v3/src/client/mod.rs
@@ -105,7 +105,7 @@ fn into_base_path(input: &str, correct_scheme: Option<&'static str>) -> Result<S
 /// A client that implements the API by making HTTP calls out to a server.
 pub struct Client<F> where
   F: Future<Item=hyper::Response, Error=hyper::Error> + 'static {
-    client_service: Arc<Box<hyper::client::Service<Request=hyper::Request<hyper::Body>, Response=hyper::Response, Error=hyper::Error, Future=F>>>,
+    client_service: Arc<Box<dyn hyper::client::Service<Request=hyper::Request<hyper::Body>, Response=hyper::Response, Error=hyper::Error, Future=F>>>,
     base_path: String,
 }
 
@@ -216,7 +216,7 @@ impl Client<hyper::client::FutureResponse> {
         handle: Handle,
         base_path: &str,
         protocol: Option<&'static str>,
-        connector_fn: Box<Fn(&Handle) -> C + Send + Sync>,
+        connector_fn: Box<dyn Fn(&Handle) -> C + Send + Sync>,
     ) -> Result<Client<hyper::client::FutureResponse>, ClientInitError>
     where
         C: hyper::client::Connect + hyper::client::Service,
@@ -243,7 +243,7 @@ impl Client<hyper::client::FutureResponse> {
     /// should be mentioned here.
     #[deprecated(note="Use try_new_with_client_service instead")]
     pub fn try_new_with_hyper_client(
-        hyper_client: Arc<Box<hyper::client::Service<Request=hyper::Request<hyper::Body>, Response=hyper::Response, Error=hyper::Error, Future=hyper::client::FutureResponse>>>,
+        hyper_client: Arc<Box<dyn hyper::client::Service<Request=hyper::Request<hyper::Body>, Response=hyper::Response, Error=hyper::Error, Future=hyper::client::FutureResponse>>>,
         handle: Handle,
         base_path: &str
     ) -> Result<Client<hyper::client::FutureResponse>, ClientInitError>
@@ -261,7 +261,7 @@ impl<F> Client<F> where
     /// Constructor for creating a `Client` by passing in a pre-made `hyper` client Service.
     ///
     /// This allows adding custom wrappers around the underlying transport, for example for logging.
-    pub fn try_new_with_client_service(client_service: Arc<Box<hyper::client::Service<Request=hyper::Request<hyper::Body>, Response=hyper::Response, Error=hyper::Error, Future=F>>>,
+    pub fn try_new_with_client_service(client_service: Arc<Box<dyn hyper::client::Service<Request=hyper::Request<hyper::Body>, Response=hyper::Response, Error=hyper::Error, Future=F>>>,
                                        handle: Handle,
                                        base_path: &str)
                                     -> Result<Client<F>, ClientInitError>
@@ -277,7 +277,7 @@ impl<F, C> Api<C> for Client<F> where
     F: Future<Item=hyper::Response, Error=hyper::Error>  + 'static,
     C: Has<XSpanIdString> {
 
-    fn op10_get(&self, context: &C) -> Box<Future<Item=Op10GetResponse, Error=ApiError>> {
+    fn op10_get(&self, context: &C) -> Box<dyn Future<Item=Op10GetResponse, Error=ApiError>> {
         let mut uri = format!(
             "{}/op10",
             self.base_path
@@ -300,7 +300,7 @@ impl<F, C> Api<C> for Client<F> where
         let mut request = hyper::Request::new(hyper::Method::Get, uri);
 
 
-        request.headers_mut().set(XSpanId((context as &Has<XSpanIdString>).get().0.clone()));
+        request.headers_mut().set(XSpanId((context as &dyn Has<XSpanIdString>).get().0.clone()));
         Box::new(self.client_service.call(request)
                              .map_err(|e| ApiError(format!("No response received: {}", e)))
                              .and_then(|mut response| {
@@ -312,7 +312,7 @@ impl<F, C> Api<C> for Client<F> where
                         future::ok(
                             Op10GetResponse::OK
                         )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 },
                 code => {
                     let headers = response.headers().clone();
@@ -331,14 +331,14 @@ impl<F, C> Api<C> for Client<F> where
                                         Err(e) => Cow::from(format!("<Failed to read body: {}>", e)),
                                     })))
                             )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 }
             }
         }))
 
     }
 
-    fn op11_get(&self, context: &C) -> Box<Future<Item=Op11GetResponse, Error=ApiError>> {
+    fn op11_get(&self, context: &C) -> Box<dyn Future<Item=Op11GetResponse, Error=ApiError>> {
         let mut uri = format!(
             "{}/op11",
             self.base_path
@@ -361,7 +361,7 @@ impl<F, C> Api<C> for Client<F> where
         let mut request = hyper::Request::new(hyper::Method::Get, uri);
 
 
-        request.headers_mut().set(XSpanId((context as &Has<XSpanIdString>).get().0.clone()));
+        request.headers_mut().set(XSpanId((context as &dyn Has<XSpanIdString>).get().0.clone()));
         Box::new(self.client_service.call(request)
                              .map_err(|e| ApiError(format!("No response received: {}", e)))
                              .and_then(|mut response| {
@@ -373,7 +373,7 @@ impl<F, C> Api<C> for Client<F> where
                         future::ok(
                             Op11GetResponse::OK
                         )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 },
                 code => {
                     let headers = response.headers().clone();
@@ -392,14 +392,14 @@ impl<F, C> Api<C> for Client<F> where
                                         Err(e) => Cow::from(format!("<Failed to read body: {}>", e)),
                                     })))
                             )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 }
             }
         }))
 
     }
 
-    fn op12_get(&self, context: &C) -> Box<Future<Item=Op12GetResponse, Error=ApiError>> {
+    fn op12_get(&self, context: &C) -> Box<dyn Future<Item=Op12GetResponse, Error=ApiError>> {
         let mut uri = format!(
             "{}/op12",
             self.base_path
@@ -422,7 +422,7 @@ impl<F, C> Api<C> for Client<F> where
         let mut request = hyper::Request::new(hyper::Method::Get, uri);
 
 
-        request.headers_mut().set(XSpanId((context as &Has<XSpanIdString>).get().0.clone()));
+        request.headers_mut().set(XSpanId((context as &dyn Has<XSpanIdString>).get().0.clone()));
         Box::new(self.client_service.call(request)
                              .map_err(|e| ApiError(format!("No response received: {}", e)))
                              .and_then(|mut response| {
@@ -434,7 +434,7 @@ impl<F, C> Api<C> for Client<F> where
                         future::ok(
                             Op12GetResponse::OK
                         )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 },
                 code => {
                     let headers = response.headers().clone();
@@ -453,14 +453,14 @@ impl<F, C> Api<C> for Client<F> where
                                         Err(e) => Cow::from(format!("<Failed to read body: {}>", e)),
                                     })))
                             )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 }
             }
         }))
 
     }
 
-    fn op13_get(&self, context: &C) -> Box<Future<Item=Op13GetResponse, Error=ApiError>> {
+    fn op13_get(&self, context: &C) -> Box<dyn Future<Item=Op13GetResponse, Error=ApiError>> {
         let mut uri = format!(
             "{}/op13",
             self.base_path
@@ -483,7 +483,7 @@ impl<F, C> Api<C> for Client<F> where
         let mut request = hyper::Request::new(hyper::Method::Get, uri);
 
 
-        request.headers_mut().set(XSpanId((context as &Has<XSpanIdString>).get().0.clone()));
+        request.headers_mut().set(XSpanId((context as &dyn Has<XSpanIdString>).get().0.clone()));
         Box::new(self.client_service.call(request)
                              .map_err(|e| ApiError(format!("No response received: {}", e)))
                              .and_then(|mut response| {
@@ -495,7 +495,7 @@ impl<F, C> Api<C> for Client<F> where
                         future::ok(
                             Op13GetResponse::OK
                         )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 },
                 code => {
                     let headers = response.headers().clone();
@@ -514,14 +514,14 @@ impl<F, C> Api<C> for Client<F> where
                                         Err(e) => Cow::from(format!("<Failed to read body: {}>", e)),
                                     })))
                             )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 }
             }
         }))
 
     }
 
-    fn op14_get(&self, context: &C) -> Box<Future<Item=Op14GetResponse, Error=ApiError>> {
+    fn op14_get(&self, context: &C) -> Box<dyn Future<Item=Op14GetResponse, Error=ApiError>> {
         let mut uri = format!(
             "{}/op14",
             self.base_path
@@ -544,7 +544,7 @@ impl<F, C> Api<C> for Client<F> where
         let mut request = hyper::Request::new(hyper::Method::Get, uri);
 
 
-        request.headers_mut().set(XSpanId((context as &Has<XSpanIdString>).get().0.clone()));
+        request.headers_mut().set(XSpanId((context as &dyn Has<XSpanIdString>).get().0.clone()));
         Box::new(self.client_service.call(request)
                              .map_err(|e| ApiError(format!("No response received: {}", e)))
                              .and_then(|mut response| {
@@ -556,7 +556,7 @@ impl<F, C> Api<C> for Client<F> where
                         future::ok(
                             Op14GetResponse::OK
                         )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 },
                 code => {
                     let headers = response.headers().clone();
@@ -575,14 +575,14 @@ impl<F, C> Api<C> for Client<F> where
                                         Err(e) => Cow::from(format!("<Failed to read body: {}>", e)),
                                     })))
                             )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 }
             }
         }))
 
     }
 
-    fn op15_get(&self, context: &C) -> Box<Future<Item=Op15GetResponse, Error=ApiError>> {
+    fn op15_get(&self, context: &C) -> Box<dyn Future<Item=Op15GetResponse, Error=ApiError>> {
         let mut uri = format!(
             "{}/op15",
             self.base_path
@@ -605,7 +605,7 @@ impl<F, C> Api<C> for Client<F> where
         let mut request = hyper::Request::new(hyper::Method::Get, uri);
 
 
-        request.headers_mut().set(XSpanId((context as &Has<XSpanIdString>).get().0.clone()));
+        request.headers_mut().set(XSpanId((context as &dyn Has<XSpanIdString>).get().0.clone()));
         Box::new(self.client_service.call(request)
                              .map_err(|e| ApiError(format!("No response received: {}", e)))
                              .and_then(|mut response| {
@@ -617,7 +617,7 @@ impl<F, C> Api<C> for Client<F> where
                         future::ok(
                             Op15GetResponse::OK
                         )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 },
                 code => {
                     let headers = response.headers().clone();
@@ -636,14 +636,14 @@ impl<F, C> Api<C> for Client<F> where
                                         Err(e) => Cow::from(format!("<Failed to read body: {}>", e)),
                                     })))
                             )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 }
             }
         }))
 
     }
 
-    fn op16_get(&self, context: &C) -> Box<Future<Item=Op16GetResponse, Error=ApiError>> {
+    fn op16_get(&self, context: &C) -> Box<dyn Future<Item=Op16GetResponse, Error=ApiError>> {
         let mut uri = format!(
             "{}/op16",
             self.base_path
@@ -666,7 +666,7 @@ impl<F, C> Api<C> for Client<F> where
         let mut request = hyper::Request::new(hyper::Method::Get, uri);
 
 
-        request.headers_mut().set(XSpanId((context as &Has<XSpanIdString>).get().0.clone()));
+        request.headers_mut().set(XSpanId((context as &dyn Has<XSpanIdString>).get().0.clone()));
         Box::new(self.client_service.call(request)
                              .map_err(|e| ApiError(format!("No response received: {}", e)))
                              .and_then(|mut response| {
@@ -678,7 +678,7 @@ impl<F, C> Api<C> for Client<F> where
                         future::ok(
                             Op16GetResponse::OK
                         )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 },
                 code => {
                     let headers = response.headers().clone();
@@ -697,14 +697,14 @@ impl<F, C> Api<C> for Client<F> where
                                         Err(e) => Cow::from(format!("<Failed to read body: {}>", e)),
                                     })))
                             )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 }
             }
         }))
 
     }
 
-    fn op17_get(&self, context: &C) -> Box<Future<Item=Op17GetResponse, Error=ApiError>> {
+    fn op17_get(&self, context: &C) -> Box<dyn Future<Item=Op17GetResponse, Error=ApiError>> {
         let mut uri = format!(
             "{}/op17",
             self.base_path
@@ -727,7 +727,7 @@ impl<F, C> Api<C> for Client<F> where
         let mut request = hyper::Request::new(hyper::Method::Get, uri);
 
 
-        request.headers_mut().set(XSpanId((context as &Has<XSpanIdString>).get().0.clone()));
+        request.headers_mut().set(XSpanId((context as &dyn Has<XSpanIdString>).get().0.clone()));
         Box::new(self.client_service.call(request)
                              .map_err(|e| ApiError(format!("No response received: {}", e)))
                              .and_then(|mut response| {
@@ -739,7 +739,7 @@ impl<F, C> Api<C> for Client<F> where
                         future::ok(
                             Op17GetResponse::OK
                         )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 },
                 code => {
                     let headers = response.headers().clone();
@@ -758,14 +758,14 @@ impl<F, C> Api<C> for Client<F> where
                                         Err(e) => Cow::from(format!("<Failed to read body: {}>", e)),
                                     })))
                             )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 }
             }
         }))
 
     }
 
-    fn op18_get(&self, context: &C) -> Box<Future<Item=Op18GetResponse, Error=ApiError>> {
+    fn op18_get(&self, context: &C) -> Box<dyn Future<Item=Op18GetResponse, Error=ApiError>> {
         let mut uri = format!(
             "{}/op18",
             self.base_path
@@ -788,7 +788,7 @@ impl<F, C> Api<C> for Client<F> where
         let mut request = hyper::Request::new(hyper::Method::Get, uri);
 
 
-        request.headers_mut().set(XSpanId((context as &Has<XSpanIdString>).get().0.clone()));
+        request.headers_mut().set(XSpanId((context as &dyn Has<XSpanIdString>).get().0.clone()));
         Box::new(self.client_service.call(request)
                              .map_err(|e| ApiError(format!("No response received: {}", e)))
                              .and_then(|mut response| {
@@ -800,7 +800,7 @@ impl<F, C> Api<C> for Client<F> where
                         future::ok(
                             Op18GetResponse::OK
                         )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 },
                 code => {
                     let headers = response.headers().clone();
@@ -819,14 +819,14 @@ impl<F, C> Api<C> for Client<F> where
                                         Err(e) => Cow::from(format!("<Failed to read body: {}>", e)),
                                     })))
                             )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 }
             }
         }))
 
     }
 
-    fn op19_get(&self, context: &C) -> Box<Future<Item=Op19GetResponse, Error=ApiError>> {
+    fn op19_get(&self, context: &C) -> Box<dyn Future<Item=Op19GetResponse, Error=ApiError>> {
         let mut uri = format!(
             "{}/op19",
             self.base_path
@@ -849,7 +849,7 @@ impl<F, C> Api<C> for Client<F> where
         let mut request = hyper::Request::new(hyper::Method::Get, uri);
 
 
-        request.headers_mut().set(XSpanId((context as &Has<XSpanIdString>).get().0.clone()));
+        request.headers_mut().set(XSpanId((context as &dyn Has<XSpanIdString>).get().0.clone()));
         Box::new(self.client_service.call(request)
                              .map_err(|e| ApiError(format!("No response received: {}", e)))
                              .and_then(|mut response| {
@@ -861,7 +861,7 @@ impl<F, C> Api<C> for Client<F> where
                         future::ok(
                             Op19GetResponse::OK
                         )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 },
                 code => {
                     let headers = response.headers().clone();
@@ -880,14 +880,14 @@ impl<F, C> Api<C> for Client<F> where
                                         Err(e) => Cow::from(format!("<Failed to read body: {}>", e)),
                                     })))
                             )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 }
             }
         }))
 
     }
 
-    fn op1_get(&self, context: &C) -> Box<Future<Item=Op1GetResponse, Error=ApiError>> {
+    fn op1_get(&self, context: &C) -> Box<dyn Future<Item=Op1GetResponse, Error=ApiError>> {
         let mut uri = format!(
             "{}/op1",
             self.base_path
@@ -910,7 +910,7 @@ impl<F, C> Api<C> for Client<F> where
         let mut request = hyper::Request::new(hyper::Method::Get, uri);
 
 
-        request.headers_mut().set(XSpanId((context as &Has<XSpanIdString>).get().0.clone()));
+        request.headers_mut().set(XSpanId((context as &dyn Has<XSpanIdString>).get().0.clone()));
         Box::new(self.client_service.call(request)
                              .map_err(|e| ApiError(format!("No response received: {}", e)))
                              .and_then(|mut response| {
@@ -922,7 +922,7 @@ impl<F, C> Api<C> for Client<F> where
                         future::ok(
                             Op1GetResponse::OK
                         )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 },
                 code => {
                     let headers = response.headers().clone();
@@ -941,14 +941,14 @@ impl<F, C> Api<C> for Client<F> where
                                         Err(e) => Cow::from(format!("<Failed to read body: {}>", e)),
                                     })))
                             )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 }
             }
         }))
 
     }
 
-    fn op20_get(&self, context: &C) -> Box<Future<Item=Op20GetResponse, Error=ApiError>> {
+    fn op20_get(&self, context: &C) -> Box<dyn Future<Item=Op20GetResponse, Error=ApiError>> {
         let mut uri = format!(
             "{}/op20",
             self.base_path
@@ -971,7 +971,7 @@ impl<F, C> Api<C> for Client<F> where
         let mut request = hyper::Request::new(hyper::Method::Get, uri);
 
 
-        request.headers_mut().set(XSpanId((context as &Has<XSpanIdString>).get().0.clone()));
+        request.headers_mut().set(XSpanId((context as &dyn Has<XSpanIdString>).get().0.clone()));
         Box::new(self.client_service.call(request)
                              .map_err(|e| ApiError(format!("No response received: {}", e)))
                              .and_then(|mut response| {
@@ -983,7 +983,7 @@ impl<F, C> Api<C> for Client<F> where
                         future::ok(
                             Op20GetResponse::OK
                         )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 },
                 code => {
                     let headers = response.headers().clone();
@@ -1002,14 +1002,14 @@ impl<F, C> Api<C> for Client<F> where
                                         Err(e) => Cow::from(format!("<Failed to read body: {}>", e)),
                                     })))
                             )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 }
             }
         }))
 
     }
 
-    fn op21_get(&self, context: &C) -> Box<Future<Item=Op21GetResponse, Error=ApiError>> {
+    fn op21_get(&self, context: &C) -> Box<dyn Future<Item=Op21GetResponse, Error=ApiError>> {
         let mut uri = format!(
             "{}/op21",
             self.base_path
@@ -1032,7 +1032,7 @@ impl<F, C> Api<C> for Client<F> where
         let mut request = hyper::Request::new(hyper::Method::Get, uri);
 
 
-        request.headers_mut().set(XSpanId((context as &Has<XSpanIdString>).get().0.clone()));
+        request.headers_mut().set(XSpanId((context as &dyn Has<XSpanIdString>).get().0.clone()));
         Box::new(self.client_service.call(request)
                              .map_err(|e| ApiError(format!("No response received: {}", e)))
                              .and_then(|mut response| {
@@ -1044,7 +1044,7 @@ impl<F, C> Api<C> for Client<F> where
                         future::ok(
                             Op21GetResponse::OK
                         )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 },
                 code => {
                     let headers = response.headers().clone();
@@ -1063,14 +1063,14 @@ impl<F, C> Api<C> for Client<F> where
                                         Err(e) => Cow::from(format!("<Failed to read body: {}>", e)),
                                     })))
                             )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 }
             }
         }))
 
     }
 
-    fn op22_get(&self, context: &C) -> Box<Future<Item=Op22GetResponse, Error=ApiError>> {
+    fn op22_get(&self, context: &C) -> Box<dyn Future<Item=Op22GetResponse, Error=ApiError>> {
         let mut uri = format!(
             "{}/op22",
             self.base_path
@@ -1093,7 +1093,7 @@ impl<F, C> Api<C> for Client<F> where
         let mut request = hyper::Request::new(hyper::Method::Get, uri);
 
 
-        request.headers_mut().set(XSpanId((context as &Has<XSpanIdString>).get().0.clone()));
+        request.headers_mut().set(XSpanId((context as &dyn Has<XSpanIdString>).get().0.clone()));
         Box::new(self.client_service.call(request)
                              .map_err(|e| ApiError(format!("No response received: {}", e)))
                              .and_then(|mut response| {
@@ -1105,7 +1105,7 @@ impl<F, C> Api<C> for Client<F> where
                         future::ok(
                             Op22GetResponse::OK
                         )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 },
                 code => {
                     let headers = response.headers().clone();
@@ -1124,14 +1124,14 @@ impl<F, C> Api<C> for Client<F> where
                                         Err(e) => Cow::from(format!("<Failed to read body: {}>", e)),
                                     })))
                             )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 }
             }
         }))
 
     }
 
-    fn op23_get(&self, context: &C) -> Box<Future<Item=Op23GetResponse, Error=ApiError>> {
+    fn op23_get(&self, context: &C) -> Box<dyn Future<Item=Op23GetResponse, Error=ApiError>> {
         let mut uri = format!(
             "{}/op23",
             self.base_path
@@ -1154,7 +1154,7 @@ impl<F, C> Api<C> for Client<F> where
         let mut request = hyper::Request::new(hyper::Method::Get, uri);
 
 
-        request.headers_mut().set(XSpanId((context as &Has<XSpanIdString>).get().0.clone()));
+        request.headers_mut().set(XSpanId((context as &dyn Has<XSpanIdString>).get().0.clone()));
         Box::new(self.client_service.call(request)
                              .map_err(|e| ApiError(format!("No response received: {}", e)))
                              .and_then(|mut response| {
@@ -1166,7 +1166,7 @@ impl<F, C> Api<C> for Client<F> where
                         future::ok(
                             Op23GetResponse::OK
                         )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 },
                 code => {
                     let headers = response.headers().clone();
@@ -1185,14 +1185,14 @@ impl<F, C> Api<C> for Client<F> where
                                         Err(e) => Cow::from(format!("<Failed to read body: {}>", e)),
                                     })))
                             )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 }
             }
         }))
 
     }
 
-    fn op24_get(&self, context: &C) -> Box<Future<Item=Op24GetResponse, Error=ApiError>> {
+    fn op24_get(&self, context: &C) -> Box<dyn Future<Item=Op24GetResponse, Error=ApiError>> {
         let mut uri = format!(
             "{}/op24",
             self.base_path
@@ -1215,7 +1215,7 @@ impl<F, C> Api<C> for Client<F> where
         let mut request = hyper::Request::new(hyper::Method::Get, uri);
 
 
-        request.headers_mut().set(XSpanId((context as &Has<XSpanIdString>).get().0.clone()));
+        request.headers_mut().set(XSpanId((context as &dyn Has<XSpanIdString>).get().0.clone()));
         Box::new(self.client_service.call(request)
                              .map_err(|e| ApiError(format!("No response received: {}", e)))
                              .and_then(|mut response| {
@@ -1227,7 +1227,7 @@ impl<F, C> Api<C> for Client<F> where
                         future::ok(
                             Op24GetResponse::OK
                         )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 },
                 code => {
                     let headers = response.headers().clone();
@@ -1246,14 +1246,14 @@ impl<F, C> Api<C> for Client<F> where
                                         Err(e) => Cow::from(format!("<Failed to read body: {}>", e)),
                                     })))
                             )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 }
             }
         }))
 
     }
 
-    fn op25_get(&self, context: &C) -> Box<Future<Item=Op25GetResponse, Error=ApiError>> {
+    fn op25_get(&self, context: &C) -> Box<dyn Future<Item=Op25GetResponse, Error=ApiError>> {
         let mut uri = format!(
             "{}/op25",
             self.base_path
@@ -1276,7 +1276,7 @@ impl<F, C> Api<C> for Client<F> where
         let mut request = hyper::Request::new(hyper::Method::Get, uri);
 
 
-        request.headers_mut().set(XSpanId((context as &Has<XSpanIdString>).get().0.clone()));
+        request.headers_mut().set(XSpanId((context as &dyn Has<XSpanIdString>).get().0.clone()));
         Box::new(self.client_service.call(request)
                              .map_err(|e| ApiError(format!("No response received: {}", e)))
                              .and_then(|mut response| {
@@ -1288,7 +1288,7 @@ impl<F, C> Api<C> for Client<F> where
                         future::ok(
                             Op25GetResponse::OK
                         )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 },
                 code => {
                     let headers = response.headers().clone();
@@ -1307,14 +1307,14 @@ impl<F, C> Api<C> for Client<F> where
                                         Err(e) => Cow::from(format!("<Failed to read body: {}>", e)),
                                     })))
                             )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 }
             }
         }))
 
     }
 
-    fn op26_get(&self, context: &C) -> Box<Future<Item=Op26GetResponse, Error=ApiError>> {
+    fn op26_get(&self, context: &C) -> Box<dyn Future<Item=Op26GetResponse, Error=ApiError>> {
         let mut uri = format!(
             "{}/op26",
             self.base_path
@@ -1337,7 +1337,7 @@ impl<F, C> Api<C> for Client<F> where
         let mut request = hyper::Request::new(hyper::Method::Get, uri);
 
 
-        request.headers_mut().set(XSpanId((context as &Has<XSpanIdString>).get().0.clone()));
+        request.headers_mut().set(XSpanId((context as &dyn Has<XSpanIdString>).get().0.clone()));
         Box::new(self.client_service.call(request)
                              .map_err(|e| ApiError(format!("No response received: {}", e)))
                              .and_then(|mut response| {
@@ -1349,7 +1349,7 @@ impl<F, C> Api<C> for Client<F> where
                         future::ok(
                             Op26GetResponse::OK
                         )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 },
                 code => {
                     let headers = response.headers().clone();
@@ -1368,14 +1368,14 @@ impl<F, C> Api<C> for Client<F> where
                                         Err(e) => Cow::from(format!("<Failed to read body: {}>", e)),
                                     })))
                             )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 }
             }
         }))
 
     }
 
-    fn op27_get(&self, context: &C) -> Box<Future<Item=Op27GetResponse, Error=ApiError>> {
+    fn op27_get(&self, context: &C) -> Box<dyn Future<Item=Op27GetResponse, Error=ApiError>> {
         let mut uri = format!(
             "{}/op27",
             self.base_path
@@ -1398,7 +1398,7 @@ impl<F, C> Api<C> for Client<F> where
         let mut request = hyper::Request::new(hyper::Method::Get, uri);
 
 
-        request.headers_mut().set(XSpanId((context as &Has<XSpanIdString>).get().0.clone()));
+        request.headers_mut().set(XSpanId((context as &dyn Has<XSpanIdString>).get().0.clone()));
         Box::new(self.client_service.call(request)
                              .map_err(|e| ApiError(format!("No response received: {}", e)))
                              .and_then(|mut response| {
@@ -1410,7 +1410,7 @@ impl<F, C> Api<C> for Client<F> where
                         future::ok(
                             Op27GetResponse::OK
                         )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 },
                 code => {
                     let headers = response.headers().clone();
@@ -1429,14 +1429,14 @@ impl<F, C> Api<C> for Client<F> where
                                         Err(e) => Cow::from(format!("<Failed to read body: {}>", e)),
                                     })))
                             )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 }
             }
         }))
 
     }
 
-    fn op28_get(&self, context: &C) -> Box<Future<Item=Op28GetResponse, Error=ApiError>> {
+    fn op28_get(&self, context: &C) -> Box<dyn Future<Item=Op28GetResponse, Error=ApiError>> {
         let mut uri = format!(
             "{}/op28",
             self.base_path
@@ -1459,7 +1459,7 @@ impl<F, C> Api<C> for Client<F> where
         let mut request = hyper::Request::new(hyper::Method::Get, uri);
 
 
-        request.headers_mut().set(XSpanId((context as &Has<XSpanIdString>).get().0.clone()));
+        request.headers_mut().set(XSpanId((context as &dyn Has<XSpanIdString>).get().0.clone()));
         Box::new(self.client_service.call(request)
                              .map_err(|e| ApiError(format!("No response received: {}", e)))
                              .and_then(|mut response| {
@@ -1471,7 +1471,7 @@ impl<F, C> Api<C> for Client<F> where
                         future::ok(
                             Op28GetResponse::OK
                         )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 },
                 code => {
                     let headers = response.headers().clone();
@@ -1490,14 +1490,14 @@ impl<F, C> Api<C> for Client<F> where
                                         Err(e) => Cow::from(format!("<Failed to read body: {}>", e)),
                                     })))
                             )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 }
             }
         }))
 
     }
 
-    fn op29_get(&self, context: &C) -> Box<Future<Item=Op29GetResponse, Error=ApiError>> {
+    fn op29_get(&self, context: &C) -> Box<dyn Future<Item=Op29GetResponse, Error=ApiError>> {
         let mut uri = format!(
             "{}/op29",
             self.base_path
@@ -1520,7 +1520,7 @@ impl<F, C> Api<C> for Client<F> where
         let mut request = hyper::Request::new(hyper::Method::Get, uri);
 
 
-        request.headers_mut().set(XSpanId((context as &Has<XSpanIdString>).get().0.clone()));
+        request.headers_mut().set(XSpanId((context as &dyn Has<XSpanIdString>).get().0.clone()));
         Box::new(self.client_service.call(request)
                              .map_err(|e| ApiError(format!("No response received: {}", e)))
                              .and_then(|mut response| {
@@ -1532,7 +1532,7 @@ impl<F, C> Api<C> for Client<F> where
                         future::ok(
                             Op29GetResponse::OK
                         )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 },
                 code => {
                     let headers = response.headers().clone();
@@ -1551,14 +1551,14 @@ impl<F, C> Api<C> for Client<F> where
                                         Err(e) => Cow::from(format!("<Failed to read body: {}>", e)),
                                     })))
                             )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 }
             }
         }))
 
     }
 
-    fn op2_get(&self, context: &C) -> Box<Future<Item=Op2GetResponse, Error=ApiError>> {
+    fn op2_get(&self, context: &C) -> Box<dyn Future<Item=Op2GetResponse, Error=ApiError>> {
         let mut uri = format!(
             "{}/op2",
             self.base_path
@@ -1581,7 +1581,7 @@ impl<F, C> Api<C> for Client<F> where
         let mut request = hyper::Request::new(hyper::Method::Get, uri);
 
 
-        request.headers_mut().set(XSpanId((context as &Has<XSpanIdString>).get().0.clone()));
+        request.headers_mut().set(XSpanId((context as &dyn Has<XSpanIdString>).get().0.clone()));
         Box::new(self.client_service.call(request)
                              .map_err(|e| ApiError(format!("No response received: {}", e)))
                              .and_then(|mut response| {
@@ -1593,7 +1593,7 @@ impl<F, C> Api<C> for Client<F> where
                         future::ok(
                             Op2GetResponse::OK
                         )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 },
                 code => {
                     let headers = response.headers().clone();
@@ -1612,14 +1612,14 @@ impl<F, C> Api<C> for Client<F> where
                                         Err(e) => Cow::from(format!("<Failed to read body: {}>", e)),
                                     })))
                             )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 }
             }
         }))
 
     }
 
-    fn op30_get(&self, context: &C) -> Box<Future<Item=Op30GetResponse, Error=ApiError>> {
+    fn op30_get(&self, context: &C) -> Box<dyn Future<Item=Op30GetResponse, Error=ApiError>> {
         let mut uri = format!(
             "{}/op30",
             self.base_path
@@ -1642,7 +1642,7 @@ impl<F, C> Api<C> for Client<F> where
         let mut request = hyper::Request::new(hyper::Method::Get, uri);
 
 
-        request.headers_mut().set(XSpanId((context as &Has<XSpanIdString>).get().0.clone()));
+        request.headers_mut().set(XSpanId((context as &dyn Has<XSpanIdString>).get().0.clone()));
         Box::new(self.client_service.call(request)
                              .map_err(|e| ApiError(format!("No response received: {}", e)))
                              .and_then(|mut response| {
@@ -1654,7 +1654,7 @@ impl<F, C> Api<C> for Client<F> where
                         future::ok(
                             Op30GetResponse::OK
                         )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 },
                 code => {
                     let headers = response.headers().clone();
@@ -1673,14 +1673,14 @@ impl<F, C> Api<C> for Client<F> where
                                         Err(e) => Cow::from(format!("<Failed to read body: {}>", e)),
                                     })))
                             )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 }
             }
         }))
 
     }
 
-    fn op31_get(&self, context: &C) -> Box<Future<Item=Op31GetResponse, Error=ApiError>> {
+    fn op31_get(&self, context: &C) -> Box<dyn Future<Item=Op31GetResponse, Error=ApiError>> {
         let mut uri = format!(
             "{}/op31",
             self.base_path
@@ -1703,7 +1703,7 @@ impl<F, C> Api<C> for Client<F> where
         let mut request = hyper::Request::new(hyper::Method::Get, uri);
 
 
-        request.headers_mut().set(XSpanId((context as &Has<XSpanIdString>).get().0.clone()));
+        request.headers_mut().set(XSpanId((context as &dyn Has<XSpanIdString>).get().0.clone()));
         Box::new(self.client_service.call(request)
                              .map_err(|e| ApiError(format!("No response received: {}", e)))
                              .and_then(|mut response| {
@@ -1715,7 +1715,7 @@ impl<F, C> Api<C> for Client<F> where
                         future::ok(
                             Op31GetResponse::OK
                         )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 },
                 code => {
                     let headers = response.headers().clone();
@@ -1734,14 +1734,14 @@ impl<F, C> Api<C> for Client<F> where
                                         Err(e) => Cow::from(format!("<Failed to read body: {}>", e)),
                                     })))
                             )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 }
             }
         }))
 
     }
 
-    fn op32_get(&self, context: &C) -> Box<Future<Item=Op32GetResponse, Error=ApiError>> {
+    fn op32_get(&self, context: &C) -> Box<dyn Future<Item=Op32GetResponse, Error=ApiError>> {
         let mut uri = format!(
             "{}/op32",
             self.base_path
@@ -1764,7 +1764,7 @@ impl<F, C> Api<C> for Client<F> where
         let mut request = hyper::Request::new(hyper::Method::Get, uri);
 
 
-        request.headers_mut().set(XSpanId((context as &Has<XSpanIdString>).get().0.clone()));
+        request.headers_mut().set(XSpanId((context as &dyn Has<XSpanIdString>).get().0.clone()));
         Box::new(self.client_service.call(request)
                              .map_err(|e| ApiError(format!("No response received: {}", e)))
                              .and_then(|mut response| {
@@ -1776,7 +1776,7 @@ impl<F, C> Api<C> for Client<F> where
                         future::ok(
                             Op32GetResponse::OK
                         )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 },
                 code => {
                     let headers = response.headers().clone();
@@ -1795,14 +1795,14 @@ impl<F, C> Api<C> for Client<F> where
                                         Err(e) => Cow::from(format!("<Failed to read body: {}>", e)),
                                     })))
                             )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 }
             }
         }))
 
     }
 
-    fn op33_get(&self, context: &C) -> Box<Future<Item=Op33GetResponse, Error=ApiError>> {
+    fn op33_get(&self, context: &C) -> Box<dyn Future<Item=Op33GetResponse, Error=ApiError>> {
         let mut uri = format!(
             "{}/op33",
             self.base_path
@@ -1825,7 +1825,7 @@ impl<F, C> Api<C> for Client<F> where
         let mut request = hyper::Request::new(hyper::Method::Get, uri);
 
 
-        request.headers_mut().set(XSpanId((context as &Has<XSpanIdString>).get().0.clone()));
+        request.headers_mut().set(XSpanId((context as &dyn Has<XSpanIdString>).get().0.clone()));
         Box::new(self.client_service.call(request)
                              .map_err(|e| ApiError(format!("No response received: {}", e)))
                              .and_then(|mut response| {
@@ -1837,7 +1837,7 @@ impl<F, C> Api<C> for Client<F> where
                         future::ok(
                             Op33GetResponse::OK
                         )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 },
                 code => {
                     let headers = response.headers().clone();
@@ -1856,14 +1856,14 @@ impl<F, C> Api<C> for Client<F> where
                                         Err(e) => Cow::from(format!("<Failed to read body: {}>", e)),
                                     })))
                             )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 }
             }
         }))
 
     }
 
-    fn op34_get(&self, context: &C) -> Box<Future<Item=Op34GetResponse, Error=ApiError>> {
+    fn op34_get(&self, context: &C) -> Box<dyn Future<Item=Op34GetResponse, Error=ApiError>> {
         let mut uri = format!(
             "{}/op34",
             self.base_path
@@ -1886,7 +1886,7 @@ impl<F, C> Api<C> for Client<F> where
         let mut request = hyper::Request::new(hyper::Method::Get, uri);
 
 
-        request.headers_mut().set(XSpanId((context as &Has<XSpanIdString>).get().0.clone()));
+        request.headers_mut().set(XSpanId((context as &dyn Has<XSpanIdString>).get().0.clone()));
         Box::new(self.client_service.call(request)
                              .map_err(|e| ApiError(format!("No response received: {}", e)))
                              .and_then(|mut response| {
@@ -1898,7 +1898,7 @@ impl<F, C> Api<C> for Client<F> where
                         future::ok(
                             Op34GetResponse::OK
                         )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 },
                 code => {
                     let headers = response.headers().clone();
@@ -1917,14 +1917,14 @@ impl<F, C> Api<C> for Client<F> where
                                         Err(e) => Cow::from(format!("<Failed to read body: {}>", e)),
                                     })))
                             )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 }
             }
         }))
 
     }
 
-    fn op35_get(&self, context: &C) -> Box<Future<Item=Op35GetResponse, Error=ApiError>> {
+    fn op35_get(&self, context: &C) -> Box<dyn Future<Item=Op35GetResponse, Error=ApiError>> {
         let mut uri = format!(
             "{}/op35",
             self.base_path
@@ -1947,7 +1947,7 @@ impl<F, C> Api<C> for Client<F> where
         let mut request = hyper::Request::new(hyper::Method::Get, uri);
 
 
-        request.headers_mut().set(XSpanId((context as &Has<XSpanIdString>).get().0.clone()));
+        request.headers_mut().set(XSpanId((context as &dyn Has<XSpanIdString>).get().0.clone()));
         Box::new(self.client_service.call(request)
                              .map_err(|e| ApiError(format!("No response received: {}", e)))
                              .and_then(|mut response| {
@@ -1959,7 +1959,7 @@ impl<F, C> Api<C> for Client<F> where
                         future::ok(
                             Op35GetResponse::OK
                         )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 },
                 code => {
                     let headers = response.headers().clone();
@@ -1978,14 +1978,14 @@ impl<F, C> Api<C> for Client<F> where
                                         Err(e) => Cow::from(format!("<Failed to read body: {}>", e)),
                                     })))
                             )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 }
             }
         }))
 
     }
 
-    fn op36_get(&self, context: &C) -> Box<Future<Item=Op36GetResponse, Error=ApiError>> {
+    fn op36_get(&self, context: &C) -> Box<dyn Future<Item=Op36GetResponse, Error=ApiError>> {
         let mut uri = format!(
             "{}/op36",
             self.base_path
@@ -2008,7 +2008,7 @@ impl<F, C> Api<C> for Client<F> where
         let mut request = hyper::Request::new(hyper::Method::Get, uri);
 
 
-        request.headers_mut().set(XSpanId((context as &Has<XSpanIdString>).get().0.clone()));
+        request.headers_mut().set(XSpanId((context as &dyn Has<XSpanIdString>).get().0.clone()));
         Box::new(self.client_service.call(request)
                              .map_err(|e| ApiError(format!("No response received: {}", e)))
                              .and_then(|mut response| {
@@ -2020,7 +2020,7 @@ impl<F, C> Api<C> for Client<F> where
                         future::ok(
                             Op36GetResponse::OK
                         )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 },
                 code => {
                     let headers = response.headers().clone();
@@ -2039,14 +2039,14 @@ impl<F, C> Api<C> for Client<F> where
                                         Err(e) => Cow::from(format!("<Failed to read body: {}>", e)),
                                     })))
                             )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 }
             }
         }))
 
     }
 
-    fn op37_get(&self, context: &C) -> Box<Future<Item=Op37GetResponse, Error=ApiError>> {
+    fn op37_get(&self, context: &C) -> Box<dyn Future<Item=Op37GetResponse, Error=ApiError>> {
         let mut uri = format!(
             "{}/op37",
             self.base_path
@@ -2069,7 +2069,7 @@ impl<F, C> Api<C> for Client<F> where
         let mut request = hyper::Request::new(hyper::Method::Get, uri);
 
 
-        request.headers_mut().set(XSpanId((context as &Has<XSpanIdString>).get().0.clone()));
+        request.headers_mut().set(XSpanId((context as &dyn Has<XSpanIdString>).get().0.clone()));
         Box::new(self.client_service.call(request)
                              .map_err(|e| ApiError(format!("No response received: {}", e)))
                              .and_then(|mut response| {
@@ -2081,7 +2081,7 @@ impl<F, C> Api<C> for Client<F> where
                         future::ok(
                             Op37GetResponse::OK
                         )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 },
                 code => {
                     let headers = response.headers().clone();
@@ -2100,14 +2100,14 @@ impl<F, C> Api<C> for Client<F> where
                                         Err(e) => Cow::from(format!("<Failed to read body: {}>", e)),
                                     })))
                             )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 }
             }
         }))
 
     }
 
-    fn op3_get(&self, context: &C) -> Box<Future<Item=Op3GetResponse, Error=ApiError>> {
+    fn op3_get(&self, context: &C) -> Box<dyn Future<Item=Op3GetResponse, Error=ApiError>> {
         let mut uri = format!(
             "{}/op3",
             self.base_path
@@ -2130,7 +2130,7 @@ impl<F, C> Api<C> for Client<F> where
         let mut request = hyper::Request::new(hyper::Method::Get, uri);
 
 
-        request.headers_mut().set(XSpanId((context as &Has<XSpanIdString>).get().0.clone()));
+        request.headers_mut().set(XSpanId((context as &dyn Has<XSpanIdString>).get().0.clone()));
         Box::new(self.client_service.call(request)
                              .map_err(|e| ApiError(format!("No response received: {}", e)))
                              .and_then(|mut response| {
@@ -2142,7 +2142,7 @@ impl<F, C> Api<C> for Client<F> where
                         future::ok(
                             Op3GetResponse::OK
                         )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 },
                 code => {
                     let headers = response.headers().clone();
@@ -2161,14 +2161,14 @@ impl<F, C> Api<C> for Client<F> where
                                         Err(e) => Cow::from(format!("<Failed to read body: {}>", e)),
                                     })))
                             )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 }
             }
         }))
 
     }
 
-    fn op4_get(&self, context: &C) -> Box<Future<Item=Op4GetResponse, Error=ApiError>> {
+    fn op4_get(&self, context: &C) -> Box<dyn Future<Item=Op4GetResponse, Error=ApiError>> {
         let mut uri = format!(
             "{}/op4",
             self.base_path
@@ -2191,7 +2191,7 @@ impl<F, C> Api<C> for Client<F> where
         let mut request = hyper::Request::new(hyper::Method::Get, uri);
 
 
-        request.headers_mut().set(XSpanId((context as &Has<XSpanIdString>).get().0.clone()));
+        request.headers_mut().set(XSpanId((context as &dyn Has<XSpanIdString>).get().0.clone()));
         Box::new(self.client_service.call(request)
                              .map_err(|e| ApiError(format!("No response received: {}", e)))
                              .and_then(|mut response| {
@@ -2203,7 +2203,7 @@ impl<F, C> Api<C> for Client<F> where
                         future::ok(
                             Op4GetResponse::OK
                         )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 },
                 code => {
                     let headers = response.headers().clone();
@@ -2222,14 +2222,14 @@ impl<F, C> Api<C> for Client<F> where
                                         Err(e) => Cow::from(format!("<Failed to read body: {}>", e)),
                                     })))
                             )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 }
             }
         }))
 
     }
 
-    fn op5_get(&self, context: &C) -> Box<Future<Item=Op5GetResponse, Error=ApiError>> {
+    fn op5_get(&self, context: &C) -> Box<dyn Future<Item=Op5GetResponse, Error=ApiError>> {
         let mut uri = format!(
             "{}/op5",
             self.base_path
@@ -2252,7 +2252,7 @@ impl<F, C> Api<C> for Client<F> where
         let mut request = hyper::Request::new(hyper::Method::Get, uri);
 
 
-        request.headers_mut().set(XSpanId((context as &Has<XSpanIdString>).get().0.clone()));
+        request.headers_mut().set(XSpanId((context as &dyn Has<XSpanIdString>).get().0.clone()));
         Box::new(self.client_service.call(request)
                              .map_err(|e| ApiError(format!("No response received: {}", e)))
                              .and_then(|mut response| {
@@ -2264,7 +2264,7 @@ impl<F, C> Api<C> for Client<F> where
                         future::ok(
                             Op5GetResponse::OK
                         )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 },
                 code => {
                     let headers = response.headers().clone();
@@ -2283,14 +2283,14 @@ impl<F, C> Api<C> for Client<F> where
                                         Err(e) => Cow::from(format!("<Failed to read body: {}>", e)),
                                     })))
                             )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 }
             }
         }))
 
     }
 
-    fn op6_get(&self, context: &C) -> Box<Future<Item=Op6GetResponse, Error=ApiError>> {
+    fn op6_get(&self, context: &C) -> Box<dyn Future<Item=Op6GetResponse, Error=ApiError>> {
         let mut uri = format!(
             "{}/op6",
             self.base_path
@@ -2313,7 +2313,7 @@ impl<F, C> Api<C> for Client<F> where
         let mut request = hyper::Request::new(hyper::Method::Get, uri);
 
 
-        request.headers_mut().set(XSpanId((context as &Has<XSpanIdString>).get().0.clone()));
+        request.headers_mut().set(XSpanId((context as &dyn Has<XSpanIdString>).get().0.clone()));
         Box::new(self.client_service.call(request)
                              .map_err(|e| ApiError(format!("No response received: {}", e)))
                              .and_then(|mut response| {
@@ -2325,7 +2325,7 @@ impl<F, C> Api<C> for Client<F> where
                         future::ok(
                             Op6GetResponse::OK
                         )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 },
                 code => {
                     let headers = response.headers().clone();
@@ -2344,14 +2344,14 @@ impl<F, C> Api<C> for Client<F> where
                                         Err(e) => Cow::from(format!("<Failed to read body: {}>", e)),
                                     })))
                             )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 }
             }
         }))
 
     }
 
-    fn op7_get(&self, context: &C) -> Box<Future<Item=Op7GetResponse, Error=ApiError>> {
+    fn op7_get(&self, context: &C) -> Box<dyn Future<Item=Op7GetResponse, Error=ApiError>> {
         let mut uri = format!(
             "{}/op7",
             self.base_path
@@ -2374,7 +2374,7 @@ impl<F, C> Api<C> for Client<F> where
         let mut request = hyper::Request::new(hyper::Method::Get, uri);
 
 
-        request.headers_mut().set(XSpanId((context as &Has<XSpanIdString>).get().0.clone()));
+        request.headers_mut().set(XSpanId((context as &dyn Has<XSpanIdString>).get().0.clone()));
         Box::new(self.client_service.call(request)
                              .map_err(|e| ApiError(format!("No response received: {}", e)))
                              .and_then(|mut response| {
@@ -2386,7 +2386,7 @@ impl<F, C> Api<C> for Client<F> where
                         future::ok(
                             Op7GetResponse::OK
                         )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 },
                 code => {
                     let headers = response.headers().clone();
@@ -2405,14 +2405,14 @@ impl<F, C> Api<C> for Client<F> where
                                         Err(e) => Cow::from(format!("<Failed to read body: {}>", e)),
                                     })))
                             )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 }
             }
         }))
 
     }
 
-    fn op8_get(&self, context: &C) -> Box<Future<Item=Op8GetResponse, Error=ApiError>> {
+    fn op8_get(&self, context: &C) -> Box<dyn Future<Item=Op8GetResponse, Error=ApiError>> {
         let mut uri = format!(
             "{}/op8",
             self.base_path
@@ -2435,7 +2435,7 @@ impl<F, C> Api<C> for Client<F> where
         let mut request = hyper::Request::new(hyper::Method::Get, uri);
 
 
-        request.headers_mut().set(XSpanId((context as &Has<XSpanIdString>).get().0.clone()));
+        request.headers_mut().set(XSpanId((context as &dyn Has<XSpanIdString>).get().0.clone()));
         Box::new(self.client_service.call(request)
                              .map_err(|e| ApiError(format!("No response received: {}", e)))
                              .and_then(|mut response| {
@@ -2447,7 +2447,7 @@ impl<F, C> Api<C> for Client<F> where
                         future::ok(
                             Op8GetResponse::OK
                         )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 },
                 code => {
                     let headers = response.headers().clone();
@@ -2466,14 +2466,14 @@ impl<F, C> Api<C> for Client<F> where
                                         Err(e) => Cow::from(format!("<Failed to read body: {}>", e)),
                                     })))
                             )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 }
             }
         }))
 
     }
 
-    fn op9_get(&self, context: &C) -> Box<Future<Item=Op9GetResponse, Error=ApiError>> {
+    fn op9_get(&self, context: &C) -> Box<dyn Future<Item=Op9GetResponse, Error=ApiError>> {
         let mut uri = format!(
             "{}/op9",
             self.base_path
@@ -2496,7 +2496,7 @@ impl<F, C> Api<C> for Client<F> where
         let mut request = hyper::Request::new(hyper::Method::Get, uri);
 
 
-        request.headers_mut().set(XSpanId((context as &Has<XSpanIdString>).get().0.clone()));
+        request.headers_mut().set(XSpanId((context as &dyn Has<XSpanIdString>).get().0.clone()));
         Box::new(self.client_service.call(request)
                              .map_err(|e| ApiError(format!("No response received: {}", e)))
                              .and_then(|mut response| {
@@ -2508,7 +2508,7 @@ impl<F, C> Api<C> for Client<F> where
                         future::ok(
                             Op9GetResponse::OK
                         )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 },
                 code => {
                     let headers = response.headers().clone();
@@ -2527,7 +2527,7 @@ impl<F, C> Api<C> for Client<F> where
                                         Err(e) => Cow::from(format!("<Failed to read body: {}>", e)),
                                     })))
                             )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 }
             }
         }))
@@ -2558,7 +2558,7 @@ impl From<openssl::error::ErrorStack> for ClientInitError {
 
 impl fmt::Display for ClientInitError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        (self as &fmt::Debug).fmt(f)
+        (self as &dyn fmt::Debug).fmt(f)
     }
 }
 

--- a/samples/server/petstore/rust-server/output/ops-v3/src/lib.rs
+++ b/samples/server/petstore/rust-server/output/ops-v3/src/lib.rs
@@ -277,115 +277,115 @@ pub enum Op9GetResponse {
 pub trait Api<C> {
 
 
-    fn op10_get(&self, context: &C) -> Box<Future<Item=Op10GetResponse, Error=ApiError>>;
+    fn op10_get(&self, context: &C) -> Box<dyn Future<Item=Op10GetResponse, Error=ApiError>>;
 
 
-    fn op11_get(&self, context: &C) -> Box<Future<Item=Op11GetResponse, Error=ApiError>>;
+    fn op11_get(&self, context: &C) -> Box<dyn Future<Item=Op11GetResponse, Error=ApiError>>;
 
 
-    fn op12_get(&self, context: &C) -> Box<Future<Item=Op12GetResponse, Error=ApiError>>;
+    fn op12_get(&self, context: &C) -> Box<dyn Future<Item=Op12GetResponse, Error=ApiError>>;
 
 
-    fn op13_get(&self, context: &C) -> Box<Future<Item=Op13GetResponse, Error=ApiError>>;
+    fn op13_get(&self, context: &C) -> Box<dyn Future<Item=Op13GetResponse, Error=ApiError>>;
 
 
-    fn op14_get(&self, context: &C) -> Box<Future<Item=Op14GetResponse, Error=ApiError>>;
+    fn op14_get(&self, context: &C) -> Box<dyn Future<Item=Op14GetResponse, Error=ApiError>>;
 
 
-    fn op15_get(&self, context: &C) -> Box<Future<Item=Op15GetResponse, Error=ApiError>>;
+    fn op15_get(&self, context: &C) -> Box<dyn Future<Item=Op15GetResponse, Error=ApiError>>;
 
 
-    fn op16_get(&self, context: &C) -> Box<Future<Item=Op16GetResponse, Error=ApiError>>;
+    fn op16_get(&self, context: &C) -> Box<dyn Future<Item=Op16GetResponse, Error=ApiError>>;
 
 
-    fn op17_get(&self, context: &C) -> Box<Future<Item=Op17GetResponse, Error=ApiError>>;
+    fn op17_get(&self, context: &C) -> Box<dyn Future<Item=Op17GetResponse, Error=ApiError>>;
 
 
-    fn op18_get(&self, context: &C) -> Box<Future<Item=Op18GetResponse, Error=ApiError>>;
+    fn op18_get(&self, context: &C) -> Box<dyn Future<Item=Op18GetResponse, Error=ApiError>>;
 
 
-    fn op19_get(&self, context: &C) -> Box<Future<Item=Op19GetResponse, Error=ApiError>>;
+    fn op19_get(&self, context: &C) -> Box<dyn Future<Item=Op19GetResponse, Error=ApiError>>;
 
 
-    fn op1_get(&self, context: &C) -> Box<Future<Item=Op1GetResponse, Error=ApiError>>;
+    fn op1_get(&self, context: &C) -> Box<dyn Future<Item=Op1GetResponse, Error=ApiError>>;
 
 
-    fn op20_get(&self, context: &C) -> Box<Future<Item=Op20GetResponse, Error=ApiError>>;
+    fn op20_get(&self, context: &C) -> Box<dyn Future<Item=Op20GetResponse, Error=ApiError>>;
 
 
-    fn op21_get(&self, context: &C) -> Box<Future<Item=Op21GetResponse, Error=ApiError>>;
+    fn op21_get(&self, context: &C) -> Box<dyn Future<Item=Op21GetResponse, Error=ApiError>>;
 
 
-    fn op22_get(&self, context: &C) -> Box<Future<Item=Op22GetResponse, Error=ApiError>>;
+    fn op22_get(&self, context: &C) -> Box<dyn Future<Item=Op22GetResponse, Error=ApiError>>;
 
 
-    fn op23_get(&self, context: &C) -> Box<Future<Item=Op23GetResponse, Error=ApiError>>;
+    fn op23_get(&self, context: &C) -> Box<dyn Future<Item=Op23GetResponse, Error=ApiError>>;
 
 
-    fn op24_get(&self, context: &C) -> Box<Future<Item=Op24GetResponse, Error=ApiError>>;
+    fn op24_get(&self, context: &C) -> Box<dyn Future<Item=Op24GetResponse, Error=ApiError>>;
 
 
-    fn op25_get(&self, context: &C) -> Box<Future<Item=Op25GetResponse, Error=ApiError>>;
+    fn op25_get(&self, context: &C) -> Box<dyn Future<Item=Op25GetResponse, Error=ApiError>>;
 
 
-    fn op26_get(&self, context: &C) -> Box<Future<Item=Op26GetResponse, Error=ApiError>>;
+    fn op26_get(&self, context: &C) -> Box<dyn Future<Item=Op26GetResponse, Error=ApiError>>;
 
 
-    fn op27_get(&self, context: &C) -> Box<Future<Item=Op27GetResponse, Error=ApiError>>;
+    fn op27_get(&self, context: &C) -> Box<dyn Future<Item=Op27GetResponse, Error=ApiError>>;
 
 
-    fn op28_get(&self, context: &C) -> Box<Future<Item=Op28GetResponse, Error=ApiError>>;
+    fn op28_get(&self, context: &C) -> Box<dyn Future<Item=Op28GetResponse, Error=ApiError>>;
 
 
-    fn op29_get(&self, context: &C) -> Box<Future<Item=Op29GetResponse, Error=ApiError>>;
+    fn op29_get(&self, context: &C) -> Box<dyn Future<Item=Op29GetResponse, Error=ApiError>>;
 
 
-    fn op2_get(&self, context: &C) -> Box<Future<Item=Op2GetResponse, Error=ApiError>>;
+    fn op2_get(&self, context: &C) -> Box<dyn Future<Item=Op2GetResponse, Error=ApiError>>;
 
 
-    fn op30_get(&self, context: &C) -> Box<Future<Item=Op30GetResponse, Error=ApiError>>;
+    fn op30_get(&self, context: &C) -> Box<dyn Future<Item=Op30GetResponse, Error=ApiError>>;
 
 
-    fn op31_get(&self, context: &C) -> Box<Future<Item=Op31GetResponse, Error=ApiError>>;
+    fn op31_get(&self, context: &C) -> Box<dyn Future<Item=Op31GetResponse, Error=ApiError>>;
 
 
-    fn op32_get(&self, context: &C) -> Box<Future<Item=Op32GetResponse, Error=ApiError>>;
+    fn op32_get(&self, context: &C) -> Box<dyn Future<Item=Op32GetResponse, Error=ApiError>>;
 
 
-    fn op33_get(&self, context: &C) -> Box<Future<Item=Op33GetResponse, Error=ApiError>>;
+    fn op33_get(&self, context: &C) -> Box<dyn Future<Item=Op33GetResponse, Error=ApiError>>;
 
 
-    fn op34_get(&self, context: &C) -> Box<Future<Item=Op34GetResponse, Error=ApiError>>;
+    fn op34_get(&self, context: &C) -> Box<dyn Future<Item=Op34GetResponse, Error=ApiError>>;
 
 
-    fn op35_get(&self, context: &C) -> Box<Future<Item=Op35GetResponse, Error=ApiError>>;
+    fn op35_get(&self, context: &C) -> Box<dyn Future<Item=Op35GetResponse, Error=ApiError>>;
 
 
-    fn op36_get(&self, context: &C) -> Box<Future<Item=Op36GetResponse, Error=ApiError>>;
+    fn op36_get(&self, context: &C) -> Box<dyn Future<Item=Op36GetResponse, Error=ApiError>>;
 
 
-    fn op37_get(&self, context: &C) -> Box<Future<Item=Op37GetResponse, Error=ApiError>>;
+    fn op37_get(&self, context: &C) -> Box<dyn Future<Item=Op37GetResponse, Error=ApiError>>;
 
 
-    fn op3_get(&self, context: &C) -> Box<Future<Item=Op3GetResponse, Error=ApiError>>;
+    fn op3_get(&self, context: &C) -> Box<dyn Future<Item=Op3GetResponse, Error=ApiError>>;
 
 
-    fn op4_get(&self, context: &C) -> Box<Future<Item=Op4GetResponse, Error=ApiError>>;
+    fn op4_get(&self, context: &C) -> Box<dyn Future<Item=Op4GetResponse, Error=ApiError>>;
 
 
-    fn op5_get(&self, context: &C) -> Box<Future<Item=Op5GetResponse, Error=ApiError>>;
+    fn op5_get(&self, context: &C) -> Box<dyn Future<Item=Op5GetResponse, Error=ApiError>>;
 
 
-    fn op6_get(&self, context: &C) -> Box<Future<Item=Op6GetResponse, Error=ApiError>>;
+    fn op6_get(&self, context: &C) -> Box<dyn Future<Item=Op6GetResponse, Error=ApiError>>;
 
 
-    fn op7_get(&self, context: &C) -> Box<Future<Item=Op7GetResponse, Error=ApiError>>;
+    fn op7_get(&self, context: &C) -> Box<dyn Future<Item=Op7GetResponse, Error=ApiError>>;
 
 
-    fn op8_get(&self, context: &C) -> Box<Future<Item=Op8GetResponse, Error=ApiError>>;
+    fn op8_get(&self, context: &C) -> Box<dyn Future<Item=Op8GetResponse, Error=ApiError>>;
 
 
-    fn op9_get(&self, context: &C) -> Box<Future<Item=Op9GetResponse, Error=ApiError>>;
+    fn op9_get(&self, context: &C) -> Box<dyn Future<Item=Op9GetResponse, Error=ApiError>>;
 
 }
 
@@ -393,115 +393,115 @@ pub trait Api<C> {
 pub trait ApiNoContext {
 
 
-    fn op10_get(&self) -> Box<Future<Item=Op10GetResponse, Error=ApiError>>;
+    fn op10_get(&self) -> Box<dyn Future<Item=Op10GetResponse, Error=ApiError>>;
 
 
-    fn op11_get(&self) -> Box<Future<Item=Op11GetResponse, Error=ApiError>>;
+    fn op11_get(&self) -> Box<dyn Future<Item=Op11GetResponse, Error=ApiError>>;
 
 
-    fn op12_get(&self) -> Box<Future<Item=Op12GetResponse, Error=ApiError>>;
+    fn op12_get(&self) -> Box<dyn Future<Item=Op12GetResponse, Error=ApiError>>;
 
 
-    fn op13_get(&self) -> Box<Future<Item=Op13GetResponse, Error=ApiError>>;
+    fn op13_get(&self) -> Box<dyn Future<Item=Op13GetResponse, Error=ApiError>>;
 
 
-    fn op14_get(&self) -> Box<Future<Item=Op14GetResponse, Error=ApiError>>;
+    fn op14_get(&self) -> Box<dyn Future<Item=Op14GetResponse, Error=ApiError>>;
 
 
-    fn op15_get(&self) -> Box<Future<Item=Op15GetResponse, Error=ApiError>>;
+    fn op15_get(&self) -> Box<dyn Future<Item=Op15GetResponse, Error=ApiError>>;
 
 
-    fn op16_get(&self) -> Box<Future<Item=Op16GetResponse, Error=ApiError>>;
+    fn op16_get(&self) -> Box<dyn Future<Item=Op16GetResponse, Error=ApiError>>;
 
 
-    fn op17_get(&self) -> Box<Future<Item=Op17GetResponse, Error=ApiError>>;
+    fn op17_get(&self) -> Box<dyn Future<Item=Op17GetResponse, Error=ApiError>>;
 
 
-    fn op18_get(&self) -> Box<Future<Item=Op18GetResponse, Error=ApiError>>;
+    fn op18_get(&self) -> Box<dyn Future<Item=Op18GetResponse, Error=ApiError>>;
 
 
-    fn op19_get(&self) -> Box<Future<Item=Op19GetResponse, Error=ApiError>>;
+    fn op19_get(&self) -> Box<dyn Future<Item=Op19GetResponse, Error=ApiError>>;
 
 
-    fn op1_get(&self) -> Box<Future<Item=Op1GetResponse, Error=ApiError>>;
+    fn op1_get(&self) -> Box<dyn Future<Item=Op1GetResponse, Error=ApiError>>;
 
 
-    fn op20_get(&self) -> Box<Future<Item=Op20GetResponse, Error=ApiError>>;
+    fn op20_get(&self) -> Box<dyn Future<Item=Op20GetResponse, Error=ApiError>>;
 
 
-    fn op21_get(&self) -> Box<Future<Item=Op21GetResponse, Error=ApiError>>;
+    fn op21_get(&self) -> Box<dyn Future<Item=Op21GetResponse, Error=ApiError>>;
 
 
-    fn op22_get(&self) -> Box<Future<Item=Op22GetResponse, Error=ApiError>>;
+    fn op22_get(&self) -> Box<dyn Future<Item=Op22GetResponse, Error=ApiError>>;
 
 
-    fn op23_get(&self) -> Box<Future<Item=Op23GetResponse, Error=ApiError>>;
+    fn op23_get(&self) -> Box<dyn Future<Item=Op23GetResponse, Error=ApiError>>;
 
 
-    fn op24_get(&self) -> Box<Future<Item=Op24GetResponse, Error=ApiError>>;
+    fn op24_get(&self) -> Box<dyn Future<Item=Op24GetResponse, Error=ApiError>>;
 
 
-    fn op25_get(&self) -> Box<Future<Item=Op25GetResponse, Error=ApiError>>;
+    fn op25_get(&self) -> Box<dyn Future<Item=Op25GetResponse, Error=ApiError>>;
 
 
-    fn op26_get(&self) -> Box<Future<Item=Op26GetResponse, Error=ApiError>>;
+    fn op26_get(&self) -> Box<dyn Future<Item=Op26GetResponse, Error=ApiError>>;
 
 
-    fn op27_get(&self) -> Box<Future<Item=Op27GetResponse, Error=ApiError>>;
+    fn op27_get(&self) -> Box<dyn Future<Item=Op27GetResponse, Error=ApiError>>;
 
 
-    fn op28_get(&self) -> Box<Future<Item=Op28GetResponse, Error=ApiError>>;
+    fn op28_get(&self) -> Box<dyn Future<Item=Op28GetResponse, Error=ApiError>>;
 
 
-    fn op29_get(&self) -> Box<Future<Item=Op29GetResponse, Error=ApiError>>;
+    fn op29_get(&self) -> Box<dyn Future<Item=Op29GetResponse, Error=ApiError>>;
 
 
-    fn op2_get(&self) -> Box<Future<Item=Op2GetResponse, Error=ApiError>>;
+    fn op2_get(&self) -> Box<dyn Future<Item=Op2GetResponse, Error=ApiError>>;
 
 
-    fn op30_get(&self) -> Box<Future<Item=Op30GetResponse, Error=ApiError>>;
+    fn op30_get(&self) -> Box<dyn Future<Item=Op30GetResponse, Error=ApiError>>;
 
 
-    fn op31_get(&self) -> Box<Future<Item=Op31GetResponse, Error=ApiError>>;
+    fn op31_get(&self) -> Box<dyn Future<Item=Op31GetResponse, Error=ApiError>>;
 
 
-    fn op32_get(&self) -> Box<Future<Item=Op32GetResponse, Error=ApiError>>;
+    fn op32_get(&self) -> Box<dyn Future<Item=Op32GetResponse, Error=ApiError>>;
 
 
-    fn op33_get(&self) -> Box<Future<Item=Op33GetResponse, Error=ApiError>>;
+    fn op33_get(&self) -> Box<dyn Future<Item=Op33GetResponse, Error=ApiError>>;
 
 
-    fn op34_get(&self) -> Box<Future<Item=Op34GetResponse, Error=ApiError>>;
+    fn op34_get(&self) -> Box<dyn Future<Item=Op34GetResponse, Error=ApiError>>;
 
 
-    fn op35_get(&self) -> Box<Future<Item=Op35GetResponse, Error=ApiError>>;
+    fn op35_get(&self) -> Box<dyn Future<Item=Op35GetResponse, Error=ApiError>>;
 
 
-    fn op36_get(&self) -> Box<Future<Item=Op36GetResponse, Error=ApiError>>;
+    fn op36_get(&self) -> Box<dyn Future<Item=Op36GetResponse, Error=ApiError>>;
 
 
-    fn op37_get(&self) -> Box<Future<Item=Op37GetResponse, Error=ApiError>>;
+    fn op37_get(&self) -> Box<dyn Future<Item=Op37GetResponse, Error=ApiError>>;
 
 
-    fn op3_get(&self) -> Box<Future<Item=Op3GetResponse, Error=ApiError>>;
+    fn op3_get(&self) -> Box<dyn Future<Item=Op3GetResponse, Error=ApiError>>;
 
 
-    fn op4_get(&self) -> Box<Future<Item=Op4GetResponse, Error=ApiError>>;
+    fn op4_get(&self) -> Box<dyn Future<Item=Op4GetResponse, Error=ApiError>>;
 
 
-    fn op5_get(&self) -> Box<Future<Item=Op5GetResponse, Error=ApiError>>;
+    fn op5_get(&self) -> Box<dyn Future<Item=Op5GetResponse, Error=ApiError>>;
 
 
-    fn op6_get(&self) -> Box<Future<Item=Op6GetResponse, Error=ApiError>>;
+    fn op6_get(&self) -> Box<dyn Future<Item=Op6GetResponse, Error=ApiError>>;
 
 
-    fn op7_get(&self) -> Box<Future<Item=Op7GetResponse, Error=ApiError>>;
+    fn op7_get(&self) -> Box<dyn Future<Item=Op7GetResponse, Error=ApiError>>;
 
 
-    fn op8_get(&self) -> Box<Future<Item=Op8GetResponse, Error=ApiError>>;
+    fn op8_get(&self) -> Box<dyn Future<Item=Op8GetResponse, Error=ApiError>>;
 
 
-    fn op9_get(&self) -> Box<Future<Item=Op9GetResponse, Error=ApiError>>;
+    fn op9_get(&self) -> Box<dyn Future<Item=Op9GetResponse, Error=ApiError>>;
 
 }
 
@@ -520,187 +520,187 @@ impl<'a, T: Api<C> + Sized, C> ContextWrapperExt<'a, C> for T {
 impl<'a, T: Api<C>, C> ApiNoContext for ContextWrapper<'a, T, C> {
 
 
-    fn op10_get(&self) -> Box<Future<Item=Op10GetResponse, Error=ApiError>> {
+    fn op10_get(&self) -> Box<dyn Future<Item=Op10GetResponse, Error=ApiError>> {
         self.api().op10_get(&self.context())
     }
 
 
-    fn op11_get(&self) -> Box<Future<Item=Op11GetResponse, Error=ApiError>> {
+    fn op11_get(&self) -> Box<dyn Future<Item=Op11GetResponse, Error=ApiError>> {
         self.api().op11_get(&self.context())
     }
 
 
-    fn op12_get(&self) -> Box<Future<Item=Op12GetResponse, Error=ApiError>> {
+    fn op12_get(&self) -> Box<dyn Future<Item=Op12GetResponse, Error=ApiError>> {
         self.api().op12_get(&self.context())
     }
 
 
-    fn op13_get(&self) -> Box<Future<Item=Op13GetResponse, Error=ApiError>> {
+    fn op13_get(&self) -> Box<dyn Future<Item=Op13GetResponse, Error=ApiError>> {
         self.api().op13_get(&self.context())
     }
 
 
-    fn op14_get(&self) -> Box<Future<Item=Op14GetResponse, Error=ApiError>> {
+    fn op14_get(&self) -> Box<dyn Future<Item=Op14GetResponse, Error=ApiError>> {
         self.api().op14_get(&self.context())
     }
 
 
-    fn op15_get(&self) -> Box<Future<Item=Op15GetResponse, Error=ApiError>> {
+    fn op15_get(&self) -> Box<dyn Future<Item=Op15GetResponse, Error=ApiError>> {
         self.api().op15_get(&self.context())
     }
 
 
-    fn op16_get(&self) -> Box<Future<Item=Op16GetResponse, Error=ApiError>> {
+    fn op16_get(&self) -> Box<dyn Future<Item=Op16GetResponse, Error=ApiError>> {
         self.api().op16_get(&self.context())
     }
 
 
-    fn op17_get(&self) -> Box<Future<Item=Op17GetResponse, Error=ApiError>> {
+    fn op17_get(&self) -> Box<dyn Future<Item=Op17GetResponse, Error=ApiError>> {
         self.api().op17_get(&self.context())
     }
 
 
-    fn op18_get(&self) -> Box<Future<Item=Op18GetResponse, Error=ApiError>> {
+    fn op18_get(&self) -> Box<dyn Future<Item=Op18GetResponse, Error=ApiError>> {
         self.api().op18_get(&self.context())
     }
 
 
-    fn op19_get(&self) -> Box<Future<Item=Op19GetResponse, Error=ApiError>> {
+    fn op19_get(&self) -> Box<dyn Future<Item=Op19GetResponse, Error=ApiError>> {
         self.api().op19_get(&self.context())
     }
 
 
-    fn op1_get(&self) -> Box<Future<Item=Op1GetResponse, Error=ApiError>> {
+    fn op1_get(&self) -> Box<dyn Future<Item=Op1GetResponse, Error=ApiError>> {
         self.api().op1_get(&self.context())
     }
 
 
-    fn op20_get(&self) -> Box<Future<Item=Op20GetResponse, Error=ApiError>> {
+    fn op20_get(&self) -> Box<dyn Future<Item=Op20GetResponse, Error=ApiError>> {
         self.api().op20_get(&self.context())
     }
 
 
-    fn op21_get(&self) -> Box<Future<Item=Op21GetResponse, Error=ApiError>> {
+    fn op21_get(&self) -> Box<dyn Future<Item=Op21GetResponse, Error=ApiError>> {
         self.api().op21_get(&self.context())
     }
 
 
-    fn op22_get(&self) -> Box<Future<Item=Op22GetResponse, Error=ApiError>> {
+    fn op22_get(&self) -> Box<dyn Future<Item=Op22GetResponse, Error=ApiError>> {
         self.api().op22_get(&self.context())
     }
 
 
-    fn op23_get(&self) -> Box<Future<Item=Op23GetResponse, Error=ApiError>> {
+    fn op23_get(&self) -> Box<dyn Future<Item=Op23GetResponse, Error=ApiError>> {
         self.api().op23_get(&self.context())
     }
 
 
-    fn op24_get(&self) -> Box<Future<Item=Op24GetResponse, Error=ApiError>> {
+    fn op24_get(&self) -> Box<dyn Future<Item=Op24GetResponse, Error=ApiError>> {
         self.api().op24_get(&self.context())
     }
 
 
-    fn op25_get(&self) -> Box<Future<Item=Op25GetResponse, Error=ApiError>> {
+    fn op25_get(&self) -> Box<dyn Future<Item=Op25GetResponse, Error=ApiError>> {
         self.api().op25_get(&self.context())
     }
 
 
-    fn op26_get(&self) -> Box<Future<Item=Op26GetResponse, Error=ApiError>> {
+    fn op26_get(&self) -> Box<dyn Future<Item=Op26GetResponse, Error=ApiError>> {
         self.api().op26_get(&self.context())
     }
 
 
-    fn op27_get(&self) -> Box<Future<Item=Op27GetResponse, Error=ApiError>> {
+    fn op27_get(&self) -> Box<dyn Future<Item=Op27GetResponse, Error=ApiError>> {
         self.api().op27_get(&self.context())
     }
 
 
-    fn op28_get(&self) -> Box<Future<Item=Op28GetResponse, Error=ApiError>> {
+    fn op28_get(&self) -> Box<dyn Future<Item=Op28GetResponse, Error=ApiError>> {
         self.api().op28_get(&self.context())
     }
 
 
-    fn op29_get(&self) -> Box<Future<Item=Op29GetResponse, Error=ApiError>> {
+    fn op29_get(&self) -> Box<dyn Future<Item=Op29GetResponse, Error=ApiError>> {
         self.api().op29_get(&self.context())
     }
 
 
-    fn op2_get(&self) -> Box<Future<Item=Op2GetResponse, Error=ApiError>> {
+    fn op2_get(&self) -> Box<dyn Future<Item=Op2GetResponse, Error=ApiError>> {
         self.api().op2_get(&self.context())
     }
 
 
-    fn op30_get(&self) -> Box<Future<Item=Op30GetResponse, Error=ApiError>> {
+    fn op30_get(&self) -> Box<dyn Future<Item=Op30GetResponse, Error=ApiError>> {
         self.api().op30_get(&self.context())
     }
 
 
-    fn op31_get(&self) -> Box<Future<Item=Op31GetResponse, Error=ApiError>> {
+    fn op31_get(&self) -> Box<dyn Future<Item=Op31GetResponse, Error=ApiError>> {
         self.api().op31_get(&self.context())
     }
 
 
-    fn op32_get(&self) -> Box<Future<Item=Op32GetResponse, Error=ApiError>> {
+    fn op32_get(&self) -> Box<dyn Future<Item=Op32GetResponse, Error=ApiError>> {
         self.api().op32_get(&self.context())
     }
 
 
-    fn op33_get(&self) -> Box<Future<Item=Op33GetResponse, Error=ApiError>> {
+    fn op33_get(&self) -> Box<dyn Future<Item=Op33GetResponse, Error=ApiError>> {
         self.api().op33_get(&self.context())
     }
 
 
-    fn op34_get(&self) -> Box<Future<Item=Op34GetResponse, Error=ApiError>> {
+    fn op34_get(&self) -> Box<dyn Future<Item=Op34GetResponse, Error=ApiError>> {
         self.api().op34_get(&self.context())
     }
 
 
-    fn op35_get(&self) -> Box<Future<Item=Op35GetResponse, Error=ApiError>> {
+    fn op35_get(&self) -> Box<dyn Future<Item=Op35GetResponse, Error=ApiError>> {
         self.api().op35_get(&self.context())
     }
 
 
-    fn op36_get(&self) -> Box<Future<Item=Op36GetResponse, Error=ApiError>> {
+    fn op36_get(&self) -> Box<dyn Future<Item=Op36GetResponse, Error=ApiError>> {
         self.api().op36_get(&self.context())
     }
 
 
-    fn op37_get(&self) -> Box<Future<Item=Op37GetResponse, Error=ApiError>> {
+    fn op37_get(&self) -> Box<dyn Future<Item=Op37GetResponse, Error=ApiError>> {
         self.api().op37_get(&self.context())
     }
 
 
-    fn op3_get(&self) -> Box<Future<Item=Op3GetResponse, Error=ApiError>> {
+    fn op3_get(&self) -> Box<dyn Future<Item=Op3GetResponse, Error=ApiError>> {
         self.api().op3_get(&self.context())
     }
 
 
-    fn op4_get(&self) -> Box<Future<Item=Op4GetResponse, Error=ApiError>> {
+    fn op4_get(&self) -> Box<dyn Future<Item=Op4GetResponse, Error=ApiError>> {
         self.api().op4_get(&self.context())
     }
 
 
-    fn op5_get(&self) -> Box<Future<Item=Op5GetResponse, Error=ApiError>> {
+    fn op5_get(&self) -> Box<dyn Future<Item=Op5GetResponse, Error=ApiError>> {
         self.api().op5_get(&self.context())
     }
 
 
-    fn op6_get(&self) -> Box<Future<Item=Op6GetResponse, Error=ApiError>> {
+    fn op6_get(&self) -> Box<dyn Future<Item=Op6GetResponse, Error=ApiError>> {
         self.api().op6_get(&self.context())
     }
 
 
-    fn op7_get(&self) -> Box<Future<Item=Op7GetResponse, Error=ApiError>> {
+    fn op7_get(&self) -> Box<dyn Future<Item=Op7GetResponse, Error=ApiError>> {
         self.api().op7_get(&self.context())
     }
 
 
-    fn op8_get(&self) -> Box<Future<Item=Op8GetResponse, Error=ApiError>> {
+    fn op8_get(&self) -> Box<dyn Future<Item=Op8GetResponse, Error=ApiError>> {
         self.api().op8_get(&self.context())
     }
 
 
-    fn op9_get(&self) -> Box<Future<Item=Op9GetResponse, Error=ApiError>> {
+    fn op9_get(&self) -> Box<dyn Future<Item=Op9GetResponse, Error=ApiError>> {
         self.api().op9_get(&self.context())
     }
 

--- a/samples/server/petstore/rust-server/output/ops-v3/src/server/mod.rs
+++ b/samples/server/petstore/rust-server/output/ops-v3/src/server/mod.rs
@@ -213,7 +213,7 @@ where
     type Request = (Request, C);
     type Response = Response;
     type Error = Error;
-    type Future = Box<Future<Item=Response, Error=Error>>;
+    type Future = Box<dyn Future<Item=Response, Error=Error>>;
 
     fn call(&self, (req, mut context): Self::Request) -> Self::Future {
         let api_impl = self.api_impl.clone();
@@ -231,7 +231,7 @@ where
                                 Box::new(api_impl.op10_get(&context)
                                     .then(move |result| {
                                         let mut response = Response::new();
-                                        response.headers_mut().set(XSpanId((&context as &Has<XSpanIdString>).get().0.to_string()));
+                                        response.headers_mut().set(XSpanId((&context as &dyn Has<XSpanIdString>).get().0.to_string()));
 
                                         match result {
                                             Ok(rsp) => match rsp {
@@ -255,7 +255,7 @@ where
                                     }
                                 ))
                         }}
-                }) as Box<Future<Item=Response, Error=Error>>
+                }) as Box<dyn Future<Item=Response, Error=Error>>
             },
 
             // Op11Get - GET /op11
@@ -265,7 +265,7 @@ where
                                 Box::new(api_impl.op11_get(&context)
                                     .then(move |result| {
                                         let mut response = Response::new();
-                                        response.headers_mut().set(XSpanId((&context as &Has<XSpanIdString>).get().0.to_string()));
+                                        response.headers_mut().set(XSpanId((&context as &dyn Has<XSpanIdString>).get().0.to_string()));
 
                                         match result {
                                             Ok(rsp) => match rsp {
@@ -289,7 +289,7 @@ where
                                     }
                                 ))
                         }}
-                }) as Box<Future<Item=Response, Error=Error>>
+                }) as Box<dyn Future<Item=Response, Error=Error>>
             },
 
             // Op12Get - GET /op12
@@ -299,7 +299,7 @@ where
                                 Box::new(api_impl.op12_get(&context)
                                     .then(move |result| {
                                         let mut response = Response::new();
-                                        response.headers_mut().set(XSpanId((&context as &Has<XSpanIdString>).get().0.to_string()));
+                                        response.headers_mut().set(XSpanId((&context as &dyn Has<XSpanIdString>).get().0.to_string()));
 
                                         match result {
                                             Ok(rsp) => match rsp {
@@ -323,7 +323,7 @@ where
                                     }
                                 ))
                         }}
-                }) as Box<Future<Item=Response, Error=Error>>
+                }) as Box<dyn Future<Item=Response, Error=Error>>
             },
 
             // Op13Get - GET /op13
@@ -333,7 +333,7 @@ where
                                 Box::new(api_impl.op13_get(&context)
                                     .then(move |result| {
                                         let mut response = Response::new();
-                                        response.headers_mut().set(XSpanId((&context as &Has<XSpanIdString>).get().0.to_string()));
+                                        response.headers_mut().set(XSpanId((&context as &dyn Has<XSpanIdString>).get().0.to_string()));
 
                                         match result {
                                             Ok(rsp) => match rsp {
@@ -357,7 +357,7 @@ where
                                     }
                                 ))
                         }}
-                }) as Box<Future<Item=Response, Error=Error>>
+                }) as Box<dyn Future<Item=Response, Error=Error>>
             },
 
             // Op14Get - GET /op14
@@ -367,7 +367,7 @@ where
                                 Box::new(api_impl.op14_get(&context)
                                     .then(move |result| {
                                         let mut response = Response::new();
-                                        response.headers_mut().set(XSpanId((&context as &Has<XSpanIdString>).get().0.to_string()));
+                                        response.headers_mut().set(XSpanId((&context as &dyn Has<XSpanIdString>).get().0.to_string()));
 
                                         match result {
                                             Ok(rsp) => match rsp {
@@ -391,7 +391,7 @@ where
                                     }
                                 ))
                         }}
-                }) as Box<Future<Item=Response, Error=Error>>
+                }) as Box<dyn Future<Item=Response, Error=Error>>
             },
 
             // Op15Get - GET /op15
@@ -401,7 +401,7 @@ where
                                 Box::new(api_impl.op15_get(&context)
                                     .then(move |result| {
                                         let mut response = Response::new();
-                                        response.headers_mut().set(XSpanId((&context as &Has<XSpanIdString>).get().0.to_string()));
+                                        response.headers_mut().set(XSpanId((&context as &dyn Has<XSpanIdString>).get().0.to_string()));
 
                                         match result {
                                             Ok(rsp) => match rsp {
@@ -425,7 +425,7 @@ where
                                     }
                                 ))
                         }}
-                }) as Box<Future<Item=Response, Error=Error>>
+                }) as Box<dyn Future<Item=Response, Error=Error>>
             },
 
             // Op16Get - GET /op16
@@ -435,7 +435,7 @@ where
                                 Box::new(api_impl.op16_get(&context)
                                     .then(move |result| {
                                         let mut response = Response::new();
-                                        response.headers_mut().set(XSpanId((&context as &Has<XSpanIdString>).get().0.to_string()));
+                                        response.headers_mut().set(XSpanId((&context as &dyn Has<XSpanIdString>).get().0.to_string()));
 
                                         match result {
                                             Ok(rsp) => match rsp {
@@ -459,7 +459,7 @@ where
                                     }
                                 ))
                         }}
-                }) as Box<Future<Item=Response, Error=Error>>
+                }) as Box<dyn Future<Item=Response, Error=Error>>
             },
 
             // Op17Get - GET /op17
@@ -469,7 +469,7 @@ where
                                 Box::new(api_impl.op17_get(&context)
                                     .then(move |result| {
                                         let mut response = Response::new();
-                                        response.headers_mut().set(XSpanId((&context as &Has<XSpanIdString>).get().0.to_string()));
+                                        response.headers_mut().set(XSpanId((&context as &dyn Has<XSpanIdString>).get().0.to_string()));
 
                                         match result {
                                             Ok(rsp) => match rsp {
@@ -493,7 +493,7 @@ where
                                     }
                                 ))
                         }}
-                }) as Box<Future<Item=Response, Error=Error>>
+                }) as Box<dyn Future<Item=Response, Error=Error>>
             },
 
             // Op18Get - GET /op18
@@ -503,7 +503,7 @@ where
                                 Box::new(api_impl.op18_get(&context)
                                     .then(move |result| {
                                         let mut response = Response::new();
-                                        response.headers_mut().set(XSpanId((&context as &Has<XSpanIdString>).get().0.to_string()));
+                                        response.headers_mut().set(XSpanId((&context as &dyn Has<XSpanIdString>).get().0.to_string()));
 
                                         match result {
                                             Ok(rsp) => match rsp {
@@ -527,7 +527,7 @@ where
                                     }
                                 ))
                         }}
-                }) as Box<Future<Item=Response, Error=Error>>
+                }) as Box<dyn Future<Item=Response, Error=Error>>
             },
 
             // Op19Get - GET /op19
@@ -537,7 +537,7 @@ where
                                 Box::new(api_impl.op19_get(&context)
                                     .then(move |result| {
                                         let mut response = Response::new();
-                                        response.headers_mut().set(XSpanId((&context as &Has<XSpanIdString>).get().0.to_string()));
+                                        response.headers_mut().set(XSpanId((&context as &dyn Has<XSpanIdString>).get().0.to_string()));
 
                                         match result {
                                             Ok(rsp) => match rsp {
@@ -561,7 +561,7 @@ where
                                     }
                                 ))
                         }}
-                }) as Box<Future<Item=Response, Error=Error>>
+                }) as Box<dyn Future<Item=Response, Error=Error>>
             },
 
             // Op1Get - GET /op1
@@ -571,7 +571,7 @@ where
                                 Box::new(api_impl.op1_get(&context)
                                     .then(move |result| {
                                         let mut response = Response::new();
-                                        response.headers_mut().set(XSpanId((&context as &Has<XSpanIdString>).get().0.to_string()));
+                                        response.headers_mut().set(XSpanId((&context as &dyn Has<XSpanIdString>).get().0.to_string()));
 
                                         match result {
                                             Ok(rsp) => match rsp {
@@ -595,7 +595,7 @@ where
                                     }
                                 ))
                         }}
-                }) as Box<Future<Item=Response, Error=Error>>
+                }) as Box<dyn Future<Item=Response, Error=Error>>
             },
 
             // Op20Get - GET /op20
@@ -605,7 +605,7 @@ where
                                 Box::new(api_impl.op20_get(&context)
                                     .then(move |result| {
                                         let mut response = Response::new();
-                                        response.headers_mut().set(XSpanId((&context as &Has<XSpanIdString>).get().0.to_string()));
+                                        response.headers_mut().set(XSpanId((&context as &dyn Has<XSpanIdString>).get().0.to_string()));
 
                                         match result {
                                             Ok(rsp) => match rsp {
@@ -629,7 +629,7 @@ where
                                     }
                                 ))
                         }}
-                }) as Box<Future<Item=Response, Error=Error>>
+                }) as Box<dyn Future<Item=Response, Error=Error>>
             },
 
             // Op21Get - GET /op21
@@ -639,7 +639,7 @@ where
                                 Box::new(api_impl.op21_get(&context)
                                     .then(move |result| {
                                         let mut response = Response::new();
-                                        response.headers_mut().set(XSpanId((&context as &Has<XSpanIdString>).get().0.to_string()));
+                                        response.headers_mut().set(XSpanId((&context as &dyn Has<XSpanIdString>).get().0.to_string()));
 
                                         match result {
                                             Ok(rsp) => match rsp {
@@ -663,7 +663,7 @@ where
                                     }
                                 ))
                         }}
-                }) as Box<Future<Item=Response, Error=Error>>
+                }) as Box<dyn Future<Item=Response, Error=Error>>
             },
 
             // Op22Get - GET /op22
@@ -673,7 +673,7 @@ where
                                 Box::new(api_impl.op22_get(&context)
                                     .then(move |result| {
                                         let mut response = Response::new();
-                                        response.headers_mut().set(XSpanId((&context as &Has<XSpanIdString>).get().0.to_string()));
+                                        response.headers_mut().set(XSpanId((&context as &dyn Has<XSpanIdString>).get().0.to_string()));
 
                                         match result {
                                             Ok(rsp) => match rsp {
@@ -697,7 +697,7 @@ where
                                     }
                                 ))
                         }}
-                }) as Box<Future<Item=Response, Error=Error>>
+                }) as Box<dyn Future<Item=Response, Error=Error>>
             },
 
             // Op23Get - GET /op23
@@ -707,7 +707,7 @@ where
                                 Box::new(api_impl.op23_get(&context)
                                     .then(move |result| {
                                         let mut response = Response::new();
-                                        response.headers_mut().set(XSpanId((&context as &Has<XSpanIdString>).get().0.to_string()));
+                                        response.headers_mut().set(XSpanId((&context as &dyn Has<XSpanIdString>).get().0.to_string()));
 
                                         match result {
                                             Ok(rsp) => match rsp {
@@ -731,7 +731,7 @@ where
                                     }
                                 ))
                         }}
-                }) as Box<Future<Item=Response, Error=Error>>
+                }) as Box<dyn Future<Item=Response, Error=Error>>
             },
 
             // Op24Get - GET /op24
@@ -741,7 +741,7 @@ where
                                 Box::new(api_impl.op24_get(&context)
                                     .then(move |result| {
                                         let mut response = Response::new();
-                                        response.headers_mut().set(XSpanId((&context as &Has<XSpanIdString>).get().0.to_string()));
+                                        response.headers_mut().set(XSpanId((&context as &dyn Has<XSpanIdString>).get().0.to_string()));
 
                                         match result {
                                             Ok(rsp) => match rsp {
@@ -765,7 +765,7 @@ where
                                     }
                                 ))
                         }}
-                }) as Box<Future<Item=Response, Error=Error>>
+                }) as Box<dyn Future<Item=Response, Error=Error>>
             },
 
             // Op25Get - GET /op25
@@ -775,7 +775,7 @@ where
                                 Box::new(api_impl.op25_get(&context)
                                     .then(move |result| {
                                         let mut response = Response::new();
-                                        response.headers_mut().set(XSpanId((&context as &Has<XSpanIdString>).get().0.to_string()));
+                                        response.headers_mut().set(XSpanId((&context as &dyn Has<XSpanIdString>).get().0.to_string()));
 
                                         match result {
                                             Ok(rsp) => match rsp {
@@ -799,7 +799,7 @@ where
                                     }
                                 ))
                         }}
-                }) as Box<Future<Item=Response, Error=Error>>
+                }) as Box<dyn Future<Item=Response, Error=Error>>
             },
 
             // Op26Get - GET /op26
@@ -809,7 +809,7 @@ where
                                 Box::new(api_impl.op26_get(&context)
                                     .then(move |result| {
                                         let mut response = Response::new();
-                                        response.headers_mut().set(XSpanId((&context as &Has<XSpanIdString>).get().0.to_string()));
+                                        response.headers_mut().set(XSpanId((&context as &dyn Has<XSpanIdString>).get().0.to_string()));
 
                                         match result {
                                             Ok(rsp) => match rsp {
@@ -833,7 +833,7 @@ where
                                     }
                                 ))
                         }}
-                }) as Box<Future<Item=Response, Error=Error>>
+                }) as Box<dyn Future<Item=Response, Error=Error>>
             },
 
             // Op27Get - GET /op27
@@ -843,7 +843,7 @@ where
                                 Box::new(api_impl.op27_get(&context)
                                     .then(move |result| {
                                         let mut response = Response::new();
-                                        response.headers_mut().set(XSpanId((&context as &Has<XSpanIdString>).get().0.to_string()));
+                                        response.headers_mut().set(XSpanId((&context as &dyn Has<XSpanIdString>).get().0.to_string()));
 
                                         match result {
                                             Ok(rsp) => match rsp {
@@ -867,7 +867,7 @@ where
                                     }
                                 ))
                         }}
-                }) as Box<Future<Item=Response, Error=Error>>
+                }) as Box<dyn Future<Item=Response, Error=Error>>
             },
 
             // Op28Get - GET /op28
@@ -877,7 +877,7 @@ where
                                 Box::new(api_impl.op28_get(&context)
                                     .then(move |result| {
                                         let mut response = Response::new();
-                                        response.headers_mut().set(XSpanId((&context as &Has<XSpanIdString>).get().0.to_string()));
+                                        response.headers_mut().set(XSpanId((&context as &dyn Has<XSpanIdString>).get().0.to_string()));
 
                                         match result {
                                             Ok(rsp) => match rsp {
@@ -901,7 +901,7 @@ where
                                     }
                                 ))
                         }}
-                }) as Box<Future<Item=Response, Error=Error>>
+                }) as Box<dyn Future<Item=Response, Error=Error>>
             },
 
             // Op29Get - GET /op29
@@ -911,7 +911,7 @@ where
                                 Box::new(api_impl.op29_get(&context)
                                     .then(move |result| {
                                         let mut response = Response::new();
-                                        response.headers_mut().set(XSpanId((&context as &Has<XSpanIdString>).get().0.to_string()));
+                                        response.headers_mut().set(XSpanId((&context as &dyn Has<XSpanIdString>).get().0.to_string()));
 
                                         match result {
                                             Ok(rsp) => match rsp {
@@ -935,7 +935,7 @@ where
                                     }
                                 ))
                         }}
-                }) as Box<Future<Item=Response, Error=Error>>
+                }) as Box<dyn Future<Item=Response, Error=Error>>
             },
 
             // Op2Get - GET /op2
@@ -945,7 +945,7 @@ where
                                 Box::new(api_impl.op2_get(&context)
                                     .then(move |result| {
                                         let mut response = Response::new();
-                                        response.headers_mut().set(XSpanId((&context as &Has<XSpanIdString>).get().0.to_string()));
+                                        response.headers_mut().set(XSpanId((&context as &dyn Has<XSpanIdString>).get().0.to_string()));
 
                                         match result {
                                             Ok(rsp) => match rsp {
@@ -969,7 +969,7 @@ where
                                     }
                                 ))
                         }}
-                }) as Box<Future<Item=Response, Error=Error>>
+                }) as Box<dyn Future<Item=Response, Error=Error>>
             },
 
             // Op30Get - GET /op30
@@ -979,7 +979,7 @@ where
                                 Box::new(api_impl.op30_get(&context)
                                     .then(move |result| {
                                         let mut response = Response::new();
-                                        response.headers_mut().set(XSpanId((&context as &Has<XSpanIdString>).get().0.to_string()));
+                                        response.headers_mut().set(XSpanId((&context as &dyn Has<XSpanIdString>).get().0.to_string()));
 
                                         match result {
                                             Ok(rsp) => match rsp {
@@ -1003,7 +1003,7 @@ where
                                     }
                                 ))
                         }}
-                }) as Box<Future<Item=Response, Error=Error>>
+                }) as Box<dyn Future<Item=Response, Error=Error>>
             },
 
             // Op31Get - GET /op31
@@ -1013,7 +1013,7 @@ where
                                 Box::new(api_impl.op31_get(&context)
                                     .then(move |result| {
                                         let mut response = Response::new();
-                                        response.headers_mut().set(XSpanId((&context as &Has<XSpanIdString>).get().0.to_string()));
+                                        response.headers_mut().set(XSpanId((&context as &dyn Has<XSpanIdString>).get().0.to_string()));
 
                                         match result {
                                             Ok(rsp) => match rsp {
@@ -1037,7 +1037,7 @@ where
                                     }
                                 ))
                         }}
-                }) as Box<Future<Item=Response, Error=Error>>
+                }) as Box<dyn Future<Item=Response, Error=Error>>
             },
 
             // Op32Get - GET /op32
@@ -1047,7 +1047,7 @@ where
                                 Box::new(api_impl.op32_get(&context)
                                     .then(move |result| {
                                         let mut response = Response::new();
-                                        response.headers_mut().set(XSpanId((&context as &Has<XSpanIdString>).get().0.to_string()));
+                                        response.headers_mut().set(XSpanId((&context as &dyn Has<XSpanIdString>).get().0.to_string()));
 
                                         match result {
                                             Ok(rsp) => match rsp {
@@ -1071,7 +1071,7 @@ where
                                     }
                                 ))
                         }}
-                }) as Box<Future<Item=Response, Error=Error>>
+                }) as Box<dyn Future<Item=Response, Error=Error>>
             },
 
             // Op33Get - GET /op33
@@ -1081,7 +1081,7 @@ where
                                 Box::new(api_impl.op33_get(&context)
                                     .then(move |result| {
                                         let mut response = Response::new();
-                                        response.headers_mut().set(XSpanId((&context as &Has<XSpanIdString>).get().0.to_string()));
+                                        response.headers_mut().set(XSpanId((&context as &dyn Has<XSpanIdString>).get().0.to_string()));
 
                                         match result {
                                             Ok(rsp) => match rsp {
@@ -1105,7 +1105,7 @@ where
                                     }
                                 ))
                         }}
-                }) as Box<Future<Item=Response, Error=Error>>
+                }) as Box<dyn Future<Item=Response, Error=Error>>
             },
 
             // Op34Get - GET /op34
@@ -1115,7 +1115,7 @@ where
                                 Box::new(api_impl.op34_get(&context)
                                     .then(move |result| {
                                         let mut response = Response::new();
-                                        response.headers_mut().set(XSpanId((&context as &Has<XSpanIdString>).get().0.to_string()));
+                                        response.headers_mut().set(XSpanId((&context as &dyn Has<XSpanIdString>).get().0.to_string()));
 
                                         match result {
                                             Ok(rsp) => match rsp {
@@ -1139,7 +1139,7 @@ where
                                     }
                                 ))
                         }}
-                }) as Box<Future<Item=Response, Error=Error>>
+                }) as Box<dyn Future<Item=Response, Error=Error>>
             },
 
             // Op35Get - GET /op35
@@ -1149,7 +1149,7 @@ where
                                 Box::new(api_impl.op35_get(&context)
                                     .then(move |result| {
                                         let mut response = Response::new();
-                                        response.headers_mut().set(XSpanId((&context as &Has<XSpanIdString>).get().0.to_string()));
+                                        response.headers_mut().set(XSpanId((&context as &dyn Has<XSpanIdString>).get().0.to_string()));
 
                                         match result {
                                             Ok(rsp) => match rsp {
@@ -1173,7 +1173,7 @@ where
                                     }
                                 ))
                         }}
-                }) as Box<Future<Item=Response, Error=Error>>
+                }) as Box<dyn Future<Item=Response, Error=Error>>
             },
 
             // Op36Get - GET /op36
@@ -1183,7 +1183,7 @@ where
                                 Box::new(api_impl.op36_get(&context)
                                     .then(move |result| {
                                         let mut response = Response::new();
-                                        response.headers_mut().set(XSpanId((&context as &Has<XSpanIdString>).get().0.to_string()));
+                                        response.headers_mut().set(XSpanId((&context as &dyn Has<XSpanIdString>).get().0.to_string()));
 
                                         match result {
                                             Ok(rsp) => match rsp {
@@ -1207,7 +1207,7 @@ where
                                     }
                                 ))
                         }}
-                }) as Box<Future<Item=Response, Error=Error>>
+                }) as Box<dyn Future<Item=Response, Error=Error>>
             },
 
             // Op37Get - GET /op37
@@ -1217,7 +1217,7 @@ where
                                 Box::new(api_impl.op37_get(&context)
                                     .then(move |result| {
                                         let mut response = Response::new();
-                                        response.headers_mut().set(XSpanId((&context as &Has<XSpanIdString>).get().0.to_string()));
+                                        response.headers_mut().set(XSpanId((&context as &dyn Has<XSpanIdString>).get().0.to_string()));
 
                                         match result {
                                             Ok(rsp) => match rsp {
@@ -1241,7 +1241,7 @@ where
                                     }
                                 ))
                         }}
-                }) as Box<Future<Item=Response, Error=Error>>
+                }) as Box<dyn Future<Item=Response, Error=Error>>
             },
 
             // Op3Get - GET /op3
@@ -1251,7 +1251,7 @@ where
                                 Box::new(api_impl.op3_get(&context)
                                     .then(move |result| {
                                         let mut response = Response::new();
-                                        response.headers_mut().set(XSpanId((&context as &Has<XSpanIdString>).get().0.to_string()));
+                                        response.headers_mut().set(XSpanId((&context as &dyn Has<XSpanIdString>).get().0.to_string()));
 
                                         match result {
                                             Ok(rsp) => match rsp {
@@ -1275,7 +1275,7 @@ where
                                     }
                                 ))
                         }}
-                }) as Box<Future<Item=Response, Error=Error>>
+                }) as Box<dyn Future<Item=Response, Error=Error>>
             },
 
             // Op4Get - GET /op4
@@ -1285,7 +1285,7 @@ where
                                 Box::new(api_impl.op4_get(&context)
                                     .then(move |result| {
                                         let mut response = Response::new();
-                                        response.headers_mut().set(XSpanId((&context as &Has<XSpanIdString>).get().0.to_string()));
+                                        response.headers_mut().set(XSpanId((&context as &dyn Has<XSpanIdString>).get().0.to_string()));
 
                                         match result {
                                             Ok(rsp) => match rsp {
@@ -1309,7 +1309,7 @@ where
                                     }
                                 ))
                         }}
-                }) as Box<Future<Item=Response, Error=Error>>
+                }) as Box<dyn Future<Item=Response, Error=Error>>
             },
 
             // Op5Get - GET /op5
@@ -1319,7 +1319,7 @@ where
                                 Box::new(api_impl.op5_get(&context)
                                     .then(move |result| {
                                         let mut response = Response::new();
-                                        response.headers_mut().set(XSpanId((&context as &Has<XSpanIdString>).get().0.to_string()));
+                                        response.headers_mut().set(XSpanId((&context as &dyn Has<XSpanIdString>).get().0.to_string()));
 
                                         match result {
                                             Ok(rsp) => match rsp {
@@ -1343,7 +1343,7 @@ where
                                     }
                                 ))
                         }}
-                }) as Box<Future<Item=Response, Error=Error>>
+                }) as Box<dyn Future<Item=Response, Error=Error>>
             },
 
             // Op6Get - GET /op6
@@ -1353,7 +1353,7 @@ where
                                 Box::new(api_impl.op6_get(&context)
                                     .then(move |result| {
                                         let mut response = Response::new();
-                                        response.headers_mut().set(XSpanId((&context as &Has<XSpanIdString>).get().0.to_string()));
+                                        response.headers_mut().set(XSpanId((&context as &dyn Has<XSpanIdString>).get().0.to_string()));
 
                                         match result {
                                             Ok(rsp) => match rsp {
@@ -1377,7 +1377,7 @@ where
                                     }
                                 ))
                         }}
-                }) as Box<Future<Item=Response, Error=Error>>
+                }) as Box<dyn Future<Item=Response, Error=Error>>
             },
 
             // Op7Get - GET /op7
@@ -1387,7 +1387,7 @@ where
                                 Box::new(api_impl.op7_get(&context)
                                     .then(move |result| {
                                         let mut response = Response::new();
-                                        response.headers_mut().set(XSpanId((&context as &Has<XSpanIdString>).get().0.to_string()));
+                                        response.headers_mut().set(XSpanId((&context as &dyn Has<XSpanIdString>).get().0.to_string()));
 
                                         match result {
                                             Ok(rsp) => match rsp {
@@ -1411,7 +1411,7 @@ where
                                     }
                                 ))
                         }}
-                }) as Box<Future<Item=Response, Error=Error>>
+                }) as Box<dyn Future<Item=Response, Error=Error>>
             },
 
             // Op8Get - GET /op8
@@ -1421,7 +1421,7 @@ where
                                 Box::new(api_impl.op8_get(&context)
                                     .then(move |result| {
                                         let mut response = Response::new();
-                                        response.headers_mut().set(XSpanId((&context as &Has<XSpanIdString>).get().0.to_string()));
+                                        response.headers_mut().set(XSpanId((&context as &dyn Has<XSpanIdString>).get().0.to_string()));
 
                                         match result {
                                             Ok(rsp) => match rsp {
@@ -1445,7 +1445,7 @@ where
                                     }
                                 ))
                         }}
-                }) as Box<Future<Item=Response, Error=Error>>
+                }) as Box<dyn Future<Item=Response, Error=Error>>
             },
 
             // Op9Get - GET /op9
@@ -1455,7 +1455,7 @@ where
                                 Box::new(api_impl.op9_get(&context)
                                     .then(move |result| {
                                         let mut response = Response::new();
-                                        response.headers_mut().set(XSpanId((&context as &Has<XSpanIdString>).get().0.to_string()));
+                                        response.headers_mut().set(XSpanId((&context as &dyn Has<XSpanIdString>).get().0.to_string()));
 
                                         match result {
                                             Ok(rsp) => match rsp {
@@ -1479,10 +1479,10 @@ where
                                     }
                                 ))
                         }}
-                }) as Box<Future<Item=Response, Error=Error>>
+                }) as Box<dyn Future<Item=Response, Error=Error>>
             },
 
-            _ => Box::new(future::ok(Response::new().with_status(StatusCode::NotFound))) as Box<Future<Item=Response, Error=Error>>,
+            _ => Box::new(future::ok(Response::new().with_status(StatusCode::NotFound))) as Box<dyn Future<Item=Response, Error=Error>>,
         }
     }
 }

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/Cargo.toml
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/Cargo.toml
@@ -16,7 +16,7 @@ conversion = ["frunk", "frunk_derives", "frunk_core", "frunk-enum-core", "frunk-
 chrono = { version = "0.4", features = ["serde"] }
 futures = "0.1"
 swagger = "2"
-lazy_static = "0.2"
+lazy_static = "1.4"
 log = "0.3.0"
 mime = "0.2.6"
 multipart = "0.13.3"

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/examples/client.rs
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/examples/client.rs
@@ -124,171 +124,171 @@ fn main() {
         // Disabled because there's no example.
         // Some("TestSpecialTags") => {
         //     let result = core.run(client.test_special_tags(???));
-        //     println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+        //     println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         //  },
 
         Some("FakeOuterBooleanSerialize") => {
             let result = core.run(client.fake_outer_boolean_serialize(None));
-            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
          },
 
         Some("FakeOuterCompositeSerialize") => {
             let result = core.run(client.fake_outer_composite_serialize(None));
-            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
          },
 
         Some("FakeOuterNumberSerialize") => {
             let result = core.run(client.fake_outer_number_serialize(None));
-            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
          },
 
         Some("FakeOuterStringSerialize") => {
             let result = core.run(client.fake_outer_string_serialize(None));
-            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
          },
 
         // Disabled because there's no example.
         // Some("TestBodyWithQueryParams") => {
         //     let result = core.run(client.test_body_with_query_params("query_example".to_string(), ???));
-        //     println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+        //     println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         //  },
 
         // Disabled because there's no example.
         // Some("TestClientModel") => {
         //     let result = core.run(client.test_client_model(???));
-        //     println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+        //     println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         //  },
 
         Some("TestEndpointParameters") => {
             let result = core.run(client.test_endpoint_parameters(8.14, 1.2, "pattern_without_delimiter_example".to_string(), swagger::ByteArray(Vec::from("BYTE_ARRAY_DATA_HERE")), Some(56), Some(56), Some(789), Some(3.4), Some("string_example".to_string()), Some(swagger::ByteArray(Vec::from("BINARY_DATA_HERE"))), None, None, Some("password_example".to_string()), Some("callback_example".to_string())));
-            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
          },
 
         Some("TestEnumParameters") => {
             let result = core.run(client.test_enum_parameters(Some(&Vec::new()), Some("enum_header_string_example".to_string()), Some(&Vec::new()), Some("enum_query_string_example".to_string()), Some(56), Some(1.2), Some("enum_form_string_example".to_string())));
-            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
          },
 
         // Disabled because there's no example.
         // Some("TestInlineAdditionalProperties") => {
         //     let result = core.run(client.test_inline_additional_properties(???));
-        //     println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+        //     println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         //  },
 
         Some("TestJsonFormData") => {
             let result = core.run(client.test_json_form_data("param_example".to_string(), "param2_example".to_string()));
-            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
          },
 
         // Disabled because there's no example.
         // Some("TestClassname") => {
         //     let result = core.run(client.test_classname(???));
-        //     println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+        //     println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         //  },
 
         // Disabled because there's no example.
         // Some("AddPet") => {
         //     let result = core.run(client.add_pet(???));
-        //     println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+        //     println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         //  },
 
         Some("DeletePet") => {
             let result = core.run(client.delete_pet(789, Some("api_key_example".to_string())));
-            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
          },
 
         Some("FindPetsByStatus") => {
             let result = core.run(client.find_pets_by_status(&Vec::new()));
-            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
          },
 
         Some("FindPetsByTags") => {
             let result = core.run(client.find_pets_by_tags(&Vec::new()));
-            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
          },
 
         Some("GetPetById") => {
             let result = core.run(client.get_pet_by_id(789));
-            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
          },
 
         // Disabled because there's no example.
         // Some("UpdatePet") => {
         //     let result = core.run(client.update_pet(???));
-        //     println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+        //     println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         //  },
 
         Some("UpdatePetWithForm") => {
             let result = core.run(client.update_pet_with_form(789, Some("name_example".to_string()), Some("status_example".to_string())));
-            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
          },
 
         Some("UploadFile") => {
             let result = core.run(client.upload_file(789, Some("additional_metadata_example".to_string()), Some(swagger::ByteArray(Vec::from("BINARY_DATA_HERE")))));
-            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
          },
 
         Some("DeleteOrder") => {
             let result = core.run(client.delete_order("order_id_example".to_string()));
-            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
          },
 
         Some("GetInventory") => {
             let result = core.run(client.get_inventory());
-            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
          },
 
         Some("GetOrderById") => {
             let result = core.run(client.get_order_by_id(789));
-            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
          },
 
         // Disabled because there's no example.
         // Some("PlaceOrder") => {
         //     let result = core.run(client.place_order(???));
-        //     println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+        //     println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         //  },
 
         // Disabled because there's no example.
         // Some("CreateUser") => {
         //     let result = core.run(client.create_user(???));
-        //     println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+        //     println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         //  },
 
         Some("CreateUsersWithArrayInput") => {
             let result = core.run(client.create_users_with_array_input(&Vec::new()));
-            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
          },
 
         Some("CreateUsersWithListInput") => {
             let result = core.run(client.create_users_with_list_input(&Vec::new()));
-            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
          },
 
         Some("DeleteUser") => {
             let result = core.run(client.delete_user("username_example".to_string()));
-            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
          },
 
         Some("GetUserByName") => {
             let result = core.run(client.get_user_by_name("username_example".to_string()));
-            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
          },
 
         Some("LoginUser") => {
             let result = core.run(client.login_user("username_example".to_string(), "password_example".to_string()));
-            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
          },
 
         Some("LogoutUser") => {
             let result = core.run(client.logout_user());
-            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
          },
 
         // Disabled because there's no example.
         // Some("UpdateUser") => {
         //     let result = core.run(client.update_user("username_example".to_string(), ???));
-        //     println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+        //     println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         //  },
 
         _ => {

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/examples/server_lib/server.rs
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/examples/server_lib/server.rs
@@ -60,224 +60,224 @@ impl<C> Server<C> {
 impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
 
     /// To test special tags
-    fn test_special_tags(&self, body: models::Client, context: &C) -> Box<Future<Item=TestSpecialTagsResponse, Error=ApiError>> {
+    fn test_special_tags(&self, body: models::Client, context: &C) -> Box<dyn Future<Item=TestSpecialTagsResponse, Error=ApiError>> {
         let context = context.clone();
         println!("test_special_tags({:?}) - X-Span-ID: {:?}", body, context.get().0.clone());
         Box::new(futures::failed("Generic failure".into()))
     }
 
 
-    fn fake_outer_boolean_serialize(&self, body: Option<models::OuterBoolean>, context: &C) -> Box<Future<Item=FakeOuterBooleanSerializeResponse, Error=ApiError>> {
+    fn fake_outer_boolean_serialize(&self, body: Option<models::OuterBoolean>, context: &C) -> Box<dyn Future<Item=FakeOuterBooleanSerializeResponse, Error=ApiError>> {
         let context = context.clone();
         println!("fake_outer_boolean_serialize({:?}) - X-Span-ID: {:?}", body, context.get().0.clone());
         Box::new(futures::failed("Generic failure".into()))
     }
 
 
-    fn fake_outer_composite_serialize(&self, body: Option<models::OuterComposite>, context: &C) -> Box<Future<Item=FakeOuterCompositeSerializeResponse, Error=ApiError>> {
+    fn fake_outer_composite_serialize(&self, body: Option<models::OuterComposite>, context: &C) -> Box<dyn Future<Item=FakeOuterCompositeSerializeResponse, Error=ApiError>> {
         let context = context.clone();
         println!("fake_outer_composite_serialize({:?}) - X-Span-ID: {:?}", body, context.get().0.clone());
         Box::new(futures::failed("Generic failure".into()))
     }
 
 
-    fn fake_outer_number_serialize(&self, body: Option<models::OuterNumber>, context: &C) -> Box<Future<Item=FakeOuterNumberSerializeResponse, Error=ApiError>> {
+    fn fake_outer_number_serialize(&self, body: Option<models::OuterNumber>, context: &C) -> Box<dyn Future<Item=FakeOuterNumberSerializeResponse, Error=ApiError>> {
         let context = context.clone();
         println!("fake_outer_number_serialize({:?}) - X-Span-ID: {:?}", body, context.get().0.clone());
         Box::new(futures::failed("Generic failure".into()))
     }
 
 
-    fn fake_outer_string_serialize(&self, body: Option<models::OuterString>, context: &C) -> Box<Future<Item=FakeOuterStringSerializeResponse, Error=ApiError>> {
+    fn fake_outer_string_serialize(&self, body: Option<models::OuterString>, context: &C) -> Box<dyn Future<Item=FakeOuterStringSerializeResponse, Error=ApiError>> {
         let context = context.clone();
         println!("fake_outer_string_serialize({:?}) - X-Span-ID: {:?}", body, context.get().0.clone());
         Box::new(futures::failed("Generic failure".into()))
     }
 
 
-    fn test_body_with_query_params(&self, query: String, body: models::User, context: &C) -> Box<Future<Item=TestBodyWithQueryParamsResponse, Error=ApiError>> {
+    fn test_body_with_query_params(&self, query: String, body: models::User, context: &C) -> Box<dyn Future<Item=TestBodyWithQueryParamsResponse, Error=ApiError>> {
         let context = context.clone();
         println!("test_body_with_query_params(\"{}\", {:?}) - X-Span-ID: {:?}", query, body, context.get().0.clone());
         Box::new(futures::failed("Generic failure".into()))
     }
 
     /// To test \"client\" model
-    fn test_client_model(&self, body: models::Client, context: &C) -> Box<Future<Item=TestClientModelResponse, Error=ApiError>> {
+    fn test_client_model(&self, body: models::Client, context: &C) -> Box<dyn Future<Item=TestClientModelResponse, Error=ApiError>> {
         let context = context.clone();
         println!("test_client_model({:?}) - X-Span-ID: {:?}", body, context.get().0.clone());
         Box::new(futures::failed("Generic failure".into()))
     }
 
     /// Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
-    fn test_endpoint_parameters(&self, number: f64, double: f64, pattern_without_delimiter: String, byte: swagger::ByteArray, integer: Option<i32>, int32: Option<i32>, int64: Option<i64>, float: Option<f32>, string: Option<String>, binary: Option<swagger::ByteArray>, date: Option<chrono::DateTime<chrono::Utc>>, date_time: Option<chrono::DateTime<chrono::Utc>>, password: Option<String>, callback: Option<String>, context: &C) -> Box<Future<Item=TestEndpointParametersResponse, Error=ApiError>> {
+    fn test_endpoint_parameters(&self, number: f64, double: f64, pattern_without_delimiter: String, byte: swagger::ByteArray, integer: Option<i32>, int32: Option<i32>, int64: Option<i64>, float: Option<f32>, string: Option<String>, binary: Option<swagger::ByteArray>, date: Option<chrono::DateTime<chrono::Utc>>, date_time: Option<chrono::DateTime<chrono::Utc>>, password: Option<String>, callback: Option<String>, context: &C) -> Box<dyn Future<Item=TestEndpointParametersResponse, Error=ApiError>> {
         let context = context.clone();
         println!("test_endpoint_parameters({}, {}, \"{}\", {:?}, {:?}, {:?}, {:?}, {:?}, {:?}, {:?}, {:?}, {:?}, {:?}, {:?}) - X-Span-ID: {:?}", number, double, pattern_without_delimiter, byte, integer, int32, int64, float, string, binary, date, date_time, password, callback, context.get().0.clone());
         Box::new(futures::failed("Generic failure".into()))
     }
 
     /// To test enum parameters
-    fn test_enum_parameters(&self, enum_header_string_array: Option<&Vec<String>>, enum_header_string: Option<String>, enum_query_string_array: Option<&Vec<String>>, enum_query_string: Option<String>, enum_query_integer: Option<i32>, enum_query_double: Option<f64>, enum_form_string: Option<String>, context: &C) -> Box<Future<Item=TestEnumParametersResponse, Error=ApiError>> {
+    fn test_enum_parameters(&self, enum_header_string_array: Option<&Vec<String>>, enum_header_string: Option<String>, enum_query_string_array: Option<&Vec<String>>, enum_query_string: Option<String>, enum_query_integer: Option<i32>, enum_query_double: Option<f64>, enum_form_string: Option<String>, context: &C) -> Box<dyn Future<Item=TestEnumParametersResponse, Error=ApiError>> {
         let context = context.clone();
         println!("test_enum_parameters({:?}, {:?}, {:?}, {:?}, {:?}, {:?}, {:?}) - X-Span-ID: {:?}", enum_header_string_array, enum_header_string, enum_query_string_array, enum_query_string, enum_query_integer, enum_query_double, enum_form_string, context.get().0.clone());
         Box::new(futures::failed("Generic failure".into()))
     }
 
     /// test inline additionalProperties
-    fn test_inline_additional_properties(&self, param: HashMap<String, String>, context: &C) -> Box<Future<Item=TestInlineAdditionalPropertiesResponse, Error=ApiError>> {
+    fn test_inline_additional_properties(&self, param: HashMap<String, String>, context: &C) -> Box<dyn Future<Item=TestInlineAdditionalPropertiesResponse, Error=ApiError>> {
         let context = context.clone();
         println!("test_inline_additional_properties({:?}) - X-Span-ID: {:?}", param, context.get().0.clone());
         Box::new(futures::failed("Generic failure".into()))
     }
 
     /// test json serialization of form data
-    fn test_json_form_data(&self, param: String, param2: String, context: &C) -> Box<Future<Item=TestJsonFormDataResponse, Error=ApiError>> {
+    fn test_json_form_data(&self, param: String, param2: String, context: &C) -> Box<dyn Future<Item=TestJsonFormDataResponse, Error=ApiError>> {
         let context = context.clone();
         println!("test_json_form_data(\"{}\", \"{}\") - X-Span-ID: {:?}", param, param2, context.get().0.clone());
         Box::new(futures::failed("Generic failure".into()))
     }
 
     /// To test class name in snake case
-    fn test_classname(&self, body: models::Client, context: &C) -> Box<Future<Item=TestClassnameResponse, Error=ApiError>> {
+    fn test_classname(&self, body: models::Client, context: &C) -> Box<dyn Future<Item=TestClassnameResponse, Error=ApiError>> {
         let context = context.clone();
         println!("test_classname({:?}) - X-Span-ID: {:?}", body, context.get().0.clone());
         Box::new(futures::failed("Generic failure".into()))
     }
 
     /// Add a new pet to the store
-    fn add_pet(&self, body: models::Pet, context: &C) -> Box<Future<Item=AddPetResponse, Error=ApiError>> {
+    fn add_pet(&self, body: models::Pet, context: &C) -> Box<dyn Future<Item=AddPetResponse, Error=ApiError>> {
         let context = context.clone();
         println!("add_pet({:?}) - X-Span-ID: {:?}", body, context.get().0.clone());
         Box::new(futures::failed("Generic failure".into()))
     }
 
     /// Deletes a pet
-    fn delete_pet(&self, pet_id: i64, api_key: Option<String>, context: &C) -> Box<Future<Item=DeletePetResponse, Error=ApiError>> {
+    fn delete_pet(&self, pet_id: i64, api_key: Option<String>, context: &C) -> Box<dyn Future<Item=DeletePetResponse, Error=ApiError>> {
         let context = context.clone();
         println!("delete_pet({}, {:?}) - X-Span-ID: {:?}", pet_id, api_key, context.get().0.clone());
         Box::new(futures::failed("Generic failure".into()))
     }
 
     /// Finds Pets by status
-    fn find_pets_by_status(&self, status: &Vec<String>, context: &C) -> Box<Future<Item=FindPetsByStatusResponse, Error=ApiError>> {
+    fn find_pets_by_status(&self, status: &Vec<String>, context: &C) -> Box<dyn Future<Item=FindPetsByStatusResponse, Error=ApiError>> {
         let context = context.clone();
         println!("find_pets_by_status({:?}) - X-Span-ID: {:?}", status, context.get().0.clone());
         Box::new(futures::failed("Generic failure".into()))
     }
 
     /// Finds Pets by tags
-    fn find_pets_by_tags(&self, tags: &Vec<String>, context: &C) -> Box<Future<Item=FindPetsByTagsResponse, Error=ApiError>> {
+    fn find_pets_by_tags(&self, tags: &Vec<String>, context: &C) -> Box<dyn Future<Item=FindPetsByTagsResponse, Error=ApiError>> {
         let context = context.clone();
         println!("find_pets_by_tags({:?}) - X-Span-ID: {:?}", tags, context.get().0.clone());
         Box::new(futures::failed("Generic failure".into()))
     }
 
     /// Find pet by ID
-    fn get_pet_by_id(&self, pet_id: i64, context: &C) -> Box<Future<Item=GetPetByIdResponse, Error=ApiError>> {
+    fn get_pet_by_id(&self, pet_id: i64, context: &C) -> Box<dyn Future<Item=GetPetByIdResponse, Error=ApiError>> {
         let context = context.clone();
         println!("get_pet_by_id({}) - X-Span-ID: {:?}", pet_id, context.get().0.clone());
         Box::new(futures::failed("Generic failure".into()))
     }
 
     /// Update an existing pet
-    fn update_pet(&self, body: models::Pet, context: &C) -> Box<Future<Item=UpdatePetResponse, Error=ApiError>> {
+    fn update_pet(&self, body: models::Pet, context: &C) -> Box<dyn Future<Item=UpdatePetResponse, Error=ApiError>> {
         let context = context.clone();
         println!("update_pet({:?}) - X-Span-ID: {:?}", body, context.get().0.clone());
         Box::new(futures::failed("Generic failure".into()))
     }
 
     /// Updates a pet in the store with form data
-    fn update_pet_with_form(&self, pet_id: i64, name: Option<String>, status: Option<String>, context: &C) -> Box<Future<Item=UpdatePetWithFormResponse, Error=ApiError>> {
+    fn update_pet_with_form(&self, pet_id: i64, name: Option<String>, status: Option<String>, context: &C) -> Box<dyn Future<Item=UpdatePetWithFormResponse, Error=ApiError>> {
         let context = context.clone();
         println!("update_pet_with_form({}, {:?}, {:?}) - X-Span-ID: {:?}", pet_id, name, status, context.get().0.clone());
         Box::new(futures::failed("Generic failure".into()))
     }
 
     /// uploads an image
-    fn upload_file(&self, pet_id: i64, additional_metadata: Option<String>, file: Option<swagger::ByteArray>, context: &C) -> Box<Future<Item=UploadFileResponse, Error=ApiError>> {
+    fn upload_file(&self, pet_id: i64, additional_metadata: Option<String>, file: Option<swagger::ByteArray>, context: &C) -> Box<dyn Future<Item=UploadFileResponse, Error=ApiError>> {
         let context = context.clone();
         println!("upload_file({}, {:?}, {:?}) - X-Span-ID: {:?}", pet_id, additional_metadata, file, context.get().0.clone());
         Box::new(futures::failed("Generic failure".into()))
     }
 
     /// Delete purchase order by ID
-    fn delete_order(&self, order_id: String, context: &C) -> Box<Future<Item=DeleteOrderResponse, Error=ApiError>> {
+    fn delete_order(&self, order_id: String, context: &C) -> Box<dyn Future<Item=DeleteOrderResponse, Error=ApiError>> {
         let context = context.clone();
         println!("delete_order(\"{}\") - X-Span-ID: {:?}", order_id, context.get().0.clone());
         Box::new(futures::failed("Generic failure".into()))
     }
 
     /// Returns pet inventories by status
-    fn get_inventory(&self, context: &C) -> Box<Future<Item=GetInventoryResponse, Error=ApiError>> {
+    fn get_inventory(&self, context: &C) -> Box<dyn Future<Item=GetInventoryResponse, Error=ApiError>> {
         let context = context.clone();
         println!("get_inventory() - X-Span-ID: {:?}", context.get().0.clone());
         Box::new(futures::failed("Generic failure".into()))
     }
 
     /// Find purchase order by ID
-    fn get_order_by_id(&self, order_id: i64, context: &C) -> Box<Future<Item=GetOrderByIdResponse, Error=ApiError>> {
+    fn get_order_by_id(&self, order_id: i64, context: &C) -> Box<dyn Future<Item=GetOrderByIdResponse, Error=ApiError>> {
         let context = context.clone();
         println!("get_order_by_id({}) - X-Span-ID: {:?}", order_id, context.get().0.clone());
         Box::new(futures::failed("Generic failure".into()))
     }
 
     /// Place an order for a pet
-    fn place_order(&self, body: models::Order, context: &C) -> Box<Future<Item=PlaceOrderResponse, Error=ApiError>> {
+    fn place_order(&self, body: models::Order, context: &C) -> Box<dyn Future<Item=PlaceOrderResponse, Error=ApiError>> {
         let context = context.clone();
         println!("place_order({:?}) - X-Span-ID: {:?}", body, context.get().0.clone());
         Box::new(futures::failed("Generic failure".into()))
     }
 
     /// Create user
-    fn create_user(&self, body: models::User, context: &C) -> Box<Future<Item=CreateUserResponse, Error=ApiError>> {
+    fn create_user(&self, body: models::User, context: &C) -> Box<dyn Future<Item=CreateUserResponse, Error=ApiError>> {
         let context = context.clone();
         println!("create_user({:?}) - X-Span-ID: {:?}", body, context.get().0.clone());
         Box::new(futures::failed("Generic failure".into()))
     }
 
     /// Creates list of users with given input array
-    fn create_users_with_array_input(&self, body: &Vec<models::User>, context: &C) -> Box<Future<Item=CreateUsersWithArrayInputResponse, Error=ApiError>> {
+    fn create_users_with_array_input(&self, body: &Vec<models::User>, context: &C) -> Box<dyn Future<Item=CreateUsersWithArrayInputResponse, Error=ApiError>> {
         let context = context.clone();
         println!("create_users_with_array_input({:?}) - X-Span-ID: {:?}", body, context.get().0.clone());
         Box::new(futures::failed("Generic failure".into()))
     }
 
     /// Creates list of users with given input array
-    fn create_users_with_list_input(&self, body: &Vec<models::User>, context: &C) -> Box<Future<Item=CreateUsersWithListInputResponse, Error=ApiError>> {
+    fn create_users_with_list_input(&self, body: &Vec<models::User>, context: &C) -> Box<dyn Future<Item=CreateUsersWithListInputResponse, Error=ApiError>> {
         let context = context.clone();
         println!("create_users_with_list_input({:?}) - X-Span-ID: {:?}", body, context.get().0.clone());
         Box::new(futures::failed("Generic failure".into()))
     }
 
     /// Delete user
-    fn delete_user(&self, username: String, context: &C) -> Box<Future<Item=DeleteUserResponse, Error=ApiError>> {
+    fn delete_user(&self, username: String, context: &C) -> Box<dyn Future<Item=DeleteUserResponse, Error=ApiError>> {
         let context = context.clone();
         println!("delete_user(\"{}\") - X-Span-ID: {:?}", username, context.get().0.clone());
         Box::new(futures::failed("Generic failure".into()))
     }
 
     /// Get user by user name
-    fn get_user_by_name(&self, username: String, context: &C) -> Box<Future<Item=GetUserByNameResponse, Error=ApiError>> {
+    fn get_user_by_name(&self, username: String, context: &C) -> Box<dyn Future<Item=GetUserByNameResponse, Error=ApiError>> {
         let context = context.clone();
         println!("get_user_by_name(\"{}\") - X-Span-ID: {:?}", username, context.get().0.clone());
         Box::new(futures::failed("Generic failure".into()))
     }
 
     /// Logs user into the system
-    fn login_user(&self, username: String, password: String, context: &C) -> Box<Future<Item=LoginUserResponse, Error=ApiError>> {
+    fn login_user(&self, username: String, password: String, context: &C) -> Box<dyn Future<Item=LoginUserResponse, Error=ApiError>> {
         let context = context.clone();
         println!("login_user(\"{}\", \"{}\") - X-Span-ID: {:?}", username, password, context.get().0.clone());
         Box::new(futures::failed("Generic failure".into()))
     }
 
     /// Logs out current logged in user session
-    fn logout_user(&self, context: &C) -> Box<Future<Item=LogoutUserResponse, Error=ApiError>> {
+    fn logout_user(&self, context: &C) -> Box<dyn Future<Item=LogoutUserResponse, Error=ApiError>> {
         let context = context.clone();
         println!("logout_user() - X-Span-ID: {:?}", context.get().0.clone());
         Box::new(futures::failed("Generic failure".into()))
     }
 
     /// Updated user
-    fn update_user(&self, username: String, body: models::User, context: &C) -> Box<Future<Item=UpdateUserResponse, Error=ApiError>> {
+    fn update_user(&self, username: String, body: models::User, context: &C) -> Box<dyn Future<Item=UpdateUserResponse, Error=ApiError>> {
         let context = context.clone();
         println!("update_user(\"{}\", {:?}) - X-Span-ID: {:?}", username, body, context.get().0.clone());
         Box::new(futures::failed("Generic failure".into()))

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/src/client/mod.rs
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/src/client/mod.rs
@@ -107,7 +107,7 @@ fn into_base_path(input: &str, correct_scheme: Option<&'static str>) -> Result<S
 /// A client that implements the API by making HTTP calls out to a server.
 pub struct Client<F> where
   F: Future<Item=hyper::Response, Error=hyper::Error> + 'static {
-    client_service: Arc<Box<hyper::client::Service<Request=hyper::Request<hyper::Body>, Response=hyper::Response, Error=hyper::Error, Future=F>>>,
+    client_service: Arc<Box<dyn hyper::client::Service<Request=hyper::Request<hyper::Body>, Response=hyper::Response, Error=hyper::Error, Future=F>>>,
     base_path: String,
 }
 
@@ -218,7 +218,7 @@ impl Client<hyper::client::FutureResponse> {
         handle: Handle,
         base_path: &str,
         protocol: Option<&'static str>,
-        connector_fn: Box<Fn(&Handle) -> C + Send + Sync>,
+        connector_fn: Box<dyn Fn(&Handle) -> C + Send + Sync>,
     ) -> Result<Client<hyper::client::FutureResponse>, ClientInitError>
     where
         C: hyper::client::Connect + hyper::client::Service,
@@ -245,7 +245,7 @@ impl Client<hyper::client::FutureResponse> {
     /// should be mentioned here.
     #[deprecated(note="Use try_new_with_client_service instead")]
     pub fn try_new_with_hyper_client(
-        hyper_client: Arc<Box<hyper::client::Service<Request=hyper::Request<hyper::Body>, Response=hyper::Response, Error=hyper::Error, Future=hyper::client::FutureResponse>>>,
+        hyper_client: Arc<Box<dyn hyper::client::Service<Request=hyper::Request<hyper::Body>, Response=hyper::Response, Error=hyper::Error, Future=hyper::client::FutureResponse>>>,
         handle: Handle,
         base_path: &str
     ) -> Result<Client<hyper::client::FutureResponse>, ClientInitError>
@@ -263,7 +263,7 @@ impl<F> Client<F> where
     /// Constructor for creating a `Client` by passing in a pre-made `hyper` client Service.
     ///
     /// This allows adding custom wrappers around the underlying transport, for example for logging.
-    pub fn try_new_with_client_service(client_service: Arc<Box<hyper::client::Service<Request=hyper::Request<hyper::Body>, Response=hyper::Response, Error=hyper::Error, Future=F>>>,
+    pub fn try_new_with_client_service(client_service: Arc<Box<dyn hyper::client::Service<Request=hyper::Request<hyper::Body>, Response=hyper::Response, Error=hyper::Error, Future=F>>>,
                                        handle: Handle,
                                        base_path: &str)
                                     -> Result<Client<F>, ClientInitError>
@@ -279,7 +279,7 @@ impl<F, C> Api<C> for Client<F> where
     F: Future<Item=hyper::Response, Error=hyper::Error>  + 'static,
     C: Has<XSpanIdString> + Has<Option<AuthData>>{
 
-    fn test_special_tags(&self, param_body: models::Client, context: &C) -> Box<Future<Item=TestSpecialTagsResponse, Error=ApiError>> {
+    fn test_special_tags(&self, param_body: models::Client, context: &C) -> Box<dyn Future<Item=TestSpecialTagsResponse, Error=ApiError>> {
         let mut uri = format!(
             "{}/v2/another-fake/dummy",
             self.base_path
@@ -307,7 +307,7 @@ impl<F, C> Api<C> for Client<F> where
 
         request.headers_mut().set(ContentType(mimetypes::requests::TEST_SPECIAL_TAGS.clone()));
 
-        request.headers_mut().set(XSpanId((context as &Has<XSpanIdString>).get().0.clone()));
+        request.headers_mut().set(XSpanId((context as &dyn Has<XSpanIdString>).get().0.clone()));
         Box::new(self.client_service.call(request)
                              .map_err(|e| ApiError(format!("No response received: {}", e)))
                              .and_then(|mut response| {
@@ -329,7 +329,7 @@ impl<F, C> Api<C> for Client<F> where
                         .map(move |body| {
                             TestSpecialTagsResponse::SuccessfulOperation(body)
                         })
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 },
                 code => {
                     let headers = response.headers().clone();
@@ -348,14 +348,14 @@ impl<F, C> Api<C> for Client<F> where
                                         Err(e) => Cow::from(format!("<Failed to read body: {}>", e)),
                                     })))
                             )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 }
             }
         }))
 
     }
 
-    fn fake_outer_boolean_serialize(&self, param_body: Option<models::OuterBoolean>, context: &C) -> Box<Future<Item=FakeOuterBooleanSerializeResponse, Error=ApiError>> {
+    fn fake_outer_boolean_serialize(&self, param_body: Option<models::OuterBoolean>, context: &C) -> Box<dyn Future<Item=FakeOuterBooleanSerializeResponse, Error=ApiError>> {
         let mut uri = format!(
             "{}/v2/fake/outer/boolean",
             self.base_path
@@ -388,7 +388,7 @@ impl<F, C> Api<C> for Client<F> where
 
         request.headers_mut().set(ContentType(mimetypes::requests::FAKE_OUTER_BOOLEAN_SERIALIZE.clone()));
 
-        request.headers_mut().set(XSpanId((context as &Has<XSpanIdString>).get().0.clone()));
+        request.headers_mut().set(XSpanId((context as &dyn Has<XSpanIdString>).get().0.clone()));
         Box::new(self.client_service.call(request)
                              .map_err(|e| ApiError(format!("No response received: {}", e)))
                              .and_then(|mut response| {
@@ -410,7 +410,7 @@ impl<F, C> Api<C> for Client<F> where
                         .map(move |body| {
                             FakeOuterBooleanSerializeResponse::OutputBoolean(body)
                         })
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 },
                 code => {
                     let headers = response.headers().clone();
@@ -429,14 +429,14 @@ impl<F, C> Api<C> for Client<F> where
                                         Err(e) => Cow::from(format!("<Failed to read body: {}>", e)),
                                     })))
                             )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 }
             }
         }))
 
     }
 
-    fn fake_outer_composite_serialize(&self, param_body: Option<models::OuterComposite>, context: &C) -> Box<Future<Item=FakeOuterCompositeSerializeResponse, Error=ApiError>> {
+    fn fake_outer_composite_serialize(&self, param_body: Option<models::OuterComposite>, context: &C) -> Box<dyn Future<Item=FakeOuterCompositeSerializeResponse, Error=ApiError>> {
         let mut uri = format!(
             "{}/v2/fake/outer/composite",
             self.base_path
@@ -468,7 +468,7 @@ impl<F, C> Api<C> for Client<F> where
 
         request.headers_mut().set(ContentType(mimetypes::requests::FAKE_OUTER_COMPOSITE_SERIALIZE.clone()));
 
-        request.headers_mut().set(XSpanId((context as &Has<XSpanIdString>).get().0.clone()));
+        request.headers_mut().set(XSpanId((context as &dyn Has<XSpanIdString>).get().0.clone()));
         Box::new(self.client_service.call(request)
                              .map_err(|e| ApiError(format!("No response received: {}", e)))
                              .and_then(|mut response| {
@@ -490,7 +490,7 @@ impl<F, C> Api<C> for Client<F> where
                         .map(move |body| {
                             FakeOuterCompositeSerializeResponse::OutputComposite(body)
                         })
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 },
                 code => {
                     let headers = response.headers().clone();
@@ -509,14 +509,14 @@ impl<F, C> Api<C> for Client<F> where
                                         Err(e) => Cow::from(format!("<Failed to read body: {}>", e)),
                                     })))
                             )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 }
             }
         }))
 
     }
 
-    fn fake_outer_number_serialize(&self, param_body: Option<models::OuterNumber>, context: &C) -> Box<Future<Item=FakeOuterNumberSerializeResponse, Error=ApiError>> {
+    fn fake_outer_number_serialize(&self, param_body: Option<models::OuterNumber>, context: &C) -> Box<dyn Future<Item=FakeOuterNumberSerializeResponse, Error=ApiError>> {
         let mut uri = format!(
             "{}/v2/fake/outer/number",
             self.base_path
@@ -548,7 +548,7 @@ impl<F, C> Api<C> for Client<F> where
 
         request.headers_mut().set(ContentType(mimetypes::requests::FAKE_OUTER_NUMBER_SERIALIZE.clone()));
 
-        request.headers_mut().set(XSpanId((context as &Has<XSpanIdString>).get().0.clone()));
+        request.headers_mut().set(XSpanId((context as &dyn Has<XSpanIdString>).get().0.clone()));
         Box::new(self.client_service.call(request)
                              .map_err(|e| ApiError(format!("No response received: {}", e)))
                              .and_then(|mut response| {
@@ -570,7 +570,7 @@ impl<F, C> Api<C> for Client<F> where
                         .map(move |body| {
                             FakeOuterNumberSerializeResponse::OutputNumber(body)
                         })
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 },
                 code => {
                     let headers = response.headers().clone();
@@ -589,14 +589,14 @@ impl<F, C> Api<C> for Client<F> where
                                         Err(e) => Cow::from(format!("<Failed to read body: {}>", e)),
                                     })))
                             )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 }
             }
         }))
 
     }
 
-    fn fake_outer_string_serialize(&self, param_body: Option<models::OuterString>, context: &C) -> Box<Future<Item=FakeOuterStringSerializeResponse, Error=ApiError>> {
+    fn fake_outer_string_serialize(&self, param_body: Option<models::OuterString>, context: &C) -> Box<dyn Future<Item=FakeOuterStringSerializeResponse, Error=ApiError>> {
         let mut uri = format!(
             "{}/v2/fake/outer/string",
             self.base_path
@@ -628,7 +628,7 @@ impl<F, C> Api<C> for Client<F> where
 
         request.headers_mut().set(ContentType(mimetypes::requests::FAKE_OUTER_STRING_SERIALIZE.clone()));
 
-        request.headers_mut().set(XSpanId((context as &Has<XSpanIdString>).get().0.clone()));
+        request.headers_mut().set(XSpanId((context as &dyn Has<XSpanIdString>).get().0.clone()));
         Box::new(self.client_service.call(request)
                              .map_err(|e| ApiError(format!("No response received: {}", e)))
                              .and_then(|mut response| {
@@ -650,7 +650,7 @@ impl<F, C> Api<C> for Client<F> where
                         .map(move |body| {
                             FakeOuterStringSerializeResponse::OutputString(body)
                         })
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 },
                 code => {
                     let headers = response.headers().clone();
@@ -669,14 +669,14 @@ impl<F, C> Api<C> for Client<F> where
                                         Err(e) => Cow::from(format!("<Failed to read body: {}>", e)),
                                     })))
                             )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 }
             }
         }))
 
     }
 
-    fn test_body_with_query_params(&self, param_query: String, param_body: models::User, context: &C) -> Box<Future<Item=TestBodyWithQueryParamsResponse, Error=ApiError>> {
+    fn test_body_with_query_params(&self, param_query: String, param_body: models::User, context: &C) -> Box<dyn Future<Item=TestBodyWithQueryParamsResponse, Error=ApiError>> {
         let mut uri = format!(
             "{}/v2/fake/body-with-query-params",
             self.base_path
@@ -704,7 +704,7 @@ impl<F, C> Api<C> for Client<F> where
 
         request.headers_mut().set(ContentType(mimetypes::requests::TEST_BODY_WITH_QUERY_PARAMS.clone()));
 
-        request.headers_mut().set(XSpanId((context as &Has<XSpanIdString>).get().0.clone()));
+        request.headers_mut().set(XSpanId((context as &dyn Has<XSpanIdString>).get().0.clone()));
         Box::new(self.client_service.call(request)
                              .map_err(|e| ApiError(format!("No response received: {}", e)))
                              .and_then(|mut response| {
@@ -716,7 +716,7 @@ impl<F, C> Api<C> for Client<F> where
                         future::ok(
                             TestBodyWithQueryParamsResponse::Success
                         )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 },
                 code => {
                     let headers = response.headers().clone();
@@ -735,14 +735,14 @@ impl<F, C> Api<C> for Client<F> where
                                         Err(e) => Cow::from(format!("<Failed to read body: {}>", e)),
                                     })))
                             )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 }
             }
         }))
 
     }
 
-    fn test_client_model(&self, param_body: models::Client, context: &C) -> Box<Future<Item=TestClientModelResponse, Error=ApiError>> {
+    fn test_client_model(&self, param_body: models::Client, context: &C) -> Box<dyn Future<Item=TestClientModelResponse, Error=ApiError>> {
         let mut uri = format!(
             "{}/v2/fake",
             self.base_path
@@ -769,7 +769,7 @@ impl<F, C> Api<C> for Client<F> where
 
         request.headers_mut().set(ContentType(mimetypes::requests::TEST_CLIENT_MODEL.clone()));
 
-        request.headers_mut().set(XSpanId((context as &Has<XSpanIdString>).get().0.clone()));
+        request.headers_mut().set(XSpanId((context as &dyn Has<XSpanIdString>).get().0.clone()));
         Box::new(self.client_service.call(request)
                              .map_err(|e| ApiError(format!("No response received: {}", e)))
                              .and_then(|mut response| {
@@ -791,7 +791,7 @@ impl<F, C> Api<C> for Client<F> where
                         .map(move |body| {
                             TestClientModelResponse::SuccessfulOperation(body)
                         })
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 },
                 code => {
                     let headers = response.headers().clone();
@@ -810,14 +810,14 @@ impl<F, C> Api<C> for Client<F> where
                                         Err(e) => Cow::from(format!("<Failed to read body: {}>", e)),
                                     })))
                             )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 }
             }
         }))
 
     }
 
-    fn test_endpoint_parameters(&self, param_number: f64, param_double: f64, param_pattern_without_delimiter: String, param_byte: swagger::ByteArray, param_integer: Option<i32>, param_int32: Option<i32>, param_int64: Option<i64>, param_float: Option<f32>, param_string: Option<String>, param_binary: Option<swagger::ByteArray>, param_date: Option<chrono::DateTime<chrono::Utc>>, param_date_time: Option<chrono::DateTime<chrono::Utc>>, param_password: Option<String>, param_callback: Option<String>, context: &C) -> Box<Future<Item=TestEndpointParametersResponse, Error=ApiError>> {
+    fn test_endpoint_parameters(&self, param_number: f64, param_double: f64, param_pattern_without_delimiter: String, param_byte: swagger::ByteArray, param_integer: Option<i32>, param_int32: Option<i32>, param_int64: Option<i64>, param_float: Option<f32>, param_string: Option<String>, param_binary: Option<swagger::ByteArray>, param_date: Option<chrono::DateTime<chrono::Utc>>, param_date_time: Option<chrono::DateTime<chrono::Utc>>, param_password: Option<String>, param_callback: Option<String>, context: &C) -> Box<dyn Future<Item=TestEndpointParametersResponse, Error=ApiError>> {
         let mut uri = format!(
             "{}/v2/fake",
             self.base_path
@@ -860,9 +860,9 @@ impl<F, C> Api<C> for Client<F> where
         request.headers_mut().set(ContentType(mimetypes::requests::TEST_ENDPOINT_PARAMETERS.clone()));
         request.set_body(body.into_bytes());
 
-        request.headers_mut().set(XSpanId((context as &Has<XSpanIdString>).get().0.clone()));
+        request.headers_mut().set(XSpanId((context as &dyn Has<XSpanIdString>).get().0.clone()));
 
-        (context as &Has<Option<AuthData>>).get().as_ref().map(|auth_data| {
+        (context as &dyn Has<Option<AuthData>>).get().as_ref().map(|auth_data| {
             // Currently only authentication with Basic, API Key, and Bearer are supported
             match auth_data {
                 &AuthData::Basic(ref basic_header) => {
@@ -884,7 +884,7 @@ impl<F, C> Api<C> for Client<F> where
                         future::ok(
                             TestEndpointParametersResponse::InvalidUsernameSupplied
                         )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 },
                 404 => {
                     let body = response.body();
@@ -893,7 +893,7 @@ impl<F, C> Api<C> for Client<F> where
                         future::ok(
                             TestEndpointParametersResponse::UserNotFound
                         )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 },
                 code => {
                     let headers = response.headers().clone();
@@ -912,14 +912,14 @@ impl<F, C> Api<C> for Client<F> where
                                         Err(e) => Cow::from(format!("<Failed to read body: {}>", e)),
                                     })))
                             )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 }
             }
         }))
 
     }
 
-    fn test_enum_parameters(&self, param_enum_header_string_array: Option<&Vec<String>>, param_enum_header_string: Option<String>, param_enum_query_string_array: Option<&Vec<String>>, param_enum_query_string: Option<String>, param_enum_query_integer: Option<i32>, param_enum_query_double: Option<f64>, param_enum_form_string: Option<String>, context: &C) -> Box<Future<Item=TestEnumParametersResponse, Error=ApiError>> {
+    fn test_enum_parameters(&self, param_enum_header_string_array: Option<&Vec<String>>, param_enum_header_string: Option<String>, param_enum_query_string_array: Option<&Vec<String>>, param_enum_query_string: Option<String>, param_enum_query_integer: Option<i32>, param_enum_query_double: Option<f64>, param_enum_form_string: Option<String>, context: &C) -> Box<dyn Future<Item=TestEnumParametersResponse, Error=ApiError>> {
         let mut uri = format!(
             "{}/v2/fake",
             self.base_path
@@ -961,7 +961,7 @@ impl<F, C> Api<C> for Client<F> where
         request.headers_mut().set(ContentType(mimetypes::requests::TEST_ENUM_PARAMETERS.clone()));
         request.set_body(body.into_bytes());
 
-        request.headers_mut().set(XSpanId((context as &Has<XSpanIdString>).get().0.clone()));
+        request.headers_mut().set(XSpanId((context as &dyn Has<XSpanIdString>).get().0.clone()));
 
         // Header parameters
         header! { (RequestEnumHeaderStringArray, "enum_header_string_array") => (String)* }
@@ -979,7 +979,7 @@ impl<F, C> Api<C> for Client<F> where
                         future::ok(
                             TestEnumParametersResponse::InvalidRequest
                         )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 },
                 404 => {
                     let body = response.body();
@@ -988,7 +988,7 @@ impl<F, C> Api<C> for Client<F> where
                         future::ok(
                             TestEnumParametersResponse::NotFound
                         )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 },
                 code => {
                     let headers = response.headers().clone();
@@ -1007,14 +1007,14 @@ impl<F, C> Api<C> for Client<F> where
                                         Err(e) => Cow::from(format!("<Failed to read body: {}>", e)),
                                     })))
                             )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 }
             }
         }))
 
     }
 
-    fn test_inline_additional_properties(&self, param_param: HashMap<String, String>, context: &C) -> Box<Future<Item=TestInlineAdditionalPropertiesResponse, Error=ApiError>> {
+    fn test_inline_additional_properties(&self, param_param: HashMap<String, String>, context: &C) -> Box<dyn Future<Item=TestInlineAdditionalPropertiesResponse, Error=ApiError>> {
         let mut uri = format!(
             "{}/v2/fake/inline-additionalProperties",
             self.base_path
@@ -1041,7 +1041,7 @@ impl<F, C> Api<C> for Client<F> where
 
         request.headers_mut().set(ContentType(mimetypes::requests::TEST_INLINE_ADDITIONAL_PROPERTIES.clone()));
 
-        request.headers_mut().set(XSpanId((context as &Has<XSpanIdString>).get().0.clone()));
+        request.headers_mut().set(XSpanId((context as &dyn Has<XSpanIdString>).get().0.clone()));
         Box::new(self.client_service.call(request)
                              .map_err(|e| ApiError(format!("No response received: {}", e)))
                              .and_then(|mut response| {
@@ -1053,7 +1053,7 @@ impl<F, C> Api<C> for Client<F> where
                         future::ok(
                             TestInlineAdditionalPropertiesResponse::SuccessfulOperation
                         )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 },
                 code => {
                     let headers = response.headers().clone();
@@ -1072,14 +1072,14 @@ impl<F, C> Api<C> for Client<F> where
                                         Err(e) => Cow::from(format!("<Failed to read body: {}>", e)),
                                     })))
                             )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 }
             }
         }))
 
     }
 
-    fn test_json_form_data(&self, param_param: String, param_param2: String, context: &C) -> Box<Future<Item=TestJsonFormDataResponse, Error=ApiError>> {
+    fn test_json_form_data(&self, param_param: String, param_param2: String, context: &C) -> Box<dyn Future<Item=TestJsonFormDataResponse, Error=ApiError>> {
         let mut uri = format!(
             "{}/v2/fake/jsonFormData",
             self.base_path
@@ -1110,7 +1110,7 @@ impl<F, C> Api<C> for Client<F> where
         request.headers_mut().set(ContentType(mimetypes::requests::TEST_JSON_FORM_DATA.clone()));
         request.set_body(body.into_bytes());
 
-        request.headers_mut().set(XSpanId((context as &Has<XSpanIdString>).get().0.clone()));
+        request.headers_mut().set(XSpanId((context as &dyn Has<XSpanIdString>).get().0.clone()));
         Box::new(self.client_service.call(request)
                              .map_err(|e| ApiError(format!("No response received: {}", e)))
                              .and_then(|mut response| {
@@ -1122,7 +1122,7 @@ impl<F, C> Api<C> for Client<F> where
                         future::ok(
                             TestJsonFormDataResponse::SuccessfulOperation
                         )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 },
                 code => {
                     let headers = response.headers().clone();
@@ -1141,14 +1141,14 @@ impl<F, C> Api<C> for Client<F> where
                                         Err(e) => Cow::from(format!("<Failed to read body: {}>", e)),
                                     })))
                             )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 }
             }
         }))
 
     }
 
-    fn test_classname(&self, param_body: models::Client, context: &C) -> Box<Future<Item=TestClassnameResponse, Error=ApiError>> {
+    fn test_classname(&self, param_body: models::Client, context: &C) -> Box<dyn Future<Item=TestClassnameResponse, Error=ApiError>> {
         let mut uri = format!(
             "{}/v2/fake_classname_test",
             self.base_path
@@ -1156,7 +1156,7 @@ impl<F, C> Api<C> for Client<F> where
 
         let mut query_string = self::url::form_urlencoded::Serializer::new("".to_owned());
 
-        if let Some(auth_data) = (context as &Has<Option<AuthData>>).get().as_ref() {
+        if let Some(auth_data) = (context as &dyn Has<Option<AuthData>>).get().as_ref() {
             if let AuthData::ApiKey(ref api_key) = *auth_data {
                 query_string.append_pair("api_key_query", api_key);
             }
@@ -1180,7 +1180,7 @@ impl<F, C> Api<C> for Client<F> where
 
         request.headers_mut().set(ContentType(mimetypes::requests::TEST_CLASSNAME.clone()));
 
-        request.headers_mut().set(XSpanId((context as &Has<XSpanIdString>).get().0.clone()));
+        request.headers_mut().set(XSpanId((context as &dyn Has<XSpanIdString>).get().0.clone()));
         Box::new(self.client_service.call(request)
                              .map_err(|e| ApiError(format!("No response received: {}", e)))
                              .and_then(|mut response| {
@@ -1202,7 +1202,7 @@ impl<F, C> Api<C> for Client<F> where
                         .map(move |body| {
                             TestClassnameResponse::SuccessfulOperation(body)
                         })
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 },
                 code => {
                     let headers = response.headers().clone();
@@ -1221,14 +1221,14 @@ impl<F, C> Api<C> for Client<F> where
                                         Err(e) => Cow::from(format!("<Failed to read body: {}>", e)),
                                     })))
                             )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 }
             }
         }))
 
     }
 
-    fn add_pet(&self, param_body: models::Pet, context: &C) -> Box<Future<Item=AddPetResponse, Error=ApiError>> {
+    fn add_pet(&self, param_body: models::Pet, context: &C) -> Box<dyn Future<Item=AddPetResponse, Error=ApiError>> {
         let mut uri = format!(
             "{}/v2/pet",
             self.base_path
@@ -1256,9 +1256,9 @@ impl<F, C> Api<C> for Client<F> where
 
         request.headers_mut().set(ContentType(mimetypes::requests::ADD_PET.clone()));
 
-        request.headers_mut().set(XSpanId((context as &Has<XSpanIdString>).get().0.clone()));
+        request.headers_mut().set(XSpanId((context as &dyn Has<XSpanIdString>).get().0.clone()));
 
-        (context as &Has<Option<AuthData>>).get().as_ref().map(|auth_data| {
+        (context as &dyn Has<Option<AuthData>>).get().as_ref().map(|auth_data| {
             // Currently only authentication with Basic, API Key, and Bearer are supported
             match auth_data {
                 &AuthData::Bearer(ref bearer_header) => {
@@ -1280,7 +1280,7 @@ impl<F, C> Api<C> for Client<F> where
                         future::ok(
                             AddPetResponse::InvalidInput
                         )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 },
                 code => {
                     let headers = response.headers().clone();
@@ -1299,14 +1299,14 @@ impl<F, C> Api<C> for Client<F> where
                                         Err(e) => Cow::from(format!("<Failed to read body: {}>", e)),
                                     })))
                             )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 }
             }
         }))
 
     }
 
-    fn delete_pet(&self, param_pet_id: i64, param_api_key: Option<String>, context: &C) -> Box<Future<Item=DeletePetResponse, Error=ApiError>> {
+    fn delete_pet(&self, param_pet_id: i64, param_api_key: Option<String>, context: &C) -> Box<dyn Future<Item=DeletePetResponse, Error=ApiError>> {
         let mut uri = format!(
             "{}/v2/pet/{petId}",
             self.base_path, petId=utf8_percent_encode(&param_pet_id.to_string(), ID_ENCODE_SET)
@@ -1329,9 +1329,9 @@ impl<F, C> Api<C> for Client<F> where
         let mut request = hyper::Request::new(hyper::Method::Delete, uri);
 
 
-        request.headers_mut().set(XSpanId((context as &Has<XSpanIdString>).get().0.clone()));
+        request.headers_mut().set(XSpanId((context as &dyn Has<XSpanIdString>).get().0.clone()));
 
-        (context as &Has<Option<AuthData>>).get().as_ref().map(|auth_data| {
+        (context as &dyn Has<Option<AuthData>>).get().as_ref().map(|auth_data| {
             // Currently only authentication with Basic, API Key, and Bearer are supported
             match auth_data {
                 &AuthData::Bearer(ref bearer_header) => {
@@ -1357,7 +1357,7 @@ impl<F, C> Api<C> for Client<F> where
                         future::ok(
                             DeletePetResponse::InvalidPetValue
                         )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 },
                 code => {
                     let headers = response.headers().clone();
@@ -1376,14 +1376,14 @@ impl<F, C> Api<C> for Client<F> where
                                         Err(e) => Cow::from(format!("<Failed to read body: {}>", e)),
                                     })))
                             )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 }
             }
         }))
 
     }
 
-    fn find_pets_by_status(&self, param_status: &Vec<String>, context: &C) -> Box<Future<Item=FindPetsByStatusResponse, Error=ApiError>> {
+    fn find_pets_by_status(&self, param_status: &Vec<String>, context: &C) -> Box<dyn Future<Item=FindPetsByStatusResponse, Error=ApiError>> {
         let mut uri = format!(
             "{}/v2/pet/findByStatus",
             self.base_path
@@ -1407,9 +1407,9 @@ impl<F, C> Api<C> for Client<F> where
         let mut request = hyper::Request::new(hyper::Method::Get, uri);
 
 
-        request.headers_mut().set(XSpanId((context as &Has<XSpanIdString>).get().0.clone()));
+        request.headers_mut().set(XSpanId((context as &dyn Has<XSpanIdString>).get().0.clone()));
 
-        (context as &Has<Option<AuthData>>).get().as_ref().map(|auth_data| {
+        (context as &dyn Has<Option<AuthData>>).get().as_ref().map(|auth_data| {
             // Currently only authentication with Basic, API Key, and Bearer are supported
             match auth_data {
                 &AuthData::Bearer(ref bearer_header) => {
@@ -1443,7 +1443,7 @@ impl<F, C> Api<C> for Client<F> where
                         .map(move |body| {
                             FindPetsByStatusResponse::SuccessfulOperation(body)
                         })
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 },
                 400 => {
                     let body = response.body();
@@ -1452,7 +1452,7 @@ impl<F, C> Api<C> for Client<F> where
                         future::ok(
                             FindPetsByStatusResponse::InvalidStatusValue
                         )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 },
                 code => {
                     let headers = response.headers().clone();
@@ -1471,14 +1471,14 @@ impl<F, C> Api<C> for Client<F> where
                                         Err(e) => Cow::from(format!("<Failed to read body: {}>", e)),
                                     })))
                             )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 }
             }
         }))
 
     }
 
-    fn find_pets_by_tags(&self, param_tags: &Vec<String>, context: &C) -> Box<Future<Item=FindPetsByTagsResponse, Error=ApiError>> {
+    fn find_pets_by_tags(&self, param_tags: &Vec<String>, context: &C) -> Box<dyn Future<Item=FindPetsByTagsResponse, Error=ApiError>> {
         let mut uri = format!(
             "{}/v2/pet/findByTags",
             self.base_path
@@ -1502,9 +1502,9 @@ impl<F, C> Api<C> for Client<F> where
         let mut request = hyper::Request::new(hyper::Method::Get, uri);
 
 
-        request.headers_mut().set(XSpanId((context as &Has<XSpanIdString>).get().0.clone()));
+        request.headers_mut().set(XSpanId((context as &dyn Has<XSpanIdString>).get().0.clone()));
 
-        (context as &Has<Option<AuthData>>).get().as_ref().map(|auth_data| {
+        (context as &dyn Has<Option<AuthData>>).get().as_ref().map(|auth_data| {
             // Currently only authentication with Basic, API Key, and Bearer are supported
             match auth_data {
                 &AuthData::Bearer(ref bearer_header) => {
@@ -1538,7 +1538,7 @@ impl<F, C> Api<C> for Client<F> where
                         .map(move |body| {
                             FindPetsByTagsResponse::SuccessfulOperation(body)
                         })
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 },
                 400 => {
                     let body = response.body();
@@ -1547,7 +1547,7 @@ impl<F, C> Api<C> for Client<F> where
                         future::ok(
                             FindPetsByTagsResponse::InvalidTagValue
                         )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 },
                 code => {
                     let headers = response.headers().clone();
@@ -1566,14 +1566,14 @@ impl<F, C> Api<C> for Client<F> where
                                         Err(e) => Cow::from(format!("<Failed to read body: {}>", e)),
                                     })))
                             )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 }
             }
         }))
 
     }
 
-    fn get_pet_by_id(&self, param_pet_id: i64, context: &C) -> Box<Future<Item=GetPetByIdResponse, Error=ApiError>> {
+    fn get_pet_by_id(&self, param_pet_id: i64, context: &C) -> Box<dyn Future<Item=GetPetByIdResponse, Error=ApiError>> {
         let mut uri = format!(
             "{}/v2/pet/{petId}",
             self.base_path, petId=utf8_percent_encode(&param_pet_id.to_string(), ID_ENCODE_SET)
@@ -1596,9 +1596,9 @@ impl<F, C> Api<C> for Client<F> where
         let mut request = hyper::Request::new(hyper::Method::Get, uri);
 
 
-        request.headers_mut().set(XSpanId((context as &Has<XSpanIdString>).get().0.clone()));
+        request.headers_mut().set(XSpanId((context as &dyn Has<XSpanIdString>).get().0.clone()));
 
-        (context as &Has<Option<AuthData>>).get().as_ref().map(|auth_data| {
+        (context as &dyn Has<Option<AuthData>>).get().as_ref().map(|auth_data| {
             // Currently only authentication with Basic, API Key, and Bearer are supported
             match auth_data {
                 &AuthData::ApiKey(ref api_key) => {
@@ -1633,7 +1633,7 @@ impl<F, C> Api<C> for Client<F> where
                         .map(move |body| {
                             GetPetByIdResponse::SuccessfulOperation(body)
                         })
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 },
                 400 => {
                     let body = response.body();
@@ -1642,7 +1642,7 @@ impl<F, C> Api<C> for Client<F> where
                         future::ok(
                             GetPetByIdResponse::InvalidIDSupplied
                         )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 },
                 404 => {
                     let body = response.body();
@@ -1651,7 +1651,7 @@ impl<F, C> Api<C> for Client<F> where
                         future::ok(
                             GetPetByIdResponse::PetNotFound
                         )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 },
                 code => {
                     let headers = response.headers().clone();
@@ -1670,14 +1670,14 @@ impl<F, C> Api<C> for Client<F> where
                                         Err(e) => Cow::from(format!("<Failed to read body: {}>", e)),
                                     })))
                             )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 }
             }
         }))
 
     }
 
-    fn update_pet(&self, param_body: models::Pet, context: &C) -> Box<Future<Item=UpdatePetResponse, Error=ApiError>> {
+    fn update_pet(&self, param_body: models::Pet, context: &C) -> Box<dyn Future<Item=UpdatePetResponse, Error=ApiError>> {
         let mut uri = format!(
             "{}/v2/pet",
             self.base_path
@@ -1704,9 +1704,9 @@ impl<F, C> Api<C> for Client<F> where
 
         request.headers_mut().set(ContentType(mimetypes::requests::UPDATE_PET.clone()));
 
-        request.headers_mut().set(XSpanId((context as &Has<XSpanIdString>).get().0.clone()));
+        request.headers_mut().set(XSpanId((context as &dyn Has<XSpanIdString>).get().0.clone()));
 
-        (context as &Has<Option<AuthData>>).get().as_ref().map(|auth_data| {
+        (context as &dyn Has<Option<AuthData>>).get().as_ref().map(|auth_data| {
             // Currently only authentication with Basic, API Key, and Bearer are supported
             match auth_data {
                 &AuthData::Bearer(ref bearer_header) => {
@@ -1728,7 +1728,7 @@ impl<F, C> Api<C> for Client<F> where
                         future::ok(
                             UpdatePetResponse::InvalidIDSupplied
                         )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 },
                 404 => {
                     let body = response.body();
@@ -1737,7 +1737,7 @@ impl<F, C> Api<C> for Client<F> where
                         future::ok(
                             UpdatePetResponse::PetNotFound
                         )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 },
                 405 => {
                     let body = response.body();
@@ -1746,7 +1746,7 @@ impl<F, C> Api<C> for Client<F> where
                         future::ok(
                             UpdatePetResponse::ValidationException
                         )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 },
                 code => {
                     let headers = response.headers().clone();
@@ -1765,14 +1765,14 @@ impl<F, C> Api<C> for Client<F> where
                                         Err(e) => Cow::from(format!("<Failed to read body: {}>", e)),
                                     })))
                             )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 }
             }
         }))
 
     }
 
-    fn update_pet_with_form(&self, param_pet_id: i64, param_name: Option<String>, param_status: Option<String>, context: &C) -> Box<Future<Item=UpdatePetWithFormResponse, Error=ApiError>> {
+    fn update_pet_with_form(&self, param_pet_id: i64, param_name: Option<String>, param_status: Option<String>, context: &C) -> Box<dyn Future<Item=UpdatePetWithFormResponse, Error=ApiError>> {
         let mut uri = format!(
             "{}/v2/pet/{petId}",
             self.base_path, petId=utf8_percent_encode(&param_pet_id.to_string(), ID_ENCODE_SET)
@@ -1803,9 +1803,9 @@ impl<F, C> Api<C> for Client<F> where
         request.headers_mut().set(ContentType(mimetypes::requests::UPDATE_PET_WITH_FORM.clone()));
         request.set_body(body.into_bytes());
 
-        request.headers_mut().set(XSpanId((context as &Has<XSpanIdString>).get().0.clone()));
+        request.headers_mut().set(XSpanId((context as &dyn Has<XSpanIdString>).get().0.clone()));
 
-        (context as &Has<Option<AuthData>>).get().as_ref().map(|auth_data| {
+        (context as &dyn Has<Option<AuthData>>).get().as_ref().map(|auth_data| {
             // Currently only authentication with Basic, API Key, and Bearer are supported
             match auth_data {
                 &AuthData::Bearer(ref bearer_header) => {
@@ -1827,7 +1827,7 @@ impl<F, C> Api<C> for Client<F> where
                         future::ok(
                             UpdatePetWithFormResponse::InvalidInput
                         )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 },
                 code => {
                     let headers = response.headers().clone();
@@ -1846,14 +1846,14 @@ impl<F, C> Api<C> for Client<F> where
                                         Err(e) => Cow::from(format!("<Failed to read body: {}>", e)),
                                     })))
                             )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 }
             }
         }))
 
     }
 
-    fn upload_file(&self, param_pet_id: i64, param_additional_metadata: Option<String>, param_file: Option<swagger::ByteArray>, context: &C) -> Box<Future<Item=UploadFileResponse, Error=ApiError>> {
+    fn upload_file(&self, param_pet_id: i64, param_additional_metadata: Option<String>, param_file: Option<swagger::ByteArray>, context: &C) -> Box<dyn Future<Item=UploadFileResponse, Error=ApiError>> {
         let mut uri = format!(
             "{}/v2/pet/{petId}/uploadImage",
             self.base_path, petId=utf8_percent_encode(&param_pet_id.to_string(), ID_ENCODE_SET)
@@ -1925,9 +1925,9 @@ impl<F, C> Api<C> for Client<F> where
         request.headers_mut().set(ContentType(multipart_header));
 
 
-        request.headers_mut().set(XSpanId((context as &Has<XSpanIdString>).get().0.clone()));
+        request.headers_mut().set(XSpanId((context as &dyn Has<XSpanIdString>).get().0.clone()));
 
-        (context as &Has<Option<AuthData>>).get().as_ref().map(|auth_data| {
+        (context as &dyn Has<Option<AuthData>>).get().as_ref().map(|auth_data| {
             // Currently only authentication with Basic, API Key, and Bearer are supported
             match auth_data {
                 &AuthData::Bearer(ref bearer_header) => {
@@ -1959,7 +1959,7 @@ impl<F, C> Api<C> for Client<F> where
                         .map(move |body| {
                             UploadFileResponse::SuccessfulOperation(body)
                         })
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 },
                 code => {
                     let headers = response.headers().clone();
@@ -1978,14 +1978,14 @@ impl<F, C> Api<C> for Client<F> where
                                         Err(e) => Cow::from(format!("<Failed to read body: {}>", e)),
                                     })))
                             )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 }
             }
         }))
 
     }
 
-    fn delete_order(&self, param_order_id: String, context: &C) -> Box<Future<Item=DeleteOrderResponse, Error=ApiError>> {
+    fn delete_order(&self, param_order_id: String, context: &C) -> Box<dyn Future<Item=DeleteOrderResponse, Error=ApiError>> {
         let mut uri = format!(
             "{}/v2/store/order/{order_id}",
             self.base_path, order_id=utf8_percent_encode(&param_order_id.to_string(), ID_ENCODE_SET)
@@ -2008,7 +2008,7 @@ impl<F, C> Api<C> for Client<F> where
         let mut request = hyper::Request::new(hyper::Method::Delete, uri);
 
 
-        request.headers_mut().set(XSpanId((context as &Has<XSpanIdString>).get().0.clone()));
+        request.headers_mut().set(XSpanId((context as &dyn Has<XSpanIdString>).get().0.clone()));
         Box::new(self.client_service.call(request)
                              .map_err(|e| ApiError(format!("No response received: {}", e)))
                              .and_then(|mut response| {
@@ -2020,7 +2020,7 @@ impl<F, C> Api<C> for Client<F> where
                         future::ok(
                             DeleteOrderResponse::InvalidIDSupplied
                         )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 },
                 404 => {
                     let body = response.body();
@@ -2029,7 +2029,7 @@ impl<F, C> Api<C> for Client<F> where
                         future::ok(
                             DeleteOrderResponse::OrderNotFound
                         )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 },
                 code => {
                     let headers = response.headers().clone();
@@ -2048,14 +2048,14 @@ impl<F, C> Api<C> for Client<F> where
                                         Err(e) => Cow::from(format!("<Failed to read body: {}>", e)),
                                     })))
                             )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 }
             }
         }))
 
     }
 
-    fn get_inventory(&self, context: &C) -> Box<Future<Item=GetInventoryResponse, Error=ApiError>> {
+    fn get_inventory(&self, context: &C) -> Box<dyn Future<Item=GetInventoryResponse, Error=ApiError>> {
         let mut uri = format!(
             "{}/v2/store/inventory",
             self.base_path
@@ -2078,9 +2078,9 @@ impl<F, C> Api<C> for Client<F> where
         let mut request = hyper::Request::new(hyper::Method::Get, uri);
 
 
-        request.headers_mut().set(XSpanId((context as &Has<XSpanIdString>).get().0.clone()));
+        request.headers_mut().set(XSpanId((context as &dyn Has<XSpanIdString>).get().0.clone()));
 
-        (context as &Has<Option<AuthData>>).get().as_ref().map(|auth_data| {
+        (context as &dyn Has<Option<AuthData>>).get().as_ref().map(|auth_data| {
             // Currently only authentication with Basic, API Key, and Bearer are supported
             match auth_data {
                 &AuthData::ApiKey(ref api_key) => {
@@ -2113,7 +2113,7 @@ impl<F, C> Api<C> for Client<F> where
                         .map(move |body| {
                             GetInventoryResponse::SuccessfulOperation(body)
                         })
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 },
                 code => {
                     let headers = response.headers().clone();
@@ -2132,14 +2132,14 @@ impl<F, C> Api<C> for Client<F> where
                                         Err(e) => Cow::from(format!("<Failed to read body: {}>", e)),
                                     })))
                             )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 }
             }
         }))
 
     }
 
-    fn get_order_by_id(&self, param_order_id: i64, context: &C) -> Box<Future<Item=GetOrderByIdResponse, Error=ApiError>> {
+    fn get_order_by_id(&self, param_order_id: i64, context: &C) -> Box<dyn Future<Item=GetOrderByIdResponse, Error=ApiError>> {
         let mut uri = format!(
             "{}/v2/store/order/{order_id}",
             self.base_path, order_id=utf8_percent_encode(&param_order_id.to_string(), ID_ENCODE_SET)
@@ -2162,7 +2162,7 @@ impl<F, C> Api<C> for Client<F> where
         let mut request = hyper::Request::new(hyper::Method::Get, uri);
 
 
-        request.headers_mut().set(XSpanId((context as &Has<XSpanIdString>).get().0.clone()));
+        request.headers_mut().set(XSpanId((context as &dyn Has<XSpanIdString>).get().0.clone()));
         Box::new(self.client_service.call(request)
                              .map_err(|e| ApiError(format!("No response received: {}", e)))
                              .and_then(|mut response| {
@@ -2186,7 +2186,7 @@ impl<F, C> Api<C> for Client<F> where
                         .map(move |body| {
                             GetOrderByIdResponse::SuccessfulOperation(body)
                         })
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 },
                 400 => {
                     let body = response.body();
@@ -2195,7 +2195,7 @@ impl<F, C> Api<C> for Client<F> where
                         future::ok(
                             GetOrderByIdResponse::InvalidIDSupplied
                         )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 },
                 404 => {
                     let body = response.body();
@@ -2204,7 +2204,7 @@ impl<F, C> Api<C> for Client<F> where
                         future::ok(
                             GetOrderByIdResponse::OrderNotFound
                         )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 },
                 code => {
                     let headers = response.headers().clone();
@@ -2223,14 +2223,14 @@ impl<F, C> Api<C> for Client<F> where
                                         Err(e) => Cow::from(format!("<Failed to read body: {}>", e)),
                                     })))
                             )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 }
             }
         }))
 
     }
 
-    fn place_order(&self, param_body: models::Order, context: &C) -> Box<Future<Item=PlaceOrderResponse, Error=ApiError>> {
+    fn place_order(&self, param_body: models::Order, context: &C) -> Box<dyn Future<Item=PlaceOrderResponse, Error=ApiError>> {
         let mut uri = format!(
             "{}/v2/store/order",
             self.base_path
@@ -2257,7 +2257,7 @@ impl<F, C> Api<C> for Client<F> where
 
         request.headers_mut().set(ContentType(mimetypes::requests::PLACE_ORDER.clone()));
 
-        request.headers_mut().set(XSpanId((context as &Has<XSpanIdString>).get().0.clone()));
+        request.headers_mut().set(XSpanId((context as &dyn Has<XSpanIdString>).get().0.clone()));
         Box::new(self.client_service.call(request)
                              .map_err(|e| ApiError(format!("No response received: {}", e)))
                              .and_then(|mut response| {
@@ -2281,7 +2281,7 @@ impl<F, C> Api<C> for Client<F> where
                         .map(move |body| {
                             PlaceOrderResponse::SuccessfulOperation(body)
                         })
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 },
                 400 => {
                     let body = response.body();
@@ -2290,7 +2290,7 @@ impl<F, C> Api<C> for Client<F> where
                         future::ok(
                             PlaceOrderResponse::InvalidOrder
                         )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 },
                 code => {
                     let headers = response.headers().clone();
@@ -2309,14 +2309,14 @@ impl<F, C> Api<C> for Client<F> where
                                         Err(e) => Cow::from(format!("<Failed to read body: {}>", e)),
                                     })))
                             )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 }
             }
         }))
 
     }
 
-    fn create_user(&self, param_body: models::User, context: &C) -> Box<Future<Item=CreateUserResponse, Error=ApiError>> {
+    fn create_user(&self, param_body: models::User, context: &C) -> Box<dyn Future<Item=CreateUserResponse, Error=ApiError>> {
         let mut uri = format!(
             "{}/v2/user",
             self.base_path
@@ -2344,7 +2344,7 @@ impl<F, C> Api<C> for Client<F> where
 
         request.headers_mut().set(ContentType(mimetypes::requests::CREATE_USER.clone()));
 
-        request.headers_mut().set(XSpanId((context as &Has<XSpanIdString>).get().0.clone()));
+        request.headers_mut().set(XSpanId((context as &dyn Has<XSpanIdString>).get().0.clone()));
         Box::new(self.client_service.call(request)
                              .map_err(|e| ApiError(format!("No response received: {}", e)))
                              .and_then(|mut response| {
@@ -2356,7 +2356,7 @@ impl<F, C> Api<C> for Client<F> where
                         future::ok(
                             CreateUserResponse::SuccessfulOperation
                         )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 },
                 code => {
                     let headers = response.headers().clone();
@@ -2375,14 +2375,14 @@ impl<F, C> Api<C> for Client<F> where
                                         Err(e) => Cow::from(format!("<Failed to read body: {}>", e)),
                                     })))
                             )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 }
             }
         }))
 
     }
 
-    fn create_users_with_array_input(&self, param_body: &Vec<models::User>, context: &C) -> Box<Future<Item=CreateUsersWithArrayInputResponse, Error=ApiError>> {
+    fn create_users_with_array_input(&self, param_body: &Vec<models::User>, context: &C) -> Box<dyn Future<Item=CreateUsersWithArrayInputResponse, Error=ApiError>> {
         let mut uri = format!(
             "{}/v2/user/createWithArray",
             self.base_path
@@ -2409,7 +2409,7 @@ impl<F, C> Api<C> for Client<F> where
 
         request.headers_mut().set(ContentType(mimetypes::requests::CREATE_USERS_WITH_ARRAY_INPUT.clone()));
 
-        request.headers_mut().set(XSpanId((context as &Has<XSpanIdString>).get().0.clone()));
+        request.headers_mut().set(XSpanId((context as &dyn Has<XSpanIdString>).get().0.clone()));
         Box::new(self.client_service.call(request)
                              .map_err(|e| ApiError(format!("No response received: {}", e)))
                              .and_then(|mut response| {
@@ -2421,7 +2421,7 @@ impl<F, C> Api<C> for Client<F> where
                         future::ok(
                             CreateUsersWithArrayInputResponse::SuccessfulOperation
                         )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 },
                 code => {
                     let headers = response.headers().clone();
@@ -2440,14 +2440,14 @@ impl<F, C> Api<C> for Client<F> where
                                         Err(e) => Cow::from(format!("<Failed to read body: {}>", e)),
                                     })))
                             )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 }
             }
         }))
 
     }
 
-    fn create_users_with_list_input(&self, param_body: &Vec<models::User>, context: &C) -> Box<Future<Item=CreateUsersWithListInputResponse, Error=ApiError>> {
+    fn create_users_with_list_input(&self, param_body: &Vec<models::User>, context: &C) -> Box<dyn Future<Item=CreateUsersWithListInputResponse, Error=ApiError>> {
         let mut uri = format!(
             "{}/v2/user/createWithList",
             self.base_path
@@ -2474,7 +2474,7 @@ impl<F, C> Api<C> for Client<F> where
 
         request.headers_mut().set(ContentType(mimetypes::requests::CREATE_USERS_WITH_LIST_INPUT.clone()));
 
-        request.headers_mut().set(XSpanId((context as &Has<XSpanIdString>).get().0.clone()));
+        request.headers_mut().set(XSpanId((context as &dyn Has<XSpanIdString>).get().0.clone()));
         Box::new(self.client_service.call(request)
                              .map_err(|e| ApiError(format!("No response received: {}", e)))
                              .and_then(|mut response| {
@@ -2486,7 +2486,7 @@ impl<F, C> Api<C> for Client<F> where
                         future::ok(
                             CreateUsersWithListInputResponse::SuccessfulOperation
                         )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 },
                 code => {
                     let headers = response.headers().clone();
@@ -2505,14 +2505,14 @@ impl<F, C> Api<C> for Client<F> where
                                         Err(e) => Cow::from(format!("<Failed to read body: {}>", e)),
                                     })))
                             )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 }
             }
         }))
 
     }
 
-    fn delete_user(&self, param_username: String, context: &C) -> Box<Future<Item=DeleteUserResponse, Error=ApiError>> {
+    fn delete_user(&self, param_username: String, context: &C) -> Box<dyn Future<Item=DeleteUserResponse, Error=ApiError>> {
         let mut uri = format!(
             "{}/v2/user/{username}",
             self.base_path, username=utf8_percent_encode(&param_username.to_string(), ID_ENCODE_SET)
@@ -2535,7 +2535,7 @@ impl<F, C> Api<C> for Client<F> where
         let mut request = hyper::Request::new(hyper::Method::Delete, uri);
 
 
-        request.headers_mut().set(XSpanId((context as &Has<XSpanIdString>).get().0.clone()));
+        request.headers_mut().set(XSpanId((context as &dyn Has<XSpanIdString>).get().0.clone()));
         Box::new(self.client_service.call(request)
                              .map_err(|e| ApiError(format!("No response received: {}", e)))
                              .and_then(|mut response| {
@@ -2547,7 +2547,7 @@ impl<F, C> Api<C> for Client<F> where
                         future::ok(
                             DeleteUserResponse::InvalidUsernameSupplied
                         )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 },
                 404 => {
                     let body = response.body();
@@ -2556,7 +2556,7 @@ impl<F, C> Api<C> for Client<F> where
                         future::ok(
                             DeleteUserResponse::UserNotFound
                         )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 },
                 code => {
                     let headers = response.headers().clone();
@@ -2575,14 +2575,14 @@ impl<F, C> Api<C> for Client<F> where
                                         Err(e) => Cow::from(format!("<Failed to read body: {}>", e)),
                                     })))
                             )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 }
             }
         }))
 
     }
 
-    fn get_user_by_name(&self, param_username: String, context: &C) -> Box<Future<Item=GetUserByNameResponse, Error=ApiError>> {
+    fn get_user_by_name(&self, param_username: String, context: &C) -> Box<dyn Future<Item=GetUserByNameResponse, Error=ApiError>> {
         let mut uri = format!(
             "{}/v2/user/{username}",
             self.base_path, username=utf8_percent_encode(&param_username.to_string(), ID_ENCODE_SET)
@@ -2605,7 +2605,7 @@ impl<F, C> Api<C> for Client<F> where
         let mut request = hyper::Request::new(hyper::Method::Get, uri);
 
 
-        request.headers_mut().set(XSpanId((context as &Has<XSpanIdString>).get().0.clone()));
+        request.headers_mut().set(XSpanId((context as &dyn Has<XSpanIdString>).get().0.clone()));
         Box::new(self.client_service.call(request)
                              .map_err(|e| ApiError(format!("No response received: {}", e)))
                              .and_then(|mut response| {
@@ -2629,7 +2629,7 @@ impl<F, C> Api<C> for Client<F> where
                         .map(move |body| {
                             GetUserByNameResponse::SuccessfulOperation(body)
                         })
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 },
                 400 => {
                     let body = response.body();
@@ -2638,7 +2638,7 @@ impl<F, C> Api<C> for Client<F> where
                         future::ok(
                             GetUserByNameResponse::InvalidUsernameSupplied
                         )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 },
                 404 => {
                     let body = response.body();
@@ -2647,7 +2647,7 @@ impl<F, C> Api<C> for Client<F> where
                         future::ok(
                             GetUserByNameResponse::UserNotFound
                         )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 },
                 code => {
                     let headers = response.headers().clone();
@@ -2666,14 +2666,14 @@ impl<F, C> Api<C> for Client<F> where
                                         Err(e) => Cow::from(format!("<Failed to read body: {}>", e)),
                                     })))
                             )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 }
             }
         }))
 
     }
 
-    fn login_user(&self, param_username: String, param_password: String, context: &C) -> Box<Future<Item=LoginUserResponse, Error=ApiError>> {
+    fn login_user(&self, param_username: String, param_password: String, context: &C) -> Box<dyn Future<Item=LoginUserResponse, Error=ApiError>> {
         let mut uri = format!(
             "{}/v2/user/login",
             self.base_path
@@ -2698,7 +2698,7 @@ impl<F, C> Api<C> for Client<F> where
         let mut request = hyper::Request::new(hyper::Method::Get, uri);
 
 
-        request.headers_mut().set(XSpanId((context as &Has<XSpanIdString>).get().0.clone()));
+        request.headers_mut().set(XSpanId((context as &dyn Has<XSpanIdString>).get().0.clone()));
         Box::new(self.client_service.call(request)
                              .map_err(|e| ApiError(format!("No response received: {}", e)))
                              .and_then(|mut response| {
@@ -2707,12 +2707,12 @@ impl<F, C> Api<C> for Client<F> where
                     header! { (ResponseXRateLimit, "X-Rate-Limit") => [i32] }
                     let response_x_rate_limit = match response.headers().get::<ResponseXRateLimit>() {
                         Some(response_x_rate_limit) => response_x_rate_limit.0.clone(),
-                        None => return Box::new(future::err(ApiError(String::from("Required response header X-Rate-Limit for response 200 was not found.")))) as Box<Future<Item=_, Error=_>>,
+                        None => return Box::new(future::err(ApiError(String::from("Required response header X-Rate-Limit for response 200 was not found.")))) as Box<dyn Future<Item=_, Error=_>>,
                     };
                     header! { (ResponseXExpiresAfter, "X-Expires-After") => [chrono::DateTime<chrono::Utc>] }
                     let response_x_expires_after = match response.headers().get::<ResponseXExpiresAfter>() {
                         Some(response_x_expires_after) => response_x_expires_after.0.clone(),
-                        None => return Box::new(future::err(ApiError(String::from("Required response header X-Expires-After for response 200 was not found.")))) as Box<Future<Item=_, Error=_>>,
+                        None => return Box::new(future::err(ApiError(String::from("Required response header X-Expires-After for response 200 was not found.")))) as Box<dyn Future<Item=_, Error=_>>,
                     };
                     let body = response.body();
                     Box::new(
@@ -2732,7 +2732,7 @@ impl<F, C> Api<C> for Client<F> where
                         .map(move |body| {
                             LoginUserResponse::SuccessfulOperation{ body: body, x_rate_limit: response_x_rate_limit, x_expires_after: response_x_expires_after }
                         })
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 },
                 400 => {
                     let body = response.body();
@@ -2741,7 +2741,7 @@ impl<F, C> Api<C> for Client<F> where
                         future::ok(
                             LoginUserResponse::InvalidUsername
                         )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 },
                 code => {
                     let headers = response.headers().clone();
@@ -2760,14 +2760,14 @@ impl<F, C> Api<C> for Client<F> where
                                         Err(e) => Cow::from(format!("<Failed to read body: {}>", e)),
                                     })))
                             )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 }
             }
         }))
 
     }
 
-    fn logout_user(&self, context: &C) -> Box<Future<Item=LogoutUserResponse, Error=ApiError>> {
+    fn logout_user(&self, context: &C) -> Box<dyn Future<Item=LogoutUserResponse, Error=ApiError>> {
         let mut uri = format!(
             "{}/v2/user/logout",
             self.base_path
@@ -2790,7 +2790,7 @@ impl<F, C> Api<C> for Client<F> where
         let mut request = hyper::Request::new(hyper::Method::Get, uri);
 
 
-        request.headers_mut().set(XSpanId((context as &Has<XSpanIdString>).get().0.clone()));
+        request.headers_mut().set(XSpanId((context as &dyn Has<XSpanIdString>).get().0.clone()));
         Box::new(self.client_service.call(request)
                              .map_err(|e| ApiError(format!("No response received: {}", e)))
                              .and_then(|mut response| {
@@ -2802,7 +2802,7 @@ impl<F, C> Api<C> for Client<F> where
                         future::ok(
                             LogoutUserResponse::SuccessfulOperation
                         )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 },
                 code => {
                     let headers = response.headers().clone();
@@ -2821,14 +2821,14 @@ impl<F, C> Api<C> for Client<F> where
                                         Err(e) => Cow::from(format!("<Failed to read body: {}>", e)),
                                     })))
                             )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 }
             }
         }))
 
     }
 
-    fn update_user(&self, param_username: String, param_body: models::User, context: &C) -> Box<Future<Item=UpdateUserResponse, Error=ApiError>> {
+    fn update_user(&self, param_username: String, param_body: models::User, context: &C) -> Box<dyn Future<Item=UpdateUserResponse, Error=ApiError>> {
         let mut uri = format!(
             "{}/v2/user/{username}",
             self.base_path, username=utf8_percent_encode(&param_username.to_string(), ID_ENCODE_SET)
@@ -2855,7 +2855,7 @@ impl<F, C> Api<C> for Client<F> where
 
         request.headers_mut().set(ContentType(mimetypes::requests::UPDATE_USER.clone()));
 
-        request.headers_mut().set(XSpanId((context as &Has<XSpanIdString>).get().0.clone()));
+        request.headers_mut().set(XSpanId((context as &dyn Has<XSpanIdString>).get().0.clone()));
         Box::new(self.client_service.call(request)
                              .map_err(|e| ApiError(format!("No response received: {}", e)))
                              .and_then(|mut response| {
@@ -2867,7 +2867,7 @@ impl<F, C> Api<C> for Client<F> where
                         future::ok(
                             UpdateUserResponse::InvalidUserSupplied
                         )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 },
                 404 => {
                     let body = response.body();
@@ -2876,7 +2876,7 @@ impl<F, C> Api<C> for Client<F> where
                         future::ok(
                             UpdateUserResponse::UserNotFound
                         )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 },
                 code => {
                     let headers = response.headers().clone();
@@ -2895,7 +2895,7 @@ impl<F, C> Api<C> for Client<F> where
                                         Err(e) => Cow::from(format!("<Failed to read body: {}>", e)),
                                     })))
                             )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 }
             }
         }))
@@ -2926,7 +2926,7 @@ impl From<openssl::error::ErrorStack> for ClientInitError {
 
 impl fmt::Display for ClientInitError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        (self as &fmt::Debug).fmt(f)
+        (self as &dyn fmt::Debug).fmt(f)
     }
 }
 

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/src/lib.rs
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/src/lib.rs
@@ -319,100 +319,100 @@ pub enum UpdateUserResponse {
 pub trait Api<C> {
 
     /// To test special tags
-    fn test_special_tags(&self, body: models::Client, context: &C) -> Box<Future<Item=TestSpecialTagsResponse, Error=ApiError>>;
+    fn test_special_tags(&self, body: models::Client, context: &C) -> Box<dyn Future<Item=TestSpecialTagsResponse, Error=ApiError>>;
 
 
-    fn fake_outer_boolean_serialize(&self, body: Option<models::OuterBoolean>, context: &C) -> Box<Future<Item=FakeOuterBooleanSerializeResponse, Error=ApiError>>;
+    fn fake_outer_boolean_serialize(&self, body: Option<models::OuterBoolean>, context: &C) -> Box<dyn Future<Item=FakeOuterBooleanSerializeResponse, Error=ApiError>>;
 
 
-    fn fake_outer_composite_serialize(&self, body: Option<models::OuterComposite>, context: &C) -> Box<Future<Item=FakeOuterCompositeSerializeResponse, Error=ApiError>>;
+    fn fake_outer_composite_serialize(&self, body: Option<models::OuterComposite>, context: &C) -> Box<dyn Future<Item=FakeOuterCompositeSerializeResponse, Error=ApiError>>;
 
 
-    fn fake_outer_number_serialize(&self, body: Option<models::OuterNumber>, context: &C) -> Box<Future<Item=FakeOuterNumberSerializeResponse, Error=ApiError>>;
+    fn fake_outer_number_serialize(&self, body: Option<models::OuterNumber>, context: &C) -> Box<dyn Future<Item=FakeOuterNumberSerializeResponse, Error=ApiError>>;
 
 
-    fn fake_outer_string_serialize(&self, body: Option<models::OuterString>, context: &C) -> Box<Future<Item=FakeOuterStringSerializeResponse, Error=ApiError>>;
+    fn fake_outer_string_serialize(&self, body: Option<models::OuterString>, context: &C) -> Box<dyn Future<Item=FakeOuterStringSerializeResponse, Error=ApiError>>;
 
 
-    fn test_body_with_query_params(&self, query: String, body: models::User, context: &C) -> Box<Future<Item=TestBodyWithQueryParamsResponse, Error=ApiError>>;
+    fn test_body_with_query_params(&self, query: String, body: models::User, context: &C) -> Box<dyn Future<Item=TestBodyWithQueryParamsResponse, Error=ApiError>>;
 
     /// To test \"client\" model
-    fn test_client_model(&self, body: models::Client, context: &C) -> Box<Future<Item=TestClientModelResponse, Error=ApiError>>;
+    fn test_client_model(&self, body: models::Client, context: &C) -> Box<dyn Future<Item=TestClientModelResponse, Error=ApiError>>;
 
     /// Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
-    fn test_endpoint_parameters(&self, number: f64, double: f64, pattern_without_delimiter: String, byte: swagger::ByteArray, integer: Option<i32>, int32: Option<i32>, int64: Option<i64>, float: Option<f32>, string: Option<String>, binary: Option<swagger::ByteArray>, date: Option<chrono::DateTime<chrono::Utc>>, date_time: Option<chrono::DateTime<chrono::Utc>>, password: Option<String>, callback: Option<String>, context: &C) -> Box<Future<Item=TestEndpointParametersResponse, Error=ApiError>>;
+    fn test_endpoint_parameters(&self, number: f64, double: f64, pattern_without_delimiter: String, byte: swagger::ByteArray, integer: Option<i32>, int32: Option<i32>, int64: Option<i64>, float: Option<f32>, string: Option<String>, binary: Option<swagger::ByteArray>, date: Option<chrono::DateTime<chrono::Utc>>, date_time: Option<chrono::DateTime<chrono::Utc>>, password: Option<String>, callback: Option<String>, context: &C) -> Box<dyn Future<Item=TestEndpointParametersResponse, Error=ApiError>>;
 
     /// To test enum parameters
-    fn test_enum_parameters(&self, enum_header_string_array: Option<&Vec<String>>, enum_header_string: Option<String>, enum_query_string_array: Option<&Vec<String>>, enum_query_string: Option<String>, enum_query_integer: Option<i32>, enum_query_double: Option<f64>, enum_form_string: Option<String>, context: &C) -> Box<Future<Item=TestEnumParametersResponse, Error=ApiError>>;
+    fn test_enum_parameters(&self, enum_header_string_array: Option<&Vec<String>>, enum_header_string: Option<String>, enum_query_string_array: Option<&Vec<String>>, enum_query_string: Option<String>, enum_query_integer: Option<i32>, enum_query_double: Option<f64>, enum_form_string: Option<String>, context: &C) -> Box<dyn Future<Item=TestEnumParametersResponse, Error=ApiError>>;
 
     /// test inline additionalProperties
-    fn test_inline_additional_properties(&self, param: HashMap<String, String>, context: &C) -> Box<Future<Item=TestInlineAdditionalPropertiesResponse, Error=ApiError>>;
+    fn test_inline_additional_properties(&self, param: HashMap<String, String>, context: &C) -> Box<dyn Future<Item=TestInlineAdditionalPropertiesResponse, Error=ApiError>>;
 
     /// test json serialization of form data
-    fn test_json_form_data(&self, param: String, param2: String, context: &C) -> Box<Future<Item=TestJsonFormDataResponse, Error=ApiError>>;
+    fn test_json_form_data(&self, param: String, param2: String, context: &C) -> Box<dyn Future<Item=TestJsonFormDataResponse, Error=ApiError>>;
 
     /// To test class name in snake case
-    fn test_classname(&self, body: models::Client, context: &C) -> Box<Future<Item=TestClassnameResponse, Error=ApiError>>;
+    fn test_classname(&self, body: models::Client, context: &C) -> Box<dyn Future<Item=TestClassnameResponse, Error=ApiError>>;
 
     /// Add a new pet to the store
-    fn add_pet(&self, body: models::Pet, context: &C) -> Box<Future<Item=AddPetResponse, Error=ApiError>>;
+    fn add_pet(&self, body: models::Pet, context: &C) -> Box<dyn Future<Item=AddPetResponse, Error=ApiError>>;
 
     /// Deletes a pet
-    fn delete_pet(&self, pet_id: i64, api_key: Option<String>, context: &C) -> Box<Future<Item=DeletePetResponse, Error=ApiError>>;
+    fn delete_pet(&self, pet_id: i64, api_key: Option<String>, context: &C) -> Box<dyn Future<Item=DeletePetResponse, Error=ApiError>>;
 
     /// Finds Pets by status
-    fn find_pets_by_status(&self, status: &Vec<String>, context: &C) -> Box<Future<Item=FindPetsByStatusResponse, Error=ApiError>>;
+    fn find_pets_by_status(&self, status: &Vec<String>, context: &C) -> Box<dyn Future<Item=FindPetsByStatusResponse, Error=ApiError>>;
 
     /// Finds Pets by tags
-    fn find_pets_by_tags(&self, tags: &Vec<String>, context: &C) -> Box<Future<Item=FindPetsByTagsResponse, Error=ApiError>>;
+    fn find_pets_by_tags(&self, tags: &Vec<String>, context: &C) -> Box<dyn Future<Item=FindPetsByTagsResponse, Error=ApiError>>;
 
     /// Find pet by ID
-    fn get_pet_by_id(&self, pet_id: i64, context: &C) -> Box<Future<Item=GetPetByIdResponse, Error=ApiError>>;
+    fn get_pet_by_id(&self, pet_id: i64, context: &C) -> Box<dyn Future<Item=GetPetByIdResponse, Error=ApiError>>;
 
     /// Update an existing pet
-    fn update_pet(&self, body: models::Pet, context: &C) -> Box<Future<Item=UpdatePetResponse, Error=ApiError>>;
+    fn update_pet(&self, body: models::Pet, context: &C) -> Box<dyn Future<Item=UpdatePetResponse, Error=ApiError>>;
 
     /// Updates a pet in the store with form data
-    fn update_pet_with_form(&self, pet_id: i64, name: Option<String>, status: Option<String>, context: &C) -> Box<Future<Item=UpdatePetWithFormResponse, Error=ApiError>>;
+    fn update_pet_with_form(&self, pet_id: i64, name: Option<String>, status: Option<String>, context: &C) -> Box<dyn Future<Item=UpdatePetWithFormResponse, Error=ApiError>>;
 
     /// uploads an image
-    fn upload_file(&self, pet_id: i64, additional_metadata: Option<String>, file: Option<swagger::ByteArray>, context: &C) -> Box<Future<Item=UploadFileResponse, Error=ApiError>>;
+    fn upload_file(&self, pet_id: i64, additional_metadata: Option<String>, file: Option<swagger::ByteArray>, context: &C) -> Box<dyn Future<Item=UploadFileResponse, Error=ApiError>>;
 
     /// Delete purchase order by ID
-    fn delete_order(&self, order_id: String, context: &C) -> Box<Future<Item=DeleteOrderResponse, Error=ApiError>>;
+    fn delete_order(&self, order_id: String, context: &C) -> Box<dyn Future<Item=DeleteOrderResponse, Error=ApiError>>;
 
     /// Returns pet inventories by status
-    fn get_inventory(&self, context: &C) -> Box<Future<Item=GetInventoryResponse, Error=ApiError>>;
+    fn get_inventory(&self, context: &C) -> Box<dyn Future<Item=GetInventoryResponse, Error=ApiError>>;
 
     /// Find purchase order by ID
-    fn get_order_by_id(&self, order_id: i64, context: &C) -> Box<Future<Item=GetOrderByIdResponse, Error=ApiError>>;
+    fn get_order_by_id(&self, order_id: i64, context: &C) -> Box<dyn Future<Item=GetOrderByIdResponse, Error=ApiError>>;
 
     /// Place an order for a pet
-    fn place_order(&self, body: models::Order, context: &C) -> Box<Future<Item=PlaceOrderResponse, Error=ApiError>>;
+    fn place_order(&self, body: models::Order, context: &C) -> Box<dyn Future<Item=PlaceOrderResponse, Error=ApiError>>;
 
     /// Create user
-    fn create_user(&self, body: models::User, context: &C) -> Box<Future<Item=CreateUserResponse, Error=ApiError>>;
+    fn create_user(&self, body: models::User, context: &C) -> Box<dyn Future<Item=CreateUserResponse, Error=ApiError>>;
 
     /// Creates list of users with given input array
-    fn create_users_with_array_input(&self, body: &Vec<models::User>, context: &C) -> Box<Future<Item=CreateUsersWithArrayInputResponse, Error=ApiError>>;
+    fn create_users_with_array_input(&self, body: &Vec<models::User>, context: &C) -> Box<dyn Future<Item=CreateUsersWithArrayInputResponse, Error=ApiError>>;
 
     /// Creates list of users with given input array
-    fn create_users_with_list_input(&self, body: &Vec<models::User>, context: &C) -> Box<Future<Item=CreateUsersWithListInputResponse, Error=ApiError>>;
+    fn create_users_with_list_input(&self, body: &Vec<models::User>, context: &C) -> Box<dyn Future<Item=CreateUsersWithListInputResponse, Error=ApiError>>;
 
     /// Delete user
-    fn delete_user(&self, username: String, context: &C) -> Box<Future<Item=DeleteUserResponse, Error=ApiError>>;
+    fn delete_user(&self, username: String, context: &C) -> Box<dyn Future<Item=DeleteUserResponse, Error=ApiError>>;
 
     /// Get user by user name
-    fn get_user_by_name(&self, username: String, context: &C) -> Box<Future<Item=GetUserByNameResponse, Error=ApiError>>;
+    fn get_user_by_name(&self, username: String, context: &C) -> Box<dyn Future<Item=GetUserByNameResponse, Error=ApiError>>;
 
     /// Logs user into the system
-    fn login_user(&self, username: String, password: String, context: &C) -> Box<Future<Item=LoginUserResponse, Error=ApiError>>;
+    fn login_user(&self, username: String, password: String, context: &C) -> Box<dyn Future<Item=LoginUserResponse, Error=ApiError>>;
 
     /// Logs out current logged in user session
-    fn logout_user(&self, context: &C) -> Box<Future<Item=LogoutUserResponse, Error=ApiError>>;
+    fn logout_user(&self, context: &C) -> Box<dyn Future<Item=LogoutUserResponse, Error=ApiError>>;
 
     /// Updated user
-    fn update_user(&self, username: String, body: models::User, context: &C) -> Box<Future<Item=UpdateUserResponse, Error=ApiError>>;
+    fn update_user(&self, username: String, body: models::User, context: &C) -> Box<dyn Future<Item=UpdateUserResponse, Error=ApiError>>;
 
 }
 
@@ -420,100 +420,100 @@ pub trait Api<C> {
 pub trait ApiNoContext {
 
     /// To test special tags
-    fn test_special_tags(&self, body: models::Client) -> Box<Future<Item=TestSpecialTagsResponse, Error=ApiError>>;
+    fn test_special_tags(&self, body: models::Client) -> Box<dyn Future<Item=TestSpecialTagsResponse, Error=ApiError>>;
 
 
-    fn fake_outer_boolean_serialize(&self, body: Option<models::OuterBoolean>) -> Box<Future<Item=FakeOuterBooleanSerializeResponse, Error=ApiError>>;
+    fn fake_outer_boolean_serialize(&self, body: Option<models::OuterBoolean>) -> Box<dyn Future<Item=FakeOuterBooleanSerializeResponse, Error=ApiError>>;
 
 
-    fn fake_outer_composite_serialize(&self, body: Option<models::OuterComposite>) -> Box<Future<Item=FakeOuterCompositeSerializeResponse, Error=ApiError>>;
+    fn fake_outer_composite_serialize(&self, body: Option<models::OuterComposite>) -> Box<dyn Future<Item=FakeOuterCompositeSerializeResponse, Error=ApiError>>;
 
 
-    fn fake_outer_number_serialize(&self, body: Option<models::OuterNumber>) -> Box<Future<Item=FakeOuterNumberSerializeResponse, Error=ApiError>>;
+    fn fake_outer_number_serialize(&self, body: Option<models::OuterNumber>) -> Box<dyn Future<Item=FakeOuterNumberSerializeResponse, Error=ApiError>>;
 
 
-    fn fake_outer_string_serialize(&self, body: Option<models::OuterString>) -> Box<Future<Item=FakeOuterStringSerializeResponse, Error=ApiError>>;
+    fn fake_outer_string_serialize(&self, body: Option<models::OuterString>) -> Box<dyn Future<Item=FakeOuterStringSerializeResponse, Error=ApiError>>;
 
 
-    fn test_body_with_query_params(&self, query: String, body: models::User) -> Box<Future<Item=TestBodyWithQueryParamsResponse, Error=ApiError>>;
+    fn test_body_with_query_params(&self, query: String, body: models::User) -> Box<dyn Future<Item=TestBodyWithQueryParamsResponse, Error=ApiError>>;
 
     /// To test \"client\" model
-    fn test_client_model(&self, body: models::Client) -> Box<Future<Item=TestClientModelResponse, Error=ApiError>>;
+    fn test_client_model(&self, body: models::Client) -> Box<dyn Future<Item=TestClientModelResponse, Error=ApiError>>;
 
     /// Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
-    fn test_endpoint_parameters(&self, number: f64, double: f64, pattern_without_delimiter: String, byte: swagger::ByteArray, integer: Option<i32>, int32: Option<i32>, int64: Option<i64>, float: Option<f32>, string: Option<String>, binary: Option<swagger::ByteArray>, date: Option<chrono::DateTime<chrono::Utc>>, date_time: Option<chrono::DateTime<chrono::Utc>>, password: Option<String>, callback: Option<String>) -> Box<Future<Item=TestEndpointParametersResponse, Error=ApiError>>;
+    fn test_endpoint_parameters(&self, number: f64, double: f64, pattern_without_delimiter: String, byte: swagger::ByteArray, integer: Option<i32>, int32: Option<i32>, int64: Option<i64>, float: Option<f32>, string: Option<String>, binary: Option<swagger::ByteArray>, date: Option<chrono::DateTime<chrono::Utc>>, date_time: Option<chrono::DateTime<chrono::Utc>>, password: Option<String>, callback: Option<String>) -> Box<dyn Future<Item=TestEndpointParametersResponse, Error=ApiError>>;
 
     /// To test enum parameters
-    fn test_enum_parameters(&self, enum_header_string_array: Option<&Vec<String>>, enum_header_string: Option<String>, enum_query_string_array: Option<&Vec<String>>, enum_query_string: Option<String>, enum_query_integer: Option<i32>, enum_query_double: Option<f64>, enum_form_string: Option<String>) -> Box<Future<Item=TestEnumParametersResponse, Error=ApiError>>;
+    fn test_enum_parameters(&self, enum_header_string_array: Option<&Vec<String>>, enum_header_string: Option<String>, enum_query_string_array: Option<&Vec<String>>, enum_query_string: Option<String>, enum_query_integer: Option<i32>, enum_query_double: Option<f64>, enum_form_string: Option<String>) -> Box<dyn Future<Item=TestEnumParametersResponse, Error=ApiError>>;
 
     /// test inline additionalProperties
-    fn test_inline_additional_properties(&self, param: HashMap<String, String>) -> Box<Future<Item=TestInlineAdditionalPropertiesResponse, Error=ApiError>>;
+    fn test_inline_additional_properties(&self, param: HashMap<String, String>) -> Box<dyn Future<Item=TestInlineAdditionalPropertiesResponse, Error=ApiError>>;
 
     /// test json serialization of form data
-    fn test_json_form_data(&self, param: String, param2: String) -> Box<Future<Item=TestJsonFormDataResponse, Error=ApiError>>;
+    fn test_json_form_data(&self, param: String, param2: String) -> Box<dyn Future<Item=TestJsonFormDataResponse, Error=ApiError>>;
 
     /// To test class name in snake case
-    fn test_classname(&self, body: models::Client) -> Box<Future<Item=TestClassnameResponse, Error=ApiError>>;
+    fn test_classname(&self, body: models::Client) -> Box<dyn Future<Item=TestClassnameResponse, Error=ApiError>>;
 
     /// Add a new pet to the store
-    fn add_pet(&self, body: models::Pet) -> Box<Future<Item=AddPetResponse, Error=ApiError>>;
+    fn add_pet(&self, body: models::Pet) -> Box<dyn Future<Item=AddPetResponse, Error=ApiError>>;
 
     /// Deletes a pet
-    fn delete_pet(&self, pet_id: i64, api_key: Option<String>) -> Box<Future<Item=DeletePetResponse, Error=ApiError>>;
+    fn delete_pet(&self, pet_id: i64, api_key: Option<String>) -> Box<dyn Future<Item=DeletePetResponse, Error=ApiError>>;
 
     /// Finds Pets by status
-    fn find_pets_by_status(&self, status: &Vec<String>) -> Box<Future<Item=FindPetsByStatusResponse, Error=ApiError>>;
+    fn find_pets_by_status(&self, status: &Vec<String>) -> Box<dyn Future<Item=FindPetsByStatusResponse, Error=ApiError>>;
 
     /// Finds Pets by tags
-    fn find_pets_by_tags(&self, tags: &Vec<String>) -> Box<Future<Item=FindPetsByTagsResponse, Error=ApiError>>;
+    fn find_pets_by_tags(&self, tags: &Vec<String>) -> Box<dyn Future<Item=FindPetsByTagsResponse, Error=ApiError>>;
 
     /// Find pet by ID
-    fn get_pet_by_id(&self, pet_id: i64) -> Box<Future<Item=GetPetByIdResponse, Error=ApiError>>;
+    fn get_pet_by_id(&self, pet_id: i64) -> Box<dyn Future<Item=GetPetByIdResponse, Error=ApiError>>;
 
     /// Update an existing pet
-    fn update_pet(&self, body: models::Pet) -> Box<Future<Item=UpdatePetResponse, Error=ApiError>>;
+    fn update_pet(&self, body: models::Pet) -> Box<dyn Future<Item=UpdatePetResponse, Error=ApiError>>;
 
     /// Updates a pet in the store with form data
-    fn update_pet_with_form(&self, pet_id: i64, name: Option<String>, status: Option<String>) -> Box<Future<Item=UpdatePetWithFormResponse, Error=ApiError>>;
+    fn update_pet_with_form(&self, pet_id: i64, name: Option<String>, status: Option<String>) -> Box<dyn Future<Item=UpdatePetWithFormResponse, Error=ApiError>>;
 
     /// uploads an image
-    fn upload_file(&self, pet_id: i64, additional_metadata: Option<String>, file: Option<swagger::ByteArray>) -> Box<Future<Item=UploadFileResponse, Error=ApiError>>;
+    fn upload_file(&self, pet_id: i64, additional_metadata: Option<String>, file: Option<swagger::ByteArray>) -> Box<dyn Future<Item=UploadFileResponse, Error=ApiError>>;
 
     /// Delete purchase order by ID
-    fn delete_order(&self, order_id: String) -> Box<Future<Item=DeleteOrderResponse, Error=ApiError>>;
+    fn delete_order(&self, order_id: String) -> Box<dyn Future<Item=DeleteOrderResponse, Error=ApiError>>;
 
     /// Returns pet inventories by status
-    fn get_inventory(&self) -> Box<Future<Item=GetInventoryResponse, Error=ApiError>>;
+    fn get_inventory(&self) -> Box<dyn Future<Item=GetInventoryResponse, Error=ApiError>>;
 
     /// Find purchase order by ID
-    fn get_order_by_id(&self, order_id: i64) -> Box<Future<Item=GetOrderByIdResponse, Error=ApiError>>;
+    fn get_order_by_id(&self, order_id: i64) -> Box<dyn Future<Item=GetOrderByIdResponse, Error=ApiError>>;
 
     /// Place an order for a pet
-    fn place_order(&self, body: models::Order) -> Box<Future<Item=PlaceOrderResponse, Error=ApiError>>;
+    fn place_order(&self, body: models::Order) -> Box<dyn Future<Item=PlaceOrderResponse, Error=ApiError>>;
 
     /// Create user
-    fn create_user(&self, body: models::User) -> Box<Future<Item=CreateUserResponse, Error=ApiError>>;
+    fn create_user(&self, body: models::User) -> Box<dyn Future<Item=CreateUserResponse, Error=ApiError>>;
 
     /// Creates list of users with given input array
-    fn create_users_with_array_input(&self, body: &Vec<models::User>) -> Box<Future<Item=CreateUsersWithArrayInputResponse, Error=ApiError>>;
+    fn create_users_with_array_input(&self, body: &Vec<models::User>) -> Box<dyn Future<Item=CreateUsersWithArrayInputResponse, Error=ApiError>>;
 
     /// Creates list of users with given input array
-    fn create_users_with_list_input(&self, body: &Vec<models::User>) -> Box<Future<Item=CreateUsersWithListInputResponse, Error=ApiError>>;
+    fn create_users_with_list_input(&self, body: &Vec<models::User>) -> Box<dyn Future<Item=CreateUsersWithListInputResponse, Error=ApiError>>;
 
     /// Delete user
-    fn delete_user(&self, username: String) -> Box<Future<Item=DeleteUserResponse, Error=ApiError>>;
+    fn delete_user(&self, username: String) -> Box<dyn Future<Item=DeleteUserResponse, Error=ApiError>>;
 
     /// Get user by user name
-    fn get_user_by_name(&self, username: String) -> Box<Future<Item=GetUserByNameResponse, Error=ApiError>>;
+    fn get_user_by_name(&self, username: String) -> Box<dyn Future<Item=GetUserByNameResponse, Error=ApiError>>;
 
     /// Logs user into the system
-    fn login_user(&self, username: String, password: String) -> Box<Future<Item=LoginUserResponse, Error=ApiError>>;
+    fn login_user(&self, username: String, password: String) -> Box<dyn Future<Item=LoginUserResponse, Error=ApiError>>;
 
     /// Logs out current logged in user session
-    fn logout_user(&self) -> Box<Future<Item=LogoutUserResponse, Error=ApiError>>;
+    fn logout_user(&self) -> Box<dyn Future<Item=LogoutUserResponse, Error=ApiError>>;
 
     /// Updated user
-    fn update_user(&self, username: String, body: models::User) -> Box<Future<Item=UpdateUserResponse, Error=ApiError>>;
+    fn update_user(&self, username: String, body: models::User) -> Box<dyn Future<Item=UpdateUserResponse, Error=ApiError>>;
 
 }
 
@@ -532,162 +532,162 @@ impl<'a, T: Api<C> + Sized, C> ContextWrapperExt<'a, C> for T {
 impl<'a, T: Api<C>, C> ApiNoContext for ContextWrapper<'a, T, C> {
 
     /// To test special tags
-    fn test_special_tags(&self, body: models::Client) -> Box<Future<Item=TestSpecialTagsResponse, Error=ApiError>> {
+    fn test_special_tags(&self, body: models::Client) -> Box<dyn Future<Item=TestSpecialTagsResponse, Error=ApiError>> {
         self.api().test_special_tags(body, &self.context())
     }
 
 
-    fn fake_outer_boolean_serialize(&self, body: Option<models::OuterBoolean>) -> Box<Future<Item=FakeOuterBooleanSerializeResponse, Error=ApiError>> {
+    fn fake_outer_boolean_serialize(&self, body: Option<models::OuterBoolean>) -> Box<dyn Future<Item=FakeOuterBooleanSerializeResponse, Error=ApiError>> {
         self.api().fake_outer_boolean_serialize(body, &self.context())
     }
 
 
-    fn fake_outer_composite_serialize(&self, body: Option<models::OuterComposite>) -> Box<Future<Item=FakeOuterCompositeSerializeResponse, Error=ApiError>> {
+    fn fake_outer_composite_serialize(&self, body: Option<models::OuterComposite>) -> Box<dyn Future<Item=FakeOuterCompositeSerializeResponse, Error=ApiError>> {
         self.api().fake_outer_composite_serialize(body, &self.context())
     }
 
 
-    fn fake_outer_number_serialize(&self, body: Option<models::OuterNumber>) -> Box<Future<Item=FakeOuterNumberSerializeResponse, Error=ApiError>> {
+    fn fake_outer_number_serialize(&self, body: Option<models::OuterNumber>) -> Box<dyn Future<Item=FakeOuterNumberSerializeResponse, Error=ApiError>> {
         self.api().fake_outer_number_serialize(body, &self.context())
     }
 
 
-    fn fake_outer_string_serialize(&self, body: Option<models::OuterString>) -> Box<Future<Item=FakeOuterStringSerializeResponse, Error=ApiError>> {
+    fn fake_outer_string_serialize(&self, body: Option<models::OuterString>) -> Box<dyn Future<Item=FakeOuterStringSerializeResponse, Error=ApiError>> {
         self.api().fake_outer_string_serialize(body, &self.context())
     }
 
 
-    fn test_body_with_query_params(&self, query: String, body: models::User) -> Box<Future<Item=TestBodyWithQueryParamsResponse, Error=ApiError>> {
+    fn test_body_with_query_params(&self, query: String, body: models::User) -> Box<dyn Future<Item=TestBodyWithQueryParamsResponse, Error=ApiError>> {
         self.api().test_body_with_query_params(query, body, &self.context())
     }
 
     /// To test \"client\" model
-    fn test_client_model(&self, body: models::Client) -> Box<Future<Item=TestClientModelResponse, Error=ApiError>> {
+    fn test_client_model(&self, body: models::Client) -> Box<dyn Future<Item=TestClientModelResponse, Error=ApiError>> {
         self.api().test_client_model(body, &self.context())
     }
 
     /// Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
-    fn test_endpoint_parameters(&self, number: f64, double: f64, pattern_without_delimiter: String, byte: swagger::ByteArray, integer: Option<i32>, int32: Option<i32>, int64: Option<i64>, float: Option<f32>, string: Option<String>, binary: Option<swagger::ByteArray>, date: Option<chrono::DateTime<chrono::Utc>>, date_time: Option<chrono::DateTime<chrono::Utc>>, password: Option<String>, callback: Option<String>) -> Box<Future<Item=TestEndpointParametersResponse, Error=ApiError>> {
+    fn test_endpoint_parameters(&self, number: f64, double: f64, pattern_without_delimiter: String, byte: swagger::ByteArray, integer: Option<i32>, int32: Option<i32>, int64: Option<i64>, float: Option<f32>, string: Option<String>, binary: Option<swagger::ByteArray>, date: Option<chrono::DateTime<chrono::Utc>>, date_time: Option<chrono::DateTime<chrono::Utc>>, password: Option<String>, callback: Option<String>) -> Box<dyn Future<Item=TestEndpointParametersResponse, Error=ApiError>> {
         self.api().test_endpoint_parameters(number, double, pattern_without_delimiter, byte, integer, int32, int64, float, string, binary, date, date_time, password, callback, &self.context())
     }
 
     /// To test enum parameters
-    fn test_enum_parameters(&self, enum_header_string_array: Option<&Vec<String>>, enum_header_string: Option<String>, enum_query_string_array: Option<&Vec<String>>, enum_query_string: Option<String>, enum_query_integer: Option<i32>, enum_query_double: Option<f64>, enum_form_string: Option<String>) -> Box<Future<Item=TestEnumParametersResponse, Error=ApiError>> {
+    fn test_enum_parameters(&self, enum_header_string_array: Option<&Vec<String>>, enum_header_string: Option<String>, enum_query_string_array: Option<&Vec<String>>, enum_query_string: Option<String>, enum_query_integer: Option<i32>, enum_query_double: Option<f64>, enum_form_string: Option<String>) -> Box<dyn Future<Item=TestEnumParametersResponse, Error=ApiError>> {
         self.api().test_enum_parameters(enum_header_string_array, enum_header_string, enum_query_string_array, enum_query_string, enum_query_integer, enum_query_double, enum_form_string, &self.context())
     }
 
     /// test inline additionalProperties
-    fn test_inline_additional_properties(&self, param: HashMap<String, String>) -> Box<Future<Item=TestInlineAdditionalPropertiesResponse, Error=ApiError>> {
+    fn test_inline_additional_properties(&self, param: HashMap<String, String>) -> Box<dyn Future<Item=TestInlineAdditionalPropertiesResponse, Error=ApiError>> {
         self.api().test_inline_additional_properties(param, &self.context())
     }
 
     /// test json serialization of form data
-    fn test_json_form_data(&self, param: String, param2: String) -> Box<Future<Item=TestJsonFormDataResponse, Error=ApiError>> {
+    fn test_json_form_data(&self, param: String, param2: String) -> Box<dyn Future<Item=TestJsonFormDataResponse, Error=ApiError>> {
         self.api().test_json_form_data(param, param2, &self.context())
     }
 
     /// To test class name in snake case
-    fn test_classname(&self, body: models::Client) -> Box<Future<Item=TestClassnameResponse, Error=ApiError>> {
+    fn test_classname(&self, body: models::Client) -> Box<dyn Future<Item=TestClassnameResponse, Error=ApiError>> {
         self.api().test_classname(body, &self.context())
     }
 
     /// Add a new pet to the store
-    fn add_pet(&self, body: models::Pet) -> Box<Future<Item=AddPetResponse, Error=ApiError>> {
+    fn add_pet(&self, body: models::Pet) -> Box<dyn Future<Item=AddPetResponse, Error=ApiError>> {
         self.api().add_pet(body, &self.context())
     }
 
     /// Deletes a pet
-    fn delete_pet(&self, pet_id: i64, api_key: Option<String>) -> Box<Future<Item=DeletePetResponse, Error=ApiError>> {
+    fn delete_pet(&self, pet_id: i64, api_key: Option<String>) -> Box<dyn Future<Item=DeletePetResponse, Error=ApiError>> {
         self.api().delete_pet(pet_id, api_key, &self.context())
     }
 
     /// Finds Pets by status
-    fn find_pets_by_status(&self, status: &Vec<String>) -> Box<Future<Item=FindPetsByStatusResponse, Error=ApiError>> {
+    fn find_pets_by_status(&self, status: &Vec<String>) -> Box<dyn Future<Item=FindPetsByStatusResponse, Error=ApiError>> {
         self.api().find_pets_by_status(status, &self.context())
     }
 
     /// Finds Pets by tags
-    fn find_pets_by_tags(&self, tags: &Vec<String>) -> Box<Future<Item=FindPetsByTagsResponse, Error=ApiError>> {
+    fn find_pets_by_tags(&self, tags: &Vec<String>) -> Box<dyn Future<Item=FindPetsByTagsResponse, Error=ApiError>> {
         self.api().find_pets_by_tags(tags, &self.context())
     }
 
     /// Find pet by ID
-    fn get_pet_by_id(&self, pet_id: i64) -> Box<Future<Item=GetPetByIdResponse, Error=ApiError>> {
+    fn get_pet_by_id(&self, pet_id: i64) -> Box<dyn Future<Item=GetPetByIdResponse, Error=ApiError>> {
         self.api().get_pet_by_id(pet_id, &self.context())
     }
 
     /// Update an existing pet
-    fn update_pet(&self, body: models::Pet) -> Box<Future<Item=UpdatePetResponse, Error=ApiError>> {
+    fn update_pet(&self, body: models::Pet) -> Box<dyn Future<Item=UpdatePetResponse, Error=ApiError>> {
         self.api().update_pet(body, &self.context())
     }
 
     /// Updates a pet in the store with form data
-    fn update_pet_with_form(&self, pet_id: i64, name: Option<String>, status: Option<String>) -> Box<Future<Item=UpdatePetWithFormResponse, Error=ApiError>> {
+    fn update_pet_with_form(&self, pet_id: i64, name: Option<String>, status: Option<String>) -> Box<dyn Future<Item=UpdatePetWithFormResponse, Error=ApiError>> {
         self.api().update_pet_with_form(pet_id, name, status, &self.context())
     }
 
     /// uploads an image
-    fn upload_file(&self, pet_id: i64, additional_metadata: Option<String>, file: Option<swagger::ByteArray>) -> Box<Future<Item=UploadFileResponse, Error=ApiError>> {
+    fn upload_file(&self, pet_id: i64, additional_metadata: Option<String>, file: Option<swagger::ByteArray>) -> Box<dyn Future<Item=UploadFileResponse, Error=ApiError>> {
         self.api().upload_file(pet_id, additional_metadata, file, &self.context())
     }
 
     /// Delete purchase order by ID
-    fn delete_order(&self, order_id: String) -> Box<Future<Item=DeleteOrderResponse, Error=ApiError>> {
+    fn delete_order(&self, order_id: String) -> Box<dyn Future<Item=DeleteOrderResponse, Error=ApiError>> {
         self.api().delete_order(order_id, &self.context())
     }
 
     /// Returns pet inventories by status
-    fn get_inventory(&self) -> Box<Future<Item=GetInventoryResponse, Error=ApiError>> {
+    fn get_inventory(&self) -> Box<dyn Future<Item=GetInventoryResponse, Error=ApiError>> {
         self.api().get_inventory(&self.context())
     }
 
     /// Find purchase order by ID
-    fn get_order_by_id(&self, order_id: i64) -> Box<Future<Item=GetOrderByIdResponse, Error=ApiError>> {
+    fn get_order_by_id(&self, order_id: i64) -> Box<dyn Future<Item=GetOrderByIdResponse, Error=ApiError>> {
         self.api().get_order_by_id(order_id, &self.context())
     }
 
     /// Place an order for a pet
-    fn place_order(&self, body: models::Order) -> Box<Future<Item=PlaceOrderResponse, Error=ApiError>> {
+    fn place_order(&self, body: models::Order) -> Box<dyn Future<Item=PlaceOrderResponse, Error=ApiError>> {
         self.api().place_order(body, &self.context())
     }
 
     /// Create user
-    fn create_user(&self, body: models::User) -> Box<Future<Item=CreateUserResponse, Error=ApiError>> {
+    fn create_user(&self, body: models::User) -> Box<dyn Future<Item=CreateUserResponse, Error=ApiError>> {
         self.api().create_user(body, &self.context())
     }
 
     /// Creates list of users with given input array
-    fn create_users_with_array_input(&self, body: &Vec<models::User>) -> Box<Future<Item=CreateUsersWithArrayInputResponse, Error=ApiError>> {
+    fn create_users_with_array_input(&self, body: &Vec<models::User>) -> Box<dyn Future<Item=CreateUsersWithArrayInputResponse, Error=ApiError>> {
         self.api().create_users_with_array_input(body, &self.context())
     }
 
     /// Creates list of users with given input array
-    fn create_users_with_list_input(&self, body: &Vec<models::User>) -> Box<Future<Item=CreateUsersWithListInputResponse, Error=ApiError>> {
+    fn create_users_with_list_input(&self, body: &Vec<models::User>) -> Box<dyn Future<Item=CreateUsersWithListInputResponse, Error=ApiError>> {
         self.api().create_users_with_list_input(body, &self.context())
     }
 
     /// Delete user
-    fn delete_user(&self, username: String) -> Box<Future<Item=DeleteUserResponse, Error=ApiError>> {
+    fn delete_user(&self, username: String) -> Box<dyn Future<Item=DeleteUserResponse, Error=ApiError>> {
         self.api().delete_user(username, &self.context())
     }
 
     /// Get user by user name
-    fn get_user_by_name(&self, username: String) -> Box<Future<Item=GetUserByNameResponse, Error=ApiError>> {
+    fn get_user_by_name(&self, username: String) -> Box<dyn Future<Item=GetUserByNameResponse, Error=ApiError>> {
         self.api().get_user_by_name(username, &self.context())
     }
 
     /// Logs user into the system
-    fn login_user(&self, username: String, password: String) -> Box<Future<Item=LoginUserResponse, Error=ApiError>> {
+    fn login_user(&self, username: String, password: String) -> Box<dyn Future<Item=LoginUserResponse, Error=ApiError>> {
         self.api().login_user(username, password, &self.context())
     }
 
     /// Logs out current logged in user session
-    fn logout_user(&self) -> Box<Future<Item=LogoutUserResponse, Error=ApiError>> {
+    fn logout_user(&self) -> Box<dyn Future<Item=LogoutUserResponse, Error=ApiError>> {
         self.api().logout_user(&self.context())
     }
 
     /// Updated user
-    fn update_user(&self, username: String, body: models::User) -> Box<Future<Item=UpdateUserResponse, Error=ApiError>> {
+    fn update_user(&self, username: String, body: models::User) -> Box<dyn Future<Item=UpdateUserResponse, Error=ApiError>> {
         self.api().update_user(username, body, &self.context())
     }
 

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/src/server/mod.rs
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/src/server/mod.rs
@@ -200,7 +200,7 @@ where
     type Request = (Request, C);
     type Response = Response;
     type Error = Error;
-    type Future = Box<Future<Item=Response, Error=Error>>;
+    type Future = Box<dyn Future<Item=Response, Error=Error>>;
 
     fn call(&self, (req, mut context): Self::Request) -> Self::Future {
         let api_impl = self.api_impl.clone();
@@ -217,7 +217,7 @@ where
                 // values, rather than causing a 400 response). Produce warning header and logs for
                 // any unused fields.
                 Box::new(body.concat2()
-                    .then(move |result| -> Box<Future<Item=Response, Error=Error>> {
+                    .then(move |result| -> Box<dyn Future<Item=Response, Error=Error>> {
                         match result {
                             Ok(body) => {
                                 let mut unused_elements = Vec::new();
@@ -240,7 +240,7 @@ where
                                 Box::new(api_impl.test_special_tags(param_body, &context)
                                     .then(move |result| {
                                         let mut response = Response::new();
-                                        response.headers_mut().set(XSpanId((&context as &Has<XSpanIdString>).get().0.to_string()));
+                                        response.headers_mut().set(XSpanId((&context as &dyn Has<XSpanIdString>).get().0.to_string()));
 
                                         if !unused_elements.is_empty() {
                                             response.headers_mut().set(Warning(format!("Ignoring unknown fields in body: {:?}", unused_elements)));
@@ -277,7 +277,7 @@ where
                             Err(e) => Box::new(future::ok(Response::new().with_status(StatusCode::BadRequest).with_body(format!("Couldn't read body parameter body: {}", e)))),
                         }
                     })
-                ) as Box<Future<Item=Response, Error=Error>>
+                ) as Box<dyn Future<Item=Response, Error=Error>>
             },
 
             // FakeOuterBooleanSerialize - POST /fake/outer/boolean
@@ -286,7 +286,7 @@ where
                 // values, rather than causing a 400 response). Produce warning header and logs for
                 // any unused fields.
                 Box::new(body.concat2()
-                    .then(move |result| -> Box<Future<Item=Response, Error=Error>> {
+                    .then(move |result| -> Box<dyn Future<Item=Response, Error=Error>> {
                         match result {
                             Ok(body) => {
                                 let mut unused_elements = Vec::new();
@@ -305,7 +305,7 @@ where
                                 Box::new(api_impl.fake_outer_boolean_serialize(param_body, &context)
                                     .then(move |result| {
                                         let mut response = Response::new();
-                                        response.headers_mut().set(XSpanId((&context as &Has<XSpanIdString>).get().0.to_string()));
+                                        response.headers_mut().set(XSpanId((&context as &dyn Has<XSpanIdString>).get().0.to_string()));
 
                                         if !unused_elements.is_empty() {
                                             response.headers_mut().set(Warning(format!("Ignoring unknown fields in body: {:?}", unused_elements)));
@@ -342,7 +342,7 @@ where
                             Err(e) => Box::new(future::ok(Response::new().with_status(StatusCode::BadRequest).with_body(format!("Couldn't read body parameter body: {}", e)))),
                         }
                     })
-                ) as Box<Future<Item=Response, Error=Error>>
+                ) as Box<dyn Future<Item=Response, Error=Error>>
             },
 
             // FakeOuterCompositeSerialize - POST /fake/outer/composite
@@ -351,7 +351,7 @@ where
                 // values, rather than causing a 400 response). Produce warning header and logs for
                 // any unused fields.
                 Box::new(body.concat2()
-                    .then(move |result| -> Box<Future<Item=Response, Error=Error>> {
+                    .then(move |result| -> Box<dyn Future<Item=Response, Error=Error>> {
                         match result {
                             Ok(body) => {
                                 let mut unused_elements = Vec::new();
@@ -370,7 +370,7 @@ where
                                 Box::new(api_impl.fake_outer_composite_serialize(param_body, &context)
                                     .then(move |result| {
                                         let mut response = Response::new();
-                                        response.headers_mut().set(XSpanId((&context as &Has<XSpanIdString>).get().0.to_string()));
+                                        response.headers_mut().set(XSpanId((&context as &dyn Has<XSpanIdString>).get().0.to_string()));
 
                                         if !unused_elements.is_empty() {
                                             response.headers_mut().set(Warning(format!("Ignoring unknown fields in body: {:?}", unused_elements)));
@@ -407,7 +407,7 @@ where
                             Err(e) => Box::new(future::ok(Response::new().with_status(StatusCode::BadRequest).with_body(format!("Couldn't read body parameter body: {}", e)))),
                         }
                     })
-                ) as Box<Future<Item=Response, Error=Error>>
+                ) as Box<dyn Future<Item=Response, Error=Error>>
             },
 
             // FakeOuterNumberSerialize - POST /fake/outer/number
@@ -416,7 +416,7 @@ where
                 // values, rather than causing a 400 response). Produce warning header and logs for
                 // any unused fields.
                 Box::new(body.concat2()
-                    .then(move |result| -> Box<Future<Item=Response, Error=Error>> {
+                    .then(move |result| -> Box<dyn Future<Item=Response, Error=Error>> {
                         match result {
                             Ok(body) => {
                                 let mut unused_elements = Vec::new();
@@ -435,7 +435,7 @@ where
                                 Box::new(api_impl.fake_outer_number_serialize(param_body, &context)
                                     .then(move |result| {
                                         let mut response = Response::new();
-                                        response.headers_mut().set(XSpanId((&context as &Has<XSpanIdString>).get().0.to_string()));
+                                        response.headers_mut().set(XSpanId((&context as &dyn Has<XSpanIdString>).get().0.to_string()));
 
                                         if !unused_elements.is_empty() {
                                             response.headers_mut().set(Warning(format!("Ignoring unknown fields in body: {:?}", unused_elements)));
@@ -472,7 +472,7 @@ where
                             Err(e) => Box::new(future::ok(Response::new().with_status(StatusCode::BadRequest).with_body(format!("Couldn't read body parameter body: {}", e)))),
                         }
                     })
-                ) as Box<Future<Item=Response, Error=Error>>
+                ) as Box<dyn Future<Item=Response, Error=Error>>
             },
 
             // FakeOuterStringSerialize - POST /fake/outer/string
@@ -481,7 +481,7 @@ where
                 // values, rather than causing a 400 response). Produce warning header and logs for
                 // any unused fields.
                 Box::new(body.concat2()
-                    .then(move |result| -> Box<Future<Item=Response, Error=Error>> {
+                    .then(move |result| -> Box<dyn Future<Item=Response, Error=Error>> {
                         match result {
                             Ok(body) => {
                                 let mut unused_elements = Vec::new();
@@ -500,7 +500,7 @@ where
                                 Box::new(api_impl.fake_outer_string_serialize(param_body, &context)
                                     .then(move |result| {
                                         let mut response = Response::new();
-                                        response.headers_mut().set(XSpanId((&context as &Has<XSpanIdString>).get().0.to_string()));
+                                        response.headers_mut().set(XSpanId((&context as &dyn Has<XSpanIdString>).get().0.to_string()));
 
                                         if !unused_elements.is_empty() {
                                             response.headers_mut().set(Warning(format!("Ignoring unknown fields in body: {:?}", unused_elements)));
@@ -537,7 +537,7 @@ where
                             Err(e) => Box::new(future::ok(Response::new().with_status(StatusCode::BadRequest).with_body(format!("Couldn't read body parameter body: {}", e)))),
                         }
                     })
-                ) as Box<Future<Item=Response, Error=Error>>
+                ) as Box<dyn Future<Item=Response, Error=Error>>
             },
 
             // TestBodyWithQueryParams - PUT /fake/body-with-query-params
@@ -557,7 +557,7 @@ where
                 // values, rather than causing a 400 response). Produce warning header and logs for
                 // any unused fields.
                 Box::new(body.concat2()
-                    .then(move |result| -> Box<Future<Item=Response, Error=Error>> {
+                    .then(move |result| -> Box<dyn Future<Item=Response, Error=Error>> {
                         match result {
                             Ok(body) => {
                                 let mut unused_elements = Vec::new();
@@ -580,7 +580,7 @@ where
                                 Box::new(api_impl.test_body_with_query_params(param_query, param_body, &context)
                                     .then(move |result| {
                                         let mut response = Response::new();
-                                        response.headers_mut().set(XSpanId((&context as &Has<XSpanIdString>).get().0.to_string()));
+                                        response.headers_mut().set(XSpanId((&context as &dyn Has<XSpanIdString>).get().0.to_string()));
 
                                         if !unused_elements.is_empty() {
                                             response.headers_mut().set(Warning(format!("Ignoring unknown fields in body: {:?}", unused_elements)));
@@ -611,7 +611,7 @@ where
                             Err(e) => Box::new(future::ok(Response::new().with_status(StatusCode::BadRequest).with_body(format!("Couldn't read body parameter body: {}", e)))),
                         }
                     })
-                ) as Box<Future<Item=Response, Error=Error>>
+                ) as Box<dyn Future<Item=Response, Error=Error>>
             },
 
             // TestClientModel - PATCH /fake
@@ -620,7 +620,7 @@ where
                 // values, rather than causing a 400 response). Produce warning header and logs for
                 // any unused fields.
                 Box::new(body.concat2()
-                    .then(move |result| -> Box<Future<Item=Response, Error=Error>> {
+                    .then(move |result| -> Box<dyn Future<Item=Response, Error=Error>> {
                         match result {
                             Ok(body) => {
                                 let mut unused_elements = Vec::new();
@@ -643,7 +643,7 @@ where
                                 Box::new(api_impl.test_client_model(param_body, &context)
                                     .then(move |result| {
                                         let mut response = Response::new();
-                                        response.headers_mut().set(XSpanId((&context as &Has<XSpanIdString>).get().0.to_string()));
+                                        response.headers_mut().set(XSpanId((&context as &dyn Has<XSpanIdString>).get().0.to_string()));
 
                                         if !unused_elements.is_empty() {
                                             response.headers_mut().set(Warning(format!("Ignoring unknown fields in body: {:?}", unused_elements)));
@@ -680,13 +680,13 @@ where
                             Err(e) => Box::new(future::ok(Response::new().with_status(StatusCode::BadRequest).with_body(format!("Couldn't read body parameter body: {}", e)))),
                         }
                     })
-                ) as Box<Future<Item=Response, Error=Error>>
+                ) as Box<dyn Future<Item=Response, Error=Error>>
             },
 
             // TestEndpointParameters - POST /fake
             &hyper::Method::Post if path.matched(paths::ID_FAKE) => {
                 {
-                    let authorization = match (&context as &Has<Option<Authorization>>).get() {
+                    let authorization = match (&context as &dyn Has<Option<Authorization>>).get() {
                         &Some(ref authorization) => authorization,
                         &None => return Box::new(future::ok(Response::new()
                                                 .with_status(StatusCode::Forbidden)
@@ -714,7 +714,7 @@ where
                                 Box::new(api_impl.test_endpoint_parameters(param_number, param_double, param_pattern_without_delimiter, param_byte, param_integer, param_int32, param_int64, param_float, param_string, param_binary, param_date, param_date_time, param_password, param_callback, &context)
                                     .then(move |result| {
                                         let mut response = Response::new();
-                                        response.headers_mut().set(XSpanId((&context as &Has<XSpanIdString>).get().0.to_string()));
+                                        response.headers_mut().set(XSpanId((&context as &dyn Has<XSpanIdString>).get().0.to_string()));
 
                                         match result {
                                             Ok(rsp) => match rsp {
@@ -745,7 +745,7 @@ where
                                     }
                                 ))
                         }}
-                }) as Box<Future<Item=Response, Error=Error>>
+                }) as Box<dyn Future<Item=Response, Error=Error>>
             },
 
             // TestEnumParameters - GET /fake
@@ -784,7 +784,7 @@ where
                                 Box::new(api_impl.test_enum_parameters(param_enum_header_string_array.as_ref(), param_enum_header_string, param_enum_query_string_array.as_ref(), param_enum_query_string, param_enum_query_integer, param_enum_query_double, param_enum_form_string, &context)
                                     .then(move |result| {
                                         let mut response = Response::new();
-                                        response.headers_mut().set(XSpanId((&context as &Has<XSpanIdString>).get().0.to_string()));
+                                        response.headers_mut().set(XSpanId((&context as &dyn Has<XSpanIdString>).get().0.to_string()));
 
                                         match result {
                                             Ok(rsp) => match rsp {
@@ -815,7 +815,7 @@ where
                                     }
                                 ))
                         }}
-                }) as Box<Future<Item=Response, Error=Error>>
+                }) as Box<dyn Future<Item=Response, Error=Error>>
             },
 
             // TestInlineAdditionalProperties - POST /fake/inline-additionalProperties
@@ -824,7 +824,7 @@ where
                 // values, rather than causing a 400 response). Produce warning header and logs for
                 // any unused fields.
                 Box::new(body.concat2()
-                    .then(move |result| -> Box<Future<Item=Response, Error=Error>> {
+                    .then(move |result| -> Box<dyn Future<Item=Response, Error=Error>> {
                         match result {
                             Ok(body) => {
                                 let mut unused_elements = Vec::new();
@@ -847,7 +847,7 @@ where
                                 Box::new(api_impl.test_inline_additional_properties(param_param, &context)
                                     .then(move |result| {
                                         let mut response = Response::new();
-                                        response.headers_mut().set(XSpanId((&context as &Has<XSpanIdString>).get().0.to_string()));
+                                        response.headers_mut().set(XSpanId((&context as &dyn Has<XSpanIdString>).get().0.to_string()));
 
                                         if !unused_elements.is_empty() {
                                             response.headers_mut().set(Warning(format!("Ignoring unknown fields in body: {:?}", unused_elements)));
@@ -878,7 +878,7 @@ where
                             Err(e) => Box::new(future::ok(Response::new().with_status(StatusCode::BadRequest).with_body(format!("Couldn't read body parameter param: {}", e)))),
                         }
                     })
-                ) as Box<Future<Item=Response, Error=Error>>
+                ) as Box<dyn Future<Item=Response, Error=Error>>
             },
 
             // TestJsonFormData - GET /fake/jsonFormData
@@ -891,7 +891,7 @@ where
                                 Box::new(api_impl.test_json_form_data(param_param, param_param2, &context)
                                     .then(move |result| {
                                         let mut response = Response::new();
-                                        response.headers_mut().set(XSpanId((&context as &Has<XSpanIdString>).get().0.to_string()));
+                                        response.headers_mut().set(XSpanId((&context as &dyn Has<XSpanIdString>).get().0.to_string()));
 
                                         match result {
                                             Ok(rsp) => match rsp {
@@ -915,13 +915,13 @@ where
                                     }
                                 ))
                         }}
-                }) as Box<Future<Item=Response, Error=Error>>
+                }) as Box<dyn Future<Item=Response, Error=Error>>
             },
 
             // TestClassname - PATCH /fake_classname_test
             &hyper::Method::Patch if path.matched(paths::ID_FAKE_CLASSNAME_TEST) => {
                 {
-                    let authorization = match (&context as &Has<Option<Authorization>>).get() {
+                    let authorization = match (&context as &dyn Has<Option<Authorization>>).get() {
                         &Some(ref authorization) => authorization,
                         &None => return Box::new(future::ok(Response::new()
                                                 .with_status(StatusCode::Forbidden)
@@ -933,7 +933,7 @@ where
                 // values, rather than causing a 400 response). Produce warning header and logs for
                 // any unused fields.
                 Box::new(body.concat2()
-                    .then(move |result| -> Box<Future<Item=Response, Error=Error>> {
+                    .then(move |result| -> Box<dyn Future<Item=Response, Error=Error>> {
                         match result {
                             Ok(body) => {
                                 let mut unused_elements = Vec::new();
@@ -956,7 +956,7 @@ where
                                 Box::new(api_impl.test_classname(param_body, &context)
                                     .then(move |result| {
                                         let mut response = Response::new();
-                                        response.headers_mut().set(XSpanId((&context as &Has<XSpanIdString>).get().0.to_string()));
+                                        response.headers_mut().set(XSpanId((&context as &dyn Has<XSpanIdString>).get().0.to_string()));
 
                                         if !unused_elements.is_empty() {
                                             response.headers_mut().set(Warning(format!("Ignoring unknown fields in body: {:?}", unused_elements)));
@@ -993,13 +993,13 @@ where
                             Err(e) => Box::new(future::ok(Response::new().with_status(StatusCode::BadRequest).with_body(format!("Couldn't read body parameter body: {}", e)))),
                         }
                     })
-                ) as Box<Future<Item=Response, Error=Error>>
+                ) as Box<dyn Future<Item=Response, Error=Error>>
             },
 
             // AddPet - POST /pet
             &hyper::Method::Post if path.matched(paths::ID_PET) => {
                 {
-                    let authorization = match (&context as &Has<Option<Authorization>>).get() {
+                    let authorization = match (&context as &dyn Has<Option<Authorization>>).get() {
                         &Some(ref authorization) => authorization,
                         &None => return Box::new(future::ok(Response::new()
                                                 .with_status(StatusCode::Forbidden)
@@ -1029,7 +1029,7 @@ where
                 // values, rather than causing a 400 response). Produce warning header and logs for
                 // any unused fields.
                 Box::new(body.concat2()
-                    .then(move |result| -> Box<Future<Item=Response, Error=Error>> {
+                    .then(move |result| -> Box<dyn Future<Item=Response, Error=Error>> {
                         match result {
                             Ok(body) => {
                                 let mut unused_elements = Vec::new();
@@ -1052,7 +1052,7 @@ where
                                 Box::new(api_impl.add_pet(param_body, &context)
                                     .then(move |result| {
                                         let mut response = Response::new();
-                                        response.headers_mut().set(XSpanId((&context as &Has<XSpanIdString>).get().0.to_string()));
+                                        response.headers_mut().set(XSpanId((&context as &dyn Has<XSpanIdString>).get().0.to_string()));
 
                                         if !unused_elements.is_empty() {
                                             response.headers_mut().set(Warning(format!("Ignoring unknown fields in body: {:?}", unused_elements)));
@@ -1083,13 +1083,13 @@ where
                             Err(e) => Box::new(future::ok(Response::new().with_status(StatusCode::BadRequest).with_body(format!("Couldn't read body parameter body: {}", e)))),
                         }
                     })
-                ) as Box<Future<Item=Response, Error=Error>>
+                ) as Box<dyn Future<Item=Response, Error=Error>>
             },
 
             // DeletePet - DELETE /pet/{petId}
             &hyper::Method::Delete if path.matched(paths::ID_PET_PETID) => {
                 {
-                    let authorization = match (&context as &Has<Option<Authorization>>).get() {
+                    let authorization = match (&context as &dyn Has<Option<Authorization>>).get() {
                         &Some(ref authorization) => authorization,
                         &None => return Box::new(future::ok(Response::new()
                                                 .with_status(StatusCode::Forbidden)
@@ -1138,7 +1138,7 @@ where
                                 Box::new(api_impl.delete_pet(param_pet_id, param_api_key, &context)
                                     .then(move |result| {
                                         let mut response = Response::new();
-                                        response.headers_mut().set(XSpanId((&context as &Has<XSpanIdString>).get().0.to_string()));
+                                        response.headers_mut().set(XSpanId((&context as &dyn Has<XSpanIdString>).get().0.to_string()));
 
                                         match result {
                                             Ok(rsp) => match rsp {
@@ -1162,13 +1162,13 @@ where
                                     }
                                 ))
                         }}
-                }) as Box<Future<Item=Response, Error=Error>>
+                }) as Box<dyn Future<Item=Response, Error=Error>>
             },
 
             // FindPetsByStatus - GET /pet/findByStatus
             &hyper::Method::Get if path.matched(paths::ID_PET_FINDBYSTATUS) => {
                 {
-                    let authorization = match (&context as &Has<Option<Authorization>>).get() {
+                    let authorization = match (&context as &dyn Has<Option<Authorization>>).get() {
                         &Some(ref authorization) => authorization,
                         &None => return Box::new(future::ok(Response::new()
                                                 .with_status(StatusCode::Forbidden)
@@ -1204,7 +1204,7 @@ where
                                 Box::new(api_impl.find_pets_by_status(param_status.as_ref(), &context)
                                     .then(move |result| {
                                         let mut response = Response::new();
-                                        response.headers_mut().set(XSpanId((&context as &Has<XSpanIdString>).get().0.to_string()));
+                                        response.headers_mut().set(XSpanId((&context as &dyn Has<XSpanIdString>).get().0.to_string()));
 
                                         match result {
                                             Ok(rsp) => match rsp {
@@ -1241,13 +1241,13 @@ where
                                     }
                                 ))
                         }}
-                }) as Box<Future<Item=Response, Error=Error>>
+                }) as Box<dyn Future<Item=Response, Error=Error>>
             },
 
             // FindPetsByTags - GET /pet/findByTags
             &hyper::Method::Get if path.matched(paths::ID_PET_FINDBYTAGS) => {
                 {
-                    let authorization = match (&context as &Has<Option<Authorization>>).get() {
+                    let authorization = match (&context as &dyn Has<Option<Authorization>>).get() {
                         &Some(ref authorization) => authorization,
                         &None => return Box::new(future::ok(Response::new()
                                                 .with_status(StatusCode::Forbidden)
@@ -1283,7 +1283,7 @@ where
                                 Box::new(api_impl.find_pets_by_tags(param_tags.as_ref(), &context)
                                     .then(move |result| {
                                         let mut response = Response::new();
-                                        response.headers_mut().set(XSpanId((&context as &Has<XSpanIdString>).get().0.to_string()));
+                                        response.headers_mut().set(XSpanId((&context as &dyn Has<XSpanIdString>).get().0.to_string()));
 
                                         match result {
                                             Ok(rsp) => match rsp {
@@ -1320,13 +1320,13 @@ where
                                     }
                                 ))
                         }}
-                }) as Box<Future<Item=Response, Error=Error>>
+                }) as Box<dyn Future<Item=Response, Error=Error>>
             },
 
             // GetPetById - GET /pet/{petId}
             &hyper::Method::Get if path.matched(paths::ID_PET_PETID) => {
                 {
-                    let authorization = match (&context as &Has<Option<Authorization>>).get() {
+                    let authorization = match (&context as &dyn Has<Option<Authorization>>).get() {
                         &Some(ref authorization) => authorization,
                         &None => return Box::new(future::ok(Response::new()
                                                 .with_status(StatusCode::Forbidden)
@@ -1354,7 +1354,7 @@ where
                                 Box::new(api_impl.get_pet_by_id(param_pet_id, &context)
                                     .then(move |result| {
                                         let mut response = Response::new();
-                                        response.headers_mut().set(XSpanId((&context as &Has<XSpanIdString>).get().0.to_string()));
+                                        response.headers_mut().set(XSpanId((&context as &dyn Has<XSpanIdString>).get().0.to_string()));
 
                                         match result {
                                             Ok(rsp) => match rsp {
@@ -1398,13 +1398,13 @@ where
                                     }
                                 ))
                         }}
-                }) as Box<Future<Item=Response, Error=Error>>
+                }) as Box<dyn Future<Item=Response, Error=Error>>
             },
 
             // UpdatePet - PUT /pet
             &hyper::Method::Put if path.matched(paths::ID_PET) => {
                 {
-                    let authorization = match (&context as &Has<Option<Authorization>>).get() {
+                    let authorization = match (&context as &dyn Has<Option<Authorization>>).get() {
                         &Some(ref authorization) => authorization,
                         &None => return Box::new(future::ok(Response::new()
                                                 .with_status(StatusCode::Forbidden)
@@ -1434,7 +1434,7 @@ where
                 // values, rather than causing a 400 response). Produce warning header and logs for
                 // any unused fields.
                 Box::new(body.concat2()
-                    .then(move |result| -> Box<Future<Item=Response, Error=Error>> {
+                    .then(move |result| -> Box<dyn Future<Item=Response, Error=Error>> {
                         match result {
                             Ok(body) => {
                                 let mut unused_elements = Vec::new();
@@ -1457,7 +1457,7 @@ where
                                 Box::new(api_impl.update_pet(param_body, &context)
                                     .then(move |result| {
                                         let mut response = Response::new();
-                                        response.headers_mut().set(XSpanId((&context as &Has<XSpanIdString>).get().0.to_string()));
+                                        response.headers_mut().set(XSpanId((&context as &dyn Has<XSpanIdString>).get().0.to_string()));
 
                                         if !unused_elements.is_empty() {
                                             response.headers_mut().set(Warning(format!("Ignoring unknown fields in body: {:?}", unused_elements)));
@@ -1502,13 +1502,13 @@ where
                             Err(e) => Box::new(future::ok(Response::new().with_status(StatusCode::BadRequest).with_body(format!("Couldn't read body parameter body: {}", e)))),
                         }
                     })
-                ) as Box<Future<Item=Response, Error=Error>>
+                ) as Box<dyn Future<Item=Response, Error=Error>>
             },
 
             // UpdatePetWithForm - POST /pet/{petId}
             &hyper::Method::Post if path.matched(paths::ID_PET_PETID) => {
                 {
-                    let authorization = match (&context as &Has<Option<Authorization>>).get() {
+                    let authorization = match (&context as &dyn Has<Option<Authorization>>).get() {
                         &Some(ref authorization) => authorization,
                         &None => return Box::new(future::ok(Response::new()
                                                 .with_status(StatusCode::Forbidden)
@@ -1557,7 +1557,7 @@ where
                                 Box::new(api_impl.update_pet_with_form(param_pet_id, param_name, param_status, &context)
                                     .then(move |result| {
                                         let mut response = Response::new();
-                                        response.headers_mut().set(XSpanId((&context as &Has<XSpanIdString>).get().0.to_string()));
+                                        response.headers_mut().set(XSpanId((&context as &dyn Has<XSpanIdString>).get().0.to_string()));
 
                                         match result {
                                             Ok(rsp) => match rsp {
@@ -1581,13 +1581,13 @@ where
                                     }
                                 ))
                         }}
-                }) as Box<Future<Item=Response, Error=Error>>
+                }) as Box<dyn Future<Item=Response, Error=Error>>
             },
 
             // UploadFile - POST /pet/{petId}/uploadImage
             &hyper::Method::Post if path.matched(paths::ID_PET_PETID_UPLOADIMAGE) => {
                 {
-                    let authorization = match (&context as &Has<Option<Authorization>>).get() {
+                    let authorization = match (&context as &dyn Has<Option<Authorization>>).get() {
                         &Some(ref authorization) => authorization,
                         &None => return Box::new(future::ok(Response::new()
                                                 .with_status(StatusCode::Forbidden)
@@ -1636,7 +1636,7 @@ where
                 // values, rather than causing a 400 response). Produce warning header and logs for
                 // any unused fields.
                 Box::new(body.concat2()
-                    .then(move |result| -> Box<Future<Item=Response, Error=Error>> {
+                    .then(move |result| -> Box<dyn Future<Item=Response, Error=Error>> {
                         match result {
                             Ok(body) => {
                                 // Read Form Parameters from body
@@ -1677,7 +1677,7 @@ where
                                 Box::new(api_impl.upload_file(param_pet_id, param_additional_metadata, param_file, &context)
                                     .then(move |result| {
                                         let mut response = Response::new();
-                                        response.headers_mut().set(XSpanId((&context as &Has<XSpanIdString>).get().0.to_string()));
+                                        response.headers_mut().set(XSpanId((&context as &dyn Has<XSpanIdString>).get().0.to_string()));
 
                                         match result {
                                             Ok(rsp) => match rsp {
@@ -1706,7 +1706,7 @@ where
                                         future::ok(response)
                                     }
                                 ))
-                                as Box<Future<Item=Response, Error=Error>>
+                                as Box<dyn Future<Item=Response, Error=Error>>
                             },
                             Err(e) => Box::new(future::ok(Response::new().with_status(StatusCode::BadRequest).with_body(format!("Couldn't read multipart body")))),
                         }
@@ -1736,7 +1736,7 @@ where
                                 Box::new(api_impl.delete_order(param_order_id, &context)
                                     .then(move |result| {
                                         let mut response = Response::new();
-                                        response.headers_mut().set(XSpanId((&context as &Has<XSpanIdString>).get().0.to_string()));
+                                        response.headers_mut().set(XSpanId((&context as &dyn Has<XSpanIdString>).get().0.to_string()));
 
                                         match result {
                                             Ok(rsp) => match rsp {
@@ -1767,13 +1767,13 @@ where
                                     }
                                 ))
                         }}
-                }) as Box<Future<Item=Response, Error=Error>>
+                }) as Box<dyn Future<Item=Response, Error=Error>>
             },
 
             // GetInventory - GET /store/inventory
             &hyper::Method::Get if path.matched(paths::ID_STORE_INVENTORY) => {
                 {
-                    let authorization = match (&context as &Has<Option<Authorization>>).get() {
+                    let authorization = match (&context as &dyn Has<Option<Authorization>>).get() {
                         &Some(ref authorization) => authorization,
                         &None => return Box::new(future::ok(Response::new()
                                                 .with_status(StatusCode::Forbidden)
@@ -1786,7 +1786,7 @@ where
                                 Box::new(api_impl.get_inventory(&context)
                                     .then(move |result| {
                                         let mut response = Response::new();
-                                        response.headers_mut().set(XSpanId((&context as &Has<XSpanIdString>).get().0.to_string()));
+                                        response.headers_mut().set(XSpanId((&context as &dyn Has<XSpanIdString>).get().0.to_string()));
 
                                         match result {
                                             Ok(rsp) => match rsp {
@@ -1816,7 +1816,7 @@ where
                                     }
                                 ))
                         }}
-                }) as Box<Future<Item=Response, Error=Error>>
+                }) as Box<dyn Future<Item=Response, Error=Error>>
             },
 
             // GetOrderById - GET /store/order/{order_id}
@@ -1841,7 +1841,7 @@ where
                                 Box::new(api_impl.get_order_by_id(param_order_id, &context)
                                     .then(move |result| {
                                         let mut response = Response::new();
-                                        response.headers_mut().set(XSpanId((&context as &Has<XSpanIdString>).get().0.to_string()));
+                                        response.headers_mut().set(XSpanId((&context as &dyn Has<XSpanIdString>).get().0.to_string()));
 
                                         match result {
                                             Ok(rsp) => match rsp {
@@ -1885,7 +1885,7 @@ where
                                     }
                                 ))
                         }}
-                }) as Box<Future<Item=Response, Error=Error>>
+                }) as Box<dyn Future<Item=Response, Error=Error>>
             },
 
             // PlaceOrder - POST /store/order
@@ -1894,7 +1894,7 @@ where
                 // values, rather than causing a 400 response). Produce warning header and logs for
                 // any unused fields.
                 Box::new(body.concat2()
-                    .then(move |result| -> Box<Future<Item=Response, Error=Error>> {
+                    .then(move |result| -> Box<dyn Future<Item=Response, Error=Error>> {
                         match result {
                             Ok(body) => {
                                 let mut unused_elements = Vec::new();
@@ -1917,7 +1917,7 @@ where
                                 Box::new(api_impl.place_order(param_body, &context)
                                     .then(move |result| {
                                         let mut response = Response::new();
-                                        response.headers_mut().set(XSpanId((&context as &Has<XSpanIdString>).get().0.to_string()));
+                                        response.headers_mut().set(XSpanId((&context as &dyn Has<XSpanIdString>).get().0.to_string()));
 
                                         if !unused_elements.is_empty() {
                                             response.headers_mut().set(Warning(format!("Ignoring unknown fields in body: {:?}", unused_elements)));
@@ -1961,7 +1961,7 @@ where
                             Err(e) => Box::new(future::ok(Response::new().with_status(StatusCode::BadRequest).with_body(format!("Couldn't read body parameter body: {}", e)))),
                         }
                     })
-                ) as Box<Future<Item=Response, Error=Error>>
+                ) as Box<dyn Future<Item=Response, Error=Error>>
             },
 
             // CreateUser - POST /user
@@ -1970,7 +1970,7 @@ where
                 // values, rather than causing a 400 response). Produce warning header and logs for
                 // any unused fields.
                 Box::new(body.concat2()
-                    .then(move |result| -> Box<Future<Item=Response, Error=Error>> {
+                    .then(move |result| -> Box<dyn Future<Item=Response, Error=Error>> {
                         match result {
                             Ok(body) => {
                                 let mut unused_elements = Vec::new();
@@ -1993,7 +1993,7 @@ where
                                 Box::new(api_impl.create_user(param_body, &context)
                                     .then(move |result| {
                                         let mut response = Response::new();
-                                        response.headers_mut().set(XSpanId((&context as &Has<XSpanIdString>).get().0.to_string()));
+                                        response.headers_mut().set(XSpanId((&context as &dyn Has<XSpanIdString>).get().0.to_string()));
 
                                         if !unused_elements.is_empty() {
                                             response.headers_mut().set(Warning(format!("Ignoring unknown fields in body: {:?}", unused_elements)));
@@ -2024,7 +2024,7 @@ where
                             Err(e) => Box::new(future::ok(Response::new().with_status(StatusCode::BadRequest).with_body(format!("Couldn't read body parameter body: {}", e)))),
                         }
                     })
-                ) as Box<Future<Item=Response, Error=Error>>
+                ) as Box<dyn Future<Item=Response, Error=Error>>
             },
 
             // CreateUsersWithArrayInput - POST /user/createWithArray
@@ -2033,7 +2033,7 @@ where
                 // values, rather than causing a 400 response). Produce warning header and logs for
                 // any unused fields.
                 Box::new(body.concat2()
-                    .then(move |result| -> Box<Future<Item=Response, Error=Error>> {
+                    .then(move |result| -> Box<dyn Future<Item=Response, Error=Error>> {
                         match result {
                             Ok(body) => {
                                 let mut unused_elements = Vec::new();
@@ -2056,7 +2056,7 @@ where
                                 Box::new(api_impl.create_users_with_array_input(param_body.as_ref(), &context)
                                     .then(move |result| {
                                         let mut response = Response::new();
-                                        response.headers_mut().set(XSpanId((&context as &Has<XSpanIdString>).get().0.to_string()));
+                                        response.headers_mut().set(XSpanId((&context as &dyn Has<XSpanIdString>).get().0.to_string()));
 
                                         if !unused_elements.is_empty() {
                                             response.headers_mut().set(Warning(format!("Ignoring unknown fields in body: {:?}", unused_elements)));
@@ -2087,7 +2087,7 @@ where
                             Err(e) => Box::new(future::ok(Response::new().with_status(StatusCode::BadRequest).with_body(format!("Couldn't read body parameter body: {}", e)))),
                         }
                     })
-                ) as Box<Future<Item=Response, Error=Error>>
+                ) as Box<dyn Future<Item=Response, Error=Error>>
             },
 
             // CreateUsersWithListInput - POST /user/createWithList
@@ -2096,7 +2096,7 @@ where
                 // values, rather than causing a 400 response). Produce warning header and logs for
                 // any unused fields.
                 Box::new(body.concat2()
-                    .then(move |result| -> Box<Future<Item=Response, Error=Error>> {
+                    .then(move |result| -> Box<dyn Future<Item=Response, Error=Error>> {
                         match result {
                             Ok(body) => {
                                 let mut unused_elements = Vec::new();
@@ -2119,7 +2119,7 @@ where
                                 Box::new(api_impl.create_users_with_list_input(param_body.as_ref(), &context)
                                     .then(move |result| {
                                         let mut response = Response::new();
-                                        response.headers_mut().set(XSpanId((&context as &Has<XSpanIdString>).get().0.to_string()));
+                                        response.headers_mut().set(XSpanId((&context as &dyn Has<XSpanIdString>).get().0.to_string()));
 
                                         if !unused_elements.is_empty() {
                                             response.headers_mut().set(Warning(format!("Ignoring unknown fields in body: {:?}", unused_elements)));
@@ -2150,7 +2150,7 @@ where
                             Err(e) => Box::new(future::ok(Response::new().with_status(StatusCode::BadRequest).with_body(format!("Couldn't read body parameter body: {}", e)))),
                         }
                     })
-                ) as Box<Future<Item=Response, Error=Error>>
+                ) as Box<dyn Future<Item=Response, Error=Error>>
             },
 
             // DeleteUser - DELETE /user/{username}
@@ -2175,7 +2175,7 @@ where
                                 Box::new(api_impl.delete_user(param_username, &context)
                                     .then(move |result| {
                                         let mut response = Response::new();
-                                        response.headers_mut().set(XSpanId((&context as &Has<XSpanIdString>).get().0.to_string()));
+                                        response.headers_mut().set(XSpanId((&context as &dyn Has<XSpanIdString>).get().0.to_string()));
 
                                         match result {
                                             Ok(rsp) => match rsp {
@@ -2206,7 +2206,7 @@ where
                                     }
                                 ))
                         }}
-                }) as Box<Future<Item=Response, Error=Error>>
+                }) as Box<dyn Future<Item=Response, Error=Error>>
             },
 
             // GetUserByName - GET /user/{username}
@@ -2231,7 +2231,7 @@ where
                                 Box::new(api_impl.get_user_by_name(param_username, &context)
                                     .then(move |result| {
                                         let mut response = Response::new();
-                                        response.headers_mut().set(XSpanId((&context as &Has<XSpanIdString>).get().0.to_string()));
+                                        response.headers_mut().set(XSpanId((&context as &dyn Has<XSpanIdString>).get().0.to_string()));
 
                                         match result {
                                             Ok(rsp) => match rsp {
@@ -2275,7 +2275,7 @@ where
                                     }
                                 ))
                         }}
-                }) as Box<Future<Item=Response, Error=Error>>
+                }) as Box<dyn Future<Item=Response, Error=Error>>
             },
 
             // LoginUser - GET /user/login
@@ -2305,7 +2305,7 @@ where
                                 Box::new(api_impl.login_user(param_username, param_password, &context)
                                     .then(move |result| {
                                         let mut response = Response::new();
-                                        response.headers_mut().set(XSpanId((&context as &Has<XSpanIdString>).get().0.to_string()));
+                                        response.headers_mut().set(XSpanId((&context as &dyn Has<XSpanIdString>).get().0.to_string()));
 
                                         match result {
                                             Ok(rsp) => match rsp {
@@ -2351,7 +2351,7 @@ where
                                     }
                                 ))
                         }}
-                }) as Box<Future<Item=Response, Error=Error>>
+                }) as Box<dyn Future<Item=Response, Error=Error>>
             },
 
             // LogoutUser - GET /user/logout
@@ -2361,7 +2361,7 @@ where
                                 Box::new(api_impl.logout_user(&context)
                                     .then(move |result| {
                                         let mut response = Response::new();
-                                        response.headers_mut().set(XSpanId((&context as &Has<XSpanIdString>).get().0.to_string()));
+                                        response.headers_mut().set(XSpanId((&context as &dyn Has<XSpanIdString>).get().0.to_string()));
 
                                         match result {
                                             Ok(rsp) => match rsp {
@@ -2385,7 +2385,7 @@ where
                                     }
                                 ))
                         }}
-                }) as Box<Future<Item=Response, Error=Error>>
+                }) as Box<dyn Future<Item=Response, Error=Error>>
             },
 
             // UpdateUser - PUT /user/{username}
@@ -2409,7 +2409,7 @@ where
                 // values, rather than causing a 400 response). Produce warning header and logs for
                 // any unused fields.
                 Box::new(body.concat2()
-                    .then(move |result| -> Box<Future<Item=Response, Error=Error>> {
+                    .then(move |result| -> Box<dyn Future<Item=Response, Error=Error>> {
                         match result {
                             Ok(body) => {
                                 let mut unused_elements = Vec::new();
@@ -2432,7 +2432,7 @@ where
                                 Box::new(api_impl.update_user(param_username, param_body, &context)
                                     .then(move |result| {
                                         let mut response = Response::new();
-                                        response.headers_mut().set(XSpanId((&context as &Has<XSpanIdString>).get().0.to_string()));
+                                        response.headers_mut().set(XSpanId((&context as &dyn Has<XSpanIdString>).get().0.to_string()));
 
                                         if !unused_elements.is_empty() {
                                             response.headers_mut().set(Warning(format!("Ignoring unknown fields in body: {:?}", unused_elements)));
@@ -2470,10 +2470,10 @@ where
                             Err(e) => Box::new(future::ok(Response::new().with_status(StatusCode::BadRequest).with_body(format!("Couldn't read body parameter body: {}", e)))),
                         }
                     })
-                ) as Box<Future<Item=Response, Error=Error>>
+                ) as Box<dyn Future<Item=Response, Error=Error>>
             },
 
-            _ => Box::new(future::ok(Response::new().with_status(StatusCode::NotFound))) as Box<Future<Item=Response, Error=Error>>,
+            _ => Box::new(future::ok(Response::new().with_status(StatusCode::NotFound))) as Box<dyn Future<Item=Response, Error=Error>>,
         }
     }
 }

--- a/samples/server/petstore/rust-server/output/rust-server-test/Cargo.toml
+++ b/samples/server/petstore/rust-server/output/rust-server-test/Cargo.toml
@@ -16,7 +16,7 @@ conversion = ["frunk", "frunk_derives", "frunk_core", "frunk-enum-core", "frunk-
 chrono = { version = "0.4", features = ["serde"] }
 futures = "0.1"
 swagger = "2"
-lazy_static = "0.2"
+lazy_static = "1.4"
 log = "0.3.0"
 mime = "0.2.6"
 multipart = "0.13.3"

--- a/samples/server/petstore/rust-server/output/rust-server-test/examples/client.rs
+++ b/samples/server/petstore/rust-server/output/rust-server-test/examples/client.rs
@@ -78,28 +78,28 @@ fn main() {
 
         Some("DummyGet") => {
             let result = core.run(client.dummy_get());
-            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
          },
 
         // Disabled because there's no example.
         // Some("DummyPut") => {
         //     let result = core.run(client.dummy_put(???));
-        //     println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+        //     println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         //  },
 
         Some("FileResponseGet") => {
             let result = core.run(client.file_response_get());
-            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
          },
 
         Some("HtmlPost") => {
             let result = core.run(client.html_post("body_example".to_string()));
-            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
          },
 
         Some("RawJsonGet") => {
             let result = core.run(client.raw_json_get());
-            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
          },
 
         _ => {

--- a/samples/server/petstore/rust-server/output/rust-server-test/examples/server_lib/server.rs
+++ b/samples/server/petstore/rust-server/output/rust-server-test/examples/server_lib/server.rs
@@ -32,35 +32,35 @@ impl<C> Server<C> {
 impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
 
     /// A dummy endpoint to make the spec valid.
-    fn dummy_get(&self, context: &C) -> Box<Future<Item=DummyGetResponse, Error=ApiError>> {
+    fn dummy_get(&self, context: &C) -> Box<dyn Future<Item=DummyGetResponse, Error=ApiError>> {
         let context = context.clone();
         println!("dummy_get() - X-Span-ID: {:?}", context.get().0.clone());
         Box::new(futures::failed("Generic failure".into()))
     }
 
 
-    fn dummy_put(&self, nested_response: models::InlineObject, context: &C) -> Box<Future<Item=DummyPutResponse, Error=ApiError>> {
+    fn dummy_put(&self, nested_response: models::InlineObject, context: &C) -> Box<dyn Future<Item=DummyPutResponse, Error=ApiError>> {
         let context = context.clone();
         println!("dummy_put({:?}) - X-Span-ID: {:?}", nested_response, context.get().0.clone());
         Box::new(futures::failed("Generic failure".into()))
     }
 
     /// Get a file
-    fn file_response_get(&self, context: &C) -> Box<Future<Item=FileResponseGetResponse, Error=ApiError>> {
+    fn file_response_get(&self, context: &C) -> Box<dyn Future<Item=FileResponseGetResponse, Error=ApiError>> {
         let context = context.clone();
         println!("file_response_get() - X-Span-ID: {:?}", context.get().0.clone());
         Box::new(futures::failed("Generic failure".into()))
     }
 
     /// Test HTML handling
-    fn html_post(&self, body: String, context: &C) -> Box<Future<Item=HtmlPostResponse, Error=ApiError>> {
+    fn html_post(&self, body: String, context: &C) -> Box<dyn Future<Item=HtmlPostResponse, Error=ApiError>> {
         let context = context.clone();
         println!("html_post(\"{}\") - X-Span-ID: {:?}", body, context.get().0.clone());
         Box::new(futures::failed("Generic failure".into()))
     }
 
     /// Get an arbitrary JSON blob.
-    fn raw_json_get(&self, context: &C) -> Box<Future<Item=RawJsonGetResponse, Error=ApiError>> {
+    fn raw_json_get(&self, context: &C) -> Box<dyn Future<Item=RawJsonGetResponse, Error=ApiError>> {
         let context = context.clone();
         println!("raw_json_get() - X-Span-ID: {:?}", context.get().0.clone());
         Box::new(futures::failed("Generic failure".into()))

--- a/samples/server/petstore/rust-server/output/rust-server-test/src/client/mod.rs
+++ b/samples/server/petstore/rust-server/output/rust-server-test/src/client/mod.rs
@@ -73,7 +73,7 @@ fn into_base_path(input: &str, correct_scheme: Option<&'static str>) -> Result<S
 /// A client that implements the API by making HTTP calls out to a server.
 pub struct Client<F> where
   F: Future<Item=hyper::Response, Error=hyper::Error> + 'static {
-    client_service: Arc<Box<hyper::client::Service<Request=hyper::Request<hyper::Body>, Response=hyper::Response, Error=hyper::Error, Future=F>>>,
+    client_service: Arc<Box<dyn hyper::client::Service<Request=hyper::Request<hyper::Body>, Response=hyper::Response, Error=hyper::Error, Future=F>>>,
     base_path: String,
 }
 
@@ -184,7 +184,7 @@ impl Client<hyper::client::FutureResponse> {
         handle: Handle,
         base_path: &str,
         protocol: Option<&'static str>,
-        connector_fn: Box<Fn(&Handle) -> C + Send + Sync>,
+        connector_fn: Box<dyn Fn(&Handle) -> C + Send + Sync>,
     ) -> Result<Client<hyper::client::FutureResponse>, ClientInitError>
     where
         C: hyper::client::Connect + hyper::client::Service,
@@ -211,7 +211,7 @@ impl Client<hyper::client::FutureResponse> {
     /// should be mentioned here.
     #[deprecated(note="Use try_new_with_client_service instead")]
     pub fn try_new_with_hyper_client(
-        hyper_client: Arc<Box<hyper::client::Service<Request=hyper::Request<hyper::Body>, Response=hyper::Response, Error=hyper::Error, Future=hyper::client::FutureResponse>>>,
+        hyper_client: Arc<Box<dyn hyper::client::Service<Request=hyper::Request<hyper::Body>, Response=hyper::Response, Error=hyper::Error, Future=hyper::client::FutureResponse>>>,
         handle: Handle,
         base_path: &str
     ) -> Result<Client<hyper::client::FutureResponse>, ClientInitError>
@@ -229,7 +229,7 @@ impl<F> Client<F> where
     /// Constructor for creating a `Client` by passing in a pre-made `hyper` client Service.
     ///
     /// This allows adding custom wrappers around the underlying transport, for example for logging.
-    pub fn try_new_with_client_service(client_service: Arc<Box<hyper::client::Service<Request=hyper::Request<hyper::Body>, Response=hyper::Response, Error=hyper::Error, Future=F>>>,
+    pub fn try_new_with_client_service(client_service: Arc<Box<dyn hyper::client::Service<Request=hyper::Request<hyper::Body>, Response=hyper::Response, Error=hyper::Error, Future=F>>>,
                                        handle: Handle,
                                        base_path: &str)
                                     -> Result<Client<F>, ClientInitError>
@@ -245,7 +245,7 @@ impl<F, C> Api<C> for Client<F> where
     F: Future<Item=hyper::Response, Error=hyper::Error>  + 'static,
     C: Has<XSpanIdString> {
 
-    fn dummy_get(&self, context: &C) -> Box<Future<Item=DummyGetResponse, Error=ApiError>> {
+    fn dummy_get(&self, context: &C) -> Box<dyn Future<Item=DummyGetResponse, Error=ApiError>> {
         let mut uri = format!(
             "{}/dummy",
             self.base_path
@@ -268,7 +268,7 @@ impl<F, C> Api<C> for Client<F> where
         let mut request = hyper::Request::new(hyper::Method::Get, uri);
 
 
-        request.headers_mut().set(XSpanId((context as &Has<XSpanIdString>).get().0.clone()));
+        request.headers_mut().set(XSpanId((context as &dyn Has<XSpanIdString>).get().0.clone()));
         Box::new(self.client_service.call(request)
                              .map_err(|e| ApiError(format!("No response received: {}", e)))
                              .and_then(|mut response| {
@@ -280,7 +280,7 @@ impl<F, C> Api<C> for Client<F> where
                         future::ok(
                             DummyGetResponse::Success
                         )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 },
                 code => {
                     let headers = response.headers().clone();
@@ -299,14 +299,14 @@ impl<F, C> Api<C> for Client<F> where
                                         Err(e) => Cow::from(format!("<Failed to read body: {}>", e)),
                                     })))
                             )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 }
             }
         }))
 
     }
 
-    fn dummy_put(&self, param_nested_response: models::InlineObject, context: &C) -> Box<Future<Item=DummyPutResponse, Error=ApiError>> {
+    fn dummy_put(&self, param_nested_response: models::InlineObject, context: &C) -> Box<dyn Future<Item=DummyPutResponse, Error=ApiError>> {
         let mut uri = format!(
             "{}/dummy",
             self.base_path
@@ -333,7 +333,7 @@ impl<F, C> Api<C> for Client<F> where
 
         request.headers_mut().set(ContentType(mimetypes::requests::DUMMY_PUT.clone()));
 
-        request.headers_mut().set(XSpanId((context as &Has<XSpanIdString>).get().0.clone()));
+        request.headers_mut().set(XSpanId((context as &dyn Has<XSpanIdString>).get().0.clone()));
         Box::new(self.client_service.call(request)
                              .map_err(|e| ApiError(format!("No response received: {}", e)))
                              .and_then(|mut response| {
@@ -345,7 +345,7 @@ impl<F, C> Api<C> for Client<F> where
                         future::ok(
                             DummyPutResponse::Success
                         )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 },
                 code => {
                     let headers = response.headers().clone();
@@ -364,14 +364,14 @@ impl<F, C> Api<C> for Client<F> where
                                         Err(e) => Cow::from(format!("<Failed to read body: {}>", e)),
                                     })))
                             )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 }
             }
         }))
 
     }
 
-    fn file_response_get(&self, context: &C) -> Box<Future<Item=FileResponseGetResponse, Error=ApiError>> {
+    fn file_response_get(&self, context: &C) -> Box<dyn Future<Item=FileResponseGetResponse, Error=ApiError>> {
         let mut uri = format!(
             "{}/file_response",
             self.base_path
@@ -394,7 +394,7 @@ impl<F, C> Api<C> for Client<F> where
         let mut request = hyper::Request::new(hyper::Method::Get, uri);
 
 
-        request.headers_mut().set(XSpanId((context as &Has<XSpanIdString>).get().0.clone()));
+        request.headers_mut().set(XSpanId((context as &dyn Has<XSpanIdString>).get().0.clone()));
         Box::new(self.client_service.call(request)
                              .map_err(|e| ApiError(format!("No response received: {}", e)))
                              .and_then(|mut response| {
@@ -416,7 +416,7 @@ impl<F, C> Api<C> for Client<F> where
                         .map(move |body| {
                             FileResponseGetResponse::Success(body)
                         })
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 },
                 code => {
                     let headers = response.headers().clone();
@@ -435,14 +435,14 @@ impl<F, C> Api<C> for Client<F> where
                                         Err(e) => Cow::from(format!("<Failed to read body: {}>", e)),
                                     })))
                             )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 }
             }
         }))
 
     }
 
-    fn html_post(&self, param_body: String, context: &C) -> Box<Future<Item=HtmlPostResponse, Error=ApiError>> {
+    fn html_post(&self, param_body: String, context: &C) -> Box<dyn Future<Item=HtmlPostResponse, Error=ApiError>> {
         let mut uri = format!(
             "{}/html",
             self.base_path
@@ -469,7 +469,7 @@ impl<F, C> Api<C> for Client<F> where
 
         request.headers_mut().set(ContentType(mimetypes::requests::HTML_POST.clone()));
 
-        request.headers_mut().set(XSpanId((context as &Has<XSpanIdString>).get().0.clone()));
+        request.headers_mut().set(XSpanId((context as &dyn Has<XSpanIdString>).get().0.clone()));
         Box::new(self.client_service.call(request)
                              .map_err(|e| ApiError(format!("No response received: {}", e)))
                              .and_then(|mut response| {
@@ -490,7 +490,7 @@ impl<F, C> Api<C> for Client<F> where
                         .map(move |body| {
                             HtmlPostResponse::Success(body)
                         })
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 },
                 code => {
                     let headers = response.headers().clone();
@@ -509,14 +509,14 @@ impl<F, C> Api<C> for Client<F> where
                                         Err(e) => Cow::from(format!("<Failed to read body: {}>", e)),
                                     })))
                             )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 }
             }
         }))
 
     }
 
-    fn raw_json_get(&self, context: &C) -> Box<Future<Item=RawJsonGetResponse, Error=ApiError>> {
+    fn raw_json_get(&self, context: &C) -> Box<dyn Future<Item=RawJsonGetResponse, Error=ApiError>> {
         let mut uri = format!(
             "{}/raw_json",
             self.base_path
@@ -539,7 +539,7 @@ impl<F, C> Api<C> for Client<F> where
         let mut request = hyper::Request::new(hyper::Method::Get, uri);
 
 
-        request.headers_mut().set(XSpanId((context as &Has<XSpanIdString>).get().0.clone()));
+        request.headers_mut().set(XSpanId((context as &dyn Has<XSpanIdString>).get().0.clone()));
         Box::new(self.client_service.call(request)
                              .map_err(|e| ApiError(format!("No response received: {}", e)))
                              .and_then(|mut response| {
@@ -561,7 +561,7 @@ impl<F, C> Api<C> for Client<F> where
                         .map(move |body| {
                             RawJsonGetResponse::Success(body)
                         })
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 },
                 code => {
                     let headers = response.headers().clone();
@@ -580,7 +580,7 @@ impl<F, C> Api<C> for Client<F> where
                                         Err(e) => Cow::from(format!("<Failed to read body: {}>", e)),
                                     })))
                             )
-                    ) as Box<Future<Item=_, Error=_>>
+                    ) as Box<dyn Future<Item=_, Error=_>>
                 }
             }
         }))
@@ -611,7 +611,7 @@ impl From<openssl::error::ErrorStack> for ClientInitError {
 
 impl fmt::Display for ClientInitError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        (self as &fmt::Debug).fmt(f)
+        (self as &dyn fmt::Debug).fmt(f)
     }
 }
 

--- a/samples/server/petstore/rust-server/output/rust-server-test/src/lib.rs
+++ b/samples/server/petstore/rust-server/output/rust-server-test/src/lib.rs
@@ -88,19 +88,19 @@ pub enum RawJsonGetResponse {
 pub trait Api<C> {
 
     /// A dummy endpoint to make the spec valid.
-    fn dummy_get(&self, context: &C) -> Box<Future<Item=DummyGetResponse, Error=ApiError>>;
+    fn dummy_get(&self, context: &C) -> Box<dyn Future<Item=DummyGetResponse, Error=ApiError>>;
 
 
-    fn dummy_put(&self, nested_response: models::InlineObject, context: &C) -> Box<Future<Item=DummyPutResponse, Error=ApiError>>;
+    fn dummy_put(&self, nested_response: models::InlineObject, context: &C) -> Box<dyn Future<Item=DummyPutResponse, Error=ApiError>>;
 
     /// Get a file
-    fn file_response_get(&self, context: &C) -> Box<Future<Item=FileResponseGetResponse, Error=ApiError>>;
+    fn file_response_get(&self, context: &C) -> Box<dyn Future<Item=FileResponseGetResponse, Error=ApiError>>;
 
     /// Test HTML handling
-    fn html_post(&self, body: String, context: &C) -> Box<Future<Item=HtmlPostResponse, Error=ApiError>>;
+    fn html_post(&self, body: String, context: &C) -> Box<dyn Future<Item=HtmlPostResponse, Error=ApiError>>;
 
     /// Get an arbitrary JSON blob.
-    fn raw_json_get(&self, context: &C) -> Box<Future<Item=RawJsonGetResponse, Error=ApiError>>;
+    fn raw_json_get(&self, context: &C) -> Box<dyn Future<Item=RawJsonGetResponse, Error=ApiError>>;
 
 }
 
@@ -108,19 +108,19 @@ pub trait Api<C> {
 pub trait ApiNoContext {
 
     /// A dummy endpoint to make the spec valid.
-    fn dummy_get(&self) -> Box<Future<Item=DummyGetResponse, Error=ApiError>>;
+    fn dummy_get(&self) -> Box<dyn Future<Item=DummyGetResponse, Error=ApiError>>;
 
 
-    fn dummy_put(&self, nested_response: models::InlineObject) -> Box<Future<Item=DummyPutResponse, Error=ApiError>>;
+    fn dummy_put(&self, nested_response: models::InlineObject) -> Box<dyn Future<Item=DummyPutResponse, Error=ApiError>>;
 
     /// Get a file
-    fn file_response_get(&self) -> Box<Future<Item=FileResponseGetResponse, Error=ApiError>>;
+    fn file_response_get(&self) -> Box<dyn Future<Item=FileResponseGetResponse, Error=ApiError>>;
 
     /// Test HTML handling
-    fn html_post(&self, body: String) -> Box<Future<Item=HtmlPostResponse, Error=ApiError>>;
+    fn html_post(&self, body: String) -> Box<dyn Future<Item=HtmlPostResponse, Error=ApiError>>;
 
     /// Get an arbitrary JSON blob.
-    fn raw_json_get(&self) -> Box<Future<Item=RawJsonGetResponse, Error=ApiError>>;
+    fn raw_json_get(&self) -> Box<dyn Future<Item=RawJsonGetResponse, Error=ApiError>>;
 
 }
 
@@ -139,27 +139,27 @@ impl<'a, T: Api<C> + Sized, C> ContextWrapperExt<'a, C> for T {
 impl<'a, T: Api<C>, C> ApiNoContext for ContextWrapper<'a, T, C> {
 
     /// A dummy endpoint to make the spec valid.
-    fn dummy_get(&self) -> Box<Future<Item=DummyGetResponse, Error=ApiError>> {
+    fn dummy_get(&self) -> Box<dyn Future<Item=DummyGetResponse, Error=ApiError>> {
         self.api().dummy_get(&self.context())
     }
 
 
-    fn dummy_put(&self, nested_response: models::InlineObject) -> Box<Future<Item=DummyPutResponse, Error=ApiError>> {
+    fn dummy_put(&self, nested_response: models::InlineObject) -> Box<dyn Future<Item=DummyPutResponse, Error=ApiError>> {
         self.api().dummy_put(nested_response, &self.context())
     }
 
     /// Get a file
-    fn file_response_get(&self) -> Box<Future<Item=FileResponseGetResponse, Error=ApiError>> {
+    fn file_response_get(&self) -> Box<dyn Future<Item=FileResponseGetResponse, Error=ApiError>> {
         self.api().file_response_get(&self.context())
     }
 
     /// Test HTML handling
-    fn html_post(&self, body: String) -> Box<Future<Item=HtmlPostResponse, Error=ApiError>> {
+    fn html_post(&self, body: String) -> Box<dyn Future<Item=HtmlPostResponse, Error=ApiError>> {
         self.api().html_post(body, &self.context())
     }
 
     /// Get an arbitrary JSON blob.
-    fn raw_json_get(&self) -> Box<Future<Item=RawJsonGetResponse, Error=ApiError>> {
+    fn raw_json_get(&self) -> Box<dyn Future<Item=RawJsonGetResponse, Error=ApiError>> {
         self.api().raw_json_get(&self.context())
     }
 

--- a/samples/server/petstore/rust-server/output/rust-server-test/src/server/mod.rs
+++ b/samples/server/petstore/rust-server/output/rust-server-test/src/server/mod.rs
@@ -115,7 +115,7 @@ where
     type Request = (Request, C);
     type Response = Response;
     type Error = Error;
-    type Future = Box<Future<Item=Response, Error=Error>>;
+    type Future = Box<dyn Future<Item=Response, Error=Error>>;
 
     fn call(&self, (req, mut context): Self::Request) -> Self::Future {
         let api_impl = self.api_impl.clone();
@@ -133,7 +133,7 @@ where
                                 Box::new(api_impl.dummy_get(&context)
                                     .then(move |result| {
                                         let mut response = Response::new();
-                                        response.headers_mut().set(XSpanId((&context as &Has<XSpanIdString>).get().0.to_string()));
+                                        response.headers_mut().set(XSpanId((&context as &dyn Has<XSpanIdString>).get().0.to_string()));
 
                                         match result {
                                             Ok(rsp) => match rsp {
@@ -157,7 +157,7 @@ where
                                     }
                                 ))
                         }}
-                }) as Box<Future<Item=Response, Error=Error>>
+                }) as Box<dyn Future<Item=Response, Error=Error>>
             },
 
             // DummyPut - PUT /dummy
@@ -166,7 +166,7 @@ where
                 // values, rather than causing a 400 response). Produce warning header and logs for
                 // any unused fields.
                 Box::new(body.concat2()
-                    .then(move |result| -> Box<Future<Item=Response, Error=Error>> {
+                    .then(move |result| -> Box<dyn Future<Item=Response, Error=Error>> {
                         match result {
                             Ok(body) => {
                                 let mut unused_elements = Vec::new();
@@ -189,7 +189,7 @@ where
                                 Box::new(api_impl.dummy_put(param_nested_response, &context)
                                     .then(move |result| {
                                         let mut response = Response::new();
-                                        response.headers_mut().set(XSpanId((&context as &Has<XSpanIdString>).get().0.to_string()));
+                                        response.headers_mut().set(XSpanId((&context as &dyn Has<XSpanIdString>).get().0.to_string()));
 
                                         if !unused_elements.is_empty() {
                                             response.headers_mut().set(Warning(format!("Ignoring unknown fields in body: {:?}", unused_elements)));
@@ -220,7 +220,7 @@ where
                             Err(e) => Box::new(future::ok(Response::new().with_status(StatusCode::BadRequest).with_body(format!("Couldn't read body parameter nested_response: {}", e)))),
                         }
                     })
-                ) as Box<Future<Item=Response, Error=Error>>
+                ) as Box<dyn Future<Item=Response, Error=Error>>
             },
 
             // FileResponseGet - GET /file_response
@@ -230,7 +230,7 @@ where
                                 Box::new(api_impl.file_response_get(&context)
                                     .then(move |result| {
                                         let mut response = Response::new();
-                                        response.headers_mut().set(XSpanId((&context as &Has<XSpanIdString>).get().0.to_string()));
+                                        response.headers_mut().set(XSpanId((&context as &dyn Has<XSpanIdString>).get().0.to_string()));
 
                                         match result {
                                             Ok(rsp) => match rsp {
@@ -260,7 +260,7 @@ where
                                     }
                                 ))
                         }}
-                }) as Box<Future<Item=Response, Error=Error>>
+                }) as Box<dyn Future<Item=Response, Error=Error>>
             },
 
             // HtmlPost - POST /html
@@ -269,7 +269,7 @@ where
                 // values, rather than causing a 400 response). Produce warning header and logs for
                 // any unused fields.
                 Box::new(body.concat2()
-                    .then(move |result| -> Box<Future<Item=Response, Error=Error>> {
+                    .then(move |result| -> Box<dyn Future<Item=Response, Error=Error>> {
                         match result {
                             Ok(body) => {
                                 let param_body: Option<String> = if !body.is_empty() {
@@ -284,7 +284,7 @@ where
                                 Box::new(api_impl.html_post(param_body, &context)
                                     .then(move |result| {
                                         let mut response = Response::new();
-                                        response.headers_mut().set(XSpanId((&context as &Has<XSpanIdString>).get().0.to_string()));
+                                        response.headers_mut().set(XSpanId((&context as &dyn Has<XSpanIdString>).get().0.to_string()));
 
                                         match result {
                                             Ok(rsp) => match rsp {
@@ -317,7 +317,7 @@ where
                             Err(e) => Box::new(future::ok(Response::new().with_status(StatusCode::BadRequest).with_body(format!("Couldn't read body parameter body: {}", e)))),
                         }
                     })
-                ) as Box<Future<Item=Response, Error=Error>>
+                ) as Box<dyn Future<Item=Response, Error=Error>>
             },
 
             // RawJsonGet - GET /raw_json
@@ -327,7 +327,7 @@ where
                                 Box::new(api_impl.raw_json_get(&context)
                                     .then(move |result| {
                                         let mut response = Response::new();
-                                        response.headers_mut().set(XSpanId((&context as &Has<XSpanIdString>).get().0.to_string()));
+                                        response.headers_mut().set(XSpanId((&context as &dyn Has<XSpanIdString>).get().0.to_string()));
 
                                         match result {
                                             Ok(rsp) => match rsp {
@@ -357,10 +357,10 @@ where
                                     }
                                 ))
                         }}
-                }) as Box<Future<Item=Response, Error=Error>>
+                }) as Box<dyn Future<Item=Response, Error=Error>>
             },
 
-            _ => Box::new(future::ok(Response::new().with_status(StatusCode::NotFound))) as Box<Future<Item=Response, Error=Error>>,
+            _ => Box::new(future::ok(Response::new().with_status(StatusCode::NotFound))) as Box<dyn Future<Item=Response, Error=Error>>,
         }
     }
 }


### PR DESCRIPTION
This updates the generated code to be compatible with Rust 1.39.

There are two key changes:
- Move to lazy static 1.4 - this fixes #4271 
- Add all of the required `dyn` markers to fix the warning `warning: trait objects without an explicit `dyn` are deprecated`.

### Rust Technical Committee

@frol @farcaller @bjgill @richardwhiuk

### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [X] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [X] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
