### PR TITLE
[test] Removes jmockit in favor of mockito

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.scannerwork/
 .vscode
 *.iml
 out/

--- a/modules/openapi-generator-cli/pom.xml
+++ b/modules/openapi-generator-cli/pom.xml
@@ -109,9 +109,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.jmockit</groupId>
-            <artifactId>jmockit</artifactId>
-<!--             <version>${jmockit-version}</version> -->
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>${mockito-version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/modules/openapi-generator-cli/src/test/java/org/openapitools/codegen/cmd/GenerateTest.java
+++ b/modules/openapi-generator-cli/src/test/java/org/openapitools/codegen/cmd/GenerateTest.java
@@ -17,446 +17,413 @@
 
 package org.openapitools.codegen.cmd;
 
-import org.mockito.MockSettings;
-import org.openapitools.codegen.ClientOptInput;
-import org.openapitools.codegen.DefaultGenerator;
-import org.openapitools.codegen.OpenAPIGenerator;
-import org.openapitools.codegen.config.CodegenConfigurator;
+import io.airlift.airline.Cli;
 import org.apache.commons.lang3.ArrayUtils;
+import org.mockito.MockSettings;
+import org.openapitools.codegen.DefaultGenerator;
+import org.openapitools.codegen.Generator;
+import org.openapitools.codegen.config.CodegenConfigurator;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
 
 import static org.mockito.Answers.CALLS_REAL_METHODS;
 import static org.mockito.Mockito.*;
+import static org.testng.Assert.fail;
 
 @SuppressWarnings("unused")
 public class GenerateTest {
 
     protected MockSettings mockSettings = withSettings().useConstructor().defaultAnswer(CALLS_REAL_METHODS);
-
-    private DefaultGenerator generator;
+    private Generator generator;
     private CodegenConfigurator configurator;
-    File outputDirectory;
+    private Path outputDirectory;
 
-    // ???
-    ClientOptInput clientOptInput;
+    @AfterMethod
+    public void afterEachTest() {
+        outputDirectory.toFile().deleteOnExit();
+    }
 
     @BeforeMethod
     public void beforeEachTest() throws IOException {
-        generator = mock(DefaultGenerator.class, mockSettings);
+        outputDirectory = Files.createTempDirectory("GenerateTest");
+        generator = mock(DefaultGenerator.class);
+        when(generator.generate()).thenReturn(new ArrayList<>());
+
         configurator = mock(CodegenConfigurator.class, mockSettings);
-        outputDirectory = Files.createTempDirectory("GenerateTest").toFile();
     }
-//
-//    @Test
-//    public void testVerboseShort() throws Exception {
-//        setupAndRunGenericTest("-v");
-//        verify(configurator).setVerbose(true);
-//    }
-//
-//    @Test
-//    public void testVerboseLong() throws Exception {
-//        setupAndRunGenericTest("--verbose");
-//        verify(configurator).setVerbose(true);
-//    }
-//
-//    @Test
-//    public void testRequiredArgs_ShortArgs() throws Exception {
-//        setupAndRunTest("-i", "src/test/resources/swagger.yaml", "-g", "java", "-o", "src/main/java", false, null, "-p", "foo=bar");
-//        verify(configurator).addAdditionalProperty("foo", "bar");
-//    }
-//
-//    @Test
-//    public void testRequiredArgs_LongArgs() throws Exception {
-//        setupAndRunTest("--input-spec", "src/test/resources/swagger.yaml", "--generator-name", "java", "--output",
-//                "src/main/java", false, null);
-//
-//        // TODO: I added these
-//        verify(configurator).addAdditionalProperty("generatorName", "java");
-//        verify(configurator).addAdditionalProperty("inputSpec", "src/test/resources/swagger.yaml");
-//    }
-//
-//    @Test
-//    public void testTemplateDirShort() throws Exception {
-//        final String templateDir = "src/main/resources/customTemplates";
-//        setupAndRunGenericTest("-t", templateDir);
-//        verify(configurator).setTemplateDir(templateDir);
-//    }
-//
-//    @Test
-//    public void testTemplateDirLong() throws Exception {
-//        final String templateDir = "src/main/resources/customTemplates";
-//        setupAndRunGenericTest("--template-dir", templateDir);
-//        verify(configurator).setTemplateDir(templateDir);
-//    }
-//
-//    @Test
-//    public void testAuthLong() throws Exception {
-//        final String auth = "hello:world";
-//        setupAndRunGenericTest("--auth", auth);
-//        verify(configurator).setAuth(auth);
-//    }
-//
-//    @Test
-//    public void testAuthShort() throws Exception {
-//        final String auth = "hello:world";
-//        setupAndRunGenericTest("-a", auth);
-//        verify(configurator).setAuth(auth);
-//    }
-//
-//    @Test
-//    public void testAuthUnspecified() throws Exception {
-//        setupAndRunGenericTest();
-//        verify(configurator, never()).setAuth(anyString());
-//    }
-//
-//    @Test
-//    public void testConfigJsonShort() throws Exception {
-//        setupAndRunTest("-i", "src/test/resources/swagger.yaml", "-g", "java", "-o", "src/main/java", true,
-//                "config.json", "-c", "config.json");
-//        // TODO: Verifications
-//    }
-//
-//    @Test
-//    public void testConfigJsonLong() throws Exception {
-//        setupAndRunTest("-i", "src/test/resources/swagger.yaml", "-g", "java", "-o", "src/main/java", true,
-//                "config.json", "--config", "config.json");
-//        // TODO: Verifications
-//    }
-//
-//    @Test
-//    public void testConfigYamlShort() throws Exception {
-//        setupAndRunTest("-i", "src/test/resources/swagger.yaml", "-g", "java", "-o", "src/main/java", true,
-//                "config.yaml", "-c", "config.yaml");
-//
-//        // TODO: Verifications
-//    }
-//
-//    @Test
-//    public void testConfigYamlLong() throws Exception {
-//
-//        setupAndRunTest("-i", "src/test/resources/swagger.yaml", "-g", "java", "-o", "src/main/java", true,
-//                "config.yaml", "--config", "config.yaml");
-//
-//        // TODO: Verifications
-//    }
-//
-//    @Test
-//    public void testSkipOverwriteShort() throws Exception {
-//        setupAndRunGenericTest("-s");
-//        verify(configurator).setSkipOverwrite(true);
-//    }
-//
-//    @Test
-//    public void testSkipOverwriteLong() throws Exception {
-//        setupAndRunGenericTest("--skip-overwrite");
-//        verify(configurator).setSkipOverwrite(true);
-//    }
-//
-//    @Test
-//    public void testStrictSpec() throws Exception {
-//
-//        setupAndRunGenericTest("--strict-spec", "true");
-//        new FullVerifications() {
-//            {
-//                configurator.setStrictSpecBehavior(true);
-//                times = 1;
-//            }
-//        };
-//
-//        setupAndRunGenericTest("--strict-spec", "false");
-//        new FullVerifications() {
-//            {
-//                configurator.setStrictSpecBehavior(false);
-//                times = 1;
-//            }
-//        };
-//    }
-//
-//    @Test
-//    public void testPackageName() throws Exception {
-//        final String value = "io.foo.bar.baz";
-//        setupAndRunGenericTest("--package-name", value);
-//
-//        new FullVerifications() {
-//            {
-//                configurator.setPackageName(value);
-//                times = 1;
-//            }
-//        };
-//    }
-//
-//    @Test
-//    public void testApiPackage() throws Exception {
-//        final String value = "io.foo.bar.api";
-//        setupAndRunGenericTest("--api-package", value);
-//
-//        new FullVerifications() {
-//            {
-//                configurator.setApiPackage(value);
-//                times = 1;
-//            }
-//        };
-//    }
-//
-//    @Test
-//    public void testModelPackage() throws Exception {
-//        final String value = "io.foo.bar.api";
-//        setupAndRunGenericTest("--model-package", value);
-//
-//        new FullVerifications() {
-//            {
-//                configurator.setModelPackage(value);
-//                times = 1;
-//            }
-//        };
-//    }
-//
-//    @Test
-//    public void testInstantiationTypes() throws Exception {
-//
-//        setupAndRunGenericTest("--instantiation-types", "hello=world,key=,foo=bar,key2");
-//
-//        new FullVerifications() {
-//            {
-//                configurator.addInstantiationType("hello", "world");
-//                times = 1;
-//                configurator.addInstantiationType("foo", "bar");
-//                times = 1;
-//                configurator.addInstantiationType("key", "");
-//                times = 1;
-//                configurator.addInstantiationType("key2", "");
-//                times = 1;
-//            }
-//        };
-//
-//        setupAndRunGenericTest("--instantiation-types", "hello=world", "--instantiation-types",
-//                "key=", "--instantiation-types", "foo=bar", "--instantiation-types", "key2");
-//
-//        new FullVerifications() {
-//            {
-//                configurator.addInstantiationType("hello", "world");
-//                times = 1;
-//                configurator.addInstantiationType("foo", "bar");
-//                times = 1;
-//                configurator.addInstantiationType("key", "");
-//                times = 1;
-//                configurator.addInstantiationType("key2", "");
-//                times = 1;
-//            }
-//        };
-//    }
-//
-//    @Test
-//    public void testTypeMappings() throws Exception {
-//        setupAndRunGenericTest("--type-mappings", "hello=world,key=,foo=bar,key2");
-//
-//        new FullVerifications() {
-//            {
-//                configurator.addTypeMapping("hello", "world");
-//                times = 1;
-//                configurator.addTypeMapping("foo", "bar");
-//                times = 1;
-//                configurator.addTypeMapping("key", "");
-//                times = 1;
-//                configurator.addTypeMapping("key2", "");
-//                times = 1;
-//            }
-//        };
-//
-//        setupAndRunGenericTest("--type-mappings", "hello=world", "--type-mappings", "key=",
-//                "--type-mappings", "foo=bar", "--type-mappings", "key2");
-//
-//        new FullVerifications() {
-//            {
-//                configurator.addTypeMapping("hello", "world");
-//                times = 1;
-//                configurator.addTypeMapping("foo", "bar");
-//                times = 1;
-//                configurator.addTypeMapping("key", "");
-//                times = 1;
-//                configurator.addTypeMapping("key2", "");
-//                times = 1;
-//            }
-//        };
-//    }
-//
-//    @Test
-//    public void testAdditionalProperties() throws Exception {
-//        setupAndRunGenericTest("--additional-properties", "hello=world,key=,foo=bar,key2");
-//
-//        new FullVerifications() {
-//            {
-//                configurator.addAdditionalProperty("hello", "world");
-//                times = 1;
-//                configurator.addAdditionalProperty("foo", "bar");
-//                times = 1;
-//                configurator.addAdditionalProperty("key", "");
-//                times = 1;
-//                configurator.addAdditionalProperty("key2", "");
-//                times = 1;
-//            }
-//        };
-//
-//        setupAndRunGenericTest("--additional-properties", "hello=world", "--additional-properties",
-//                "key=", "--additional-properties", "foo=bar", "--additional-properties", "key2");
-//
-//        new FullVerifications() {
-//            {
-//                configurator.addAdditionalProperty("hello", "world");
-//                times = 1;
-//                configurator.addAdditionalProperty("foo", "bar");
-//                times = 1;
-//                configurator.addAdditionalProperty("key", "");
-//                times = 1;
-//                configurator.addAdditionalProperty("key2", "");
-//                times = 1;
-//            }
-//        };
-//    }
-//
-//    @Test
-//    public void testLanguageSpecificPrimitives() throws Exception {
-//        setupAndRunGenericTest("--language-specific-primitives", "foo,,bar",
-//                "--language-specific-primitives", "hello,world");
-//
-//        new FullVerifications() {
-//            {
-//                configurator.addLanguageSpecificPrimitive("foo");
-//                times = 1;
-//                configurator.addLanguageSpecificPrimitive("bar");
-//                times = 1;
-//                configurator.addLanguageSpecificPrimitive("hello");
-//                times = 1;
-//                configurator.addLanguageSpecificPrimitive("world");
-//                times = 1;
-//            }
-//        };
-//    }
-//
-//    @Test
-//    public void testImportMappings() throws Exception {
-//        setupAndRunGenericTest("--import-mappings", "hello=world,key=,foo=bar,key2");
-//
-//        new FullVerifications() {
-//            {
-//                configurator.addImportMapping("hello", "world");
-//                times = 1;
-//                configurator.addImportMapping("foo", "bar");
-//                times = 1;
-//                configurator.addImportMapping("key", "");
-//                times = 1;
-//                configurator.addImportMapping("key2", "");
-//                times = 1;
-//            }
-//        };
-//
-//        setupAndRunGenericTest("--import-mappings", "hello=world", "--import-mappings", "key=",
-//                "--import-mappings", "foo=bar", "--import-mappings", "key2");
-//
-//        new FullVerifications() {
-//            {
-//                configurator.addImportMapping("hello", "world");
-//                times = 1;
-//                configurator.addImportMapping("foo", "bar");
-//                times = 1;
-//                configurator.addImportMapping("key", "");
-//                times = 1;
-//                configurator.addImportMapping("key2", "");
-//                times = 1;
-//            }
-//        };
-//    }
-//
-//    @Test
-//    public void testInvokerPackage() throws Exception {
-//        final String value = "io.foo.bar.api";
-//        setupAndRunGenericTest("--invoker-package", value);
-//
-//        new FullVerifications() {
-//            {
-//                configurator.setInvokerPackage(value);
-//                times = 1;
-//            }
-//        };
-//    }
-//
-//    @Test
-//    public void testGroupId() throws Exception {
-//        final String value = "io.foo.bar.api";
-//        setupAndRunGenericTest("--group-id", value);
-//
-//        new FullVerifications() {
-//            {
-//                configurator.setGroupId(value);
-//                times = 1;
-//            }
-//        };
-//    }
-//
-//    @Test
-//    public void testArtifactId() throws Exception {
-//        final String value = "awesome-api";
-//        setupAndRunGenericTest("--artifact-id", value);
-//
-//        new FullVerifications() {
-//            {
-//                configurator.setArtifactId(value);
-//                times = 1;
-//            }
-//        };
-//    }
-//
-//    @Test
-//    public void testArtifactVersion() throws Exception {
-//        final String value = "1.2.3";
-//        setupAndRunGenericTest("--artifact-version", value);
-//
-//        new FullVerifications() {
-//            {
-//                configurator.setArtifactVersion(value);
-//                times = 1;
-//            }
-//        };
-//    }
-//
-//    @Test
-//    public void testLibrary() throws Exception {
-//        final String value = "library1";
-//        setupAndRunGenericTest("--library", value);
-//
-//        new FullVerifications() {
-//            {
-//                configurator.setLibrary(value);
-//                times = 1;
-//            }
-//        };
-//    }
 
-    private void setupAndRunTest(String specFlag, final String spec, String langFlag,
-            final String lang, String outputDirFlag, final String outputDir,
-            boolean configuratorFromFile, final String configFile, String... additionalParameters) {
-        File actualOutputDir = new File(outputDirectory, outputDir);
-        final String[] commonArgs =
-                {"generate", langFlag, lang, outputDirFlag, actualOutputDir.getAbsolutePath(), specFlag, spec};
+    @Test
+    public void testAdditionalPropertiesLong() {
+        setupAndRunGenericTest("--additional-properties", "hello=world,key=,foo=bar,key2");
+        verify(configurator).addAdditionalProperty("hello", "world");
+        verify(configurator).addAdditionalProperty("foo", "bar");
+        verify(configurator).addAdditionalProperty("key", "");
+        verify(configurator).addAdditionalProperty("key2", "");
+    }
 
-        String[] argsToUse = ArrayUtils.addAll(commonArgs, additionalParameters);
+    @Test
+    public void testAdditionalPropertiesLongMultiple() {
+        setupAndRunGenericTest("--additional-properties", "hello=world", "--additional-properties",
+                "key=", "--additional-properties", "foo=bar", "--additional-properties", "key2");
+        verify(configurator).addAdditionalProperty("hello", "world");
+        verify(configurator).addAdditionalProperty("foo", "bar");
+        verify(configurator).addAdditionalProperty("key", "");
+        verify(configurator).addAdditionalProperty("key2", "");
+    }
 
+    @Test
+    public void testApiPackage() {
+        final String value = "io.foo.bar.api";
+        setupAndRunGenericTest("--api-package", value);
+        verify(configurator).setApiPackage(value);
+    }
 
-        OpenAPIGenerator.main(argsToUse);
+    @Test
+    public void testArtifactId() {
+        final String value = "awesome-api";
+        setupAndRunGenericTest("--artifact-id", value);
 
-//        verify(configurator).toClientOptInput();
-        verify(configurator).setGeneratorName(lang);
-        verify(configurator).setInputSpec(spec);
-        verify(configurator).setOutputDir(outputDir);
+        verify(configurator).setArtifactId(value);
     }
 
     private void setupAndRunGenericTest(String... additionalParameters) {
         setupAndRunTest("-i", "src/test/resources/swagger.yaml", "-g", "java", "-o", "src/main/java", false, null,
                 additionalParameters);
+    }
+
+    @SuppressWarnings("SameParameterValue")
+    private void setupAndRunTest(String specFlag, final String spec, String langFlag,
+                                 final String lang, String outputDirFlag, final String outputDir,
+                                 boolean configuratorFromFile, final String configFile, String... additionalParameters) {
+        final String[] commonArgs =
+                {"generate", langFlag, lang, outputDirFlag, outputDir, specFlag, spec};
+
+        String[] argsToUse = ArrayUtils.addAll(commonArgs, additionalParameters);
+
+        Cli.CliBuilder<Runnable> builder =
+                Cli.<Runnable>builder("openapi-generator-cli")
+                        .withCommands(Generate.class);
+
+        Generate generate = (Generate) builder.build().parse(argsToUse);
+
+        generate.configurator = configurator;
+        generate.generator = generator;
+
+        try {
+            generate.run();
+        } finally {
+            verify(configurator).setInputSpec(spec);
+            verify(configurator).setGeneratorName(lang);
+            verify(configurator).setOutputDir(outputDir);
+        }
+    }
+
+    @Test
+    public void testArtifactVersion() {
+        final String value = "1.2.3";
+        setupAndRunGenericTest("--artifact-version", value);
+
+        verify(configurator).setArtifactVersion(value);
+    }
+
+    @Test
+    public void testAuthLong() {
+        final String auth = "hello:world";
+        setupAndRunGenericTest("--auth", auth);
+        verify(configurator).toClientOptInput();
+        verify(configurator).toContext();
+        verify(configurator).setAuth(auth);
+        verifyNoMoreInteractions(configurator);
+    }
+
+    @Test
+    public void testAuthShort() {
+        final String auth = "hello:world";
+        setupAndRunGenericTest("-a", auth);
+        verify(configurator).toClientOptInput();
+        verify(configurator).toContext();
+        verify(configurator).setAuth(auth);
+        verifyNoMoreInteractions(configurator);
+    }
+
+    @Test
+    public void testAuthUnspecified() {
+        setupAndRunGenericTest();
+
+        verify(configurator).toClientOptInput();
+        verify(configurator).toContext();
+
+        verify(configurator, never()).setAuth(anyString());
+        verifyNoMoreInteractions(configurator);
+    }
+
+    @Test
+    public void testConfigJsonLong() {
+        setupAndRunTest("-i", "src/test/resources/swagger.yaml", "-g", "java", "-o", "src/main/java", true,
+                "config.json", "--config", "config.json");
+
+        verify(configurator).toClientOptInput();
+        verify(configurator).toContext();
+
+        verifyNoMoreInteractions(configurator);
+    }
+
+    @Test
+    public void testConfigJsonShort() {
+        setupAndRunTest("-i", "src/test/resources/swagger.yaml", "-g", "java", "-o", "src/main/java", true,
+                "config.json", "-c", "config.json");
+
+        // on top of those in setupAndRunTest
+        verify(configurator).toClientOptInput();
+        verify(configurator).toContext();
+
+        verifyNoMoreInteractions(configurator);
+    }
+
+    @Test
+    public void testConfigYamlLong() {
+        setupAndRunTest("-i", "src/test/resources/swagger.yaml", "-g", "java", "-o", "src/main/java", true,
+                "config.yaml", "--config", "config.yaml");
+
+        verify(configurator).toClientOptInput();
+        verify(configurator).toContext();
+
+        verifyNoMoreInteractions(configurator);
+    }
+
+    @Test
+    public void testConfigYamlShort() {
+        setupAndRunTest("-i", "src/test/resources/swagger.yaml", "-g", "java", "-o", "src/main/java", true,
+                "config.yaml", "-c", "config.yaml");
+
+        // on top of those in setupAndRunTest
+        verify(configurator).toClientOptInput();
+        verify(configurator).toContext();
+
+        verifyNoMoreInteractions(configurator);
+    }
+
+    @Test
+    public void testGroupId() {
+        final String value = "io.foo.bar.api";
+        setupAndRunGenericTest("--group-id", value);
+        verify(configurator).setGroupId(value);
+    }
+
+    @Test
+    public void testImportMappingsLong() {
+        setupAndRunGenericTest("--import-mappings", "hello=world,key=,foo=bar,key2");
+
+        verify(configurator).addImportMapping("hello", "world");
+        verify(configurator).addImportMapping("foo", "bar");
+        verify(configurator).addImportMapping("key", "");
+        verify(configurator).addImportMapping("key2", "");
+    }
+
+    @Test
+    public void testImportMappingsLongMultiple() {
+        setupAndRunGenericTest("--import-mappings", "hello=world", "--import-mappings", "key=",
+                "--import-mappings", "foo=bar", "--import-mappings", "key2");
+
+        verify(configurator).addImportMapping("hello", "world");
+        verify(configurator).addImportMapping("foo", "bar");
+        verify(configurator).addImportMapping("key", "");
+        verify(configurator).addImportMapping("key2", "");
+    }
+
+    @Test
+    public void testInstantiationTypesLong() {
+        setupAndRunGenericTest("--instantiation-types", "hello=world,key=,foo=bar,key2");
+        verify(configurator).addInstantiationType("hello", "world");
+        verify(configurator).addInstantiationType("foo", "bar");
+        verify(configurator).addInstantiationType("key", "");
+        verify(configurator).addInstantiationType("key2", "");
+    }
+
+    @Test
+    public void testInstantiationTypesLongMultiple() {
+        setupAndRunGenericTest("--instantiation-types", "hello=world", "--instantiation-types",
+                "key=", "--instantiation-types", "foo=bar", "--instantiation-types", "key2");
+        verify(configurator).addInstantiationType("hello", "world");
+        verify(configurator).addInstantiationType("foo", "bar");
+        verify(configurator).addInstantiationType("key", "");
+        verify(configurator).addInstantiationType("key2", "");
+    }
+
+    @Test
+    public void testInvokerPackage() {
+        final String value = "io.foo.bar.api";
+        setupAndRunGenericTest("--invoker-package", value);
+        verify(configurator).setInvokerPackage(value);
+    }
+
+    @Test
+    public void testLanguageSpecificPrimitives() {
+        setupAndRunGenericTest("--language-specific-primitives", "foo,,bar",
+                "--language-specific-primitives", "hello,world");
+
+        verify(configurator).addLanguageSpecificPrimitive("foo");
+        verify(configurator).addLanguageSpecificPrimitive("bar");
+        verify(configurator).addLanguageSpecificPrimitive("hello");
+        verify(configurator).addLanguageSpecificPrimitive("world");
+    }
+
+    @Test
+    public void testLibrary() {
+        final String value = "feign";
+        setupAndRunGenericTest("--library", value);
+        verify(configurator).setLibrary(value);
+    }
+
+    @Test
+    public void testModelPackage() {
+        final String value = "io.foo.bar.api";
+        setupAndRunGenericTest("--model-package", value);
+        verify(configurator).setModelPackage(value);
+    }
+
+    @Test
+    public void testPackageName() {
+        final String value = "io.foo.bar.baz";
+        setupAndRunGenericTest("--package-name", value);
+        verify(configurator).setPackageName(value);
+    }
+
+    @Test
+    public void testRequiredArgs_LongArgs() {
+        setupAndRunTest("--input-spec", "src/test/resources/swagger.yaml", "--generator-name", "java", "--output",
+                "src/main/java", false, null);
+
+        // on top of those in setupAndRunTest:
+        verify(configurator).toClientOptInput();
+        verify(configurator).toContext();
+
+        verifyNoMoreInteractions(configurator);
+    }
+
+    @Test
+    public void testRequiredArgs_ShortArgs() {
+        setupAndRunTest("-i", "src/test/resources/swagger.yaml", "-g", "java", "-o", "src/main/java", false, null, "-p", "foo=bar");
+
+        verify(configurator).addAdditionalProperty("foo", "bar");
+        verify(configurator).toClientOptInput();
+        verify(configurator).toContext();
+
+        verifyNoMoreInteractions(configurator);
+    }
+
+    @Test
+    public void testSkipOverwriteLong() {
+        setupAndRunGenericTest("--skip-overwrite");
+        verify(configurator).setSkipOverwrite(true);
+        verify(configurator).toClientOptInput();
+        verify(configurator).toContext();
+        verifyNoMoreInteractions(configurator);
+    }
+
+    @Test
+    public void testSkipOverwriteShort() {
+        setupAndRunGenericTest("-s");
+        verify(configurator).setSkipOverwrite(true);
+        verify(configurator).toClientOptInput();
+        verify(configurator).toContext();
+        verifyNoMoreInteractions(configurator);
+    }
+
+    @Test
+    public void testStrictSpecFalse() {
+        setupAndRunGenericTest("--strict-spec", "false");
+        verify(configurator).setStrictSpecBehavior(false);
+    }
+
+    @Test
+    public void testStrictSpecTrue() {
+        setupAndRunGenericTest("--strict-spec", "true");
+        verify(configurator).setStrictSpecBehavior(true);
+    }
+
+    @SuppressWarnings("ResultOfMethodCallIgnored")
+    @Test
+    public void testTemplateDirLong() {
+        final String templateDir = "src/main/resources/customTemplates";
+        File f = outputDirectory.resolve(templateDir).toFile();
+        try {
+            f.mkdirs();
+            setupAndRunGenericTest("--template-dir", f.getAbsolutePath());
+            verify(configurator).setTemplateDir(f.getAbsolutePath());
+            verify(configurator).toClientOptInput();
+            verify(configurator).toContext();
+            verifyNoMoreInteractions(configurator);
+        } finally {
+            f.delete();
+        }
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "Template directory src/main/resources/customTemplates does not exist.")
+    public void testTemplateDirMustExist() {
+        final String templateDir = "src/main/resources/customTemplates";
+        setupAndRunGenericTest("-t", templateDir);
+        fail("Expected exception was not thrown.");
+    }
+
+    @SuppressWarnings("ResultOfMethodCallIgnored")
+    @Test
+    public void testTemplateDirShort() {
+        final String templateDir = "src/main/resources/customTemplates";
+        File f = outputDirectory.resolve(templateDir).toFile();
+        try {
+            f.mkdirs();
+            setupAndRunGenericTest("-t", f.getAbsolutePath());
+        } finally {
+            verify(configurator).setTemplateDir(f.getAbsolutePath());
+            verify(configurator).toClientOptInput();
+            verify(configurator).toContext();
+            verifyNoMoreInteractions(configurator);
+            f.delete();
+        }
+    }
+
+    @Test
+    public void testTypeMappingsLong() {
+        setupAndRunGenericTest("--type-mappings", "hello=world,key=,foo=bar,key2");
+        verify(configurator).addTypeMapping("hello", "world");
+        verify(configurator).addTypeMapping("foo", "bar");
+        verify(configurator).addTypeMapping("key", "");
+        verify(configurator).addTypeMapping("key2", "");
+    }
+
+    @Test
+    public void testTypeMappingsLongMultiple() {
+        setupAndRunGenericTest("--type-mappings", "hello=world", "--type-mappings", "key=",
+                "--type-mappings", "foo=bar", "--type-mappings", "key2");
+        verify(configurator).addTypeMapping("hello", "world");
+        verify(configurator).addTypeMapping("foo", "bar");
+        verify(configurator).addTypeMapping("key", "");
+        verify(configurator).addTypeMapping("key2", "");
+    }
+
+    @Test
+    public void testVerboseLong() {
+        setupAndRunGenericTest("--verbose");
+        verify(configurator).setVerbose(true);
+        verify(configurator).toClientOptInput();
+        verify(configurator).toContext();
+        verifyNoMoreInteractions(configurator);
+    }
+
+    @Test
+    public void testVerboseShort() {
+        setupAndRunGenericTest("-v");
+        verify(configurator).setVerbose(true);
+        verify(configurator).toClientOptInput();
+        verify(configurator).toContext();
+        verifyNoMoreInteractions(configurator);
     }
 }

--- a/modules/openapi-generator-cli/src/test/java/org/openapitools/codegen/cmd/GenerateTest.java
+++ b/modules/openapi-generator-cli/src/test/java/org/openapitools/codegen/cmd/GenerateTest.java
@@ -362,7 +362,9 @@ public class GenerateTest {
             verify(configurator).toContext();
             verifyNoMoreInteractions(configurator);
         } finally {
-            f.delete();
+            if(!f.delete()) {
+                System.out.println("Directory didn't delete. You can ignore this.");
+            }
         }
     }
 
@@ -386,7 +388,9 @@ public class GenerateTest {
             verify(configurator).toClientOptInput();
             verify(configurator).toContext();
             verifyNoMoreInteractions(configurator);
-            f.delete();
+            if(!f.delete()) {
+                System.out.println("Directory didn't delete. You can ignore this.");
+            }
         }
     }
 

--- a/modules/openapi-generator-cli/src/test/java/org/openapitools/codegen/cmd/GenerateTest.java
+++ b/modules/openapi-generator-cli/src/test/java/org/openapitools/codegen/cmd/GenerateTest.java
@@ -17,532 +17,442 @@
 
 package org.openapitools.codegen.cmd;
 
+import org.mockito.MockSettings;
 import org.openapitools.codegen.ClientOptInput;
 import org.openapitools.codegen.DefaultGenerator;
 import org.openapitools.codegen.OpenAPIGenerator;
 import org.openapitools.codegen.config.CodegenConfigurator;
-import mockit.Expectations;
-import mockit.FullVerifications;
-import mockit.Injectable;
-import mockit.Mocked;
-import mockit.Verifications;
 import org.apache.commons.lang3.ArrayUtils;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+
+import static org.mockito.Answers.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.*;
 
 @SuppressWarnings("unused")
 public class GenerateTest {
 
-    @Mocked
-    CodegenConfigurator configurator;
+    protected MockSettings mockSettings = withSettings().useConstructor().defaultAnswer(CALLS_REAL_METHODS);
 
-    @Injectable
+    private DefaultGenerator generator;
+    private CodegenConfigurator configurator;
+    File outputDirectory;
+
+    // ???
     ClientOptInput clientOptInput;
 
-    @Mocked
-    DefaultGenerator generator;
-
-    @Test
-    public void testVerbose() throws Exception {
-        setupAndRunGenericTest("-v");
-
-        new FullVerifications() {
-            {
-                configurator.setVerbose(true);
-                times = 1;
-            }
-        };
-
-        setupAndRunGenericTest("--verbose");
-
-        new FullVerifications() {
-            {
-                configurator.setVerbose(true);
-                times = 1;
-            }
-        };
+    @BeforeMethod
+    public void beforeEachTest() throws IOException {
+        generator = mock(DefaultGenerator.class, mockSettings);
+        configurator = mock(CodegenConfigurator.class, mockSettings);
+        outputDirectory = Files.createTempDirectory("GenerateTest").toFile();
     }
-
-    @Test
-    public void testRequiredArgs_ShortArgs() throws Exception {
-        setupAndRunTest("-i", "src/test/resources/swagger.yaml", "-g", "java", "-o", "src/main/java", false, null, "-p", "foo=bar");
-        new FullVerifications() {
-            {
-                configurator.addAdditionalProperty("foo", "bar");
-                times = 1;
-            }
-        };
-    }
-
-    @Test
-    public void testRequiredArgs_LongArgs() throws Exception {
-        setupAndRunTest("--input-spec", "src/test/resources/swagger.yaml", "--generator-name", "java", "--output",
-                "src/main/java", false, null);
-        new FullVerifications() {
-            {
-            }
-        };
-    }
-
-    @Test
-    public void testTemplateDir() throws Exception {
-
-        final String templateDir = "src/main/resources/customTemplates";
-
-        setupAndRunGenericTest("--template-dir", templateDir);
-
-        new FullVerifications() {
-            {
-                configurator.setTemplateDir(templateDir);
-                times = 1;
-            }
-        };
-
-        setupAndRunGenericTest("-t", templateDir);
-
-        new FullVerifications() {
-            {
-                configurator.setTemplateDir(templateDir);
-                times = 1;
-            }
-        };
-    }
-
-    @Test
-    public void testAuth() throws Exception {
-
-        final String auth = "hello:world";
-
-        setupAndRunGenericTest("--auth", auth);
-
-        new FullVerifications() {
-            {
-                configurator.setAuth(auth);
-                times = 1;
-            }
-        };
-
-        setupAndRunGenericTest("-a", auth);
-
-        new FullVerifications() {
-            {
-                configurator.setAuth(auth);
-                times = 1;
-            }
-        };
-
-        setupAndRunGenericTest();
-
-        new FullVerifications() {
-            {
-                configurator.setAuth(anyString);
-                times = 0;
-            }
-        };
-    }
-
-    @Test
-    public void testConfigJson() throws Exception {
-
-        setupAndRunTest("-i", "src/test/resources/swagger.yaml", "-g", "java", "-o", "src/main/java", true,
-                "config.json", "-c", "config.json");
-
-        new FullVerifications() {
-            {
-            }
-        };
-
-        setupAndRunTest("-i", "src/test/resources/swagger.yaml", "-g", "java", "-o", "src/main/java", true,
-                "config.json", "--config", "config.json");
-
-        new FullVerifications() {
-            {
-            }
-        };
-    }
-
-    @Test
-    public void testConfigYaml() throws Exception {
-
-        setupAndRunTest("-i", "src/test/resources/swagger.yaml", "-g", "java", "-o", "src/main/java", true,
-                "config.yaml", "-c", "config.yaml");
-
-        new FullVerifications() {
-            {
-            }
-        };
-
-        setupAndRunTest("-i", "src/test/resources/swagger.yaml", "-g", "java", "-o", "src/main/java", true,
-                "config.yaml", "--config", "config.yaml");
-
-        new FullVerifications() {
-            {
-            }
-        };
-    }
-
-    @Test
-    public void testSkipOverwrite() throws Exception {
-
-        setupAndRunGenericTest("-s");
-        new FullVerifications() {
-            {
-                configurator.setSkipOverwrite(true);
-                times = 1;
-            }
-        };
-
-        setupAndRunGenericTest("--skip-overwrite");
-        new FullVerifications() {
-            {
-                configurator.setSkipOverwrite(true);
-                times = 1;
-            }
-        };
-    }
-
-    @Test
-    public void testStrictSpec() throws Exception {
-
-        setupAndRunGenericTest("--strict-spec", "true");
-        new FullVerifications() {
-            {
-                configurator.setStrictSpecBehavior(true);
-                times = 1;
-            }
-        };
-
-        setupAndRunGenericTest("--strict-spec", "false");
-        new FullVerifications() {
-            {
-                configurator.setStrictSpecBehavior(false);
-                times = 1;
-            }
-        };
-    }
-
-    @Test
-    public void testPackageName() throws Exception {
-        final String value = "io.foo.bar.baz";
-        setupAndRunGenericTest("--package-name", value);
-
-        new FullVerifications() {
-            {
-                configurator.setPackageName(value);
-                times = 1;
-            }
-        };
-    }
-
-    @Test
-    public void testApiPackage() throws Exception {
-        final String value = "io.foo.bar.api";
-        setupAndRunGenericTest("--api-package", value);
-
-        new FullVerifications() {
-            {
-                configurator.setApiPackage(value);
-                times = 1;
-            }
-        };
-    }
-
-    @Test
-    public void testModelPackage() throws Exception {
-        final String value = "io.foo.bar.api";
-        setupAndRunGenericTest("--model-package", value);
-
-        new FullVerifications() {
-            {
-                configurator.setModelPackage(value);
-                times = 1;
-            }
-        };
-    }
-
-    @Test
-    public void testInstantiationTypes() throws Exception {
-
-        setupAndRunGenericTest("--instantiation-types", "hello=world,key=,foo=bar,key2");
-
-        new FullVerifications() {
-            {
-                configurator.addInstantiationType("hello", "world");
-                times = 1;
-                configurator.addInstantiationType("foo", "bar");
-                times = 1;
-                configurator.addInstantiationType("key", "");
-                times = 1;
-                configurator.addInstantiationType("key2", "");
-                times = 1;
-            }
-        };
-
-        setupAndRunGenericTest("--instantiation-types", "hello=world", "--instantiation-types",
-                "key=", "--instantiation-types", "foo=bar", "--instantiation-types", "key2");
-
-        new FullVerifications() {
-            {
-                configurator.addInstantiationType("hello", "world");
-                times = 1;
-                configurator.addInstantiationType("foo", "bar");
-                times = 1;
-                configurator.addInstantiationType("key", "");
-                times = 1;
-                configurator.addInstantiationType("key2", "");
-                times = 1;
-            }
-        };
-    }
-
-    @Test
-    public void testTypeMappings() throws Exception {
-        setupAndRunGenericTest("--type-mappings", "hello=world,key=,foo=bar,key2");
-
-        new FullVerifications() {
-            {
-                configurator.addTypeMapping("hello", "world");
-                times = 1;
-                configurator.addTypeMapping("foo", "bar");
-                times = 1;
-                configurator.addTypeMapping("key", "");
-                times = 1;
-                configurator.addTypeMapping("key2", "");
-                times = 1;
-            }
-        };
-
-        setupAndRunGenericTest("--type-mappings", "hello=world", "--type-mappings", "key=",
-                "--type-mappings", "foo=bar", "--type-mappings", "key2");
-
-        new FullVerifications() {
-            {
-                configurator.addTypeMapping("hello", "world");
-                times = 1;
-                configurator.addTypeMapping("foo", "bar");
-                times = 1;
-                configurator.addTypeMapping("key", "");
-                times = 1;
-                configurator.addTypeMapping("key2", "");
-                times = 1;
-            }
-        };
-    }
-
-    @Test
-    public void testAdditionalProperties() throws Exception {
-        setupAndRunGenericTest("--additional-properties", "hello=world,key=,foo=bar,key2");
-
-        new FullVerifications() {
-            {
-                configurator.addAdditionalProperty("hello", "world");
-                times = 1;
-                configurator.addAdditionalProperty("foo", "bar");
-                times = 1;
-                configurator.addAdditionalProperty("key", "");
-                times = 1;
-                configurator.addAdditionalProperty("key2", "");
-                times = 1;
-            }
-        };
-
-        setupAndRunGenericTest("--additional-properties", "hello=world", "--additional-properties",
-                "key=", "--additional-properties", "foo=bar", "--additional-properties", "key2");
-
-        new FullVerifications() {
-            {
-                configurator.addAdditionalProperty("hello", "world");
-                times = 1;
-                configurator.addAdditionalProperty("foo", "bar");
-                times = 1;
-                configurator.addAdditionalProperty("key", "");
-                times = 1;
-                configurator.addAdditionalProperty("key2", "");
-                times = 1;
-            }
-        };
-    }
-
-    @Test
-    public void testLanguageSpecificPrimitives() throws Exception {
-        setupAndRunGenericTest("--language-specific-primitives", "foo,,bar",
-                "--language-specific-primitives", "hello,world");
-
-        new FullVerifications() {
-            {
-                configurator.addLanguageSpecificPrimitive("foo");
-                times = 1;
-                configurator.addLanguageSpecificPrimitive("bar");
-                times = 1;
-                configurator.addLanguageSpecificPrimitive("hello");
-                times = 1;
-                configurator.addLanguageSpecificPrimitive("world");
-                times = 1;
-            }
-        };
-    }
-
-    @Test
-    public void testImportMappings() throws Exception {
-        setupAndRunGenericTest("--import-mappings", "hello=world,key=,foo=bar,key2");
-
-        new FullVerifications() {
-            {
-                configurator.addImportMapping("hello", "world");
-                times = 1;
-                configurator.addImportMapping("foo", "bar");
-                times = 1;
-                configurator.addImportMapping("key", "");
-                times = 1;
-                configurator.addImportMapping("key2", "");
-                times = 1;
-            }
-        };
-
-        setupAndRunGenericTest("--import-mappings", "hello=world", "--import-mappings", "key=",
-                "--import-mappings", "foo=bar", "--import-mappings", "key2");
-
-        new FullVerifications() {
-            {
-                configurator.addImportMapping("hello", "world");
-                times = 1;
-                configurator.addImportMapping("foo", "bar");
-                times = 1;
-                configurator.addImportMapping("key", "");
-                times = 1;
-                configurator.addImportMapping("key2", "");
-                times = 1;
-            }
-        };
-    }
-
-    @Test
-    public void testInvokerPackage() throws Exception {
-        final String value = "io.foo.bar.api";
-        setupAndRunGenericTest("--invoker-package", value);
-
-        new FullVerifications() {
-            {
-                configurator.setInvokerPackage(value);
-                times = 1;
-            }
-        };
-    }
-
-    @Test
-    public void testGroupId() throws Exception {
-        final String value = "io.foo.bar.api";
-        setupAndRunGenericTest("--group-id", value);
-
-        new FullVerifications() {
-            {
-                configurator.setGroupId(value);
-                times = 1;
-            }
-        };
-    }
-
-    @Test
-    public void testArtifactId() throws Exception {
-        final String value = "awesome-api";
-        setupAndRunGenericTest("--artifact-id", value);
-
-        new FullVerifications() {
-            {
-                configurator.setArtifactId(value);
-                times = 1;
-            }
-        };
-    }
-
-    @Test
-    public void testArtifactVersion() throws Exception {
-        final String value = "1.2.3";
-        setupAndRunGenericTest("--artifact-version", value);
-
-        new FullVerifications() {
-            {
-                configurator.setArtifactVersion(value);
-                times = 1;
-            }
-        };
-    }
-
-    @Test
-    public void testLibrary() throws Exception {
-        final String value = "library1";
-        setupAndRunGenericTest("--library", value);
-
-        new FullVerifications() {
-            {
-                configurator.setLibrary(value);
-                times = 1;
-            }
-        };
-    }
+//
+//    @Test
+//    public void testVerboseShort() throws Exception {
+//        setupAndRunGenericTest("-v");
+//        verify(configurator).setVerbose(true);
+//    }
+//
+//    @Test
+//    public void testVerboseLong() throws Exception {
+//        setupAndRunGenericTest("--verbose");
+//        verify(configurator).setVerbose(true);
+//    }
+//
+//    @Test
+//    public void testRequiredArgs_ShortArgs() throws Exception {
+//        setupAndRunTest("-i", "src/test/resources/swagger.yaml", "-g", "java", "-o", "src/main/java", false, null, "-p", "foo=bar");
+//        verify(configurator).addAdditionalProperty("foo", "bar");
+//    }
+//
+//    @Test
+//    public void testRequiredArgs_LongArgs() throws Exception {
+//        setupAndRunTest("--input-spec", "src/test/resources/swagger.yaml", "--generator-name", "java", "--output",
+//                "src/main/java", false, null);
+//
+//        // TODO: I added these
+//        verify(configurator).addAdditionalProperty("generatorName", "java");
+//        verify(configurator).addAdditionalProperty("inputSpec", "src/test/resources/swagger.yaml");
+//    }
+//
+//    @Test
+//    public void testTemplateDirShort() throws Exception {
+//        final String templateDir = "src/main/resources/customTemplates";
+//        setupAndRunGenericTest("-t", templateDir);
+//        verify(configurator).setTemplateDir(templateDir);
+//    }
+//
+//    @Test
+//    public void testTemplateDirLong() throws Exception {
+//        final String templateDir = "src/main/resources/customTemplates";
+//        setupAndRunGenericTest("--template-dir", templateDir);
+//        verify(configurator).setTemplateDir(templateDir);
+//    }
+//
+//    @Test
+//    public void testAuthLong() throws Exception {
+//        final String auth = "hello:world";
+//        setupAndRunGenericTest("--auth", auth);
+//        verify(configurator).setAuth(auth);
+//    }
+//
+//    @Test
+//    public void testAuthShort() throws Exception {
+//        final String auth = "hello:world";
+//        setupAndRunGenericTest("-a", auth);
+//        verify(configurator).setAuth(auth);
+//    }
+//
+//    @Test
+//    public void testAuthUnspecified() throws Exception {
+//        setupAndRunGenericTest();
+//        verify(configurator, never()).setAuth(anyString());
+//    }
+//
+//    @Test
+//    public void testConfigJsonShort() throws Exception {
+//        setupAndRunTest("-i", "src/test/resources/swagger.yaml", "-g", "java", "-o", "src/main/java", true,
+//                "config.json", "-c", "config.json");
+//        // TODO: Verifications
+//    }
+//
+//    @Test
+//    public void testConfigJsonLong() throws Exception {
+//        setupAndRunTest("-i", "src/test/resources/swagger.yaml", "-g", "java", "-o", "src/main/java", true,
+//                "config.json", "--config", "config.json");
+//        // TODO: Verifications
+//    }
+//
+//    @Test
+//    public void testConfigYamlShort() throws Exception {
+//        setupAndRunTest("-i", "src/test/resources/swagger.yaml", "-g", "java", "-o", "src/main/java", true,
+//                "config.yaml", "-c", "config.yaml");
+//
+//        // TODO: Verifications
+//    }
+//
+//    @Test
+//    public void testConfigYamlLong() throws Exception {
+//
+//        setupAndRunTest("-i", "src/test/resources/swagger.yaml", "-g", "java", "-o", "src/main/java", true,
+//                "config.yaml", "--config", "config.yaml");
+//
+//        // TODO: Verifications
+//    }
+//
+//    @Test
+//    public void testSkipOverwriteShort() throws Exception {
+//        setupAndRunGenericTest("-s");
+//        verify(configurator).setSkipOverwrite(true);
+//    }
+//
+//    @Test
+//    public void testSkipOverwriteLong() throws Exception {
+//        setupAndRunGenericTest("--skip-overwrite");
+//        verify(configurator).setSkipOverwrite(true);
+//    }
+//
+//    @Test
+//    public void testStrictSpec() throws Exception {
+//
+//        setupAndRunGenericTest("--strict-spec", "true");
+//        new FullVerifications() {
+//            {
+//                configurator.setStrictSpecBehavior(true);
+//                times = 1;
+//            }
+//        };
+//
+//        setupAndRunGenericTest("--strict-spec", "false");
+//        new FullVerifications() {
+//            {
+//                configurator.setStrictSpecBehavior(false);
+//                times = 1;
+//            }
+//        };
+//    }
+//
+//    @Test
+//    public void testPackageName() throws Exception {
+//        final String value = "io.foo.bar.baz";
+//        setupAndRunGenericTest("--package-name", value);
+//
+//        new FullVerifications() {
+//            {
+//                configurator.setPackageName(value);
+//                times = 1;
+//            }
+//        };
+//    }
+//
+//    @Test
+//    public void testApiPackage() throws Exception {
+//        final String value = "io.foo.bar.api";
+//        setupAndRunGenericTest("--api-package", value);
+//
+//        new FullVerifications() {
+//            {
+//                configurator.setApiPackage(value);
+//                times = 1;
+//            }
+//        };
+//    }
+//
+//    @Test
+//    public void testModelPackage() throws Exception {
+//        final String value = "io.foo.bar.api";
+//        setupAndRunGenericTest("--model-package", value);
+//
+//        new FullVerifications() {
+//            {
+//                configurator.setModelPackage(value);
+//                times = 1;
+//            }
+//        };
+//    }
+//
+//    @Test
+//    public void testInstantiationTypes() throws Exception {
+//
+//        setupAndRunGenericTest("--instantiation-types", "hello=world,key=,foo=bar,key2");
+//
+//        new FullVerifications() {
+//            {
+//                configurator.addInstantiationType("hello", "world");
+//                times = 1;
+//                configurator.addInstantiationType("foo", "bar");
+//                times = 1;
+//                configurator.addInstantiationType("key", "");
+//                times = 1;
+//                configurator.addInstantiationType("key2", "");
+//                times = 1;
+//            }
+//        };
+//
+//        setupAndRunGenericTest("--instantiation-types", "hello=world", "--instantiation-types",
+//                "key=", "--instantiation-types", "foo=bar", "--instantiation-types", "key2");
+//
+//        new FullVerifications() {
+//            {
+//                configurator.addInstantiationType("hello", "world");
+//                times = 1;
+//                configurator.addInstantiationType("foo", "bar");
+//                times = 1;
+//                configurator.addInstantiationType("key", "");
+//                times = 1;
+//                configurator.addInstantiationType("key2", "");
+//                times = 1;
+//            }
+//        };
+//    }
+//
+//    @Test
+//    public void testTypeMappings() throws Exception {
+//        setupAndRunGenericTest("--type-mappings", "hello=world,key=,foo=bar,key2");
+//
+//        new FullVerifications() {
+//            {
+//                configurator.addTypeMapping("hello", "world");
+//                times = 1;
+//                configurator.addTypeMapping("foo", "bar");
+//                times = 1;
+//                configurator.addTypeMapping("key", "");
+//                times = 1;
+//                configurator.addTypeMapping("key2", "");
+//                times = 1;
+//            }
+//        };
+//
+//        setupAndRunGenericTest("--type-mappings", "hello=world", "--type-mappings", "key=",
+//                "--type-mappings", "foo=bar", "--type-mappings", "key2");
+//
+//        new FullVerifications() {
+//            {
+//                configurator.addTypeMapping("hello", "world");
+//                times = 1;
+//                configurator.addTypeMapping("foo", "bar");
+//                times = 1;
+//                configurator.addTypeMapping("key", "");
+//                times = 1;
+//                configurator.addTypeMapping("key2", "");
+//                times = 1;
+//            }
+//        };
+//    }
+//
+//    @Test
+//    public void testAdditionalProperties() throws Exception {
+//        setupAndRunGenericTest("--additional-properties", "hello=world,key=,foo=bar,key2");
+//
+//        new FullVerifications() {
+//            {
+//                configurator.addAdditionalProperty("hello", "world");
+//                times = 1;
+//                configurator.addAdditionalProperty("foo", "bar");
+//                times = 1;
+//                configurator.addAdditionalProperty("key", "");
+//                times = 1;
+//                configurator.addAdditionalProperty("key2", "");
+//                times = 1;
+//            }
+//        };
+//
+//        setupAndRunGenericTest("--additional-properties", "hello=world", "--additional-properties",
+//                "key=", "--additional-properties", "foo=bar", "--additional-properties", "key2");
+//
+//        new FullVerifications() {
+//            {
+//                configurator.addAdditionalProperty("hello", "world");
+//                times = 1;
+//                configurator.addAdditionalProperty("foo", "bar");
+//                times = 1;
+//                configurator.addAdditionalProperty("key", "");
+//                times = 1;
+//                configurator.addAdditionalProperty("key2", "");
+//                times = 1;
+//            }
+//        };
+//    }
+//
+//    @Test
+//    public void testLanguageSpecificPrimitives() throws Exception {
+//        setupAndRunGenericTest("--language-specific-primitives", "foo,,bar",
+//                "--language-specific-primitives", "hello,world");
+//
+//        new FullVerifications() {
+//            {
+//                configurator.addLanguageSpecificPrimitive("foo");
+//                times = 1;
+//                configurator.addLanguageSpecificPrimitive("bar");
+//                times = 1;
+//                configurator.addLanguageSpecificPrimitive("hello");
+//                times = 1;
+//                configurator.addLanguageSpecificPrimitive("world");
+//                times = 1;
+//            }
+//        };
+//    }
+//
+//    @Test
+//    public void testImportMappings() throws Exception {
+//        setupAndRunGenericTest("--import-mappings", "hello=world,key=,foo=bar,key2");
+//
+//        new FullVerifications() {
+//            {
+//                configurator.addImportMapping("hello", "world");
+//                times = 1;
+//                configurator.addImportMapping("foo", "bar");
+//                times = 1;
+//                configurator.addImportMapping("key", "");
+//                times = 1;
+//                configurator.addImportMapping("key2", "");
+//                times = 1;
+//            }
+//        };
+//
+//        setupAndRunGenericTest("--import-mappings", "hello=world", "--import-mappings", "key=",
+//                "--import-mappings", "foo=bar", "--import-mappings", "key2");
+//
+//        new FullVerifications() {
+//            {
+//                configurator.addImportMapping("hello", "world");
+//                times = 1;
+//                configurator.addImportMapping("foo", "bar");
+//                times = 1;
+//                configurator.addImportMapping("key", "");
+//                times = 1;
+//                configurator.addImportMapping("key2", "");
+//                times = 1;
+//            }
+//        };
+//    }
+//
+//    @Test
+//    public void testInvokerPackage() throws Exception {
+//        final String value = "io.foo.bar.api";
+//        setupAndRunGenericTest("--invoker-package", value);
+//
+//        new FullVerifications() {
+//            {
+//                configurator.setInvokerPackage(value);
+//                times = 1;
+//            }
+//        };
+//    }
+//
+//    @Test
+//    public void testGroupId() throws Exception {
+//        final String value = "io.foo.bar.api";
+//        setupAndRunGenericTest("--group-id", value);
+//
+//        new FullVerifications() {
+//            {
+//                configurator.setGroupId(value);
+//                times = 1;
+//            }
+//        };
+//    }
+//
+//    @Test
+//    public void testArtifactId() throws Exception {
+//        final String value = "awesome-api";
+//        setupAndRunGenericTest("--artifact-id", value);
+//
+//        new FullVerifications() {
+//            {
+//                configurator.setArtifactId(value);
+//                times = 1;
+//            }
+//        };
+//    }
+//
+//    @Test
+//    public void testArtifactVersion() throws Exception {
+//        final String value = "1.2.3";
+//        setupAndRunGenericTest("--artifact-version", value);
+//
+//        new FullVerifications() {
+//            {
+//                configurator.setArtifactVersion(value);
+//                times = 1;
+//            }
+//        };
+//    }
+//
+//    @Test
+//    public void testLibrary() throws Exception {
+//        final String value = "library1";
+//        setupAndRunGenericTest("--library", value);
+//
+//        new FullVerifications() {
+//            {
+//                configurator.setLibrary(value);
+//                times = 1;
+//            }
+//        };
+//    }
 
     private void setupAndRunTest(String specFlag, final String spec, String langFlag,
             final String lang, String outputDirFlag, final String outputDir,
             boolean configuratorFromFile, final String configFile, String... additionalParameters) {
+        File actualOutputDir = new File(outputDirectory, outputDir);
         final String[] commonArgs =
-                {"generate", langFlag, lang, outputDirFlag, outputDir, specFlag, spec};
+                {"generate", langFlag, lang, outputDirFlag, actualOutputDir.getAbsolutePath(), specFlag, spec};
 
         String[] argsToUse = ArrayUtils.addAll(commonArgs, additionalParameters);
 
-        if (configuratorFromFile) {
-
-            new Expectations() {
-                {
-                    CodegenConfigurator.fromFile(configFile);
-                    times = 1;
-                    result = configurator;
-                }
-            };
-
-        } else {
-            new Expectations() {
-                {
-                    CodegenConfigurator.fromFile(anyString);
-                    result = null;
-
-                    new CodegenConfigurator();
-                    times = 1;
-                    result = configurator;
-                }
-            };
-        }
-
-        new Expectations() {
-            {
-
-                configurator.toClientOptInput();
-                times = 1;
-                result = clientOptInput;
-
-                new DefaultGenerator();
-                times = 1;
-                result = generator;
-
-                generator.opts(clientOptInput);
-                times = 1;
-                result = generator;
-
-                generator.generate();
-                times = 1;
-
-            }
-        };
 
         OpenAPIGenerator.main(argsToUse);
 
-        new Verifications() {
-            {
-                configurator.setGeneratorName(lang);
-                times = 1;
-                configurator.setInputSpec(spec);
-                times = 1;
-                configurator.setOutputDir(outputDir);
-            }
-        };
+//        verify(configurator).toClientOptInput();
+        verify(configurator).setGeneratorName(lang);
+        verify(configurator).setInputSpec(spec);
+        verify(configurator).setOutputDir(outputDir);
     }
 
     private void setupAndRunGenericTest(String... additionalParameters) {

--- a/modules/openapi-generator/pom.xml
+++ b/modules/openapi-generator/pom.xml
@@ -292,12 +292,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.jmockit</groupId>
-            <artifactId>jmockit</artifactId>
-<!--             <version>${jmockit-version}</version> -->
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>com.googlecode.java-diff-utils</groupId>
             <artifactId>diffutils</artifactId>
             <version>${diffutils-version}</version>
@@ -311,7 +305,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>3.2.0</version>
+            <version>${mockito-version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/AbstractOptionsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/AbstractOptionsTest.java
@@ -19,8 +19,8 @@ package org.openapitools.codegen;
 
 import com.google.common.base.Function;
 import com.google.common.collect.Lists;
-import mockit.FullVerifications;
 import org.apache.commons.lang3.StringUtils;
+import org.mockito.MockSettings;
 import org.openapitools.codegen.options.OptionsProvider;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -29,8 +29,16 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
+import java.util.stream.Collectors;
 
+import static org.mockito.Answers.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.withSettings;
+
+/**
+ * Base class for applying and processing generator options, then invoking a helper method to verify those options.
+ */
 public abstract class AbstractOptionsTest {
+    protected MockSettings mockSettings = withSettings().useConstructor().defaultAnswer(CALLS_REAL_METHODS);
     private final OptionsProvider optionsProvider;
 
     protected AbstractOptionsTest(OptionsProvider optionsProvider) {
@@ -41,17 +49,13 @@ public abstract class AbstractOptionsTest {
     @Test
     public void checkOptionsProcessing() {
         getCodegenConfig().additionalProperties().putAll(optionsProvider.createOptions());
-        setExpectations();
-
         getCodegenConfig().processOpts();
-
-        new FullVerifications() {{
-        }};
+        verifyOptions();
     }
 
     @Test(description = "check if all options described in documentation are presented in test case")
     public void checkOptionsHelp() {
-        final List<String> cliOptions = Lists.transform(getCodegenConfig().cliOptions(), getCliOptionTransformer());
+        final List<String> cliOptions = getCodegenConfig().cliOptions().stream().map(getCliOptionTransformer()).collect(Collectors.toList());
         final Set<String> testOptions = optionsProvider.createOptions().keySet();
         final Set<String> skipped = new HashSet<String>(cliOptions);
         skipped.removeAll(testOptions);
@@ -76,5 +80,5 @@ public abstract class AbstractOptionsTest {
 
     protected abstract CodegenConfig getCodegenConfig();
 
-    protected abstract void setExpectations();
+    protected abstract void verifyOptions();
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/bash/BashClientOptionsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/bash/BashClientOptionsTest.java
@@ -17,17 +17,16 @@
 
 package org.openapitools.codegen.bash;
 
-import mockit.Expectations;
-import mockit.Tested;
 import org.openapitools.codegen.AbstractOptionsTest;
 import org.openapitools.codegen.CodegenConfig;
 import org.openapitools.codegen.languages.BashClientCodegen;
 import org.openapitools.codegen.options.BashClientOptionsProvider;
 
-public class BashClientOptionsTest extends AbstractOptionsTest {
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
-    @Tested
-    private BashClientCodegen clientCodegen;
+public class BashClientOptionsTest extends AbstractOptionsTest {
+    private BashClientCodegen clientCodegen = mock(BashClientCodegen.class, mockSettings);
 
     public BashClientOptionsTest() {
         super(new BashClientOptionsProvider());
@@ -40,36 +39,25 @@ public class BashClientOptionsTest extends AbstractOptionsTest {
 
     @SuppressWarnings("unused")
     @Override
-    protected void setExpectations() {
-        new Expectations(clientCodegen) {{
-            clientCodegen.setCurlOptions(
+    protected void verifyOptions() {
+        verify(clientCodegen).setCurlOptions(
                 BashClientOptionsProvider.CURL_OPTIONS);
-            times = 1;
-            clientCodegen.setProcessMarkdown(
+        verify(clientCodegen).setProcessMarkdown(
                 Boolean.parseBoolean(
-                    BashClientOptionsProvider.PROCESS_MARKDOWN));
-            times = 1;
-            clientCodegen.setScriptName(
+                        BashClientOptionsProvider.PROCESS_MARKDOWN));
+        verify(clientCodegen).setScriptName(
                 BashClientOptionsProvider.SCRIPT_NAME);
-            times = 1;
-            clientCodegen.setGenerateBashCompletion(
+        verify(clientCodegen).setGenerateBashCompletion(
                 Boolean.parseBoolean(
-                    BashClientOptionsProvider.GENERATE_BASH_COMPLETION));
-            times = 1;
-            clientCodegen.setGenerateZshCompletion(
+                        BashClientOptionsProvider.GENERATE_BASH_COMPLETION));
+        verify(clientCodegen).setGenerateZshCompletion(
                 Boolean.parseBoolean(
-                    BashClientOptionsProvider.GENERATE_ZSH_COMPLETION));
-            times = 1;           
-            clientCodegen.setHostEnvironmentVariable(
+                        BashClientOptionsProvider.GENERATE_ZSH_COMPLETION));
+        verify(clientCodegen).setHostEnvironmentVariable(
                 BashClientOptionsProvider.HOST_ENVIRONMENT_VARIABLE_NAME);
-            times = 1;            
-            clientCodegen.setApiKeyAuthEnvironmentVariable(
+        verify(clientCodegen).setApiKeyAuthEnvironmentVariable(
                 BashClientOptionsProvider.APIKEY_AUTH_ENVIRONMENT_VARIABLE_NAME);
-            times = 1;
-            clientCodegen.setAllowUnicodeIdentifiers(Boolean.valueOf(BashClientOptionsProvider.ALLOW_UNICODE_IDENTIFIERS_VALUE));
-            times = 1;
-
-        }};
+        verify(clientCodegen).setAllowUnicodeIdentifiers(Boolean.valueOf(BashClientOptionsProvider.ALLOW_UNICODE_IDENTIFIERS_VALUE));
     }
 }
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/dart/DartClientOptionsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/dart/DartClientOptionsTest.java
@@ -17,17 +17,16 @@
 
 package org.openapitools.codegen.dart;
 
-import mockit.Expectations;
-import mockit.Tested;
 import org.openapitools.codegen.AbstractOptionsTest;
 import org.openapitools.codegen.CodegenConfig;
 import org.openapitools.codegen.languages.DartClientCodegen;
 import org.openapitools.codegen.options.DartClientOptionsProvider;
 
-public class DartClientOptionsTest extends AbstractOptionsTest {
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
-    @Tested
-    private DartClientCodegen clientCodegen;
+public class DartClientOptionsTest extends AbstractOptionsTest {
+    private DartClientCodegen clientCodegen = mock(DartClientCodegen.class, mockSettings);
 
     public DartClientOptionsTest() {
         super(new DartClientOptionsProvider());
@@ -40,28 +39,16 @@ public class DartClientOptionsTest extends AbstractOptionsTest {
 
     @SuppressWarnings("unused")
     @Override
-    protected void setExpectations() {
-        new Expectations(clientCodegen) {{
-            clientCodegen.setSortParamsByRequiredFlag(Boolean.valueOf(DartClientOptionsProvider.SORT_PARAMS_VALUE));
-            times = 1;
-            clientCodegen.setBrowserClient(Boolean.valueOf(DartClientOptionsProvider.BROWSER_CLIENT_VALUE));
-            times = 1;
-            clientCodegen.setPubName(DartClientOptionsProvider.PUB_NAME_VALUE);
-            times = 1;
-            clientCodegen.setPubVersion(DartClientOptionsProvider.PUB_VERSION_VALUE);
-            times = 1;
-            clientCodegen.setPubDescription(DartClientOptionsProvider.PUB_DESCRIPTION_VALUE);
-            times = 1;
-            clientCodegen.setPubAuthor(DartClientOptionsProvider.PUB_AUTHOR_VALUE);
-            times = 1;
-            clientCodegen.setPubAuthorEmail(DartClientOptionsProvider.PUB_AUTHOR_EMAIL_VALUE);
-            times = 1;
-            clientCodegen.setPubHomepage(DartClientOptionsProvider.PUB_HOMEPAGE_VALUE);
-            times = 1;
-            clientCodegen.setSourceFolder(DartClientOptionsProvider.SOURCE_FOLDER_VALUE);
-            times = 1;
-            clientCodegen.setUseEnumExtension(Boolean.valueOf(DartClientOptionsProvider.USE_ENUM_EXTENSION));
-            times = 1;
-        }};
+    protected void verifyOptions() {
+        verify(clientCodegen).setSortParamsByRequiredFlag(Boolean.valueOf(DartClientOptionsProvider.SORT_PARAMS_VALUE));
+        verify(clientCodegen).setBrowserClient(Boolean.parseBoolean(DartClientOptionsProvider.BROWSER_CLIENT_VALUE));
+        verify(clientCodegen).setPubName(DartClientOptionsProvider.PUB_NAME_VALUE);
+        verify(clientCodegen).setPubVersion(DartClientOptionsProvider.PUB_VERSION_VALUE);
+        verify(clientCodegen).setPubDescription(DartClientOptionsProvider.PUB_DESCRIPTION_VALUE);
+        verify(clientCodegen).setPubAuthor(DartClientOptionsProvider.PUB_AUTHOR_VALUE);
+        verify(clientCodegen).setPubAuthorEmail(DartClientOptionsProvider.PUB_AUTHOR_EMAIL_VALUE);
+        verify(clientCodegen).setPubHomepage(DartClientOptionsProvider.PUB_HOMEPAGE_VALUE);
+        verify(clientCodegen).setSourceFolder(DartClientOptionsProvider.SOURCE_FOLDER_VALUE);
+        verify(clientCodegen).setUseEnumExtension(Boolean.parseBoolean(DartClientOptionsProvider.USE_ENUM_EXTENSION));
     }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/dartdio/DartDioClientOptionsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/dartdio/DartDioClientOptionsTest.java
@@ -17,17 +17,16 @@
 
 package org.openapitools.codegen.dartdio;
 
-import mockit.Expectations;
-import mockit.Tested;
 import org.openapitools.codegen.AbstractOptionsTest;
 import org.openapitools.codegen.CodegenConfig;
 import org.openapitools.codegen.languages.DartDioClientCodegen;
 import org.openapitools.codegen.options.DartDioClientOptionsProvider;
 
-public class DartDioClientOptionsTest extends AbstractOptionsTest {
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
-    @Tested
-    private DartDioClientCodegen clientCodegen;
+public class DartDioClientOptionsTest extends AbstractOptionsTest {
+    private DartDioClientCodegen clientCodegen = mock(DartDioClientCodegen.class, mockSettings);
 
     public DartDioClientOptionsTest() {
         super(new DartDioClientOptionsProvider());
@@ -40,32 +39,18 @@ public class DartDioClientOptionsTest extends AbstractOptionsTest {
 
     @SuppressWarnings("unused")
     @Override
-    protected void setExpectations() {
-        new Expectations(clientCodegen) {{
-            clientCodegen.setSortParamsByRequiredFlag(Boolean.valueOf(DartDioClientOptionsProvider.SORT_PARAMS_VALUE));
-            times = 1;
-            clientCodegen.setBrowserClient(Boolean.valueOf(DartDioClientOptionsProvider.BROWSER_CLIENT_VALUE));
-            times = 1;
-            clientCodegen.setPubName(DartDioClientOptionsProvider.PUB_NAME_VALUE);
-            times = 1;
-            clientCodegen.setPubVersion(DartDioClientOptionsProvider.PUB_VERSION_VALUE);
-            times = 1;
-            clientCodegen.setPubDescription(DartDioClientOptionsProvider.PUB_DESCRIPTION_VALUE);
-            times = 1;
-            //clientCodegen.setPubAuthor(DartDioClientOptionsProvider.PUB_AUTHOR_VALUE);
-            //times = 1;
-            //clientCodegen.setPubAuthorEmail(DartDioClientOptionsProvider.PUB_AUTHOR_EMAIL_VALUE);
-            //times = 1;
-            //clientCodegen.setPubHomepage(DartDioClientOptionsProvider.PUB_HOMEPAGE_VALUE);
-            //times = 1;
-            clientCodegen.setSourceFolder(DartDioClientOptionsProvider.SOURCE_FOLDER_VALUE);
-            times = 1;
-            clientCodegen.setUseEnumExtension(Boolean.valueOf(DartDioClientOptionsProvider.USE_ENUM_EXTENSION));
-            times = 1;
-            clientCodegen.setDateLibrary(DartDioClientOptionsProvider.DATE_LIBRARY);
-            times = 1;
-            clientCodegen.setNullableFields(Boolean.valueOf(DartDioClientOptionsProvider.NULLABLE_FIELDS));
-            times = 1;
-        }};
+    protected void verifyOptions() {
+        verify(clientCodegen).setSortParamsByRequiredFlag(Boolean.valueOf(DartDioClientOptionsProvider.SORT_PARAMS_VALUE));
+        verify(clientCodegen).setBrowserClient(Boolean.parseBoolean(DartDioClientOptionsProvider.BROWSER_CLIENT_VALUE));
+        verify(clientCodegen).setPubName(DartDioClientOptionsProvider.PUB_NAME_VALUE);
+        verify(clientCodegen).setPubVersion(DartDioClientOptionsProvider.PUB_VERSION_VALUE);
+        verify(clientCodegen).setPubDescription(DartDioClientOptionsProvider.PUB_DESCRIPTION_VALUE);
+        //verify(clientCodegen).setPubAuthor(DartDioClientOptionsProvider.PUB_AUTHOR_VALUE);
+        //verify(clientCodegen).setPubAuthorEmail(DartDioClientOptionsProvider.PUB_AUTHOR_EMAIL_VALUE);
+        //verify(clientCodegen).setPubHomepage(DartDioClientOptionsProvider.PUB_HOMEPAGE_VALUE);
+        verify(clientCodegen).setSourceFolder(DartDioClientOptionsProvider.SOURCE_FOLDER_VALUE);
+        verify(clientCodegen).setUseEnumExtension(Boolean.parseBoolean(DartDioClientOptionsProvider.USE_ENUM_EXTENSION));
+        verify(clientCodegen).setDateLibrary(DartDioClientOptionsProvider.DATE_LIBRARY);
+        verify(clientCodegen).setNullableFields(Boolean.parseBoolean(DartDioClientOptionsProvider.NULLABLE_FIELDS));
     }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/elixir/ElixirClientOptionsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/elixir/ElixirClientOptionsTest.java
@@ -17,17 +17,17 @@
 
 package org.openapitools.codegen.elixir;
 
-import mockit.Expectations;
-import mockit.Tested;
 import org.openapitools.codegen.AbstractOptionsTest;
 import org.openapitools.codegen.CodegenConfig;
 import org.openapitools.codegen.languages.ElixirClientCodegen;
 import org.openapitools.codegen.options.ElixirClientOptionsProvider;
 
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
 public class ElixirClientOptionsTest extends AbstractOptionsTest {
 
-    @Tested
-    private ElixirClientCodegen clientCodegen;
+    private ElixirClientCodegen clientCodegen = mock(ElixirClientCodegen.class, mockSettings);
 
     public ElixirClientOptionsTest() {
         super(new ElixirClientOptionsProvider());
@@ -40,10 +40,7 @@ public class ElixirClientOptionsTest extends AbstractOptionsTest {
 
     @SuppressWarnings("unused")
     @Override
-    protected void setExpectations() {
-        new Expectations(clientCodegen) {{
-            clientCodegen.setModuleName(ElixirClientOptionsProvider.INVOKER_PACKAGE_VALUE);
-            times = 1;
-        }};
+    protected void verifyOptions() {
+        verify(clientCodegen).setModuleName(ElixirClientOptionsProvider.INVOKER_PACKAGE_VALUE);
     }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/go/GoClientOptionsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/go/GoClientOptionsTest.java
@@ -17,17 +17,17 @@
 
 package org.openapitools.codegen.go;
 
-import mockit.Expectations;
-import mockit.Tested;
 import org.openapitools.codegen.AbstractOptionsTest;
 import org.openapitools.codegen.CodegenConfig;
 import org.openapitools.codegen.languages.GoClientCodegen;
 import org.openapitools.codegen.options.GoClientOptionsProvider;
 
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
 public class GoClientOptionsTest extends AbstractOptionsTest {
 
-    @Tested
-    private GoClientCodegen clientCodegen;
+    private GoClientCodegen clientCodegen = mock(GoClientCodegen.class, mockSettings);
 
     public GoClientOptionsTest() {
         super(new GoClientOptionsProvider());
@@ -40,26 +40,15 @@ public class GoClientOptionsTest extends AbstractOptionsTest {
 
     @SuppressWarnings("unused")
     @Override
-    protected void setExpectations() {
-        new Expectations(clientCodegen) {{
-            clientCodegen.setPackageVersion(GoClientOptionsProvider.PACKAGE_VERSION_VALUE);
-            times = 1;
-            clientCodegen.setPackageName(GoClientOptionsProvider.PACKAGE_NAME_VALUE);
-            times = 1;
-            clientCodegen.setWithGoCodegenComment(GoClientOptionsProvider.WITH_GO_CODEGEN_COMMENT_VALUE);
-            times = 1;
-            clientCodegen.setWithXml(GoClientOptionsProvider.WITH_XML_VALUE);
-            times = 1;
-            clientCodegen.setWithXml(GoClientOptionsProvider.ENUM_CLASS_PREFIX_VALUE);
-            times = 1;
-            clientCodegen.setPrependFormOrBodyParameters(Boolean.valueOf(GoClientOptionsProvider.PREPEND_FORM_OR_BODY_PARAMETERS_VALUE));
-            times = 1;
-            clientCodegen.setIsGoSubmodule(Boolean.valueOf(GoClientOptionsProvider.IS_GO_SUBMODULE_VALUE));
-            times = 1;
-            clientCodegen.setStructPrefix(Boolean.valueOf(GoClientOptionsProvider.STRUCT_PREFIX_VALUE));
-            times = 1;
-            clientCodegen.setWithAWSV4Signature(Boolean.valueOf(GoClientOptionsProvider.WITH_AWSV4_SIGNATURE));
-            times = 1;
-        }};
+    protected void verifyOptions() {
+        verify(clientCodegen).setPackageVersion(GoClientOptionsProvider.PACKAGE_VERSION_VALUE);
+        verify(clientCodegen).setPackageName(GoClientOptionsProvider.PACKAGE_NAME_VALUE);
+        verify(clientCodegen).setWithGoCodegenComment(GoClientOptionsProvider.WITH_GO_CODEGEN_COMMENT_VALUE);
+        verify(clientCodegen).setWithXml(GoClientOptionsProvider.WITH_XML_VALUE);
+        verify(clientCodegen).setWithXml(GoClientOptionsProvider.ENUM_CLASS_PREFIX_VALUE);
+        verify(clientCodegen).setPrependFormOrBodyParameters(GoClientOptionsProvider.PREPEND_FORM_OR_BODY_PARAMETERS_VALUE);
+        verify(clientCodegen).setIsGoSubmodule(GoClientOptionsProvider.IS_GO_SUBMODULE_VALUE);
+        verify(clientCodegen).setStructPrefix(GoClientOptionsProvider.STRUCT_PREFIX_VALUE);
+        verify(clientCodegen).setWithAWSV4Signature(GoClientOptionsProvider.WITH_AWSV4_SIGNATURE);
     }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/haskellservant/HaskellServantOptionsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/haskellservant/HaskellServantOptionsTest.java
@@ -17,18 +17,17 @@
 
 package org.openapitools.codegen.haskellservant;
 
-
-import mockit.Expectations;
-import mockit.Tested;
 import org.openapitools.codegen.AbstractOptionsTest;
 import org.openapitools.codegen.CodegenConfig;
 import org.openapitools.codegen.languages.HaskellServantCodegen;
 import org.openapitools.codegen.options.HaskellServantOptionsProvider;
 
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
 public class HaskellServantOptionsTest extends AbstractOptionsTest {
 
-    @Tested
-    private HaskellServantCodegen clientCodegen;
+    private HaskellServantCodegen clientCodegen = mock(HaskellServantCodegen.class, mockSettings);
 
     public HaskellServantOptionsTest() {
         super(new HaskellServantOptionsProvider());
@@ -40,14 +39,9 @@ public class HaskellServantOptionsTest extends AbstractOptionsTest {
     }
 
     @Override
-    protected void setExpectations() {
-        new Expectations(clientCodegen) {{
-            clientCodegen.setModelPackage(HaskellServantOptionsProvider.MODEL_PACKAGE_VALUE);
-            times = 1;
-            clientCodegen.setApiPackage(HaskellServantOptionsProvider.API_PACKAGE_VALUE);
-            times = 1;
-            clientCodegen.setSortParamsByRequiredFlag(Boolean.valueOf(HaskellServantOptionsProvider.SORT_PARAMS_VALUE));
-            times = 1;
-        }};
+    protected void verifyOptions() {
+        verify(clientCodegen).setModelPackage(HaskellServantOptionsProvider.MODEL_PACKAGE_VALUE);
+        verify(clientCodegen).setApiPackage(HaskellServantOptionsProvider.API_PACKAGE_VALUE);
+        verify(clientCodegen).setSortParamsByRequiredFlag(Boolean.valueOf(HaskellServantOptionsProvider.SORT_PARAMS_VALUE));
     }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/lumen/PhpLumenServerOptionsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/lumen/PhpLumenServerOptionsTest.java
@@ -17,17 +17,16 @@
 
 package org.openapitools.codegen.lumen;
 
-import mockit.Expectations;
-import mockit.Tested;
 import org.openapitools.codegen.AbstractOptionsTest;
 import org.openapitools.codegen.CodegenConfig;
 import org.openapitools.codegen.languages.PhpLumenServerCodegen;
 import org.openapitools.codegen.options.PhpLumenServerOptionsProvider;
 
-public class PhpLumenServerOptionsTest extends AbstractOptionsTest {
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
-    @Tested
-    private PhpLumenServerCodegen clientCodegen;
+public class PhpLumenServerOptionsTest extends AbstractOptionsTest {
+    private PhpLumenServerCodegen clientCodegen = mock(PhpLumenServerCodegen.class, mockSettings);
 
     public PhpLumenServerOptionsTest() {
         super(new PhpLumenServerOptionsProvider());
@@ -40,24 +39,14 @@ public class PhpLumenServerOptionsTest extends AbstractOptionsTest {
 
     @SuppressWarnings("unused")
     @Override
-    protected void setExpectations() {
-        new Expectations(clientCodegen) {{
-            clientCodegen.setSortParamsByRequiredFlag(Boolean.valueOf(PhpLumenServerOptionsProvider.SORT_PARAMS_VALUE));
-            times = 1;
-            clientCodegen.setParameterNamingConvention(PhpLumenServerOptionsProvider.VARIABLE_NAMING_CONVENTION_VALUE);
-            clientCodegen.setModelPackage(PhpLumenServerOptionsProvider.MODEL_PACKAGE_VALUE);
-            times = 1;
-            clientCodegen.setApiPackage(PhpLumenServerOptionsProvider.API_PACKAGE_VALUE);
-            times = 1;
-            times = 1;
-            clientCodegen.setInvokerPackage(PhpLumenServerOptionsProvider.INVOKER_PACKAGE_VALUE);
-            times = 1;
-            clientCodegen.setPackageName(PhpLumenServerOptionsProvider.PACKAGE_NAME_VALUE);
-            times = 1;
-            clientCodegen.setSrcBasePath(PhpLumenServerOptionsProvider.SRC_BASE_PATH_VALUE);
-            times = 1;
-            clientCodegen.setArtifactVersion(PhpLumenServerOptionsProvider.ARTIFACT_VERSION_VALUE);
-            times = 1;
-        }};
+    protected void verifyOptions() {
+        verify(clientCodegen).setSortParamsByRequiredFlag(Boolean.valueOf(PhpLumenServerOptionsProvider.SORT_PARAMS_VALUE));
+        verify(clientCodegen).setParameterNamingConvention(PhpLumenServerOptionsProvider.VARIABLE_NAMING_CONVENTION_VALUE);
+        verify(clientCodegen).setModelPackage(PhpLumenServerOptionsProvider.MODEL_PACKAGE_VALUE);
+        verify(clientCodegen).setApiPackage(PhpLumenServerOptionsProvider.API_PACKAGE_VALUE);
+        verify(clientCodegen).setInvokerPackage(PhpLumenServerOptionsProvider.INVOKER_PACKAGE_VALUE);
+        verify(clientCodegen).setPackageName(PhpLumenServerOptionsProvider.PACKAGE_NAME_VALUE);
+        verify(clientCodegen).setSrcBasePath(PhpLumenServerOptionsProvider.SRC_BASE_PATH_VALUE);
+        verify(clientCodegen).setArtifactVersion(PhpLumenServerOptionsProvider.ARTIFACT_VERSION_VALUE);
     }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/mysql/MysqlSchemaOptionsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/mysql/MysqlSchemaOptionsTest.java
@@ -16,17 +16,16 @@
 
 package org.openapitools.codegen.mysql;
 
-import mockit.Expectations;
-import mockit.Tested;
 import org.openapitools.codegen.AbstractOptionsTest;
 import org.openapitools.codegen.CodegenConfig;
 import org.openapitools.codegen.languages.MysqlSchemaCodegen;
 import org.openapitools.codegen.options.MysqlSchemaOptionsProvider;
 
-public class MysqlSchemaOptionsTest extends AbstractOptionsTest {
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
-    @Tested
-    private MysqlSchemaCodegen clientCodegen;
+public class MysqlSchemaOptionsTest extends AbstractOptionsTest {
+    private MysqlSchemaCodegen clientCodegen = mock(MysqlSchemaCodegen.class, mockSettings);
 
     public MysqlSchemaOptionsTest() {
         super(new MysqlSchemaOptionsProvider());
@@ -39,14 +38,9 @@ public class MysqlSchemaOptionsTest extends AbstractOptionsTest {
 
     @SuppressWarnings("unused")
     @Override
-    protected void setExpectations() {
-        new Expectations(clientCodegen) {{
-            clientCodegen.setDefaultDatabaseName(MysqlSchemaOptionsProvider.DEFAULT_DATABASE_NAME_VALUE);
-            times = 1;
-            clientCodegen.setJsonDataTypeEnabled(Boolean.valueOf(MysqlSchemaOptionsProvider.JSON_DATA_TYPE_ENABLED_VALUE));
-            times = 1;
-            clientCodegen.setIdentifierNamingConvention(MysqlSchemaOptionsProvider.IDENTIFIER_NAMING_CONVENTION_VALUE);
-            times = 1;
-        }};
+    protected void verifyOptions() {
+        verify(clientCodegen).setDefaultDatabaseName(MysqlSchemaOptionsProvider.DEFAULT_DATABASE_NAME_VALUE);
+        verify(clientCodegen).setJsonDataTypeEnabled(Boolean.valueOf(MysqlSchemaOptionsProvider.JSON_DATA_TYPE_ENABLED_VALUE));
+        verify(clientCodegen).setIdentifierNamingConvention(MysqlSchemaOptionsProvider.IDENTIFIER_NAMING_CONVENTION_VALUE);
     }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/objc/ObjcClientOptionsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/objc/ObjcClientOptionsTest.java
@@ -17,17 +17,16 @@
 
 package org.openapitools.codegen.objc;
 
-import mockit.Expectations;
-import mockit.Tested;
 import org.openapitools.codegen.AbstractOptionsTest;
 import org.openapitools.codegen.CodegenConfig;
 import org.openapitools.codegen.languages.ObjcClientCodegen;
 import org.openapitools.codegen.options.ObjcClientOptionsProvider;
 
-public class ObjcClientOptionsTest extends AbstractOptionsTest {
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
-    @Tested
-    private ObjcClientCodegen clientCodegen;
+public class ObjcClientOptionsTest extends AbstractOptionsTest {
+    private ObjcClientCodegen clientCodegen = mock(ObjcClientCodegen.class, mockSettings);
 
     public ObjcClientOptionsTest() {
         super(new ObjcClientOptionsProvider());
@@ -40,20 +39,12 @@ public class ObjcClientOptionsTest extends AbstractOptionsTest {
 
     @SuppressWarnings("unused")
     @Override
-    protected void setExpectations() {
-        new Expectations(clientCodegen) {{
-            clientCodegen.setClassPrefix(ObjcClientOptionsProvider.CLASS_PREFIX_VALUE);
-            times = 1;
-            clientCodegen.setPodName(ObjcClientOptionsProvider.POD_NAME_VALUE);
-            times = 1;
-            clientCodegen.setPodVersion(ObjcClientOptionsProvider.POD_VERSION_VALUE);
-            times = 1;
-            clientCodegen.setAuthorName(ObjcClientOptionsProvider.AUTHOR_NAME_VALUE);
-            times = 1;
-            clientCodegen.setAuthorEmail(ObjcClientOptionsProvider.AUTHOR_EMAIL_VALUE);
-            times = 1;
-            clientCodegen.setGitRepoURL(ObjcClientOptionsProvider.GIT_REPO_URL_VALUE);
-            times = 1;
-        }};
+    protected void verifyOptions() {
+        verify(clientCodegen).setClassPrefix(ObjcClientOptionsProvider.CLASS_PREFIX_VALUE);
+        verify(clientCodegen).setPodName(ObjcClientOptionsProvider.POD_NAME_VALUE);
+        verify(clientCodegen).setPodVersion(ObjcClientOptionsProvider.POD_VERSION_VALUE);
+        verify(clientCodegen).setAuthorName(ObjcClientOptionsProvider.AUTHOR_NAME_VALUE);
+        verify(clientCodegen).setAuthorEmail(ObjcClientOptionsProvider.AUTHOR_EMAIL_VALUE);
+        verify(clientCodegen).setGitRepoURL(ObjcClientOptionsProvider.GIT_REPO_URL_VALUE);
     }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/ScalaHttpClientOptionsProvider.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/ScalaHttpClientOptionsProvider.java
@@ -29,7 +29,7 @@ public class ScalaHttpClientOptionsProvider implements OptionsProvider {
     public static final String SORT_PARAMS_VALUE = "false";
     public static final String SORT_MODEL_PROPERTIES_VALUE = "false";
     public static final String ENSURE_UNIQUE_PARAMS_VALUE = "true";
-    public static final String MODEL_PROPERTY_NAMING = "modelPropertyNaming";
+    public static final String MODEL_PROPERTY_NAMING = "PascalCase";
     public static final String ALLOW_UNICODE_IDENTIFIERS_VALUE = "false";
     public static final String PREPEND_FORM_OR_BODY_PARAMETERS_VALUE = "true";
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/perl/PerlClientOptionsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/perl/PerlClientOptionsTest.java
@@ -17,17 +17,16 @@
 
 package org.openapitools.codegen.perl;
 
-import mockit.Expectations;
-import mockit.Tested;
 import org.openapitools.codegen.AbstractOptionsTest;
 import org.openapitools.codegen.CodegenConfig;
 import org.openapitools.codegen.languages.PerlClientCodegen;
 import org.openapitools.codegen.options.PerlClientOptionsProvider;
 
-public class PerlClientOptionsTest extends AbstractOptionsTest {
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
-    @Tested
-    private PerlClientCodegen clientCodegen;
+public class PerlClientOptionsTest extends AbstractOptionsTest {
+    private PerlClientCodegen clientCodegen = mock(PerlClientCodegen.class, mockSettings);
 
     public PerlClientOptionsTest() {
         super(new PerlClientOptionsProvider());
@@ -40,14 +39,9 @@ public class PerlClientOptionsTest extends AbstractOptionsTest {
 
     @SuppressWarnings("unused")
     @Override
-    protected void setExpectations() {
-        new Expectations(clientCodegen) {{
-            clientCodegen.setModuleName(PerlClientOptionsProvider.MODULE_NAME_VALUE);
-            times = 1;
-            clientCodegen.setModuleVersion(PerlClientOptionsProvider.MODULE_VERSION_VALUE);
-            times = 1;
-            clientCodegen.setPrependFormOrBodyParameters(Boolean.valueOf(PerlClientOptionsProvider.PREPEND_FORM_OR_BODY_PARAMETERS_VALUE));
-            times = 1;
-        }};
+    protected void verifyOptions() {
+        verify(clientCodegen).setModuleName(PerlClientOptionsProvider.MODULE_NAME_VALUE);
+        verify(clientCodegen).setModuleVersion(PerlClientOptionsProvider.MODULE_VERSION_VALUE);
+        verify(clientCodegen).setPrependFormOrBodyParameters(Boolean.valueOf(PerlClientOptionsProvider.PREPEND_FORM_OR_BODY_PARAMETERS_VALUE));
     }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/php/PhpClientOptionsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/php/PhpClientOptionsTest.java
@@ -17,17 +17,16 @@
 
 package org.openapitools.codegen.php;
 
-import mockit.Expectations;
-import mockit.Tested;
 import org.openapitools.codegen.AbstractOptionsTest;
 import org.openapitools.codegen.CodegenConfig;
 import org.openapitools.codegen.languages.PhpClientCodegen;
 import org.openapitools.codegen.options.PhpClientOptionsProvider;
 
-public class PhpClientOptionsTest extends AbstractOptionsTest {
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
-    @Tested
-    private PhpClientCodegen clientCodegen;
+public class PhpClientOptionsTest extends AbstractOptionsTest {
+    private PhpClientCodegen clientCodegen = mock(PhpClientCodegen.class, mockSettings);
 
     public PhpClientOptionsTest() {
         super(new PhpClientOptionsProvider());
@@ -40,24 +39,14 @@ public class PhpClientOptionsTest extends AbstractOptionsTest {
 
     @SuppressWarnings("unused")
     @Override
-    protected void setExpectations() {
-        new Expectations(clientCodegen) {{
-            clientCodegen.setModelPackage(PhpClientOptionsProvider.MODEL_PACKAGE_VALUE);
-            times = 1;
-            clientCodegen.setApiPackage(PhpClientOptionsProvider.API_PACKAGE_VALUE);
-            times = 1;
-            clientCodegen.setSortParamsByRequiredFlag(Boolean.valueOf(PhpClientOptionsProvider.SORT_PARAMS_VALUE));
-            times = 1;
-            clientCodegen.setParameterNamingConvention(PhpClientOptionsProvider.VARIABLE_NAMING_CONVENTION_VALUE);
-            times = 1;
-            clientCodegen.setInvokerPackage(PhpClientOptionsProvider.INVOKER_PACKAGE_VALUE);
-            times = 1;
-            clientCodegen.setPackageName(PhpClientOptionsProvider.PACKAGE_NAME_VALUE);
-            times = 1;
-            clientCodegen.setSrcBasePath(PhpClientOptionsProvider.SRC_BASE_PATH_VALUE);
-            times = 1;
-            clientCodegen.setArtifactVersion(PhpClientOptionsProvider.ARTIFACT_VERSION_VALUE);
-            times = 1;
-        }};
+    protected void verifyOptions() {
+        verify(clientCodegen).setModelPackage(PhpClientOptionsProvider.MODEL_PACKAGE_VALUE);
+        verify(clientCodegen).setApiPackage(PhpClientOptionsProvider.API_PACKAGE_VALUE);
+        verify(clientCodegen).setSortParamsByRequiredFlag(Boolean.valueOf(PhpClientOptionsProvider.SORT_PARAMS_VALUE));
+        verify(clientCodegen).setParameterNamingConvention(PhpClientOptionsProvider.VARIABLE_NAMING_CONVENTION_VALUE);
+        verify(clientCodegen).setInvokerPackage(PhpClientOptionsProvider.INVOKER_PACKAGE_VALUE);
+        verify(clientCodegen).setPackageName(PhpClientOptionsProvider.PACKAGE_NAME_VALUE);
+        verify(clientCodegen).setSrcBasePath(PhpClientOptionsProvider.SRC_BASE_PATH_VALUE);
+        verify(clientCodegen).setArtifactVersion(PhpClientOptionsProvider.ARTIFACT_VERSION_VALUE);
     }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/python/PythonClientOptionsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/python/PythonClientOptionsTest.java
@@ -17,19 +17,19 @@
 
 package org.openapitools.codegen.python;
 
-import mockit.Expectations;
-import mockit.Tested;
 import org.openapitools.codegen.AbstractOptionsTest;
 import org.openapitools.codegen.CodegenConfig;
 import org.openapitools.codegen.languages.PythonClientCodegen;
 import org.openapitools.codegen.options.PythonClientOptionsProvider;
+import org.testng.Assert;
 
 import java.io.File;
 
-public class PythonClientOptionsTest extends AbstractOptionsTest {
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
-    @Tested
-    private PythonClientCodegen clientCodegen;
+public class PythonClientOptionsTest extends AbstractOptionsTest {
+    private PythonClientCodegen clientCodegen = mock(PythonClientCodegen.class, mockSettings);
 
     public PythonClientOptionsTest() {
         super(new PythonClientOptionsProvider());
@@ -42,26 +42,13 @@ public class PythonClientOptionsTest extends AbstractOptionsTest {
 
     @SuppressWarnings("unused")
     @Override
-    protected void setExpectations() {
-        new Expectations(clientCodegen) {{
-            clientCodegen.setPackageName(PythonClientOptionsProvider.PACKAGE_NAME_VALUE);
-            times = 1;
+    protected void verifyOptions() {
+        Assert.assertEquals(clientCodegen.packagePath(), PythonClientOptionsProvider.PACKAGE_NAME_VALUE.replace('.', File.separatorChar));
 
-            clientCodegen.setProjectName(PythonClientOptionsProvider.PROJECT_NAME_VALUE);
-            times = 1;
-
-            clientCodegen.setPackageVersion(PythonClientOptionsProvider.PACKAGE_VERSION_VALUE);
-            times = 1;
-
-            clientCodegen.setPackageUrl(PythonClientOptionsProvider.PACKAGE_URL_VALUE);
-            times = 1;
-
-            clientCodegen.setUseNose(PythonClientOptionsProvider.USE_NOSE_VALUE);
-            times = 1;
-
-            clientCodegen.packagePath();
-            result = PythonClientOptionsProvider.PACKAGE_NAME_VALUE.replace('.', File.separatorChar);
-            minTimes = 1;
-        }};
+        verify(clientCodegen).setPackageName(PythonClientOptionsProvider.PACKAGE_NAME_VALUE);
+        verify(clientCodegen).setProjectName(PythonClientOptionsProvider.PROJECT_NAME_VALUE);
+        verify(clientCodegen).setPackageVersion(PythonClientOptionsProvider.PACKAGE_VERSION_VALUE);
+        verify(clientCodegen).setPackageUrl(PythonClientOptionsProvider.PACKAGE_URL_VALUE);
+        verify(clientCodegen).setUseNose(PythonClientOptionsProvider.USE_NOSE_VALUE);
     }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/ruby/RubyClientOptionsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/ruby/RubyClientOptionsTest.java
@@ -17,17 +17,16 @@
 
 package org.openapitools.codegen.ruby;
 
-import mockit.Expectations;
-import mockit.Tested;
 import org.openapitools.codegen.AbstractOptionsTest;
 import org.openapitools.codegen.CodegenConfig;
 import org.openapitools.codegen.languages.RubyClientCodegen;
 import org.openapitools.codegen.options.RubyClientOptionsProvider;
 
-public class RubyClientOptionsTest extends AbstractOptionsTest {
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
-    @Tested
-    private RubyClientCodegen clientCodegen;
+public class RubyClientOptionsTest extends AbstractOptionsTest {
+    private RubyClientCodegen clientCodegen = mock(RubyClientCodegen.class, mockSettings);
 
     public RubyClientOptionsTest() {
         super(new RubyClientOptionsProvider());
@@ -40,29 +39,16 @@ public class RubyClientOptionsTest extends AbstractOptionsTest {
 
     @SuppressWarnings("unused")
     @Override
-    protected void setExpectations() {
-        new Expectations(clientCodegen) {{
-            clientCodegen.setGemName(RubyClientOptionsProvider.GEM_NAME_VALUE);
-            times = 1;
-            clientCodegen.setModuleName(RubyClientOptionsProvider.MODULE_NAME_VALUE);
-            times = 1;
-            clientCodegen.setGemVersion(RubyClientOptionsProvider.GEM_VERSION_VALUE);
-            times = 1;
-            clientCodegen.setGemLicense(RubyClientOptionsProvider.GEM_LICENSE_VALUE);
-            times = 1;
-            clientCodegen.setGemRequiredRubyVersion(RubyClientOptionsProvider.GEM_REQUIRED_RUBY_VERSION_VALUE);
-            times = 1;
-            clientCodegen.setGemHomepage(RubyClientOptionsProvider.GEM_HOMEPAGE_VALUE);
-            times = 1;
-            clientCodegen.setGemDescription(RubyClientOptionsProvider.GEM_DESCRIPTION_VALUE);
-            times = 1;
-            clientCodegen.setGemSummary(RubyClientOptionsProvider.GEM_SUMMARY_VALUE);
-            times = 1;
-            clientCodegen.setGemAuthor(RubyClientOptionsProvider.GEM_AUTHOR_VALUE);
-            times = 1;
-            clientCodegen.setGemAuthorEmail(RubyClientOptionsProvider.GEM_AUTHOR_EMAIL_VALUE);
-            times = 1;
-
-        }};
+    protected void verifyOptions() {
+        verify(clientCodegen).setGemName(RubyClientOptionsProvider.GEM_NAME_VALUE);
+        verify(clientCodegen).setModuleName(RubyClientOptionsProvider.MODULE_NAME_VALUE);
+        verify(clientCodegen).setGemVersion(RubyClientOptionsProvider.GEM_VERSION_VALUE);
+        verify(clientCodegen).setGemLicense(RubyClientOptionsProvider.GEM_LICENSE_VALUE);
+        verify(clientCodegen).setGemRequiredRubyVersion(RubyClientOptionsProvider.GEM_REQUIRED_RUBY_VERSION_VALUE);
+        verify(clientCodegen).setGemHomepage(RubyClientOptionsProvider.GEM_HOMEPAGE_VALUE);
+        verify(clientCodegen).setGemDescription(RubyClientOptionsProvider.GEM_DESCRIPTION_VALUE);
+        verify(clientCodegen).setGemSummary(RubyClientOptionsProvider.GEM_SUMMARY_VALUE);
+        verify(clientCodegen).setGemAuthor(RubyClientOptionsProvider.GEM_AUTHOR_VALUE);
+        verify(clientCodegen).setGemAuthorEmail(RubyClientOptionsProvider.GEM_AUTHOR_EMAIL_VALUE);
     }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/rubysinatra/RubySinatraServerOptionsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/rubysinatra/RubySinatraServerOptionsTest.java
@@ -17,17 +17,16 @@
 
 package org.openapitools.codegen.rubysinatra;
 
-import mockit.Expectations;
-import mockit.Tested;
 import org.openapitools.codegen.AbstractOptionsTest;
 import org.openapitools.codegen.CodegenConfig;
 import org.openapitools.codegen.languages.RubySinatraServerCodegen;
 import org.openapitools.codegen.options.RubySinatraServerOptionsProvider;
 
-public class RubySinatraServerOptionsTest extends AbstractOptionsTest {
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
-    @Tested
-    private RubySinatraServerCodegen clientCodegen;
+public class RubySinatraServerOptionsTest extends AbstractOptionsTest {
+    private RubySinatraServerCodegen clientCodegen = mock(RubySinatraServerCodegen.class, mockSettings);
 
     public RubySinatraServerOptionsTest() {
         super(new RubySinatraServerOptionsProvider());
@@ -40,8 +39,7 @@ public class RubySinatraServerOptionsTest extends AbstractOptionsTest {
 
     @SuppressWarnings("unused")
     @Override
-    protected void setExpectations() {
-        new Expectations(clientCodegen) {{
-        }};
+    protected void verifyOptions() {
+        // TODO verify ruby sinatra opts
     }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/scalaakka/ScalaAkkaClientOptionsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/scalaakka/ScalaAkkaClientOptionsTest.java
@@ -17,17 +17,16 @@
 
 package org.openapitools.codegen.scalaakka;
 
-import mockit.Expectations;
-import mockit.Tested;
 import org.openapitools.codegen.AbstractOptionsTest;
 import org.openapitools.codegen.CodegenConfig;
 import org.openapitools.codegen.languages.ScalaAkkaClientCodegen;
 import org.openapitools.codegen.options.ScalaAkkaClientOptionsProvider;
 
-public class ScalaAkkaClientOptionsTest extends AbstractOptionsTest {
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
-    @Tested
-    private ScalaAkkaClientCodegen clientCodegen;
+public class ScalaAkkaClientOptionsTest extends AbstractOptionsTest {
+    private ScalaAkkaClientCodegen clientCodegen = mock(ScalaAkkaClientCodegen.class, mockSettings);
 
     public ScalaAkkaClientOptionsTest() {
         super(new ScalaAkkaClientOptionsProvider());
@@ -40,20 +39,12 @@ public class ScalaAkkaClientOptionsTest extends AbstractOptionsTest {
 
     @SuppressWarnings("unused")
     @Override
-    protected void setExpectations() {
-        new Expectations(clientCodegen) {{
-            clientCodegen.setModelPackage(ScalaAkkaClientOptionsProvider.MODEL_PACKAGE_VALUE);
-            times = 1;
-            clientCodegen.setApiPackage(ScalaAkkaClientOptionsProvider.API_PACKAGE_VALUE);
-            times = 1;
-            clientCodegen.setSortParamsByRequiredFlag(Boolean.valueOf(ScalaAkkaClientOptionsProvider.SORT_PARAMS_VALUE));
-            times = 1;
-            clientCodegen.setSourceFolder(ScalaAkkaClientOptionsProvider.SOURCE_FOLDER_VALUE);
-            times = 1;
-            clientCodegen.setPrependFormOrBodyParameters(Boolean.valueOf(ScalaAkkaClientOptionsProvider.PREPEND_FORM_OR_BODY_PARAMETERS_VALUE));
-            times = 1;
-            clientCodegen.setMainPackage(ScalaAkkaClientOptionsProvider.MAIN_PACKAGE_VALUE);
-            times = 1;
-        }};
+    protected void verifyOptions() {
+        verify(clientCodegen).setModelPackage(ScalaAkkaClientOptionsProvider.MODEL_PACKAGE_VALUE);
+        verify(clientCodegen).setApiPackage(ScalaAkkaClientOptionsProvider.API_PACKAGE_VALUE);
+        verify(clientCodegen).setSortParamsByRequiredFlag(Boolean.valueOf(ScalaAkkaClientOptionsProvider.SORT_PARAMS_VALUE));
+        verify(clientCodegen).setSourceFolder(ScalaAkkaClientOptionsProvider.SOURCE_FOLDER_VALUE);
+        verify(clientCodegen).setPrependFormOrBodyParameters(Boolean.valueOf(ScalaAkkaClientOptionsProvider.PREPEND_FORM_OR_BODY_PARAMETERS_VALUE));
+        verify(clientCodegen).setMainPackage(ScalaAkkaClientOptionsProvider.MAIN_PACKAGE_VALUE);
     }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/scalahttpclient/ScalaHttpClientOptionsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/scalahttpclient/ScalaHttpClientOptionsTest.java
@@ -17,17 +17,16 @@
 
 package org.openapitools.codegen.scalahttpclient;
 
-import mockit.Expectations;
-import mockit.Tested;
 import org.openapitools.codegen.AbstractOptionsTest;
 import org.openapitools.codegen.CodegenConfig;
 import org.openapitools.codegen.languages.ScalaHttpClientCodegen;
 import org.openapitools.codegen.options.ScalaHttpClientOptionsProvider;
 
-public class ScalaHttpClientOptionsTest extends AbstractOptionsTest {
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
-    @Tested
-    private ScalaHttpClientCodegen clientCodegen;
+public class ScalaHttpClientOptionsTest extends AbstractOptionsTest {
+    private ScalaHttpClientCodegen clientCodegen = mock(ScalaHttpClientCodegen.class, mockSettings);
 
     public ScalaHttpClientOptionsTest() {
         super(new ScalaHttpClientOptionsProvider());
@@ -40,20 +39,12 @@ public class ScalaHttpClientOptionsTest extends AbstractOptionsTest {
 
     @SuppressWarnings("unused")
     @Override
-    protected void setExpectations() {
-        new Expectations(clientCodegen) {{
-            clientCodegen.setModelPackage(ScalaHttpClientOptionsProvider.MODEL_PACKAGE_VALUE);
-            times = 1;
-            clientCodegen.setApiPackage(ScalaHttpClientOptionsProvider.API_PACKAGE_VALUE);
-            times = 1;
-            clientCodegen.setSortParamsByRequiredFlag(Boolean.valueOf(ScalaHttpClientOptionsProvider.SORT_PARAMS_VALUE));
-            times = 1;
-            clientCodegen.setModelPropertyNaming(ScalaHttpClientOptionsProvider.MODEL_PROPERTY_NAMING);
-            times = 1;
-            clientCodegen.setSourceFolder(ScalaHttpClientOptionsProvider.SOURCE_FOLDER_VALUE);
-            times = 1;
-            clientCodegen.setPrependFormOrBodyParameters(Boolean.valueOf(ScalaHttpClientOptionsProvider.PREPEND_FORM_OR_BODY_PARAMETERS_VALUE));
-            times = 1;
-        }};
+    protected void verifyOptions() {
+        verify(clientCodegen).setModelPackage(ScalaHttpClientOptionsProvider.MODEL_PACKAGE_VALUE);
+        verify(clientCodegen).setApiPackage(ScalaHttpClientOptionsProvider.API_PACKAGE_VALUE);
+        verify(clientCodegen).setSortParamsByRequiredFlag(Boolean.valueOf(ScalaHttpClientOptionsProvider.SORT_PARAMS_VALUE));
+        verify(clientCodegen).setModelPropertyNaming(ScalaHttpClientOptionsProvider.MODEL_PROPERTY_NAMING);
+        verify(clientCodegen).setSourceFolder(ScalaHttpClientOptionsProvider.SOURCE_FOLDER_VALUE);
+        verify(clientCodegen).setPrependFormOrBodyParameters(Boolean.valueOf(ScalaHttpClientOptionsProvider.PREPEND_FORM_OR_BODY_PARAMETERS_VALUE));
     }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/silex/PhpSilexServerOptionsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/silex/PhpSilexServerOptionsTest.java
@@ -17,17 +17,16 @@
 
 package org.openapitools.codegen.silex;
 
-import mockit.Expectations;
-import mockit.Tested;
 import org.openapitools.codegen.AbstractOptionsTest;
 import org.openapitools.codegen.CodegenConfig;
 import org.openapitools.codegen.languages.PhpSilexServerCodegen;
 import org.openapitools.codegen.options.PhpSilexServerOptionsProvider;
 
-public class PhpSilexServerOptionsTest extends AbstractOptionsTest {
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
-    @Tested
-    private PhpSilexServerCodegen clientCodegen;
+public class PhpSilexServerOptionsTest extends AbstractOptionsTest {
+    private PhpSilexServerCodegen clientCodegen = mock(PhpSilexServerCodegen.class, mockSettings);
 
     public PhpSilexServerOptionsTest() {
         super(new PhpSilexServerOptionsProvider());
@@ -40,10 +39,7 @@ public class PhpSilexServerOptionsTest extends AbstractOptionsTest {
 
     @SuppressWarnings("unused")
     @Override
-    protected void setExpectations() {
-        new Expectations(clientCodegen) {{
-            clientCodegen.setSortParamsByRequiredFlag(Boolean.valueOf(PhpSilexServerOptionsProvider.SORT_PARAMS_VALUE));
-            times = 1;
-        }};
+    protected void verifyOptions() {
+        verify(clientCodegen).setSortParamsByRequiredFlag(Boolean.valueOf(PhpSilexServerOptionsProvider.SORT_PARAMS_VALUE));
     }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/slim/PhpSlimServerOptionsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/slim/PhpSlimServerOptionsTest.java
@@ -17,17 +17,16 @@
 
 package org.openapitools.codegen.slim;
 
-import mockit.Expectations;
-import mockit.Tested;
 import org.openapitools.codegen.AbstractOptionsTest;
 import org.openapitools.codegen.CodegenConfig;
 import org.openapitools.codegen.languages.PhpSlimServerCodegen;
 import org.openapitools.codegen.options.PhpSlimServerOptionsProvider;
 
-public class PhpSlimServerOptionsTest extends AbstractOptionsTest {
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
-    @Tested
-    private PhpSlimServerCodegen clientCodegen;
+public class PhpSlimServerOptionsTest extends AbstractOptionsTest {
+    private PhpSlimServerCodegen clientCodegen = mock(PhpSlimServerCodegen.class, mockSettings);
 
     public PhpSlimServerOptionsTest() {
         super(new PhpSlimServerOptionsProvider());
@@ -40,24 +39,14 @@ public class PhpSlimServerOptionsTest extends AbstractOptionsTest {
 
     @SuppressWarnings("unused")
     @Override
-    protected void setExpectations() {
-        new Expectations(clientCodegen) {{
-            clientCodegen.setModelPackage(PhpSlimServerOptionsProvider.MODEL_PACKAGE_VALUE);
-            times = 1;
-            clientCodegen.setApiPackage(PhpSlimServerOptionsProvider.API_PACKAGE_VALUE);
-            times = 1;
-            clientCodegen.setParameterNamingConvention(PhpSlimServerOptionsProvider.VARIABLE_NAMING_CONVENTION_VALUE);
-            times = 1;
-            clientCodegen.setInvokerPackage(PhpSlimServerOptionsProvider.INVOKER_PACKAGE_VALUE);
-            times = 1;
-            clientCodegen.setPackageName(PhpSlimServerOptionsProvider.PACKAGE_NAME_VALUE);
-            times = 1;
-            clientCodegen.setSrcBasePath(PhpSlimServerOptionsProvider.SRC_BASE_PATH_VALUE);
-            times = 1;
-            clientCodegen.setArtifactVersion(PhpSlimServerOptionsProvider.ARTIFACT_VERSION_VALUE);
-            times = 1;
-            clientCodegen.setSortParamsByRequiredFlag(Boolean.valueOf(PhpSlimServerOptionsProvider.SORT_PARAMS_VALUE));
-            times = 1;
-        }};
+    protected void verifyOptions() {
+        verify(clientCodegen).setModelPackage(PhpSlimServerOptionsProvider.MODEL_PACKAGE_VALUE);
+        verify(clientCodegen).setApiPackage(PhpSlimServerOptionsProvider.API_PACKAGE_VALUE);
+        verify(clientCodegen).setParameterNamingConvention(PhpSlimServerOptionsProvider.VARIABLE_NAMING_CONVENTION_VALUE);
+        verify(clientCodegen).setInvokerPackage(PhpSlimServerOptionsProvider.INVOKER_PACKAGE_VALUE);
+        verify(clientCodegen).setPackageName(PhpSlimServerOptionsProvider.PACKAGE_NAME_VALUE);
+        verify(clientCodegen).setSrcBasePath(PhpSlimServerOptionsProvider.SRC_BASE_PATH_VALUE);
+        verify(clientCodegen).setArtifactVersion(PhpSlimServerOptionsProvider.ARTIFACT_VERSION_VALUE);
+        verify(clientCodegen).setSortParamsByRequiredFlag(Boolean.valueOf(PhpSlimServerOptionsProvider.SORT_PARAMS_VALUE));
     }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/slim4/PhpSlim4ServerOptionsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/slim4/PhpSlim4ServerOptionsTest.java
@@ -17,17 +17,16 @@
 
 package org.openapitools.codegen.slim4;
 
-import mockit.Expectations;
-import mockit.Tested;
 import org.openapitools.codegen.AbstractOptionsTest;
 import org.openapitools.codegen.CodegenConfig;
 import org.openapitools.codegen.languages.PhpSlim4ServerCodegen;
 import org.openapitools.codegen.options.PhpSlim4ServerOptionsProvider;
 
-public class PhpSlim4ServerOptionsTest extends AbstractOptionsTest {
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
-    @Tested
-    private PhpSlim4ServerCodegen clientCodegen;
+public class PhpSlim4ServerOptionsTest extends AbstractOptionsTest {
+    private PhpSlim4ServerCodegen clientCodegen = mock(PhpSlim4ServerCodegen.class, mockSettings);
 
     public PhpSlim4ServerOptionsTest() {
         super(new PhpSlim4ServerOptionsProvider());
@@ -40,27 +39,16 @@ public class PhpSlim4ServerOptionsTest extends AbstractOptionsTest {
 
     @SuppressWarnings("unused")
     @Override
-    protected void setExpectations() {
-        new Expectations(clientCodegen) {{
-            clientCodegen.setModelPackage(PhpSlim4ServerOptionsProvider.MODEL_PACKAGE_VALUE);
-            times = 1;
-            clientCodegen.setApiPackage(PhpSlim4ServerOptionsProvider.API_PACKAGE_VALUE);
-            times = 1;
-            clientCodegen.setParameterNamingConvention(PhpSlim4ServerOptionsProvider.VARIABLE_NAMING_CONVENTION_VALUE);
-            times = 1;
-            clientCodegen.setInvokerPackage(PhpSlim4ServerOptionsProvider.INVOKER_PACKAGE_VALUE);
-            times = 1;
-            clientCodegen.setPackageName(PhpSlim4ServerOptionsProvider.PACKAGE_NAME_VALUE);
-            times = 1;
-            clientCodegen.setSrcBasePath(PhpSlim4ServerOptionsProvider.SRC_BASE_PATH_VALUE);
-            times = 1;
-            clientCodegen.setArtifactVersion(PhpSlim4ServerOptionsProvider.ARTIFACT_VERSION_VALUE);
-            times = 1;
-            clientCodegen.setSortParamsByRequiredFlag(Boolean.valueOf(PhpSlim4ServerOptionsProvider.SORT_PARAMS_VALUE));
-            times = 1;
-            clientCodegen.setPsr7Implementation(PhpSlim4ServerOptionsProvider.PSR7_IMPLEMENTATION_VALUE);
-            times = 1;
-        }};
+    protected void verifyOptions() {
+        verify(clientCodegen).setModelPackage(PhpSlim4ServerOptionsProvider.MODEL_PACKAGE_VALUE);
+        verify(clientCodegen).setApiPackage(PhpSlim4ServerOptionsProvider.API_PACKAGE_VALUE);
+        verify(clientCodegen).setParameterNamingConvention(PhpSlim4ServerOptionsProvider.VARIABLE_NAMING_CONVENTION_VALUE);
+        verify(clientCodegen).setInvokerPackage(PhpSlim4ServerOptionsProvider.INVOKER_PACKAGE_VALUE);
+        verify(clientCodegen).setPackageName(PhpSlim4ServerOptionsProvider.PACKAGE_NAME_VALUE);
+        verify(clientCodegen).setSrcBasePath(PhpSlim4ServerOptionsProvider.SRC_BASE_PATH_VALUE);
+        verify(clientCodegen).setArtifactVersion(PhpSlim4ServerOptionsProvider.ARTIFACT_VERSION_VALUE);
+        verify(clientCodegen).setSortParamsByRequiredFlag(Boolean.valueOf(PhpSlim4ServerOptionsProvider.SORT_PARAMS_VALUE));
+        verify(clientCodegen).setPsr7Implementation(PhpSlim4ServerOptionsProvider.PSR7_IMPLEMENTATION_VALUE);
     }
 }
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/swift3/Swift3OptionsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/swift3/Swift3OptionsTest.java
@@ -17,17 +17,16 @@
 
 package org.openapitools.codegen.swift3;
 
-import mockit.Expectations;
-import mockit.Tested;
 import org.openapitools.codegen.AbstractOptionsTest;
 import org.openapitools.codegen.CodegenConfig;
 import org.openapitools.codegen.languages.Swift3Codegen;
 import org.openapitools.codegen.options.Swift3OptionsProvider;
 
-public class Swift3OptionsTest extends AbstractOptionsTest {
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
-    @Tested
-    private Swift3Codegen clientCodegen;
+public class Swift3OptionsTest extends AbstractOptionsTest {
+    private Swift3Codegen clientCodegen = mock(Swift3Codegen.class, mockSettings);
 
     public Swift3OptionsTest() {
         super(new Swift3OptionsProvider());
@@ -40,22 +39,13 @@ public class Swift3OptionsTest extends AbstractOptionsTest {
 
     @SuppressWarnings("unused")
     @Override
-    protected void setExpectations() {
-        new Expectations(clientCodegen) {{
-            clientCodegen.setSortParamsByRequiredFlag(Boolean.valueOf(Swift3OptionsProvider.SORT_PARAMS_VALUE));
-            times = 1;
-            clientCodegen.setProjectName(Swift3OptionsProvider.PROJECT_NAME_VALUE);
-            times = 1;
-            clientCodegen.setResponseAs(Swift3OptionsProvider.RESPONSE_AS_VALUE.split(","));
-            times = 1;
-            clientCodegen.setUnwrapRequired(Boolean.valueOf(Swift3OptionsProvider.UNWRAP_REQUIRED_VALUE));
-            times = 1;
-            clientCodegen.setObjcCompatible(Boolean.valueOf(Swift3OptionsProvider.OBJC_COMPATIBLE_VALUE));
-            times = 1;
-            clientCodegen.setLenientTypeCast(Boolean.valueOf(Swift3OptionsProvider.LENIENT_TYPE_CAST_VALUE));
-            times = 1;
-            clientCodegen.setPrependFormOrBodyParameters(Boolean.valueOf(Swift3OptionsProvider.PREPEND_FORM_OR_BODY_PARAMETERS_VALUE));
-            times = 1;
-        }};
+    protected void verifyOptions() {
+        verify(clientCodegen).setSortParamsByRequiredFlag(Boolean.parseBoolean(Swift3OptionsProvider.SORT_PARAMS_VALUE));
+        verify(clientCodegen).setProjectName(Swift3OptionsProvider.PROJECT_NAME_VALUE);
+        verify(clientCodegen).setResponseAs(Swift3OptionsProvider.RESPONSE_AS_VALUE.split(","));
+        verify(clientCodegen).setUnwrapRequired(Boolean.parseBoolean(Swift3OptionsProvider.UNWRAP_REQUIRED_VALUE));
+        verify(clientCodegen).setObjcCompatible(Boolean.parseBoolean(Swift3OptionsProvider.OBJC_COMPATIBLE_VALUE));
+        verify(clientCodegen).setLenientTypeCast(Boolean.parseBoolean(Swift3OptionsProvider.LENIENT_TYPE_CAST_VALUE));
+        verify(clientCodegen).setPrependFormOrBodyParameters(Boolean.parseBoolean(Swift3OptionsProvider.PREPEND_FORM_OR_BODY_PARAMETERS_VALUE));
     }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/swift4/Swift4OptionsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/swift4/Swift4OptionsTest.java
@@ -17,17 +17,16 @@
 
 package org.openapitools.codegen.swift4;
 
-import mockit.Expectations;
-import mockit.Tested;
 import org.openapitools.codegen.AbstractOptionsTest;
 import org.openapitools.codegen.CodegenConfig;
 import org.openapitools.codegen.languages.Swift4Codegen;
 import org.openapitools.codegen.options.Swift4OptionsProvider;
 
-public class Swift4OptionsTest extends AbstractOptionsTest {
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
-    @Tested
-    private Swift4Codegen clientCodegen;
+public class Swift4OptionsTest extends AbstractOptionsTest {
+    private Swift4Codegen clientCodegen = mock(Swift4Codegen.class, mockSettings);
 
     public Swift4OptionsTest() {
         super(new Swift4OptionsProvider());
@@ -40,24 +39,14 @@ public class Swift4OptionsTest extends AbstractOptionsTest {
 
     @SuppressWarnings("unused")
     @Override
-    protected void setExpectations() {
-        new Expectations(clientCodegen) {{
-            clientCodegen.setSortParamsByRequiredFlag(Boolean.valueOf(Swift4OptionsProvider.SORT_PARAMS_VALUE));
-            times = 1;
-            clientCodegen.setProjectName(Swift4OptionsProvider.PROJECT_NAME_VALUE);
-            times = 1;
-            clientCodegen.setResponseAs(Swift4OptionsProvider.RESPONSE_AS_VALUE.split(","));
-            times = 1;
-            clientCodegen.setNonPublicApi(Boolean.valueOf(Swift4OptionsProvider.NON_PUBLIC_API_REQUIRED_VALUE));
-            times = 1;
-            clientCodegen.setUnwrapRequired(Boolean.valueOf(Swift4OptionsProvider.UNWRAP_REQUIRED_VALUE));
-            times = 1;
-            clientCodegen.setObjcCompatible(Boolean.valueOf(Swift4OptionsProvider.OBJC_COMPATIBLE_VALUE));
-            times = 1;
-            clientCodegen.setLenientTypeCast(Boolean.valueOf(Swift4OptionsProvider.LENIENT_TYPE_CAST_VALUE));
-            times = 1;
-            clientCodegen.setPrependFormOrBodyParameters(Boolean.valueOf(Swift4OptionsProvider.PREPEND_FORM_OR_BODY_PARAMETERS_VALUE));
-            times = 1;
-        }};
+    protected void verifyOptions() {
+        verify(clientCodegen).setSortParamsByRequiredFlag(Boolean.valueOf(Swift4OptionsProvider.SORT_PARAMS_VALUE));
+        verify(clientCodegen).setProjectName(Swift4OptionsProvider.PROJECT_NAME_VALUE);
+        verify(clientCodegen).setResponseAs(Swift4OptionsProvider.RESPONSE_AS_VALUE.split(","));
+        verify(clientCodegen).setNonPublicApi(Boolean.parseBoolean(Swift4OptionsProvider.NON_PUBLIC_API_REQUIRED_VALUE));
+        verify(clientCodegen).setUnwrapRequired(Boolean.parseBoolean(Swift4OptionsProvider.UNWRAP_REQUIRED_VALUE));
+        verify(clientCodegen).setObjcCompatible(Boolean.parseBoolean(Swift4OptionsProvider.OBJC_COMPATIBLE_VALUE));
+        verify(clientCodegen).setLenientTypeCast(Boolean.parseBoolean(Swift4OptionsProvider.LENIENT_TYPE_CAST_VALUE));
+        verify(clientCodegen).setPrependFormOrBodyParameters(Boolean.valueOf(Swift4OptionsProvider.PREPEND_FORM_OR_BODY_PARAMETERS_VALUE));
     }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/swift5/Swift5OptionsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/swift5/Swift5OptionsTest.java
@@ -17,17 +17,16 @@
 
 package org.openapitools.codegen.swift5;
 
-import mockit.Expectations;
-import mockit.Tested;
 import org.openapitools.codegen.AbstractOptionsTest;
 import org.openapitools.codegen.CodegenConfig;
 import org.openapitools.codegen.languages.Swift5ClientCodegen;
 import org.openapitools.codegen.options.Swift5OptionsProvider;
 
-public class Swift5OptionsTest extends AbstractOptionsTest {
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
-    @Tested
-    private Swift5ClientCodegen clientCodegen;
+public class Swift5OptionsTest extends AbstractOptionsTest {
+    private Swift5ClientCodegen clientCodegen = mock(Swift5ClientCodegen.class, mockSettings);
 
     public Swift5OptionsTest() {
         super(new Swift5OptionsProvider());
@@ -40,22 +39,13 @@ public class Swift5OptionsTest extends AbstractOptionsTest {
 
     @SuppressWarnings("unused")
     @Override
-    protected void setExpectations() {
-        new Expectations(clientCodegen) {{
-            clientCodegen.setSortParamsByRequiredFlag(Boolean.valueOf(Swift5OptionsProvider.SORT_PARAMS_VALUE));
-            times = 1;
-            clientCodegen.setProjectName(Swift5OptionsProvider.PROJECT_NAME_VALUE);
-            times = 1;
-            clientCodegen.setResponseAs(Swift5OptionsProvider.RESPONSE_AS_VALUE.split(","));
-            times = 1;
-            clientCodegen.setNonPublicApi(Boolean.valueOf(Swift5OptionsProvider.NON_PUBLIC_API_REQUIRED_VALUE));
-            times = 1;
-            clientCodegen.setObjcCompatible(Boolean.valueOf(Swift5OptionsProvider.OBJC_COMPATIBLE_VALUE));
-            times = 1;
-            clientCodegen.setLenientTypeCast(Boolean.valueOf(Swift5OptionsProvider.LENIENT_TYPE_CAST_VALUE));
-            times = 1;
-            clientCodegen.setPrependFormOrBodyParameters(Boolean.valueOf(Swift5OptionsProvider.PREPEND_FORM_OR_BODY_PARAMETERS_VALUE));
-            times = 1;
-        }};
+    protected void verifyOptions() {
+        verify(clientCodegen).setSortParamsByRequiredFlag(Boolean.valueOf(Swift5OptionsProvider.SORT_PARAMS_VALUE));
+        verify(clientCodegen).setProjectName(Swift5OptionsProvider.PROJECT_NAME_VALUE);
+        verify(clientCodegen).setResponseAs(Swift5OptionsProvider.RESPONSE_AS_VALUE.split(","));
+        verify(clientCodegen).setNonPublicApi(Boolean.parseBoolean(Swift5OptionsProvider.NON_PUBLIC_API_REQUIRED_VALUE));
+        verify(clientCodegen).setObjcCompatible(Boolean.parseBoolean(Swift5OptionsProvider.OBJC_COMPATIBLE_VALUE));
+        verify(clientCodegen).setLenientTypeCast(Boolean.parseBoolean(Swift5OptionsProvider.LENIENT_TYPE_CAST_VALUE));
+        verify(clientCodegen).setPrependFormOrBodyParameters(Boolean.valueOf(Swift5OptionsProvider.PREPEND_FORM_OR_BODY_PARAMETERS_VALUE));
     }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/aurelia/TypeScriptAureliaClientOptionsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/aurelia/TypeScriptAureliaClientOptionsTest.java
@@ -17,17 +17,16 @@
 
 package org.openapitools.codegen.typescript.aurelia;
 
-import mockit.Expectations;
-import mockit.Tested;
 import org.openapitools.codegen.AbstractOptionsTest;
 import org.openapitools.codegen.CodegenConfig;
 import org.openapitools.codegen.languages.TypeScriptAureliaClientCodegen;
 import org.openapitools.codegen.options.TypeScriptAureliaClientOptionsProvider;
 
-public class TypeScriptAureliaClientOptionsTest extends AbstractOptionsTest {
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
-    @Tested
-    private TypeScriptAureliaClientCodegen clientCodegen;
+public class TypeScriptAureliaClientOptionsTest extends AbstractOptionsTest {
+    private TypeScriptAureliaClientCodegen clientCodegen = mock(TypeScriptAureliaClientCodegen.class, mockSettings);
 
     public TypeScriptAureliaClientOptionsTest() {
         super(new TypeScriptAureliaClientOptionsProvider());
@@ -40,16 +39,10 @@ public class TypeScriptAureliaClientOptionsTest extends AbstractOptionsTest {
 
     @SuppressWarnings("unused")
     @Override
-    protected void setExpectations() {
-        new Expectations(clientCodegen) {{
-            clientCodegen.setSortParamsByRequiredFlag(Boolean.valueOf(TypeScriptAureliaClientOptionsProvider.SORT_PARAMS_VALUE));
-            times = 1;
-            clientCodegen.setModelPropertyNaming(TypeScriptAureliaClientOptionsProvider.MODEL_PROPERTY_NAMING_VALUE);
-            times = 1;
-            clientCodegen.setSupportsES6(TypeScriptAureliaClientOptionsProvider.SUPPORTS_ES6_VALUE);
-            times = 1;
-            clientCodegen.setPrependFormOrBodyParameters(Boolean.valueOf(TypeScriptAureliaClientOptionsProvider.PREPEND_FORM_OR_BODY_PARAMETERS_VALUE));
-            times = 1;
-        }};
+    protected void verifyOptions() {
+        verify(clientCodegen).setSortParamsByRequiredFlag(Boolean.valueOf(TypeScriptAureliaClientOptionsProvider.SORT_PARAMS_VALUE));
+        verify(clientCodegen).setModelPropertyNaming(TypeScriptAureliaClientOptionsProvider.MODEL_PROPERTY_NAMING_VALUE);
+        verify(clientCodegen).setSupportsES6(TypeScriptAureliaClientOptionsProvider.SUPPORTS_ES6_VALUE);
+        verify(clientCodegen).setPrependFormOrBodyParameters(Boolean.valueOf(TypeScriptAureliaClientOptionsProvider.PREPEND_FORM_OR_BODY_PARAMETERS_VALUE));
     }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/fetch/TypeScriptFetchClientOptionsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/fetch/TypeScriptFetchClientOptionsTest.java
@@ -17,17 +17,16 @@
 
 package org.openapitools.codegen.typescript.fetch;
 
-import mockit.Expectations;
-import mockit.Tested;
 import org.openapitools.codegen.AbstractOptionsTest;
 import org.openapitools.codegen.CodegenConfig;
 import org.openapitools.codegen.languages.TypeScriptFetchClientCodegen;
 import org.openapitools.codegen.options.TypeScriptFetchClientOptionsProvider;
 
-public class TypeScriptFetchClientOptionsTest extends AbstractOptionsTest {
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
-    @Tested
-    private TypeScriptFetchClientCodegen clientCodegen;
+public class TypeScriptFetchClientOptionsTest extends AbstractOptionsTest {
+    private TypeScriptFetchClientCodegen clientCodegen = mock(TypeScriptFetchClientCodegen.class, mockSettings);
 
     public TypeScriptFetchClientOptionsTest() {
         super(new TypeScriptFetchClientOptionsProvider());
@@ -40,18 +39,11 @@ public class TypeScriptFetchClientOptionsTest extends AbstractOptionsTest {
 
     @SuppressWarnings("unused")
     @Override
-    protected void setExpectations() {
-        new Expectations(clientCodegen) {{
-            clientCodegen.setSortParamsByRequiredFlag(Boolean.valueOf(TypeScriptFetchClientOptionsProvider.SORT_PARAMS_VALUE));
-            times = 1;
-            clientCodegen.setModelPropertyNaming(TypeScriptFetchClientOptionsProvider.MODEL_PROPERTY_NAMING_VALUE);
-            times = 1;
-            clientCodegen.setSupportsES6(TypeScriptFetchClientOptionsProvider.SUPPORTS_ES6_VALUE);
-            times = 1;
-            clientCodegen.setPrependFormOrBodyParameters(Boolean.valueOf(TypeScriptFetchClientOptionsProvider.PREPEND_FORM_OR_BODY_PARAMETERS_VALUE));
-            times = 1;
-            clientCodegen.setTypescriptThreePlus(Boolean.valueOf(TypeScriptFetchClientOptionsProvider.TYPESCRIPT_THREE_PLUS));
-            times = 1;
-        }};
+    protected void verifyOptions() {
+        verify(clientCodegen).setSortParamsByRequiredFlag(Boolean.valueOf(TypeScriptFetchClientOptionsProvider.SORT_PARAMS_VALUE));
+        verify(clientCodegen).setModelPropertyNaming(TypeScriptFetchClientOptionsProvider.MODEL_PROPERTY_NAMING_VALUE);
+        verify(clientCodegen).setSupportsES6(TypeScriptFetchClientOptionsProvider.SUPPORTS_ES6_VALUE);
+        verify(clientCodegen).setPrependFormOrBodyParameters(Boolean.valueOf(TypeScriptFetchClientOptionsProvider.PREPEND_FORM_OR_BODY_PARAMETERS_VALUE));
+        verify(clientCodegen).setTypescriptThreePlus(Boolean.valueOf(TypeScriptFetchClientOptionsProvider.TYPESCRIPT_THREE_PLUS));
     }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/typescriptangular/TypeScriptAngularClientOptionsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/typescriptangular/TypeScriptAngularClientOptionsTest.java
@@ -17,17 +17,16 @@
 
 package org.openapitools.codegen.typescript.typescriptangular;
 
-import mockit.Expectations;
-import mockit.Tested;
 import org.openapitools.codegen.AbstractOptionsTest;
 import org.openapitools.codegen.CodegenConfig;
 import org.openapitools.codegen.languages.TypeScriptAngularClientCodegen;
 import org.openapitools.codegen.options.TypeScriptAngularClientOptionsProvider;
 
-public class TypeScriptAngularClientOptionsTest extends AbstractOptionsTest {
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
-    @Tested
-    private TypeScriptAngularClientCodegen clientCodegen;
+public class TypeScriptAngularClientOptionsTest extends AbstractOptionsTest {
+    private TypeScriptAngularClientCodegen clientCodegen = mock(TypeScriptAngularClientCodegen.class, mockSettings);
 
     public TypeScriptAngularClientOptionsTest() {
         super(new TypeScriptAngularClientOptionsProvider());
@@ -40,18 +39,11 @@ public class TypeScriptAngularClientOptionsTest extends AbstractOptionsTest {
 
     @SuppressWarnings("unused")
     @Override
-    protected void setExpectations() {
-        new Expectations(clientCodegen) {{
-            clientCodegen.setSortParamsByRequiredFlag(Boolean.valueOf(TypeScriptAngularClientOptionsProvider.SORT_PARAMS_VALUE));
-            times = 1;
-            clientCodegen.setModelPropertyNaming(TypeScriptAngularClientOptionsProvider.MODEL_PROPERTY_NAMING_VALUE);
-            times = 1;
-            clientCodegen.setSupportsES6(Boolean.valueOf(TypeScriptAngularClientOptionsProvider.SUPPORTS_ES6_VALUE));
-            times = 1;
-            clientCodegen.setStringEnums(Boolean.valueOf(TypeScriptAngularClientOptionsProvider.STRING_ENUMS_VALUE));
-            times = 1;
-            clientCodegen.setPrependFormOrBodyParameters(Boolean.valueOf(TypeScriptAngularClientOptionsProvider.PREPEND_FORM_OR_BODY_PARAMETERS_VALUE));
-            times = 1;
-        }};
+    protected void verifyOptions() {
+        verify(clientCodegen).setSortParamsByRequiredFlag(Boolean.valueOf(TypeScriptAngularClientOptionsProvider.SORT_PARAMS_VALUE));
+        verify(clientCodegen).setModelPropertyNaming(TypeScriptAngularClientOptionsProvider.MODEL_PROPERTY_NAMING_VALUE);
+        verify(clientCodegen).setSupportsES6(Boolean.valueOf(TypeScriptAngularClientOptionsProvider.SUPPORTS_ES6_VALUE));
+        verify(clientCodegen).setStringEnums(Boolean.parseBoolean(TypeScriptAngularClientOptionsProvider.STRING_ENUMS_VALUE));
+        verify(clientCodegen).setPrependFormOrBodyParameters(Boolean.valueOf(TypeScriptAngularClientOptionsProvider.PREPEND_FORM_OR_BODY_PARAMETERS_VALUE));
     }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/typescriptangularjs/TypeScriptAngularJsClientOptionsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/typescriptangularjs/TypeScriptAngularJsClientOptionsTest.java
@@ -17,17 +17,16 @@
 
 package org.openapitools.codegen.typescript.typescriptangularjs;
 
-import mockit.Expectations;
-import mockit.Tested;
 import org.openapitools.codegen.AbstractOptionsTest;
 import org.openapitools.codegen.CodegenConfig;
 import org.openapitools.codegen.languages.TypeScriptAngularJsClientCodegen;
 import org.openapitools.codegen.options.TypeScriptAngularJsClientOptionsProvider;
 
-public class TypeScriptAngularJsClientOptionsTest extends AbstractOptionsTest {
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
-    @Tested
-    private TypeScriptAngularJsClientCodegen clientCodegen;
+public class TypeScriptAngularJsClientOptionsTest extends AbstractOptionsTest {
+    private TypeScriptAngularJsClientCodegen clientCodegen = mock(TypeScriptAngularJsClientCodegen.class, mockSettings);
 
     public TypeScriptAngularJsClientOptionsTest() {
         super(new TypeScriptAngularJsClientOptionsProvider());
@@ -40,16 +39,10 @@ public class TypeScriptAngularJsClientOptionsTest extends AbstractOptionsTest {
 
     @SuppressWarnings("unused")
     @Override
-    protected void setExpectations() {
-        new Expectations(clientCodegen) {{
-            clientCodegen.setSortParamsByRequiredFlag(Boolean.valueOf(TypeScriptAngularJsClientOptionsProvider.SORT_PARAMS_VALUE));
-            times = 1;
-            clientCodegen.setModelPropertyNaming(TypeScriptAngularJsClientOptionsProvider.MODEL_PROPERTY_NAMING_VALUE);
-            times = 1;
-            clientCodegen.setSupportsES6(Boolean.valueOf(TypeScriptAngularJsClientOptionsProvider.SUPPORTS_ES6_VALUE));
-            times = 1;
-            clientCodegen.setPrependFormOrBodyParameters(Boolean.valueOf(TypeScriptAngularJsClientOptionsProvider.PREPEND_FORM_OR_BODY_PARAMETERS_VALUE));
-            times = 1;
-        }};
+    protected void verifyOptions() {
+        verify(clientCodegen).setSortParamsByRequiredFlag(Boolean.valueOf(TypeScriptAngularJsClientOptionsProvider.SORT_PARAMS_VALUE));
+        verify(clientCodegen).setModelPropertyNaming(TypeScriptAngularJsClientOptionsProvider.MODEL_PROPERTY_NAMING_VALUE);
+        verify(clientCodegen).setSupportsES6(Boolean.valueOf(TypeScriptAngularJsClientOptionsProvider.SUPPORTS_ES6_VALUE));
+        verify(clientCodegen).setPrependFormOrBodyParameters(Boolean.valueOf(TypeScriptAngularJsClientOptionsProvider.PREPEND_FORM_OR_BODY_PARAMETERS_VALUE));
     }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/typescriptnode/TypeScriptNodeClientOptionsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/typescriptnode/TypeScriptNodeClientOptionsTest.java
@@ -17,17 +17,16 @@
 
 package org.openapitools.codegen.typescript.typescriptnode;
 
-import mockit.Expectations;
-import mockit.Tested;
 import org.openapitools.codegen.AbstractOptionsTest;
 import org.openapitools.codegen.CodegenConfig;
 import org.openapitools.codegen.languages.TypeScriptNodeClientCodegen;
 import org.openapitools.codegen.options.TypeScriptNodeClientOptionsProvider;
 
-public class TypeScriptNodeClientOptionsTest extends AbstractOptionsTest {
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
-    @Tested
-    private TypeScriptNodeClientCodegen clientCodegen;
+public class TypeScriptNodeClientOptionsTest extends AbstractOptionsTest {
+    private TypeScriptNodeClientCodegen clientCodegen = mock(TypeScriptNodeClientCodegen.class, mockSettings);
 
     public TypeScriptNodeClientOptionsTest() {
         super(new TypeScriptNodeClientOptionsProvider());
@@ -40,16 +39,10 @@ public class TypeScriptNodeClientOptionsTest extends AbstractOptionsTest {
 
     @SuppressWarnings("unused")
     @Override
-    protected void setExpectations() {
-        new Expectations(clientCodegen) {{
-            clientCodegen.setSortParamsByRequiredFlag(Boolean.valueOf(TypeScriptNodeClientOptionsProvider.SORT_PARAMS_VALUE));
-            times = 1;
-            clientCodegen.setModelPropertyNaming(TypeScriptNodeClientOptionsProvider.MODEL_PROPERTY_NAMING_VALUE);
-            times = 1;
-            clientCodegen.setSupportsES6(Boolean.valueOf(TypeScriptNodeClientOptionsProvider.SUPPORTS_ES6_VALUE));
-            times = 1;
-            clientCodegen.setPrependFormOrBodyParameters(Boolean.valueOf(TypeScriptNodeClientOptionsProvider.PREPEND_FORM_OR_BODY_PARAMETERS_VALUE));
-            times = 1;
-        }};
+    protected void verifyOptions() {
+        verify(clientCodegen).setSortParamsByRequiredFlag(Boolean.valueOf(TypeScriptNodeClientOptionsProvider.SORT_PARAMS_VALUE));
+        verify(clientCodegen).setModelPropertyNaming(TypeScriptNodeClientOptionsProvider.MODEL_PROPERTY_NAMING_VALUE);
+        verify(clientCodegen).setSupportsES6(Boolean.valueOf(TypeScriptNodeClientOptionsProvider.SUPPORTS_ES6_VALUE));
+        verify(clientCodegen).setPrependFormOrBodyParameters(Boolean.valueOf(TypeScriptNodeClientOptionsProvider.PREPEND_FORM_OR_BODY_PARAMETERS_VALUE));
     }
 }

--- a/new.sh
+++ b/new.sh
@@ -344,7 +344,7 @@ public class ${lang_classname}OptionsTest extends AbstractOptionsTest {
 
     @SuppressWarnings("unused")
     @Override
-    protected void setExpectations() {
+    protected void verifyOptions() {
         // TODO: Complete options using Mockito
         // verify(codegen).someMethod(arguments)
     }

--- a/new.sh
+++ b/new.sh
@@ -327,13 +327,11 @@ import org.openapitools.codegen.CodegenConfig;
 import org.openapitools.codegen.languages.${lang_classname};
 import org.openapitools.codegen.options.${lang_classname}OptionsProvider;
 
-import mockit.Expectations;
-import mockit.Tested;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 public class ${lang_classname}OptionsTest extends AbstractOptionsTest {
-
-    @Tested
-    private ${lang_classname} codegen;
+    private ${lang_classname} codegen = mock(${lang_classname}.class, mockSettings);
 
     public ${lang_classname}OptionsTest() {
         super(new ${lang_classname}OptionsProvider());
@@ -347,10 +345,8 @@ public class ${lang_classname}OptionsTest extends AbstractOptionsTest {
     @SuppressWarnings("unused")
     @Override
     protected void setExpectations() {
-        // TODO: Complete options
-        new Expectations(codegen) {{
-
-        }};
+        // TODO: Complete options using Mockito
+        // verify(codegen).someMethod(arguments)
     }
 }
 

--- a/pom.xml
+++ b/pom.xml
@@ -160,17 +160,7 @@
                     <junitArtifactName>none:none</junitArtifactName>
                     <testNGArtifactName>org.testng:testng</testNGArtifactName>
                     <argLine>-XX:+StartAttachListener</argLine>
-                    <argLine>-javaagent:"${settings.localRepository}/org/jmockit/jmockit/${jmockit-version}/jmockit-${jmockit-version}.jar"</argLine>
                 </configuration>
-                <dependencies>
-                    <!-- Required to be set so it can be downloaded for surefire plugin -->
-                    <dependency>
-                        <groupId>org.jmockit</groupId>
-                        <artifactId>jmockit</artifactId>
-                        <version>${jmockit-version}</version>
-                        <scope>compile</scope>
-                    </dependency>
-                </dependencies>
             </plugin>
             <plugin>
                 <artifactId>maven-dependency-plugin</artifactId>
@@ -1381,12 +1371,6 @@
                 <version>${testng-version}</version>
                 <scope>test</scope>
             </dependency>
-            <dependency>
-                <groupId>org.jmockit</groupId>
-                <artifactId>jmockit</artifactId>
-                <version>${jmockit-version}</version>
-                <scope>test</scope>
-            </dependency>
         </dependencies>
     </dependencyManagement>
     <repositories>
@@ -1418,7 +1402,7 @@
         <handlebars.java-version>4.1.2</handlebars.java-version>
         <testng-version>6.14.3</testng-version>
         <surefire-version>3.0.0-M3</surefire-version>
-        <jmockit-version>1.46</jmockit-version>
         <reflections-version>0.9.10</reflections-version>
+        <mockito-version>3.2.0</mockito-version>
     </properties>
 </project>


### PR DESCRIPTION
We use mockito in many tests. This removes jmockit which is run as a javaagent in favor of Mockito which is not.

This work is in preparation for applying some static analysis tools, while evaluating others such as Jacoco. I'm also look at ways to improve build times while also decreasing "ramp up time" for contributions from the community. Reducing the number of mock frameworks and dependencies is a step toward that goal.

I'm opening this for discussion. It seems like jmockit was used heavily in `GenerateTest` in the CLI to test the internals of the generate task. I think this is the wrong approach; each component of that task should be tested in isolation.

I think this approach cleans up the options tests, as it was never really clear to me and most likely to others how to use the Expectations API in jmockit. I also found while testing that the Expectations of jmockit would silently swallow exceptions. For example, scala-http-client defines this method:

```
public void setModelPropertyNaming(String naming) {
    if ("original".equals(naming) || "camelCase".equals(naming) ||
            "PascalCase".equals(naming) || "snake_case".equals(naming)) {
        this.modelPropertyNaming = naming;
    } else {
        throw new IllegalArgumentException("Invalid model property naming '
                naming + "'. Must be 'original', 'camelCase', " +
                "'PascalCase' or 'snake_case'");
    }
}
```

The expectation in the test passed `modelPropertyNaming` as the option and verified that it was executed once. That execution should have resulted in an IllegalArgumentException on invocation, but jmockit's Expectation only cared that the method was called and hid that it was called with invalid data.

~I plan to look at replacing the `GenerateTest` tests with unit tests, and whether it would make sense to construct the Generate class to evaluate argument parsing.~ The generate task now evaluates that CodgenConfigurator is called as expected. The `DefaultGenerator` implementation should be tested separately, considering previous tests weren't evaluating anything that was generated.

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

cc @OpenAPITools/generator-core-team 