### PR TITLE
[r] Ignore cran-comments file from the build

### DIFF
--- a/modules/openapi-generator/src/main/resources/r/Rbuildignore.mustache
+++ b/modules/openapi-generator/src/main/resources/r/Rbuildignore.mustache
@@ -6,3 +6,4 @@
 ^docs$
 ^git_push\.sh$
 ^README\.md$
+^cran-comments\.md$

--- a/samples/client/petstore/R/.Rbuildignore
+++ b/samples/client/petstore/R/.Rbuildignore
@@ -6,3 +6,4 @@
 ^docs$
 ^git_push\.sh$
 ^README\.md$
+^cran-comments\.md$


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
`cran-comments.md` is the file where we address CRAN maintainer's comments/feedback. We need to add that file at the root location of the library's code repository and need to be ignored from the build.

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@Ramanth 