### PR TITLE
[go][client] fix when schema have multiple servers

### DIFF
--- a/modules/openapi-generator/src/main/resources/go-experimental/configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/go-experimental/configuration.mustache
@@ -95,31 +95,31 @@ func NewConfiguration() *Configuration {
 		{{#-first}}
 		Servers:          ServerConfigurations{
 		{{/-first}}
-		{
-			URL: "{{{url}}}",
-			Description: "{{{description}}}{{^description}}No description provided{{/description}}",
-			{{#variables}}
-			{{#-first}}
-			Variables: map[string]ServerVariable{
-			{{/-first}}
-				"{{{name}}}": ServerVariable{
-					Description: "{{{description}}}{{^description}}No description provided{{/description}}",
-					DefaultValue: "{{{defaultValue}}}",
-					{{#enumValues}}
-					{{#-first}}
-					EnumValues: []string{
-					{{/-first}}
-						"{{{.}}}",
-					{{#-last}}
+			{
+				URL: "{{{url}}}",
+				Description: "{{{description}}}{{^description}}No description provided{{/description}}",
+				{{#variables}}
+				{{#-first}}
+				Variables: map[string]ServerVariable{
+				{{/-first}}
+					"{{{name}}}": ServerVariable{
+						Description: "{{{description}}}{{^description}}No description provided{{/description}}",
+						DefaultValue: "{{{defaultValue}}}",
+						{{#enumValues}}
+						{{#-first}}
+						EnumValues: []string{
+						{{/-first}}
+							"{{{.}}}",
+						{{#-last}}
+						},
+						{{/-last}}
+						{{/enumValues}}
 					},
-					{{/-last}}
-					{{/enumValues}}
+				{{#-last}}
 				},
-			{{#-last}}
+				{{/-last}}
+				{{/variables}}
 			},
-			{{/-last}}
-			{{/variables}}
-		},
 		{{#-last}}
 		},
 		{{/-last}}

--- a/modules/openapi-generator/src/main/resources/go/configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/go/configuration.mustache
@@ -92,32 +92,33 @@ func NewConfiguration() *Configuration {
 		Debug:         false,
 		{{#servers}}
 		{{#-first}}
-		Servers:       []ServerConfiguration{{
+		Servers:       []ServerConfiguration{
 		{{/-first}}
-			Url: "{{{url}}}",
-			Description: "{{{description}}}{{^description}}No description provided{{/description}}",
-			{{#variables}}
-			{{#-first}}
-			Variables: map[string]ServerVariable{
-			{{/-first}}
-				"{{{name}}}": ServerVariable{
-					Description: "{{{description}}}{{^description}}No description provided{{/description}}",
-					DefaultValue: "{{{defaultValue}}}",
-					{{#enumValues}}
-					{{#-first}}
-					EnumValues: []string{
-					{{/-first}}
-						"{{{.}}}",
-					{{#-last}}
+			{
+				Url: "{{{url}}}",
+				Description: "{{{description}}}{{^description}}No description provided{{/description}}",
+				{{#variables}}
+				{{#-first}}
+				Variables: map[string]ServerVariable{
+				{{/-first}}
+					"{{{name}}}": ServerVariable{
+						Description: "{{{description}}}{{^description}}No description provided{{/description}}",
+						DefaultValue: "{{{defaultValue}}}",
+						{{#enumValues}}
+						{{#-first}}
+						EnumValues: []string{
+						{{/-first}}
+							"{{{.}}}",
+						{{#-last}}
+						},
+						{{/-last}}
+						{{/enumValues}}
 					},
-					{{/-last}}
-					{{/enumValues}}
+				{{#-last}}
 				},
-			{{#-last}}
+				{{/-last}}
+				{{/variables}}
 			},
-			{{/-last}}
-			{{/variables}}
-		},
 		{{#-last}}
 		},
 		{{/-last}}

--- a/samples/client/petstore/go-experimental/go-petstore/configuration.go
+++ b/samples/client/petstore/go-experimental/go-petstore/configuration.go
@@ -100,10 +100,10 @@ func NewConfiguration() *Configuration {
 		UserAgent:        "OpenAPI-Generator/1.0.0/go",
 		Debug:            false,
 		Servers:          ServerConfigurations{
-		{
-			URL: "http://petstore.swagger.io:80/v2",
-			Description: "No description provided",
-		},
+			{
+				URL: "http://petstore.swagger.io:80/v2",
+				Description: "No description provided",
+			},
 		},
 		OperationServers: map[string]ServerConfigurations{
 		},

--- a/samples/client/petstore/go/go-petstore-withXml/configuration.go
+++ b/samples/client/petstore/go/go-petstore-withXml/configuration.go
@@ -87,10 +87,11 @@ func NewConfiguration() *Configuration {
 		DefaultHeader: make(map[string]string),
 		UserAgent:     "OpenAPI-Generator/1.0.0/go",
 		Debug:         false,
-		Servers:       []ServerConfiguration{{
-			Url: "http://petstore.swagger.io:80/v2",
-			Description: "No description provided",
-		},
+		Servers:       []ServerConfiguration{
+			{
+				Url: "http://petstore.swagger.io:80/v2",
+				Description: "No description provided",
+			},
 		},
 	}
 	return cfg

--- a/samples/client/petstore/go/go-petstore/configuration.go
+++ b/samples/client/petstore/go/go-petstore/configuration.go
@@ -86,10 +86,11 @@ func NewConfiguration() *Configuration {
 		DefaultHeader: make(map[string]string),
 		UserAgent:     "OpenAPI-Generator/1.0.0/go",
 		Debug:         false,
-		Servers:       []ServerConfiguration{{
-			Url: "http://petstore.swagger.io:80/v2",
-			Description: "No description provided",
-		},
+		Servers:       []ServerConfiguration{
+			{
+				Url: "http://petstore.swagger.io:80/v2",
+				Description: "No description provided",
+			},
 		},
 	}
 	return cfg

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/configuration.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/configuration.go
@@ -100,43 +100,43 @@ func NewConfiguration() *Configuration {
 		UserAgent:        "OpenAPI-Generator/1.0.0/go",
 		Debug:            false,
 		Servers:          ServerConfigurations{
-		{
-			URL: "http://{server}.swagger.io:{port}/v2",
-			Description: "petstore server",
-			Variables: map[string]ServerVariable{
-				"server": ServerVariable{
-					Description: "No description provided",
-					DefaultValue: "petstore",
-					EnumValues: []string{
-						"petstore",
-						"qa-petstore",
-						"dev-petstore",
+			{
+				URL: "http://{server}.swagger.io:{port}/v2",
+				Description: "petstore server",
+				Variables: map[string]ServerVariable{
+					"server": ServerVariable{
+						Description: "No description provided",
+						DefaultValue: "petstore",
+						EnumValues: []string{
+							"petstore",
+							"qa-petstore",
+							"dev-petstore",
+						},
 					},
-				},
-				"port": ServerVariable{
-					Description: "No description provided",
-					DefaultValue: "80",
-					EnumValues: []string{
-						"80",
-						"8080",
-					},
-				},
-			},
-		},
-		{
-			URL: "https://localhost:8080/{version}",
-			Description: "The local server",
-			Variables: map[string]ServerVariable{
-				"version": ServerVariable{
-					Description: "No description provided",
-					DefaultValue: "v2",
-					EnumValues: []string{
-						"v1",
-						"v2",
+					"port": ServerVariable{
+						Description: "No description provided",
+						DefaultValue: "80",
+						EnumValues: []string{
+							"80",
+							"8080",
+						},
 					},
 				},
 			},
-		},
+			{
+				URL: "https://localhost:8080/{version}",
+				Description: "The local server",
+				Variables: map[string]ServerVariable{
+					"version": ServerVariable{
+						Description: "No description provided",
+						DefaultValue: "v2",
+						EnumValues: []string{
+							"v1",
+							"v2",
+						},
+					},
+				},
+			},
 		},
 		OperationServers: map[string]ServerConfigurations{
 			"PetApiService.AddPet": {

--- a/samples/openapi3/client/petstore/go/go-petstore/configuration.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/configuration.go
@@ -86,42 +86,44 @@ func NewConfiguration() *Configuration {
 		DefaultHeader: make(map[string]string),
 		UserAgent:     "OpenAPI-Generator/1.0.0/go",
 		Debug:         false,
-		Servers:       []ServerConfiguration{{
-			Url: "http://{server}.swagger.io:{port}/v2",
-			Description: "petstore server",
-			Variables: map[string]ServerVariable{
-				"server": ServerVariable{
-					Description: "No description provided",
-					DefaultValue: "petstore",
-					EnumValues: []string{
-						"petstore",
-						"qa-petstore",
-						"dev-petstore",
+		Servers:       []ServerConfiguration{
+			{
+				Url: "http://{server}.swagger.io:{port}/v2",
+				Description: "petstore server",
+				Variables: map[string]ServerVariable{
+					"server": ServerVariable{
+						Description: "No description provided",
+						DefaultValue: "petstore",
+						EnumValues: []string{
+							"petstore",
+							"qa-petstore",
+							"dev-petstore",
+						},
 					},
-				},
-				"port": ServerVariable{
-					Description: "No description provided",
-					DefaultValue: "80",
-					EnumValues: []string{
-						"80",
-						"8080",
-					},
-				},
-			},
-		},
-			Url: "https://localhost:8080/{version}",
-			Description: "The local server",
-			Variables: map[string]ServerVariable{
-				"version": ServerVariable{
-					Description: "No description provided",
-					DefaultValue: "v2",
-					EnumValues: []string{
-						"v1",
-						"v2",
+					"port": ServerVariable{
+						Description: "No description provided",
+						DefaultValue: "80",
+						EnumValues: []string{
+							"80",
+							"8080",
+						},
 					},
 				},
 			},
-		},
+			{
+				Url: "https://localhost:8080/{version}",
+				Description: "The local server",
+				Variables: map[string]ServerVariable{
+					"version": ServerVariable{
+						Description: "No description provided",
+						DefaultValue: "v2",
+						EnumValues: []string{
+							"v1",
+							"v2",
+						},
+					},
+				},
+			},
 		},
 	}
 	return cfg


### PR DESCRIPTION
Fix `configuration.go` for schema with multiple servers (copy from go-experimental code)

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
