### PR TITLE
[Slim4] Add integer formats support to Data Mocker

### DIFF
--- a/modules/openapi-generator/src/main/resources/php-slim4-server/openapi_data_mocker.mustache
+++ b/modules/openapi-generator/src/main/resources/php-slim4-server/openapi_data_mocker.mustache
@@ -127,6 +127,22 @@ final class OpenApiDataMocker implements IMocker
         $exclusiveMinimum = false,
         $exclusiveMaximum = false
     ) {
+        $dataFormat = is_string($dataFormat) ? strtolower($dataFormat) : $dataFormat;
+        switch ($dataFormat) {
+            case IMocker::DATA_FORMAT_INT32:
+                // -2147483647..2147483647
+                $minimum = is_numeric($minimum) ? max($minimum, -2147483647) : -2147483647;
+                $maximum = is_numeric($maximum) ? min($maximum, 2147483647) : 2147483647;
+                break;
+            case IMocker::DATA_FORMAT_INT64:
+                // -9223372036854775807..9223372036854775807
+                $minimum = is_numeric($minimum) ? max($minimum, -9223372036854775807) : -9223372036854775807;
+                $maximum = is_numeric($maximum) ? min($maximum, 9223372036854775807) : 9223372036854775807;
+                break;
+            default:
+                // do nothing, unsupported format
+        }
+
         return $this->getRandomNumber($minimum, $maximum, $exclusiveMinimum, $exclusiveMaximum, 0);
     }
 
@@ -525,7 +541,7 @@ final class OpenApiDataMocker implements IMocker
         if ($maxDecimals > 0) {
             return round($min + mt_rand() / mt_getrandmax() * ($max - $min), $maxDecimals);
         }
-        return mt_rand($min, $max);
+        return mt_rand((int) $min, (int) $max);
     }
 }
 {{/apiInfo}}

--- a/modules/openapi-generator/src/main/resources/php-slim4-server/openapi_data_mocker.mustache
+++ b/modules/openapi-generator/src/main/resources/php-slim4-server/openapi_data_mocker.mustache
@@ -381,7 +381,7 @@ final class OpenApiDataMocker implements IMocker
         foreach ($properties as $propName => $propValue) {
             $options = $this->extractSchemaProperties($propValue);
             $dataType = $options['type'];
-            $dataFormat = $options['dataFormat'] ?? null;
+            $dataFormat = $options['format'] ?? null;
             $ref = $options['$ref'] ?? null;
             $data = $this->mockFromRef($ref);
             $obj->$propName = ($data) ? $data : $this->mock($dataType, $dataFormat, $options);

--- a/modules/openapi-generator/src/main/resources/php-slim4-server/openapi_data_mocker_test.mustache
+++ b/modules/openapi-generator/src/main/resources/php-slim4-server/openapi_data_mocker_test.mustache
@@ -199,6 +199,36 @@ class OpenApiDataMockerTest extends TestCase
     }
 
     /**
+     * @covers ::mockInteger
+     * @dataProvider provideMockIntegerFormats
+     */
+    public function testMockIntegerWithFormats(
+        $dataFormat,
+        $minimum,
+        $maximum,
+        $expectedMin,
+        $expectedMax
+    ) {
+        $mocker = new OpenApiDataMocker();
+        $integer = $mocker->mockInteger($dataFormat, $minimum, $maximum);
+        $this->assertGreaterThanOrEqual($expectedMin, $integer);
+        $this->assertLessThanOrEqual($expectedMax, $integer);
+    }
+
+    public function provideMockIntegerFormats()
+    {
+        return [
+            [IMocker::DATA_FORMAT_INT32, -2147483648, 2147483648, -2147483647, 2147483647],
+            [IMocker::DATA_FORMAT_INT64, '-9223372036854775808', '9223372036854775808', -9223372036854775807, 9223372036854775807],
+            [IMocker::DATA_FORMAT_INT32, -10, 10, -10, 10],
+            [IMocker::DATA_FORMAT_INT64, -10, 10, -10, 10],
+            [IMocker::DATA_FORMAT_INT32, -9223372036854775807, 9223372036854775807, -2147483647, 2147483647],
+            [strtoupper(IMocker::DATA_FORMAT_INT32), -2147483648, 2147483648, -2147483647, 2147483647],
+            [strtoupper(IMocker::DATA_FORMAT_INT64), '-9223372036854775808', '9223372036854775808', -9223372036854775807, 9223372036854775807],
+        ];
+    }
+
+    /**
      * @dataProvider provideMockNumberCorrectArguments
      * @covers ::mockNumber
      */

--- a/samples/server/petstore/php-slim4/lib/Mock/OpenApiDataMocker.php
+++ b/samples/server/petstore/php-slim4/lib/Mock/OpenApiDataMocker.php
@@ -119,6 +119,22 @@ final class OpenApiDataMocker implements IMocker
         $exclusiveMinimum = false,
         $exclusiveMaximum = false
     ) {
+        $dataFormat = is_string($dataFormat) ? strtolower($dataFormat) : $dataFormat;
+        switch ($dataFormat) {
+            case IMocker::DATA_FORMAT_INT32:
+                // -2147483647..2147483647
+                $minimum = is_numeric($minimum) ? max($minimum, -2147483647) : -2147483647;
+                $maximum = is_numeric($maximum) ? min($maximum, 2147483647) : 2147483647;
+                break;
+            case IMocker::DATA_FORMAT_INT64:
+                // -9223372036854775807..9223372036854775807
+                $minimum = is_numeric($minimum) ? max($minimum, -9223372036854775807) : -9223372036854775807;
+                $maximum = is_numeric($maximum) ? min($maximum, 9223372036854775807) : 9223372036854775807;
+                break;
+            default:
+                // do nothing, unsupported format
+        }
+
         return $this->getRandomNumber($minimum, $maximum, $exclusiveMinimum, $exclusiveMaximum, 0);
     }
 
@@ -357,7 +373,7 @@ final class OpenApiDataMocker implements IMocker
         foreach ($properties as $propName => $propValue) {
             $options = $this->extractSchemaProperties($propValue);
             $dataType = $options['type'];
-            $dataFormat = $options['dataFormat'] ?? null;
+            $dataFormat = $options['format'] ?? null;
             $ref = $options['$ref'] ?? null;
             $data = $this->mockFromRef($ref);
             $obj->$propName = ($data) ? $data : $this->mock($dataType, $dataFormat, $options);
@@ -517,6 +533,6 @@ final class OpenApiDataMocker implements IMocker
         if ($maxDecimals > 0) {
             return round($min + mt_rand() / mt_getrandmax() * ($max - $min), $maxDecimals);
         }
-        return mt_rand($min, $max);
+        return mt_rand((int) $min, (int) $max);
     }
 }

--- a/samples/server/petstore/php-slim4/test/Mock/OpenApiDataMockerTest.php
+++ b/samples/server/petstore/php-slim4/test/Mock/OpenApiDataMockerTest.php
@@ -191,6 +191,36 @@ class OpenApiDataMockerTest extends TestCase
     }
 
     /**
+     * @covers ::mockInteger
+     * @dataProvider provideMockIntegerFormats
+     */
+    public function testMockIntegerWithFormats(
+        $dataFormat,
+        $minimum,
+        $maximum,
+        $expectedMin,
+        $expectedMax
+    ) {
+        $mocker = new OpenApiDataMocker();
+        $integer = $mocker->mockInteger($dataFormat, $minimum, $maximum);
+        $this->assertGreaterThanOrEqual($expectedMin, $integer);
+        $this->assertLessThanOrEqual($expectedMax, $integer);
+    }
+
+    public function provideMockIntegerFormats()
+    {
+        return [
+            [IMocker::DATA_FORMAT_INT32, -2147483648, 2147483648, -2147483647, 2147483647],
+            [IMocker::DATA_FORMAT_INT64, '-9223372036854775808', '9223372036854775808', -9223372036854775807, 9223372036854775807],
+            [IMocker::DATA_FORMAT_INT32, -10, 10, -10, 10],
+            [IMocker::DATA_FORMAT_INT64, -10, 10, -10, 10],
+            [IMocker::DATA_FORMAT_INT32, -9223372036854775807, 9223372036854775807, -2147483647, 2147483647],
+            [strtoupper(IMocker::DATA_FORMAT_INT32), -2147483648, 2147483648, -2147483647, 2147483647],
+            [strtoupper(IMocker::DATA_FORMAT_INT64), '-9223372036854775808', '9223372036854775808', -9223372036854775807, 9223372036854775807],
+        ];
+    }
+
+    /**
      * @dataProvider provideMockNumberCorrectArguments
      * @covers ::mockNumber
      */


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Current progress

Tiny PR to support `int32` and `int64` integer formats. Now `DataMocker` generates values in specific ranges for `int32` format.

```php
<?php
require __DIR__ . '/vendor/autoload.php';

use OpenAPIServer\Mock\OpenApiDataMocker as Mocker;
$mocker = new Mocker();
$data = $mocker->mockFromSchema([
    'type' => 'object',
    'properties' => [
        'integer_from_1_to_100' => [
            'type' => 'integer',
            'minimum' => 1,
            'maximum' => 100,
        ],
        'float_from_minus3_to_3' => [
            'type' => 'number',
            'minimum' => -3,
            'maximum' => 3,
        ],
        'string_10chars' => [
            'type' => 'string',
            'minLength' => 10,
            'maxLength' => 10,
        ],
        'boolean' => [
            'type' => 'boolean',
        ],
        'array_of_strings' => [
            'type' => 'array',
            'items' => [
                'type' => 'string',
                'maxLength' => 20,
            ],
        ],
        'Object' => [
            'type' => 'object',
            'properties' => [
                'id' => [
                    'type' => 'integer',
                    'minimum' => 1,
                    'maximum' => 10
                ],
                'username' => [
                    'type' => 'string',
                    'maxLength' => 10,
                ],
            ],
        ],
        'Order_referenced_model' => [
            '$ref' => '#/components/schemas/Order',
        ],
    ],
]);

echo json_encode($data, JSON_PRETTY_PRINT);
```
output:
```json
{
    "integer_from_1_to_100": 45,
    "float_from_minus3_to_3": -1.741,
    "string_10chars": "Lorem ipsu",
    "boolean": false,
    "array_of_strings": [
        "Lore"
    ],
    "Object": {
        "id": 3,
        "username": "L"
    },
    "Order_referenced_model": {
        "id": 1259632416,
        "petId": 350744286,
        "quantity": 331569927,
        "shipDate": "Lorem ipsum dolor sit amet, consectetur adipiscing el",
        "status": "approved",
        "complete": false
    }
}
```

Related to #3545

cc @jebentier, @dkarlovi, @mandrean, @jfastnacht, @ackintosh, @renepardon

