### PR TITLE
adds Recursive Discriminator support

### DIFF
--- a/modules/openapi-generator/src/main/resources/python/python-experimental/model_utils.mustache
+++ b/modules/openapi-generator/src/main/resources/python/python-experimental/model_utils.mustache
@@ -592,8 +592,11 @@ def deserialize_model(model_data, model_class, path_to_item, check_type,
 
     used_model_class = model_class
     if model_class.discriminator() is not None:
-        used_model_class = model_class.get_discriminator_class(
-            from_server, model_data)
+        used_model_class = recursive_discriminator_lookup(model_class, from_server, model_data)
+
+    # This is the case if the used_model_class isn't a subclass but rather the parent class itself
+    if not used_model_class:
+        used_model_class = model_class
 
     if issubclass(used_model_class, ModelSimple):
         instance = used_model_class(value=model_data, **kw_args)
@@ -609,6 +612,35 @@ def deserialize_model(model_data, model_class, path_to_item, check_type,
         instance = used_model_class(**kw_args)
     return instance
 
+recursive_discriminators_cache = {}
+
+def recursive_discriminators(model_class):
+    """
+    Return the discriminator mapping for all possible subtypes (recursively found down to the leaves)
+    :param model_class:
+    :return:
+    """
+    if model_class in recursive_discriminators_cache:
+        return recursive_discriminators_cache[model_class]
+    recursive_discriminated_types = model_class.discriminator()
+    if not recursive_discriminated_types:
+        return {}
+    for discriminator_key, discriminator_dict in model_class.discriminator().items():
+        for child_class in discriminator_dict.values():
+            for child_discriminator_key, child_discriminator_dict in recursive_discriminators(child_class).items():
+                if child_discriminator_key in recursive_discriminated_types:
+                    recursive_discriminated_types[child_discriminator_key].update(child_discriminator_dict)
+                else:
+                    recursive_discriminated_types[child_discriminator_key] = child_discriminator_dict
+    recursive_discriminators_cache[model_class] = recursive_discriminated_types
+    return recursive_discriminated_types
+
+def recursive_discriminator_lookup(model_class, from_server, model_data):
+    discr_propertyname_py = list(model_class.discriminator().keys())[0]
+    try:
+        return recursive_discriminators(model_class)[discr_propertyname_py][model_data[model_class.attribute_map[discr_propertyname_py]]]
+    except KeyError as e:
+        return
 
 def deserialize_file(response_data, configuration, content_disposition=None):
     """Deserializes body to file

--- a/samples/client/petstore/python-experimental/petstore_api/model_utils.py
+++ b/samples/client/petstore/python-experimental/petstore_api/model_utils.py
@@ -848,6 +848,10 @@ def deserialize_model(model_data, model_class, path_to_item, check_type,
         used_model_class = model_class.get_discriminator_class(
             from_server, model_data)
 
+    # This is the case if the used_model_class isn't a subclass but rather the parent class itself
+    if not used_model_class:
+        used_model_class = model_class
+
     if issubclass(used_model_class, ModelSimple):
         instance = used_model_class(value=model_data, **kw_args)
         return instance


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

For now this is just a draft to start discussion with @spacether 

<!-- Please check the completed items below -->
### PR checklist

- [x ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [ ] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [ ] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
