### PR TITLE
fix #4990 Disables Swift4 tests in Bitrise because they keep failing

### DIFF
--- a/CI/bitrise.yml
+++ b/CI/bitrise.yml
@@ -39,16 +39,16 @@ workflows:
             set -e
 
             sh bin/swift4-all.sh
-    - script@1.1.5:
-        title: Run Swift4 tests
-        inputs:
-        - content: |
-            #!/usr/bin/env bash
-
-            set -e
-
-            ./samples/client/petstore/swift4/swift4_test_all.sh
-            ./samples/client/test/swift4/swift4_test_all.sh
+    # - script@1.1.5:
+    #     title: Run Swift4 tests
+    #     inputs:
+    #     - content: |
+    #         #!/usr/bin/env bash
+    #
+    #         set -e
+    #
+    #         ./samples/client/petstore/swift4/swift4_test_all.sh
+    #         ./samples/client/test/swift4/swift4_test_all.sh
     - script@1.1.5:
         title: Run all bin scripts
         inputs:


### PR DESCRIPTION
Our Bitrise Swift4 tests keep failing
It appears that the last time that the test worked was 6 days ago in this PR:
https://github.com/OpenAPITools/openapi-generator/pull/4940
Since then 19 PRs have been submitted, all of which are failing Swift4 tests in Bitrise
This PR comments out the Swift4 testing so we can:
- fix Swift4 later
- get back to having all of our CI tests pass for any open or updated PRs

This PR fixes this issue:
https://github.com/OpenAPITools/openapi-generator/issues/4990

<!-- Please check the completed items below -->
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [ ] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [X] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

Core Team:
@wing328 (2015/07) 
@jimschubert (2016/05) 
@cbornet (2016/05)
@ackintosh (2018/02) 
@jmini (2018/04) 
@etherealjoy (2019/06)

Swift Team:
@jgavris (2017/07)
@ehyche (2017/08)
@Edubits (2017/09)
@jaz-ah (2017/09)
@4brunu (2019/11)
