### PR TITLE
[dart-dio] Various fixes

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/DartDioClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/DartDioClientCodegen.java
@@ -247,10 +247,10 @@ public class DartDioClientCodegen extends DartClientCodegen {
             additionalProperties.put("timeMachine", "true");
             typeMapping.put("date", "LocalDate");
             typeMapping.put("Date", "LocalDate");
-            typeMapping.put("DateTime", "OffsetDateTime");
-            typeMapping.put("datetime", "OffsetDateTime");
+            typeMapping.put("DateTime", "LocalDateTime");
+            typeMapping.put("datetime", "LocalDateTime");
             importMapping.put("LocalDate", "package:time_machine/time_machine.dart");
-            importMapping.put("OffsetDateTime", "package:time_machine/time_machine.dart");
+            importMapping.put("LocalDateTime", "package:time_machine/time_machine.dart");
             supportingFiles.add(new SupportingFile("local_date_serializer.mustache", libFolder, "local_date_serializer.dart"));
 
         }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/DartDioClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/DartDioClientCodegen.java
@@ -245,12 +245,12 @@ public class DartDioClientCodegen extends DartClientCodegen {
             typeMapping.put("date", "DateTime");
         } else if ("timemachine".equals(dateLibrary)) {
             additionalProperties.put("timeMachine", "true");
-            typeMapping.put("date", "LocalDate");
-            typeMapping.put("Date", "LocalDate");
-            typeMapping.put("DateTime", "LocalDateTime");
-            typeMapping.put("datetime", "LocalDateTime");
-            importMapping.put("LocalDate", "package:time_machine/time_machine.dart");
-            importMapping.put("LocalDateTime", "package:time_machine/time_machine.dart");
+            typeMapping.put("date", "OffsetDate");
+            typeMapping.put("Date", "OffsetDate");
+            typeMapping.put("DateTime", "OffsetDateTime");
+            typeMapping.put("datetime", "OffsetDateTime");
+            importMapping.put("OffsetDate", "package:time_machine/time_machine.dart");
+            importMapping.put("OffsetDateTime", "package:time_machine/time_machine.dart");
             supportingFiles.add(new SupportingFile("local_date_serializer.mustache", libFolder, "local_date_serializer.dart"));
 
         }

--- a/modules/openapi-generator/src/main/resources/dart-dio/api.mustache
+++ b/modules/openapi-generator/src/main/resources/dart-dio/api.mustache
@@ -23,17 +23,17 @@ class {{classname}} {
         /// {{notes}}
         Future<Response{{#returnType}}<{{{returnType}}}>{{/returnType}}>{{nickname}}({{#allParams}}{{#required}}{{{dataType}}} {{paramName}},{{/required}}{{/allParams}}{ {{#allParams}}{{^required}}{{{dataType}}} {{paramName}},{{/required}}{{/allParams}}CancelToken cancelToken, Map<String, String> headers,}) async {
 
-        String path = "{{{path}}}"{{#pathParams}}.replaceAll("{" + "{{baseName}}" + "}", {{{paramName}}}.toString()){{/pathParams}};
+        String path = "{{{path}}}"{{#pathParams}}.replaceAll("{" r'{{baseName}}' "}", {{{paramName}}}.toString()){{/pathParams}};
 
         Map<String, dynamic> queryParams = {};
         Map<String, String> headerParams = Map.from(headers ?? {});
         dynamic bodyData;
 
         {{#headerParams}}
-                headerParams["{{baseName}}"] = {{paramName}};
+                headerParams[r'{{baseName}}'] = {{paramName}};
         {{/headerParams}}
         {{#queryParams}}
-                queryParams["{{baseName}}"] = {{paramName}};
+                queryParams[r'{{baseName}}'] = {{paramName}};
         {{/queryParams}}
         queryParams.removeWhere((key, value) => value == null);
         headerParams.removeWhere((key, value) => value == null);
@@ -46,12 +46,12 @@ class {{classname}} {
         {{#isMultipart}}
             {{^isFile}}
                 if ({{paramName}} != null) {
-                    formData['{{baseName}}'] = parameterToString(_serializers, {{paramName}});
+                    formData[r'{{baseName}}'] = parameterToString(_serializers, {{paramName}});
                 }
             {{/isFile}}
             {{#isFile}}
                 if ({{paramName}} != null) {
-                    formData['{{baseName}}'] = MultipartFile.fromBytes({{paramName}}, filename: "{{baseName}}");
+                    formData[r'{{baseName}}'] = MultipartFile.fromBytes({{paramName}}, filename: r'{{baseName}}');
                 }
             {{/isFile}}
         {{/isMultipart}}

--- a/modules/openapi-generator/src/main/resources/dart-dio/api.mustache
+++ b/modules/openapi-generator/src/main/resources/dart-dio/api.mustache
@@ -23,7 +23,7 @@ class {{classname}} {
         /// {{notes}}
         Future<Response{{#returnType}}<{{{returnType}}}>{{/returnType}}>{{nickname}}({{#allParams}}{{#required}}{{{dataType}}} {{paramName}},{{/required}}{{/allParams}}{ {{#allParams}}{{^required}}{{{dataType}}} {{paramName}},{{/required}}{{/allParams}}CancelToken cancelToken, Map<String, String> headers,}) async {
 
-        String path = "{{{path}}}"{{#pathParams}}.replaceAll("{" r'{{baseName}}' "}", {{{paramName}}}.toString()){{/pathParams}};
+        String _path = "{{{path}}}"{{#pathParams}}.replaceAll("{" r'{{baseName}}' "}", {{{paramName}}}.toString()){{/pathParams}};
 
         Map<String, dynamic> queryParams = {};
         Map<String, String> headerParams = Map.from(headers ?? {});
@@ -72,7 +72,7 @@ class {{classname}} {
         {{/bodyParam}}
 
             return _dio.request(
-            path,
+            _path,
             queryParameters: queryParams,
             data: bodyData,
             options: Options(

--- a/modules/openapi-generator/src/main/resources/dart-dio/apilib.mustache
+++ b/modules/openapi-generator/src/main/resources/dart-dio/apilib.mustache
@@ -1,6 +1,5 @@
 library {{pubName}}.api;
 
-import 'package:http/io_client.dart';
 import 'package:dio/dio.dart';
 import 'package:built_value/serializer.dart';
 import 'package:{{pubName}}/serializers.dart';

--- a/modules/openapi-generator/src/main/resources/dart-dio/class.mustache
+++ b/modules/openapi-generator/src/main/resources/dart-dio/class.mustache
@@ -10,7 +10,7 @@ abstract class {{classname}} implements Built<{{classname}}, {{classname}}Builde
     {{#isNullable}}
         @nullable
     {{/isNullable}}
-    @BuiltValueField(wireName: '{{baseName}}')
+    @BuiltValueField(wireName: r'{{baseName}}')
     {{{dataType}}} get {{name}};
     {{#allowableValues}}
         {{#min}} // range from {{min}} to {{max}}{{/min}}//{{^min}}enum {{name}}Enum { {{#values}} {{.}}, {{/values}} };{{/min}}

--- a/modules/openapi-generator/src/main/resources/dart-dio/local_date_serializer.mustache
+++ b/modules/openapi-generator/src/main/resources/dart-dio/local_date_serializer.mustache
@@ -2,42 +2,44 @@ import 'package:built_collection/built_collection.dart';
 import 'package:built_value/serializer.dart';
 import 'package:time_machine/time_machine.dart';
 
-class LocalDateSerializer implements PrimitiveSerializer<LocalDate> {
+class OffsetDateSerializer implements PrimitiveSerializer<OffsetDate> {
   @override
-  Iterable<Type> get types => BuiltList<Type>([LocalDate]);
+  Iterable<Type> get types => BuiltList<Type>([OffsetDate]);
 
-    @override
-    String get wireName => "LocalDate";
+  @override
+  String get wireName => "OffsetDate";
 
-    @override
-    LocalDate deserialize(Serializers serializers, Object serialized,
-    {FullType specifiedType = FullType.unspecified}) {
-    return LocalDate.dateTime(DateTime.parse(serialized as String));
-    }
+  @override
+  OffsetDate deserialize(Serializers serializers, Object serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final local = LocalDate.dateTime(DateTime.parse(serialized as String));
+    return OffsetDate(local, Offset(0));
+  }
 
-    @override
-    Object serialize(Serializers serializers, LocalDate localDate,
-    {FullType specifiedType = FullType.unspecified}) {
-    return localDate.toString('yyyy-MM-dd');
-    }
+  @override
+  Object serialize(Serializers serializers, OffsetDate offsetDate,
+      {FullType specifiedType = FullType.unspecified}) {
+    return offsetDate.toString('yyyy-MM-dd');
+  }
 }
 
-class LocalDateTimeSerializer implements PrimitiveSerializer<LocalDateTime> {
+class OffsetDateTimeSerializer implements PrimitiveSerializer<OffsetDateTime> {
   @override
-  Iterable<Type> get types => BuiltList<Type>([LocalDateTime]);
+  Iterable<Type> get types => BuiltList<Type>([OffsetDateTime]);
 
-    @override
-    String get wireName => "LocalDateTime";
+  @override
+  String get wireName => "OffsetDateTime";
 
-    @override
-    LocalDateTime deserialize(Serializers serializers, Object serialized,
-    {FullType specifiedType = FullType.unspecified}) {
-    return LocalDateTime.dateTime(DateTime.parse(serialized as String));
-    }
+  @override
+  OffsetDateTime deserialize(Serializers serializers, Object serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final local = LocalDateTime.dateTime(DateTime.parse(serialized as String));
+    return OffsetDateTime(local, Offset(0));
+  }
 
-    @override
-    Object serialize(Serializers serializers, LocalDateTime localDateTime,
-    {FullType specifiedType = FullType.unspecified}) {
-    return localDateTime.toString('yyyy-MM-dd HH:mm:ss');
-    }
+  @override
+  Object serialize(Serializers serializers, OffsetDateTime offsetDateTime,
+      {FullType specifiedType = FullType.unspecified}) {
+    return offsetDateTime.toString();
+  }
 }

--- a/modules/openapi-generator/src/main/resources/dart-dio/local_date_serializer.mustache
+++ b/modules/openapi-generator/src/main/resources/dart-dio/local_date_serializer.mustache
@@ -21,3 +21,23 @@ class LocalDateSerializer implements PrimitiveSerializer<LocalDate> {
     return localDate.toString('yyyy-MM-dd');
     }
 }
+
+class LocalDateTimeSerializer implements PrimitiveSerializer<LocalDateTime> {
+  @override
+  Iterable<Type> get types => BuiltList<Type>([LocalDateTime]);
+
+    @override
+    String get wireName => "LocalDateTime";
+
+    @override
+    LocalDateTime deserialize(Serializers serializers, Object serialized,
+    {FullType specifiedType = FullType.unspecified}) {
+    return LocalDateTime.dateTime(DateTime.parse(serialized as String));
+    }
+
+    @override
+    Object serialize(Serializers serializers, LocalDateTime localDateTime,
+    {FullType specifiedType = FullType.unspecified}) {
+    return localDateTime.toString('yyyy-MM-dd HH:mm:ss');
+    }
+}

--- a/modules/openapi-generator/src/main/resources/dart-dio/serializers.mustache
+++ b/modules/openapi-generator/src/main/resources/dart-dio/serializers.mustache
@@ -4,7 +4,8 @@ import 'package:built_value/serializer.dart';
 import 'package:built_collection/built_collection.dart';
 import 'package:built_value/json_object.dart';
 import 'package:built_value/standard_json_plugin.dart';
-{{#timeMachine}}import 'package:{{pubName}}/local_date_serializer.dart';{{/timeMachine}}
+{{#timeMachine}}import 'package:time_machine/time_machine.dart';
+import 'package:{{pubName}}/local_date_serializer.dart';{{/timeMachine}}
 {{#models}}{{#model}}import 'package:{{pubName}}/model/{{classFilename}}.dart';
 {{/model}}{{/models}}
 
@@ -25,4 +26,6 @@ const FullType(BuiltList, const [const FullType({{classname}})]),
 
 Serializers standardSerializers =
 (serializers.toBuilder()
-{{#timeMachine}}..add(LocalDateSerializer()){{/timeMachine}}..addPlugin(StandardJsonPlugin())).build();
+{{#timeMachine}}..add(LocalDateSerializer())
+..add(LocalDateTimeSerializer())
+{{/timeMachine}}..addPlugin(StandardJsonPlugin())).build();

--- a/modules/openapi-generator/src/main/resources/dart-dio/serializers.mustache
+++ b/modules/openapi-generator/src/main/resources/dart-dio/serializers.mustache
@@ -26,6 +26,6 @@ const FullType(BuiltList, const [const FullType({{classname}})]),
 
 Serializers standardSerializers =
 (serializers.toBuilder()
-{{#timeMachine}}..add(LocalDateSerializer())
-..add(LocalDateTimeSerializer())
+{{#timeMachine}}..add(OffsetDateSerializer())
+..add(OffsetDateTimeSerializer())
 {{/timeMachine}}..addPlugin(StandardJsonPlugin())).build();

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/dartdio/DartDioModelTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/dartdio/DartDioModelTest.java
@@ -162,11 +162,11 @@ public class DartDioModelTest {
 
         final CodegenProperty property4 = cm.vars.get(3);
         Assert.assertEquals(property4.baseName, "birthDate");
-        Assert.assertEquals(property4.complexType, "LocalDate");
-        Assert.assertEquals(property4.dataType, "LocalDate");
+        Assert.assertEquals(property4.complexType, "OffsetDate");
+        Assert.assertEquals(property4.dataType, "OffsetDate");
         Assert.assertEquals(property4.name, "birthDate");
         Assert.assertEquals(property4.defaultValue, "null");
-        Assert.assertEquals(property4.baseType, "LocalDate");
+        Assert.assertEquals(property4.baseType, "OffsetDate");
         Assert.assertFalse(property4.hasMore);
         Assert.assertFalse(property4.required);
         Assert.assertFalse(property4.isContainer);

--- a/samples/client/petstore/dart-dio/lib/api.dart
+++ b/samples/client/petstore/dart-dio/lib/api.dart
@@ -1,6 +1,5 @@
 library openapi.api;
 
-import 'package:http/io_client.dart';
 import 'package:dio/dio.dart';
 import 'package:built_value/serializer.dart';
 import 'package:openapi/serializers.dart';

--- a/samples/client/petstore/dart-dio/lib/api/pet_api.dart
+++ b/samples/client/petstore/dart-dio/lib/api/pet_api.dart
@@ -21,7 +21,7 @@ class PetApi {
         /// 
         Future<Response>addPet(Pet body,{ CancelToken cancelToken, Map<String, String> headers,}) async {
 
-        String path = "/pet";
+        String _path = "/pet";
 
         Map<String, dynamic> queryParams = {};
         Map<String, String> headerParams = Map.from(headers ?? {});
@@ -38,7 +38,7 @@ class PetApi {
             bodyData = jsonbody;
 
             return _dio.request(
-            path,
+            _path,
             queryParameters: queryParams,
             data: bodyData,
             options: Options(
@@ -54,7 +54,7 @@ class PetApi {
         /// 
         Future<Response>deletePet(int petId,{ String apiKey,CancelToken cancelToken, Map<String, String> headers,}) async {
 
-        String path = "/pet/{petId}".replaceAll("{" r'petId' "}", petId.toString());
+        String _path = "/pet/{petId}".replaceAll("{" r'petId' "}", petId.toString());
 
         Map<String, dynamic> queryParams = {};
         Map<String, String> headerParams = Map.from(headers ?? {});
@@ -69,7 +69,7 @@ class PetApi {
 
 
             return _dio.request(
-            path,
+            _path,
             queryParameters: queryParams,
             data: bodyData,
             options: Options(
@@ -85,7 +85,7 @@ class PetApi {
         /// Multiple status values can be provided with comma separated strings
         Future<Response<List<Pet>>>findPetsByStatus(List<String> status,{ CancelToken cancelToken, Map<String, String> headers,}) async {
 
-        String path = "/pet/findByStatus";
+        String _path = "/pet/findByStatus";
 
         Map<String, dynamic> queryParams = {};
         Map<String, String> headerParams = Map.from(headers ?? {});
@@ -100,7 +100,7 @@ class PetApi {
 
 
             return _dio.request(
-            path,
+            _path,
             queryParameters: queryParams,
             data: bodyData,
             options: Options(
@@ -131,7 +131,7 @@ class PetApi {
         /// Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
         Future<Response<List<Pet>>>findPetsByTags(List<String> tags,{ CancelToken cancelToken, Map<String, String> headers,}) async {
 
-        String path = "/pet/findByTags";
+        String _path = "/pet/findByTags";
 
         Map<String, dynamic> queryParams = {};
         Map<String, String> headerParams = Map.from(headers ?? {});
@@ -146,7 +146,7 @@ class PetApi {
 
 
             return _dio.request(
-            path,
+            _path,
             queryParameters: queryParams,
             data: bodyData,
             options: Options(
@@ -177,7 +177,7 @@ class PetApi {
         /// Returns a single pet
         Future<Response<Pet>>getPetById(int petId,{ CancelToken cancelToken, Map<String, String> headers,}) async {
 
-        String path = "/pet/{petId}".replaceAll("{" r'petId' "}", petId.toString());
+        String _path = "/pet/{petId}".replaceAll("{" r'petId' "}", petId.toString());
 
         Map<String, dynamic> queryParams = {};
         Map<String, String> headerParams = Map.from(headers ?? {});
@@ -191,7 +191,7 @@ class PetApi {
 
 
             return _dio.request(
-            path,
+            _path,
             queryParameters: queryParams,
             data: bodyData,
             options: Options(
@@ -221,7 +221,7 @@ class PetApi {
         /// 
         Future<Response>updatePet(Pet body,{ CancelToken cancelToken, Map<String, String> headers,}) async {
 
-        String path = "/pet";
+        String _path = "/pet";
 
         Map<String, dynamic> queryParams = {};
         Map<String, String> headerParams = Map.from(headers ?? {});
@@ -238,7 +238,7 @@ class PetApi {
             bodyData = jsonbody;
 
             return _dio.request(
-            path,
+            _path,
             queryParameters: queryParams,
             data: bodyData,
             options: Options(
@@ -254,7 +254,7 @@ class PetApi {
         /// 
         Future<Response>updatePetWithForm(int petId,{ String name,String status,CancelToken cancelToken, Map<String, String> headers,}) async {
 
-        String path = "/pet/{petId}".replaceAll("{" r'petId' "}", petId.toString());
+        String _path = "/pet/{petId}".replaceAll("{" r'petId' "}", petId.toString());
 
         Map<String, dynamic> queryParams = {};
         Map<String, String> headerParams = Map.from(headers ?? {});
@@ -270,7 +270,7 @@ class PetApi {
 
 
             return _dio.request(
-            path,
+            _path,
             queryParameters: queryParams,
             data: bodyData,
             options: Options(
@@ -286,7 +286,7 @@ class PetApi {
         /// 
         Future<Response<ApiResponse>>uploadFile(int petId,{ String additionalMetadata,Uint8List file,CancelToken cancelToken, Map<String, String> headers,}) async {
 
-        String path = "/pet/{petId}/uploadImage".replaceAll("{" r'petId' "}", petId.toString());
+        String _path = "/pet/{petId}/uploadImage".replaceAll("{" r'petId' "}", petId.toString());
 
         Map<String, dynamic> queryParams = {};
         Map<String, String> headerParams = Map.from(headers ?? {});
@@ -308,7 +308,7 @@ class PetApi {
 
 
             return _dio.request(
-            path,
+            _path,
             queryParameters: queryParams,
             data: bodyData,
             options: Options(

--- a/samples/client/petstore/dart-dio/lib/api/pet_api.dart
+++ b/samples/client/petstore/dart-dio/lib/api/pet_api.dart
@@ -54,13 +54,13 @@ class PetApi {
         /// 
         Future<Response>deletePet(int petId,{ String apiKey,CancelToken cancelToken, Map<String, String> headers,}) async {
 
-        String path = "/pet/{petId}".replaceAll("{" + "petId" + "}", petId.toString());
+        String path = "/pet/{petId}".replaceAll("{" r'petId' "}", petId.toString());
 
         Map<String, dynamic> queryParams = {};
         Map<String, String> headerParams = Map.from(headers ?? {});
         dynamic bodyData;
 
-                headerParams["api_key"] = apiKey;
+                headerParams[r'api_key'] = apiKey;
         queryParams.removeWhere((key, value) => value == null);
         headerParams.removeWhere((key, value) => value == null);
 
@@ -91,7 +91,7 @@ class PetApi {
         Map<String, String> headerParams = Map.from(headers ?? {});
         dynamic bodyData;
 
-                queryParams["status"] = status;
+                queryParams[r'status'] = status;
         queryParams.removeWhere((key, value) => value == null);
         headerParams.removeWhere((key, value) => value == null);
 
@@ -137,7 +137,7 @@ class PetApi {
         Map<String, String> headerParams = Map.from(headers ?? {});
         dynamic bodyData;
 
-                queryParams["tags"] = tags;
+                queryParams[r'tags'] = tags;
         queryParams.removeWhere((key, value) => value == null);
         headerParams.removeWhere((key, value) => value == null);
 
@@ -177,7 +177,7 @@ class PetApi {
         /// Returns a single pet
         Future<Response<Pet>>getPetById(int petId,{ CancelToken cancelToken, Map<String, String> headers,}) async {
 
-        String path = "/pet/{petId}".replaceAll("{" + "petId" + "}", petId.toString());
+        String path = "/pet/{petId}".replaceAll("{" r'petId' "}", petId.toString());
 
         Map<String, dynamic> queryParams = {};
         Map<String, String> headerParams = Map.from(headers ?? {});
@@ -254,7 +254,7 @@ class PetApi {
         /// 
         Future<Response>updatePetWithForm(int petId,{ String name,String status,CancelToken cancelToken, Map<String, String> headers,}) async {
 
-        String path = "/pet/{petId}".replaceAll("{" + "petId" + "}", petId.toString());
+        String path = "/pet/{petId}".replaceAll("{" r'petId' "}", petId.toString());
 
         Map<String, dynamic> queryParams = {};
         Map<String, String> headerParams = Map.from(headers ?? {});
@@ -286,7 +286,7 @@ class PetApi {
         /// 
         Future<Response<ApiResponse>>uploadFile(int petId,{ String additionalMetadata,Uint8List file,CancelToken cancelToken, Map<String, String> headers,}) async {
 
-        String path = "/pet/{petId}/uploadImage".replaceAll("{" + "petId" + "}", petId.toString());
+        String path = "/pet/{petId}/uploadImage".replaceAll("{" r'petId' "}", petId.toString());
 
         Map<String, dynamic> queryParams = {};
         Map<String, String> headerParams = Map.from(headers ?? {});
@@ -299,10 +299,10 @@ class PetApi {
 
         Map<String, dynamic> formData = {};
                 if (additionalMetadata != null) {
-                    formData['additionalMetadata'] = parameterToString(_serializers, additionalMetadata);
+                    formData[r'additionalMetadata'] = parameterToString(_serializers, additionalMetadata);
                 }
                 if (file != null) {
-                    formData['file'] = MultipartFile.fromBytes(file, filename: "file");
+                    formData[r'file'] = MultipartFile.fromBytes(file, filename: r'file');
                 }
         bodyData = FormData.fromMap(formData);
 

--- a/samples/client/petstore/dart-dio/lib/api/store_api.dart
+++ b/samples/client/petstore/dart-dio/lib/api/store_api.dart
@@ -18,7 +18,7 @@ class StoreApi {
         /// For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
         Future<Response>deleteOrder(String orderId,{ CancelToken cancelToken, Map<String, String> headers,}) async {
 
-        String path = "/store/order/{orderId}".replaceAll("{" r'orderId' "}", orderId.toString());
+        String _path = "/store/order/{orderId}".replaceAll("{" r'orderId' "}", orderId.toString());
 
         Map<String, dynamic> queryParams = {};
         Map<String, String> headerParams = Map.from(headers ?? {});
@@ -32,7 +32,7 @@ class StoreApi {
 
 
             return _dio.request(
-            path,
+            _path,
             queryParameters: queryParams,
             data: bodyData,
             options: Options(
@@ -48,7 +48,7 @@ class StoreApi {
         /// Returns a map of status codes to quantities
         Future<Response<Map<String, int>>>getInventory({ CancelToken cancelToken, Map<String, String> headers,}) async {
 
-        String path = "/store/inventory";
+        String _path = "/store/inventory";
 
         Map<String, dynamic> queryParams = {};
         Map<String, String> headerParams = Map.from(headers ?? {});
@@ -62,7 +62,7 @@ class StoreApi {
 
 
             return _dio.request(
-            path,
+            _path,
             queryParameters: queryParams,
             data: bodyData,
             options: Options(
@@ -92,7 +92,7 @@ class StoreApi {
         /// For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generated exceptions
         Future<Response<Order>>getOrderById(int orderId,{ CancelToken cancelToken, Map<String, String> headers,}) async {
 
-        String path = "/store/order/{orderId}".replaceAll("{" r'orderId' "}", orderId.toString());
+        String _path = "/store/order/{orderId}".replaceAll("{" r'orderId' "}", orderId.toString());
 
         Map<String, dynamic> queryParams = {};
         Map<String, String> headerParams = Map.from(headers ?? {});
@@ -106,7 +106,7 @@ class StoreApi {
 
 
             return _dio.request(
-            path,
+            _path,
             queryParameters: queryParams,
             data: bodyData,
             options: Options(
@@ -136,7 +136,7 @@ class StoreApi {
         /// 
         Future<Response<Order>>placeOrder(Order body,{ CancelToken cancelToken, Map<String, String> headers,}) async {
 
-        String path = "/store/order";
+        String _path = "/store/order";
 
         Map<String, dynamic> queryParams = {};
         Map<String, String> headerParams = Map.from(headers ?? {});
@@ -153,7 +153,7 @@ class StoreApi {
             bodyData = jsonbody;
 
             return _dio.request(
-            path,
+            _path,
             queryParameters: queryParams,
             data: bodyData,
             options: Options(

--- a/samples/client/petstore/dart-dio/lib/api/store_api.dart
+++ b/samples/client/petstore/dart-dio/lib/api/store_api.dart
@@ -18,7 +18,7 @@ class StoreApi {
         /// For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
         Future<Response>deleteOrder(String orderId,{ CancelToken cancelToken, Map<String, String> headers,}) async {
 
-        String path = "/store/order/{orderId}".replaceAll("{" + "orderId" + "}", orderId.toString());
+        String path = "/store/order/{orderId}".replaceAll("{" r'orderId' "}", orderId.toString());
 
         Map<String, dynamic> queryParams = {};
         Map<String, String> headerParams = Map.from(headers ?? {});
@@ -92,7 +92,7 @@ class StoreApi {
         /// For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generated exceptions
         Future<Response<Order>>getOrderById(int orderId,{ CancelToken cancelToken, Map<String, String> headers,}) async {
 
-        String path = "/store/order/{orderId}".replaceAll("{" + "orderId" + "}", orderId.toString());
+        String path = "/store/order/{orderId}".replaceAll("{" r'orderId' "}", orderId.toString());
 
         Map<String, dynamic> queryParams = {};
         Map<String, String> headerParams = Map.from(headers ?? {});

--- a/samples/client/petstore/dart-dio/lib/api/user_api.dart
+++ b/samples/client/petstore/dart-dio/lib/api/user_api.dart
@@ -119,7 +119,7 @@ class UserApi {
         /// This can only be done by the logged in user.
         Future<Response>deleteUser(String username,{ CancelToken cancelToken, Map<String, String> headers,}) async {
 
-        String path = "/user/{username}".replaceAll("{" + "username" + "}", username.toString());
+        String path = "/user/{username}".replaceAll("{" r'username' "}", username.toString());
 
         Map<String, dynamic> queryParams = {};
         Map<String, String> headerParams = Map.from(headers ?? {});
@@ -149,7 +149,7 @@ class UserApi {
         /// 
         Future<Response<User>>getUserByName(String username,{ CancelToken cancelToken, Map<String, String> headers,}) async {
 
-        String path = "/user/{username}".replaceAll("{" + "username" + "}", username.toString());
+        String path = "/user/{username}".replaceAll("{" r'username' "}", username.toString());
 
         Map<String, dynamic> queryParams = {};
         Map<String, String> headerParams = Map.from(headers ?? {});
@@ -199,8 +199,8 @@ class UserApi {
         Map<String, String> headerParams = Map.from(headers ?? {});
         dynamic bodyData;
 
-                queryParams["username"] = username;
-                queryParams["password"] = password;
+                queryParams[r'username'] = username;
+                queryParams[r'password'] = password;
         queryParams.removeWhere((key, value) => value == null);
         headerParams.removeWhere((key, value) => value == null);
 
@@ -269,7 +269,7 @@ class UserApi {
         /// This can only be done by the logged in user.
         Future<Response>updateUser(String username,User body,{ CancelToken cancelToken, Map<String, String> headers,}) async {
 
-        String path = "/user/{username}".replaceAll("{" + "username" + "}", username.toString());
+        String path = "/user/{username}".replaceAll("{" r'username' "}", username.toString());
 
         Map<String, dynamic> queryParams = {};
         Map<String, String> headerParams = Map.from(headers ?? {});

--- a/samples/client/petstore/dart-dio/lib/api/user_api.dart
+++ b/samples/client/petstore/dart-dio/lib/api/user_api.dart
@@ -18,7 +18,7 @@ class UserApi {
         /// This can only be done by the logged in user.
         Future<Response>createUser(User body,{ CancelToken cancelToken, Map<String, String> headers,}) async {
 
-        String path = "/user";
+        String _path = "/user";
 
         Map<String, dynamic> queryParams = {};
         Map<String, String> headerParams = Map.from(headers ?? {});
@@ -35,7 +35,7 @@ class UserApi {
             bodyData = jsonbody;
 
             return _dio.request(
-            path,
+            _path,
             queryParameters: queryParams,
             data: bodyData,
             options: Options(
@@ -51,7 +51,7 @@ class UserApi {
         /// 
         Future<Response>createUsersWithArrayInput(List<User> body,{ CancelToken cancelToken, Map<String, String> headers,}) async {
 
-        String path = "/user/createWithArray";
+        String _path = "/user/createWithArray";
 
         Map<String, dynamic> queryParams = {};
         Map<String, String> headerParams = Map.from(headers ?? {});
@@ -69,7 +69,7 @@ class UserApi {
             bodyData = jsonbody;
 
             return _dio.request(
-            path,
+            _path,
             queryParameters: queryParams,
             data: bodyData,
             options: Options(
@@ -85,7 +85,7 @@ class UserApi {
         /// 
         Future<Response>createUsersWithListInput(List<User> body,{ CancelToken cancelToken, Map<String, String> headers,}) async {
 
-        String path = "/user/createWithList";
+        String _path = "/user/createWithList";
 
         Map<String, dynamic> queryParams = {};
         Map<String, String> headerParams = Map.from(headers ?? {});
@@ -103,7 +103,7 @@ class UserApi {
             bodyData = jsonbody;
 
             return _dio.request(
-            path,
+            _path,
             queryParameters: queryParams,
             data: bodyData,
             options: Options(
@@ -119,7 +119,7 @@ class UserApi {
         /// This can only be done by the logged in user.
         Future<Response>deleteUser(String username,{ CancelToken cancelToken, Map<String, String> headers,}) async {
 
-        String path = "/user/{username}".replaceAll("{" r'username' "}", username.toString());
+        String _path = "/user/{username}".replaceAll("{" r'username' "}", username.toString());
 
         Map<String, dynamic> queryParams = {};
         Map<String, String> headerParams = Map.from(headers ?? {});
@@ -133,7 +133,7 @@ class UserApi {
 
 
             return _dio.request(
-            path,
+            _path,
             queryParameters: queryParams,
             data: bodyData,
             options: Options(
@@ -149,7 +149,7 @@ class UserApi {
         /// 
         Future<Response<User>>getUserByName(String username,{ CancelToken cancelToken, Map<String, String> headers,}) async {
 
-        String path = "/user/{username}".replaceAll("{" r'username' "}", username.toString());
+        String _path = "/user/{username}".replaceAll("{" r'username' "}", username.toString());
 
         Map<String, dynamic> queryParams = {};
         Map<String, String> headerParams = Map.from(headers ?? {});
@@ -163,7 +163,7 @@ class UserApi {
 
 
             return _dio.request(
-            path,
+            _path,
             queryParameters: queryParams,
             data: bodyData,
             options: Options(
@@ -193,7 +193,7 @@ class UserApi {
         /// 
         Future<Response<String>>loginUser(String username,String password,{ CancelToken cancelToken, Map<String, String> headers,}) async {
 
-        String path = "/user/login";
+        String _path = "/user/login";
 
         Map<String, dynamic> queryParams = {};
         Map<String, String> headerParams = Map.from(headers ?? {});
@@ -209,7 +209,7 @@ class UserApi {
 
 
             return _dio.request(
-            path,
+            _path,
             queryParameters: queryParams,
             data: bodyData,
             options: Options(
@@ -239,7 +239,7 @@ class UserApi {
         /// 
         Future<Response>logoutUser({ CancelToken cancelToken, Map<String, String> headers,}) async {
 
-        String path = "/user/logout";
+        String _path = "/user/logout";
 
         Map<String, dynamic> queryParams = {};
         Map<String, String> headerParams = Map.from(headers ?? {});
@@ -253,7 +253,7 @@ class UserApi {
 
 
             return _dio.request(
-            path,
+            _path,
             queryParameters: queryParams,
             data: bodyData,
             options: Options(
@@ -269,7 +269,7 @@ class UserApi {
         /// This can only be done by the logged in user.
         Future<Response>updateUser(String username,User body,{ CancelToken cancelToken, Map<String, String> headers,}) async {
 
-        String path = "/user/{username}".replaceAll("{" r'username' "}", username.toString());
+        String _path = "/user/{username}".replaceAll("{" r'username' "}", username.toString());
 
         Map<String, dynamic> queryParams = {};
         Map<String, String> headerParams = Map.from(headers ?? {});
@@ -286,7 +286,7 @@ class UserApi {
             bodyData = jsonbody;
 
             return _dio.request(
-            path,
+            _path,
             queryParameters: queryParams,
             data: bodyData,
             options: Options(

--- a/samples/client/petstore/dart-dio/lib/model/api_response.dart
+++ b/samples/client/petstore/dart-dio/lib/model/api_response.dart
@@ -7,15 +7,15 @@ abstract class ApiResponse implements Built<ApiResponse, ApiResponseBuilder> {
 
     
         @nullable
-    @BuiltValueField(wireName: 'code')
+    @BuiltValueField(wireName: r'code')
     int get code;
     
         @nullable
-    @BuiltValueField(wireName: 'type')
+    @BuiltValueField(wireName: r'type')
     String get type;
     
         @nullable
-    @BuiltValueField(wireName: 'message')
+    @BuiltValueField(wireName: r'message')
     String get message;
 
     // Boilerplate code needed to wire-up generated code

--- a/samples/client/petstore/dart-dio/lib/model/api_response.g.dart
+++ b/samples/client/petstore/dart-dio/lib/model/api_response.g.dart
@@ -17,16 +17,25 @@ class _$ApiResponseSerializer implements StructuredSerializer<ApiResponse> {
   @override
   Iterable<Object> serialize(Serializers serializers, ApiResponse object,
       {FullType specifiedType = FullType.unspecified}) {
-    final result = <Object>[
-      'code',
-      serializers.serialize(object.code, specifiedType: const FullType(int)),
-      'type',
-      serializers.serialize(object.type, specifiedType: const FullType(String)),
-      'message',
-      serializers.serialize(object.message,
-          specifiedType: const FullType(String)),
-    ];
-
+    final result = <Object>[];
+    if (object.code != null) {
+      result
+        ..add('code')
+        ..add(serializers.serialize(object.code,
+            specifiedType: const FullType(int)));
+    }
+    if (object.type != null) {
+      result
+        ..add('type')
+        ..add(serializers.serialize(object.type,
+            specifiedType: const FullType(String)));
+    }
+    if (object.message != null) {
+      result
+        ..add('message')
+        ..add(serializers.serialize(object.message,
+            specifiedType: const FullType(String)));
+    }
     return result;
   }
 
@@ -71,17 +80,7 @@ class _$ApiResponse extends ApiResponse {
   factory _$ApiResponse([void Function(ApiResponseBuilder) updates]) =>
       (new ApiResponseBuilder()..update(updates)).build();
 
-  _$ApiResponse._({this.code, this.type, this.message}) : super._() {
-    if (code == null) {
-      throw new BuiltValueNullFieldError('ApiResponse', 'code');
-    }
-    if (type == null) {
-      throw new BuiltValueNullFieldError('ApiResponse', 'type');
-    }
-    if (message == null) {
-      throw new BuiltValueNullFieldError('ApiResponse', 'message');
-    }
-  }
+  _$ApiResponse._({this.code, this.type, this.message}) : super._();
 
   @override
   ApiResponse rebuild(void Function(ApiResponseBuilder) updates) =>

--- a/samples/client/petstore/dart-dio/lib/model/category.dart
+++ b/samples/client/petstore/dart-dio/lib/model/category.dart
@@ -7,11 +7,11 @@ abstract class Category implements Built<Category, CategoryBuilder> {
 
     
         @nullable
-    @BuiltValueField(wireName: 'id')
+    @BuiltValueField(wireName: r'id')
     int get id;
     
         @nullable
-    @BuiltValueField(wireName: 'name')
+    @BuiltValueField(wireName: r'name')
     String get name;
 
     // Boilerplate code needed to wire-up generated code

--- a/samples/client/petstore/dart-dio/lib/model/category.g.dart
+++ b/samples/client/petstore/dart-dio/lib/model/category.g.dart
@@ -17,13 +17,19 @@ class _$CategorySerializer implements StructuredSerializer<Category> {
   @override
   Iterable<Object> serialize(Serializers serializers, Category object,
       {FullType specifiedType = FullType.unspecified}) {
-    final result = <Object>[
-      'id',
-      serializers.serialize(object.id, specifiedType: const FullType(int)),
-      'name',
-      serializers.serialize(object.name, specifiedType: const FullType(String)),
-    ];
-
+    final result = <Object>[];
+    if (object.id != null) {
+      result
+        ..add('id')
+        ..add(serializers.serialize(object.id,
+            specifiedType: const FullType(int)));
+    }
+    if (object.name != null) {
+      result
+        ..add('name')
+        ..add(serializers.serialize(object.name,
+            specifiedType: const FullType(String)));
+    }
     return result;
   }
 
@@ -62,14 +68,7 @@ class _$Category extends Category {
   factory _$Category([void Function(CategoryBuilder) updates]) =>
       (new CategoryBuilder()..update(updates)).build();
 
-  _$Category._({this.id, this.name}) : super._() {
-    if (id == null) {
-      throw new BuiltValueNullFieldError('Category', 'id');
-    }
-    if (name == null) {
-      throw new BuiltValueNullFieldError('Category', 'name');
-    }
-  }
+  _$Category._({this.id, this.name}) : super._();
 
   @override
   Category rebuild(void Function(CategoryBuilder) updates) =>

--- a/samples/client/petstore/dart-dio/lib/model/order.dart
+++ b/samples/client/petstore/dart-dio/lib/model/order.dart
@@ -7,28 +7,28 @@ abstract class Order implements Built<Order, OrderBuilder> {
 
     
         @nullable
-    @BuiltValueField(wireName: 'id')
+    @BuiltValueField(wireName: r'id')
     int get id;
     
         @nullable
-    @BuiltValueField(wireName: 'petId')
+    @BuiltValueField(wireName: r'petId')
     int get petId;
     
         @nullable
-    @BuiltValueField(wireName: 'quantity')
+    @BuiltValueField(wireName: r'quantity')
     int get quantity;
     
         @nullable
-    @BuiltValueField(wireName: 'shipDate')
+    @BuiltValueField(wireName: r'shipDate')
     DateTime get shipDate;
     /* Order Status */
         @nullable
-    @BuiltValueField(wireName: 'status')
+    @BuiltValueField(wireName: r'status')
     String get status;
         //enum statusEnum {  placed,  approved,  delivered,  };
     
         @nullable
-    @BuiltValueField(wireName: 'complete')
+    @BuiltValueField(wireName: r'complete')
     bool get complete;
 
     // Boilerplate code needed to wire-up generated code

--- a/samples/client/petstore/dart-dio/lib/model/order.g.dart
+++ b/samples/client/petstore/dart-dio/lib/model/order.g.dart
@@ -17,25 +17,43 @@ class _$OrderSerializer implements StructuredSerializer<Order> {
   @override
   Iterable<Object> serialize(Serializers serializers, Order object,
       {FullType specifiedType = FullType.unspecified}) {
-    final result = <Object>[
-      'id',
-      serializers.serialize(object.id, specifiedType: const FullType(int)),
-      'petId',
-      serializers.serialize(object.petId, specifiedType: const FullType(int)),
-      'quantity',
-      serializers.serialize(object.quantity,
-          specifiedType: const FullType(int)),
-      'shipDate',
-      serializers.serialize(object.shipDate,
-          specifiedType: const FullType(DateTime)),
-      'status',
-      serializers.serialize(object.status,
-          specifiedType: const FullType(String)),
-      'complete',
-      serializers.serialize(object.complete,
-          specifiedType: const FullType(bool)),
-    ];
-
+    final result = <Object>[];
+    if (object.id != null) {
+      result
+        ..add('id')
+        ..add(serializers.serialize(object.id,
+            specifiedType: const FullType(int)));
+    }
+    if (object.petId != null) {
+      result
+        ..add('petId')
+        ..add(serializers.serialize(object.petId,
+            specifiedType: const FullType(int)));
+    }
+    if (object.quantity != null) {
+      result
+        ..add('quantity')
+        ..add(serializers.serialize(object.quantity,
+            specifiedType: const FullType(int)));
+    }
+    if (object.shipDate != null) {
+      result
+        ..add('shipDate')
+        ..add(serializers.serialize(object.shipDate,
+            specifiedType: const FullType(DateTime)));
+    }
+    if (object.status != null) {
+      result
+        ..add('status')
+        ..add(serializers.serialize(object.status,
+            specifiedType: const FullType(String)));
+    }
+    if (object.complete != null) {
+      result
+        ..add('complete')
+        ..add(serializers.serialize(object.complete,
+            specifiedType: const FullType(bool)));
+    }
     return result;
   }
 
@@ -105,26 +123,7 @@ class _$Order extends Order {
       this.shipDate,
       this.status,
       this.complete})
-      : super._() {
-    if (id == null) {
-      throw new BuiltValueNullFieldError('Order', 'id');
-    }
-    if (petId == null) {
-      throw new BuiltValueNullFieldError('Order', 'petId');
-    }
-    if (quantity == null) {
-      throw new BuiltValueNullFieldError('Order', 'quantity');
-    }
-    if (shipDate == null) {
-      throw new BuiltValueNullFieldError('Order', 'shipDate');
-    }
-    if (status == null) {
-      throw new BuiltValueNullFieldError('Order', 'status');
-    }
-    if (complete == null) {
-      throw new BuiltValueNullFieldError('Order', 'complete');
-    }
-  }
+      : super._();
 
   @override
   Order rebuild(void Function(OrderBuilder) updates) =>

--- a/samples/client/petstore/dart-dio/lib/model/pet.dart
+++ b/samples/client/petstore/dart-dio/lib/model/pet.dart
@@ -10,27 +10,27 @@ abstract class Pet implements Built<Pet, PetBuilder> {
 
     
         @nullable
-    @BuiltValueField(wireName: 'id')
+    @BuiltValueField(wireName: r'id')
     int get id;
     
         @nullable
-    @BuiltValueField(wireName: 'category')
+    @BuiltValueField(wireName: r'category')
     Category get category;
     
         @nullable
-    @BuiltValueField(wireName: 'name')
+    @BuiltValueField(wireName: r'name')
     String get name;
     
         @nullable
-    @BuiltValueField(wireName: 'photoUrls')
+    @BuiltValueField(wireName: r'photoUrls')
     BuiltList<String> get photoUrls;
     
         @nullable
-    @BuiltValueField(wireName: 'tags')
+    @BuiltValueField(wireName: r'tags')
     BuiltList<Tag> get tags;
     /* pet status in the store */
         @nullable
-    @BuiltValueField(wireName: 'status')
+    @BuiltValueField(wireName: r'status')
     String get status;
         //enum statusEnum {  available,  pending,  sold,  };
 

--- a/samples/client/petstore/dart-dio/lib/model/pet.g.dart
+++ b/samples/client/petstore/dart-dio/lib/model/pet.g.dart
@@ -17,25 +17,45 @@ class _$PetSerializer implements StructuredSerializer<Pet> {
   @override
   Iterable<Object> serialize(Serializers serializers, Pet object,
       {FullType specifiedType = FullType.unspecified}) {
-    final result = <Object>[
-      'id',
-      serializers.serialize(object.id, specifiedType: const FullType(int)),
-      'category',
-      serializers.serialize(object.category,
-          specifiedType: const FullType(Category)),
-      'name',
-      serializers.serialize(object.name, specifiedType: const FullType(String)),
-      'photoUrls',
-      serializers.serialize(object.photoUrls,
-          specifiedType: const FullType(List, const [const FullType(String)])),
-      'tags',
-      serializers.serialize(object.tags,
-          specifiedType: const FullType(List, const [const FullType(Tag)])),
-      'status',
-      serializers.serialize(object.status,
-          specifiedType: const FullType(String)),
-    ];
-
+    final result = <Object>[];
+    if (object.id != null) {
+      result
+        ..add('id')
+        ..add(serializers.serialize(object.id,
+            specifiedType: const FullType(int)));
+    }
+    if (object.category != null) {
+      result
+        ..add('category')
+        ..add(serializers.serialize(object.category,
+            specifiedType: const FullType(Category)));
+    }
+    if (object.name != null) {
+      result
+        ..add('name')
+        ..add(serializers.serialize(object.name,
+            specifiedType: const FullType(String)));
+    }
+    if (object.photoUrls != null) {
+      result
+        ..add('photoUrls')
+        ..add(serializers.serialize(object.photoUrls,
+            specifiedType:
+                const FullType(BuiltList, const [const FullType(String)])));
+    }
+    if (object.tags != null) {
+      result
+        ..add('tags')
+        ..add(serializers.serialize(object.tags,
+            specifiedType:
+                const FullType(BuiltList, const [const FullType(Tag)])));
+    }
+    if (object.status != null) {
+      result
+        ..add('status')
+        ..add(serializers.serialize(object.status,
+            specifiedType: const FullType(String)));
+    }
     return result;
   }
 
@@ -63,16 +83,16 @@ class _$PetSerializer implements StructuredSerializer<Pet> {
               specifiedType: const FullType(String)) as String;
           break;
         case 'photoUrls':
-          result.photoUrls = serializers.deserialize(value,
+          result.photoUrls.replace(serializers.deserialize(value,
                   specifiedType:
-                      const FullType(List, const [const FullType(String)]))
-              as List<String>;
+                      const FullType(BuiltList, const [const FullType(String)]))
+              as BuiltList<dynamic>);
           break;
         case 'tags':
-          result.tags = serializers.deserialize(value,
+          result.tags.replace(serializers.deserialize(value,
                   specifiedType:
-                      const FullType(List, const [const FullType(Tag)]))
-              as List<Tag>;
+                      const FullType(BuiltList, const [const FullType(Tag)]))
+              as BuiltList<dynamic>);
           break;
         case 'status':
           result.status = serializers.deserialize(value,
@@ -93,9 +113,9 @@ class _$Pet extends Pet {
   @override
   final String name;
   @override
-  final List<String> photoUrls;
+  final BuiltList<String> photoUrls;
   @override
-  final List<Tag> tags;
+  final BuiltList<Tag> tags;
   @override
   final String status;
 
@@ -109,26 +129,7 @@ class _$Pet extends Pet {
       this.photoUrls,
       this.tags,
       this.status})
-      : super._() {
-    if (id == null) {
-      throw new BuiltValueNullFieldError('Pet', 'id');
-    }
-    if (category == null) {
-      throw new BuiltValueNullFieldError('Pet', 'category');
-    }
-    if (name == null) {
-      throw new BuiltValueNullFieldError('Pet', 'name');
-    }
-    if (photoUrls == null) {
-      throw new BuiltValueNullFieldError('Pet', 'photoUrls');
-    }
-    if (tags == null) {
-      throw new BuiltValueNullFieldError('Pet', 'tags');
-    }
-    if (status == null) {
-      throw new BuiltValueNullFieldError('Pet', 'status');
-    }
-  }
+      : super._();
 
   @override
   Pet rebuild(void Function(PetBuilder) updates) =>
@@ -187,13 +188,14 @@ class PetBuilder implements Builder<Pet, PetBuilder> {
   String get name => _$this._name;
   set name(String name) => _$this._name = name;
 
-  List<String> _photoUrls;
-  List<String> get photoUrls => _$this._photoUrls;
-  set photoUrls(List<String> photoUrls) => _$this._photoUrls = photoUrls;
+  ListBuilder<String> _photoUrls;
+  ListBuilder<String> get photoUrls =>
+      _$this._photoUrls ??= new ListBuilder<String>();
+  set photoUrls(ListBuilder<String> photoUrls) => _$this._photoUrls = photoUrls;
 
-  List<Tag> _tags;
-  List<Tag> get tags => _$this._tags;
-  set tags(List<Tag> tags) => _$this._tags = tags;
+  ListBuilder<Tag> _tags;
+  ListBuilder<Tag> get tags => _$this._tags ??= new ListBuilder<Tag>();
+  set tags(ListBuilder<Tag> tags) => _$this._tags = tags;
 
   String _status;
   String get status => _$this._status;
@@ -206,8 +208,8 @@ class PetBuilder implements Builder<Pet, PetBuilder> {
       _id = _$v.id;
       _category = _$v.category?.toBuilder();
       _name = _$v.name;
-      _photoUrls = _$v.photoUrls;
-      _tags = _$v.tags;
+      _photoUrls = _$v.photoUrls?.toBuilder();
+      _tags = _$v.tags?.toBuilder();
       _status = _$v.status;
       _$v = null;
     }
@@ -234,16 +236,21 @@ class PetBuilder implements Builder<Pet, PetBuilder> {
       _$result = _$v ??
           new _$Pet._(
               id: id,
-              category: category.build(),
+              category: _category?.build(),
               name: name,
-              photoUrls: photoUrls,
-              tags: tags,
+              photoUrls: _photoUrls?.build(),
+              tags: _tags?.build(),
               status: status);
     } catch (_) {
       String _$failedField;
       try {
         _$failedField = 'category';
-        category.build();
+        _category?.build();
+
+        _$failedField = 'photoUrls';
+        _photoUrls?.build();
+        _$failedField = 'tags';
+        _tags?.build();
       } catch (e) {
         throw new BuiltValueNestedFieldError(
             'Pet', _$failedField, e.toString());

--- a/samples/client/petstore/dart-dio/lib/model/tag.dart
+++ b/samples/client/petstore/dart-dio/lib/model/tag.dart
@@ -7,11 +7,11 @@ abstract class Tag implements Built<Tag, TagBuilder> {
 
     
         @nullable
-    @BuiltValueField(wireName: 'id')
+    @BuiltValueField(wireName: r'id')
     int get id;
     
         @nullable
-    @BuiltValueField(wireName: 'name')
+    @BuiltValueField(wireName: r'name')
     String get name;
 
     // Boilerplate code needed to wire-up generated code

--- a/samples/client/petstore/dart-dio/lib/model/tag.g.dart
+++ b/samples/client/petstore/dart-dio/lib/model/tag.g.dart
@@ -17,13 +17,19 @@ class _$TagSerializer implements StructuredSerializer<Tag> {
   @override
   Iterable<Object> serialize(Serializers serializers, Tag object,
       {FullType specifiedType = FullType.unspecified}) {
-    final result = <Object>[
-      'id',
-      serializers.serialize(object.id, specifiedType: const FullType(int)),
-      'name',
-      serializers.serialize(object.name, specifiedType: const FullType(String)),
-    ];
-
+    final result = <Object>[];
+    if (object.id != null) {
+      result
+        ..add('id')
+        ..add(serializers.serialize(object.id,
+            specifiedType: const FullType(int)));
+    }
+    if (object.name != null) {
+      result
+        ..add('name')
+        ..add(serializers.serialize(object.name,
+            specifiedType: const FullType(String)));
+    }
     return result;
   }
 
@@ -62,14 +68,7 @@ class _$Tag extends Tag {
   factory _$Tag([void Function(TagBuilder) updates]) =>
       (new TagBuilder()..update(updates)).build();
 
-  _$Tag._({this.id, this.name}) : super._() {
-    if (id == null) {
-      throw new BuiltValueNullFieldError('Tag', 'id');
-    }
-    if (name == null) {
-      throw new BuiltValueNullFieldError('Tag', 'name');
-    }
-  }
+  _$Tag._({this.id, this.name}) : super._();
 
   @override
   Tag rebuild(void Function(TagBuilder) updates) =>

--- a/samples/client/petstore/dart-dio/lib/model/user.dart
+++ b/samples/client/petstore/dart-dio/lib/model/user.dart
@@ -7,35 +7,35 @@ abstract class User implements Built<User, UserBuilder> {
 
     
         @nullable
-    @BuiltValueField(wireName: 'id')
+    @BuiltValueField(wireName: r'id')
     int get id;
     
         @nullable
-    @BuiltValueField(wireName: 'username')
+    @BuiltValueField(wireName: r'username')
     String get username;
     
         @nullable
-    @BuiltValueField(wireName: 'firstName')
+    @BuiltValueField(wireName: r'firstName')
     String get firstName;
     
         @nullable
-    @BuiltValueField(wireName: 'lastName')
+    @BuiltValueField(wireName: r'lastName')
     String get lastName;
     
         @nullable
-    @BuiltValueField(wireName: 'email')
+    @BuiltValueField(wireName: r'email')
     String get email;
     
         @nullable
-    @BuiltValueField(wireName: 'password')
+    @BuiltValueField(wireName: r'password')
     String get password;
     
         @nullable
-    @BuiltValueField(wireName: 'phone')
+    @BuiltValueField(wireName: r'phone')
     String get phone;
     /* User Status */
         @nullable
-    @BuiltValueField(wireName: 'userStatus')
+    @BuiltValueField(wireName: r'userStatus')
     int get userStatus;
 
     // Boilerplate code needed to wire-up generated code

--- a/samples/client/petstore/dart-dio/lib/model/user.g.dart
+++ b/samples/client/petstore/dart-dio/lib/model/user.g.dart
@@ -17,32 +17,55 @@ class _$UserSerializer implements StructuredSerializer<User> {
   @override
   Iterable<Object> serialize(Serializers serializers, User object,
       {FullType specifiedType = FullType.unspecified}) {
-    final result = <Object>[
-      'id',
-      serializers.serialize(object.id, specifiedType: const FullType(int)),
-      'username',
-      serializers.serialize(object.username,
-          specifiedType: const FullType(String)),
-      'firstName',
-      serializers.serialize(object.firstName,
-          specifiedType: const FullType(String)),
-      'lastName',
-      serializers.serialize(object.lastName,
-          specifiedType: const FullType(String)),
-      'email',
-      serializers.serialize(object.email,
-          specifiedType: const FullType(String)),
-      'password',
-      serializers.serialize(object.password,
-          specifiedType: const FullType(String)),
-      'phone',
-      serializers.serialize(object.phone,
-          specifiedType: const FullType(String)),
-      'userStatus',
-      serializers.serialize(object.userStatus,
-          specifiedType: const FullType(int)),
-    ];
-
+    final result = <Object>[];
+    if (object.id != null) {
+      result
+        ..add('id')
+        ..add(serializers.serialize(object.id,
+            specifiedType: const FullType(int)));
+    }
+    if (object.username != null) {
+      result
+        ..add('username')
+        ..add(serializers.serialize(object.username,
+            specifiedType: const FullType(String)));
+    }
+    if (object.firstName != null) {
+      result
+        ..add('firstName')
+        ..add(serializers.serialize(object.firstName,
+            specifiedType: const FullType(String)));
+    }
+    if (object.lastName != null) {
+      result
+        ..add('lastName')
+        ..add(serializers.serialize(object.lastName,
+            specifiedType: const FullType(String)));
+    }
+    if (object.email != null) {
+      result
+        ..add('email')
+        ..add(serializers.serialize(object.email,
+            specifiedType: const FullType(String)));
+    }
+    if (object.password != null) {
+      result
+        ..add('password')
+        ..add(serializers.serialize(object.password,
+            specifiedType: const FullType(String)));
+    }
+    if (object.phone != null) {
+      result
+        ..add('phone')
+        ..add(serializers.serialize(object.phone,
+            specifiedType: const FullType(String)));
+    }
+    if (object.userStatus != null) {
+      result
+        ..add('userStatus')
+        ..add(serializers.serialize(object.userStatus,
+            specifiedType: const FullType(int)));
+    }
     return result;
   }
 
@@ -126,32 +149,7 @@ class _$User extends User {
       this.password,
       this.phone,
       this.userStatus})
-      : super._() {
-    if (id == null) {
-      throw new BuiltValueNullFieldError('User', 'id');
-    }
-    if (username == null) {
-      throw new BuiltValueNullFieldError('User', 'username');
-    }
-    if (firstName == null) {
-      throw new BuiltValueNullFieldError('User', 'firstName');
-    }
-    if (lastName == null) {
-      throw new BuiltValueNullFieldError('User', 'lastName');
-    }
-    if (email == null) {
-      throw new BuiltValueNullFieldError('User', 'email');
-    }
-    if (password == null) {
-      throw new BuiltValueNullFieldError('User', 'password');
-    }
-    if (phone == null) {
-      throw new BuiltValueNullFieldError('User', 'phone');
-    }
-    if (userStatus == null) {
-      throw new BuiltValueNullFieldError('User', 'userStatus');
-    }
-  }
+      : super._();
 
   @override
   User rebuild(void Function(UserBuilder) updates) =>

--- a/samples/client/petstore/dart-dio/lib/serializers.g.dart
+++ b/samples/client/petstore/dart-dio/lib/serializers.g.dart
@@ -12,7 +12,13 @@ Serializers _$serializers = (new Serializers().toBuilder()
       ..add(Order.serializer)
       ..add(Pet.serializer)
       ..add(Tag.serializer)
-      ..add(User.serializer))
+      ..add(User.serializer)
+      ..addBuilderFactory(
+          const FullType(BuiltList, const [const FullType(String)]),
+          () => new ListBuilder<String>())
+      ..addBuilderFactory(
+          const FullType(BuiltList, const [const FullType(Tag)]),
+          () => new ListBuilder<Tag>()))
     .build();
 
 // ignore_for_file: always_put_control_body_on_new_line,always_specify_types,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,lines_longer_than_80_chars,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new


### PR DESCRIPTION
This PR includes a few different fixes:

- Add missing import, serializer for `dateLibrary=timemachine`
- Remove bad import `package:http/io_client.dart`
- Use raw strings for those that contain variable name. This should eliminate potential issue with variables like `$ref`.
- Use `_path` instead of `path` to avoid potential conflict with op params.

These fixes are required when I try to generate for Kubernetes API ([example json here](https://gist.github.com/daohoangson/6431f46beb4c2d0d163f3a4791f518e8)).

Please note that this PR needs another PR to work properly (https://github.com/google/built_value.dart/pull/804).

CC @ircecho @swipesight @jaumard @nickmeinhold @athornz @amondnet

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
