### PR TITLE
[typescript-axios] Fixed call of toISOString on a string type when using string type-map…

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-axios/apiInner.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-axios/apiInner.mustache
@@ -115,7 +115,9 @@ export const {{classname}}AxiosParamCreator = function (configuration?: Configur
             {{^isListContainer}}
             if ({{paramName}} !== undefined) {
                 {{#isDateTime}}
-                localVarQueryParameter['{{baseName}}'] = ({{paramName}} as any).toISOString();
+                localVarQueryParameter['{{baseName}}'] = ({{paramName}} as any instanceof Date) ?
+                    ({{paramName}} as any).toISOString() :
+                    {{paramName}};
                 {{/isDateTime}}
                 {{^isDateTime}}
                 {{#isDate}}


### PR DESCRIPTION
@TiFu @taxpon @sebastianhaas @kenisteward @Vrolijkx @macjohnny @nicokoenig @topce @akehir @petejohansonxo

Created a detailed repro repository [here](https://github.com/LiamMartens/openapi-toisostring-datetime-example)  

Basic gist of it is the following, let's assume you have following swagger definition
```
"parameters": [
    {
        "name": "param",
        "in": "query",
        "required": false,
        "type": "string",
        "format": "date-time"
    }
],
```
When type mapping `date` to `string` this results in the following generated code 
```
example(param?: string, options: any = {}): RequestArgs {
    ....
    if (param !== undefined) {
        localVarQueryParameter['param'] = (param as any).toISOString(); <-- toISOString() on string type
    }
    ...
},
```

This same fix was applied to the `isDate` template.

<!-- Please check the completed items below -->
### PR checklist

- [x ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x ] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x ] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
