### PR TITLE
[Python] Enables CI tests for python-flask-python2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1079,7 +1079,7 @@
                 <module>samples/client/petstore/typescript-angular-v7-provided-in-root</module>
                 <module>samples/server/petstore/rust-server</module>
                 <module>samples/server/petstore/python-flask</module>
-                <!--<module>samples/server/petstore/python-flask-python2</module>-->
+                <module>samples/server/petstore/python-flask-python2</module>
             </modules>
         </profile>
         <!-- test with JDK8 in CircleCI -->


### PR DESCRIPTION
python-flask-python2 tests were previously failing and were disabled in https://github.com/OpenAPITools/openapi-generator/commit/62e5d1f43bfdf0c9298841b596e002cd9feab570
They were failing because the latest python connexion library was being installed, which was not python 2.7 compatible
This was fixed in https://github.com/OpenAPITools/openapi-generator/pull/4765
The only remaining step is to turn the CI tests back on and they should pass
That's what we're doing here

### Issues Impacted
If merged, this PR will close https://github.com/OpenAPITools/openapi-generator/issues/4823

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [ ] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [X] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

Python Technical Committee:
@taxpon (2017/07) @frol (2017/07) @mbohlool (2017/07) @cbornet (2017/09) @kenjones-cisco (2017/11) @tomplus (2018/10) @Jyhess (2019/01) @slash-arun (2019/11) @spacether (2019/11)