### PR TITLE
[gradle] consistent use of maven url in gradle files

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -51,7 +51,7 @@ To include in your project, add the following to `build.gradle`:
 buildscript {
   repositories {
     mavenLocal()
-    maven { url = "https://repo1.maven.org/maven2" }
+    maven { url "https://repo1.maven.org/maven2" }
   }
   dependencies {
     classpath "org.openapitools:openapi-generator-gradle-plugin:3.3.4"

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -51,7 +51,7 @@ To include in your project, add the following to `build.gradle`:
 buildscript {
   repositories {
     mavenLocal()
-    maven { url = uri("https://repo1.maven.org/maven2") }
+    maven { url = "https://repo1.maven.org/maven2" }
   }
   dependencies {
     classpath "org.openapitools:openapi-generator-gradle-plugin:3.3.4"

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -51,7 +51,7 @@ To include in your project, add the following to `build.gradle`:
 buildscript {
   repositories {
     mavenLocal()
-    maven { url = "https://repo1.maven.org/maven2" }
+    maven { url = uri("https://repo1.maven.org/maven2") }
   }
   dependencies {
     classpath "org.openapitools:openapi-generator-gradle-plugin:3.3.4"

--- a/modules/openapi-generator-gradle-plugin/README.adoc
+++ b/modules/openapi-generator-gradle-plugin/README.adoc
@@ -56,7 +56,7 @@ Using https://docs.gradle.org/current/userguide/plugins.html#sec:old_plugin_appl
 buildscript {
   repositories {
     mavenLocal()
-    maven { url = "https://repo1.maven.org/maven2" }
+    maven { url "https://repo1.maven.org/maven2" }
     // or, via Gradle Plugin Portal:
     // url "https://plugins.gradle.org/m2/"
   }

--- a/modules/openapi-generator-gradle-plugin/README.adoc
+++ b/modules/openapi-generator-gradle-plugin/README.adoc
@@ -56,7 +56,7 @@ Using https://docs.gradle.org/current/userguide/plugins.html#sec:old_plugin_appl
 buildscript {
   repositories {
     mavenLocal()
-    maven { url = "https://repo1.maven.org/maven2" }
+    maven { url = uri("https://repo1.maven.org/maven2") }
     // or, via Gradle Plugin Portal:
     // url "https://plugins.gradle.org/m2/"
   }

--- a/modules/openapi-generator-gradle-plugin/README.adoc
+++ b/modules/openapi-generator-gradle-plugin/README.adoc
@@ -56,7 +56,7 @@ Using https://docs.gradle.org/current/userguide/plugins.html#sec:old_plugin_appl
 buildscript {
   repositories {
     mavenLocal()
-    maven { url = uri("https://repo1.maven.org/maven2") }
+    maven { url = "https://repo1.maven.org/maven2" }
     // or, via Gradle Plugin Portal:
     // url "https://plugins.gradle.org/m2/"
   }

--- a/modules/openapi-generator-gradle-plugin/build.gradle
+++ b/modules/openapi-generator-gradle-plugin/build.gradle
@@ -2,7 +2,7 @@ buildscript {
     ext.kotlin_version = '1.3.20'
     repositories {
         mavenLocal()
-        maven { url = "https://repo1.maven.org/maven2" }
+        maven { url = uri("https://repo1.maven.org/maven2") }
         maven {
             url "https://plugins.gradle.org/m2/"
         }
@@ -46,7 +46,7 @@ targetCompatibility = 1.8
 
 repositories {
     jcenter()
-    maven { url = "https://repo1.maven.org/maven2" }
+    maven { url = uri("https://repo1.maven.org/maven2") }
     mavenLocal()
     maven {
         url "https://oss.sonatype.org/content/repositories/releases/"

--- a/modules/openapi-generator-gradle-plugin/build.gradle
+++ b/modules/openapi-generator-gradle-plugin/build.gradle
@@ -2,7 +2,7 @@ buildscript {
     ext.kotlin_version = '1.3.20'
     repositories {
         mavenLocal()
-        maven { url = uri("https://repo1.maven.org/maven2") }
+        maven { url "https://repo1.maven.org/maven2" }
         maven {
             url "https://plugins.gradle.org/m2/"
         }
@@ -46,7 +46,7 @@ targetCompatibility = 1.8
 
 repositories {
     jcenter()
-    maven { url = uri("https://repo1.maven.org/maven2") }
+    maven { url "https://repo1.maven.org/maven2" }
     mavenLocal()
     maven {
         url "https://oss.sonatype.org/content/repositories/releases/"

--- a/modules/openapi-generator-gradle-plugin/build.gradle
+++ b/modules/openapi-generator-gradle-plugin/build.gradle
@@ -2,7 +2,7 @@ buildscript {
     ext.kotlin_version = '1.3.20'
     repositories {
         mavenLocal()
-        maven { url "https://repo1.maven.org/maven2" }
+        maven { url = "https://repo1.maven.org/maven2" }
         maven {
             url "https://plugins.gradle.org/m2/"
         }
@@ -46,7 +46,7 @@ targetCompatibility = 1.8
 
 repositories {
     jcenter()
-    maven { url "https://repo1.maven.org/maven2" }
+    maven { url = "https://repo1.maven.org/maven2" }
     mavenLocal()
     maven {
         url "https://oss.sonatype.org/content/repositories/releases/"

--- a/modules/openapi-generator-gradle-plugin/build.gradle
+++ b/modules/openapi-generator-gradle-plugin/build.gradle
@@ -2,7 +2,7 @@ buildscript {
     ext.kotlin_version = '1.3.20'
     repositories {
         mavenLocal()
-        maven { url = "https://repo1.maven.org/maven2" }
+        maven { url "https://repo1.maven.org/maven2" }
         maven {
             url "https://plugins.gradle.org/m2/"
         }
@@ -46,7 +46,7 @@ targetCompatibility = 1.8
 
 repositories {
     jcenter()
-    maven { url = "https://repo1.maven.org/maven2" }
+    maven { url "https://repo1.maven.org/maven2" }
     mavenLocal()
     maven {
         url "https://oss.sonatype.org/content/repositories/releases/"

--- a/modules/openapi-generator-gradle-plugin/samples/local-spec/build.gradle
+++ b/modules/openapi-generator-gradle-plugin/samples/local-spec/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     repositories {
         mavenLocal()
-        maven { url = "https://repo1.maven.org/maven2" }
+        maven { url "https://repo1.maven.org/maven2" }
         maven {
             url "https://plugins.gradle.org/m2/"
         }

--- a/modules/openapi-generator-gradle-plugin/samples/local-spec/build.gradle
+++ b/modules/openapi-generator-gradle-plugin/samples/local-spec/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     repositories {
         mavenLocal()
-        maven { url "https://repo1.maven.org/maven2" }
+        maven { url = "https://repo1.maven.org/maven2" }
         maven {
             url "https://plugins.gradle.org/m2/"
         }

--- a/modules/openapi-generator-gradle-plugin/samples/local-spec/build.gradle
+++ b/modules/openapi-generator-gradle-plugin/samples/local-spec/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     repositories {
         mavenLocal()
-        maven { url = "https://repo1.maven.org/maven2" }
+        maven { url = uri("https://repo1.maven.org/maven2") }
         maven {
             url "https://plugins.gradle.org/m2/"
         }

--- a/modules/openapi-generator-gradle-plugin/samples/local-spec/build.gradle
+++ b/modules/openapi-generator-gradle-plugin/samples/local-spec/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     repositories {
         mavenLocal()
-        maven { url = uri("https://repo1.maven.org/maven2") }
+        maven { url "https://repo1.maven.org/maven2" }
         maven {
             url "https://plugins.gradle.org/m2/"
         }

--- a/modules/openapi-generator/src/main/resources/Groovy/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Groovy/build.gradle.mustache
@@ -14,7 +14,7 @@ wrapper {
 buildscript {
     repositories {
         maven { url = "https://repo1.maven.org/maven2" }
-        maven { url 'https://repo.jfrog.org/artifactory/gradle-plugins' }
+        maven { url = 'https://repo.jfrog.org/artifactory/gradle-plugins' }
     }
     dependencies {
         classpath(group: 'org.jfrog.buildinfo', name: 'build-info-extractor-gradle', version: '2.0.16')

--- a/modules/openapi-generator/src/main/resources/Groovy/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Groovy/build.gradle.mustache
@@ -13,7 +13,7 @@ wrapper {
 
 buildscript {
     repositories {
-        maven { url = "https://repo1.maven.org/maven2" }
+        maven { url "https://repo1.maven.org/maven2" }
         maven { url = 'https://repo.jfrog.org/artifactory/gradle-plugins' }
     }
     dependencies {
@@ -22,7 +22,7 @@ buildscript {
 }
 
 repositories {
-    maven { url = "https://repo1.maven.org/maven2" }
+    maven { url "https://repo1.maven.org/maven2" }
     mavenLocal()
 }
 

--- a/modules/openapi-generator/src/main/resources/Groovy/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Groovy/build.gradle.mustache
@@ -22,7 +22,7 @@ buildscript {
 }
 
 repositories {
-    maven { url = "https://repo1.maven.org/maven2" }
+    maven { url = uri("https://repo1.maven.org/maven2") }
     mavenLocal()
 }
 

--- a/modules/openapi-generator/src/main/resources/Groovy/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Groovy/build.gradle.mustache
@@ -22,7 +22,7 @@ buildscript {
 }
 
 repositories {
-    maven { url = uri("https://repo1.maven.org/maven2") }
+    maven { url "https://repo1.maven.org/maven2" }
     mavenLocal()
 }
 

--- a/modules/openapi-generator/src/main/resources/Groovy/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Groovy/build.gradle.mustache
@@ -13,7 +13,7 @@ wrapper {
 
 buildscript {
     repositories {
-        maven { url "https://repo1.maven.org/maven2" }
+        maven { url = "https://repo1.maven.org/maven2" }
         maven { url 'https://repo.jfrog.org/artifactory/gradle-plugins' }
     }
     dependencies {
@@ -22,7 +22,7 @@ buildscript {
 }
 
 repositories {
-    maven { url "https://repo1.maven.org/maven2" }
+    maven { url = "https://repo1.maven.org/maven2" }
     mavenLocal()
 }
 

--- a/modules/openapi-generator/src/main/resources/Java/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/build.gradle.mustache
@@ -6,7 +6,7 @@ version = '{{artifactVersion}}'
 
 buildscript {
     repositories {
-        maven { url "https://repo1.maven.org/maven2" }
+        maven { url = "https://repo1.maven.org/maven2" }
         jcenter()
     }
     dependencies {
@@ -16,7 +16,7 @@ buildscript {
 }
 
 repositories {
-    maven { url "https://repo1.maven.org/maven2" }
+    maven { url = "https://repo1.maven.org/maven2" }
     jcenter()
 }
 

--- a/modules/openapi-generator/src/main/resources/Java/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/build.gradle.mustache
@@ -6,7 +6,7 @@ version = '{{artifactVersion}}'
 
 buildscript {
     repositories {
-        maven { url = "https://repo1.maven.org/maven2" }
+        maven { url = uri("https://repo1.maven.org/maven2") }
         jcenter()
     }
     dependencies {
@@ -16,7 +16,7 @@ buildscript {
 }
 
 repositories {
-    maven { url = "https://repo1.maven.org/maven2" }
+    maven { url = uri("https://repo1.maven.org/maven2") }
     jcenter()
 }
 

--- a/modules/openapi-generator/src/main/resources/Java/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/build.gradle.mustache
@@ -6,7 +6,7 @@ version = '{{artifactVersion}}'
 
 buildscript {
     repositories {
-        maven { url = "https://repo1.maven.org/maven2" }
+        maven { url "https://repo1.maven.org/maven2" }
         jcenter()
     }
     dependencies {
@@ -16,7 +16,7 @@ buildscript {
 }
 
 repositories {
-    maven { url = "https://repo1.maven.org/maven2" }
+    maven { url "https://repo1.maven.org/maven2" }
     jcenter()
 }
 

--- a/modules/openapi-generator/src/main/resources/Java/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/build.gradle.mustache
@@ -6,7 +6,7 @@ version = '{{artifactVersion}}'
 
 buildscript {
     repositories {
-        maven { url = uri("https://repo1.maven.org/maven2") }
+        maven { url "https://repo1.maven.org/maven2" }
         jcenter()
     }
     dependencies {
@@ -16,7 +16,7 @@ buildscript {
 }
 
 repositories {
-    maven { url = uri("https://repo1.maven.org/maven2") }
+    maven { url "https://repo1.maven.org/maven2" }
     jcenter()
 }
 

--- a/modules/openapi-generator/src/main/resources/Java/libraries/feign/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/feign/build.gradle.mustache
@@ -6,7 +6,7 @@ version = '{{artifactVersion}}'
 
 buildscript {
     repositories {
-        maven { url = "https://repo1.maven.org/maven2" }
+        maven { url = uri("https://repo1.maven.org/maven2") }
         jcenter()
     }
     dependencies {

--- a/modules/openapi-generator/src/main/resources/Java/libraries/feign/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/feign/build.gradle.mustache
@@ -6,7 +6,7 @@ version = '{{artifactVersion}}'
 
 buildscript {
     repositories {
-        maven { url = "https://repo1.maven.org/maven2" }
+        maven { url "https://repo1.maven.org/maven2" }
         jcenter()
     }
     dependencies {

--- a/modules/openapi-generator/src/main/resources/Java/libraries/feign/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/feign/build.gradle.mustache
@@ -6,7 +6,7 @@ version = '{{artifactVersion}}'
 
 buildscript {
     repositories {
-        maven { url "https://repo1.maven.org/maven2" }
+        maven { url = "https://repo1.maven.org/maven2" }
         jcenter()
     }
     dependencies {

--- a/modules/openapi-generator/src/main/resources/Java/libraries/feign/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/feign/build.gradle.mustache
@@ -6,7 +6,7 @@ version = '{{artifactVersion}}'
 
 buildscript {
     repositories {
-        maven { url = uri("https://repo1.maven.org/maven2") }
+        maven { url "https://repo1.maven.org/maven2" }
         jcenter()
     }
     dependencies {

--- a/modules/openapi-generator/src/main/resources/Java/libraries/google-api-client/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/google-api-client/build.gradle.mustache
@@ -6,7 +6,7 @@ version = '{{artifactVersion}}'
 
 buildscript {
     repositories {
-        maven { url = "https://repo1.maven.org/maven2" }
+        maven { url = uri("https://repo1.maven.org/maven2") }
         jcenter()
     }
     dependencies {

--- a/modules/openapi-generator/src/main/resources/Java/libraries/google-api-client/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/google-api-client/build.gradle.mustache
@@ -6,7 +6,7 @@ version = '{{artifactVersion}}'
 
 buildscript {
     repositories {
-        maven { url = "https://repo1.maven.org/maven2" }
+        maven { url "https://repo1.maven.org/maven2" }
         jcenter()
     }
     dependencies {

--- a/modules/openapi-generator/src/main/resources/Java/libraries/google-api-client/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/google-api-client/build.gradle.mustache
@@ -6,7 +6,7 @@ version = '{{artifactVersion}}'
 
 buildscript {
     repositories {
-        maven { url "https://repo1.maven.org/maven2" }
+        maven { url = "https://repo1.maven.org/maven2" }
         jcenter()
     }
     dependencies {

--- a/modules/openapi-generator/src/main/resources/Java/libraries/google-api-client/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/google-api-client/build.gradle.mustache
@@ -6,7 +6,7 @@ version = '{{artifactVersion}}'
 
 buildscript {
     repositories {
-        maven { url = uri("https://repo1.maven.org/maven2") }
+        maven { url "https://repo1.maven.org/maven2" }
         jcenter()
     }
     dependencies {

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/build.gradle.mustache
@@ -6,7 +6,7 @@ version = '{{artifactVersion}}'
 
 buildscript {
     repositories {
-        maven { url = "https://repo1.maven.org/maven2" }
+        maven { url = uri("https://repo1.maven.org/maven2") }
         jcenter()
     }
     dependencies {

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/build.gradle.mustache
@@ -6,7 +6,7 @@ version = '{{artifactVersion}}'
 
 buildscript {
     repositories {
-        maven { url = "https://repo1.maven.org/maven2" }
+        maven { url "https://repo1.maven.org/maven2" }
         jcenter()
     }
     dependencies {

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/build.gradle.mustache
@@ -6,7 +6,7 @@ version = '{{artifactVersion}}'
 
 buildscript {
     repositories {
-        maven { url "https://repo1.maven.org/maven2" }
+        maven { url = "https://repo1.maven.org/maven2" }
         jcenter()
     }
     dependencies {

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/build.gradle.mustache
@@ -6,7 +6,7 @@ version = '{{artifactVersion}}'
 
 buildscript {
     repositories {
-        maven { url = uri("https://repo1.maven.org/maven2") }
+        maven { url "https://repo1.maven.org/maven2" }
         jcenter()
     }
     dependencies {

--- a/modules/openapi-generator/src/main/resources/Java/libraries/native/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/native/build.gradle.mustache
@@ -6,13 +6,13 @@ version = '{{artifactVersion}}'
 
 buildscript {
     repositories {
-        maven { url "https://repo1.maven.org/maven2" }
+        maven { url = "https://repo1.maven.org/maven2" }
         jcenter()
     }
 }
 
 repositories {
-    maven { url "https://repo1.maven.org/maven2" }
+    maven { url = "https://repo1.maven.org/maven2" }
     jcenter()
 }
 

--- a/modules/openapi-generator/src/main/resources/Java/libraries/native/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/native/build.gradle.mustache
@@ -6,13 +6,13 @@ version = '{{artifactVersion}}'
 
 buildscript {
     repositories {
-        maven { url = uri("https://repo1.maven.org/maven2") }
+        maven { url "https://repo1.maven.org/maven2" }
         jcenter()
     }
 }
 
 repositories {
-    maven { url = uri("https://repo1.maven.org/maven2") }
+    maven { url "https://repo1.maven.org/maven2" }
     jcenter()
 }
 

--- a/modules/openapi-generator/src/main/resources/Java/libraries/native/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/native/build.gradle.mustache
@@ -6,13 +6,13 @@ version = '{{artifactVersion}}'
 
 buildscript {
     repositories {
-        maven { url = "https://repo1.maven.org/maven2" }
+        maven { url = uri("https://repo1.maven.org/maven2") }
         jcenter()
     }
 }
 
 repositories {
-    maven { url = "https://repo1.maven.org/maven2" }
+    maven { url = uri("https://repo1.maven.org/maven2") }
     jcenter()
 }
 

--- a/modules/openapi-generator/src/main/resources/Java/libraries/native/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/native/build.gradle.mustache
@@ -6,13 +6,13 @@ version = '{{artifactVersion}}'
 
 buildscript {
     repositories {
-        maven { url = "https://repo1.maven.org/maven2" }
+        maven { url "https://repo1.maven.org/maven2" }
         jcenter()
     }
 }
 
 repositories {
-    maven { url = "https://repo1.maven.org/maven2" }
+    maven { url "https://repo1.maven.org/maven2" }
     jcenter()
 }
 

--- a/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/build.gradle.mustache
@@ -9,7 +9,7 @@ version = '{{artifactVersion}}'
 
 buildscript {
     repositories {
-        maven { url = "https://repo1.maven.org/maven2" }
+        maven { url = uri("https://repo1.maven.org/maven2") }
         jcenter()
     }
     dependencies {

--- a/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/build.gradle.mustache
@@ -9,7 +9,7 @@ version = '{{artifactVersion}}'
 
 buildscript {
     repositories {
-        maven { url = uri("https://repo1.maven.org/maven2") }
+        maven { url "https://repo1.maven.org/maven2" }
         jcenter()
     }
     dependencies {

--- a/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/build.gradle.mustache
@@ -9,7 +9,7 @@ version = '{{artifactVersion}}'
 
 buildscript {
     repositories {
-        maven { url = "https://repo1.maven.org/maven2" }
+        maven { url "https://repo1.maven.org/maven2" }
         jcenter()
     }
     dependencies {

--- a/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/build.gradle.mustache
@@ -9,7 +9,7 @@ version = '{{artifactVersion}}'
 
 buildscript {
     repositories {
-        maven { url "https://repo1.maven.org/maven2" }
+        maven { url = "https://repo1.maven.org/maven2" }
         jcenter()
     }
     dependencies {

--- a/modules/openapi-generator/src/main/resources/Java/libraries/rest-assured/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/rest-assured/build.gradle.mustache
@@ -6,7 +6,7 @@ version = '{{artifactVersion}}'
 
 buildscript {
     repositories {
-        maven { url = "https://repo1.maven.org/maven2" }
+        maven { url = uri("https://repo1.maven.org/maven2") }
         jcenter()
     }
     dependencies {

--- a/modules/openapi-generator/src/main/resources/Java/libraries/rest-assured/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/rest-assured/build.gradle.mustache
@@ -6,7 +6,7 @@ version = '{{artifactVersion}}'
 
 buildscript {
     repositories {
-        maven { url = "https://repo1.maven.org/maven2" }
+        maven { url "https://repo1.maven.org/maven2" }
         jcenter()
     }
     dependencies {

--- a/modules/openapi-generator/src/main/resources/Java/libraries/rest-assured/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/rest-assured/build.gradle.mustache
@@ -6,7 +6,7 @@ version = '{{artifactVersion}}'
 
 buildscript {
     repositories {
-        maven { url "https://repo1.maven.org/maven2" }
+        maven { url = "https://repo1.maven.org/maven2" }
         jcenter()
     }
     dependencies {

--- a/modules/openapi-generator/src/main/resources/Java/libraries/rest-assured/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/rest-assured/build.gradle.mustache
@@ -6,7 +6,7 @@ version = '{{artifactVersion}}'
 
 buildscript {
     repositories {
-        maven { url = uri("https://repo1.maven.org/maven2") }
+        maven { url "https://repo1.maven.org/maven2" }
         jcenter()
     }
     dependencies {

--- a/modules/openapi-generator/src/main/resources/Java/libraries/resteasy/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/resteasy/build.gradle.mustache
@@ -6,7 +6,7 @@ version = '{{artifactVersion}}'
 
 buildscript {
     repositories {
-        maven { url = "https://repo1.maven.org/maven2" }
+        maven { url = uri("https://repo1.maven.org/maven2") }
         jcenter()
     }
     dependencies {

--- a/modules/openapi-generator/src/main/resources/Java/libraries/resteasy/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/resteasy/build.gradle.mustache
@@ -6,7 +6,7 @@ version = '{{artifactVersion}}'
 
 buildscript {
     repositories {
-        maven { url = "https://repo1.maven.org/maven2" }
+        maven { url "https://repo1.maven.org/maven2" }
         jcenter()
     }
     dependencies {

--- a/modules/openapi-generator/src/main/resources/Java/libraries/resteasy/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/resteasy/build.gradle.mustache
@@ -6,7 +6,7 @@ version = '{{artifactVersion}}'
 
 buildscript {
     repositories {
-        maven { url "https://repo1.maven.org/maven2" }
+        maven { url = "https://repo1.maven.org/maven2" }
         jcenter()
     }
     dependencies {

--- a/modules/openapi-generator/src/main/resources/Java/libraries/resteasy/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/resteasy/build.gradle.mustache
@@ -6,7 +6,7 @@ version = '{{artifactVersion}}'
 
 buildscript {
     repositories {
-        maven { url = uri("https://repo1.maven.org/maven2") }
+        maven { url "https://repo1.maven.org/maven2" }
         jcenter()
     }
     dependencies {

--- a/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/build.gradle.mustache
@@ -6,7 +6,7 @@ version = '{{artifactVersion}}'
 
 buildscript {
     repositories {
-        maven { url = "https://repo1.maven.org/maven2" }
+        maven { url = uri("https://repo1.maven.org/maven2") }
         jcenter()
     }
     dependencies {

--- a/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/build.gradle.mustache
@@ -6,7 +6,7 @@ version = '{{artifactVersion}}'
 
 buildscript {
     repositories {
-        maven { url = "https://repo1.maven.org/maven2" }
+        maven { url "https://repo1.maven.org/maven2" }
         jcenter()
     }
     dependencies {

--- a/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/build.gradle.mustache
@@ -6,7 +6,7 @@ version = '{{artifactVersion}}'
 
 buildscript {
     repositories {
-        maven { url "https://repo1.maven.org/maven2" }
+        maven { url = "https://repo1.maven.org/maven2" }
         jcenter()
     }
     dependencies {

--- a/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/build.gradle.mustache
@@ -6,7 +6,7 @@ version = '{{artifactVersion}}'
 
 buildscript {
     repositories {
-        maven { url = uri("https://repo1.maven.org/maven2") }
+        maven { url "https://repo1.maven.org/maven2" }
         jcenter()
     }
     dependencies {

--- a/modules/openapi-generator/src/main/resources/Java/libraries/retrofit/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/retrofit/build.gradle.mustache
@@ -6,7 +6,7 @@ version = '{{artifactVersion}}'
 
 buildscript {
     repositories {
-        maven { url = "https://repo1.maven.org/maven2" }
+        maven { url = uri("https://repo1.maven.org/maven2") }
         jcenter()
     }
     dependencies {

--- a/modules/openapi-generator/src/main/resources/Java/libraries/retrofit/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/retrofit/build.gradle.mustache
@@ -6,7 +6,7 @@ version = '{{artifactVersion}}'
 
 buildscript {
     repositories {
-        maven { url = "https://repo1.maven.org/maven2" }
+        maven { url "https://repo1.maven.org/maven2" }
         jcenter()
     }
     dependencies {

--- a/modules/openapi-generator/src/main/resources/Java/libraries/retrofit/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/retrofit/build.gradle.mustache
@@ -6,7 +6,7 @@ version = '{{artifactVersion}}'
 
 buildscript {
     repositories {
-        maven { url "https://repo1.maven.org/maven2" }
+        maven { url = "https://repo1.maven.org/maven2" }
         jcenter()
     }
     dependencies {

--- a/modules/openapi-generator/src/main/resources/Java/libraries/retrofit/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/retrofit/build.gradle.mustache
@@ -6,7 +6,7 @@ version = '{{artifactVersion}}'
 
 buildscript {
     repositories {
-        maven { url = uri("https://repo1.maven.org/maven2") }
+        maven { url "https://repo1.maven.org/maven2" }
         jcenter()
     }
     dependencies {

--- a/modules/openapi-generator/src/main/resources/Java/libraries/retrofit2/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/retrofit2/build.gradle.mustache
@@ -6,7 +6,7 @@ version = '{{artifactVersion}}'
 
 buildscript {
     repositories {
-        maven { url = "https://repo1.maven.org/maven2" }
+        maven { url = uri("https://repo1.maven.org/maven2") }
         jcenter()
     }
     dependencies {

--- a/modules/openapi-generator/src/main/resources/Java/libraries/retrofit2/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/retrofit2/build.gradle.mustache
@@ -6,7 +6,7 @@ version = '{{artifactVersion}}'
 
 buildscript {
     repositories {
-        maven { url = "https://repo1.maven.org/maven2" }
+        maven { url "https://repo1.maven.org/maven2" }
         jcenter()
     }
     dependencies {

--- a/modules/openapi-generator/src/main/resources/Java/libraries/retrofit2/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/retrofit2/build.gradle.mustache
@@ -6,7 +6,7 @@ version = '{{artifactVersion}}'
 
 buildscript {
     repositories {
-        maven { url "https://repo1.maven.org/maven2" }
+        maven { url = "https://repo1.maven.org/maven2" }
         jcenter()
     }
     dependencies {

--- a/modules/openapi-generator/src/main/resources/Java/libraries/retrofit2/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/retrofit2/build.gradle.mustache
@@ -6,7 +6,7 @@ version = '{{artifactVersion}}'
 
 buildscript {
     repositories {
-        maven { url = uri("https://repo1.maven.org/maven2") }
+        maven { url "https://repo1.maven.org/maven2" }
         jcenter()
     }
     dependencies {

--- a/modules/openapi-generator/src/main/resources/Java/libraries/vertx/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/vertx/build.gradle.mustache
@@ -5,7 +5,7 @@ group = '{{groupId}}'
 version = '{{artifactVersion}}'
 
 repositories {
-    maven { url "https://repo1.maven.org/maven2" }
+    maven { url = "https://repo1.maven.org/maven2" }
     jcenter()
 }
 

--- a/modules/openapi-generator/src/main/resources/Java/libraries/vertx/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/vertx/build.gradle.mustache
@@ -5,7 +5,7 @@ group = '{{groupId}}'
 version = '{{artifactVersion}}'
 
 repositories {
-    maven { url = "https://repo1.maven.org/maven2" }
+    maven { url = uri("https://repo1.maven.org/maven2") }
     jcenter()
 }
 

--- a/modules/openapi-generator/src/main/resources/Java/libraries/vertx/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/vertx/build.gradle.mustache
@@ -5,7 +5,7 @@ group = '{{groupId}}'
 version = '{{artifactVersion}}'
 
 repositories {
-    maven { url = "https://repo1.maven.org/maven2" }
+    maven { url "https://repo1.maven.org/maven2" }
     jcenter()
 }
 

--- a/modules/openapi-generator/src/main/resources/Java/libraries/vertx/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/vertx/build.gradle.mustache
@@ -5,7 +5,7 @@ group = '{{groupId}}'
 version = '{{artifactVersion}}'
 
 repositories {
-    maven { url = uri("https://repo1.maven.org/maven2") }
+    maven { url "https://repo1.maven.org/maven2" }
     jcenter()
 }
 

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy/eap/gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy/eap/gradle.mustache
@@ -4,7 +4,7 @@ project.version = "{{artifactVersion}}"
 project.group = "{{groupId}}"
 
 repositories {
-    maven { url = uri("https://repo1.maven.org/maven2") }
+    maven { url = "https://repo1.maven.org/maven2" }
 }
 
 dependencies {

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy/eap/gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy/eap/gradle.mustache
@@ -4,7 +4,7 @@ project.version = "{{artifactVersion}}"
 project.group = "{{groupId}}"
 
 repositories {
-    maven { url = "https://repo1.maven.org/maven2" }
+    maven { url "https://repo1.maven.org/maven2" }
 }
 
 dependencies {

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy/eap/gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy/eap/gradle.mustache
@@ -4,7 +4,7 @@ project.version = "{{artifactVersion}}"
 project.group = "{{groupId}}"
 
 repositories {
-    maven { url = "https://repo1.maven.org/maven2" }
+    maven { url = uri("https://repo1.maven.org/maven2") }
 }
 
 dependencies {

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy/gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy/gradle.mustache
@@ -4,7 +4,7 @@ project.version = "{{artifactVersion}}"
 project.group = "{{groupId}}"
 
 repositories {
-    maven { url = uri("https://repo1.maven.org/maven2") }
+    maven { url = "https://repo1.maven.org/maven2" }
 }
 
 dependencies {

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy/gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy/gradle.mustache
@@ -4,7 +4,7 @@ project.version = "{{artifactVersion}}"
 project.group = "{{groupId}}"
 
 repositories {
-    maven { url = "https://repo1.maven.org/maven2" }
+    maven { url "https://repo1.maven.org/maven2" }
 }
 
 dependencies {

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy/gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy/gradle.mustache
@@ -4,7 +4,7 @@ project.version = "{{artifactVersion}}"
 project.group = "{{groupId}}"
 
 repositories {
-    maven { url = "https://repo1.maven.org/maven2" }
+    maven { url = uri("https://repo1.maven.org/maven2") }
 }
 
 dependencies {

--- a/modules/openapi-generator/src/main/resources/android/build.mustache
+++ b/modules/openapi-generator/src/main/resources/android/build.mustache
@@ -5,7 +5,7 @@ project.version = '{{artifactVersion}}'
 
 buildscript {
     repositories {
-        maven { url = uri("https://repo1.maven.org/maven2") }
+        maven { url = "https://repo1.maven.org/maven2" }
         jcenter()
     }
     dependencies {

--- a/modules/openapi-generator/src/main/resources/android/build.mustache
+++ b/modules/openapi-generator/src/main/resources/android/build.mustache
@@ -5,7 +5,7 @@ project.version = '{{artifactVersion}}'
 
 buildscript {
     repositories {
-        maven { url = "https://repo1.maven.org/maven2" }
+        maven { url = uri("https://repo1.maven.org/maven2") }
         jcenter()
     }
     dependencies {

--- a/modules/openapi-generator/src/main/resources/android/build.mustache
+++ b/modules/openapi-generator/src/main/resources/android/build.mustache
@@ -5,7 +5,7 @@ project.version = '{{artifactVersion}}'
 
 buildscript {
     repositories {
-        maven { url = "https://repo1.maven.org/maven2" }
+        maven { url "https://repo1.maven.org/maven2" }
         jcenter()
     }
     dependencies {

--- a/modules/openapi-generator/src/main/resources/android/libraries/volley/build.mustache
+++ b/modules/openapi-generator/src/main/resources/android/libraries/volley/build.mustache
@@ -5,7 +5,7 @@ project.version = '{{artifactVersion}}'
 
 buildscript {
     repositories {
-        maven { url = uri("https://repo1.maven.org/maven2") }
+        maven { url = "https://repo1.maven.org/maven2" }
         jcenter()
     }
     dependencies {

--- a/modules/openapi-generator/src/main/resources/android/libraries/volley/build.mustache
+++ b/modules/openapi-generator/src/main/resources/android/libraries/volley/build.mustache
@@ -5,7 +5,7 @@ project.version = '{{artifactVersion}}'
 
 buildscript {
     repositories {
-        maven { url = "https://repo1.maven.org/maven2" }
+        maven { url = uri("https://repo1.maven.org/maven2") }
         jcenter()
     }
     dependencies {

--- a/modules/openapi-generator/src/main/resources/android/libraries/volley/build.mustache
+++ b/modules/openapi-generator/src/main/resources/android/libraries/volley/build.mustache
@@ -5,7 +5,7 @@ project.version = '{{artifactVersion}}'
 
 buildscript {
     repositories {
-        maven { url = "https://repo1.maven.org/maven2" }
+        maven { url "https://repo1.maven.org/maven2" }
         jcenter()
     }
     dependencies {

--- a/modules/openapi-generator/src/main/resources/codegen/kotlin/build_gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/codegen/kotlin/build_gradle.mustache
@@ -11,7 +11,7 @@ version = "1.0-SNAPSHOT"
 
 repositories {
     mavenLocal()
-    maven { url "https://repo1.maven.org/maven2" }
+    maven { url = uri("https://repo1.maven.org/maven2") }
 }
 
 dependencies {

--- a/modules/openapi-generator/src/main/resources/codegen/kotlin/build_gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/codegen/kotlin/build_gradle.mustache
@@ -11,7 +11,7 @@ version = "1.0-SNAPSHOT"
 
 repositories {
     mavenLocal()
-    maven { url = "https://repo1.maven.org/maven2" }
+    maven { url = uri("https://repo1.maven.org/maven2") }
 }
 
 dependencies {

--- a/modules/openapi-generator/src/main/resources/codegen/kotlin/build_gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/codegen/kotlin/build_gradle.mustache
@@ -11,7 +11,7 @@ version = "1.0-SNAPSHOT"
 
 repositories {
     mavenLocal()
-    maven { url = uri("https://repo1.maven.org/maven2") }
+    maven { url = "https://repo1.maven.org/maven2" }
 }
 
 dependencies {

--- a/modules/openapi-generator/src/main/resources/codegen/kotlin/build_gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/codegen/kotlin/build_gradle.mustache
@@ -11,7 +11,7 @@ version = "1.0-SNAPSHOT"
 
 repositories {
     mavenLocal()
-    maven { url = "https://repo1.maven.org/maven2" }
+    maven { url "https://repo1.maven.org/maven2" }
 }
 
 dependencies {

--- a/modules/openapi-generator/src/main/resources/kotlin-client/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/build.gradle.mustache
@@ -13,7 +13,7 @@ buildscript {
     {{/jvm-retrofit2}}
 
     repositories {
-        maven { url = uri("https://repo1.maven.org/maven2") }
+        maven { url "https://repo1.maven.org/maven2" }
     }
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
@@ -26,7 +26,7 @@ apply plugin: 'kotlin-kapt'
 {{/moshiCodeGen}}
 
 repositories {
-    maven { url = uri("https://repo1.maven.org/maven2") }
+    maven { url "https://repo1.maven.org/maven2" }
 }
 
 test {

--- a/modules/openapi-generator/src/main/resources/kotlin-client/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/build.gradle.mustache
@@ -13,7 +13,7 @@ buildscript {
     {{/jvm-retrofit2}}
 
     repositories {
-        maven { url "https://repo1.maven.org/maven2" }
+        maven { url = "https://repo1.maven.org/maven2" }
     }
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
@@ -26,7 +26,7 @@ apply plugin: 'kotlin-kapt'
 {{/moshiCodeGen}}
 
 repositories {
-    maven { url "https://repo1.maven.org/maven2" }
+    maven { url = "https://repo1.maven.org/maven2" }
 }
 
 test {

--- a/modules/openapi-generator/src/main/resources/kotlin-client/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/build.gradle.mustache
@@ -13,7 +13,7 @@ buildscript {
     {{/jvm-retrofit2}}
 
     repositories {
-        maven { url = "https://repo1.maven.org/maven2" }
+        maven { url "https://repo1.maven.org/maven2" }
     }
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
@@ -26,7 +26,7 @@ apply plugin: 'kotlin-kapt'
 {{/moshiCodeGen}}
 
 repositories {
-    maven { url = "https://repo1.maven.org/maven2" }
+    maven { url "https://repo1.maven.org/maven2" }
 }
 
 test {

--- a/modules/openapi-generator/src/main/resources/kotlin-client/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/build.gradle.mustache
@@ -13,7 +13,7 @@ buildscript {
     {{/jvm-retrofit2}}
 
     repositories {
-        maven { url = "https://repo1.maven.org/maven2" }
+        maven { url = uri("https://repo1.maven.org/maven2") }
     }
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
@@ -26,7 +26,7 @@ apply plugin: 'kotlin-kapt'
 {{/moshiCodeGen}}
 
 repositories {
-    maven { url = "https://repo1.maven.org/maven2" }
+    maven { url = uri("https://repo1.maven.org/maven2") }
 }
 
 test {

--- a/modules/openapi-generator/src/main/resources/kotlin-server/libraries/ktor/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-server/libraries/ktor/build.gradle.mustache
@@ -12,7 +12,7 @@ buildscript {
     ext.shadow_version = '2.0.3'
 
     repositories {
-        maven { url = "https://repo1.maven.org/maven2" }
+        maven { url "https://repo1.maven.org/maven2" }
         maven {
             url = "https://plugins.gradle.org/m2/"
         }
@@ -50,9 +50,9 @@ shadowJar {
 }
 
 repositories {
-    maven { url = "https://repo1.maven.org/maven2" }
-    maven { url = "https://dl.bintray.com/kotlin/ktor" }
-    maven { url = "https://dl.bintray.com/kotlin/kotlinx" }
+    maven { url "https://repo1.maven.org/maven2" }
+    maven { url "https://dl.bintray.com/kotlin/ktor" }
+    maven { url "https://dl.bintray.com/kotlin/kotlinx" }
 }
 
 dependencies {

--- a/modules/openapi-generator/src/main/resources/kotlin-server/libraries/ktor/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-server/libraries/ktor/build.gradle.mustache
@@ -12,7 +12,7 @@ buildscript {
     ext.shadow_version = '2.0.3'
 
     repositories {
-        maven { url = "https://repo1.maven.org/maven2" }
+        maven { url = uri("https://repo1.maven.org/maven2") }
         maven {
             url "https://plugins.gradle.org/m2/"
         }
@@ -50,7 +50,7 @@ shadowJar {
 }
 
 repositories {
-    maven { url = "https://repo1.maven.org/maven2" }
+    maven { url = uri("https://repo1.maven.org/maven2") }
     maven { url  "https://dl.bintray.com/kotlin/ktor" }
     maven { url "https://dl.bintray.com/kotlin/kotlinx" }
 }

--- a/modules/openapi-generator/src/main/resources/kotlin-server/libraries/ktor/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-server/libraries/ktor/build.gradle.mustache
@@ -12,7 +12,7 @@ buildscript {
     ext.shadow_version = '2.0.3'
 
     repositories {
-        maven { url = uri("https://repo1.maven.org/maven2") }
+        maven { url "https://repo1.maven.org/maven2" }
         maven {
             url "https://plugins.gradle.org/m2/"
         }
@@ -50,7 +50,7 @@ shadowJar {
 }
 
 repositories {
-    maven { url = uri("https://repo1.maven.org/maven2") }
+    maven { url "https://repo1.maven.org/maven2" }
     maven { url  "https://dl.bintray.com/kotlin/ktor" }
     maven { url "https://dl.bintray.com/kotlin/kotlinx" }
 }

--- a/modules/openapi-generator/src/main/resources/kotlin-server/libraries/ktor/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-server/libraries/ktor/build.gradle.mustache
@@ -12,7 +12,7 @@ buildscript {
     ext.shadow_version = '2.0.3'
 
     repositories {
-        maven { url "https://repo1.maven.org/maven2" }
+        maven { url = "https://repo1.maven.org/maven2" }
         maven {
             url "https://plugins.gradle.org/m2/"
         }
@@ -50,7 +50,7 @@ shadowJar {
 }
 
 repositories {
-    maven { url "https://repo1.maven.org/maven2" }
+    maven { url = "https://repo1.maven.org/maven2" }
     maven { url  "https://dl.bintray.com/kotlin/ktor" }
     maven { url "https://dl.bintray.com/kotlin/kotlinx" }
 }

--- a/modules/openapi-generator/src/main/resources/kotlin-server/libraries/ktor/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-server/libraries/ktor/build.gradle.mustache
@@ -14,7 +14,7 @@ buildscript {
     repositories {
         maven { url = "https://repo1.maven.org/maven2" }
         maven {
-            url "https://plugins.gradle.org/m2/"
+            url = "https://plugins.gradle.org/m2/"
         }
     }
     dependencies {

--- a/modules/openapi-generator/src/main/resources/kotlin-server/libraries/ktor/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-server/libraries/ktor/build.gradle.mustache
@@ -51,8 +51,8 @@ shadowJar {
 
 repositories {
     maven { url = "https://repo1.maven.org/maven2" }
-    maven { url  "https://dl.bintray.com/kotlin/ktor" }
-    maven { url "https://dl.bintray.com/kotlin/kotlinx" }
+    maven { url = "https://dl.bintray.com/kotlin/ktor" }
+    maven { url = "https://dl.bintray.com/kotlin/kotlinx" }
 }
 
 dependencies {

--- a/modules/openapi-generator/src/main/resources/scala-gatling/build.gradle
+++ b/modules/openapi-generator/src/main/resources/scala-gatling/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 repositories {
-    maven { url = "https://repo1.maven.org/maven2" }
+    maven { url "https://repo1.maven.org/maven2" }
 }
 
 dependencies {

--- a/modules/openapi-generator/src/main/resources/scala-gatling/build.gradle
+++ b/modules/openapi-generator/src/main/resources/scala-gatling/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 repositories {
-    maven { url "https://repo1.maven.org/maven2" }
+    maven { url = "https://repo1.maven.org/maven2" }
 }
 
 dependencies {

--- a/modules/openapi-generator/src/main/resources/scala-gatling/build.gradle
+++ b/modules/openapi-generator/src/main/resources/scala-gatling/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 repositories {
-    maven { url = "https://repo1.maven.org/maven2" }
+    maven { url = uri("https://repo1.maven.org/maven2") }
 }
 
 dependencies {

--- a/modules/openapi-generator/src/main/resources/scala-gatling/build.gradle
+++ b/modules/openapi-generator/src/main/resources/scala-gatling/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 repositories {
-    maven { url = uri("https://repo1.maven.org/maven2") }
+    maven { url "https://repo1.maven.org/maven2" }
 }
 
 dependencies {

--- a/modules/openapi-generator/src/main/resources/scala-httpclient/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/scala-httpclient/build.gradle.mustache
@@ -109,7 +109,7 @@ ext {
 
 repositories {
     mavenLocal()
-    maven { url = uri("https://repo1.maven.org/maven2") }
+    maven { url "https://repo1.maven.org/maven2" }
 }
 
 dependencies {

--- a/modules/openapi-generator/src/main/resources/scala-httpclient/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/scala-httpclient/build.gradle.mustache
@@ -109,7 +109,7 @@ ext {
 
 repositories {
     mavenLocal()
-    maven { url = "https://repo1.maven.org/maven2" }
+    maven { url = uri("https://repo1.maven.org/maven2") }
 }
 
 dependencies {

--- a/modules/openapi-generator/src/main/resources/scala-httpclient/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/scala-httpclient/build.gradle.mustache
@@ -109,7 +109,7 @@ ext {
 
 repositories {
     mavenLocal()
-    maven { url "https://repo1.maven.org/maven2" }
+    maven { url = "https://repo1.maven.org/maven2" }
 }
 
 dependencies {

--- a/modules/openapi-generator/src/main/resources/scala-httpclient/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/scala-httpclient/build.gradle.mustache
@@ -109,7 +109,7 @@ ext {
 
 repositories {
     mavenLocal()
-    maven { url = "https://repo1.maven.org/maven2" }
+    maven { url "https://repo1.maven.org/maven2" }
 }
 
 dependencies {

--- a/samples/client/petstore/groovy/build.gradle
+++ b/samples/client/petstore/groovy/build.gradle
@@ -14,7 +14,7 @@ wrapper {
 buildscript {
     repositories {
         maven { url = "https://repo1.maven.org/maven2" }
-        maven { url 'https://repo.jfrog.org/artifactory/gradle-plugins' }
+        maven { url = 'https://repo.jfrog.org/artifactory/gradle-plugins' }
     }
     dependencies {
         classpath(group: 'org.jfrog.buildinfo', name: 'build-info-extractor-gradle', version: '2.0.16')

--- a/samples/client/petstore/groovy/build.gradle
+++ b/samples/client/petstore/groovy/build.gradle
@@ -13,7 +13,7 @@ wrapper {
 
 buildscript {
     repositories {
-        maven { url = "https://repo1.maven.org/maven2" }
+        maven { url "https://repo1.maven.org/maven2" }
         maven { url = 'https://repo.jfrog.org/artifactory/gradle-plugins' }
     }
     dependencies {
@@ -22,7 +22,7 @@ buildscript {
 }
 
 repositories {
-    maven { url = "https://repo1.maven.org/maven2" }
+    maven { url "https://repo1.maven.org/maven2" }
     mavenLocal()
 }
 

--- a/samples/client/petstore/groovy/build.gradle
+++ b/samples/client/petstore/groovy/build.gradle
@@ -22,7 +22,7 @@ buildscript {
 }
 
 repositories {
-    maven { url = "https://repo1.maven.org/maven2" }
+    maven { url = uri("https://repo1.maven.org/maven2") }
     mavenLocal()
 }
 

--- a/samples/client/petstore/groovy/build.gradle
+++ b/samples/client/petstore/groovy/build.gradle
@@ -22,7 +22,7 @@ buildscript {
 }
 
 repositories {
-    maven { url = uri("https://repo1.maven.org/maven2") }
+    maven { url "https://repo1.maven.org/maven2" }
     mavenLocal()
 }
 

--- a/samples/client/petstore/groovy/build.gradle
+++ b/samples/client/petstore/groovy/build.gradle
@@ -13,7 +13,7 @@ wrapper {
 
 buildscript {
     repositories {
-        maven { url "https://repo1.maven.org/maven2" }
+        maven { url = "https://repo1.maven.org/maven2" }
         maven { url 'https://repo.jfrog.org/artifactory/gradle-plugins' }
     }
     dependencies {
@@ -22,7 +22,7 @@ buildscript {
 }
 
 repositories {
-    maven { url "https://repo1.maven.org/maven2" }
+    maven { url = "https://repo1.maven.org/maven2" }
     mavenLocal()
 }
 

--- a/samples/client/petstore/java/feign/build.gradle
+++ b/samples/client/petstore/java/feign/build.gradle
@@ -6,7 +6,7 @@ version = '1.0.0'
 
 buildscript {
     repositories {
-        maven { url = uri("https://repo1.maven.org/maven2") }
+        maven { url "https://repo1.maven.org/maven2" }
         jcenter()
     }
     dependencies {

--- a/samples/client/petstore/java/feign/build.gradle
+++ b/samples/client/petstore/java/feign/build.gradle
@@ -6,7 +6,7 @@ version = '1.0.0'
 
 buildscript {
     repositories {
-        maven { url "https://repo1.maven.org/maven2" }
+        maven { url = "https://repo1.maven.org/maven2" }
         jcenter()
     }
     dependencies {

--- a/samples/client/petstore/java/feign/build.gradle
+++ b/samples/client/petstore/java/feign/build.gradle
@@ -6,7 +6,7 @@ version = '1.0.0'
 
 buildscript {
     repositories {
-        maven { url = "https://repo1.maven.org/maven2" }
+        maven { url = uri("https://repo1.maven.org/maven2") }
         jcenter()
     }
     dependencies {

--- a/samples/client/petstore/java/feign/build.gradle
+++ b/samples/client/petstore/java/feign/build.gradle
@@ -6,7 +6,7 @@ version = '1.0.0'
 
 buildscript {
     repositories {
-        maven { url = "https://repo1.maven.org/maven2" }
+        maven { url "https://repo1.maven.org/maven2" }
         jcenter()
     }
     dependencies {

--- a/samples/client/petstore/java/feign10x/build.gradle
+++ b/samples/client/petstore/java/feign10x/build.gradle
@@ -6,7 +6,7 @@ version = '1.0.0'
 
 buildscript {
     repositories {
-        maven { url = uri("https://repo1.maven.org/maven2") }
+        maven { url "https://repo1.maven.org/maven2" }
         jcenter()
     }
     dependencies {

--- a/samples/client/petstore/java/feign10x/build.gradle
+++ b/samples/client/petstore/java/feign10x/build.gradle
@@ -6,7 +6,7 @@ version = '1.0.0'
 
 buildscript {
     repositories {
-        maven { url "https://repo1.maven.org/maven2" }
+        maven { url = "https://repo1.maven.org/maven2" }
         jcenter()
     }
     dependencies {

--- a/samples/client/petstore/java/feign10x/build.gradle
+++ b/samples/client/petstore/java/feign10x/build.gradle
@@ -6,7 +6,7 @@ version = '1.0.0'
 
 buildscript {
     repositories {
-        maven { url = "https://repo1.maven.org/maven2" }
+        maven { url = uri("https://repo1.maven.org/maven2") }
         jcenter()
     }
     dependencies {

--- a/samples/client/petstore/java/feign10x/build.gradle
+++ b/samples/client/petstore/java/feign10x/build.gradle
@@ -6,7 +6,7 @@ version = '1.0.0'
 
 buildscript {
     repositories {
-        maven { url = "https://repo1.maven.org/maven2" }
+        maven { url "https://repo1.maven.org/maven2" }
         jcenter()
     }
     dependencies {

--- a/samples/client/petstore/java/google-api-client/build.gradle
+++ b/samples/client/petstore/java/google-api-client/build.gradle
@@ -6,7 +6,7 @@ version = '1.0.0'
 
 buildscript {
     repositories {
-        maven { url = uri("https://repo1.maven.org/maven2") }
+        maven { url "https://repo1.maven.org/maven2" }
         jcenter()
     }
     dependencies {

--- a/samples/client/petstore/java/google-api-client/build.gradle
+++ b/samples/client/petstore/java/google-api-client/build.gradle
@@ -6,7 +6,7 @@ version = '1.0.0'
 
 buildscript {
     repositories {
-        maven { url "https://repo1.maven.org/maven2" }
+        maven { url = "https://repo1.maven.org/maven2" }
         jcenter()
     }
     dependencies {

--- a/samples/client/petstore/java/google-api-client/build.gradle
+++ b/samples/client/petstore/java/google-api-client/build.gradle
@@ -6,7 +6,7 @@ version = '1.0.0'
 
 buildscript {
     repositories {
-        maven { url = "https://repo1.maven.org/maven2" }
+        maven { url = uri("https://repo1.maven.org/maven2") }
         jcenter()
     }
     dependencies {

--- a/samples/client/petstore/java/google-api-client/build.gradle
+++ b/samples/client/petstore/java/google-api-client/build.gradle
@@ -6,7 +6,7 @@ version = '1.0.0'
 
 buildscript {
     repositories {
-        maven { url = "https://repo1.maven.org/maven2" }
+        maven { url "https://repo1.maven.org/maven2" }
         jcenter()
     }
     dependencies {

--- a/samples/client/petstore/java/jersey1/build.gradle
+++ b/samples/client/petstore/java/jersey1/build.gradle
@@ -6,7 +6,7 @@ version = '1.0.0'
 
 buildscript {
     repositories {
-        maven { url = uri("https://repo1.maven.org/maven2") }
+        maven { url "https://repo1.maven.org/maven2" }
         jcenter()
     }
     dependencies {
@@ -16,7 +16,7 @@ buildscript {
 }
 
 repositories {
-    maven { url = uri("https://repo1.maven.org/maven2") }
+    maven { url "https://repo1.maven.org/maven2" }
     jcenter()
 }
 

--- a/samples/client/petstore/java/jersey1/build.gradle
+++ b/samples/client/petstore/java/jersey1/build.gradle
@@ -6,7 +6,7 @@ version = '1.0.0'
 
 buildscript {
     repositories {
-        maven { url "https://repo1.maven.org/maven2" }
+        maven { url = "https://repo1.maven.org/maven2" }
         jcenter()
     }
     dependencies {
@@ -16,7 +16,7 @@ buildscript {
 }
 
 repositories {
-    maven { url "https://repo1.maven.org/maven2" }
+    maven { url = "https://repo1.maven.org/maven2" }
     jcenter()
 }
 

--- a/samples/client/petstore/java/jersey1/build.gradle
+++ b/samples/client/petstore/java/jersey1/build.gradle
@@ -6,7 +6,7 @@ version = '1.0.0'
 
 buildscript {
     repositories {
-        maven { url = "https://repo1.maven.org/maven2" }
+        maven { url "https://repo1.maven.org/maven2" }
         jcenter()
     }
     dependencies {
@@ -16,7 +16,7 @@ buildscript {
 }
 
 repositories {
-    maven { url = "https://repo1.maven.org/maven2" }
+    maven { url "https://repo1.maven.org/maven2" }
     jcenter()
 }
 

--- a/samples/client/petstore/java/jersey1/build.gradle
+++ b/samples/client/petstore/java/jersey1/build.gradle
@@ -6,7 +6,7 @@ version = '1.0.0'
 
 buildscript {
     repositories {
-        maven { url = "https://repo1.maven.org/maven2" }
+        maven { url = uri("https://repo1.maven.org/maven2") }
         jcenter()
     }
     dependencies {
@@ -16,7 +16,7 @@ buildscript {
 }
 
 repositories {
-    maven { url = "https://repo1.maven.org/maven2" }
+    maven { url = uri("https://repo1.maven.org/maven2") }
     jcenter()
 }
 

--- a/samples/client/petstore/java/jersey2-java8/build.gradle
+++ b/samples/client/petstore/java/jersey2-java8/build.gradle
@@ -6,7 +6,7 @@ version = '1.0.0'
 
 buildscript {
     repositories {
-        maven { url = uri("https://repo1.maven.org/maven2") }
+        maven { url "https://repo1.maven.org/maven2" }
         jcenter()
     }
     dependencies {

--- a/samples/client/petstore/java/jersey2-java8/build.gradle
+++ b/samples/client/petstore/java/jersey2-java8/build.gradle
@@ -6,7 +6,7 @@ version = '1.0.0'
 
 buildscript {
     repositories {
-        maven { url "https://repo1.maven.org/maven2" }
+        maven { url = "https://repo1.maven.org/maven2" }
         jcenter()
     }
     dependencies {

--- a/samples/client/petstore/java/jersey2-java8/build.gradle
+++ b/samples/client/petstore/java/jersey2-java8/build.gradle
@@ -6,7 +6,7 @@ version = '1.0.0'
 
 buildscript {
     repositories {
-        maven { url = "https://repo1.maven.org/maven2" }
+        maven { url = uri("https://repo1.maven.org/maven2") }
         jcenter()
     }
     dependencies {

--- a/samples/client/petstore/java/jersey2-java8/build.gradle
+++ b/samples/client/petstore/java/jersey2-java8/build.gradle
@@ -6,7 +6,7 @@ version = '1.0.0'
 
 buildscript {
     repositories {
-        maven { url = "https://repo1.maven.org/maven2" }
+        maven { url "https://repo1.maven.org/maven2" }
         jcenter()
     }
     dependencies {

--- a/samples/client/petstore/java/jersey2/build.gradle
+++ b/samples/client/petstore/java/jersey2/build.gradle
@@ -6,7 +6,7 @@ version = '1.0.0'
 
 buildscript {
     repositories {
-        maven { url = uri("https://repo1.maven.org/maven2") }
+        maven { url "https://repo1.maven.org/maven2" }
         jcenter()
     }
     dependencies {

--- a/samples/client/petstore/java/jersey2/build.gradle
+++ b/samples/client/petstore/java/jersey2/build.gradle
@@ -6,7 +6,7 @@ version = '1.0.0'
 
 buildscript {
     repositories {
-        maven { url "https://repo1.maven.org/maven2" }
+        maven { url = "https://repo1.maven.org/maven2" }
         jcenter()
     }
     dependencies {

--- a/samples/client/petstore/java/jersey2/build.gradle
+++ b/samples/client/petstore/java/jersey2/build.gradle
@@ -6,7 +6,7 @@ version = '1.0.0'
 
 buildscript {
     repositories {
-        maven { url = "https://repo1.maven.org/maven2" }
+        maven { url = uri("https://repo1.maven.org/maven2") }
         jcenter()
     }
     dependencies {

--- a/samples/client/petstore/java/jersey2/build.gradle
+++ b/samples/client/petstore/java/jersey2/build.gradle
@@ -6,7 +6,7 @@ version = '1.0.0'
 
 buildscript {
     repositories {
-        maven { url = "https://repo1.maven.org/maven2" }
+        maven { url "https://repo1.maven.org/maven2" }
         jcenter()
     }
     dependencies {

--- a/samples/client/petstore/java/native/build.gradle
+++ b/samples/client/petstore/java/native/build.gradle
@@ -6,13 +6,13 @@ version = '1.0.0'
 
 buildscript {
     repositories {
-        maven { url = "https://repo1.maven.org/maven2" }
+        maven { url = uri("https://repo1.maven.org/maven2") }
         jcenter()
     }
 }
 
 repositories {
-    maven { url = "https://repo1.maven.org/maven2" }
+    maven { url = uri("https://repo1.maven.org/maven2") }
     jcenter()
 }
 

--- a/samples/client/petstore/java/native/build.gradle
+++ b/samples/client/petstore/java/native/build.gradle
@@ -6,13 +6,13 @@ version = '1.0.0'
 
 buildscript {
     repositories {
-        maven { url "https://repo1.maven.org/maven2" }
+        maven { url = "https://repo1.maven.org/maven2" }
         jcenter()
     }
 }
 
 repositories {
-    maven { url "https://repo1.maven.org/maven2" }
+    maven { url = "https://repo1.maven.org/maven2" }
     jcenter()
 }
 

--- a/samples/client/petstore/java/native/build.gradle
+++ b/samples/client/petstore/java/native/build.gradle
@@ -6,13 +6,13 @@ version = '1.0.0'
 
 buildscript {
     repositories {
-        maven { url = uri("https://repo1.maven.org/maven2") }
+        maven { url "https://repo1.maven.org/maven2" }
         jcenter()
     }
 }
 
 repositories {
-    maven { url = uri("https://repo1.maven.org/maven2") }
+    maven { url "https://repo1.maven.org/maven2" }
     jcenter()
 }
 

--- a/samples/client/petstore/java/native/build.gradle
+++ b/samples/client/petstore/java/native/build.gradle
@@ -6,13 +6,13 @@ version = '1.0.0'
 
 buildscript {
     repositories {
-        maven { url = "https://repo1.maven.org/maven2" }
+        maven { url "https://repo1.maven.org/maven2" }
         jcenter()
     }
 }
 
 repositories {
-    maven { url = "https://repo1.maven.org/maven2" }
+    maven { url "https://repo1.maven.org/maven2" }
     jcenter()
 }
 

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/build.gradle
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/build.gradle
@@ -7,7 +7,7 @@ version = '1.0.0'
 
 buildscript {
     repositories {
-        maven { url = "https://repo1.maven.org/maven2" }
+        maven { url "https://repo1.maven.org/maven2" }
         jcenter()
     }
     dependencies {

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/build.gradle
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/build.gradle
@@ -7,7 +7,7 @@ version = '1.0.0'
 
 buildscript {
     repositories {
-        maven { url = "https://repo1.maven.org/maven2" }
+        maven { url = uri("https://repo1.maven.org/maven2") }
         jcenter()
     }
     dependencies {

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/build.gradle
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/build.gradle
@@ -7,7 +7,7 @@ version = '1.0.0'
 
 buildscript {
     repositories {
-        maven { url "https://repo1.maven.org/maven2" }
+        maven { url = "https://repo1.maven.org/maven2" }
         jcenter()
     }
     dependencies {

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/build.gradle
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/build.gradle
@@ -7,7 +7,7 @@ version = '1.0.0'
 
 buildscript {
     repositories {
-        maven { url = uri("https://repo1.maven.org/maven2") }
+        maven { url "https://repo1.maven.org/maven2" }
         jcenter()
     }
     dependencies {

--- a/samples/client/petstore/java/okhttp-gson/build.gradle
+++ b/samples/client/petstore/java/okhttp-gson/build.gradle
@@ -7,7 +7,7 @@ version = '1.0.0'
 
 buildscript {
     repositories {
-        maven { url = "https://repo1.maven.org/maven2" }
+        maven { url "https://repo1.maven.org/maven2" }
         jcenter()
     }
     dependencies {

--- a/samples/client/petstore/java/okhttp-gson/build.gradle
+++ b/samples/client/petstore/java/okhttp-gson/build.gradle
@@ -7,7 +7,7 @@ version = '1.0.0'
 
 buildscript {
     repositories {
-        maven { url = "https://repo1.maven.org/maven2" }
+        maven { url = uri("https://repo1.maven.org/maven2") }
         jcenter()
     }
     dependencies {

--- a/samples/client/petstore/java/okhttp-gson/build.gradle
+++ b/samples/client/petstore/java/okhttp-gson/build.gradle
@@ -7,7 +7,7 @@ version = '1.0.0'
 
 buildscript {
     repositories {
-        maven { url "https://repo1.maven.org/maven2" }
+        maven { url = "https://repo1.maven.org/maven2" }
         jcenter()
     }
     dependencies {

--- a/samples/client/petstore/java/okhttp-gson/build.gradle
+++ b/samples/client/petstore/java/okhttp-gson/build.gradle
@@ -7,7 +7,7 @@ version = '1.0.0'
 
 buildscript {
     repositories {
-        maven { url = uri("https://repo1.maven.org/maven2") }
+        maven { url "https://repo1.maven.org/maven2" }
         jcenter()
     }
     dependencies {

--- a/samples/client/petstore/java/rest-assured/build.gradle
+++ b/samples/client/petstore/java/rest-assured/build.gradle
@@ -6,7 +6,7 @@ version = '1.0.0'
 
 buildscript {
     repositories {
-        maven { url = uri("https://repo1.maven.org/maven2") }
+        maven { url "https://repo1.maven.org/maven2" }
         jcenter()
     }
     dependencies {

--- a/samples/client/petstore/java/rest-assured/build.gradle
+++ b/samples/client/petstore/java/rest-assured/build.gradle
@@ -6,7 +6,7 @@ version = '1.0.0'
 
 buildscript {
     repositories {
-        maven { url "https://repo1.maven.org/maven2" }
+        maven { url = "https://repo1.maven.org/maven2" }
         jcenter()
     }
     dependencies {

--- a/samples/client/petstore/java/rest-assured/build.gradle
+++ b/samples/client/petstore/java/rest-assured/build.gradle
@@ -6,7 +6,7 @@ version = '1.0.0'
 
 buildscript {
     repositories {
-        maven { url = "https://repo1.maven.org/maven2" }
+        maven { url = uri("https://repo1.maven.org/maven2") }
         jcenter()
     }
     dependencies {

--- a/samples/client/petstore/java/rest-assured/build.gradle
+++ b/samples/client/petstore/java/rest-assured/build.gradle
@@ -6,7 +6,7 @@ version = '1.0.0'
 
 buildscript {
     repositories {
-        maven { url = "https://repo1.maven.org/maven2" }
+        maven { url "https://repo1.maven.org/maven2" }
         jcenter()
     }
     dependencies {

--- a/samples/client/petstore/java/resteasy/build.gradle
+++ b/samples/client/petstore/java/resteasy/build.gradle
@@ -6,7 +6,7 @@ version = '1.0.0'
 
 buildscript {
     repositories {
-        maven { url = uri("https://repo1.maven.org/maven2") }
+        maven { url "https://repo1.maven.org/maven2" }
         jcenter()
     }
     dependencies {

--- a/samples/client/petstore/java/resteasy/build.gradle
+++ b/samples/client/petstore/java/resteasy/build.gradle
@@ -6,7 +6,7 @@ version = '1.0.0'
 
 buildscript {
     repositories {
-        maven { url "https://repo1.maven.org/maven2" }
+        maven { url = "https://repo1.maven.org/maven2" }
         jcenter()
     }
     dependencies {

--- a/samples/client/petstore/java/resteasy/build.gradle
+++ b/samples/client/petstore/java/resteasy/build.gradle
@@ -6,7 +6,7 @@ version = '1.0.0'
 
 buildscript {
     repositories {
-        maven { url = "https://repo1.maven.org/maven2" }
+        maven { url = uri("https://repo1.maven.org/maven2") }
         jcenter()
     }
     dependencies {

--- a/samples/client/petstore/java/resteasy/build.gradle
+++ b/samples/client/petstore/java/resteasy/build.gradle
@@ -6,7 +6,7 @@ version = '1.0.0'
 
 buildscript {
     repositories {
-        maven { url = "https://repo1.maven.org/maven2" }
+        maven { url "https://repo1.maven.org/maven2" }
         jcenter()
     }
     dependencies {

--- a/samples/client/petstore/java/resttemplate-withXml/build.gradle
+++ b/samples/client/petstore/java/resttemplate-withXml/build.gradle
@@ -6,7 +6,7 @@ version = '1.0.0'
 
 buildscript {
     repositories {
-        maven { url = uri("https://repo1.maven.org/maven2") }
+        maven { url "https://repo1.maven.org/maven2" }
         jcenter()
     }
     dependencies {

--- a/samples/client/petstore/java/resttemplate-withXml/build.gradle
+++ b/samples/client/petstore/java/resttemplate-withXml/build.gradle
@@ -6,7 +6,7 @@ version = '1.0.0'
 
 buildscript {
     repositories {
-        maven { url "https://repo1.maven.org/maven2" }
+        maven { url = "https://repo1.maven.org/maven2" }
         jcenter()
     }
     dependencies {

--- a/samples/client/petstore/java/resttemplate-withXml/build.gradle
+++ b/samples/client/petstore/java/resttemplate-withXml/build.gradle
@@ -6,7 +6,7 @@ version = '1.0.0'
 
 buildscript {
     repositories {
-        maven { url = "https://repo1.maven.org/maven2" }
+        maven { url = uri("https://repo1.maven.org/maven2") }
         jcenter()
     }
     dependencies {

--- a/samples/client/petstore/java/resttemplate-withXml/build.gradle
+++ b/samples/client/petstore/java/resttemplate-withXml/build.gradle
@@ -6,7 +6,7 @@ version = '1.0.0'
 
 buildscript {
     repositories {
-        maven { url = "https://repo1.maven.org/maven2" }
+        maven { url "https://repo1.maven.org/maven2" }
         jcenter()
     }
     dependencies {

--- a/samples/client/petstore/java/resttemplate/build.gradle
+++ b/samples/client/petstore/java/resttemplate/build.gradle
@@ -6,7 +6,7 @@ version = '1.0.0'
 
 buildscript {
     repositories {
-        maven { url = uri("https://repo1.maven.org/maven2") }
+        maven { url "https://repo1.maven.org/maven2" }
         jcenter()
     }
     dependencies {

--- a/samples/client/petstore/java/resttemplate/build.gradle
+++ b/samples/client/petstore/java/resttemplate/build.gradle
@@ -6,7 +6,7 @@ version = '1.0.0'
 
 buildscript {
     repositories {
-        maven { url "https://repo1.maven.org/maven2" }
+        maven { url = "https://repo1.maven.org/maven2" }
         jcenter()
     }
     dependencies {

--- a/samples/client/petstore/java/resttemplate/build.gradle
+++ b/samples/client/petstore/java/resttemplate/build.gradle
@@ -6,7 +6,7 @@ version = '1.0.0'
 
 buildscript {
     repositories {
-        maven { url = "https://repo1.maven.org/maven2" }
+        maven { url = uri("https://repo1.maven.org/maven2") }
         jcenter()
     }
     dependencies {

--- a/samples/client/petstore/java/resttemplate/build.gradle
+++ b/samples/client/petstore/java/resttemplate/build.gradle
@@ -6,7 +6,7 @@ version = '1.0.0'
 
 buildscript {
     repositories {
-        maven { url = "https://repo1.maven.org/maven2" }
+        maven { url "https://repo1.maven.org/maven2" }
         jcenter()
     }
     dependencies {

--- a/samples/client/petstore/java/retrofit/build.gradle
+++ b/samples/client/petstore/java/retrofit/build.gradle
@@ -6,7 +6,7 @@ version = '1.0.0'
 
 buildscript {
     repositories {
-        maven { url = uri("https://repo1.maven.org/maven2") }
+        maven { url "https://repo1.maven.org/maven2" }
         jcenter()
     }
     dependencies {

--- a/samples/client/petstore/java/retrofit/build.gradle
+++ b/samples/client/petstore/java/retrofit/build.gradle
@@ -6,7 +6,7 @@ version = '1.0.0'
 
 buildscript {
     repositories {
-        maven { url "https://repo1.maven.org/maven2" }
+        maven { url = "https://repo1.maven.org/maven2" }
         jcenter()
     }
     dependencies {

--- a/samples/client/petstore/java/retrofit/build.gradle
+++ b/samples/client/petstore/java/retrofit/build.gradle
@@ -6,7 +6,7 @@ version = '1.0.0'
 
 buildscript {
     repositories {
-        maven { url = "https://repo1.maven.org/maven2" }
+        maven { url = uri("https://repo1.maven.org/maven2") }
         jcenter()
     }
     dependencies {

--- a/samples/client/petstore/java/retrofit/build.gradle
+++ b/samples/client/petstore/java/retrofit/build.gradle
@@ -6,7 +6,7 @@ version = '1.0.0'
 
 buildscript {
     repositories {
-        maven { url = "https://repo1.maven.org/maven2" }
+        maven { url "https://repo1.maven.org/maven2" }
         jcenter()
     }
     dependencies {

--- a/samples/client/petstore/java/retrofit2-play24/build.gradle
+++ b/samples/client/petstore/java/retrofit2-play24/build.gradle
@@ -6,7 +6,7 @@ version = '1.0.0'
 
 buildscript {
     repositories {
-        maven { url = uri("https://repo1.maven.org/maven2") }
+        maven { url "https://repo1.maven.org/maven2" }
         jcenter()
     }
     dependencies {

--- a/samples/client/petstore/java/retrofit2-play24/build.gradle
+++ b/samples/client/petstore/java/retrofit2-play24/build.gradle
@@ -6,7 +6,7 @@ version = '1.0.0'
 
 buildscript {
     repositories {
-        maven { url "https://repo1.maven.org/maven2" }
+        maven { url = "https://repo1.maven.org/maven2" }
         jcenter()
     }
     dependencies {

--- a/samples/client/petstore/java/retrofit2-play24/build.gradle
+++ b/samples/client/petstore/java/retrofit2-play24/build.gradle
@@ -6,7 +6,7 @@ version = '1.0.0'
 
 buildscript {
     repositories {
-        maven { url = "https://repo1.maven.org/maven2" }
+        maven { url = uri("https://repo1.maven.org/maven2") }
         jcenter()
     }
     dependencies {

--- a/samples/client/petstore/java/retrofit2-play24/build.gradle
+++ b/samples/client/petstore/java/retrofit2-play24/build.gradle
@@ -6,7 +6,7 @@ version = '1.0.0'
 
 buildscript {
     repositories {
-        maven { url = "https://repo1.maven.org/maven2" }
+        maven { url "https://repo1.maven.org/maven2" }
         jcenter()
     }
     dependencies {

--- a/samples/client/petstore/java/retrofit2-play25/build.gradle
+++ b/samples/client/petstore/java/retrofit2-play25/build.gradle
@@ -6,7 +6,7 @@ version = '1.0.0'
 
 buildscript {
     repositories {
-        maven { url = uri("https://repo1.maven.org/maven2") }
+        maven { url "https://repo1.maven.org/maven2" }
         jcenter()
     }
     dependencies {

--- a/samples/client/petstore/java/retrofit2-play25/build.gradle
+++ b/samples/client/petstore/java/retrofit2-play25/build.gradle
@@ -6,7 +6,7 @@ version = '1.0.0'
 
 buildscript {
     repositories {
-        maven { url "https://repo1.maven.org/maven2" }
+        maven { url = "https://repo1.maven.org/maven2" }
         jcenter()
     }
     dependencies {

--- a/samples/client/petstore/java/retrofit2-play25/build.gradle
+++ b/samples/client/petstore/java/retrofit2-play25/build.gradle
@@ -6,7 +6,7 @@ version = '1.0.0'
 
 buildscript {
     repositories {
-        maven { url = "https://repo1.maven.org/maven2" }
+        maven { url = uri("https://repo1.maven.org/maven2") }
         jcenter()
     }
     dependencies {

--- a/samples/client/petstore/java/retrofit2-play25/build.gradle
+++ b/samples/client/petstore/java/retrofit2-play25/build.gradle
@@ -6,7 +6,7 @@ version = '1.0.0'
 
 buildscript {
     repositories {
-        maven { url = "https://repo1.maven.org/maven2" }
+        maven { url "https://repo1.maven.org/maven2" }
         jcenter()
     }
     dependencies {

--- a/samples/client/petstore/java/retrofit2-play26/build.gradle
+++ b/samples/client/petstore/java/retrofit2-play26/build.gradle
@@ -6,7 +6,7 @@ version = '1.0.0'
 
 buildscript {
     repositories {
-        maven { url = uri("https://repo1.maven.org/maven2") }
+        maven { url "https://repo1.maven.org/maven2" }
         jcenter()
     }
     dependencies {

--- a/samples/client/petstore/java/retrofit2-play26/build.gradle
+++ b/samples/client/petstore/java/retrofit2-play26/build.gradle
@@ -6,7 +6,7 @@ version = '1.0.0'
 
 buildscript {
     repositories {
-        maven { url "https://repo1.maven.org/maven2" }
+        maven { url = "https://repo1.maven.org/maven2" }
         jcenter()
     }
     dependencies {

--- a/samples/client/petstore/java/retrofit2-play26/build.gradle
+++ b/samples/client/petstore/java/retrofit2-play26/build.gradle
@@ -6,7 +6,7 @@ version = '1.0.0'
 
 buildscript {
     repositories {
-        maven { url = "https://repo1.maven.org/maven2" }
+        maven { url = uri("https://repo1.maven.org/maven2") }
         jcenter()
     }
     dependencies {

--- a/samples/client/petstore/java/retrofit2-play26/build.gradle
+++ b/samples/client/petstore/java/retrofit2-play26/build.gradle
@@ -6,7 +6,7 @@ version = '1.0.0'
 
 buildscript {
     repositories {
-        maven { url = "https://repo1.maven.org/maven2" }
+        maven { url "https://repo1.maven.org/maven2" }
         jcenter()
     }
     dependencies {

--- a/samples/client/petstore/java/retrofit2/build.gradle
+++ b/samples/client/petstore/java/retrofit2/build.gradle
@@ -6,7 +6,7 @@ version = '1.0.0'
 
 buildscript {
     repositories {
-        maven { url = uri("https://repo1.maven.org/maven2") }
+        maven { url "https://repo1.maven.org/maven2" }
         jcenter()
     }
     dependencies {

--- a/samples/client/petstore/java/retrofit2/build.gradle
+++ b/samples/client/petstore/java/retrofit2/build.gradle
@@ -6,7 +6,7 @@ version = '1.0.0'
 
 buildscript {
     repositories {
-        maven { url "https://repo1.maven.org/maven2" }
+        maven { url = "https://repo1.maven.org/maven2" }
         jcenter()
     }
     dependencies {

--- a/samples/client/petstore/java/retrofit2/build.gradle
+++ b/samples/client/petstore/java/retrofit2/build.gradle
@@ -6,7 +6,7 @@ version = '1.0.0'
 
 buildscript {
     repositories {
-        maven { url = "https://repo1.maven.org/maven2" }
+        maven { url = uri("https://repo1.maven.org/maven2") }
         jcenter()
     }
     dependencies {

--- a/samples/client/petstore/java/retrofit2/build.gradle
+++ b/samples/client/petstore/java/retrofit2/build.gradle
@@ -6,7 +6,7 @@ version = '1.0.0'
 
 buildscript {
     repositories {
-        maven { url = "https://repo1.maven.org/maven2" }
+        maven { url "https://repo1.maven.org/maven2" }
         jcenter()
     }
     dependencies {

--- a/samples/client/petstore/java/retrofit2rx/build.gradle
+++ b/samples/client/petstore/java/retrofit2rx/build.gradle
@@ -6,7 +6,7 @@ version = '1.0.0'
 
 buildscript {
     repositories {
-        maven { url = uri("https://repo1.maven.org/maven2") }
+        maven { url "https://repo1.maven.org/maven2" }
         jcenter()
     }
     dependencies {

--- a/samples/client/petstore/java/retrofit2rx/build.gradle
+++ b/samples/client/petstore/java/retrofit2rx/build.gradle
@@ -6,7 +6,7 @@ version = '1.0.0'
 
 buildscript {
     repositories {
-        maven { url "https://repo1.maven.org/maven2" }
+        maven { url = "https://repo1.maven.org/maven2" }
         jcenter()
     }
     dependencies {

--- a/samples/client/petstore/java/retrofit2rx/build.gradle
+++ b/samples/client/petstore/java/retrofit2rx/build.gradle
@@ -6,7 +6,7 @@ version = '1.0.0'
 
 buildscript {
     repositories {
-        maven { url = "https://repo1.maven.org/maven2" }
+        maven { url = uri("https://repo1.maven.org/maven2") }
         jcenter()
     }
     dependencies {

--- a/samples/client/petstore/java/retrofit2rx/build.gradle
+++ b/samples/client/petstore/java/retrofit2rx/build.gradle
@@ -6,7 +6,7 @@ version = '1.0.0'
 
 buildscript {
     repositories {
-        maven { url = "https://repo1.maven.org/maven2" }
+        maven { url "https://repo1.maven.org/maven2" }
         jcenter()
     }
     dependencies {

--- a/samples/client/petstore/java/retrofit2rx2/build.gradle
+++ b/samples/client/petstore/java/retrofit2rx2/build.gradle
@@ -6,7 +6,7 @@ version = '1.0.0'
 
 buildscript {
     repositories {
-        maven { url = uri("https://repo1.maven.org/maven2") }
+        maven { url "https://repo1.maven.org/maven2" }
         jcenter()
     }
     dependencies {

--- a/samples/client/petstore/java/retrofit2rx2/build.gradle
+++ b/samples/client/petstore/java/retrofit2rx2/build.gradle
@@ -6,7 +6,7 @@ version = '1.0.0'
 
 buildscript {
     repositories {
-        maven { url "https://repo1.maven.org/maven2" }
+        maven { url = "https://repo1.maven.org/maven2" }
         jcenter()
     }
     dependencies {

--- a/samples/client/petstore/java/retrofit2rx2/build.gradle
+++ b/samples/client/petstore/java/retrofit2rx2/build.gradle
@@ -6,7 +6,7 @@ version = '1.0.0'
 
 buildscript {
     repositories {
-        maven { url = "https://repo1.maven.org/maven2" }
+        maven { url = uri("https://repo1.maven.org/maven2") }
         jcenter()
     }
     dependencies {

--- a/samples/client/petstore/java/retrofit2rx2/build.gradle
+++ b/samples/client/petstore/java/retrofit2rx2/build.gradle
@@ -6,7 +6,7 @@ version = '1.0.0'
 
 buildscript {
     repositories {
-        maven { url = "https://repo1.maven.org/maven2" }
+        maven { url "https://repo1.maven.org/maven2" }
         jcenter()
     }
     dependencies {

--- a/samples/client/petstore/java/vertx/build.gradle
+++ b/samples/client/petstore/java/vertx/build.gradle
@@ -5,7 +5,7 @@ group = 'org.openapitools'
 version = '1.0.0'
 
 repositories {
-    maven { url = uri("https://repo1.maven.org/maven2") }
+    maven { url "https://repo1.maven.org/maven2" }
     jcenter()
 }
 

--- a/samples/client/petstore/java/vertx/build.gradle
+++ b/samples/client/petstore/java/vertx/build.gradle
@@ -5,7 +5,7 @@ group = 'org.openapitools'
 version = '1.0.0'
 
 repositories {
-    maven { url "https://repo1.maven.org/maven2" }
+    maven { url = "https://repo1.maven.org/maven2" }
     jcenter()
 }
 

--- a/samples/client/petstore/java/vertx/build.gradle
+++ b/samples/client/petstore/java/vertx/build.gradle
@@ -5,7 +5,7 @@ group = 'org.openapitools'
 version = '1.0.0'
 
 repositories {
-    maven { url = "https://repo1.maven.org/maven2" }
+    maven { url = uri("https://repo1.maven.org/maven2") }
     jcenter()
 }
 

--- a/samples/client/petstore/java/vertx/build.gradle
+++ b/samples/client/petstore/java/vertx/build.gradle
@@ -5,7 +5,7 @@ group = 'org.openapitools'
 version = '1.0.0'
 
 repositories {
-    maven { url = "https://repo1.maven.org/maven2" }
+    maven { url "https://repo1.maven.org/maven2" }
     jcenter()
 }
 

--- a/samples/client/petstore/java/webclient/build.gradle
+++ b/samples/client/petstore/java/webclient/build.gradle
@@ -6,7 +6,7 @@ version = '1.0.0'
 
 buildscript {
     repositories {
-        maven { url = uri("https://repo1.maven.org/maven2") }
+        maven { url "https://repo1.maven.org/maven2" }
         jcenter()
     }
     dependencies {
@@ -16,7 +16,7 @@ buildscript {
 }
 
 repositories {
-    maven { url = uri("https://repo1.maven.org/maven2") }
+    maven { url "https://repo1.maven.org/maven2" }
     jcenter()
 }
 

--- a/samples/client/petstore/java/webclient/build.gradle
+++ b/samples/client/petstore/java/webclient/build.gradle
@@ -6,7 +6,7 @@ version = '1.0.0'
 
 buildscript {
     repositories {
-        maven { url "https://repo1.maven.org/maven2" }
+        maven { url = "https://repo1.maven.org/maven2" }
         jcenter()
     }
     dependencies {
@@ -16,7 +16,7 @@ buildscript {
 }
 
 repositories {
-    maven { url "https://repo1.maven.org/maven2" }
+    maven { url = "https://repo1.maven.org/maven2" }
     jcenter()
 }
 

--- a/samples/client/petstore/java/webclient/build.gradle
+++ b/samples/client/petstore/java/webclient/build.gradle
@@ -6,7 +6,7 @@ version = '1.0.0'
 
 buildscript {
     repositories {
-        maven { url = "https://repo1.maven.org/maven2" }
+        maven { url "https://repo1.maven.org/maven2" }
         jcenter()
     }
     dependencies {
@@ -16,7 +16,7 @@ buildscript {
 }
 
 repositories {
-    maven { url = "https://repo1.maven.org/maven2" }
+    maven { url "https://repo1.maven.org/maven2" }
     jcenter()
 }
 

--- a/samples/client/petstore/java/webclient/build.gradle
+++ b/samples/client/petstore/java/webclient/build.gradle
@@ -6,7 +6,7 @@ version = '1.0.0'
 
 buildscript {
     repositories {
-        maven { url = "https://repo1.maven.org/maven2" }
+        maven { url = uri("https://repo1.maven.org/maven2") }
         jcenter()
     }
     dependencies {
@@ -16,7 +16,7 @@ buildscript {
 }
 
 repositories {
-    maven { url = "https://repo1.maven.org/maven2" }
+    maven { url = uri("https://repo1.maven.org/maven2") }
     jcenter()
 }
 

--- a/samples/client/petstore/kotlin-gson/build.gradle
+++ b/samples/client/petstore/kotlin-gson/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     ext.kotlin_version = '1.3.61'
 
     repositories {
-        maven { url "https://repo1.maven.org/maven2" }
+        maven { url = "https://repo1.maven.org/maven2" }
     }
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
@@ -20,7 +20,7 @@ buildscript {
 apply plugin: 'kotlin'
 
 repositories {
-    maven { url "https://repo1.maven.org/maven2" }
+    maven { url = "https://repo1.maven.org/maven2" }
 }
 
 test {

--- a/samples/client/petstore/kotlin-gson/build.gradle
+++ b/samples/client/petstore/kotlin-gson/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     ext.kotlin_version = '1.3.61'
 
     repositories {
-        maven { url = "https://repo1.maven.org/maven2" }
+        maven { url "https://repo1.maven.org/maven2" }
     }
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
@@ -20,7 +20,7 @@ buildscript {
 apply plugin: 'kotlin'
 
 repositories {
-    maven { url = "https://repo1.maven.org/maven2" }
+    maven { url "https://repo1.maven.org/maven2" }
 }
 
 test {

--- a/samples/client/petstore/kotlin-gson/build.gradle
+++ b/samples/client/petstore/kotlin-gson/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     ext.kotlin_version = '1.3.61'
 
     repositories {
-        maven { url = "https://repo1.maven.org/maven2" }
+        maven { url = uri("https://repo1.maven.org/maven2") }
     }
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
@@ -20,7 +20,7 @@ buildscript {
 apply plugin: 'kotlin'
 
 repositories {
-    maven { url = "https://repo1.maven.org/maven2" }
+    maven { url = uri("https://repo1.maven.org/maven2") }
 }
 
 test {

--- a/samples/client/petstore/kotlin-gson/build.gradle
+++ b/samples/client/petstore/kotlin-gson/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     ext.kotlin_version = '1.3.61'
 
     repositories {
-        maven { url = uri("https://repo1.maven.org/maven2") }
+        maven { url "https://repo1.maven.org/maven2" }
     }
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
@@ -20,7 +20,7 @@ buildscript {
 apply plugin: 'kotlin'
 
 repositories {
-    maven { url = uri("https://repo1.maven.org/maven2") }
+    maven { url "https://repo1.maven.org/maven2" }
 }
 
 test {

--- a/samples/client/petstore/kotlin-json-request-date/build.gradle
+++ b/samples/client/petstore/kotlin-json-request-date/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     ext.kotlin_version = '1.3.61'
 
     repositories {
-        maven { url "https://repo1.maven.org/maven2" }
+        maven { url = "https://repo1.maven.org/maven2" }
     }
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
@@ -20,7 +20,7 @@ buildscript {
 apply plugin: 'kotlin'
 
 repositories {
-    maven { url "https://repo1.maven.org/maven2" }
+    maven { url = "https://repo1.maven.org/maven2" }
 }
 
 test {

--- a/samples/client/petstore/kotlin-json-request-date/build.gradle
+++ b/samples/client/petstore/kotlin-json-request-date/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     ext.kotlin_version = '1.3.61'
 
     repositories {
-        maven { url = "https://repo1.maven.org/maven2" }
+        maven { url "https://repo1.maven.org/maven2" }
     }
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
@@ -20,7 +20,7 @@ buildscript {
 apply plugin: 'kotlin'
 
 repositories {
-    maven { url = "https://repo1.maven.org/maven2" }
+    maven { url "https://repo1.maven.org/maven2" }
 }
 
 test {

--- a/samples/client/petstore/kotlin-json-request-date/build.gradle
+++ b/samples/client/petstore/kotlin-json-request-date/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     ext.kotlin_version = '1.3.61'
 
     repositories {
-        maven { url = "https://repo1.maven.org/maven2" }
+        maven { url = uri("https://repo1.maven.org/maven2") }
     }
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
@@ -20,7 +20,7 @@ buildscript {
 apply plugin: 'kotlin'
 
 repositories {
-    maven { url = "https://repo1.maven.org/maven2" }
+    maven { url = uri("https://repo1.maven.org/maven2") }
 }
 
 test {

--- a/samples/client/petstore/kotlin-json-request-date/build.gradle
+++ b/samples/client/petstore/kotlin-json-request-date/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     ext.kotlin_version = '1.3.61'
 
     repositories {
-        maven { url = uri("https://repo1.maven.org/maven2") }
+        maven { url "https://repo1.maven.org/maven2" }
     }
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
@@ -20,7 +20,7 @@ buildscript {
 apply plugin: 'kotlin'
 
 repositories {
-    maven { url = uri("https://repo1.maven.org/maven2") }
+    maven { url "https://repo1.maven.org/maven2" }
 }
 
 test {

--- a/samples/client/petstore/kotlin-moshi-codegen/build.gradle
+++ b/samples/client/petstore/kotlin-moshi-codegen/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     ext.kotlin_version = '1.3.61'
 
     repositories {
-        maven { url = uri("https://repo1.maven.org/maven2") }
+        maven { url "https://repo1.maven.org/maven2" }
     }
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
@@ -21,7 +21,7 @@ apply plugin: 'kotlin'
 apply plugin: 'kotlin-kapt'
 
 repositories {
-    maven { url = uri("https://repo1.maven.org/maven2") }
+    maven { url "https://repo1.maven.org/maven2" }
 }
 
 test {

--- a/samples/client/petstore/kotlin-moshi-codegen/build.gradle
+++ b/samples/client/petstore/kotlin-moshi-codegen/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     ext.kotlin_version = '1.3.61'
 
     repositories {
-        maven { url = "https://repo1.maven.org/maven2" }
+        maven { url = uri("https://repo1.maven.org/maven2") }
     }
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
@@ -21,7 +21,7 @@ apply plugin: 'kotlin'
 apply plugin: 'kotlin-kapt'
 
 repositories {
-    maven { url = "https://repo1.maven.org/maven2" }
+    maven { url = uri("https://repo1.maven.org/maven2") }
 }
 
 test {

--- a/samples/client/petstore/kotlin-moshi-codegen/build.gradle
+++ b/samples/client/petstore/kotlin-moshi-codegen/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     ext.kotlin_version = '1.3.61'
 
     repositories {
-        maven { url = "https://repo1.maven.org/maven2" }
+        maven { url "https://repo1.maven.org/maven2" }
     }
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
@@ -21,7 +21,7 @@ apply plugin: 'kotlin'
 apply plugin: 'kotlin-kapt'
 
 repositories {
-    maven { url = "https://repo1.maven.org/maven2" }
+    maven { url "https://repo1.maven.org/maven2" }
 }
 
 test {

--- a/samples/client/petstore/kotlin-moshi-codegen/build.gradle
+++ b/samples/client/petstore/kotlin-moshi-codegen/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     ext.kotlin_version = '1.3.61'
 
     repositories {
-        maven { url "https://repo1.maven.org/maven2" }
+        maven { url = "https://repo1.maven.org/maven2" }
     }
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
@@ -21,7 +21,7 @@ apply plugin: 'kotlin'
 apply plugin: 'kotlin-kapt'
 
 repositories {
-    maven { url "https://repo1.maven.org/maven2" }
+    maven { url = "https://repo1.maven.org/maven2" }
 }
 
 test {

--- a/samples/client/petstore/kotlin-nonpublic/build.gradle
+++ b/samples/client/petstore/kotlin-nonpublic/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     ext.kotlin_version = '1.3.61'
 
     repositories {
-        maven { url "https://repo1.maven.org/maven2" }
+        maven { url = "https://repo1.maven.org/maven2" }
     }
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
@@ -20,7 +20,7 @@ buildscript {
 apply plugin: 'kotlin'
 
 repositories {
-    maven { url "https://repo1.maven.org/maven2" }
+    maven { url = "https://repo1.maven.org/maven2" }
 }
 
 test {

--- a/samples/client/petstore/kotlin-nonpublic/build.gradle
+++ b/samples/client/petstore/kotlin-nonpublic/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     ext.kotlin_version = '1.3.61'
 
     repositories {
-        maven { url = "https://repo1.maven.org/maven2" }
+        maven { url "https://repo1.maven.org/maven2" }
     }
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
@@ -20,7 +20,7 @@ buildscript {
 apply plugin: 'kotlin'
 
 repositories {
-    maven { url = "https://repo1.maven.org/maven2" }
+    maven { url "https://repo1.maven.org/maven2" }
 }
 
 test {

--- a/samples/client/petstore/kotlin-nonpublic/build.gradle
+++ b/samples/client/petstore/kotlin-nonpublic/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     ext.kotlin_version = '1.3.61'
 
     repositories {
-        maven { url = "https://repo1.maven.org/maven2" }
+        maven { url = uri("https://repo1.maven.org/maven2") }
     }
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
@@ -20,7 +20,7 @@ buildscript {
 apply plugin: 'kotlin'
 
 repositories {
-    maven { url = "https://repo1.maven.org/maven2" }
+    maven { url = uri("https://repo1.maven.org/maven2") }
 }
 
 test {

--- a/samples/client/petstore/kotlin-nonpublic/build.gradle
+++ b/samples/client/petstore/kotlin-nonpublic/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     ext.kotlin_version = '1.3.61'
 
     repositories {
-        maven { url = uri("https://repo1.maven.org/maven2") }
+        maven { url "https://repo1.maven.org/maven2" }
     }
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
@@ -20,7 +20,7 @@ buildscript {
 apply plugin: 'kotlin'
 
 repositories {
-    maven { url = uri("https://repo1.maven.org/maven2") }
+    maven { url "https://repo1.maven.org/maven2" }
 }
 
 test {

--- a/samples/client/petstore/kotlin-nullable/build.gradle
+++ b/samples/client/petstore/kotlin-nullable/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     ext.kotlin_version = '1.3.61'
 
     repositories {
-        maven { url "https://repo1.maven.org/maven2" }
+        maven { url = "https://repo1.maven.org/maven2" }
     }
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
@@ -20,7 +20,7 @@ buildscript {
 apply plugin: 'kotlin'
 
 repositories {
-    maven { url "https://repo1.maven.org/maven2" }
+    maven { url = "https://repo1.maven.org/maven2" }
 }
 
 test {

--- a/samples/client/petstore/kotlin-nullable/build.gradle
+++ b/samples/client/petstore/kotlin-nullable/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     ext.kotlin_version = '1.3.61'
 
     repositories {
-        maven { url = "https://repo1.maven.org/maven2" }
+        maven { url "https://repo1.maven.org/maven2" }
     }
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
@@ -20,7 +20,7 @@ buildscript {
 apply plugin: 'kotlin'
 
 repositories {
-    maven { url = "https://repo1.maven.org/maven2" }
+    maven { url "https://repo1.maven.org/maven2" }
 }
 
 test {

--- a/samples/client/petstore/kotlin-nullable/build.gradle
+++ b/samples/client/petstore/kotlin-nullable/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     ext.kotlin_version = '1.3.61'
 
     repositories {
-        maven { url = "https://repo1.maven.org/maven2" }
+        maven { url = uri("https://repo1.maven.org/maven2") }
     }
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
@@ -20,7 +20,7 @@ buildscript {
 apply plugin: 'kotlin'
 
 repositories {
-    maven { url = "https://repo1.maven.org/maven2" }
+    maven { url = uri("https://repo1.maven.org/maven2") }
 }
 
 test {

--- a/samples/client/petstore/kotlin-nullable/build.gradle
+++ b/samples/client/petstore/kotlin-nullable/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     ext.kotlin_version = '1.3.61'
 
     repositories {
-        maven { url = uri("https://repo1.maven.org/maven2") }
+        maven { url "https://repo1.maven.org/maven2" }
     }
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
@@ -20,7 +20,7 @@ buildscript {
 apply plugin: 'kotlin'
 
 repositories {
-    maven { url = uri("https://repo1.maven.org/maven2") }
+    maven { url "https://repo1.maven.org/maven2" }
 }
 
 test {

--- a/samples/client/petstore/kotlin-okhttp3/build.gradle
+++ b/samples/client/petstore/kotlin-okhttp3/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     ext.kotlin_version = '1.3.61'
 
     repositories {
-        maven { url "https://repo1.maven.org/maven2" }
+        maven { url = "https://repo1.maven.org/maven2" }
     }
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
@@ -20,7 +20,7 @@ buildscript {
 apply plugin: 'kotlin'
 
 repositories {
-    maven { url "https://repo1.maven.org/maven2" }
+    maven { url = "https://repo1.maven.org/maven2" }
 }
 
 test {

--- a/samples/client/petstore/kotlin-okhttp3/build.gradle
+++ b/samples/client/petstore/kotlin-okhttp3/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     ext.kotlin_version = '1.3.61'
 
     repositories {
-        maven { url = "https://repo1.maven.org/maven2" }
+        maven { url "https://repo1.maven.org/maven2" }
     }
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
@@ -20,7 +20,7 @@ buildscript {
 apply plugin: 'kotlin'
 
 repositories {
-    maven { url = "https://repo1.maven.org/maven2" }
+    maven { url "https://repo1.maven.org/maven2" }
 }
 
 test {

--- a/samples/client/petstore/kotlin-okhttp3/build.gradle
+++ b/samples/client/petstore/kotlin-okhttp3/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     ext.kotlin_version = '1.3.61'
 
     repositories {
-        maven { url = "https://repo1.maven.org/maven2" }
+        maven { url = uri("https://repo1.maven.org/maven2") }
     }
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
@@ -20,7 +20,7 @@ buildscript {
 apply plugin: 'kotlin'
 
 repositories {
-    maven { url = "https://repo1.maven.org/maven2" }
+    maven { url = uri("https://repo1.maven.org/maven2") }
 }
 
 test {

--- a/samples/client/petstore/kotlin-okhttp3/build.gradle
+++ b/samples/client/petstore/kotlin-okhttp3/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     ext.kotlin_version = '1.3.61'
 
     repositories {
-        maven { url = uri("https://repo1.maven.org/maven2") }
+        maven { url "https://repo1.maven.org/maven2" }
     }
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
@@ -20,7 +20,7 @@ buildscript {
 apply plugin: 'kotlin'
 
 repositories {
-    maven { url = uri("https://repo1.maven.org/maven2") }
+    maven { url "https://repo1.maven.org/maven2" }
 }
 
 test {

--- a/samples/client/petstore/kotlin-retrofit2/build.gradle
+++ b/samples/client/petstore/kotlin-retrofit2/build.gradle
@@ -11,7 +11,7 @@ buildscript {
     ext.retrofitVersion = '2.6.2'
 
     repositories {
-        maven { url = "https://repo1.maven.org/maven2" }
+        maven { url "https://repo1.maven.org/maven2" }
     }
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
@@ -21,7 +21,7 @@ buildscript {
 apply plugin: 'kotlin'
 
 repositories {
-    maven { url = "https://repo1.maven.org/maven2" }
+    maven { url "https://repo1.maven.org/maven2" }
 }
 
 test {

--- a/samples/client/petstore/kotlin-retrofit2/build.gradle
+++ b/samples/client/petstore/kotlin-retrofit2/build.gradle
@@ -11,7 +11,7 @@ buildscript {
     ext.retrofitVersion = '2.6.2'
 
     repositories {
-        maven { url = uri("https://repo1.maven.org/maven2") }
+        maven { url "https://repo1.maven.org/maven2" }
     }
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
@@ -21,7 +21,7 @@ buildscript {
 apply plugin: 'kotlin'
 
 repositories {
-    maven { url = uri("https://repo1.maven.org/maven2") }
+    maven { url "https://repo1.maven.org/maven2" }
 }
 
 test {

--- a/samples/client/petstore/kotlin-retrofit2/build.gradle
+++ b/samples/client/petstore/kotlin-retrofit2/build.gradle
@@ -11,7 +11,7 @@ buildscript {
     ext.retrofitVersion = '2.6.2'
 
     repositories {
-        maven { url "https://repo1.maven.org/maven2" }
+        maven { url = "https://repo1.maven.org/maven2" }
     }
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
@@ -21,7 +21,7 @@ buildscript {
 apply plugin: 'kotlin'
 
 repositories {
-    maven { url "https://repo1.maven.org/maven2" }
+    maven { url = "https://repo1.maven.org/maven2" }
 }
 
 test {

--- a/samples/client/petstore/kotlin-retrofit2/build.gradle
+++ b/samples/client/petstore/kotlin-retrofit2/build.gradle
@@ -11,7 +11,7 @@ buildscript {
     ext.retrofitVersion = '2.6.2'
 
     repositories {
-        maven { url = "https://repo1.maven.org/maven2" }
+        maven { url = uri("https://repo1.maven.org/maven2") }
     }
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
@@ -21,7 +21,7 @@ buildscript {
 apply plugin: 'kotlin'
 
 repositories {
-    maven { url = "https://repo1.maven.org/maven2" }
+    maven { url = uri("https://repo1.maven.org/maven2") }
 }
 
 test {

--- a/samples/client/petstore/kotlin-string/build.gradle
+++ b/samples/client/petstore/kotlin-string/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     ext.kotlin_version = '1.3.61'
 
     repositories {
-        maven { url "https://repo1.maven.org/maven2" }
+        maven { url = "https://repo1.maven.org/maven2" }
     }
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
@@ -20,7 +20,7 @@ buildscript {
 apply plugin: 'kotlin'
 
 repositories {
-    maven { url "https://repo1.maven.org/maven2" }
+    maven { url = "https://repo1.maven.org/maven2" }
 }
 
 test {

--- a/samples/client/petstore/kotlin-string/build.gradle
+++ b/samples/client/petstore/kotlin-string/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     ext.kotlin_version = '1.3.61'
 
     repositories {
-        maven { url = "https://repo1.maven.org/maven2" }
+        maven { url "https://repo1.maven.org/maven2" }
     }
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
@@ -20,7 +20,7 @@ buildscript {
 apply plugin: 'kotlin'
 
 repositories {
-    maven { url = "https://repo1.maven.org/maven2" }
+    maven { url "https://repo1.maven.org/maven2" }
 }
 
 test {

--- a/samples/client/petstore/kotlin-string/build.gradle
+++ b/samples/client/petstore/kotlin-string/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     ext.kotlin_version = '1.3.61'
 
     repositories {
-        maven { url = "https://repo1.maven.org/maven2" }
+        maven { url = uri("https://repo1.maven.org/maven2") }
     }
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
@@ -20,7 +20,7 @@ buildscript {
 apply plugin: 'kotlin'
 
 repositories {
-    maven { url = "https://repo1.maven.org/maven2" }
+    maven { url = uri("https://repo1.maven.org/maven2") }
 }
 
 test {

--- a/samples/client/petstore/kotlin-string/build.gradle
+++ b/samples/client/petstore/kotlin-string/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     ext.kotlin_version = '1.3.61'
 
     repositories {
-        maven { url = uri("https://repo1.maven.org/maven2") }
+        maven { url "https://repo1.maven.org/maven2" }
     }
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
@@ -20,7 +20,7 @@ buildscript {
 apply plugin: 'kotlin'
 
 repositories {
-    maven { url = uri("https://repo1.maven.org/maven2") }
+    maven { url "https://repo1.maven.org/maven2" }
 }
 
 test {

--- a/samples/client/petstore/kotlin-threetenbp/build.gradle
+++ b/samples/client/petstore/kotlin-threetenbp/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     ext.kotlin_version = '1.3.61'
 
     repositories {
-        maven { url "https://repo1.maven.org/maven2" }
+        maven { url = "https://repo1.maven.org/maven2" }
     }
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
@@ -20,7 +20,7 @@ buildscript {
 apply plugin: 'kotlin'
 
 repositories {
-    maven { url "https://repo1.maven.org/maven2" }
+    maven { url = "https://repo1.maven.org/maven2" }
 }
 
 test {

--- a/samples/client/petstore/kotlin-threetenbp/build.gradle
+++ b/samples/client/petstore/kotlin-threetenbp/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     ext.kotlin_version = '1.3.61'
 
     repositories {
-        maven { url = "https://repo1.maven.org/maven2" }
+        maven { url "https://repo1.maven.org/maven2" }
     }
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
@@ -20,7 +20,7 @@ buildscript {
 apply plugin: 'kotlin'
 
 repositories {
-    maven { url = "https://repo1.maven.org/maven2" }
+    maven { url "https://repo1.maven.org/maven2" }
 }
 
 test {

--- a/samples/client/petstore/kotlin-threetenbp/build.gradle
+++ b/samples/client/petstore/kotlin-threetenbp/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     ext.kotlin_version = '1.3.61'
 
     repositories {
-        maven { url = "https://repo1.maven.org/maven2" }
+        maven { url = uri("https://repo1.maven.org/maven2") }
     }
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
@@ -20,7 +20,7 @@ buildscript {
 apply plugin: 'kotlin'
 
 repositories {
-    maven { url = "https://repo1.maven.org/maven2" }
+    maven { url = uri("https://repo1.maven.org/maven2") }
 }
 
 test {

--- a/samples/client/petstore/kotlin-threetenbp/build.gradle
+++ b/samples/client/petstore/kotlin-threetenbp/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     ext.kotlin_version = '1.3.61'
 
     repositories {
-        maven { url = uri("https://repo1.maven.org/maven2") }
+        maven { url "https://repo1.maven.org/maven2" }
     }
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
@@ -20,7 +20,7 @@ buildscript {
 apply plugin: 'kotlin'
 
 repositories {
-    maven { url = uri("https://repo1.maven.org/maven2") }
+    maven { url "https://repo1.maven.org/maven2" }
 }
 
 test {

--- a/samples/client/petstore/kotlin/build.gradle
+++ b/samples/client/petstore/kotlin/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     ext.kotlin_version = '1.3.61'
 
     repositories {
-        maven { url "https://repo1.maven.org/maven2" }
+        maven { url = "https://repo1.maven.org/maven2" }
     }
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
@@ -20,7 +20,7 @@ buildscript {
 apply plugin: 'kotlin'
 
 repositories {
-    maven { url "https://repo1.maven.org/maven2" }
+    maven { url = "https://repo1.maven.org/maven2" }
 }
 
 test {

--- a/samples/client/petstore/kotlin/build.gradle
+++ b/samples/client/petstore/kotlin/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     ext.kotlin_version = '1.3.61'
 
     repositories {
-        maven { url = "https://repo1.maven.org/maven2" }
+        maven { url "https://repo1.maven.org/maven2" }
     }
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
@@ -20,7 +20,7 @@ buildscript {
 apply plugin: 'kotlin'
 
 repositories {
-    maven { url = "https://repo1.maven.org/maven2" }
+    maven { url "https://repo1.maven.org/maven2" }
 }
 
 test {

--- a/samples/client/petstore/kotlin/build.gradle
+++ b/samples/client/petstore/kotlin/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     ext.kotlin_version = '1.3.61'
 
     repositories {
-        maven { url = "https://repo1.maven.org/maven2" }
+        maven { url = uri("https://repo1.maven.org/maven2") }
     }
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
@@ -20,7 +20,7 @@ buildscript {
 apply plugin: 'kotlin'
 
 repositories {
-    maven { url = "https://repo1.maven.org/maven2" }
+    maven { url = uri("https://repo1.maven.org/maven2") }
 }
 
 test {

--- a/samples/client/petstore/kotlin/build.gradle
+++ b/samples/client/petstore/kotlin/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     ext.kotlin_version = '1.3.61'
 
     repositories {
-        maven { url = uri("https://repo1.maven.org/maven2") }
+        maven { url "https://repo1.maven.org/maven2" }
     }
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
@@ -20,7 +20,7 @@ buildscript {
 apply plugin: 'kotlin'
 
 repositories {
-    maven { url = uri("https://repo1.maven.org/maven2") }
+    maven { url "https://repo1.maven.org/maven2" }
 }
 
 test {

--- a/samples/server/petstore/jaxrs-resteasy/eap-java8/build.gradle
+++ b/samples/server/petstore/jaxrs-resteasy/eap-java8/build.gradle
@@ -4,7 +4,7 @@ project.version = "1.0.0"
 project.group = "org.openapitools"
 
 repositories {
-    maven { url = "https://repo1.maven.org/maven2" }
+    maven { url "https://repo1.maven.org/maven2" }
 }
 
 dependencies {

--- a/samples/server/petstore/jaxrs-resteasy/eap-java8/build.gradle
+++ b/samples/server/petstore/jaxrs-resteasy/eap-java8/build.gradle
@@ -4,7 +4,7 @@ project.version = "1.0.0"
 project.group = "org.openapitools"
 
 repositories {
-    maven { url "https://repo1.maven.org/maven2" }
+    maven { url = "https://repo1.maven.org/maven2" }
 }
 
 dependencies {

--- a/samples/server/petstore/jaxrs-resteasy/eap-java8/build.gradle
+++ b/samples/server/petstore/jaxrs-resteasy/eap-java8/build.gradle
@@ -4,7 +4,7 @@ project.version = "1.0.0"
 project.group = "org.openapitools"
 
 repositories {
-    maven { url = uri("https://repo1.maven.org/maven2") }
+    maven { url "https://repo1.maven.org/maven2" }
 }
 
 dependencies {

--- a/samples/server/petstore/jaxrs-resteasy/eap-java8/build.gradle
+++ b/samples/server/petstore/jaxrs-resteasy/eap-java8/build.gradle
@@ -4,7 +4,7 @@ project.version = "1.0.0"
 project.group = "org.openapitools"
 
 repositories {
-    maven { url = "https://repo1.maven.org/maven2" }
+    maven { url = uri("https://repo1.maven.org/maven2") }
 }
 
 dependencies {

--- a/samples/server/petstore/jaxrs-resteasy/eap-joda/build.gradle
+++ b/samples/server/petstore/jaxrs-resteasy/eap-joda/build.gradle
@@ -4,7 +4,7 @@ project.version = "1.0.0"
 project.group = "org.openapitools"
 
 repositories {
-    maven { url = "https://repo1.maven.org/maven2" }
+    maven { url "https://repo1.maven.org/maven2" }
 }
 
 dependencies {

--- a/samples/server/petstore/jaxrs-resteasy/eap-joda/build.gradle
+++ b/samples/server/petstore/jaxrs-resteasy/eap-joda/build.gradle
@@ -4,7 +4,7 @@ project.version = "1.0.0"
 project.group = "org.openapitools"
 
 repositories {
-    maven { url "https://repo1.maven.org/maven2" }
+    maven { url = "https://repo1.maven.org/maven2" }
 }
 
 dependencies {

--- a/samples/server/petstore/jaxrs-resteasy/eap-joda/build.gradle
+++ b/samples/server/petstore/jaxrs-resteasy/eap-joda/build.gradle
@@ -4,7 +4,7 @@ project.version = "1.0.0"
 project.group = "org.openapitools"
 
 repositories {
-    maven { url = uri("https://repo1.maven.org/maven2") }
+    maven { url "https://repo1.maven.org/maven2" }
 }
 
 dependencies {

--- a/samples/server/petstore/jaxrs-resteasy/eap-joda/build.gradle
+++ b/samples/server/petstore/jaxrs-resteasy/eap-joda/build.gradle
@@ -4,7 +4,7 @@ project.version = "1.0.0"
 project.group = "org.openapitools"
 
 repositories {
-    maven { url = "https://repo1.maven.org/maven2" }
+    maven { url = uri("https://repo1.maven.org/maven2") }
 }
 
 dependencies {

--- a/samples/server/petstore/jaxrs-resteasy/eap/build.gradle
+++ b/samples/server/petstore/jaxrs-resteasy/eap/build.gradle
@@ -4,7 +4,7 @@ project.version = "1.0.0"
 project.group = "org.openapitools"
 
 repositories {
-    maven { url = "https://repo1.maven.org/maven2" }
+    maven { url "https://repo1.maven.org/maven2" }
 }
 
 dependencies {

--- a/samples/server/petstore/jaxrs-resteasy/eap/build.gradle
+++ b/samples/server/petstore/jaxrs-resteasy/eap/build.gradle
@@ -4,7 +4,7 @@ project.version = "1.0.0"
 project.group = "org.openapitools"
 
 repositories {
-    maven { url "https://repo1.maven.org/maven2" }
+    maven { url = "https://repo1.maven.org/maven2" }
 }
 
 dependencies {

--- a/samples/server/petstore/jaxrs-resteasy/eap/build.gradle
+++ b/samples/server/petstore/jaxrs-resteasy/eap/build.gradle
@@ -4,7 +4,7 @@ project.version = "1.0.0"
 project.group = "org.openapitools"
 
 repositories {
-    maven { url = uri("https://repo1.maven.org/maven2") }
+    maven { url "https://repo1.maven.org/maven2" }
 }
 
 dependencies {

--- a/samples/server/petstore/jaxrs-resteasy/eap/build.gradle
+++ b/samples/server/petstore/jaxrs-resteasy/eap/build.gradle
@@ -4,7 +4,7 @@ project.version = "1.0.0"
 project.group = "org.openapitools"
 
 repositories {
-    maven { url = "https://repo1.maven.org/maven2" }
+    maven { url = uri("https://repo1.maven.org/maven2") }
 }
 
 dependencies {

--- a/samples/server/petstore/kotlin-server/ktor/build.gradle
+++ b/samples/server/petstore/kotlin-server/ktor/build.gradle
@@ -14,7 +14,7 @@ buildscript {
     repositories {
         maven { url = "https://repo1.maven.org/maven2" }
         maven {
-            url "https://plugins.gradle.org/m2/"
+            url = "https://plugins.gradle.org/m2/"
         }
     }
     dependencies {
@@ -51,8 +51,8 @@ shadowJar {
 
 repositories {
     maven { url = "https://repo1.maven.org/maven2" }
-    maven { url "https://dl.bintray.com/kotlin/ktor" }
-    maven { url "https://dl.bintray.com/kotlin/kotlinx" }
+    maven { url = "https://dl.bintray.com/kotlin/ktor" }
+    maven { url = "https://dl.bintray.com/kotlin/kotlinx" }
 }
 
 dependencies {

--- a/samples/server/petstore/kotlin-server/ktor/build.gradle
+++ b/samples/server/petstore/kotlin-server/ktor/build.gradle
@@ -12,7 +12,7 @@ buildscript {
     ext.shadow_version = '2.0.3'
 
     repositories {
-        maven { url = "https://repo1.maven.org/maven2" }
+        maven { url "https://repo1.maven.org/maven2" }
         maven {
             url = "https://plugins.gradle.org/m2/"
         }
@@ -50,9 +50,9 @@ shadowJar {
 }
 
 repositories {
-    maven { url = "https://repo1.maven.org/maven2" }
-    maven { url = "https://dl.bintray.com/kotlin/ktor" }
-    maven { url = "https://dl.bintray.com/kotlin/kotlinx" }
+    maven { url "https://repo1.maven.org/maven2" }
+    maven { url "https://dl.bintray.com/kotlin/ktor" }
+    maven { url "https://dl.bintray.com/kotlin/kotlinx" }
 }
 
 dependencies {

--- a/samples/server/petstore/kotlin-server/ktor/build.gradle
+++ b/samples/server/petstore/kotlin-server/ktor/build.gradle
@@ -12,7 +12,7 @@ buildscript {
     ext.shadow_version = '2.0.3'
 
     repositories {
-        maven { url = "https://repo1.maven.org/maven2" }
+        maven { url = uri("https://repo1.maven.org/maven2") }
         maven {
             url "https://plugins.gradle.org/m2/"
         }
@@ -50,7 +50,7 @@ shadowJar {
 }
 
 repositories {
-    maven { url = "https://repo1.maven.org/maven2" }
+    maven { url = uri("https://repo1.maven.org/maven2") }
     maven { url  "https://dl.bintray.com/kotlin/ktor" }
     maven { url "https://dl.bintray.com/kotlin/kotlinx" }
 }

--- a/samples/server/petstore/kotlin-server/ktor/build.gradle
+++ b/samples/server/petstore/kotlin-server/ktor/build.gradle
@@ -12,7 +12,7 @@ buildscript {
     ext.shadow_version = '2.0.3'
 
     repositories {
-        maven { url = uri("https://repo1.maven.org/maven2") }
+        maven { url "https://repo1.maven.org/maven2" }
         maven {
             url "https://plugins.gradle.org/m2/"
         }
@@ -50,7 +50,7 @@ shadowJar {
 }
 
 repositories {
-    maven { url = uri("https://repo1.maven.org/maven2") }
+    maven { url "https://repo1.maven.org/maven2" }
     maven { url  "https://dl.bintray.com/kotlin/ktor" }
     maven { url "https://dl.bintray.com/kotlin/kotlinx" }
 }

--- a/samples/server/petstore/kotlin-server/ktor/build.gradle
+++ b/samples/server/petstore/kotlin-server/ktor/build.gradle
@@ -12,7 +12,7 @@ buildscript {
     ext.shadow_version = '2.0.3'
 
     repositories {
-        maven { url "https://repo1.maven.org/maven2" }
+        maven { url = "https://repo1.maven.org/maven2" }
         maven {
             url "https://plugins.gradle.org/m2/"
         }
@@ -50,8 +50,8 @@ shadowJar {
 }
 
 repositories {
-    maven { url "https://repo1.maven.org/maven2" }
-    maven { url  "https://dl.bintray.com/kotlin/ktor" }
+    maven { url = "https://repo1.maven.org/maven2" }
+    maven { url "https://dl.bintray.com/kotlin/ktor" }
     maven { url "https://dl.bintray.com/kotlin/kotlinx" }
 }
 


### PR DESCRIPTION
According to https://docs.gradle.org/current/userguide/declaring_repositories.html, the syntax for maven repositories is:
```
repositories {
    maven {
        url "https://maven.springframework.org/release"
    }
}
```

There is no equal sign between the 'url' keyword and the value.


<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [ ] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [ ] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
