### PR TITLE
[Slim4] Add string formats support to Data Mocker

### DIFF
--- a/modules/openapi-generator/src/main/resources/php-slim4-server/openapi_data_mocker.mustache
+++ b/modules/openapi-generator/src/main/resources/php-slim4-server/openapi_data_mocker.mustache
@@ -36,6 +36,7 @@ namespace {{mockPackage}};
 use {{mockPackage}}\{{interfaceNamePrefix}}OpenApiDataMocker{{interfaceNameSuffix}} as IMocker;
 use {{utilsPackage}}\{{traitNamePrefix}}ModelUtils{{traitNameSuffix}};
 use StdClass;
+use DateTime;
 use InvalidArgumentException;
 
 /**
@@ -186,6 +187,16 @@ final class OpenApiDataMocker implements IMocker
                 \STR_PAD_RIGHT
             );
         };
+        $truncateOrPad = function ($text, $min = null, $max = null) {
+            if ($max !== null && mb_strlen($text) > $max) {
+                // truncate
+                $text = substr($text, 0, $max);
+            } elseif ($min !== null && mb_strlen($text) < $min) {
+                // pad
+                $text = str_pad('', $min, $text . '. ', \STR_PAD_RIGHT);
+            }
+            return $text;
+        };
 
         if ($enum !== null) {
             if (
@@ -237,9 +248,16 @@ final class OpenApiDataMocker implements IMocker
 
                 // base64 encoding produces strings devided by 4, so resulted string can exceed maxLength parameter
                 // I think truncated(invalid) base64 string is better than oversized, cause this data is fake anyway
-                if (mb_strlen($str) > $maxLength) {
-                    $str = substr($str, 0, $maxLength);
-                }
+                $str = $truncateOrPad($str, null, $maxLength);
+                break;
+            case IMocker::DATA_FORMAT_DATE:
+            case IMocker::DATA_FORMAT_DATE_TIME:
+                // min unix timestamp is 0 and max is 2147483647 for 32bit systems which equals 2038-01-19 03:14:07
+                $date = DateTime::createFromFormat('U', mt_rand(0, 2147483647));
+                $str = ($dataFormat === IMocker::DATA_FORMAT_DATE) ? $date->format('Y-m-d') : $date->format('Y-m-d\TH:i:sP');
+
+                // truncate or pad datestring to fit minLength and maxLength
+                $str = $truncateOrPad($str, $minLength, $maxLength);
                 break;
             default:
                 $str = $getLoremIpsum(mt_rand($minLength, $maxLength));

--- a/modules/openapi-generator/src/main/resources/php-slim4-server/openapi_data_mocker.mustache
+++ b/modules/openapi-generator/src/main/resources/php-slim4-server/openapi_data_mocker.mustache
@@ -290,6 +290,20 @@ final class OpenApiDataMocker implements IMocker
                 // truncate or pad password to fit minLength and maxLength
                 $str = $truncateOrPad($str, $minLength, $maxLength);
                 break;
+            case IMocker::DATA_FORMAT_EMAIL:
+                // just for visionary purpose, not related to real persons
+                $fakeEmailList = [
+                    'johndoe',
+                    'lhoswald',
+                    'ojsimpson',
+                    'mlking',
+                    'jfkennedy',
+                ];
+                $str = $fakeEmailList[mt_rand(0, count($fakeEmailList) - 1)] . '@example.com';
+
+                // truncate or pad email to fit minLength and maxLength
+                $str = $truncateOrPad($str, $minLength, $maxLength);
+                break;
             default:
                 $str = $getLoremIpsum(mt_rand($minLength, $maxLength));
         }

--- a/modules/openapi-generator/src/main/resources/php-slim4-server/openapi_data_mocker.mustache
+++ b/modules/openapi-generator/src/main/resources/php-slim4-server/openapi_data_mocker.mustache
@@ -250,6 +250,14 @@ final class OpenApiDataMocker implements IMocker
                 // I think truncated(invalid) base64 string is better than oversized, cause this data is fake anyway
                 $str = $truncateOrPad($str, null, $maxLength, '. ');
                 break;
+            case IMocker::DATA_FORMAT_BINARY:
+                // use random_bytes function
+                // no need crypto secure values
+                $binaryLength = mt_rand($minLength, $maxLength);
+                if ($binaryLength > 0) {
+                    $str = random_bytes($binaryLength);
+                }
+                break;
             case IMocker::DATA_FORMAT_DATE:
             case IMocker::DATA_FORMAT_DATE_TIME:
                 // min unix timestamp is 0 and max is 2147483647 for 32bit systems which equals 2038-01-19 03:14:07

--- a/modules/openapi-generator/src/main/resources/php-slim4-server/openapi_data_mocker.mustache
+++ b/modules/openapi-generator/src/main/resources/php-slim4-server/openapi_data_mocker.mustache
@@ -177,6 +177,16 @@ final class OpenApiDataMocker implements IMocker
         $enum = null,
         $pattern = null
     ) {
+        $str = '';
+        $getLoremIpsum = function ($length) {
+            return str_pad(
+                '',
+                $length,
+                'Lorem ipsum dolor sit amet, consectetur adipiscing elit. ',
+                \STR_PAD_RIGHT
+            );
+        };
+
         if ($enum !== null) {
             if (
                 is_array($enum) === false
@@ -215,7 +225,27 @@ final class OpenApiDataMocker implements IMocker
             throw new InvalidArgumentException('"maxLength" value cannot be less than "minLength"');
         }
 
-        return str_pad('', mt_rand($minLength, $maxLength), 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. ', \STR_PAD_RIGHT);
+        switch ($dataFormat) {
+            case IMocker::DATA_FORMAT_BYTE:
+                // base64 encoded string
+                $inputLength = 1;
+                $str = base64_encode($getLoremIpsum($inputLength));
+                while (mb_strlen($str) < $minLength) {
+                    $inputLength++;
+                    $str = base64_encode($getLoremIpsum($inputLength));
+                }
+
+                // base64 encoding produces strings devided by 4, so resulted string can exceed maxLength parameter
+                // I think truncated(invalid) base64 string is better than oversized, cause this data is fake anyway
+                if (mb_strlen($str) > $maxLength) {
+                    $str = substr($str, 0, $maxLength);
+                }
+                break;
+            default:
+                $str = $getLoremIpsum(mt_rand($minLength, $maxLength));
+        }
+
+        return $str;
     }
 
     /**

--- a/modules/openapi-generator/src/main/resources/php-slim4-server/openapi_data_mocker.mustache
+++ b/modules/openapi-generator/src/main/resources/php-slim4-server/openapi_data_mocker.mustache
@@ -187,13 +187,13 @@ final class OpenApiDataMocker implements IMocker
                 \STR_PAD_RIGHT
             );
         };
-        $truncateOrPad = function ($text, $min = null, $max = null) {
+        $truncateOrPad = function ($text, $min = null, $max = null, $glue = '') {
             if ($max !== null && mb_strlen($text) > $max) {
                 // truncate
                 $text = substr($text, 0, $max);
             } elseif ($min !== null && mb_strlen($text) < $min) {
                 // pad
-                $text = str_pad('', $min, $text . '. ', \STR_PAD_RIGHT);
+                $text = str_pad('', $min, $text . $glue, \STR_PAD_RIGHT);
             }
             return $text;
         };
@@ -248,7 +248,7 @@ final class OpenApiDataMocker implements IMocker
 
                 // base64 encoding produces strings devided by 4, so resulted string can exceed maxLength parameter
                 // I think truncated(invalid) base64 string is better than oversized, cause this data is fake anyway
-                $str = $truncateOrPad($str, null, $maxLength);
+                $str = $truncateOrPad($str, null, $maxLength, '. ');
                 break;
             case IMocker::DATA_FORMAT_DATE:
             case IMocker::DATA_FORMAT_DATE_TIME:
@@ -257,7 +257,7 @@ final class OpenApiDataMocker implements IMocker
                 $str = ($dataFormat === IMocker::DATA_FORMAT_DATE) ? $date->format('Y-m-d') : $date->format('Y-m-d\TH:i:sP');
 
                 // truncate or pad datestring to fit minLength and maxLength
-                $str = $truncateOrPad($str, $minLength, $maxLength);
+                $str = $truncateOrPad($str, $minLength, $maxLength, ' ');
                 break;
             case IMocker::DATA_FORMAT_PASSWORD:
                 // use list of most popular passwords
@@ -271,6 +271,13 @@ final class OpenApiDataMocker implements IMocker
                     'qwertyuiop[]',
                 ];
                 $str = $obviousPassList[mt_rand(0, count($obviousPassList) - 1)];
+
+                // truncate or pad password to fit minLength and maxLength
+                $str = $truncateOrPad($str, $minLength, $maxLength);
+                break;
+            case IMocker::DATA_FORMAT_UUID:
+                // use php built-in uniqid function
+                $str = uniqid();
 
                 // truncate or pad password to fit minLength and maxLength
                 $str = $truncateOrPad($str, $minLength, $maxLength);

--- a/modules/openapi-generator/src/main/resources/php-slim4-server/openapi_data_mocker.mustache
+++ b/modules/openapi-generator/src/main/resources/php-slim4-server/openapi_data_mocker.mustache
@@ -238,6 +238,7 @@ final class OpenApiDataMocker implements IMocker
 
         switch ($dataFormat) {
             case IMocker::DATA_FORMAT_BYTE:
+            case IMocker::DATA_FORMAT_BINARY:
                 // base64 encoded string
                 $inputLength = 1;
                 $str = base64_encode($getLoremIpsum($inputLength));
@@ -249,14 +250,6 @@ final class OpenApiDataMocker implements IMocker
                 // base64 encoding produces strings devided by 4, so resulted string can exceed maxLength parameter
                 // I think truncated(invalid) base64 string is better than oversized, cause this data is fake anyway
                 $str = $truncateOrPad($str, null, $maxLength, '. ');
-                break;
-            case IMocker::DATA_FORMAT_BINARY:
-                // use random_bytes function
-                // no need crypto secure values
-                $binaryLength = mt_rand($minLength, $maxLength);
-                if ($binaryLength > 0) {
-                    $str = random_bytes($binaryLength);
-                }
                 break;
             case IMocker::DATA_FORMAT_DATE:
             case IMocker::DATA_FORMAT_DATE_TIME:

--- a/modules/openapi-generator/src/main/resources/php-slim4-server/openapi_data_mocker.mustache
+++ b/modules/openapi-generator/src/main/resources/php-slim4-server/openapi_data_mocker.mustache
@@ -259,6 +259,22 @@ final class OpenApiDataMocker implements IMocker
                 // truncate or pad datestring to fit minLength and maxLength
                 $str = $truncateOrPad($str, $minLength, $maxLength);
                 break;
+            case IMocker::DATA_FORMAT_PASSWORD:
+                // use list of most popular passwords
+                $obviousPassList = [
+                    'qwerty',
+                    'qwerty12345',
+                    'hello',
+                    '12345',
+                    '0000',
+                    'qwerty12345!',
+                    'qwertyuiop[]',
+                ];
+                $str = $obviousPassList[mt_rand(0, count($obviousPassList) - 1)];
+
+                // truncate or pad password to fit minLength and maxLength
+                $str = $truncateOrPad($str, $minLength, $maxLength);
+                break;
             default:
                 $str = $getLoremIpsum(mt_rand($minLength, $maxLength));
         }

--- a/modules/openapi-generator/src/main/resources/php-slim4-server/openapi_data_mocker.mustache
+++ b/modules/openapi-generator/src/main/resources/php-slim4-server/openapi_data_mocker.mustache
@@ -451,7 +451,7 @@ final class OpenApiDataMocker implements IMocker
         foreach ($properties as $propName => $propValue) {
             $options = $this->extractSchemaProperties($propValue);
             $dataType = $options['type'];
-            $dataFormat = $options['dataFormat'] ?? null;
+            $dataFormat = $options['format'] ?? null;
             $ref = $options['$ref'] ?? null;
             $data = $this->mockFromRef($ref);
             $obj->$propName = ($data) ? $data : $this->mock($dataType, $dataFormat, $options);

--- a/modules/openapi-generator/src/main/resources/php-slim4-server/openapi_data_mocker_test.mustache
+++ b/modules/openapi-generator/src/main/resources/php-slim4-server/openapi_data_mocker_test.mustache
@@ -338,6 +338,16 @@ class OpenApiDataMockerTest extends TestCase
             [IMocker::DATA_FORMAT_PASSWORD, 10, 50, null, $types, $notTypes],
             [IMocker::DATA_FORMAT_PASSWORD, 10, 10, null, $types, $notTypes],
             [IMocker::DATA_FORMAT_PASSWORD, 0, 0, null, $types, $notTypes],
+            [IMocker::DATA_FORMAT_EMAIL, null, null, null, $types, $notTypes],
+            [IMocker::DATA_FORMAT_EMAIL, 10, null, null, $types, $notTypes],
+            [IMocker::DATA_FORMAT_EMAIL, 10, 10, null, $types, $notTypes],
+            [IMocker::DATA_FORMAT_EMAIL, null, 8, null, $types, $notTypes],
+            [IMocker::DATA_FORMAT_EMAIL, 16, null, null, $types, $notTypes],
+            [IMocker::DATA_FORMAT_EMAIL, 25, null, null, $types, $notTypes],
+            [IMocker::DATA_FORMAT_EMAIL, 25, 25, null, $types, $notTypes],
+            [IMocker::DATA_FORMAT_EMAIL, null, 20, null, $types, $notTypes],
+            [IMocker::DATA_FORMAT_EMAIL, 30, null, null, $types, $notTypes],
+            [IMocker::DATA_FORMAT_EMAIL, 1, 1, null, $types, $notTypes],
         ];
     }
 
@@ -510,9 +520,6 @@ class OpenApiDataMockerTest extends TestCase
             $str2 = $mocker->mock(IMocker::DATA_TYPE_STRING, IMocker::DATA_FORMAT_UUID, ['minLength' => $minLength, 'maxLength' => $maxLength]);
             $arr[] = $str;
             $arr2[] = $str2;
-
-            // $this->assertNotContains($str, $arr);
-            // $this->assertNotContains($str2, $arr2);
 
             $this->assertRegExp($hexPattern, $str);
             $this->assertRegExp($hexPattern, $str2);

--- a/modules/openapi-generator/src/main/resources/php-slim4-server/openapi_data_mocker_test.mustache
+++ b/modules/openapi-generator/src/main/resources/php-slim4-server/openapi_data_mocker_test.mustache
@@ -412,6 +412,41 @@ class OpenApiDataMockerTest extends TestCase
     /**
      * @covers ::mock
      * @covers ::mockString
+     * @dataProvider provideMockStringBinaryFormatArguments
+     */
+    public function testMockStringWithBinaryFormat(
+        $dataFormat,
+        $minLength,
+        $maxLength
+    ) {
+        $mocker = new OpenApiDataMocker();
+        $str = $mocker->mockString($dataFormat, $minLength, $maxLength);
+        $str2 = $mocker->mock(IMocker::DATA_TYPE_STRING, $dataFormat, ['minLength' => $minLength, 'maxLength' => $maxLength]);
+        if ($minLength !== null) {
+            $this->assertGreaterThanOrEqual($minLength, strlen($str));
+            $this->assertGreaterThanOrEqual($minLength, strlen($str2));
+        }
+        if ($maxLength !== null) {
+            $this->assertLessThanOrEqual($maxLength, strlen($str));
+            $this->assertLessThanOrEqual($maxLength, strlen($str2));
+        }
+    }
+
+    public function provideMockStringBinaryFormatArguments()
+    {
+        return [
+            [IMocker::DATA_FORMAT_BINARY, 0, null],
+            [IMocker::DATA_FORMAT_BINARY, 10, null],
+            [IMocker::DATA_FORMAT_BINARY, 0, 100],
+            [IMocker::DATA_FORMAT_BINARY, 10, 50],
+            [IMocker::DATA_FORMAT_BINARY, 10, 10],
+            [IMocker::DATA_FORMAT_BINARY, 0, 0],
+        ];
+    }
+
+    /**
+     * @covers ::mock
+     * @covers ::mockString
      * @dataProvider provideMockStringDateFormatArguments
      */
     public function testMockStringWithDateAndDateTimeFormat(

--- a/modules/openapi-generator/src/main/resources/php-slim4-server/openapi_data_mocker_test.mustache
+++ b/modules/openapi-generator/src/main/resources/php-slim4-server/openapi_data_mocker_test.mustache
@@ -458,6 +458,60 @@ class OpenApiDataMockerTest extends TestCase
     }
 
     /**
+     * @covers ::mock
+     * @covers ::mockString
+     * @dataProvider provideMockStringUuidFormatArguments
+     */
+    public function testMockStringWithUuidFormat(
+        $minLength,
+        $maxLength
+    ) {
+        $mocker = new OpenApiDataMocker();
+        $arr = [];
+        $arr2 = [];
+        $hexPattern = '/^[a-f0-9]*$/';
+
+        while (count($arr) < 100 && count($arr2) < 100) {
+            $str = $mocker->mockString(IMocker::DATA_FORMAT_UUID, $minLength, $maxLength);
+            $str2 = $mocker->mock(IMocker::DATA_TYPE_STRING, IMocker::DATA_FORMAT_UUID, ['minLength' => $minLength, 'maxLength' => $maxLength]);
+            $arr[] = $str;
+            $arr2[] = $str2;
+
+            // $this->assertNotContains($str, $arr);
+            // $this->assertNotContains($str2, $arr2);
+
+            $this->assertRegExp($hexPattern, $str);
+            $this->assertRegExp($hexPattern, $str2);
+
+            if ($minLength !== null) {
+                $this->assertGreaterThanOrEqual($minLength, mb_strlen($str));
+                $this->assertGreaterThanOrEqual($minLength, mb_strlen($str2));
+            }
+            if ($maxLength !== null) {
+                $this->assertLessThanOrEqual($maxLength, mb_strlen($str));
+                $this->assertLessThanOrEqual($maxLength, mb_strlen($str2));
+            }
+        }
+    }
+
+    public function provideMockStringUuidFormatArguments()
+    {
+        return [
+            [null, null],
+            [10, null],
+            [10, 10],
+            [null, 8],
+            [16, null],
+            [null, null],
+            [25, null],
+            [25, 25],
+            [null, 20],
+            [30, null],
+            [1, 1],
+        ];
+    }
+
+    /**
      * @covers ::mockBoolean
      */
     public function testMockBoolean()

--- a/modules/openapi-generator/src/main/resources/php-slim4-server/openapi_data_mocker_test.mustache
+++ b/modules/openapi-generator/src/main/resources/php-slim4-server/openapi_data_mocker_test.mustache
@@ -333,6 +333,12 @@ class OpenApiDataMockerTest extends TestCase
             [null, null, null, null, $types, $notTypes],
             [null, null, null, ['foobar', 'foobaz', 'hello world'], $types, $notTypes],
             [null, null, null, ['foobar'], $types, $notTypes],
+            [IMocker::DATA_FORMAT_PASSWORD, 0, null, null, $types, $notTypes],
+            [IMocker::DATA_FORMAT_PASSWORD, 10, null, null, $types, $notTypes],
+            [IMocker::DATA_FORMAT_PASSWORD, 0, 100, null, $types, $notTypes],
+            [IMocker::DATA_FORMAT_PASSWORD, 10, 50, null, $types, $notTypes],
+            [IMocker::DATA_FORMAT_PASSWORD, 10, 10, null, $types, $notTypes],
+            [IMocker::DATA_FORMAT_PASSWORD, 0, 0, null, $types, $notTypes],
         ];
     }
 

--- a/modules/openapi-generator/src/main/resources/php-slim4-server/openapi_data_mocker_test.mustache
+++ b/modules/openapi-generator/src/main/resources/php-slim4-server/openapi_data_mocker_test.mustache
@@ -312,7 +312,6 @@ class OpenApiDataMockerTest extends TestCase
             IsType::TYPE_STRING,
         ];
         $notTypes = [
-            IsType::TYPE_NUMERIC,
             IsType::TYPE_FLOAT,
             IsType::TYPE_INT,
             IsType::TYPE_ARRAY,

--- a/modules/openapi-generator/src/main/resources/php-slim4-server/openapi_data_mocker_test.mustache
+++ b/modules/openapi-generator/src/main/resources/php-slim4-server/openapi_data_mocker_test.mustache
@@ -405,6 +405,53 @@ class OpenApiDataMockerTest extends TestCase
     }
 
     /**
+     * @covers ::mock
+     * @covers ::mockString
+     * @dataProvider provideMockStringDateFormatArguments
+     */
+    public function testMockStringWithDateAndDateTimeFormat(
+        $dataFormat,
+        $minLength,
+        $maxLength,
+        $dtFormat
+    ) {
+        $mocker = new OpenApiDataMocker();
+        $str = $mocker->mockString($dataFormat, $minLength, $maxLength);
+        $str2 = $mocker->mock(IMocker::DATA_TYPE_STRING, $dataFormat, ['minLength' => $minLength, 'maxLength' => $maxLength]);
+
+        if ($dtFormat !== null) {
+            $date = DateTime::createFromFormat($dtFormat, $str);
+            $date2 = DateTime::createFromFormat($dtFormat, $str2);
+            $this->assertInstanceOf(DateTime::class, $date);
+            $this->assertInstanceOf(DateTime::class, $date2);
+        }
+        if ($minLength !== null) {
+            $this->assertGreaterThanOrEqual($minLength, mb_strlen($str));
+            $this->assertGreaterThanOrEqual($minLength, mb_strlen($str2));
+        }
+        if ($maxLength !== null) {
+            $this->assertLessThanOrEqual($maxLength, mb_strlen($str));
+            $this->assertLessThanOrEqual($maxLength, mb_strlen($str2));
+        }
+    }
+
+    public function provideMockStringDateFormatArguments()
+    {
+        return [
+            [IMocker::DATA_FORMAT_DATE, null, null, 'Y-m-d'],
+            [IMocker::DATA_FORMAT_DATE, 10, null, 'Y-m-d'],
+            [IMocker::DATA_FORMAT_DATE, 10, 10, 'Y-m-d'],
+            [IMocker::DATA_FORMAT_DATE, null, 8, null],
+            [IMocker::DATA_FORMAT_DATE, 16, null, null],
+            [IMocker::DATA_FORMAT_DATE_TIME, null, null, 'Y-m-d\TH:i:sP'],
+            [IMocker::DATA_FORMAT_DATE_TIME, 25, null, 'Y-m-d\TH:i:sP'],
+            [IMocker::DATA_FORMAT_DATE_TIME, 25, 25, 'Y-m-d\TH:i:sP'],
+            [IMocker::DATA_FORMAT_DATE_TIME, null, 20, null],
+            [IMocker::DATA_FORMAT_DATE_TIME, 30, null, null],
+        ];
+    }
+
+    /**
      * @covers ::mockBoolean
      */
     public function testMockBoolean()

--- a/modules/openapi-generator/src/main/resources/php-slim4-server/openapi_data_mocker_test.mustache
+++ b/modules/openapi-generator/src/main/resources/php-slim4-server/openapi_data_mocker_test.mustache
@@ -369,6 +369,42 @@ class OpenApiDataMockerTest extends TestCase
     }
 
     /**
+     * @covers ::mock
+     * @covers ::mockString
+     * @dataProvider provideMockStringByteFormatArguments
+     */
+    public function testMockStringWithByteFormat(
+        $dataFormat,
+        $minLength,
+        $maxLength
+    ) {
+        $mocker = new OpenApiDataMocker();
+        $str = $mocker->mockString($dataFormat, $minLength, $maxLength);
+        $str2 = $mocker->mock(IMocker::DATA_TYPE_STRING, $dataFormat, ['minLength' => $minLength, 'maxLength' => $maxLength]);
+        $base64pattern = '/^[\w\+\/\=]*$/';
+        $this->assertRegExp($base64pattern, $str);
+        $this->assertRegExp($base64pattern, $str2);
+        if ($minLength !== null) {
+            $this->assertGreaterThanOrEqual($minLength, mb_strlen($str));
+            $this->assertGreaterThanOrEqual($minLength, mb_strlen($str2));
+        }
+        if ($maxLength !== null) {
+            $this->assertLessThanOrEqual($maxLength, mb_strlen($str));
+            $this->assertLessThanOrEqual($maxLength, mb_strlen($str2));
+        }
+    }
+
+    public function provideMockStringByteFormatArguments()
+    {
+        return [
+            [IMocker::DATA_FORMAT_BYTE, null, null],
+            [IMocker::DATA_FORMAT_BYTE, 10, null],
+            [IMocker::DATA_FORMAT_BYTE, 10, 10],
+            [IMocker::DATA_FORMAT_BYTE, null, 12],
+        ];
+    }
+
+    /**
      * @covers ::mockBoolean
      */
     public function testMockBoolean()


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### New string formats mocking:
```php
use OpenAPIServer\Mock\OpenApiDataMocker as Mocker;
$mocker = new Mocker();
$data = $mocker->mockFromSchema([
    'type' => 'object',
    'properties' => [
        'byte' => [
            'type' => 'string',
            'format' => 'byte',
        ],
        'binary' => [
            'type' => 'string',
            'format' => 'binary',
            'minLength' => 16,
        ],
        'date' => [
            'type' => 'string',
            'format' => 'date',
        ],
        'datetime' => [
            'type' => 'string',
            'format' => 'date-time',
        ],
        'password' => [
            'type' => 'string',
            'format' => 'password',
        ],
        'email' => [
            'type' => 'string',
            'format' => 'email',
        ],
        'uuid' => [
            'type' => 'string',
            'format' => 'uuid',
        ],
    ],
]);

echo json_encode($data, JSON_PRETTY_PRINT);
```
Output:
```json
{
    "byte": "TA==",
    "binary": "TG9yZW0gaXBzdQ==",
    "date": "1975-10-19",
    "datetime": "2006-08-03T00:43:34+00:00",
    "password": "12345",
    "email": "mlking@example.com",
    "uuid": "5e1a245500fd5"
}
```

Related to #3545

cc @jebentier, @dkarlovi, @mandrean, @jfastnacht, @ackintosh, @renepardon