### PR TITLE
NPE and Circular reference regression fix.

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonClientExperimentalCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonClientExperimentalCodegen.java
@@ -651,7 +651,7 @@ public class PythonClientExperimentalCodegen extends PythonClientCodegen {
         // set baseType to null so the api docs will not point to a model for languageSpecificPrimitives
         if (p.baseType != null && languageSpecificPrimitives.contains(p.baseType)){
             p.baseType = null;
-        } else if (p.isListContainer && p.mostInnerItems.complexType != null && !languageSpecificPrimitives.contains(p.mostInnerItems.complexType)) {
+        } else if (p.isListContainer && p.mostInnerItems != null && p.mostInnerItems.complexType != null && !languageSpecificPrimitives.contains(p.mostInnerItems.complexType)) {
             // fix ListContainers
             p.baseType = getPythonClassName(p.mostInnerItems.complexType);
         }

--- a/modules/openapi-generator/src/main/resources/python/python-experimental/model_templates/classvars.mustache
+++ b/modules/openapi-generator/src/main/resources/python/python-experimental/model_templates/classvars.mustache
@@ -29,7 +29,10 @@
 {{/optionalVars}}
     }
 
-    openapi_types = {
+    @staticmethod
+    @property
+    def openapi_types():
+        return {
 {{#requiredVars}}
         '{{name}}': ({{{dataType}}},),  # noqa: E501
 {{/requiredVars}}

--- a/samples/client/petstore/python-experimental/petstore_api/models/additional_properties_any_type.py
+++ b/samples/client/petstore/python-experimental/petstore_api/models/additional_properties_any_type.py
@@ -59,7 +59,10 @@ class AdditionalPropertiesAnyType(ModelNormal):
     allowed_values = {
     }
 
-    openapi_types = {
+    @staticmethod
+    @property
+    def openapi_types():
+        return {
         'name': (str,),  # noqa: E501
     }
 

--- a/samples/client/petstore/python-experimental/petstore_api/models/additional_properties_array.py
+++ b/samples/client/petstore/python-experimental/petstore_api/models/additional_properties_array.py
@@ -59,7 +59,10 @@ class AdditionalPropertiesArray(ModelNormal):
     allowed_values = {
     }
 
-    openapi_types = {
+    @staticmethod
+    @property
+    def openapi_types():
+        return {
         'name': (str,),  # noqa: E501
     }
 

--- a/samples/client/petstore/python-experimental/petstore_api/models/additional_properties_boolean.py
+++ b/samples/client/petstore/python-experimental/petstore_api/models/additional_properties_boolean.py
@@ -59,7 +59,10 @@ class AdditionalPropertiesBoolean(ModelNormal):
     allowed_values = {
     }
 
-    openapi_types = {
+    @staticmethod
+    @property
+    def openapi_types():
+        return {
         'name': (str,),  # noqa: E501
     }
 

--- a/samples/client/petstore/python-experimental/petstore_api/models/additional_properties_class.py
+++ b/samples/client/petstore/python-experimental/petstore_api/models/additional_properties_class.py
@@ -59,7 +59,10 @@ class AdditionalPropertiesClass(ModelNormal):
     allowed_values = {
     }
 
-    openapi_types = {
+    @staticmethod
+    @property
+    def openapi_types():
+        return {
         'map_string': ({str: (str,)},),  # noqa: E501
         'map_number': ({str: (float,)},),  # noqa: E501
         'map_integer': ({str: (int,)},),  # noqa: E501

--- a/samples/client/petstore/python-experimental/petstore_api/models/additional_properties_integer.py
+++ b/samples/client/petstore/python-experimental/petstore_api/models/additional_properties_integer.py
@@ -59,7 +59,10 @@ class AdditionalPropertiesInteger(ModelNormal):
     allowed_values = {
     }
 
-    openapi_types = {
+    @staticmethod
+    @property
+    def openapi_types():
+        return {
         'name': (str,),  # noqa: E501
     }
 

--- a/samples/client/petstore/python-experimental/petstore_api/models/additional_properties_number.py
+++ b/samples/client/petstore/python-experimental/petstore_api/models/additional_properties_number.py
@@ -59,7 +59,10 @@ class AdditionalPropertiesNumber(ModelNormal):
     allowed_values = {
     }
 
-    openapi_types = {
+    @staticmethod
+    @property
+    def openapi_types():
+        return {
         'name': (str,),  # noqa: E501
     }
 

--- a/samples/client/petstore/python-experimental/petstore_api/models/additional_properties_object.py
+++ b/samples/client/petstore/python-experimental/petstore_api/models/additional_properties_object.py
@@ -59,7 +59,10 @@ class AdditionalPropertiesObject(ModelNormal):
     allowed_values = {
     }
 
-    openapi_types = {
+    @staticmethod
+    @property
+    def openapi_types():
+        return {
         'name': (str,),  # noqa: E501
     }
 

--- a/samples/client/petstore/python-experimental/petstore_api/models/additional_properties_string.py
+++ b/samples/client/petstore/python-experimental/petstore_api/models/additional_properties_string.py
@@ -59,7 +59,10 @@ class AdditionalPropertiesString(ModelNormal):
     allowed_values = {
     }
 
-    openapi_types = {
+    @staticmethod
+    @property
+    def openapi_types():
+        return {
         'name': (str,),  # noqa: E501
     }
 

--- a/samples/client/petstore/python-experimental/petstore_api/models/animal.py
+++ b/samples/client/petstore/python-experimental/petstore_api/models/animal.py
@@ -67,7 +67,10 @@ class Animal(ModelNormal):
     allowed_values = {
     }
 
-    openapi_types = {
+    @staticmethod
+    @property
+    def openapi_types():
+        return {
         'class_name': (str,),  # noqa: E501
         'color': (str,),  # noqa: E501
     }

--- a/samples/client/petstore/python-experimental/petstore_api/models/api_response.py
+++ b/samples/client/petstore/python-experimental/petstore_api/models/api_response.py
@@ -59,7 +59,10 @@ class ApiResponse(ModelNormal):
     allowed_values = {
     }
 
-    openapi_types = {
+    @staticmethod
+    @property
+    def openapi_types():
+        return {
         'code': (int,),  # noqa: E501
         'type': (str,),  # noqa: E501
         'message': (str,),  # noqa: E501

--- a/samples/client/petstore/python-experimental/petstore_api/models/array_of_array_of_number_only.py
+++ b/samples/client/petstore/python-experimental/petstore_api/models/array_of_array_of_number_only.py
@@ -59,7 +59,10 @@ class ArrayOfArrayOfNumberOnly(ModelNormal):
     allowed_values = {
     }
 
-    openapi_types = {
+    @staticmethod
+    @property
+    def openapi_types():
+        return {
         'array_array_number': ([[float]],),  # noqa: E501
     }
 

--- a/samples/client/petstore/python-experimental/petstore_api/models/array_of_number_only.py
+++ b/samples/client/petstore/python-experimental/petstore_api/models/array_of_number_only.py
@@ -59,7 +59,10 @@ class ArrayOfNumberOnly(ModelNormal):
     allowed_values = {
     }
 
-    openapi_types = {
+    @staticmethod
+    @property
+    def openapi_types():
+        return {
         'array_number': ([float],),  # noqa: E501
     }
 

--- a/samples/client/petstore/python-experimental/petstore_api/models/array_test.py
+++ b/samples/client/petstore/python-experimental/petstore_api/models/array_test.py
@@ -63,7 +63,10 @@ class ArrayTest(ModelNormal):
     allowed_values = {
     }
 
-    openapi_types = {
+    @staticmethod
+    @property
+    def openapi_types():
+        return {
         'array_of_string': ([str],),  # noqa: E501
         'array_array_of_integer': ([[int]],),  # noqa: E501
         'array_array_of_model': ([[read_only_first.ReadOnlyFirst]],),  # noqa: E501

--- a/samples/client/petstore/python-experimental/petstore_api/models/capitalization.py
+++ b/samples/client/petstore/python-experimental/petstore_api/models/capitalization.py
@@ -59,7 +59,10 @@ class Capitalization(ModelNormal):
     allowed_values = {
     }
 
-    openapi_types = {
+    @staticmethod
+    @property
+    def openapi_types():
+        return {
         'small_camel': (str,),  # noqa: E501
         'capital_camel': (str,),  # noqa: E501
         'small_snake': (str,),  # noqa: E501

--- a/samples/client/petstore/python-experimental/petstore_api/models/cat.py
+++ b/samples/client/petstore/python-experimental/petstore_api/models/cat.py
@@ -67,7 +67,10 @@ class Cat(ModelComposed):
     allowed_values = {
     }
 
-    openapi_types = {
+    @staticmethod
+    @property
+    def openapi_types():
+        return {
         'class_name': (str,),  # noqa: E501
         'declawed': (bool,),  # noqa: E501
         'color': (str,),  # noqa: E501

--- a/samples/client/petstore/python-experimental/petstore_api/models/cat_all_of.py
+++ b/samples/client/petstore/python-experimental/petstore_api/models/cat_all_of.py
@@ -59,7 +59,10 @@ class CatAllOf(ModelNormal):
     allowed_values = {
     }
 
-    openapi_types = {
+    @staticmethod
+    @property
+    def openapi_types():
+        return {
         'declawed': (bool,),  # noqa: E501
     }
 

--- a/samples/client/petstore/python-experimental/petstore_api/models/category.py
+++ b/samples/client/petstore/python-experimental/petstore_api/models/category.py
@@ -59,7 +59,10 @@ class Category(ModelNormal):
     allowed_values = {
     }
 
-    openapi_types = {
+    @staticmethod
+    @property
+    def openapi_types():
+        return {
         'name': (str,),  # noqa: E501
         'id': (int,),  # noqa: E501
     }

--- a/samples/client/petstore/python-experimental/petstore_api/models/child.py
+++ b/samples/client/petstore/python-experimental/petstore_api/models/child.py
@@ -67,7 +67,10 @@ class Child(ModelComposed):
     allowed_values = {
     }
 
-    openapi_types = {
+    @staticmethod
+    @property
+    def openapi_types():
+        return {
         'radio_waves': (bool,),  # noqa: E501
         'tele_vision': (bool,),  # noqa: E501
         'inter_net': (bool,),  # noqa: E501

--- a/samples/client/petstore/python-experimental/petstore_api/models/child_all_of.py
+++ b/samples/client/petstore/python-experimental/petstore_api/models/child_all_of.py
@@ -59,7 +59,10 @@ class ChildAllOf(ModelNormal):
     allowed_values = {
     }
 
-    openapi_types = {
+    @staticmethod
+    @property
+    def openapi_types():
+        return {
         'inter_net': (bool,),  # noqa: E501
     }
 

--- a/samples/client/petstore/python-experimental/petstore_api/models/child_cat.py
+++ b/samples/client/petstore/python-experimental/petstore_api/models/child_cat.py
@@ -67,7 +67,10 @@ class ChildCat(ModelComposed):
     allowed_values = {
     }
 
-    openapi_types = {
+    @staticmethod
+    @property
+    def openapi_types():
+        return {
         'pet_type': (str,),  # noqa: E501
         'name': (str,),  # noqa: E501
     }

--- a/samples/client/petstore/python-experimental/petstore_api/models/child_cat_all_of.py
+++ b/samples/client/petstore/python-experimental/petstore_api/models/child_cat_all_of.py
@@ -59,7 +59,10 @@ class ChildCatAllOf(ModelNormal):
     allowed_values = {
     }
 
-    openapi_types = {
+    @staticmethod
+    @property
+    def openapi_types():
+        return {
         'name': (str,),  # noqa: E501
     }
 

--- a/samples/client/petstore/python-experimental/petstore_api/models/child_dog.py
+++ b/samples/client/petstore/python-experimental/petstore_api/models/child_dog.py
@@ -67,7 +67,10 @@ class ChildDog(ModelComposed):
     allowed_values = {
     }
 
-    openapi_types = {
+    @staticmethod
+    @property
+    def openapi_types():
+        return {
         'pet_type': (str,),  # noqa: E501
         'bark': (str,),  # noqa: E501
     }

--- a/samples/client/petstore/python-experimental/petstore_api/models/child_dog_all_of.py
+++ b/samples/client/petstore/python-experimental/petstore_api/models/child_dog_all_of.py
@@ -59,7 +59,10 @@ class ChildDogAllOf(ModelNormal):
     allowed_values = {
     }
 
-    openapi_types = {
+    @staticmethod
+    @property
+    def openapi_types():
+        return {
         'bark': (str,),  # noqa: E501
     }
 

--- a/samples/client/petstore/python-experimental/petstore_api/models/child_lizard.py
+++ b/samples/client/petstore/python-experimental/petstore_api/models/child_lizard.py
@@ -67,7 +67,10 @@ class ChildLizard(ModelComposed):
     allowed_values = {
     }
 
-    openapi_types = {
+    @staticmethod
+    @property
+    def openapi_types():
+        return {
         'pet_type': (str,),  # noqa: E501
         'loves_rocks': (bool,),  # noqa: E501
     }

--- a/samples/client/petstore/python-experimental/petstore_api/models/child_lizard_all_of.py
+++ b/samples/client/petstore/python-experimental/petstore_api/models/child_lizard_all_of.py
@@ -59,7 +59,10 @@ class ChildLizardAllOf(ModelNormal):
     allowed_values = {
     }
 
-    openapi_types = {
+    @staticmethod
+    @property
+    def openapi_types():
+        return {
         'loves_rocks': (bool,),  # noqa: E501
     }
 

--- a/samples/client/petstore/python-experimental/petstore_api/models/class_model.py
+++ b/samples/client/petstore/python-experimental/petstore_api/models/class_model.py
@@ -59,7 +59,10 @@ class ClassModel(ModelNormal):
     allowed_values = {
     }
 
-    openapi_types = {
+    @staticmethod
+    @property
+    def openapi_types():
+        return {
         '_class': (str,),  # noqa: E501
     }
 

--- a/samples/client/petstore/python-experimental/petstore_api/models/client.py
+++ b/samples/client/petstore/python-experimental/petstore_api/models/client.py
@@ -59,7 +59,10 @@ class Client(ModelNormal):
     allowed_values = {
     }
 
-    openapi_types = {
+    @staticmethod
+    @property
+    def openapi_types():
+        return {
         'client': (str,),  # noqa: E501
     }
 

--- a/samples/client/petstore/python-experimental/petstore_api/models/dog.py
+++ b/samples/client/petstore/python-experimental/petstore_api/models/dog.py
@@ -67,7 +67,10 @@ class Dog(ModelComposed):
     allowed_values = {
     }
 
-    openapi_types = {
+    @staticmethod
+    @property
+    def openapi_types():
+        return {
         'class_name': (str,),  # noqa: E501
         'breed': (str,),  # noqa: E501
         'color': (str,),  # noqa: E501

--- a/samples/client/petstore/python-experimental/petstore_api/models/dog_all_of.py
+++ b/samples/client/petstore/python-experimental/petstore_api/models/dog_all_of.py
@@ -59,7 +59,10 @@ class DogAllOf(ModelNormal):
     allowed_values = {
     }
 
-    openapi_types = {
+    @staticmethod
+    @property
+    def openapi_types():
+        return {
         'breed': (str,),  # noqa: E501
     }
 

--- a/samples/client/petstore/python-experimental/petstore_api/models/enum_arrays.py
+++ b/samples/client/petstore/python-experimental/petstore_api/models/enum_arrays.py
@@ -67,7 +67,10 @@ class EnumArrays(ModelNormal):
         },
     }
 
-    openapi_types = {
+    @staticmethod
+    @property
+    def openapi_types():
+        return {
         'just_symbol': (str,),  # noqa: E501
         'array_enum': ([str],),  # noqa: E501
     }

--- a/samples/client/petstore/python-experimental/petstore_api/models/enum_class.py
+++ b/samples/client/petstore/python-experimental/petstore_api/models/enum_class.py
@@ -60,7 +60,10 @@ class EnumClass(ModelSimple):
         },
     }
 
-    openapi_types = {
+    @staticmethod
+    @property
+    def openapi_types():
+        return {
         'value': (str,),  # noqa: E501
     }
 

--- a/samples/client/petstore/python-experimental/petstore_api/models/enum_test.py
+++ b/samples/client/petstore/python-experimental/petstore_api/models/enum_test.py
@@ -81,7 +81,10 @@ class EnumTest(ModelNormal):
         },
     }
 
-    openapi_types = {
+    @staticmethod
+    @property
+    def openapi_types():
+        return {
         'enum_string_required': (str,),  # noqa: E501
         'enum_string': (str,),  # noqa: E501
         'enum_integer': (int,),  # noqa: E501

--- a/samples/client/petstore/python-experimental/petstore_api/models/file.py
+++ b/samples/client/petstore/python-experimental/petstore_api/models/file.py
@@ -59,7 +59,10 @@ class File(ModelNormal):
     allowed_values = {
     }
 
-    openapi_types = {
+    @staticmethod
+    @property
+    def openapi_types():
+        return {
         'source_uri': (str,),  # noqa: E501
     }
 

--- a/samples/client/petstore/python-experimental/petstore_api/models/file_schema_test_class.py
+++ b/samples/client/petstore/python-experimental/petstore_api/models/file_schema_test_class.py
@@ -63,7 +63,10 @@ class FileSchemaTestClass(ModelNormal):
     allowed_values = {
     }
 
-    openapi_types = {
+    @staticmethod
+    @property
+    def openapi_types():
+        return {
         'file': (file.File,),  # noqa: E501
         'files': ([file.File],),  # noqa: E501
     }

--- a/samples/client/petstore/python-experimental/petstore_api/models/format_test.py
+++ b/samples/client/petstore/python-experimental/petstore_api/models/format_test.py
@@ -59,7 +59,10 @@ class FormatTest(ModelNormal):
     allowed_values = {
     }
 
-    openapi_types = {
+    @staticmethod
+    @property
+    def openapi_types():
+        return {
         'number': (float,),  # noqa: E501
         'byte': (str,),  # noqa: E501
         'date': (date,),  # noqa: E501

--- a/samples/client/petstore/python-experimental/petstore_api/models/grandparent.py
+++ b/samples/client/petstore/python-experimental/petstore_api/models/grandparent.py
@@ -59,7 +59,10 @@ class Grandparent(ModelNormal):
     allowed_values = {
     }
 
-    openapi_types = {
+    @staticmethod
+    @property
+    def openapi_types():
+        return {
         'radio_waves': (bool,),  # noqa: E501
     }
 

--- a/samples/client/petstore/python-experimental/petstore_api/models/grandparent_animal.py
+++ b/samples/client/petstore/python-experimental/petstore_api/models/grandparent_animal.py
@@ -59,7 +59,10 @@ class GrandparentAnimal(ModelNormal):
     allowed_values = {
     }
 
-    openapi_types = {
+    @staticmethod
+    @property
+    def openapi_types():
+        return {
         'pet_type': (str,),  # noqa: E501
     }
 

--- a/samples/client/petstore/python-experimental/petstore_api/models/has_only_read_only.py
+++ b/samples/client/petstore/python-experimental/petstore_api/models/has_only_read_only.py
@@ -59,7 +59,10 @@ class HasOnlyReadOnly(ModelNormal):
     allowed_values = {
     }
 
-    openapi_types = {
+    @staticmethod
+    @property
+    def openapi_types():
+        return {
         'bar': (str,),  # noqa: E501
         'foo': (str,),  # noqa: E501
     }

--- a/samples/client/petstore/python-experimental/petstore_api/models/list.py
+++ b/samples/client/petstore/python-experimental/petstore_api/models/list.py
@@ -59,7 +59,10 @@ class List(ModelNormal):
     allowed_values = {
     }
 
-    openapi_types = {
+    @staticmethod
+    @property
+    def openapi_types():
+        return {
         '_123_list': (str,),  # noqa: E501
     }
 

--- a/samples/client/petstore/python-experimental/petstore_api/models/map_test.py
+++ b/samples/client/petstore/python-experimental/petstore_api/models/map_test.py
@@ -67,7 +67,10 @@ class MapTest(ModelNormal):
         },
     }
 
-    openapi_types = {
+    @staticmethod
+    @property
+    def openapi_types():
+        return {
         'map_map_of_string': ({str: ({str: (str,)},)},),  # noqa: E501
         'map_of_enum_string': ({str: (str,)},),  # noqa: E501
         'direct_map': ({str: (bool,)},),  # noqa: E501

--- a/samples/client/petstore/python-experimental/petstore_api/models/mixed_properties_and_additional_properties_class.py
+++ b/samples/client/petstore/python-experimental/petstore_api/models/mixed_properties_and_additional_properties_class.py
@@ -63,7 +63,10 @@ class MixedPropertiesAndAdditionalPropertiesClass(ModelNormal):
     allowed_values = {
     }
 
-    openapi_types = {
+    @staticmethod
+    @property
+    def openapi_types():
+        return {
         'uuid': (str,),  # noqa: E501
         'date_time': (datetime,),  # noqa: E501
         'map': ({str: (animal.Animal,)},),  # noqa: E501

--- a/samples/client/petstore/python-experimental/petstore_api/models/model200_response.py
+++ b/samples/client/petstore/python-experimental/petstore_api/models/model200_response.py
@@ -59,7 +59,10 @@ class Model200Response(ModelNormal):
     allowed_values = {
     }
 
-    openapi_types = {
+    @staticmethod
+    @property
+    def openapi_types():
+        return {
         'name': (int,),  # noqa: E501
         '_class': (str,),  # noqa: E501
     }

--- a/samples/client/petstore/python-experimental/petstore_api/models/model_return.py
+++ b/samples/client/petstore/python-experimental/petstore_api/models/model_return.py
@@ -59,7 +59,10 @@ class ModelReturn(ModelNormal):
     allowed_values = {
     }
 
-    openapi_types = {
+    @staticmethod
+    @property
+    def openapi_types():
+        return {
         '_return': (int,),  # noqa: E501
     }
 

--- a/samples/client/petstore/python-experimental/petstore_api/models/name.py
+++ b/samples/client/petstore/python-experimental/petstore_api/models/name.py
@@ -59,7 +59,10 @@ class Name(ModelNormal):
     allowed_values = {
     }
 
-    openapi_types = {
+    @staticmethod
+    @property
+    def openapi_types():
+        return {
         'name': (int,),  # noqa: E501
         'snake_case': (int,),  # noqa: E501
         '_property': (str,),  # noqa: E501

--- a/samples/client/petstore/python-experimental/petstore_api/models/number_only.py
+++ b/samples/client/petstore/python-experimental/petstore_api/models/number_only.py
@@ -59,7 +59,10 @@ class NumberOnly(ModelNormal):
     allowed_values = {
     }
 
-    openapi_types = {
+    @staticmethod
+    @property
+    def openapi_types():
+        return {
         'just_number': (float,),  # noqa: E501
     }
 

--- a/samples/client/petstore/python-experimental/petstore_api/models/order.py
+++ b/samples/client/petstore/python-experimental/petstore_api/models/order.py
@@ -64,7 +64,10 @@ class Order(ModelNormal):
         },
     }
 
-    openapi_types = {
+    @staticmethod
+    @property
+    def openapi_types():
+        return {
         'id': (int,),  # noqa: E501
         'pet_id': (int,),  # noqa: E501
         'quantity': (int,),  # noqa: E501

--- a/samples/client/petstore/python-experimental/petstore_api/models/outer_composite.py
+++ b/samples/client/petstore/python-experimental/petstore_api/models/outer_composite.py
@@ -63,7 +63,10 @@ class OuterComposite(ModelNormal):
     allowed_values = {
     }
 
-    openapi_types = {
+    @staticmethod
+    @property
+    def openapi_types():
+        return {
         'my_number': (outer_number.OuterNumber,),  # noqa: E501
         'my_string': (str,),  # noqa: E501
         'my_boolean': (bool,),  # noqa: E501

--- a/samples/client/petstore/python-experimental/petstore_api/models/outer_enum.py
+++ b/samples/client/petstore/python-experimental/petstore_api/models/outer_enum.py
@@ -60,7 +60,10 @@ class OuterEnum(ModelSimple):
         },
     }
 
-    openapi_types = {
+    @staticmethod
+    @property
+    def openapi_types():
+        return {
         'value': (str,),  # noqa: E501
     }
 

--- a/samples/client/petstore/python-experimental/petstore_api/models/outer_number.py
+++ b/samples/client/petstore/python-experimental/petstore_api/models/outer_number.py
@@ -55,7 +55,10 @@ class OuterNumber(ModelSimple):
     allowed_values = {
     }
 
-    openapi_types = {
+    @staticmethod
+    @property
+    def openapi_types():
+        return {
         'value': (float,),  # noqa: E501
     }
 

--- a/samples/client/petstore/python-experimental/petstore_api/models/parent.py
+++ b/samples/client/petstore/python-experimental/petstore_api/models/parent.py
@@ -67,7 +67,10 @@ class Parent(ModelComposed):
     allowed_values = {
     }
 
-    openapi_types = {
+    @staticmethod
+    @property
+    def openapi_types():
+        return {
         'radio_waves': (bool,),  # noqa: E501
         'tele_vision': (bool,),  # noqa: E501
     }

--- a/samples/client/petstore/python-experimental/petstore_api/models/parent_all_of.py
+++ b/samples/client/petstore/python-experimental/petstore_api/models/parent_all_of.py
@@ -59,7 +59,10 @@ class ParentAllOf(ModelNormal):
     allowed_values = {
     }
 
-    openapi_types = {
+    @staticmethod
+    @property
+    def openapi_types():
+        return {
         'tele_vision': (bool,),  # noqa: E501
     }
 

--- a/samples/client/petstore/python-experimental/petstore_api/models/parent_pet.py
+++ b/samples/client/petstore/python-experimental/petstore_api/models/parent_pet.py
@@ -75,7 +75,10 @@ class ParentPet(ModelComposed):
     allowed_values = {
     }
 
-    openapi_types = {
+    @staticmethod
+    @property
+    def openapi_types():
+        return {
         'pet_type': (str,),  # noqa: E501
     }
 

--- a/samples/client/petstore/python-experimental/petstore_api/models/pet.py
+++ b/samples/client/petstore/python-experimental/petstore_api/models/pet.py
@@ -72,7 +72,10 @@ class Pet(ModelNormal):
         },
     }
 
-    openapi_types = {
+    @staticmethod
+    @property
+    def openapi_types():
+        return {
         'name': (str,),  # noqa: E501
         'photo_urls': ([str],),  # noqa: E501
         'id': (int,),  # noqa: E501

--- a/samples/client/petstore/python-experimental/petstore_api/models/read_only_first.py
+++ b/samples/client/petstore/python-experimental/petstore_api/models/read_only_first.py
@@ -59,7 +59,10 @@ class ReadOnlyFirst(ModelNormal):
     allowed_values = {
     }
 
-    openapi_types = {
+    @staticmethod
+    @property
+    def openapi_types():
+        return {
         'bar': (str,),  # noqa: E501
         'baz': (str,),  # noqa: E501
     }

--- a/samples/client/petstore/python-experimental/petstore_api/models/special_model_name.py
+++ b/samples/client/petstore/python-experimental/petstore_api/models/special_model_name.py
@@ -59,7 +59,10 @@ class SpecialModelName(ModelNormal):
     allowed_values = {
     }
 
-    openapi_types = {
+    @staticmethod
+    @property
+    def openapi_types():
+        return {
         'special_property_name': (int,),  # noqa: E501
     }
 

--- a/samples/client/petstore/python-experimental/petstore_api/models/string_boolean_map.py
+++ b/samples/client/petstore/python-experimental/petstore_api/models/string_boolean_map.py
@@ -59,7 +59,10 @@ class StringBooleanMap(ModelNormal):
     allowed_values = {
     }
 
-    openapi_types = {
+    @staticmethod
+    @property
+    def openapi_types():
+        return {
     }
 
     validations = {

--- a/samples/client/petstore/python-experimental/petstore_api/models/tag.py
+++ b/samples/client/petstore/python-experimental/petstore_api/models/tag.py
@@ -59,7 +59,10 @@ class Tag(ModelNormal):
     allowed_values = {
     }
 
-    openapi_types = {
+    @staticmethod
+    @property
+    def openapi_types():
+        return {
         'id': (int,),  # noqa: E501
         'name': (str,),  # noqa: E501
         'full_name': (str,),  # noqa: E501

--- a/samples/client/petstore/python-experimental/petstore_api/models/type_holder_default.py
+++ b/samples/client/petstore/python-experimental/petstore_api/models/type_holder_default.py
@@ -59,7 +59,10 @@ class TypeHolderDefault(ModelNormal):
     allowed_values = {
     }
 
-    openapi_types = {
+    @staticmethod
+    @property
+    def openapi_types():
+        return {
         'string_item': (str,),  # noqa: E501
         'number_item': (float,),  # noqa: E501
         'integer_item': (int,),  # noqa: E501

--- a/samples/client/petstore/python-experimental/petstore_api/models/type_holder_example.py
+++ b/samples/client/petstore/python-experimental/petstore_api/models/type_holder_example.py
@@ -68,7 +68,10 @@ class TypeHolderExample(ModelNormal):
         },
     }
 
-    openapi_types = {
+    @staticmethod
+    @property
+    def openapi_types():
+        return {
         'string_item': (str,),  # noqa: E501
         'number_item': (float,),  # noqa: E501
         'integer_item': (int,),  # noqa: E501

--- a/samples/client/petstore/python-experimental/petstore_api/models/user.py
+++ b/samples/client/petstore/python-experimental/petstore_api/models/user.py
@@ -59,7 +59,10 @@ class User(ModelNormal):
     allowed_values = {
     }
 
-    openapi_types = {
+    @staticmethod
+    @property
+    def openapi_types():
+        return {
         'id': (int,),  # noqa: E501
         'username': (str,),  # noqa: E501
         'first_name': (str,),  # noqa: E501

--- a/samples/client/petstore/python-experimental/petstore_api/models/xml_item.py
+++ b/samples/client/petstore/python-experimental/petstore_api/models/xml_item.py
@@ -59,7 +59,10 @@ class XmlItem(ModelNormal):
     allowed_values = {
     }
 
-    openapi_types = {
+    @staticmethod
+    @property
+    def openapi_types():
+        return {
         'attribute_string': (str,),  # noqa: E501
         'attribute_number': (float,),  # noqa: E501
         'attribute_integer': (int,),  # noqa: E501


### PR DESCRIPTION
Fix NPE in PythonExperimentalCodegen and put openapi_types into a method so that circular dependencies don't break at module load time.

#4885

### PR checklist

- [ x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x ] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [ x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [ x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@taxpon (2017/07) @frol (2017/07) @mbohlool (2017/07) @cbornet (2017/09) @kenjones-cisco (2017/11) @tomplus (2018/10) @Jyhess (2019/01) @slash-arun (2019/11) @spacether (2019/11)
