### PR TITLE
[feature] [jaxrs-spec] Use tag by default to group paths

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
@@ -51,6 +51,7 @@ import java.net.URL;
 import java.nio.file.Path;
 import java.time.ZonedDateTime;
 import java.util.*;
+import java.util.stream.Collectors;
 
 public class DefaultGenerator extends AbstractGenerator implements Generator {
     protected final Logger LOGGER = LoggerFactory.getLogger(DefaultGenerator.class);
@@ -534,6 +535,11 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
         if (apiNames != null && !apiNames.isEmpty()) {
             apisToGenerate = new HashSet<String>(Arrays.asList(apiNames.split(",")));
         }
+
+        apisToGenerate = apisToGenerate.stream()
+                .map(config::sanitizeTag)
+                .collect(Collectors.toSet());
+
         if (apisToGenerate != null && !apisToGenerate.isEmpty()) {
             Map<String, List<CodegenOperation>> updatedPaths = new TreeMap<String, List<CodegenOperation>>();
             for (String m : paths.keySet()) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaJAXRSSpecServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaJAXRSSpecServerCodegen.java
@@ -224,21 +224,26 @@ public class JavaJAXRSSpecServerCodegen extends AbstractJavaJAXRSServerCodegen {
             basePath = basePath.substring(0, pos);
         }
 
-        String operationKey = basePath;
-        if (StringUtils.isEmpty(basePath)) {
-            basePath = tag;
-            operationKey = "";
-            primaryResourceName = tag;
-        } else if (basePath.matches("\\{.*\\}")) {
-            basePath = tag;
-            operationKey = "";
-            co.subresourceOperation = true;
-        } else {
-            if (co.path.startsWith("/" + basePath)) {
-                co.path = co.path.substring(("/" + basePath).length());
+        String operationKey = tag;
+
+        if (StringUtils.isEmpty(tag)) {
+            operationKey = basePath;
+            if (StringUtils.isEmpty(basePath)) {
+                basePath = tag;
+                operationKey = "";
+                primaryResourceName = tag;
+            } else if (basePath.matches("\\{.*\\}")) {
+                basePath = tag;
+                operationKey = "";
+                co.subresourceOperation = true;
+            } else {
+                if (co.path.startsWith("/" + basePath)) {
+                    co.path = co.path.substring(("/" + basePath).length());
+                }
+                co.subresourceOperation = !co.path.isEmpty();
             }
-            co.subresourceOperation = !co.path.isEmpty();
         }
+
         List<CodegenOperation> opList = operations.get(operationKey);
         if (opList == null || opList.isEmpty()) {
             opList = new ArrayList<CodegenOperation>();

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/jaxrs/JavaJAXRSSpecServerCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/jaxrs/JavaJAXRSSpecServerCodegenTest.java
@@ -123,8 +123,9 @@ public class JavaJAXRSSpecServerCodegenTest extends JavaJaxrsBaseTest {
         codegen.addOperationToGroup("Primaryresource", "/", operation, codegenOperation, operationList);
 
         Assert.assertEquals(operationList.size(), 1);
-        Assert.assertTrue(operationList.containsKey(""));
-        Assert.assertEquals(codegenOperation.baseName, "Primaryresource");
+        Assert.assertFalse(operationList.containsKey(""));
+        Assert.assertTrue(operationList.containsKey("Primaryresource"));
+        Assert.assertEquals(codegenOperation.baseName, "");
     }
 
     /**
@@ -141,8 +142,9 @@ public class JavaJAXRSSpecServerCodegenTest extends JavaJaxrsBaseTest {
         codegen.addOperationToGroup("Primaryresource", "/{uuid}", operation, codegenOperation, operationList);
 
         Assert.assertEquals(operationList.size(), 1);
-        Assert.assertTrue(operationList.containsKey(""));
-        Assert.assertEquals(codegenOperation.baseName, "Primaryresource");
+        Assert.assertFalse(operationList.containsKey(""));
+        Assert.assertTrue(operationList.containsKey("Primaryresource"));
+        Assert.assertEquals(codegenOperation.baseName, "{uuid}");
     }
 
     /**
@@ -161,7 +163,7 @@ public class JavaJAXRSSpecServerCodegenTest extends JavaJaxrsBaseTest {
 
         Assert.assertEquals(codegenOperation.baseName, "subresource");
         Assert.assertEquals(operationList.size(), 1);
-        Assert.assertTrue(operationList.containsKey("subresource"));
+        Assert.assertTrue(operationList.containsKey("Default"));
     }
 
     /**
@@ -185,7 +187,7 @@ public class JavaJAXRSSpecServerCodegenTest extends JavaJaxrsBaseTest {
         codegen.addOperationToGroup("Primaryresource", "/", operation, codegenOperation, operationList);
 
         final String subresource = codegen.toApiName("");
-        Assert.assertEquals(subresource, "PrimaryresourceApi");
+        Assert.assertEquals(subresource, "DefaultApi");
     }
 
     @Test
@@ -308,7 +310,7 @@ public class JavaJAXRSSpecServerCodegenTest extends JavaJaxrsBaseTest {
         Map<String, String> generatedFiles = generator.getFiles();
         validateJavaSourceFiles(generatedFiles);
         TestUtils.ensureContainsFile(generatedFiles, output, "openapi.yml");
-        TestUtils.ensureContainsFile(generatedFiles, output, "src/gen/java/org/openapitools/api/DefaultApi.java");
+        TestUtils.ensureContainsFile(generatedFiles, output, "src/gen/java/org/openapitools/api/DocumentApi.java");
 
         output.deleteOnExit();
     }


### PR DESCRIPTION
### Introduction

There is one quite nifty but undocumented option, `apis`, which could be set in system properties. It defines which API groups should be generated. Given the undocumented internal behavior of grouping all operations by tags, this gives an easy way to migrate existing projects to Open-API with minimal changes by automatically generating API definitions and then generating API interfaces with operations automatically grouped according to the existing endpoints.

Hence I am creating a few PRs (#4937, #4938, #4939) addressing this hidden gem of `openapi-generator`.

### This change

Using tag as the primary key to group paths and operations.

This comes extremely handy when used together with `apis` system property (or `additionalProperties` one, as in #4937 ) so the operations could be grouped into resources.

I tested it on our existing project together with `swagger-maven-plugin` (specifically [this hack](https://github.com/kongchen/swagger-maven-plugin/pull/805)) to minimize the change when migrating the whole project to Open-API (mostly automatically).

This definitely is a breaking change (as the resources generated will have different names), so targeting `5.0.x`.

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
