### PR TITLE
[javascript] Add npmRepository option to javascript generators

### DIFF
--- a/docs/generators/javascript.md
+++ b/docs/generators/javascript.md
@@ -26,6 +26,7 @@ sidebar_label: javascript
 |hideGenerationTimestamp|Hides the generation timestamp when files are generated.| |true|
 |useES6|use JavaScript ES6 (ECMAScript 6) (beta). Default is ES6.| |true|
 |modelPropertyNaming|Naming convention for the property: 'camelCase', 'PascalCase', 'snake_case' and 'original', which keeps the original name| |camelCase|
+|npmRepository|Use this property to set an url your private npmRepo in the package.json| |null|
 
 ## IMPORT MAPPING
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavascriptClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavascriptClientCodegen.java
@@ -48,6 +48,7 @@ public class JavascriptClientCodegen extends DefaultCodegen implements CodegenCo
     public static final String EMIT_MODEL_METHODS = "emitModelMethods";
     public static final String EMIT_JS_DOC = "emitJSDoc";
     public static final String USE_ES6 = "useES6";
+    public static final String NPM_REPOSITORY = "npmRepository";
 
     final String[][] JAVASCRIPT_SUPPORTING_FILES = new String[][]{
             new String[]{"package.mustache", "package.json"},
@@ -86,6 +87,7 @@ public class JavascriptClientCodegen extends DefaultCodegen implements CodegenCo
     protected String apiTestPath = "api/";
     protected String modelTestPath = "model/";
     protected boolean useES6 = true; // default is ES6
+    protected String npmRepository = null;
     private String modelPropertyNaming = "camelCase";
 
     public JavascriptClientCodegen() {
@@ -193,6 +195,7 @@ public class JavascriptClientCodegen extends DefaultCodegen implements CodegenCo
                 "use JavaScript ES6 (ECMAScript 6) (beta). Default is ES6.")
                 .defaultValue(Boolean.TRUE.toString()));
         cliOptions.add(new CliOption(CodegenConstants.MODEL_PROPERTY_NAMING, CodegenConstants.MODEL_PROPERTY_NAMING_DESC).defaultValue("camelCase"));
+        cliOptions.add(new CliOption(NPM_REPOSITORY, "Use this property to set an url your private npmRepo in the package.json"));
     }
 
     @Override
@@ -263,6 +266,9 @@ public class JavascriptClientCodegen extends DefaultCodegen implements CodegenCo
         if (additionalProperties.containsKey(CodegenConstants.MODEL_PROPERTY_NAMING)) {
             setModelPropertyNaming((String) additionalProperties.get(CodegenConstants.MODEL_PROPERTY_NAMING));
         }
+        if (additionalProperties.containsKey(NPM_REPOSITORY)) {
+            setNpmRepository(((String) additionalProperties.get(NPM_REPOSITORY)));
+        }
     }
 
     @Override
@@ -326,6 +332,7 @@ public class JavascriptClientCodegen extends DefaultCodegen implements CodegenCo
         additionalProperties.put(EMIT_MODEL_METHODS, emitModelMethods);
         additionalProperties.put(EMIT_JS_DOC, emitJSDoc);
         additionalProperties.put(USE_ES6, useES6);
+        additionalProperties.put(NPM_REPOSITORY, npmRepository);
 
         // make api and model doc path available in mustache template
         additionalProperties.put("apiDocPath", apiDocPath);
@@ -431,6 +438,10 @@ public class JavascriptClientCodegen extends DefaultCodegen implements CodegenCo
 
     public void setUsePromises(boolean usePromises) {
         this.usePromises = usePromises;
+    }
+
+    public void setNpmRepository(String npmRepository) {
+        this.npmRepository = npmRepository;
     }
 
     public void setUseES6(boolean useES6) {

--- a/modules/openapi-generator/src/main/resources/Javascript/es6/package.mustache
+++ b/modules/openapi-generator/src/main/resources/Javascript/es6/package.mustache
@@ -12,6 +12,11 @@
   "browser": {
     "fs": false
   },
+{{#npmRepository}}
+  "publishConfig":{
+    "registry":"{{npmRepository}}"
+  },
+{{/npmRepository}}
   "dependencies": {
     "@babel/cli": "^7.0.0",
     "superagent": "3.7.0"

--- a/modules/openapi-generator/src/main/resources/Javascript/package.mustache
+++ b/modules/openapi-generator/src/main/resources/Javascript/package.mustache
@@ -10,6 +10,11 @@
   "browser": {
     "fs": false
   },
+{{#npmRepository}}
+  "publishConfig":{
+    "registry":"{{npmRepository}}"
+  },
+{{/npmRepository}}
   "dependencies": {
     "superagent": "5.1.0"
   },


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

Adds an `npmRepository` option to the javascript generators.

This functionality is in the flow typed client generator already, as well as the typescript client generators.

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
