### PR TITLE
Use HTTPS Maven URL in Kotlin meta generator

### DIFF
--- a/modules/openapi-generator/src/main/resources/codegen/kotlin/build_gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/codegen/kotlin/build_gradle.mustache
@@ -11,7 +11,7 @@ version = "1.0-SNAPSHOT"
 
 repositories {
     mavenLocal()
-    maven { url = "https://repo1.maven.org/maven2" }
+    maven { url = uri("https://repo1.maven.org/maven2") }
 }
 
 dependencies {

--- a/samples/meta-codegen-kotlin/lib/build.gradle.kts
+++ b/samples/meta-codegen-kotlin/lib/build.gradle.kts
@@ -11,7 +11,7 @@ version = "1.0-SNAPSHOT"
 
 repositories {
     mavenLocal()
-    mavenCentral()
+    maven { url = uri("https://repo1.maven.org/maven2") }
 }
 
 dependencies {


### PR DESCRIPTION
This continues on work in #5033 and #5034 which convert all http usage
to https to unblock CircleCI builds.

In #5034, mavenCentral() DSL was updated to explicitly target the https
maven repo because Gradle didn't force TLS 1.2 until v4.8.1 and many of
our examples use earlier versions of Gradle.  The Kotlin meta generator
was missed because it is a .kts build file rather than build.gradle, and
the mustache filename doesn't have kts in it; the file was updated as if
it was build.gradle (groovy syntax).

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
