### PR TITLE
[C-libcurl] Support setting basePath and apiKeys when creating an apiClient

### DIFF
--- a/modules/openapi-generator/src/main/resources/C-libcurl/apiClient.c.mustache
+++ b/modules/openapi-generator/src/main/resources/C-libcurl/apiClient.c.mustache
@@ -9,10 +9,22 @@
 
 size_t writeDataCallback(void *buffer, size_t size, size_t nmemb, void *userp);
 
-apiClient_t *apiClient_create() {
+apiClient_t *apiClient_create(const char *basePath
+{{#hasAuthMethods}}
+{{#authMethods}}
+{{#isApiKey}}
+, list_t *apiKeys
+{{/isApiKey}}
+{{/authMethods}}
+{{/hasAuthMethods}}
+) {
     curl_global_init(CURL_GLOBAL_ALL);
     apiClient_t *apiClient = malloc(sizeof(apiClient_t));
-    apiClient->basePath = "{{{basePath}}}";
+    if(basePath){
+        apiClient->basePath = strdup(basePath);
+    }else{
+        apiClient->basePath = strdup("{{{basePath}}}");
+    }
     apiClient->dataReceived = NULL;
     apiClient->response_code = 0;
     {{#hasAuthMethods}}
@@ -25,7 +37,7 @@ apiClient_t *apiClient_create() {
     apiClient->accessToken = NULL;
     {{/isOAuth}}
     {{#isApiKey}}
-    apiClient->apiKeys = NULL;
+    apiClient->apiKeys = apiKeys;
     {{/isApiKey}}
     {{/authMethods}}
     {{/hasAuthMethods}}
@@ -34,6 +46,9 @@ apiClient_t *apiClient_create() {
 }
 
 void apiClient_free(apiClient_t *apiClient) {
+    if(apiClient->basePath) {
+        free(apiClient->basePath);
+    }
     {{#hasAuthMethods}}
     {{#authMethods}}
     {{#isBasic}}

--- a/modules/openapi-generator/src/main/resources/C-libcurl/apiClient.h.mustache
+++ b/modules/openapi-generator/src/main/resources/C-libcurl/apiClient.h.mustache
@@ -35,7 +35,15 @@ typedef struct binary_t
     unsigned int len;
 } binary_t;
 
-apiClient_t* apiClient_create();
+apiClient_t* apiClient_create(const char *basePath
+{{#hasAuthMethods}}
+{{#authMethods}}
+{{#isApiKey}}
+, list_t *apiKeys
+{{/isApiKey}}
+{{/authMethods}}
+{{/hasAuthMethods}}
+);
 
 void apiClient_free(apiClient_t *apiClient);
 


### PR DESCRIPTION
After generating a C client,  user will use apiClient_create to create an apiClient to execute REST request operation.

But for now,  apiClient_create does not accept any parameter so apiClient cannot get any user setting. 
e.g.
```c
apiClient_t *apiClient_create() {
    curl_global_init(CURL_GLOBAL_ALL);
    apiClient_t *apiClient = malloc(sizeof(apiClient_t));
    apiClient->basePath = "http://localhost";
    apiClient->dataReceived = NULL;
    apiClient->response_code = 0;
    apiClient->apiKeys = NULL;

    return apiClient;
}
```

I updated the template code, let the apiClient_create can get user settings:
```c
apiClient_t *apiClient_create(const char *basePath
, list_t *apiKeys
) {
    curl_global_init(CURL_GLOBAL_ALL);
    apiClient_t *apiClient = malloc(sizeof(apiClient_t));
    if(basePath){
        apiClient->basePath = strdup(basePath);
    }else{
        apiClient->basePath = strdup("http://localhost");
    }
    apiClient->dataReceived = NULL;
    apiClient->response_code = 0;
    apiClient->apiKeys = apiKeys;

    return apiClient;
}
```

I also updated the header file and apiClient_free.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [X] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [X] File the PR against the [master](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [X] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@wing328 @zhemant