### PR TITLE
[Rust Server] fix handling of special characters in path param names

### DIFF
--- a/modules/openapi-generator/src/main/resources/rust-server/client-mod.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/client-mod.mustache
@@ -260,8 +260,8 @@ impl<F, C> Api<C> for Client<F> where
 {{#apiInfo}}{{#apis}}{{#operations}}{{#operation}}
     fn {{#vendorExtensions}}{{{operation_id}}}{{/vendorExtensions}}(&self{{#allParams}}, param_{{{paramName}}}: {{^required}}Option<{{/required}}{{#isListContainer}}&{{/isListContainer}}{{{dataType}}}{{^required}}>{{/required}}{{/allParams}}, context: &C) -> Box<dyn Future<Item={{{operationId}}}Response, Error=ApiError>> {
         let mut uri = format!(
-            "{}{{{basePathWithoutHost}}}{{path}}",
-            self.base_path{{#pathParams}}, {{{baseName}}}=utf8_percent_encode(&param_{{{paramName}}}.to_string(), ID_ENCODE_SET){{/pathParams}}
+            "{}{{{basePathWithoutHost}}}{{#vendorExtensions}}{{pathFormatString}}{{/vendorExtensions}}",
+            self.base_path{{#pathParams}}, {{{paramName}}}=utf8_percent_encode(&param_{{{paramName}}}.to_string(), ID_ENCODE_SET){{/pathParams}}
         );
 
         let mut query_string = self::url::form_urlencoded::Serializer::new("".to_owned());

--- a/modules/openapi-generator/src/main/resources/rust-server/server-mod.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/server-mod.mustache
@@ -194,12 +194,12 @@ where
   {{/hasPathParams}}
 {{/vendorExtensions}}
 {{#pathParams}}
-                let param_{{{paramName}}} = match percent_encoding::percent_decode(path_params["{{{baseName}}}"].as_bytes()).decode_utf8() {
+                let param_{{{paramName}}} = match percent_encoding::percent_decode(path_params["{{{paramName}}}"].as_bytes()).decode_utf8() {
                     Ok(param_{{{paramName}}}) => match param_{{{paramName}}}.parse::<{{{dataType}}}>() {
                         Ok(param_{{{paramName}}}) => param_{{{paramName}}},
                         Err(e) => return Box::new(future::ok(Response::new().with_status(StatusCode::BadRequest).with_body(format!("Couldn't parse path parameter {{{baseName}}}: {:?}", e)))),
                     },
-                    Err(_) => return Box::new(future::ok(Response::new().with_status(StatusCode::BadRequest).with_body(format!("Couldn't percent-decode path parameter as UTF-8: {}", &path_params["{{{baseName}}}"]))))
+                    Err(_) => return Box::new(future::ok(Response::new().with_status(StatusCode::BadRequest).with_body(format!("Couldn't percent-decode path parameter as UTF-8: {}", &path_params["{{{paramName}}}"]))))
                 };
 {{/pathParams}}
 {{#headerParams}}

--- a/modules/openapi-generator/src/test/resources/2_0/rust-server/petstore-with-fake-endpoints-models-for-testing.yaml
+++ b/modules/openapi-generator/src/test/resources/2_0/rust-server/petstore-with-fake-endpoints-models-for-testing.yaml
@@ -948,6 +948,25 @@ paths:
           description: successful operation
           schema:
             $ref: '#/definitions/Client'
+  /fake/hyphenParam/{hyphen-param}:
+    get:
+      tags:
+        - fake
+      description: To test hyphen in path parameter name
+      operationId: hyphenParam
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - name: hyphen-param
+          in: path
+          description: Parameter with hyphen in name
+          required: true
+          type: string
+      responses:
+        200:
+          description: Success
 securityDefinitions:
   petstore_auth:
     type: oauth2

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/README.md
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/README.md
@@ -66,6 +66,7 @@ cargo run --example client FakeOuterBooleanSerialize
 cargo run --example client FakeOuterCompositeSerialize
 cargo run --example client FakeOuterNumberSerialize
 cargo run --example client FakeOuterStringSerialize
+cargo run --example client HyphenParam
 cargo run --example client TestBodyWithQueryParams
 cargo run --example client TestClientModel
 cargo run --example client TestEndpointParameters
@@ -131,6 +132,7 @@ Method | HTTP request | Description
 [**fakeOuterCompositeSerialize**](docs/fake_api.md#fakeOuterCompositeSerialize) | **POST** /fake/outer/composite | 
 [**fakeOuterNumberSerialize**](docs/fake_api.md#fakeOuterNumberSerialize) | **POST** /fake/outer/number | 
 [**fakeOuterStringSerialize**](docs/fake_api.md#fakeOuterStringSerialize) | **POST** /fake/outer/string | 
+[**hyphenParam**](docs/fake_api.md#hyphenParam) | **GET** /fake/hyphenParam/{hyphen-param} | 
 [**testBodyWithQueryParams**](docs/fake_api.md#testBodyWithQueryParams) | **PUT** /fake/body-with-query-params | 
 [**testClientModel**](docs/fake_api.md#testClientModel) | **PATCH** /fake | To test \"client\" model
 [**testEndpointParameters**](docs/fake_api.md#testEndpointParameters) | **POST** /fake | Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/api/openapi.yaml
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/api/openapi.yaml
@@ -984,6 +984,23 @@ paths:
       tags:
       - $another-fake?
       x-codegen-request-body-name: body
+  /fake/hyphenParam/{hyphen-param}:
+    get:
+      description: To test hyphen in path parameter name
+      operationId: hyphenParam
+      parameters:
+      - description: Parameter with hyphen in name
+        in: path
+        name: hyphen-param
+        required: true
+        schema:
+          type: string
+      responses:
+        200:
+          content: {}
+          description: Success
+      tags:
+      - fake
 components:
   schemas:
     Order:

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/docs/fake_api.md
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/docs/fake_api.md
@@ -8,6 +8,7 @@ Method | HTTP request | Description
 **fakeOuterCompositeSerialize**](fake_api.md#fakeOuterCompositeSerialize) | **POST** /fake/outer/composite | 
 **fakeOuterNumberSerialize**](fake_api.md#fakeOuterNumberSerialize) | **POST** /fake/outer/number | 
 **fakeOuterStringSerialize**](fake_api.md#fakeOuterStringSerialize) | **POST** /fake/outer/string | 
+**hyphenParam**](fake_api.md#hyphenParam) | **GET** /fake/hyphenParam/{hyphen-param} | 
 **testBodyWithQueryParams**](fake_api.md#testBodyWithQueryParams) | **PUT** /fake/body-with-query-params | 
 **testClientModel**](fake_api.md#testClientModel) | **PATCH** /fake | To test \"client\" model
 **testEndpointParameters**](fake_api.md#testEndpointParameters) | **POST** /fake | Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
@@ -149,6 +150,33 @@ No authorization required
 
  - **Content-Type**: Not defined
  - **Accept**: */*, 
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+# **hyphenParam**
+> hyphenParam(hyphen_param)
+
+
+To test hyphen in path parameter name
+
+### Required Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+  **hyphen_param** | **String**| Parameter with hyphen in name | 
+
+### Return type
+
+ (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: Not defined
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/examples/client.rs
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/examples/client.rs
@@ -24,6 +24,7 @@ use petstore_with_fake_endpoints_models_for_testing::{ApiNoContext, ContextWrapp
                       FakeOuterCompositeSerializeResponse,
                       FakeOuterNumberSerializeResponse,
                       FakeOuterStringSerializeResponse,
+                      HyphenParamResponse,
                       TestBodyWithQueryParamsResponse,
                       TestClientModelResponse,
                       TestEndpointParametersResponse,
@@ -63,6 +64,7 @@ fn main() {
     "FakeOuterCompositeSerialize",
     "FakeOuterNumberSerialize",
     "FakeOuterStringSerialize",
+    "HyphenParam",
     "TestEndpointParameters",
     "TestEnumParameters",
     "TestJsonFormData",
@@ -144,6 +146,11 @@ fn main() {
 
         Some("FakeOuterStringSerialize") => {
             let result = core.run(client.fake_outer_string_serialize(None));
+            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
+         },
+
+        Some("HyphenParam") => {
+            let result = core.run(client.hyphen_param("hyphen_param_example".to_string()));
             println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
          },
 

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/examples/server_lib/server.rs
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/examples/server_lib/server.rs
@@ -16,6 +16,7 @@ use petstore_with_fake_endpoints_models_for_testing::{Api, ApiError,
                       FakeOuterCompositeSerializeResponse,
                       FakeOuterNumberSerializeResponse,
                       FakeOuterStringSerializeResponse,
+                      HyphenParamResponse,
                       TestBodyWithQueryParamsResponse,
                       TestClientModelResponse,
                       TestEndpointParametersResponse,
@@ -91,6 +92,13 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
     fn fake_outer_string_serialize(&self, body: Option<models::OuterString>, context: &C) -> Box<dyn Future<Item=FakeOuterStringSerializeResponse, Error=ApiError>> {
         let context = context.clone();
         println!("fake_outer_string_serialize({:?}) - X-Span-ID: {:?}", body, context.get().0.clone());
+        Box::new(futures::failed("Generic failure".into()))
+    }
+
+
+    fn hyphen_param(&self, hyphen_param: String, context: &C) -> Box<dyn Future<Item=HyphenParamResponse, Error=ApiError>> {
+        let context = context.clone();
+        println!("hyphen_param(\"{}\") - X-Span-ID: {:?}", hyphen_param, context.get().0.clone());
         Box::new(futures::failed("Generic failure".into()))
     }
 

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/src/lib.rs
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/src/lib.rs
@@ -87,6 +87,12 @@ pub enum FakeOuterStringSerializeResponse {
 }
 
 #[derive(Debug, PartialEq)]
+pub enum HyphenParamResponse {
+    /// Success
+    Success
+}
+
+#[derive(Debug, PartialEq)]
 pub enum TestBodyWithQueryParamsResponse {
     /// Success
     Success
@@ -334,6 +340,9 @@ pub trait Api<C> {
     fn fake_outer_string_serialize(&self, body: Option<models::OuterString>, context: &C) -> Box<dyn Future<Item=FakeOuterStringSerializeResponse, Error=ApiError>>;
 
 
+    fn hyphen_param(&self, hyphen_param: String, context: &C) -> Box<dyn Future<Item=HyphenParamResponse, Error=ApiError>>;
+
+
     fn test_body_with_query_params(&self, query: String, body: models::User, context: &C) -> Box<dyn Future<Item=TestBodyWithQueryParamsResponse, Error=ApiError>>;
 
     /// To test \"client\" model
@@ -433,6 +442,9 @@ pub trait ApiNoContext {
 
 
     fn fake_outer_string_serialize(&self, body: Option<models::OuterString>) -> Box<dyn Future<Item=FakeOuterStringSerializeResponse, Error=ApiError>>;
+
+
+    fn hyphen_param(&self, hyphen_param: String) -> Box<dyn Future<Item=HyphenParamResponse, Error=ApiError>>;
 
 
     fn test_body_with_query_params(&self, query: String, body: models::User) -> Box<dyn Future<Item=TestBodyWithQueryParamsResponse, Error=ApiError>>;
@@ -554,6 +566,11 @@ impl<'a, T: Api<C>, C> ApiNoContext for ContextWrapper<'a, T, C> {
 
     fn fake_outer_string_serialize(&self, body: Option<models::OuterString>) -> Box<dyn Future<Item=FakeOuterStringSerializeResponse, Error=ApiError>> {
         self.api().fake_outer_string_serialize(body, &self.context())
+    }
+
+
+    fn hyphen_param(&self, hyphen_param: String) -> Box<dyn Future<Item=HyphenParamResponse, Error=ApiError>> {
+        self.api().hyphen_param(hyphen_param, &self.context())
     }
 
 

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/src/server/mod.rs
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/src/server/mod.rs
@@ -44,6 +44,7 @@ use {Api,
      FakeOuterCompositeSerializeResponse,
      FakeOuterNumberSerializeResponse,
      FakeOuterStringSerializeResponse,
+     HyphenParamResponse,
      TestBodyWithQueryParamsResponse,
      TestClientModelResponse,
      TestEndpointParametersResponse,
@@ -87,6 +88,7 @@ mod paths {
             r"^/v2/another-fake/dummy$",
             r"^/v2/fake$",
             r"^/v2/fake/body-with-query-params$",
+            r"^/v2/fake/hyphenParam/(?P<hyphen_param>[^/?#]*)$",
             r"^/v2/fake/inline-additionalProperties$",
             r"^/v2/fake/jsonFormData$",
             r"^/v2/fake/outer/boolean$",
@@ -97,8 +99,8 @@ mod paths {
             r"^/v2/pet$",
             r"^/v2/pet/findByStatus$",
             r"^/v2/pet/findByTags$",
-            r"^/v2/pet/(?P<petId>[^/?#]*)$",
-            r"^/v2/pet/(?P<petId>[^/?#]*)/uploadImage$",
+            r"^/v2/pet/(?P<pet_id>[^/?#]*)$",
+            r"^/v2/pet/(?P<pet_id>[^/?#]*)/uploadImage$",
             r"^/v2/store/inventory$",
             r"^/v2/store/order$",
             r"^/v2/store/order/(?P<order_id>[^/?#]*)$",
@@ -113,36 +115,40 @@ mod paths {
     pub static ID_ANOTHER_FAKE_DUMMY: usize = 0;
     pub static ID_FAKE: usize = 1;
     pub static ID_FAKE_BODY_WITH_QUERY_PARAMS: usize = 2;
-    pub static ID_FAKE_INLINE_ADDITIONALPROPERTIES: usize = 3;
-    pub static ID_FAKE_JSONFORMDATA: usize = 4;
-    pub static ID_FAKE_OUTER_BOOLEAN: usize = 5;
-    pub static ID_FAKE_OUTER_COMPOSITE: usize = 6;
-    pub static ID_FAKE_OUTER_NUMBER: usize = 7;
-    pub static ID_FAKE_OUTER_STRING: usize = 8;
-    pub static ID_FAKE_CLASSNAME_TEST: usize = 9;
-    pub static ID_PET: usize = 10;
-    pub static ID_PET_FINDBYSTATUS: usize = 11;
-    pub static ID_PET_FINDBYTAGS: usize = 12;
-    pub static ID_PET_PETID: usize = 13;
+    pub static ID_FAKE_HYPHENPARAM_HYPHEN_PARAM: usize = 3;
     lazy_static! {
-        pub static ref REGEX_PET_PETID: regex::Regex = regex::Regex::new(r"^/v2/pet/(?P<petId>[^/?#]*)$").unwrap();
+        pub static ref REGEX_FAKE_HYPHENPARAM_HYPHEN_PARAM: regex::Regex = regex::Regex::new(r"^/v2/fake/hyphenParam/(?P<hyphen_param>[^/?#]*)$").unwrap();
     }
-    pub static ID_PET_PETID_UPLOADIMAGE: usize = 14;
+    pub static ID_FAKE_INLINE_ADDITIONALPROPERTIES: usize = 4;
+    pub static ID_FAKE_JSONFORMDATA: usize = 5;
+    pub static ID_FAKE_OUTER_BOOLEAN: usize = 6;
+    pub static ID_FAKE_OUTER_COMPOSITE: usize = 7;
+    pub static ID_FAKE_OUTER_NUMBER: usize = 8;
+    pub static ID_FAKE_OUTER_STRING: usize = 9;
+    pub static ID_FAKE_CLASSNAME_TEST: usize = 10;
+    pub static ID_PET: usize = 11;
+    pub static ID_PET_FINDBYSTATUS: usize = 12;
+    pub static ID_PET_FINDBYTAGS: usize = 13;
+    pub static ID_PET_PETID: usize = 14;
     lazy_static! {
-        pub static ref REGEX_PET_PETID_UPLOADIMAGE: regex::Regex = regex::Regex::new(r"^/v2/pet/(?P<petId>[^/?#]*)/uploadImage$").unwrap();
+        pub static ref REGEX_PET_PETID: regex::Regex = regex::Regex::new(r"^/v2/pet/(?P<pet_id>[^/?#]*)$").unwrap();
     }
-    pub static ID_STORE_INVENTORY: usize = 15;
-    pub static ID_STORE_ORDER: usize = 16;
-    pub static ID_STORE_ORDER_ORDER_ID: usize = 17;
+    pub static ID_PET_PETID_UPLOADIMAGE: usize = 15;
+    lazy_static! {
+        pub static ref REGEX_PET_PETID_UPLOADIMAGE: regex::Regex = regex::Regex::new(r"^/v2/pet/(?P<pet_id>[^/?#]*)/uploadImage$").unwrap();
+    }
+    pub static ID_STORE_INVENTORY: usize = 16;
+    pub static ID_STORE_ORDER: usize = 17;
+    pub static ID_STORE_ORDER_ORDER_ID: usize = 18;
     lazy_static! {
         pub static ref REGEX_STORE_ORDER_ORDER_ID: regex::Regex = regex::Regex::new(r"^/v2/store/order/(?P<order_id>[^/?#]*)$").unwrap();
     }
-    pub static ID_USER: usize = 18;
-    pub static ID_USER_CREATEWITHARRAY: usize = 19;
-    pub static ID_USER_CREATEWITHLIST: usize = 20;
-    pub static ID_USER_LOGIN: usize = 21;
-    pub static ID_USER_LOGOUT: usize = 22;
-    pub static ID_USER_USERNAME: usize = 23;
+    pub static ID_USER: usize = 19;
+    pub static ID_USER_CREATEWITHARRAY: usize = 20;
+    pub static ID_USER_CREATEWITHLIST: usize = 21;
+    pub static ID_USER_LOGIN: usize = 22;
+    pub static ID_USER_LOGOUT: usize = 23;
+    pub static ID_USER_USERNAME: usize = 24;
     lazy_static! {
         pub static ref REGEX_USER_USERNAME: regex::Regex = regex::Regex::new(r"^/v2/user/(?P<username>[^/?#]*)$").unwrap();
     }
@@ -538,6 +544,55 @@ where
                         }
                     })
                 ) as Box<dyn Future<Item=Response, Error=Error>>
+            },
+
+            // HyphenParam - GET /fake/hyphenParam/{hyphen-param}
+            &hyper::Method::Get if path.matched(paths::ID_FAKE_HYPHENPARAM_HYPHEN_PARAM) => {
+                // Path parameters
+                let path = uri.path().to_string();
+                let path_params =
+                    paths::REGEX_FAKE_HYPHENPARAM_HYPHEN_PARAM
+                    .captures(&path)
+                    .unwrap_or_else(||
+                        panic!("Path {} matched RE FAKE_HYPHENPARAM_HYPHEN_PARAM in set but failed match against \"{}\"", path, paths::REGEX_FAKE_HYPHENPARAM_HYPHEN_PARAM.as_str())
+                    );
+                let param_hyphen_param = match percent_encoding::percent_decode(path_params["hyphen_param"].as_bytes()).decode_utf8() {
+                    Ok(param_hyphen_param) => match param_hyphen_param.parse::<String>() {
+                        Ok(param_hyphen_param) => param_hyphen_param,
+                        Err(e) => return Box::new(future::ok(Response::new().with_status(StatusCode::BadRequest).with_body(format!("Couldn't parse path parameter hyphen-param: {:?}", e)))),
+                    },
+                    Err(_) => return Box::new(future::ok(Response::new().with_status(StatusCode::BadRequest).with_body(format!("Couldn't percent-decode path parameter as UTF-8: {}", &path_params["hyphen_param"]))))
+                };
+                Box::new({
+                        {{
+                                Box::new(api_impl.hyphen_param(param_hyphen_param, &context)
+                                    .then(move |result| {
+                                        let mut response = Response::new();
+                                        response.headers_mut().set(XSpanId((&context as &dyn Has<XSpanIdString>).get().0.to_string()));
+
+                                        match result {
+                                            Ok(rsp) => match rsp {
+                                                HyphenParamResponse::Success
+
+
+                                                => {
+                                                    response.set_status(StatusCode::try_from(200).unwrap());
+
+                                                },
+                                            },
+                                            Err(_) => {
+                                                // Application code returned an error. This should not happen, as the implementation should
+                                                // return a valid response.
+                                                response.set_status(StatusCode::InternalServerError);
+                                                response.set_body("An internal error occurred");
+                                            },
+                                        }
+
+                                        future::ok(response)
+                                    }
+                                ))
+                        }}
+                }) as Box<dyn Future<Item=Response, Error=Error>>
             },
 
             // TestBodyWithQueryParams - PUT /fake/body-with-query-params
@@ -1123,12 +1178,12 @@ where
                     .unwrap_or_else(||
                         panic!("Path {} matched RE PET_PETID in set but failed match against \"{}\"", path, paths::REGEX_PET_PETID.as_str())
                     );
-                let param_pet_id = match percent_encoding::percent_decode(path_params["petId"].as_bytes()).decode_utf8() {
+                let param_pet_id = match percent_encoding::percent_decode(path_params["pet_id"].as_bytes()).decode_utf8() {
                     Ok(param_pet_id) => match param_pet_id.parse::<i64>() {
                         Ok(param_pet_id) => param_pet_id,
                         Err(e) => return Box::new(future::ok(Response::new().with_status(StatusCode::BadRequest).with_body(format!("Couldn't parse path parameter petId: {:?}", e)))),
                     },
-                    Err(_) => return Box::new(future::ok(Response::new().with_status(StatusCode::BadRequest).with_body(format!("Couldn't percent-decode path parameter as UTF-8: {}", &path_params["petId"]))))
+                    Err(_) => return Box::new(future::ok(Response::new().with_status(StatusCode::BadRequest).with_body(format!("Couldn't percent-decode path parameter as UTF-8: {}", &path_params["pet_id"]))))
                 };
                 // Header parameters
                 header! { (RequestApiKey, "api_key") => [String] }
@@ -1342,12 +1397,12 @@ where
                     .unwrap_or_else(||
                         panic!("Path {} matched RE PET_PETID in set but failed match against \"{}\"", path, paths::REGEX_PET_PETID.as_str())
                     );
-                let param_pet_id = match percent_encoding::percent_decode(path_params["petId"].as_bytes()).decode_utf8() {
+                let param_pet_id = match percent_encoding::percent_decode(path_params["pet_id"].as_bytes()).decode_utf8() {
                     Ok(param_pet_id) => match param_pet_id.parse::<i64>() {
                         Ok(param_pet_id) => param_pet_id,
                         Err(e) => return Box::new(future::ok(Response::new().with_status(StatusCode::BadRequest).with_body(format!("Couldn't parse path parameter petId: {:?}", e)))),
                     },
-                    Err(_) => return Box::new(future::ok(Response::new().with_status(StatusCode::BadRequest).with_body(format!("Couldn't percent-decode path parameter as UTF-8: {}", &path_params["petId"]))))
+                    Err(_) => return Box::new(future::ok(Response::new().with_status(StatusCode::BadRequest).with_body(format!("Couldn't percent-decode path parameter as UTF-8: {}", &path_params["pet_id"]))))
                 };
                 Box::new({
                         {{
@@ -1542,12 +1597,12 @@ where
                     .unwrap_or_else(||
                         panic!("Path {} matched RE PET_PETID in set but failed match against \"{}\"", path, paths::REGEX_PET_PETID.as_str())
                     );
-                let param_pet_id = match percent_encoding::percent_decode(path_params["petId"].as_bytes()).decode_utf8() {
+                let param_pet_id = match percent_encoding::percent_decode(path_params["pet_id"].as_bytes()).decode_utf8() {
                     Ok(param_pet_id) => match param_pet_id.parse::<i64>() {
                         Ok(param_pet_id) => param_pet_id,
                         Err(e) => return Box::new(future::ok(Response::new().with_status(StatusCode::BadRequest).with_body(format!("Couldn't parse path parameter petId: {:?}", e)))),
                     },
-                    Err(_) => return Box::new(future::ok(Response::new().with_status(StatusCode::BadRequest).with_body(format!("Couldn't percent-decode path parameter as UTF-8: {}", &path_params["petId"]))))
+                    Err(_) => return Box::new(future::ok(Response::new().with_status(StatusCode::BadRequest).with_body(format!("Couldn't percent-decode path parameter as UTF-8: {}", &path_params["pet_id"]))))
                 };
                 Box::new({
                         {{
@@ -1625,12 +1680,12 @@ where
                     .unwrap_or_else(||
                         panic!("Path {} matched RE PET_PETID_UPLOADIMAGE in set but failed match against \"{}\"", path, paths::REGEX_PET_PETID_UPLOADIMAGE.as_str())
                     );
-                let param_pet_id = match percent_encoding::percent_decode(path_params["petId"].as_bytes()).decode_utf8() {
+                let param_pet_id = match percent_encoding::percent_decode(path_params["pet_id"].as_bytes()).decode_utf8() {
                     Ok(param_pet_id) => match param_pet_id.parse::<i64>() {
                         Ok(param_pet_id) => param_pet_id,
                         Err(e) => return Box::new(future::ok(Response::new().with_status(StatusCode::BadRequest).with_body(format!("Couldn't parse path parameter petId: {:?}", e)))),
                     },
-                    Err(_) => return Box::new(future::ok(Response::new().with_status(StatusCode::BadRequest).with_body(format!("Couldn't percent-decode path parameter as UTF-8: {}", &path_params["petId"]))))
+                    Err(_) => return Box::new(future::ok(Response::new().with_status(StatusCode::BadRequest).with_body(format!("Couldn't percent-decode path parameter as UTF-8: {}", &path_params["pet_id"]))))
                 };
                 // Form Body parameters (note that non-required body parameters will ignore garbage
                 // values, rather than causing a 400 response). Produce warning header and logs for
@@ -2521,6 +2576,9 @@ impl RequestParser for ApiRequestParser {
 
             // FakeOuterStringSerialize - POST /fake/outer/string
             &hyper::Method::Post if path.matched(paths::ID_FAKE_OUTER_STRING) => Ok("FakeOuterStringSerialize"),
+
+            // HyphenParam - GET /fake/hyphenParam/{hyphen-param}
+            &hyper::Method::Get if path.matched(paths::ID_FAKE_HYPHENPARAM_HYPHEN_PARAM) => Ok("HyphenParam"),
 
             // TestBodyWithQueryParams - PUT /fake/body-with-query-params
             &hyper::Method::Put if path.matched(paths::ID_FAKE_BODY_WITH_QUERY_PARAMS) => Ok("TestBodyWithQueryParams"),


### PR DESCRIPTION
The rust server generator used the names of path parameters directly as the names of regex capture groups and format string substitutions. This is invalid when the path parameter is not a legal rust identifier. I couldn't find a specification of what characters OpenAPI permits in these names, and at least one other generator (python-flask, I think) was sanitizing path param names, so that's what I've done here.

Since I've changed the templates to use `{{paramName}}` instead of `{{baseName}}` this has the side effect of changing the previously working camel-case `petId` to `pet_id`. This seems desirable from a rust style perspective, but I'm not sure if it could be a backwards compatibility concern.

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language. @frol @farcaller @bjgill @richardwhiuk 
