### PR TITLE
[Java][Jersey] Better code format the auto-generated doc

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/api_doc.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/api_doc.mustache
@@ -14,8 +14,12 @@ Method | HTTP request | Description
 
 ## {{operationId}}
 
-{{^vendorExtensions.x-group-parameters}}> {{#returnType}}{{returnType}} {{/returnType}}{{operationId}}({{#allParams}}{{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}}){{/vendorExtensions.x-group-parameters}}
-{{#vendorExtensions.x-group-parameters}}> {{#returnType}}{{returnType}} {{/returnType}}{{operationId}}({{#pathParams}}{{paramName}}{{#hasMore}}, {{/hasMore}}{{/pathParams}}){{#allParams}}{{^isPathParam}}.{{paramName}}({{paramName}}){{/isPathParam}}{{/allParams}}.execute();{{/vendorExtensions.x-group-parameters}}
+{{^vendorExtensions.x-group-parameters}}
+> {{#returnType}}{{returnType}} {{/returnType}}{{operationId}}({{#allParams}}{{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}})
+{{/vendorExtensions.x-group-parameters}}
+{{#vendorExtensions.x-group-parameters}}
+> {{#returnType}}{{returnType}} {{/returnType}}{{operationId}}({{#pathParams}}{{paramName}}{{#hasMore}}, {{/hasMore}}{{/pathParams}}){{#allParams}}{{^isPathParam}}.{{paramName}}({{paramName}}){{/isPathParam}}{{/allParams}}.execute();
+{{/vendorExtensions.x-group-parameters}}
 
 {{summary}}{{#notes}}
 
@@ -60,12 +64,18 @@ public class Example {
         {{#allParams}}
         {{{dataType}}} {{{paramName}}} = {{{example}}}; // {{{dataType}}} | {{{description}}}
         {{/allParams}}
-        try { {{^vendorExtensions.x-group-parameters}}
-            {{#returnType}}{{{returnType}}} result = {{/returnType}}apiInstance.{{{operationId}}}({{#allParams}}{{{paramName}}}{{#hasMore}}, {{/hasMore}}{{/allParams}});{{/vendorExtensions.x-group-parameters}}
-            {{#vendorExtensions.x-group-parameters}}{{#returnType}}{{{returnType}}} result = {{/returnType}}api.{{operationId}}({{#pathParams}}{{paramName}}{{#hasMore}}, {{/hasMore}}{{/pathParams}}){{#allParams}}{{^isPathParam}}
+        try {
+            {{^vendorExtensions.x-group-parameters}}
+            {{#returnType}}{{{returnType}}} result = {{/returnType}}apiInstance.{{{operationId}}}({{#allParams}}{{{paramName}}}{{#hasMore}}, {{/hasMore}}{{/allParams}});
+            {{/vendorExtensions.x-group-parameters}}
+            {{#vendorExtensions.x-group-parameters}}
+            {{#returnType}}{{{returnType}}} result = {{/returnType}}api.{{operationId}}({{#pathParams}}{{paramName}}{{#hasMore}}, {{/hasMore}}{{/pathParams}}){{#allParams}}{{^isPathParam}}
                 .{{paramName}}({{paramName}}){{/isPathParam}}{{/allParams}}
-                .execute();{{/vendorExtensions.x-group-parameters}}
-            {{#returnType}}System.out.println(result);{{/returnType}}
+                .execute();
+            {{/vendorExtensions.x-group-parameters}}
+            {{#returnType}}
+            System.out.println(result);
+            {{/returnType}}
         } catch (ApiException e) {
             System.err.println("Exception when calling {{{classname}}}#{{{operationId}}}");
             System.err.println("Status code: " + e.getCode());

--- a/samples/client/petstore/java/jersey2-java6/docs/AnotherFakeApi.md
+++ b/samples/client/petstore/java/jersey2-java6/docs/AnotherFakeApi.md
@@ -12,7 +12,6 @@ Method | HTTP request | Description
 
 > Client call123testSpecialTags(body)
 
-
 To test special tags
 
 To test special tags and operation ID starting with number
@@ -34,9 +33,8 @@ public class Example {
 
         AnotherFakeApi apiInstance = new AnotherFakeApi(defaultClient);
         Client body = new Client(); // Client | client model
-        try { 
+        try {
             Client result = apiInstance.call123testSpecialTags(body);
-            
             System.out.println(result);
         } catch (ApiException e) {
             System.err.println("Exception when calling AnotherFakeApi#call123testSpecialTags");

--- a/samples/client/petstore/java/jersey2-java6/docs/FakeApi.md
+++ b/samples/client/petstore/java/jersey2-java6/docs/FakeApi.md
@@ -25,7 +25,6 @@ Method | HTTP request | Description
 
 > createXmlItem(xmlItem)
 
-
 creates an XmlItem
 
 this route creates an XmlItem
@@ -47,10 +46,8 @@ public class Example {
 
         FakeApi apiInstance = new FakeApi(defaultClient);
         XmlItem xmlItem = new XmlItem(); // XmlItem | XmlItem Body
-        try { 
+        try {
             apiInstance.createXmlItem(xmlItem);
-            
-            
         } catch (ApiException e) {
             System.err.println("Exception when calling FakeApi#createXmlItem");
             System.err.println("Status code: " + e.getCode());
@@ -94,7 +91,6 @@ No authorization required
 
 
 
-
 Test serialization of outer boolean types
 
 ### Example
@@ -114,9 +110,8 @@ public class Example {
 
         FakeApi apiInstance = new FakeApi(defaultClient);
         Boolean body = true; // Boolean | Input boolean as post body
-        try { 
+        try {
             Boolean result = apiInstance.fakeOuterBooleanSerialize(body);
-            
             System.out.println(result);
         } catch (ApiException e) {
             System.err.println("Exception when calling FakeApi#fakeOuterBooleanSerialize");
@@ -161,7 +156,6 @@ No authorization required
 
 
 
-
 Test serialization of object with outer number type
 
 ### Example
@@ -181,9 +175,8 @@ public class Example {
 
         FakeApi apiInstance = new FakeApi(defaultClient);
         OuterComposite body = new OuterComposite(); // OuterComposite | Input composite as post body
-        try { 
+        try {
             OuterComposite result = apiInstance.fakeOuterCompositeSerialize(body);
-            
             System.out.println(result);
         } catch (ApiException e) {
             System.err.println("Exception when calling FakeApi#fakeOuterCompositeSerialize");
@@ -228,7 +221,6 @@ No authorization required
 
 
 
-
 Test serialization of outer number types
 
 ### Example
@@ -248,9 +240,8 @@ public class Example {
 
         FakeApi apiInstance = new FakeApi(defaultClient);
         BigDecimal body = new BigDecimal(); // BigDecimal | Input number as post body
-        try { 
+        try {
             BigDecimal result = apiInstance.fakeOuterNumberSerialize(body);
-            
             System.out.println(result);
         } catch (ApiException e) {
             System.err.println("Exception when calling FakeApi#fakeOuterNumberSerialize");
@@ -295,7 +286,6 @@ No authorization required
 
 
 
-
 Test serialization of outer string types
 
 ### Example
@@ -315,9 +305,8 @@ public class Example {
 
         FakeApi apiInstance = new FakeApi(defaultClient);
         String body = "body_example"; // String | Input string as post body
-        try { 
+        try {
             String result = apiInstance.fakeOuterStringSerialize(body);
-            
             System.out.println(result);
         } catch (ApiException e) {
             System.err.println("Exception when calling FakeApi#fakeOuterStringSerialize");
@@ -362,7 +351,6 @@ No authorization required
 
 
 
-
 For this test, the body for this request much reference a schema named `File`.
 
 ### Example
@@ -382,10 +370,8 @@ public class Example {
 
         FakeApi apiInstance = new FakeApi(defaultClient);
         FileSchemaTestClass body = new FileSchemaTestClass(); // FileSchemaTestClass | 
-        try { 
+        try {
             apiInstance.testBodyWithFileSchema(body);
-            
-            
         } catch (ApiException e) {
             System.err.println("Exception when calling FakeApi#testBodyWithFileSchema");
             System.err.println("Status code: " + e.getCode());
@@ -429,7 +415,6 @@ No authorization required
 
 
 
-
 ### Example
 
 ```java
@@ -448,10 +433,8 @@ public class Example {
         FakeApi apiInstance = new FakeApi(defaultClient);
         String query = "query_example"; // String | 
         User body = new User(); // User | 
-        try { 
+        try {
             apiInstance.testBodyWithQueryParams(query, body);
-            
-            
         } catch (ApiException e) {
             System.err.println("Exception when calling FakeApi#testBodyWithQueryParams");
             System.err.println("Status code: " + e.getCode());
@@ -494,7 +477,6 @@ No authorization required
 
 > Client testClientModel(body)
 
-
 To test \&quot;client\&quot; model
 
 To test "client" model
@@ -516,9 +498,8 @@ public class Example {
 
         FakeApi apiInstance = new FakeApi(defaultClient);
         Client body = new Client(); // Client | client model
-        try { 
+        try {
             Client result = apiInstance.testClientModel(body);
-            
             System.out.println(result);
         } catch (ApiException e) {
             System.err.println("Exception when calling FakeApi#testClientModel");
@@ -560,7 +541,6 @@ No authorization required
 ## testEndpointParameters
 
 > testEndpointParameters(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, paramCallback)
-
 
 Fake endpoint for testing various parameters  假端點  偽のエンドポイント  가짜 엔드 포인트
 
@@ -605,10 +585,8 @@ public class Example {
         OffsetDateTime dateTime = new OffsetDateTime(); // OffsetDateTime | None
         String password = "password_example"; // String | None
         String paramCallback = "paramCallback_example"; // String | None
-        try { 
+        try {
             apiInstance.testEndpointParameters(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, paramCallback);
-            
-            
         } catch (ApiException e) {
             System.err.println("Exception when calling FakeApi#testEndpointParameters");
             System.err.println("Status code: " + e.getCode());
@@ -664,7 +642,6 @@ null (empty response body)
 
 > testEnumParameters(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString)
 
-
 To test enum parameters
 
 To test enum parameters
@@ -693,10 +670,8 @@ public class Example {
         Double enumQueryDouble = 3.4D; // Double | Query parameter enum test (double)
         List<String> enumFormStringArray = "$"; // List<String> | Form parameter enum test (string array)
         String enumFormString = "-efg"; // String | Form parameter enum test (string)
-        try { 
+        try {
             apiInstance.testEnumParameters(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString);
-            
-            
         } catch (ApiException e) {
             System.err.println("Exception when calling FakeApi#testEnumParameters");
             System.err.println("Status code: " + e.getCode());
@@ -744,7 +719,6 @@ No authorization required
 
 ## testGroupParameters
 
-
 > testGroupParameters().requiredStringGroup(requiredStringGroup).requiredBooleanGroup(requiredBooleanGroup).requiredInt64Group(requiredInt64Group).stringGroup(stringGroup).booleanGroup(booleanGroup).int64Group(int64Group).execute();
 
 Fake endpoint to test group parameters (optional)
@@ -773,7 +747,7 @@ public class Example {
         Integer stringGroup = 56; // Integer | String in group parameters
         Boolean booleanGroup = true; // Boolean | Boolean in group parameters
         Long int64Group = 56L; // Long | Integer in group parameters
-        try { 
+        try {
             api.testGroupParameters()
                 .requiredStringGroup(requiredStringGroup)
                 .requiredBooleanGroup(requiredBooleanGroup)
@@ -782,7 +756,6 @@ public class Example {
                 .booleanGroup(booleanGroup)
                 .int64Group(int64Group)
                 .execute();
-            
         } catch (ApiException e) {
             System.err.println("Exception when calling FakeApi#testGroupParameters");
             System.err.println("Status code: " + e.getCode());
@@ -829,7 +802,6 @@ No authorization required
 
 > testInlineAdditionalProperties(param)
 
-
 test inline additionalProperties
 
 ### Example
@@ -849,10 +821,8 @@ public class Example {
 
         FakeApi apiInstance = new FakeApi(defaultClient);
         Map<String, String> param = new HashMap(); // Map<String, String> | request body
-        try { 
+        try {
             apiInstance.testInlineAdditionalProperties(param);
-            
-            
         } catch (ApiException e) {
             System.err.println("Exception when calling FakeApi#testInlineAdditionalProperties");
             System.err.println("Status code: " + e.getCode());
@@ -894,7 +864,6 @@ No authorization required
 
 > testJsonFormData(param, param2)
 
-
 test json serialization of form data
 
 ### Example
@@ -915,10 +884,8 @@ public class Example {
         FakeApi apiInstance = new FakeApi(defaultClient);
         String param = "param_example"; // String | field1
         String param2 = "param2_example"; // String | field2
-        try { 
+        try {
             apiInstance.testJsonFormData(param, param2);
-            
-            
         } catch (ApiException e) {
             System.err.println("Exception when calling FakeApi#testJsonFormData");
             System.err.println("Status code: " + e.getCode());
@@ -963,7 +930,6 @@ No authorization required
 
 
 
-
 To test the collection format in query parameters
 
 ### Example
@@ -987,10 +953,8 @@ public class Example {
         List<String> http = Arrays.asList(); // List<String> | 
         List<String> url = Arrays.asList(); // List<String> | 
         List<String> context = Arrays.asList(); // List<String> | 
-        try { 
+        try {
             apiInstance.testQueryParameterCollectionFormat(pipe, ioutil, http, url, context);
-            
-            
         } catch (ApiException e) {
             System.err.println("Exception when calling FakeApi#testQueryParameterCollectionFormat");
             System.err.println("Status code: " + e.getCode());

--- a/samples/client/petstore/java/jersey2-java6/docs/FakeClassnameTags123Api.md
+++ b/samples/client/petstore/java/jersey2-java6/docs/FakeClassnameTags123Api.md
@@ -12,7 +12,6 @@ Method | HTTP request | Description
 
 > Client testClassname(body)
 
-
 To test class name in snake case
 
 To test class name in snake case
@@ -41,9 +40,8 @@ public class Example {
 
         FakeClassnameTags123Api apiInstance = new FakeClassnameTags123Api(defaultClient);
         Client body = new Client(); // Client | client model
-        try { 
+        try {
             Client result = apiInstance.testClassname(body);
-            
             System.out.println(result);
         } catch (ApiException e) {
             System.err.println("Exception when calling FakeClassnameTags123Api#testClassname");

--- a/samples/client/petstore/java/jersey2-java6/docs/PetApi.md
+++ b/samples/client/petstore/java/jersey2-java6/docs/PetApi.md
@@ -20,7 +20,6 @@ Method | HTTP request | Description
 
 > addPet(body)
 
-
 Add a new pet to the store
 
 ### Example
@@ -45,10 +44,8 @@ public class Example {
 
         PetApi apiInstance = new PetApi(defaultClient);
         Pet body = new Pet(); // Pet | Pet object that needs to be added to the store
-        try { 
+        try {
             apiInstance.addPet(body);
-            
-            
         } catch (ApiException e) {
             System.err.println("Exception when calling PetApi#addPet");
             System.err.println("Status code: " + e.getCode());
@@ -91,7 +88,6 @@ null (empty response body)
 
 > deletePet(petId, apiKey)
 
-
 Deletes a pet
 
 ### Example
@@ -117,10 +113,8 @@ public class Example {
         PetApi apiInstance = new PetApi(defaultClient);
         Long petId = 56L; // Long | Pet id to delete
         String apiKey = "apiKey_example"; // String | 
-        try { 
+        try {
             apiInstance.deletePet(petId, apiKey);
-            
-            
         } catch (ApiException e) {
             System.err.println("Exception when calling PetApi#deletePet");
             System.err.println("Status code: " + e.getCode());
@@ -164,7 +158,6 @@ null (empty response body)
 
 > List&lt;Pet&gt; findPetsByStatus(status)
 
-
 Finds Pets by status
 
 Multiple status values can be provided with comma separated strings
@@ -191,9 +184,8 @@ public class Example {
 
         PetApi apiInstance = new PetApi(defaultClient);
         List<String> status = Arrays.asList("available"); // List<String> | Status values that need to be considered for filter
-        try { 
+        try {
             List<Pet> result = apiInstance.findPetsByStatus(status);
-            
             System.out.println(result);
         } catch (ApiException e) {
             System.err.println("Exception when calling PetApi#findPetsByStatus");
@@ -237,7 +229,6 @@ Name | Type | Description  | Notes
 
 > List&lt;Pet&gt; findPetsByTags(tags)
 
-
 Finds Pets by tags
 
 Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
@@ -264,9 +255,8 @@ public class Example {
 
         PetApi apiInstance = new PetApi(defaultClient);
         List<String> tags = Arrays.asList(); // List<String> | Tags to filter by
-        try { 
+        try {
             List<Pet> result = apiInstance.findPetsByTags(tags);
-            
             System.out.println(result);
         } catch (ApiException e) {
             System.err.println("Exception when calling PetApi#findPetsByTags");
@@ -310,7 +300,6 @@ Name | Type | Description  | Notes
 
 > Pet getPetById(petId)
 
-
 Find pet by ID
 
 Returns a single pet
@@ -339,9 +328,8 @@ public class Example {
 
         PetApi apiInstance = new PetApi(defaultClient);
         Long petId = 56L; // Long | ID of pet to return
-        try { 
+        try {
             Pet result = apiInstance.getPetById(petId);
-            
             System.out.println(result);
         } catch (ApiException e) {
             System.err.println("Exception when calling PetApi#getPetById");
@@ -386,7 +374,6 @@ Name | Type | Description  | Notes
 
 > updatePet(body)
 
-
 Update an existing pet
 
 ### Example
@@ -411,10 +398,8 @@ public class Example {
 
         PetApi apiInstance = new PetApi(defaultClient);
         Pet body = new Pet(); // Pet | Pet object that needs to be added to the store
-        try { 
+        try {
             apiInstance.updatePet(body);
-            
-            
         } catch (ApiException e) {
             System.err.println("Exception when calling PetApi#updatePet");
             System.err.println("Status code: " + e.getCode());
@@ -459,7 +444,6 @@ null (empty response body)
 
 > updatePetWithForm(petId, name, status)
 
-
 Updates a pet in the store with form data
 
 ### Example
@@ -486,10 +470,8 @@ public class Example {
         Long petId = 56L; // Long | ID of pet that needs to be updated
         String name = "name_example"; // String | Updated name of the pet
         String status = "status_example"; // String | Updated status of the pet
-        try { 
+        try {
             apiInstance.updatePetWithForm(petId, name, status);
-            
-            
         } catch (ApiException e) {
             System.err.println("Exception when calling PetApi#updatePetWithForm");
             System.err.println("Status code: " + e.getCode());
@@ -533,7 +515,6 @@ null (empty response body)
 
 > ModelApiResponse uploadFile(petId, additionalMetadata, file)
 
-
 uploads an image
 
 ### Example
@@ -560,9 +541,8 @@ public class Example {
         Long petId = 56L; // Long | ID of pet to update
         String additionalMetadata = "additionalMetadata_example"; // String | Additional data to pass to server
         File file = new File("/path/to/file"); // File | file to upload
-        try { 
+        try {
             ModelApiResponse result = apiInstance.uploadFile(petId, additionalMetadata, file);
-            
             System.out.println(result);
         } catch (ApiException e) {
             System.err.println("Exception when calling PetApi#uploadFile");
@@ -607,7 +587,6 @@ Name | Type | Description  | Notes
 
 > ModelApiResponse uploadFileWithRequiredFile(petId, requiredFile, additionalMetadata)
 
-
 uploads an image (required)
 
 ### Example
@@ -634,9 +613,8 @@ public class Example {
         Long petId = 56L; // Long | ID of pet to update
         File requiredFile = new File("/path/to/file"); // File | file to upload
         String additionalMetadata = "additionalMetadata_example"; // String | Additional data to pass to server
-        try { 
+        try {
             ModelApiResponse result = apiInstance.uploadFileWithRequiredFile(petId, requiredFile, additionalMetadata);
-            
             System.out.println(result);
         } catch (ApiException e) {
             System.err.println("Exception when calling PetApi#uploadFileWithRequiredFile");

--- a/samples/client/petstore/java/jersey2-java6/docs/StoreApi.md
+++ b/samples/client/petstore/java/jersey2-java6/docs/StoreApi.md
@@ -15,7 +15,6 @@ Method | HTTP request | Description
 
 > deleteOrder(orderId)
 
-
 Delete purchase order by ID
 
 For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
@@ -37,10 +36,8 @@ public class Example {
 
         StoreApi apiInstance = new StoreApi(defaultClient);
         String orderId = "orderId_example"; // String | ID of the order that needs to be deleted
-        try { 
+        try {
             apiInstance.deleteOrder(orderId);
-            
-            
         } catch (ApiException e) {
             System.err.println("Exception when calling StoreApi#deleteOrder");
             System.err.println("Status code: " + e.getCode());
@@ -83,7 +80,6 @@ No authorization required
 
 > Map&lt;String, Integer&gt; getInventory()
 
-
 Returns pet inventories by status
 
 Returns a map of status codes to quantities
@@ -111,9 +107,8 @@ public class Example {
         //api_key.setApiKeyPrefix("Token");
 
         StoreApi apiInstance = new StoreApi(defaultClient);
-        try { 
+        try {
             Map<String, Integer> result = apiInstance.getInventory();
-            
             System.out.println(result);
         } catch (ApiException e) {
             System.err.println("Exception when calling StoreApi#getInventory");
@@ -153,7 +148,6 @@ This endpoint does not need any parameter.
 
 > Order getOrderById(orderId)
 
-
 Find purchase order by ID
 
 For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
@@ -175,9 +169,8 @@ public class Example {
 
         StoreApi apiInstance = new StoreApi(defaultClient);
         Long orderId = 56L; // Long | ID of pet that needs to be fetched
-        try { 
+        try {
             Order result = apiInstance.getOrderById(orderId);
-            
             System.out.println(result);
         } catch (ApiException e) {
             System.err.println("Exception when calling StoreApi#getOrderById");
@@ -222,7 +215,6 @@ No authorization required
 
 > Order placeOrder(body)
 
-
 Place an order for a pet
 
 ### Example
@@ -242,9 +234,8 @@ public class Example {
 
         StoreApi apiInstance = new StoreApi(defaultClient);
         Order body = new Order(); // Order | order placed for purchasing the pet
-        try { 
+        try {
             Order result = apiInstance.placeOrder(body);
-            
             System.out.println(result);
         } catch (ApiException e) {
             System.err.println("Exception when calling StoreApi#placeOrder");

--- a/samples/client/petstore/java/jersey2-java6/docs/UserApi.md
+++ b/samples/client/petstore/java/jersey2-java6/docs/UserApi.md
@@ -19,7 +19,6 @@ Method | HTTP request | Description
 
 > createUser(body)
 
-
 Create user
 
 This can only be done by the logged in user.
@@ -41,10 +40,8 @@ public class Example {
 
         UserApi apiInstance = new UserApi(defaultClient);
         User body = new User(); // User | Created user object
-        try { 
+        try {
             apiInstance.createUser(body);
-            
-            
         } catch (ApiException e) {
             System.err.println("Exception when calling UserApi#createUser");
             System.err.println("Status code: " + e.getCode());
@@ -86,7 +83,6 @@ No authorization required
 
 > createUsersWithArrayInput(body)
 
-
 Creates list of users with given input array
 
 ### Example
@@ -106,10 +102,8 @@ public class Example {
 
         UserApi apiInstance = new UserApi(defaultClient);
         List<User> body = Arrays.asList(); // List<User> | List of user object
-        try { 
+        try {
             apiInstance.createUsersWithArrayInput(body);
-            
-            
         } catch (ApiException e) {
             System.err.println("Exception when calling UserApi#createUsersWithArrayInput");
             System.err.println("Status code: " + e.getCode());
@@ -151,7 +145,6 @@ No authorization required
 
 > createUsersWithListInput(body)
 
-
 Creates list of users with given input array
 
 ### Example
@@ -171,10 +164,8 @@ public class Example {
 
         UserApi apiInstance = new UserApi(defaultClient);
         List<User> body = Arrays.asList(); // List<User> | List of user object
-        try { 
+        try {
             apiInstance.createUsersWithListInput(body);
-            
-            
         } catch (ApiException e) {
             System.err.println("Exception when calling UserApi#createUsersWithListInput");
             System.err.println("Status code: " + e.getCode());
@@ -216,7 +207,6 @@ No authorization required
 
 > deleteUser(username)
 
-
 Delete user
 
 This can only be done by the logged in user.
@@ -238,10 +228,8 @@ public class Example {
 
         UserApi apiInstance = new UserApi(defaultClient);
         String username = "username_example"; // String | The name that needs to be deleted
-        try { 
+        try {
             apiInstance.deleteUser(username);
-            
-            
         } catch (ApiException e) {
             System.err.println("Exception when calling UserApi#deleteUser");
             System.err.println("Status code: " + e.getCode());
@@ -284,7 +272,6 @@ No authorization required
 
 > User getUserByName(username)
 
-
 Get user by user name
 
 ### Example
@@ -304,9 +291,8 @@ public class Example {
 
         UserApi apiInstance = new UserApi(defaultClient);
         String username = "username_example"; // String | The name that needs to be fetched. Use user1 for testing.
-        try { 
+        try {
             User result = apiInstance.getUserByName(username);
-            
             System.out.println(result);
         } catch (ApiException e) {
             System.err.println("Exception when calling UserApi#getUserByName");
@@ -351,7 +337,6 @@ No authorization required
 
 > String loginUser(username, password)
 
-
 Logs user into the system
 
 ### Example
@@ -372,9 +357,8 @@ public class Example {
         UserApi apiInstance = new UserApi(defaultClient);
         String username = "username_example"; // String | The user name for login
         String password = "password_example"; // String | The password for login in clear text
-        try { 
+        try {
             String result = apiInstance.loginUser(username, password);
-            
             System.out.println(result);
         } catch (ApiException e) {
             System.err.println("Exception when calling UserApi#loginUser");
@@ -419,7 +403,6 @@ No authorization required
 
 > logoutUser()
 
-
 Logs out current logged in user session
 
 ### Example
@@ -438,10 +421,8 @@ public class Example {
         defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
         UserApi apiInstance = new UserApi(defaultClient);
-        try { 
+        try {
             apiInstance.logoutUser();
-            
-            
         } catch (ApiException e) {
             System.err.println("Exception when calling UserApi#logoutUser");
             System.err.println("Status code: " + e.getCode());
@@ -480,7 +461,6 @@ No authorization required
 
 > updateUser(username, body)
 
-
 Updated user
 
 This can only be done by the logged in user.
@@ -503,10 +483,8 @@ public class Example {
         UserApi apiInstance = new UserApi(defaultClient);
         String username = "username_example"; // String | name that need to be deleted
         User body = new User(); // User | Updated user object
-        try { 
+        try {
             apiInstance.updateUser(username, body);
-            
-            
         } catch (ApiException e) {
             System.err.println("Exception when calling UserApi#updateUser");
             System.err.println("Status code: " + e.getCode());

--- a/samples/client/petstore/java/jersey2-java8/docs/AnotherFakeApi.md
+++ b/samples/client/petstore/java/jersey2-java8/docs/AnotherFakeApi.md
@@ -12,7 +12,6 @@ Method | HTTP request | Description
 
 > Client call123testSpecialTags(body)
 
-
 To test special tags
 
 To test special tags and operation ID starting with number
@@ -34,9 +33,8 @@ public class Example {
 
         AnotherFakeApi apiInstance = new AnotherFakeApi(defaultClient);
         Client body = new Client(); // Client | client model
-        try { 
+        try {
             Client result = apiInstance.call123testSpecialTags(body);
-            
             System.out.println(result);
         } catch (ApiException e) {
             System.err.println("Exception when calling AnotherFakeApi#call123testSpecialTags");

--- a/samples/client/petstore/java/jersey2-java8/docs/FakeApi.md
+++ b/samples/client/petstore/java/jersey2-java8/docs/FakeApi.md
@@ -25,7 +25,6 @@ Method | HTTP request | Description
 
 > createXmlItem(xmlItem)
 
-
 creates an XmlItem
 
 this route creates an XmlItem
@@ -47,10 +46,8 @@ public class Example {
 
         FakeApi apiInstance = new FakeApi(defaultClient);
         XmlItem xmlItem = new XmlItem(); // XmlItem | XmlItem Body
-        try { 
+        try {
             apiInstance.createXmlItem(xmlItem);
-            
-            
         } catch (ApiException e) {
             System.err.println("Exception when calling FakeApi#createXmlItem");
             System.err.println("Status code: " + e.getCode());
@@ -94,7 +91,6 @@ No authorization required
 
 
 
-
 Test serialization of outer boolean types
 
 ### Example
@@ -114,9 +110,8 @@ public class Example {
 
         FakeApi apiInstance = new FakeApi(defaultClient);
         Boolean body = true; // Boolean | Input boolean as post body
-        try { 
+        try {
             Boolean result = apiInstance.fakeOuterBooleanSerialize(body);
-            
             System.out.println(result);
         } catch (ApiException e) {
             System.err.println("Exception when calling FakeApi#fakeOuterBooleanSerialize");
@@ -161,7 +156,6 @@ No authorization required
 
 
 
-
 Test serialization of object with outer number type
 
 ### Example
@@ -181,9 +175,8 @@ public class Example {
 
         FakeApi apiInstance = new FakeApi(defaultClient);
         OuterComposite body = new OuterComposite(); // OuterComposite | Input composite as post body
-        try { 
+        try {
             OuterComposite result = apiInstance.fakeOuterCompositeSerialize(body);
-            
             System.out.println(result);
         } catch (ApiException e) {
             System.err.println("Exception when calling FakeApi#fakeOuterCompositeSerialize");
@@ -228,7 +221,6 @@ No authorization required
 
 
 
-
 Test serialization of outer number types
 
 ### Example
@@ -248,9 +240,8 @@ public class Example {
 
         FakeApi apiInstance = new FakeApi(defaultClient);
         BigDecimal body = new BigDecimal(); // BigDecimal | Input number as post body
-        try { 
+        try {
             BigDecimal result = apiInstance.fakeOuterNumberSerialize(body);
-            
             System.out.println(result);
         } catch (ApiException e) {
             System.err.println("Exception when calling FakeApi#fakeOuterNumberSerialize");
@@ -295,7 +286,6 @@ No authorization required
 
 
 
-
 Test serialization of outer string types
 
 ### Example
@@ -315,9 +305,8 @@ public class Example {
 
         FakeApi apiInstance = new FakeApi(defaultClient);
         String body = "body_example"; // String | Input string as post body
-        try { 
+        try {
             String result = apiInstance.fakeOuterStringSerialize(body);
-            
             System.out.println(result);
         } catch (ApiException e) {
             System.err.println("Exception when calling FakeApi#fakeOuterStringSerialize");
@@ -362,7 +351,6 @@ No authorization required
 
 
 
-
 For this test, the body for this request much reference a schema named `File`.
 
 ### Example
@@ -382,10 +370,8 @@ public class Example {
 
         FakeApi apiInstance = new FakeApi(defaultClient);
         FileSchemaTestClass body = new FileSchemaTestClass(); // FileSchemaTestClass | 
-        try { 
+        try {
             apiInstance.testBodyWithFileSchema(body);
-            
-            
         } catch (ApiException e) {
             System.err.println("Exception when calling FakeApi#testBodyWithFileSchema");
             System.err.println("Status code: " + e.getCode());
@@ -429,7 +415,6 @@ No authorization required
 
 
 
-
 ### Example
 
 ```java
@@ -448,10 +433,8 @@ public class Example {
         FakeApi apiInstance = new FakeApi(defaultClient);
         String query = "query_example"; // String | 
         User body = new User(); // User | 
-        try { 
+        try {
             apiInstance.testBodyWithQueryParams(query, body);
-            
-            
         } catch (ApiException e) {
             System.err.println("Exception when calling FakeApi#testBodyWithQueryParams");
             System.err.println("Status code: " + e.getCode());
@@ -494,7 +477,6 @@ No authorization required
 
 > Client testClientModel(body)
 
-
 To test \&quot;client\&quot; model
 
 To test "client" model
@@ -516,9 +498,8 @@ public class Example {
 
         FakeApi apiInstance = new FakeApi(defaultClient);
         Client body = new Client(); // Client | client model
-        try { 
+        try {
             Client result = apiInstance.testClientModel(body);
-            
             System.out.println(result);
         } catch (ApiException e) {
             System.err.println("Exception when calling FakeApi#testClientModel");
@@ -560,7 +541,6 @@ No authorization required
 ## testEndpointParameters
 
 > testEndpointParameters(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, paramCallback)
-
 
 Fake endpoint for testing various parameters  假端點  偽のエンドポイント  가짜 엔드 포인트
 
@@ -605,10 +585,8 @@ public class Example {
         OffsetDateTime dateTime = new OffsetDateTime(); // OffsetDateTime | None
         String password = "password_example"; // String | None
         String paramCallback = "paramCallback_example"; // String | None
-        try { 
+        try {
             apiInstance.testEndpointParameters(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, paramCallback);
-            
-            
         } catch (ApiException e) {
             System.err.println("Exception when calling FakeApi#testEndpointParameters");
             System.err.println("Status code: " + e.getCode());
@@ -664,7 +642,6 @@ null (empty response body)
 
 > testEnumParameters(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString)
 
-
 To test enum parameters
 
 To test enum parameters
@@ -693,10 +670,8 @@ public class Example {
         Double enumQueryDouble = 3.4D; // Double | Query parameter enum test (double)
         List<String> enumFormStringArray = "$"; // List<String> | Form parameter enum test (string array)
         String enumFormString = "-efg"; // String | Form parameter enum test (string)
-        try { 
+        try {
             apiInstance.testEnumParameters(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString);
-            
-            
         } catch (ApiException e) {
             System.err.println("Exception when calling FakeApi#testEnumParameters");
             System.err.println("Status code: " + e.getCode());
@@ -744,7 +719,6 @@ No authorization required
 
 ## testGroupParameters
 
-
 > testGroupParameters().requiredStringGroup(requiredStringGroup).requiredBooleanGroup(requiredBooleanGroup).requiredInt64Group(requiredInt64Group).stringGroup(stringGroup).booleanGroup(booleanGroup).int64Group(int64Group).execute();
 
 Fake endpoint to test group parameters (optional)
@@ -773,7 +747,7 @@ public class Example {
         Integer stringGroup = 56; // Integer | String in group parameters
         Boolean booleanGroup = true; // Boolean | Boolean in group parameters
         Long int64Group = 56L; // Long | Integer in group parameters
-        try { 
+        try {
             api.testGroupParameters()
                 .requiredStringGroup(requiredStringGroup)
                 .requiredBooleanGroup(requiredBooleanGroup)
@@ -782,7 +756,6 @@ public class Example {
                 .booleanGroup(booleanGroup)
                 .int64Group(int64Group)
                 .execute();
-            
         } catch (ApiException e) {
             System.err.println("Exception when calling FakeApi#testGroupParameters");
             System.err.println("Status code: " + e.getCode());
@@ -829,7 +802,6 @@ No authorization required
 
 > testInlineAdditionalProperties(param)
 
-
 test inline additionalProperties
 
 ### Example
@@ -849,10 +821,8 @@ public class Example {
 
         FakeApi apiInstance = new FakeApi(defaultClient);
         Map<String, String> param = new HashMap(); // Map<String, String> | request body
-        try { 
+        try {
             apiInstance.testInlineAdditionalProperties(param);
-            
-            
         } catch (ApiException e) {
             System.err.println("Exception when calling FakeApi#testInlineAdditionalProperties");
             System.err.println("Status code: " + e.getCode());
@@ -894,7 +864,6 @@ No authorization required
 
 > testJsonFormData(param, param2)
 
-
 test json serialization of form data
 
 ### Example
@@ -915,10 +884,8 @@ public class Example {
         FakeApi apiInstance = new FakeApi(defaultClient);
         String param = "param_example"; // String | field1
         String param2 = "param2_example"; // String | field2
-        try { 
+        try {
             apiInstance.testJsonFormData(param, param2);
-            
-            
         } catch (ApiException e) {
             System.err.println("Exception when calling FakeApi#testJsonFormData");
             System.err.println("Status code: " + e.getCode());
@@ -963,7 +930,6 @@ No authorization required
 
 
 
-
 To test the collection format in query parameters
 
 ### Example
@@ -987,10 +953,8 @@ public class Example {
         List<String> http = Arrays.asList(); // List<String> | 
         List<String> url = Arrays.asList(); // List<String> | 
         List<String> context = Arrays.asList(); // List<String> | 
-        try { 
+        try {
             apiInstance.testQueryParameterCollectionFormat(pipe, ioutil, http, url, context);
-            
-            
         } catch (ApiException e) {
             System.err.println("Exception when calling FakeApi#testQueryParameterCollectionFormat");
             System.err.println("Status code: " + e.getCode());

--- a/samples/client/petstore/java/jersey2-java8/docs/FakeClassnameTags123Api.md
+++ b/samples/client/petstore/java/jersey2-java8/docs/FakeClassnameTags123Api.md
@@ -12,7 +12,6 @@ Method | HTTP request | Description
 
 > Client testClassname(body)
 
-
 To test class name in snake case
 
 To test class name in snake case
@@ -41,9 +40,8 @@ public class Example {
 
         FakeClassnameTags123Api apiInstance = new FakeClassnameTags123Api(defaultClient);
         Client body = new Client(); // Client | client model
-        try { 
+        try {
             Client result = apiInstance.testClassname(body);
-            
             System.out.println(result);
         } catch (ApiException e) {
             System.err.println("Exception when calling FakeClassnameTags123Api#testClassname");

--- a/samples/client/petstore/java/jersey2-java8/docs/PetApi.md
+++ b/samples/client/petstore/java/jersey2-java8/docs/PetApi.md
@@ -20,7 +20,6 @@ Method | HTTP request | Description
 
 > addPet(body)
 
-
 Add a new pet to the store
 
 ### Example
@@ -45,10 +44,8 @@ public class Example {
 
         PetApi apiInstance = new PetApi(defaultClient);
         Pet body = new Pet(); // Pet | Pet object that needs to be added to the store
-        try { 
+        try {
             apiInstance.addPet(body);
-            
-            
         } catch (ApiException e) {
             System.err.println("Exception when calling PetApi#addPet");
             System.err.println("Status code: " + e.getCode());
@@ -91,7 +88,6 @@ null (empty response body)
 
 > deletePet(petId, apiKey)
 
-
 Deletes a pet
 
 ### Example
@@ -117,10 +113,8 @@ public class Example {
         PetApi apiInstance = new PetApi(defaultClient);
         Long petId = 56L; // Long | Pet id to delete
         String apiKey = "apiKey_example"; // String | 
-        try { 
+        try {
             apiInstance.deletePet(petId, apiKey);
-            
-            
         } catch (ApiException e) {
             System.err.println("Exception when calling PetApi#deletePet");
             System.err.println("Status code: " + e.getCode());
@@ -164,7 +158,6 @@ null (empty response body)
 
 > List&lt;Pet&gt; findPetsByStatus(status)
 
-
 Finds Pets by status
 
 Multiple status values can be provided with comma separated strings
@@ -191,9 +184,8 @@ public class Example {
 
         PetApi apiInstance = new PetApi(defaultClient);
         List<String> status = Arrays.asList("available"); // List<String> | Status values that need to be considered for filter
-        try { 
+        try {
             List<Pet> result = apiInstance.findPetsByStatus(status);
-            
             System.out.println(result);
         } catch (ApiException e) {
             System.err.println("Exception when calling PetApi#findPetsByStatus");
@@ -237,7 +229,6 @@ Name | Type | Description  | Notes
 
 > List&lt;Pet&gt; findPetsByTags(tags)
 
-
 Finds Pets by tags
 
 Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
@@ -264,9 +255,8 @@ public class Example {
 
         PetApi apiInstance = new PetApi(defaultClient);
         List<String> tags = Arrays.asList(); // List<String> | Tags to filter by
-        try { 
+        try {
             List<Pet> result = apiInstance.findPetsByTags(tags);
-            
             System.out.println(result);
         } catch (ApiException e) {
             System.err.println("Exception when calling PetApi#findPetsByTags");
@@ -310,7 +300,6 @@ Name | Type | Description  | Notes
 
 > Pet getPetById(petId)
 
-
 Find pet by ID
 
 Returns a single pet
@@ -339,9 +328,8 @@ public class Example {
 
         PetApi apiInstance = new PetApi(defaultClient);
         Long petId = 56L; // Long | ID of pet to return
-        try { 
+        try {
             Pet result = apiInstance.getPetById(petId);
-            
             System.out.println(result);
         } catch (ApiException e) {
             System.err.println("Exception when calling PetApi#getPetById");
@@ -386,7 +374,6 @@ Name | Type | Description  | Notes
 
 > updatePet(body)
 
-
 Update an existing pet
 
 ### Example
@@ -411,10 +398,8 @@ public class Example {
 
         PetApi apiInstance = new PetApi(defaultClient);
         Pet body = new Pet(); // Pet | Pet object that needs to be added to the store
-        try { 
+        try {
             apiInstance.updatePet(body);
-            
-            
         } catch (ApiException e) {
             System.err.println("Exception when calling PetApi#updatePet");
             System.err.println("Status code: " + e.getCode());
@@ -459,7 +444,6 @@ null (empty response body)
 
 > updatePetWithForm(petId, name, status)
 
-
 Updates a pet in the store with form data
 
 ### Example
@@ -486,10 +470,8 @@ public class Example {
         Long petId = 56L; // Long | ID of pet that needs to be updated
         String name = "name_example"; // String | Updated name of the pet
         String status = "status_example"; // String | Updated status of the pet
-        try { 
+        try {
             apiInstance.updatePetWithForm(petId, name, status);
-            
-            
         } catch (ApiException e) {
             System.err.println("Exception when calling PetApi#updatePetWithForm");
             System.err.println("Status code: " + e.getCode());
@@ -533,7 +515,6 @@ null (empty response body)
 
 > ModelApiResponse uploadFile(petId, additionalMetadata, file)
 
-
 uploads an image
 
 ### Example
@@ -560,9 +541,8 @@ public class Example {
         Long petId = 56L; // Long | ID of pet to update
         String additionalMetadata = "additionalMetadata_example"; // String | Additional data to pass to server
         File file = new File("/path/to/file"); // File | file to upload
-        try { 
+        try {
             ModelApiResponse result = apiInstance.uploadFile(petId, additionalMetadata, file);
-            
             System.out.println(result);
         } catch (ApiException e) {
             System.err.println("Exception when calling PetApi#uploadFile");
@@ -607,7 +587,6 @@ Name | Type | Description  | Notes
 
 > ModelApiResponse uploadFileWithRequiredFile(petId, requiredFile, additionalMetadata)
 
-
 uploads an image (required)
 
 ### Example
@@ -634,9 +613,8 @@ public class Example {
         Long petId = 56L; // Long | ID of pet to update
         File requiredFile = new File("/path/to/file"); // File | file to upload
         String additionalMetadata = "additionalMetadata_example"; // String | Additional data to pass to server
-        try { 
+        try {
             ModelApiResponse result = apiInstance.uploadFileWithRequiredFile(petId, requiredFile, additionalMetadata);
-            
             System.out.println(result);
         } catch (ApiException e) {
             System.err.println("Exception when calling PetApi#uploadFileWithRequiredFile");

--- a/samples/client/petstore/java/jersey2-java8/docs/StoreApi.md
+++ b/samples/client/petstore/java/jersey2-java8/docs/StoreApi.md
@@ -15,7 +15,6 @@ Method | HTTP request | Description
 
 > deleteOrder(orderId)
 
-
 Delete purchase order by ID
 
 For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
@@ -37,10 +36,8 @@ public class Example {
 
         StoreApi apiInstance = new StoreApi(defaultClient);
         String orderId = "orderId_example"; // String | ID of the order that needs to be deleted
-        try { 
+        try {
             apiInstance.deleteOrder(orderId);
-            
-            
         } catch (ApiException e) {
             System.err.println("Exception when calling StoreApi#deleteOrder");
             System.err.println("Status code: " + e.getCode());
@@ -83,7 +80,6 @@ No authorization required
 
 > Map&lt;String, Integer&gt; getInventory()
 
-
 Returns pet inventories by status
 
 Returns a map of status codes to quantities
@@ -111,9 +107,8 @@ public class Example {
         //api_key.setApiKeyPrefix("Token");
 
         StoreApi apiInstance = new StoreApi(defaultClient);
-        try { 
+        try {
             Map<String, Integer> result = apiInstance.getInventory();
-            
             System.out.println(result);
         } catch (ApiException e) {
             System.err.println("Exception when calling StoreApi#getInventory");
@@ -153,7 +148,6 @@ This endpoint does not need any parameter.
 
 > Order getOrderById(orderId)
 
-
 Find purchase order by ID
 
 For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
@@ -175,9 +169,8 @@ public class Example {
 
         StoreApi apiInstance = new StoreApi(defaultClient);
         Long orderId = 56L; // Long | ID of pet that needs to be fetched
-        try { 
+        try {
             Order result = apiInstance.getOrderById(orderId);
-            
             System.out.println(result);
         } catch (ApiException e) {
             System.err.println("Exception when calling StoreApi#getOrderById");
@@ -222,7 +215,6 @@ No authorization required
 
 > Order placeOrder(body)
 
-
 Place an order for a pet
 
 ### Example
@@ -242,9 +234,8 @@ public class Example {
 
         StoreApi apiInstance = new StoreApi(defaultClient);
         Order body = new Order(); // Order | order placed for purchasing the pet
-        try { 
+        try {
             Order result = apiInstance.placeOrder(body);
-            
             System.out.println(result);
         } catch (ApiException e) {
             System.err.println("Exception when calling StoreApi#placeOrder");

--- a/samples/client/petstore/java/jersey2-java8/docs/UserApi.md
+++ b/samples/client/petstore/java/jersey2-java8/docs/UserApi.md
@@ -19,7 +19,6 @@ Method | HTTP request | Description
 
 > createUser(body)
 
-
 Create user
 
 This can only be done by the logged in user.
@@ -41,10 +40,8 @@ public class Example {
 
         UserApi apiInstance = new UserApi(defaultClient);
         User body = new User(); // User | Created user object
-        try { 
+        try {
             apiInstance.createUser(body);
-            
-            
         } catch (ApiException e) {
             System.err.println("Exception when calling UserApi#createUser");
             System.err.println("Status code: " + e.getCode());
@@ -86,7 +83,6 @@ No authorization required
 
 > createUsersWithArrayInput(body)
 
-
 Creates list of users with given input array
 
 ### Example
@@ -106,10 +102,8 @@ public class Example {
 
         UserApi apiInstance = new UserApi(defaultClient);
         List<User> body = Arrays.asList(); // List<User> | List of user object
-        try { 
+        try {
             apiInstance.createUsersWithArrayInput(body);
-            
-            
         } catch (ApiException e) {
             System.err.println("Exception when calling UserApi#createUsersWithArrayInput");
             System.err.println("Status code: " + e.getCode());
@@ -151,7 +145,6 @@ No authorization required
 
 > createUsersWithListInput(body)
 
-
 Creates list of users with given input array
 
 ### Example
@@ -171,10 +164,8 @@ public class Example {
 
         UserApi apiInstance = new UserApi(defaultClient);
         List<User> body = Arrays.asList(); // List<User> | List of user object
-        try { 
+        try {
             apiInstance.createUsersWithListInput(body);
-            
-            
         } catch (ApiException e) {
             System.err.println("Exception when calling UserApi#createUsersWithListInput");
             System.err.println("Status code: " + e.getCode());
@@ -216,7 +207,6 @@ No authorization required
 
 > deleteUser(username)
 
-
 Delete user
 
 This can only be done by the logged in user.
@@ -238,10 +228,8 @@ public class Example {
 
         UserApi apiInstance = new UserApi(defaultClient);
         String username = "username_example"; // String | The name that needs to be deleted
-        try { 
+        try {
             apiInstance.deleteUser(username);
-            
-            
         } catch (ApiException e) {
             System.err.println("Exception when calling UserApi#deleteUser");
             System.err.println("Status code: " + e.getCode());
@@ -284,7 +272,6 @@ No authorization required
 
 > User getUserByName(username)
 
-
 Get user by user name
 
 ### Example
@@ -304,9 +291,8 @@ public class Example {
 
         UserApi apiInstance = new UserApi(defaultClient);
         String username = "username_example"; // String | The name that needs to be fetched. Use user1 for testing.
-        try { 
+        try {
             User result = apiInstance.getUserByName(username);
-            
             System.out.println(result);
         } catch (ApiException e) {
             System.err.println("Exception when calling UserApi#getUserByName");
@@ -351,7 +337,6 @@ No authorization required
 
 > String loginUser(username, password)
 
-
 Logs user into the system
 
 ### Example
@@ -372,9 +357,8 @@ public class Example {
         UserApi apiInstance = new UserApi(defaultClient);
         String username = "username_example"; // String | The user name for login
         String password = "password_example"; // String | The password for login in clear text
-        try { 
+        try {
             String result = apiInstance.loginUser(username, password);
-            
             System.out.println(result);
         } catch (ApiException e) {
             System.err.println("Exception when calling UserApi#loginUser");
@@ -419,7 +403,6 @@ No authorization required
 
 > logoutUser()
 
-
 Logs out current logged in user session
 
 ### Example
@@ -438,10 +421,8 @@ public class Example {
         defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
         UserApi apiInstance = new UserApi(defaultClient);
-        try { 
+        try {
             apiInstance.logoutUser();
-            
-            
         } catch (ApiException e) {
             System.err.println("Exception when calling UserApi#logoutUser");
             System.err.println("Status code: " + e.getCode());
@@ -480,7 +461,6 @@ No authorization required
 
 > updateUser(username, body)
 
-
 Updated user
 
 This can only be done by the logged in user.
@@ -503,10 +483,8 @@ public class Example {
         UserApi apiInstance = new UserApi(defaultClient);
         String username = "username_example"; // String | name that need to be deleted
         User body = new User(); // User | Updated user object
-        try { 
+        try {
             apiInstance.updateUser(username, body);
-            
-            
         } catch (ApiException e) {
             System.err.println("Exception when calling UserApi#updateUser");
             System.err.println("Status code: " + e.getCode());

--- a/samples/client/petstore/java/jersey2/docs/AnotherFakeApi.md
+++ b/samples/client/petstore/java/jersey2/docs/AnotherFakeApi.md
@@ -12,7 +12,6 @@ Method | HTTP request | Description
 
 > Client call123testSpecialTags(body)
 
-
 To test special tags
 
 To test special tags and operation ID starting with number
@@ -34,9 +33,8 @@ public class Example {
 
         AnotherFakeApi apiInstance = new AnotherFakeApi(defaultClient);
         Client body = new Client(); // Client | client model
-        try { 
+        try {
             Client result = apiInstance.call123testSpecialTags(body);
-            
             System.out.println(result);
         } catch (ApiException e) {
             System.err.println("Exception when calling AnotherFakeApi#call123testSpecialTags");

--- a/samples/client/petstore/java/jersey2/docs/FakeApi.md
+++ b/samples/client/petstore/java/jersey2/docs/FakeApi.md
@@ -25,7 +25,6 @@ Method | HTTP request | Description
 
 > createXmlItem(xmlItem)
 
-
 creates an XmlItem
 
 this route creates an XmlItem
@@ -47,10 +46,8 @@ public class Example {
 
         FakeApi apiInstance = new FakeApi(defaultClient);
         XmlItem xmlItem = new XmlItem(); // XmlItem | XmlItem Body
-        try { 
+        try {
             apiInstance.createXmlItem(xmlItem);
-            
-            
         } catch (ApiException e) {
             System.err.println("Exception when calling FakeApi#createXmlItem");
             System.err.println("Status code: " + e.getCode());
@@ -94,7 +91,6 @@ No authorization required
 
 
 
-
 Test serialization of outer boolean types
 
 ### Example
@@ -114,9 +110,8 @@ public class Example {
 
         FakeApi apiInstance = new FakeApi(defaultClient);
         Boolean body = true; // Boolean | Input boolean as post body
-        try { 
+        try {
             Boolean result = apiInstance.fakeOuterBooleanSerialize(body);
-            
             System.out.println(result);
         } catch (ApiException e) {
             System.err.println("Exception when calling FakeApi#fakeOuterBooleanSerialize");
@@ -161,7 +156,6 @@ No authorization required
 
 
 
-
 Test serialization of object with outer number type
 
 ### Example
@@ -181,9 +175,8 @@ public class Example {
 
         FakeApi apiInstance = new FakeApi(defaultClient);
         OuterComposite body = new OuterComposite(); // OuterComposite | Input composite as post body
-        try { 
+        try {
             OuterComposite result = apiInstance.fakeOuterCompositeSerialize(body);
-            
             System.out.println(result);
         } catch (ApiException e) {
             System.err.println("Exception when calling FakeApi#fakeOuterCompositeSerialize");
@@ -228,7 +221,6 @@ No authorization required
 
 
 
-
 Test serialization of outer number types
 
 ### Example
@@ -248,9 +240,8 @@ public class Example {
 
         FakeApi apiInstance = new FakeApi(defaultClient);
         BigDecimal body = new BigDecimal(); // BigDecimal | Input number as post body
-        try { 
+        try {
             BigDecimal result = apiInstance.fakeOuterNumberSerialize(body);
-            
             System.out.println(result);
         } catch (ApiException e) {
             System.err.println("Exception when calling FakeApi#fakeOuterNumberSerialize");
@@ -295,7 +286,6 @@ No authorization required
 
 
 
-
 Test serialization of outer string types
 
 ### Example
@@ -315,9 +305,8 @@ public class Example {
 
         FakeApi apiInstance = new FakeApi(defaultClient);
         String body = "body_example"; // String | Input string as post body
-        try { 
+        try {
             String result = apiInstance.fakeOuterStringSerialize(body);
-            
             System.out.println(result);
         } catch (ApiException e) {
             System.err.println("Exception when calling FakeApi#fakeOuterStringSerialize");
@@ -362,7 +351,6 @@ No authorization required
 
 
 
-
 For this test, the body for this request much reference a schema named `File`.
 
 ### Example
@@ -382,10 +370,8 @@ public class Example {
 
         FakeApi apiInstance = new FakeApi(defaultClient);
         FileSchemaTestClass body = new FileSchemaTestClass(); // FileSchemaTestClass | 
-        try { 
+        try {
             apiInstance.testBodyWithFileSchema(body);
-            
-            
         } catch (ApiException e) {
             System.err.println("Exception when calling FakeApi#testBodyWithFileSchema");
             System.err.println("Status code: " + e.getCode());
@@ -429,7 +415,6 @@ No authorization required
 
 
 
-
 ### Example
 
 ```java
@@ -448,10 +433,8 @@ public class Example {
         FakeApi apiInstance = new FakeApi(defaultClient);
         String query = "query_example"; // String | 
         User body = new User(); // User | 
-        try { 
+        try {
             apiInstance.testBodyWithQueryParams(query, body);
-            
-            
         } catch (ApiException e) {
             System.err.println("Exception when calling FakeApi#testBodyWithQueryParams");
             System.err.println("Status code: " + e.getCode());
@@ -494,7 +477,6 @@ No authorization required
 
 > Client testClientModel(body)
 
-
 To test \&quot;client\&quot; model
 
 To test "client" model
@@ -516,9 +498,8 @@ public class Example {
 
         FakeApi apiInstance = new FakeApi(defaultClient);
         Client body = new Client(); // Client | client model
-        try { 
+        try {
             Client result = apiInstance.testClientModel(body);
-            
             System.out.println(result);
         } catch (ApiException e) {
             System.err.println("Exception when calling FakeApi#testClientModel");
@@ -560,7 +541,6 @@ No authorization required
 ## testEndpointParameters
 
 > testEndpointParameters(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, paramCallback)
-
 
 Fake endpoint for testing various parameters  假端點  偽のエンドポイント  가짜 엔드 포인트
 
@@ -605,10 +585,8 @@ public class Example {
         OffsetDateTime dateTime = new OffsetDateTime(); // OffsetDateTime | None
         String password = "password_example"; // String | None
         String paramCallback = "paramCallback_example"; // String | None
-        try { 
+        try {
             apiInstance.testEndpointParameters(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, paramCallback);
-            
-            
         } catch (ApiException e) {
             System.err.println("Exception when calling FakeApi#testEndpointParameters");
             System.err.println("Status code: " + e.getCode());
@@ -664,7 +642,6 @@ null (empty response body)
 
 > testEnumParameters(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString)
 
-
 To test enum parameters
 
 To test enum parameters
@@ -693,10 +670,8 @@ public class Example {
         Double enumQueryDouble = 3.4D; // Double | Query parameter enum test (double)
         List<String> enumFormStringArray = "$"; // List<String> | Form parameter enum test (string array)
         String enumFormString = "-efg"; // String | Form parameter enum test (string)
-        try { 
+        try {
             apiInstance.testEnumParameters(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString);
-            
-            
         } catch (ApiException e) {
             System.err.println("Exception when calling FakeApi#testEnumParameters");
             System.err.println("Status code: " + e.getCode());
@@ -744,7 +719,6 @@ No authorization required
 
 ## testGroupParameters
 
-
 > testGroupParameters().requiredStringGroup(requiredStringGroup).requiredBooleanGroup(requiredBooleanGroup).requiredInt64Group(requiredInt64Group).stringGroup(stringGroup).booleanGroup(booleanGroup).int64Group(int64Group).execute();
 
 Fake endpoint to test group parameters (optional)
@@ -773,7 +747,7 @@ public class Example {
         Integer stringGroup = 56; // Integer | String in group parameters
         Boolean booleanGroup = true; // Boolean | Boolean in group parameters
         Long int64Group = 56L; // Long | Integer in group parameters
-        try { 
+        try {
             api.testGroupParameters()
                 .requiredStringGroup(requiredStringGroup)
                 .requiredBooleanGroup(requiredBooleanGroup)
@@ -782,7 +756,6 @@ public class Example {
                 .booleanGroup(booleanGroup)
                 .int64Group(int64Group)
                 .execute();
-            
         } catch (ApiException e) {
             System.err.println("Exception when calling FakeApi#testGroupParameters");
             System.err.println("Status code: " + e.getCode());
@@ -829,7 +802,6 @@ No authorization required
 
 > testInlineAdditionalProperties(param)
 
-
 test inline additionalProperties
 
 ### Example
@@ -849,10 +821,8 @@ public class Example {
 
         FakeApi apiInstance = new FakeApi(defaultClient);
         Map<String, String> param = new HashMap(); // Map<String, String> | request body
-        try { 
+        try {
             apiInstance.testInlineAdditionalProperties(param);
-            
-            
         } catch (ApiException e) {
             System.err.println("Exception when calling FakeApi#testInlineAdditionalProperties");
             System.err.println("Status code: " + e.getCode());
@@ -894,7 +864,6 @@ No authorization required
 
 > testJsonFormData(param, param2)
 
-
 test json serialization of form data
 
 ### Example
@@ -915,10 +884,8 @@ public class Example {
         FakeApi apiInstance = new FakeApi(defaultClient);
         String param = "param_example"; // String | field1
         String param2 = "param2_example"; // String | field2
-        try { 
+        try {
             apiInstance.testJsonFormData(param, param2);
-            
-            
         } catch (ApiException e) {
             System.err.println("Exception when calling FakeApi#testJsonFormData");
             System.err.println("Status code: " + e.getCode());
@@ -963,7 +930,6 @@ No authorization required
 
 
 
-
 To test the collection format in query parameters
 
 ### Example
@@ -987,10 +953,8 @@ public class Example {
         List<String> http = Arrays.asList(); // List<String> | 
         List<String> url = Arrays.asList(); // List<String> | 
         List<String> context = Arrays.asList(); // List<String> | 
-        try { 
+        try {
             apiInstance.testQueryParameterCollectionFormat(pipe, ioutil, http, url, context);
-            
-            
         } catch (ApiException e) {
             System.err.println("Exception when calling FakeApi#testQueryParameterCollectionFormat");
             System.err.println("Status code: " + e.getCode());

--- a/samples/client/petstore/java/jersey2/docs/FakeClassnameTags123Api.md
+++ b/samples/client/petstore/java/jersey2/docs/FakeClassnameTags123Api.md
@@ -12,7 +12,6 @@ Method | HTTP request | Description
 
 > Client testClassname(body)
 
-
 To test class name in snake case
 
 To test class name in snake case
@@ -41,9 +40,8 @@ public class Example {
 
         FakeClassnameTags123Api apiInstance = new FakeClassnameTags123Api(defaultClient);
         Client body = new Client(); // Client | client model
-        try { 
+        try {
             Client result = apiInstance.testClassname(body);
-            
             System.out.println(result);
         } catch (ApiException e) {
             System.err.println("Exception when calling FakeClassnameTags123Api#testClassname");

--- a/samples/client/petstore/java/jersey2/docs/PetApi.md
+++ b/samples/client/petstore/java/jersey2/docs/PetApi.md
@@ -20,7 +20,6 @@ Method | HTTP request | Description
 
 > addPet(body)
 
-
 Add a new pet to the store
 
 ### Example
@@ -45,10 +44,8 @@ public class Example {
 
         PetApi apiInstance = new PetApi(defaultClient);
         Pet body = new Pet(); // Pet | Pet object that needs to be added to the store
-        try { 
+        try {
             apiInstance.addPet(body);
-            
-            
         } catch (ApiException e) {
             System.err.println("Exception when calling PetApi#addPet");
             System.err.println("Status code: " + e.getCode());
@@ -91,7 +88,6 @@ null (empty response body)
 
 > deletePet(petId, apiKey)
 
-
 Deletes a pet
 
 ### Example
@@ -117,10 +113,8 @@ public class Example {
         PetApi apiInstance = new PetApi(defaultClient);
         Long petId = 56L; // Long | Pet id to delete
         String apiKey = "apiKey_example"; // String | 
-        try { 
+        try {
             apiInstance.deletePet(petId, apiKey);
-            
-            
         } catch (ApiException e) {
             System.err.println("Exception when calling PetApi#deletePet");
             System.err.println("Status code: " + e.getCode());
@@ -164,7 +158,6 @@ null (empty response body)
 
 > List&lt;Pet&gt; findPetsByStatus(status)
 
-
 Finds Pets by status
 
 Multiple status values can be provided with comma separated strings
@@ -191,9 +184,8 @@ public class Example {
 
         PetApi apiInstance = new PetApi(defaultClient);
         List<String> status = Arrays.asList("available"); // List<String> | Status values that need to be considered for filter
-        try { 
+        try {
             List<Pet> result = apiInstance.findPetsByStatus(status);
-            
             System.out.println(result);
         } catch (ApiException e) {
             System.err.println("Exception when calling PetApi#findPetsByStatus");
@@ -237,7 +229,6 @@ Name | Type | Description  | Notes
 
 > List&lt;Pet&gt; findPetsByTags(tags)
 
-
 Finds Pets by tags
 
 Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
@@ -264,9 +255,8 @@ public class Example {
 
         PetApi apiInstance = new PetApi(defaultClient);
         List<String> tags = Arrays.asList(); // List<String> | Tags to filter by
-        try { 
+        try {
             List<Pet> result = apiInstance.findPetsByTags(tags);
-            
             System.out.println(result);
         } catch (ApiException e) {
             System.err.println("Exception when calling PetApi#findPetsByTags");
@@ -310,7 +300,6 @@ Name | Type | Description  | Notes
 
 > Pet getPetById(petId)
 
-
 Find pet by ID
 
 Returns a single pet
@@ -339,9 +328,8 @@ public class Example {
 
         PetApi apiInstance = new PetApi(defaultClient);
         Long petId = 56L; // Long | ID of pet to return
-        try { 
+        try {
             Pet result = apiInstance.getPetById(petId);
-            
             System.out.println(result);
         } catch (ApiException e) {
             System.err.println("Exception when calling PetApi#getPetById");
@@ -386,7 +374,6 @@ Name | Type | Description  | Notes
 
 > updatePet(body)
 
-
 Update an existing pet
 
 ### Example
@@ -411,10 +398,8 @@ public class Example {
 
         PetApi apiInstance = new PetApi(defaultClient);
         Pet body = new Pet(); // Pet | Pet object that needs to be added to the store
-        try { 
+        try {
             apiInstance.updatePet(body);
-            
-            
         } catch (ApiException e) {
             System.err.println("Exception when calling PetApi#updatePet");
             System.err.println("Status code: " + e.getCode());
@@ -459,7 +444,6 @@ null (empty response body)
 
 > updatePetWithForm(petId, name, status)
 
-
 Updates a pet in the store with form data
 
 ### Example
@@ -486,10 +470,8 @@ public class Example {
         Long petId = 56L; // Long | ID of pet that needs to be updated
         String name = "name_example"; // String | Updated name of the pet
         String status = "status_example"; // String | Updated status of the pet
-        try { 
+        try {
             apiInstance.updatePetWithForm(petId, name, status);
-            
-            
         } catch (ApiException e) {
             System.err.println("Exception when calling PetApi#updatePetWithForm");
             System.err.println("Status code: " + e.getCode());
@@ -533,7 +515,6 @@ null (empty response body)
 
 > ModelApiResponse uploadFile(petId, additionalMetadata, file)
 
-
 uploads an image
 
 ### Example
@@ -560,9 +541,8 @@ public class Example {
         Long petId = 56L; // Long | ID of pet to update
         String additionalMetadata = "additionalMetadata_example"; // String | Additional data to pass to server
         File file = new File("/path/to/file"); // File | file to upload
-        try { 
+        try {
             ModelApiResponse result = apiInstance.uploadFile(petId, additionalMetadata, file);
-            
             System.out.println(result);
         } catch (ApiException e) {
             System.err.println("Exception when calling PetApi#uploadFile");
@@ -607,7 +587,6 @@ Name | Type | Description  | Notes
 
 > ModelApiResponse uploadFileWithRequiredFile(petId, requiredFile, additionalMetadata)
 
-
 uploads an image (required)
 
 ### Example
@@ -634,9 +613,8 @@ public class Example {
         Long petId = 56L; // Long | ID of pet to update
         File requiredFile = new File("/path/to/file"); // File | file to upload
         String additionalMetadata = "additionalMetadata_example"; // String | Additional data to pass to server
-        try { 
+        try {
             ModelApiResponse result = apiInstance.uploadFileWithRequiredFile(petId, requiredFile, additionalMetadata);
-            
             System.out.println(result);
         } catch (ApiException e) {
             System.err.println("Exception when calling PetApi#uploadFileWithRequiredFile");

--- a/samples/client/petstore/java/jersey2/docs/StoreApi.md
+++ b/samples/client/petstore/java/jersey2/docs/StoreApi.md
@@ -15,7 +15,6 @@ Method | HTTP request | Description
 
 > deleteOrder(orderId)
 
-
 Delete purchase order by ID
 
 For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
@@ -37,10 +36,8 @@ public class Example {
 
         StoreApi apiInstance = new StoreApi(defaultClient);
         String orderId = "orderId_example"; // String | ID of the order that needs to be deleted
-        try { 
+        try {
             apiInstance.deleteOrder(orderId);
-            
-            
         } catch (ApiException e) {
             System.err.println("Exception when calling StoreApi#deleteOrder");
             System.err.println("Status code: " + e.getCode());
@@ -83,7 +80,6 @@ No authorization required
 
 > Map&lt;String, Integer&gt; getInventory()
 
-
 Returns pet inventories by status
 
 Returns a map of status codes to quantities
@@ -111,9 +107,8 @@ public class Example {
         //api_key.setApiKeyPrefix("Token");
 
         StoreApi apiInstance = new StoreApi(defaultClient);
-        try { 
+        try {
             Map<String, Integer> result = apiInstance.getInventory();
-            
             System.out.println(result);
         } catch (ApiException e) {
             System.err.println("Exception when calling StoreApi#getInventory");
@@ -153,7 +148,6 @@ This endpoint does not need any parameter.
 
 > Order getOrderById(orderId)
 
-
 Find purchase order by ID
 
 For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
@@ -175,9 +169,8 @@ public class Example {
 
         StoreApi apiInstance = new StoreApi(defaultClient);
         Long orderId = 56L; // Long | ID of pet that needs to be fetched
-        try { 
+        try {
             Order result = apiInstance.getOrderById(orderId);
-            
             System.out.println(result);
         } catch (ApiException e) {
             System.err.println("Exception when calling StoreApi#getOrderById");
@@ -222,7 +215,6 @@ No authorization required
 
 > Order placeOrder(body)
 
-
 Place an order for a pet
 
 ### Example
@@ -242,9 +234,8 @@ public class Example {
 
         StoreApi apiInstance = new StoreApi(defaultClient);
         Order body = new Order(); // Order | order placed for purchasing the pet
-        try { 
+        try {
             Order result = apiInstance.placeOrder(body);
-            
             System.out.println(result);
         } catch (ApiException e) {
             System.err.println("Exception when calling StoreApi#placeOrder");

--- a/samples/client/petstore/java/jersey2/docs/UserApi.md
+++ b/samples/client/petstore/java/jersey2/docs/UserApi.md
@@ -19,7 +19,6 @@ Method | HTTP request | Description
 
 > createUser(body)
 
-
 Create user
 
 This can only be done by the logged in user.
@@ -41,10 +40,8 @@ public class Example {
 
         UserApi apiInstance = new UserApi(defaultClient);
         User body = new User(); // User | Created user object
-        try { 
+        try {
             apiInstance.createUser(body);
-            
-            
         } catch (ApiException e) {
             System.err.println("Exception when calling UserApi#createUser");
             System.err.println("Status code: " + e.getCode());
@@ -86,7 +83,6 @@ No authorization required
 
 > createUsersWithArrayInput(body)
 
-
 Creates list of users with given input array
 
 ### Example
@@ -106,10 +102,8 @@ public class Example {
 
         UserApi apiInstance = new UserApi(defaultClient);
         List<User> body = Arrays.asList(); // List<User> | List of user object
-        try { 
+        try {
             apiInstance.createUsersWithArrayInput(body);
-            
-            
         } catch (ApiException e) {
             System.err.println("Exception when calling UserApi#createUsersWithArrayInput");
             System.err.println("Status code: " + e.getCode());
@@ -151,7 +145,6 @@ No authorization required
 
 > createUsersWithListInput(body)
 
-
 Creates list of users with given input array
 
 ### Example
@@ -171,10 +164,8 @@ public class Example {
 
         UserApi apiInstance = new UserApi(defaultClient);
         List<User> body = Arrays.asList(); // List<User> | List of user object
-        try { 
+        try {
             apiInstance.createUsersWithListInput(body);
-            
-            
         } catch (ApiException e) {
             System.err.println("Exception when calling UserApi#createUsersWithListInput");
             System.err.println("Status code: " + e.getCode());
@@ -216,7 +207,6 @@ No authorization required
 
 > deleteUser(username)
 
-
 Delete user
 
 This can only be done by the logged in user.
@@ -238,10 +228,8 @@ public class Example {
 
         UserApi apiInstance = new UserApi(defaultClient);
         String username = "username_example"; // String | The name that needs to be deleted
-        try { 
+        try {
             apiInstance.deleteUser(username);
-            
-            
         } catch (ApiException e) {
             System.err.println("Exception when calling UserApi#deleteUser");
             System.err.println("Status code: " + e.getCode());
@@ -284,7 +272,6 @@ No authorization required
 
 > User getUserByName(username)
 
-
 Get user by user name
 
 ### Example
@@ -304,9 +291,8 @@ public class Example {
 
         UserApi apiInstance = new UserApi(defaultClient);
         String username = "username_example"; // String | The name that needs to be fetched. Use user1 for testing.
-        try { 
+        try {
             User result = apiInstance.getUserByName(username);
-            
             System.out.println(result);
         } catch (ApiException e) {
             System.err.println("Exception when calling UserApi#getUserByName");
@@ -351,7 +337,6 @@ No authorization required
 
 > String loginUser(username, password)
 
-
 Logs user into the system
 
 ### Example
@@ -372,9 +357,8 @@ public class Example {
         UserApi apiInstance = new UserApi(defaultClient);
         String username = "username_example"; // String | The user name for login
         String password = "password_example"; // String | The password for login in clear text
-        try { 
+        try {
             String result = apiInstance.loginUser(username, password);
-            
             System.out.println(result);
         } catch (ApiException e) {
             System.err.println("Exception when calling UserApi#loginUser");
@@ -419,7 +403,6 @@ No authorization required
 
 > logoutUser()
 
-
 Logs out current logged in user session
 
 ### Example
@@ -438,10 +421,8 @@ public class Example {
         defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
         UserApi apiInstance = new UserApi(defaultClient);
-        try { 
+        try {
             apiInstance.logoutUser();
-            
-            
         } catch (ApiException e) {
             System.err.println("Exception when calling UserApi#logoutUser");
             System.err.println("Status code: " + e.getCode());
@@ -480,7 +461,6 @@ No authorization required
 
 > updateUser(username, body)
 
-
 Updated user
 
 This can only be done by the logged in user.
@@ -503,10 +483,8 @@ public class Example {
         UserApi apiInstance = new UserApi(defaultClient);
         String username = "username_example"; // String | name that need to be deleted
         User body = new User(); // User | Updated user object
-        try { 
+        try {
             apiInstance.updateUser(username, body);
-            
-            
         } catch (ApiException e) {
             System.err.println("Exception when calling UserApi#updateUser");
             System.err.println("Status code: " + e.getCode());


### PR DESCRIPTION
- Better code format the auto-generated doc (removed empty line breaks, trailing spaces, etc)

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

cc @bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04) @lwlee2608 (2019/10)
