### PR TITLE
Reduce scope of recommended git configuration

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,5 +101,5 @@ To start the CI tests, you can run `mvn verify -Psamples` (assuming you've all t
 - Make sure test cases passed after the change (one way is to leverage https://travis-ci.org/ to run the CI tests)
 - File a PR with meaningful title, description and commit messages.
 - Recommended git settings
-   - `git config --global core.autocrlf input` to tell Git convert CRLF to LF on commit but not the other way around 
+   - `git config core.autocrlf input` to tell Git convert CRLF to LF on commit but not the other way around 
 - To close an issue (e.g. issue 1542) automatically after a PR is merged, use keywords "fix", "close", "resolve" in the PR description, e.g. `fix #1542`. (Ref: [closing issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -105,5 +105,5 @@ To start the CI tests, you can run `mvn verify -Psamples` (assuming you've all t
 - Make sure test cases passed after the change (one way is to leverage https://travis-ci.org/ to run the CI tests)
 - File a PR with meaningful title, description and commit messages.
 - Recommended git settings
-   - `git config --global core.autocrlf input` to tell Git convert CRLF to LF on commit but not the other way around 
+   - `git config core.autocrlf input` to tell Git convert CRLF to LF on commit but not the other way around 
 - To close an issue (e.g. issue 1542) automatically after a PR is merged, use keywords "fix", "close", "resolve" in the PR description, e.g. `fix #1542`. (Ref: [closing issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
Current scope (`--global`) of recommendation for **this** project can affect **all others** projects on user's machine.

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
