### PR TITLE
[C-libcurl] Support setting basePath and apiKeys when creating an apiClient

### DIFF
--- a/modules/openapi-generator/src/main/resources/C-libcurl/apiClient.c.mustache
+++ b/modules/openapi-generator/src/main/resources/C-libcurl/apiClient.c.mustache
@@ -12,7 +12,7 @@ size_t writeDataCallback(void *buffer, size_t size, size_t nmemb, void *userp);
 apiClient_t *apiClient_create() {
     curl_global_init(CURL_GLOBAL_ALL);
     apiClient_t *apiClient = malloc(sizeof(apiClient_t));
-    apiClient->basePath = "{{{basePath}}}";
+    apiClient->basePath = strdup("{{{basePath}}}");
     apiClient->dataReceived = NULL;
     apiClient->response_code = 0;
     {{#hasAuthMethods}}
@@ -33,7 +33,56 @@ apiClient_t *apiClient_create() {
     return apiClient;
 }
 
+apiClient_t *apiClient_create_with_base_path(const char *basePath
+{{#hasAuthMethods}}
+{{#authMethods}}
+{{#isApiKey}}
+, list_t *apiKeys
+{{/isApiKey}}
+{{/authMethods}}
+{{/hasAuthMethods}}
+) {
+    curl_global_init(CURL_GLOBAL_ALL);
+    apiClient_t *apiClient = malloc(sizeof(apiClient_t));
+    if(basePath){
+        apiClient->basePath = strdup(basePath);
+    }else{
+        apiClient->basePath = strdup("{{{basePath}}}");
+    }
+    apiClient->dataReceived = NULL;
+    apiClient->response_code = 0;
+    {{#hasAuthMethods}}
+    {{#authMethods}}
+    {{#isBasic}}
+    apiClient->username = NULL;
+    apiClient->password = NULL;
+    {{/isBasic}}
+    {{#isOAuth}}
+    apiClient->accessToken = NULL;
+    {{/isOAuth}}
+    {{#isApiKey}}
+    if(apiKeys!= NULL) {
+        apiClient->apiKeys = list_create();
+        listEntry_t *listEntry = NULL;
+        list_ForEach(listEntry, apiKeys) {
+            keyValuePair_t *pair = listEntry->data;
+            keyValuePair_t *pairDup = keyValuePair_create(strdup(pair->key), strdup(pair->value));
+            list_addElement(apiClient->apiKeys, pairDup);
+        }
+    }else{
+        apiClient->apiKeys = NULL;
+    }
+    {{/isApiKey}}
+    {{/authMethods}}
+    {{/hasAuthMethods}}
+
+    return apiClient;
+}
+
 void apiClient_free(apiClient_t *apiClient) {
+    if(apiClient->basePath) {
+        free(apiClient->basePath);
+    }
     {{#hasAuthMethods}}
     {{#authMethods}}
     {{#isBasic}}
@@ -51,6 +100,17 @@ void apiClient_free(apiClient_t *apiClient) {
     {{/isOAuth}}
     {{#isApiKey}}
     if(apiClient->apiKeys) {
+        listEntry_t *listEntry = NULL;
+        list_ForEach(listEntry, apiClient->apiKeys) {
+            keyValuePair_t *pair = listEntry->data;
+            if(pair->key){
+                free(pair->key);
+            }
+            if(pair->value){
+                free(pair->value);
+            }
+            keyValuePair_free(pair);
+        }
         list_free(apiClient->apiKeys);
     }
     {{/isApiKey}}

--- a/modules/openapi-generator/src/main/resources/C-libcurl/apiClient.h.mustache
+++ b/modules/openapi-generator/src/main/resources/C-libcurl/apiClient.h.mustache
@@ -37,6 +37,16 @@ typedef struct binary_t
 
 apiClient_t* apiClient_create();
 
+apiClient_t* apiClient_create_with_base_path(const char *basePath
+{{#hasAuthMethods}}
+{{#authMethods}}
+{{#isApiKey}}
+, list_t *apiKeys
+{{/isApiKey}}
+{{/authMethods}}
+{{/hasAuthMethods}}
+);
+
 void apiClient_free(apiClient_t *apiClient);
 
 void apiClient_invoke(apiClient_t *apiClient,char* operationParameter, list_t *queryParameters, list_t *headerParameters, list_t *formParameters,list_t *headerType,list_t *contentType, char *bodyParameters, char *requestType);


### PR DESCRIPTION
After generating a C client,  user will use apiClient_create to create an apiClient to execute REST request operation.

But for now,  apiClient_create does not accept any parameter so apiClient cannot get any user setting. 
e.g.
```c
apiClient_t *apiClient_create() {
    curl_global_init(CURL_GLOBAL_ALL);
    apiClient_t *apiClient = malloc(sizeof(apiClient_t));
    apiClient->basePath = "http://localhost";
    apiClient->dataReceived = NULL;
    apiClient->response_code = 0;
    apiClient->apiKeys = NULL;

    return apiClient;
}
```

I added a new function "apiClient_create_with_base_path" to get user settings:
```c
apiClient_t *apiClient_create_with_base_path(const char *basePath
, list_t *apiKeys
) {
    curl_global_init(CURL_GLOBAL_ALL);
    apiClient_t *apiClient = malloc(sizeof(apiClient_t));
    if(basePath){
        apiClient->basePath = strdup(basePath);
    }else{
        apiClient->basePath = strdup("http://localhost");
    }
    apiClient->dataReceived = NULL;
    apiClient->response_code = 0;
    if(apiKeys!= NULL) {
        apiClient->apiKeys = list_create();
        listEntry_t *listEntry = NULL;
        list_ForEach(listEntry, apiKeys) {
            keyValuePair_t *pair = listEntry->data;
            keyValuePair_t *pairDup = keyValuePair_create(strdup(pair->key), strdup(pair->value));
            list_addElement(apiClient->apiKeys, pairDup);
        }
    }else{
        apiClient->apiKeys = NULL;
    }

    return apiClient;
}
```

And I also updated the header file and apiClient_free.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [X] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [X] File the PR against the [master](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [X] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@wing328 @zhemant