### PR TITLE
[C-libcurl] The JSON key name in request/response body should not be escaped even though it is a C key word.

### DIFF
--- a/modules/openapi-generator/src/main/resources/C-libcurl/model-body.mustache
+++ b/modules/openapi-generator/src/main/resources/C-libcurl/model-body.mustache
@@ -282,18 +282,18 @@ cJSON *{{classname}}_convertToJSON({{classname}}_t *{{classname}}) {
     {{^isContainer}}
     {{#isPrimitiveType}}
     {{#isNumeric}}
-    if(cJSON_AddNumberToObject(item, "{{{name}}}", {{{classname}}}->{{{name}}}) == NULL) {
+    if(cJSON_AddNumberToObject(item, "{{{baseName}}}", {{{classname}}}->{{{name}}}) == NULL) {
     goto fail; //Numeric
     }
     {{/isNumeric}}
     {{#isBoolean}}
-    if(cJSON_AddBoolToObject(item, "{{{name}}}", {{{classname}}}->{{{name}}}) == NULL) {
+    if(cJSON_AddBoolToObject(item, "{{{baseName}}}", {{{classname}}}->{{{name}}}) == NULL) {
     goto fail; //Bool
     }
     {{/isBoolean}}
     {{#isEnum}}
     {{#isString}}
-    if(cJSON_AddStringToObject(item, "{{{name}}}", {{{name}}}{{classname}}_ToString({{{classname}}}->{{{name}}})) == NULL)
+    if(cJSON_AddStringToObject(item, "{{{baseName}}}", {{{name}}}{{classname}}_ToString({{{classname}}}->{{{name}}})) == NULL)
     {
     goto fail; //Enum
     }
@@ -301,30 +301,30 @@ cJSON *{{classname}}_convertToJSON({{classname}}_t *{{classname}}) {
     {{/isEnum}}
     {{^isEnum}}
     {{#isString}}
-    if(cJSON_AddStringToObject(item, "{{{name}}}", {{{classname}}}->{{{name}}}) == NULL) {
+    if(cJSON_AddStringToObject(item, "{{{baseName}}}", {{{classname}}}->{{{name}}}) == NULL) {
     goto fail; //String
     }
     {{/isString}}
     {{/isEnum}}
     {{#isByteArray}}
-    if(cJSON_AddNumberToObject(item, "{{{name}}}", {{{classname}}}->{{{name}}}) == NULL) {
+    if(cJSON_AddNumberToObject(item, "{{{baseName}}}", {{{classname}}}->{{{name}}}) == NULL) {
     goto fail; //Byte
     }
     {{/isByteArray}}
     {{#isBinary}}
     char* encoded_str_{{{name}}} = base64encode({{{classname}}}->{{{name}}}->data,{{{classname}}}->{{{name}}}->len);
-    if(cJSON_AddStringToObject(item, "{{{name}}}", encoded_str_{{{name}}}) == NULL) {
+    if(cJSON_AddStringToObject(item, "{{{baseName}}}", encoded_str_{{{name}}}) == NULL) {
     goto fail; //Binary
     }
     free (encoded_str_{{{name}}});
     {{/isBinary}}
     {{#isDate}}
-    if(cJSON_AddStringToObject(item, "{{{name}}}", {{{classname}}}->{{{name}}}) == NULL) {
+    if(cJSON_AddStringToObject(item, "{{{baseName}}}", {{{classname}}}->{{{name}}}) == NULL) {
     goto fail; //Date
     }
     {{/isDate}}
     {{#isDateTime}}
-    if(cJSON_AddStringToObject(item, "{{{name}}}", {{{classname}}}->{{{name}}}) == NULL) {
+    if(cJSON_AddStringToObject(item, "{{{baseName}}}", {{{classname}}}->{{{name}}}) == NULL) {
     goto fail; //Date-Time
     }
     {{/isDateTime}}
@@ -336,7 +336,7 @@ cJSON *{{classname}}_convertToJSON({{classname}}_t *{{classname}}) {
     if({{{name}}}_enum_local_JSON == NULL) {
     goto fail; // enum
     }
-    cJSON_AddItemToObject(item, "{{{name}}}", {{{name}}}_enum_local_JSON);
+    cJSON_AddItemToObject(item, "{{{baseName}}}", {{{name}}}_enum_local_JSON);
     if(item->child == NULL) {
     goto fail;
     }
@@ -346,19 +346,19 @@ cJSON *{{classname}}_convertToJSON({{classname}}_t *{{classname}}) {
     if({{{name}}}_local_JSON == NULL) {
     goto fail; //model
     }
-    cJSON_AddItemToObject(item, "{{{name}}}", {{{name}}}_local_JSON);
+    cJSON_AddItemToObject(item, "{{{baseName}}}", {{{name}}}_local_JSON);
     if(item->child == NULL) {
     goto fail;
     }
     {{/isEnum}}
     {{/isModel}}
     {{#isUuid}}
-    if(cJSON_AddStringToObject(item, "{{{name}}}", {{{classname}}}->{{{name}}}) == NULL) {
+    if(cJSON_AddStringToObject(item, "{{{baseName}}}", {{{classname}}}->{{{name}}}) == NULL) {
     goto fail; //uuid
     }
     {{/isUuid}}
     {{#isEmail}}
-    if(cJSON_AddStringToObject(item, "{{{name}}}", {{{classname}}}->{{{name}}}) == NULL) {
+    if(cJSON_AddStringToObject(item, "{{{baseName}}}", {{{classname}}}->{{{name}}}) == NULL) {
     goto fail; //Email
     }
     {{/isEmail}}
@@ -367,7 +367,7 @@ cJSON *{{classname}}_convertToJSON({{classname}}_t *{{classname}}) {
     if({{{name}}}_object == NULL) {
     goto fail; //model
     }
-    cJSON_AddItemToObject(item, "{{{name}}}", {{{name}}}_object);
+    cJSON_AddItemToObject(item, "{{{baseName}}}", {{{name}}}_object);
     if(item->child == NULL) {
     goto fail;
     }
@@ -377,7 +377,7 @@ cJSON *{{classname}}_convertToJSON({{classname}}_t *{{classname}}) {
     {{#isContainer}}
     {{#isListContainer}}
     {{#isPrimitiveType}}
-    cJSON *{{{name}}} = cJSON_AddArrayToObject(item, "{{{name}}}");
+    cJSON *{{{name}}} = cJSON_AddArrayToObject(item, "{{{baseName}}}");
     if({{{name}}} == NULL) {
         goto fail; //primitive container
     }
@@ -401,7 +401,7 @@ cJSON *{{classname}}_convertToJSON({{classname}}_t *{{classname}}) {
     }
     {{/isPrimitiveType}}
     {{^isPrimitiveType}}
-    cJSON *{{{name}}} = cJSON_AddArrayToObject(item, "{{{name}}}");
+    cJSON *{{{name}}} = cJSON_AddArrayToObject(item, "{{{baseName}}}");
     if({{{name}}} == NULL) {
     goto fail; //nonprimitive container
     }
@@ -419,7 +419,7 @@ cJSON *{{classname}}_convertToJSON({{classname}}_t *{{classname}}) {
     {{/isPrimitiveType}}
     {{/isListContainer}}
     {{#isMapContainer}}
-    cJSON *{{{name}}} = cJSON_AddObjectToObject(item, "{{{name}}}");
+    cJSON *{{{name}}} = cJSON_AddObjectToObject(item, "{{{baseName}}}");
     if({{{name}}} == NULL) {
         goto fail; //primitive map container
     }
@@ -466,7 +466,7 @@ fail:
 
     {{#vars}}
     // {{{classname}}}->{{{name}}}
-    cJSON *{{{name}}} = cJSON_GetObjectItemCaseSensitive({{classname}}JSON, "{{{name}}}");
+    cJSON *{{{name}}} = cJSON_GetObjectItemCaseSensitive({{classname}}JSON, "{{{baseName}}}");
     {{#required}}
     if (!{{{name}}}) {
         goto end;


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

When a struct field in the generated c client is a C key word (e.g. continue), it should be escaped.  This is implemented by the [PR #4735](https://github.com/OpenAPITools/openapi-generator/pull/4735).
But #4735 introduces an issue, that is the JSON key name in request/response body is also escaped.
e.g.
```
./model/v1_list_meta.c:    if(cJSON_AddStringToObject(item, "_continue", v1_list_meta->_continue) == NULL) {
./model/v1_list_meta.c:    cJSON *_continue = cJSON_GetObjectItemCaseSensitive(v1_list_metaJSON, "_continue");
```
This will cause logic error when API server processes the request/response body.
Actually the JOSN key name should not be escaped, e.g.

```
./model/v1_list_meta.c:    if(cJSON_AddStringToObject(item, "continue", v1_list_meta->_continue) == NULL) {
./model/v1_list_meta.c:    cJSON *_continue = cJSON_GetObjectItemCaseSensitive(v1_list_metaJSON, "continue");
```
 

<!-- Please check the completed items below -->
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [X] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [X] File the PR against the [master](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [X] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@wing328 @zhemant