### PR TITLE
[PHP] fix php codegen ordering issue with CodegenSecurity

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PhpSymfonyServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PhpSymfonyServerCodegen.java
@@ -386,7 +386,7 @@ public class PhpSymfonyServerCodegen extends AbstractPhpCodegen implements Codeg
         operations.put("controllerName", toControllerName((String) operations.get("pathPrefix")));
         operations.put("symfonyService", toSymfonyService((String) operations.get("pathPrefix")));
 
-        HashSet<CodegenSecurity> authMethods = new HashSet<>();
+        List<CodegenSecurity> authMethods = new ArrayList<CodegenSecurity>();
         List<CodegenOperation> operationList = (List<CodegenOperation>) operations.get("operation");
 
         for (CodegenOperation op : operationList) {
@@ -431,7 +431,11 @@ public class PhpSymfonyServerCodegen extends AbstractPhpCodegen implements Codeg
 
             // Add operation's authentication methods to whole interface
             if (op.authMethods != null) {
-                authMethods.addAll(op.authMethods);
+                for (CodegenSecurity am : op.authMethods) {
+                    if (!authMethods.contains(am)) {
+                        authMethods.add(am);
+                    }
+                }
             }
         }
 

--- a/samples/server/petstore/php-symfony/SymfonyBundle-php/Api/PetApiInterface.php
+++ b/samples/server/petstore/php-symfony/SymfonyBundle-php/Api/PetApiInterface.php
@@ -44,15 +44,6 @@ interface PetApiInterface
 {
 
     /**
-     * Sets authentication method api_key
-     *
-     * @param string $value Value of the api_key authentication method.
-     *
-     * @return void
-     */
-    public function setapi_key($value);
-
-    /**
      * Sets authentication method petstore_auth
      *
      * @param string $value Value of the petstore_auth authentication method.
@@ -60,6 +51,15 @@ interface PetApiInterface
      * @return void
      */
     public function setpetstore_auth($value);
+
+    /**
+     * Sets authentication method api_key
+     *
+     * @param string $value Value of the api_key authentication method.
+     *
+     * @return void
+     */
+    public function setapi_key($value);
 
     /**
      * Operation addPet


### PR DESCRIPTION
Fix transient build issues with PHP symfony. The generated list of authMethods in codegen is not sorted because it is in a HashSet, hence the output is not deterministic. This means the generated code may potentially change when the code is executed or when the hash code changes.

I think codegen should return collections in a  deterministic order, such that when generating samples (in the bin directory), it does not keep swapping generated code around.

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [ ] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
