### PR TITLE
[Rust Server] Fix panic handling headers

### DIFF
--- a/modules/openapi-generator/src/main/resources/rust-server/Cargo.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/Cargo.mustache
@@ -17,7 +17,7 @@ conversion = ["frunk", "frunk_derives", "frunk_core", "frunk-enum-core", "frunk-
 # Common
 chrono = { version = "0.4", features = ["serde"] }
 futures = "0.1"
-swagger = "2"
+swagger = "2.2"
 lazy_static = "1.4"
 log = "0.3.0"
 mime = "0.2.6"

--- a/modules/openapi-generator/src/main/resources/rust-server/client-mod.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/client-mod.mustache
@@ -33,6 +33,8 @@ use std::sync::Arc;
 use std::str;
 use std::str::FromStr;
 use std::string::ToString;
+use swagger::headers::SafeHeaders;
+
 {{#apiUsesMultipart}}
 use hyper::mime::Mime; 
 use std::io::Cursor; 
@@ -478,7 +480,7 @@ impl<F, C> Api<C> for Client<F> where
 {{#responses}}
                 {{{code}}} => {
 {{#headers}}                    header! { (Response{{{nameInCamelCase}}}, "{{{baseName}}}") => [{{{datatype}}}] }
-                    let response_{{{name}}} = match response.headers().get::<Response{{{nameInCamelCase}}}>() {
+                    let response_{{{name}}} = match response.headers().safe_get::<Response{{{nameInCamelCase}}}>() {
                         Some(response_{{{name}}}) => response_{{{name}}}.0.clone(),
                         None => return Box::new(future::err(ApiError(String::from("Required response header {{{baseName}}} for response {{{code}}} was not found.")))) as Box<dyn Future<Item=_, Error=_>>,
                     };

--- a/modules/openapi-generator/src/main/resources/rust-server/server-context.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/server-context.mustache
@@ -6,6 +6,7 @@ use hyper::{Request, Response, Error, StatusCode};
 use server::url::form_urlencoded;
 use swagger::auth::{Authorization, AuthData, Scopes};
 use swagger::{Has, Pop, Push, XSpanIdString};
+use swagger::headers::SafeHeaders;
 use Api;
 
 pub struct NewAddContext<T, A>
@@ -88,7 +89,7 @@ impl<T, A, B, C, D> hyper::server::Service for AddContext<T, A>
         {
             use hyper::header::{Authorization as HyperAuth, Basic, Bearer};
             use std::ops::Deref;
-            if let Some(basic) = req.headers().get::<HyperAuth<Basic>>().cloned() {
+            if let Some(basic) = req.headers().safe_get::<HyperAuth<Basic>>() {
                 let auth_data = AuthData::Basic(basic.deref().clone());
                 let context = context.push(Some(auth_data));
                 let context = context.push(None::<Authorization>);
@@ -100,7 +101,7 @@ impl<T, A, B, C, D> hyper::server::Service for AddContext<T, A>
         {
             use hyper::header::{Authorization as HyperAuth, Basic, Bearer};
             use std::ops::Deref;
-            if let Some(bearer) = req.headers().get::<HyperAuth<Bearer>>().cloned() {
+            if let Some(bearer) = req.headers().safe_get::<HyperAuth<Bearer>>() {
                 let auth_data = AuthData::Bearer(bearer.deref().clone());
                 let context = context.push(Some(auth_data));
                 let context = context.push(None::<Authorization>);
@@ -112,7 +113,7 @@ impl<T, A, B, C, D> hyper::server::Service for AddContext<T, A>
         {{#isKeyInHeader}}
         {
             header! { (ApiKey{{-index}}, "{{{keyParamName}}}") => [String] }
-            if let Some(header) = req.headers().get::<ApiKey{{-index}}>().cloned() {
+            if let Some(header) = req.headers().safe_get::<ApiKey{{-index}}>() {
                 let auth_data = AuthData::ApiKey(header.0);
                 let context = context.push(Some(auth_data));
                 let context = context.push(None::<Authorization>);

--- a/modules/openapi-generator/src/main/resources/rust-server/server-mod.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/server-mod.mustache
@@ -45,6 +45,7 @@ use std::collections::BTreeSet;
 pub use swagger::auth::Authorization;
 use swagger::{ApiError, XSpanId, XSpanIdString, Has, RequestParser};
 use swagger::auth::Scopes;
+use swagger::headers::SafeHeaders;
 
 use {Api{{#apiInfo}}{{#apis}}{{#operations}}{{#operation}},
      {{{operationId}}}Response{{/operation}}{{/operations}}{{/apis}}{{/apiInfo}}
@@ -178,7 +179,7 @@ where
 {{#vendorExtensions}}
   {{#consumesMultipart}} 
                 let boundary = match multipart_boundary(&headers) {
-                    Some(boundary) => boundary.to_string(),
+                    Some(boundary) => boundary,
                     None => return Box::new(future::ok(Response::new().with_status(StatusCode::BadRequest).with_body("Couldn't find valid multipart body"))),
                 };
   {{/consumesMultipart}}
@@ -214,7 +215,7 @@ where
                 };
   {{/required}}
   {{^required}}
-                let param_{{{paramName}}} = headers.get::<Request{{vendorExtensions.typeName}}>().map(|header| header.0.clone());
+                let param_{{{paramName}}} = headers.safe_get::<Request{{vendorExtensions.typeName}}>().map(|header| header.0.clone());
   {{/required}}
 {{/headerParams}}
 {{#queryParams}}
@@ -530,11 +531,11 @@ impl<T, C> Clone for Service<T, C>
 
 {{#apiUsesMultipart}}
 /// Utility function to get the multipart boundary marker (if any) from the Headers.
-fn multipart_boundary<'a>(headers: &'a Headers) -> Option<&'a str> {
-    headers.get::<ContentType>().and_then(|content_type| {
-        let ContentType(ref mime) = *content_type;
+fn multipart_boundary(headers: &Headers) -> Option<String> {
+    headers.safe_get::<ContentType>().and_then(|content_type| {
+        let ContentType(mime) = content_type;
         if mime.type_() == hyper::mime::MULTIPART && mime.subtype() == hyper::mime::FORM_DATA {
-            mime.get_param(hyper::mime::BOUNDARY).map(|x| x.as_str())
+            mime.get_param(hyper::mime::BOUNDARY).map(|x| x.as_str().to_string())
         } else {
             None
         }

--- a/samples/server/petstore/rust-server/output/multipart-v3/Cargo.toml
+++ b/samples/server/petstore/rust-server/output/multipart-v3/Cargo.toml
@@ -15,7 +15,7 @@ conversion = ["frunk", "frunk_derives", "frunk_core", "frunk-enum-core", "frunk-
 # Common
 chrono = { version = "0.4", features = ["serde"] }
 futures = "0.1"
-swagger = "2"
+swagger = "2.2"
 lazy_static = "1.4"
 log = "0.3.0"
 mime = "0.2.6"

--- a/samples/server/petstore/rust-server/output/multipart-v3/src/client/mod.rs
+++ b/samples/server/petstore/rust-server/output/multipart-v3/src/client/mod.rs
@@ -25,6 +25,8 @@ use std::sync::Arc;
 use std::str;
 use std::str::FromStr;
 use std::string::ToString;
+use swagger::headers::SafeHeaders;
+
 use hyper::mime::Mime; 
 use std::io::Cursor; 
 use client::multipart::client::lazy::Multipart; 

--- a/samples/server/petstore/rust-server/output/multipart-v3/src/server/context.rs
+++ b/samples/server/petstore/rust-server/output/multipart-v3/src/server/context.rs
@@ -6,6 +6,7 @@ use hyper::{Request, Response, Error, StatusCode};
 use server::url::form_urlencoded;
 use swagger::auth::{Authorization, AuthData, Scopes};
 use swagger::{Has, Pop, Push, XSpanIdString};
+use swagger::headers::SafeHeaders;
 use Api;
 
 pub struct NewAddContext<T, A>

--- a/samples/server/petstore/rust-server/output/openapi-v3/Cargo.toml
+++ b/samples/server/petstore/rust-server/output/openapi-v3/Cargo.toml
@@ -15,7 +15,7 @@ conversion = ["frunk", "frunk_derives", "frunk_core", "frunk-enum-core", "frunk-
 # Common
 chrono = { version = "0.4", features = ["serde"] }
 futures = "0.1"
-swagger = "2"
+swagger = "2.2"
 lazy_static = "1.4"
 log = "0.3.0"
 mime = "0.2.6"

--- a/samples/server/petstore/rust-server/output/openapi-v3/src/client/mod.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/src/client/mod.rs
@@ -25,6 +25,8 @@ use std::sync::Arc;
 use std::str;
 use std::str::FromStr;
 use std::string::ToString;
+use swagger::headers::SafeHeaders;
+
 use mimetypes;
 use serde_json;
 use serde_xml_rs;
@@ -675,7 +677,7 @@ impl<F, C> Api<C> for Client<F> where
             match response.status().as_u16() {
                 200 => {
                     header! { (ResponseSuccessInfo, "Success-Info") => [String] }
-                    let response_success_info = match response.headers().get::<ResponseSuccessInfo>() {
+                    let response_success_info = match response.headers().safe_get::<ResponseSuccessInfo>() {
                         Some(response_success_info) => response_success_info.0.clone(),
                         None => return Box::new(future::err(ApiError(String::from("Required response header Success-Info for response 200 was not found.")))) as Box<dyn Future<Item=_, Error=_>>,
                     };
@@ -699,12 +701,12 @@ impl<F, C> Api<C> for Client<F> where
                 },
                 412 => {
                     header! { (ResponseFurtherInfo, "Further-Info") => [String] }
-                    let response_further_info = match response.headers().get::<ResponseFurtherInfo>() {
+                    let response_further_info = match response.headers().safe_get::<ResponseFurtherInfo>() {
                         Some(response_further_info) => response_further_info.0.clone(),
                         None => return Box::new(future::err(ApiError(String::from("Required response header Further-Info for response 412 was not found.")))) as Box<dyn Future<Item=_, Error=_>>,
                     };
                     header! { (ResponseFailureInfo, "Failure-Info") => [String] }
-                    let response_failure_info = match response.headers().get::<ResponseFailureInfo>() {
+                    let response_failure_info = match response.headers().safe_get::<ResponseFailureInfo>() {
                         Some(response_failure_info) => response_failure_info.0.clone(),
                         None => return Box::new(future::err(ApiError(String::from("Required response header Failure-Info for response 412 was not found.")))) as Box<dyn Future<Item=_, Error=_>>,
                     };

--- a/samples/server/petstore/rust-server/output/openapi-v3/src/server/context.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/src/server/context.rs
@@ -6,6 +6,7 @@ use hyper::{Request, Response, Error, StatusCode};
 use server::url::form_urlencoded;
 use swagger::auth::{Authorization, AuthData, Scopes};
 use swagger::{Has, Pop, Push, XSpanIdString};
+use swagger::headers::SafeHeaders;
 use Api;
 
 pub struct NewAddContext<T, A>
@@ -86,7 +87,7 @@ impl<T, A, B, C, D> hyper::server::Service for AddContext<T, A>
         {
             use hyper::header::{Authorization as HyperAuth, Basic, Bearer};
             use std::ops::Deref;
-            if let Some(bearer) = req.headers().get::<HyperAuth<Bearer>>().cloned() {
+            if let Some(bearer) = req.headers().safe_get::<HyperAuth<Bearer>>() {
                 let auth_data = AuthData::Bearer(bearer.deref().clone());
                 let context = context.push(Some(auth_data));
                 let context = context.push(None::<Authorization>);

--- a/samples/server/petstore/rust-server/output/openapi-v3/src/server/mod.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/src/server/mod.rs
@@ -33,6 +33,7 @@ use std::collections::BTreeSet;
 pub use swagger::auth::Authorization;
 use swagger::{ApiError, XSpanId, XSpanIdString, Has, RequestParser};
 use swagger::auth::Scopes;
+use swagger::headers::SafeHeaders;
 
 use {Api,
      MultigetGetResponse,

--- a/samples/server/petstore/rust-server/output/ops-v3/Cargo.toml
+++ b/samples/server/petstore/rust-server/output/ops-v3/Cargo.toml
@@ -15,7 +15,7 @@ conversion = ["frunk", "frunk_derives", "frunk_core", "frunk-enum-core", "frunk-
 # Common
 chrono = { version = "0.4", features = ["serde"] }
 futures = "0.1"
-swagger = "2"
+swagger = "2.2"
 lazy_static = "1.4"
 log = "0.3.0"
 mime = "0.2.6"

--- a/samples/server/petstore/rust-server/output/ops-v3/src/client/mod.rs
+++ b/samples/server/petstore/rust-server/output/ops-v3/src/client/mod.rs
@@ -24,6 +24,8 @@ use std::sync::Arc;
 use std::str;
 use std::str::FromStr;
 use std::string::ToString;
+use swagger::headers::SafeHeaders;
+
 use mimetypes;
 use serde_json;
 

--- a/samples/server/petstore/rust-server/output/ops-v3/src/server/context.rs
+++ b/samples/server/petstore/rust-server/output/ops-v3/src/server/context.rs
@@ -6,6 +6,7 @@ use hyper::{Request, Response, Error, StatusCode};
 use server::url::form_urlencoded;
 use swagger::auth::{Authorization, AuthData, Scopes};
 use swagger::{Has, Pop, Push, XSpanIdString};
+use swagger::headers::SafeHeaders;
 use Api;
 
 pub struct NewAddContext<T, A>

--- a/samples/server/petstore/rust-server/output/ops-v3/src/server/mod.rs
+++ b/samples/server/petstore/rust-server/output/ops-v3/src/server/mod.rs
@@ -31,6 +31,7 @@ use std::collections::BTreeSet;
 pub use swagger::auth::Authorization;
 use swagger::{ApiError, XSpanId, XSpanIdString, Has, RequestParser};
 use swagger::auth::Scopes;
+use swagger::headers::SafeHeaders;
 
 use {Api,
      Op10GetResponse,

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/Cargo.toml
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/Cargo.toml
@@ -15,7 +15,7 @@ conversion = ["frunk", "frunk_derives", "frunk_core", "frunk-enum-core", "frunk-
 # Common
 chrono = { version = "0.4", features = ["serde"] }
 futures = "0.1"
-swagger = "2"
+swagger = "2.2"
 lazy_static = "1.4"
 log = "0.3.0"
 mime = "0.2.6"

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/src/client/mod.rs
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/src/client/mod.rs
@@ -27,6 +27,8 @@ use std::sync::Arc;
 use std::str;
 use std::str::FromStr;
 use std::string::ToString;
+use swagger::headers::SafeHeaders;
+
 use hyper::mime::Mime; 
 use std::io::Cursor; 
 use client::multipart::client::lazy::Multipart; 
@@ -2705,12 +2707,12 @@ impl<F, C> Api<C> for Client<F> where
             match response.status().as_u16() {
                 200 => {
                     header! { (ResponseXRateLimit, "X-Rate-Limit") => [i32] }
-                    let response_x_rate_limit = match response.headers().get::<ResponseXRateLimit>() {
+                    let response_x_rate_limit = match response.headers().safe_get::<ResponseXRateLimit>() {
                         Some(response_x_rate_limit) => response_x_rate_limit.0.clone(),
                         None => return Box::new(future::err(ApiError(String::from("Required response header X-Rate-Limit for response 200 was not found.")))) as Box<dyn Future<Item=_, Error=_>>,
                     };
                     header! { (ResponseXExpiresAfter, "X-Expires-After") => [chrono::DateTime<chrono::Utc>] }
-                    let response_x_expires_after = match response.headers().get::<ResponseXExpiresAfter>() {
+                    let response_x_expires_after = match response.headers().safe_get::<ResponseXExpiresAfter>() {
                         Some(response_x_expires_after) => response_x_expires_after.0.clone(),
                         None => return Box::new(future::err(ApiError(String::from("Required response header X-Expires-After for response 200 was not found.")))) as Box<dyn Future<Item=_, Error=_>>,
                     };

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/src/server/context.rs
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/src/server/context.rs
@@ -6,6 +6,7 @@ use hyper::{Request, Response, Error, StatusCode};
 use server::url::form_urlencoded;
 use swagger::auth::{Authorization, AuthData, Scopes};
 use swagger::{Has, Pop, Push, XSpanIdString};
+use swagger::headers::SafeHeaders;
 use Api;
 
 pub struct NewAddContext<T, A>
@@ -85,7 +86,7 @@ impl<T, A, B, C, D> hyper::server::Service for AddContext<T, A>
 
         {
             header! { (ApiKey1, "api_key") => [String] }
-            if let Some(header) = req.headers().get::<ApiKey1>().cloned() {
+            if let Some(header) = req.headers().safe_get::<ApiKey1>() {
                 let auth_data = AuthData::ApiKey(header.0);
                 let context = context.push(Some(auth_data));
                 let context = context.push(None::<Authorization>);
@@ -107,7 +108,7 @@ impl<T, A, B, C, D> hyper::server::Service for AddContext<T, A>
         {
             use hyper::header::{Authorization as HyperAuth, Basic, Bearer};
             use std::ops::Deref;
-            if let Some(basic) = req.headers().get::<HyperAuth<Basic>>().cloned() {
+            if let Some(basic) = req.headers().safe_get::<HyperAuth<Basic>>() {
                 let auth_data = AuthData::Basic(basic.deref().clone());
                 let context = context.push(Some(auth_data));
                 let context = context.push(None::<Authorization>);
@@ -117,7 +118,7 @@ impl<T, A, B, C, D> hyper::server::Service for AddContext<T, A>
         {
             use hyper::header::{Authorization as HyperAuth, Basic, Bearer};
             use std::ops::Deref;
-            if let Some(bearer) = req.headers().get::<HyperAuth<Bearer>>().cloned() {
+            if let Some(bearer) = req.headers().safe_get::<HyperAuth<Bearer>>() {
                 let auth_data = AuthData::Bearer(bearer.deref().clone());
                 let context = context.push(Some(auth_data));
                 let context = context.push(None::<Authorization>);

--- a/samples/server/petstore/rust-server/output/rust-server-test/Cargo.toml
+++ b/samples/server/petstore/rust-server/output/rust-server-test/Cargo.toml
@@ -15,7 +15,7 @@ conversion = ["frunk", "frunk_derives", "frunk_core", "frunk-enum-core", "frunk-
 # Common
 chrono = { version = "0.4", features = ["serde"] }
 futures = "0.1"
-swagger = "2"
+swagger = "2.2"
 lazy_static = "1.4"
 log = "0.3.0"
 mime = "0.2.6"

--- a/samples/server/petstore/rust-server/output/rust-server-test/src/client/mod.rs
+++ b/samples/server/petstore/rust-server/output/rust-server-test/src/client/mod.rs
@@ -24,6 +24,8 @@ use std::sync::Arc;
 use std::str;
 use std::str::FromStr;
 use std::string::ToString;
+use swagger::headers::SafeHeaders;
+
 use mimetypes;
 use serde_json;
 

--- a/samples/server/petstore/rust-server/output/rust-server-test/src/server/context.rs
+++ b/samples/server/petstore/rust-server/output/rust-server-test/src/server/context.rs
@@ -6,6 +6,7 @@ use hyper::{Request, Response, Error, StatusCode};
 use server::url::form_urlencoded;
 use swagger::auth::{Authorization, AuthData, Scopes};
 use swagger::{Has, Pop, Push, XSpanIdString};
+use swagger::headers::SafeHeaders;
 use Api;
 
 pub struct NewAddContext<T, A>

--- a/samples/server/petstore/rust-server/output/rust-server-test/src/server/mod.rs
+++ b/samples/server/petstore/rust-server/output/rust-server-test/src/server/mod.rs
@@ -31,6 +31,7 @@ use std::collections::BTreeSet;
 pub use swagger::auth::Authorization;
 use swagger::{ApiError, XSpanId, XSpanIdString, Has, RequestParser};
 use swagger::auth::Scopes;
+use swagger::headers::SafeHeaders;
 
 use {Api,
      DummyGetResponse,


### PR DESCRIPTION
If we have an API which has multiple auth types, we may panic. This is because
in Hyper 0.11, the following code will panic:
    
```rust
use hyper::header::{Authorization, Basic, Bearer, Headers};

fn main() {
    let mut headers = Headers::default();
    let basic = Basic { username: "richard".to_string(), password: None };
    headers.set::<Authorization<Basic>>(Authorization(basic));
    println!("Auth: {:?}", headers.get::<Authorization<Bearer>>());
}
```
    
as it mixes up an `Authorization<Basic>` and `Authorization<Bearer>` as both
have `Authorization:` as the header name.
    
This is fixed by using `swagger::SafeHeaders` added in
https://github.com/Metaswitch/swagger-rs/pull/90

This code is no longer relevant once the Hyper 0.12 work is merged, but that is a breaking change, so this is put in for the 4.x branch.

### Rust Technical Committee

@frol @farcaller @bjgill

### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [X] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [X] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.