### PR TITLE
[typescript-angular] Fix typescript model kebab-cased filenames

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/StringUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/StringUtils.java
@@ -40,7 +40,7 @@ public class StringUtils {
      * @return The dashized version of the word, e.g. "my-name"
      */
     public static String dashize(String word) {
-        return underscore(word).replaceAll("[_ ]", "-");
+        return underscore(word).replaceAll("[_ ]+", "-");
     }
 
     /**

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/typescriptangular/TypeScriptAngularClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/typescriptangular/TypeScriptAngularClientCodegenTest.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.PathItem;
 import io.swagger.v3.oas.models.media.ComposedSchema;
 import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.media.StringSchema;
 import io.swagger.v3.oas.models.responses.ApiResponse;
 import io.swagger.v3.oas.models.responses.ApiResponses;
 import org.openapitools.codegen.CodegenOperation;
@@ -132,4 +133,24 @@ public class TypeScriptAngularClientCodegenTest {
         Assert.assertEquals(schemaType, "SchemaOne | SchemaTwo | SchemaThree");
     }
 
+    @Test
+    public void testKebabCasedModelFilenames() {
+        TypeScriptAngularClientCodegen codegen = new TypeScriptAngularClientCodegen();
+        codegen.additionalProperties().put(TypeScriptAngularClientCodegen.FILE_NAMING, "kebab-case");
+        codegen.processOpts();
+
+        final String modelName = "FooResponse__links";
+        final Schema schema = new Schema()
+            .name(modelName)
+            .description("an inline model with name previously prefixed with underscore")
+            .addRequiredItem("self")
+            .addProperties("self", new StringSchema());
+
+        OpenAPI openAPI = TestUtils.createOpenAPIWithOneSchema("test", schema);
+        codegen.setOpenAPI(openAPI);
+
+        Assert.assertEquals(codegen.toModelImport(modelName), "model/foo-response-links");
+        Assert.assertEquals(codegen.toModelFilename(modelName), "./foo-response-links");
+
+    }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/typescriptangular/TypeScriptAngularModelTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/typescriptangular/TypeScriptAngularModelTest.java
@@ -21,6 +21,7 @@ import com.google.common.collect.Sets;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.media.*;
 import io.swagger.v3.parser.util.SchemaTypeUtil;
+import org.openapitools.codegen.CodegenConstants;
 import org.openapitools.codegen.CodegenModel;
 import org.openapitools.codegen.CodegenProperty;
 import org.openapitools.codegen.DefaultCodegen;
@@ -304,4 +305,23 @@ public class TypeScriptAngularModelTest {
         Assert.assertFalse(property.isContainer);
     }
 
+    @Test(description = "convert an inline model that originally had a name prefixed with an underscore")
+    public void inlineModelWithUnderscoreNameTest() {
+        // Originally parent model "FooResponse" with inline model called "_links". The InlineModelResolver resolves
+        // that to "FooResponse__links" (double underscore)
+        final Schema schema = new Schema()
+            .description("an inline model with name previously prefixed with underscore")
+            .addRequiredItem("self")
+            .addProperties("self", new StringSchema());
+
+        TypeScriptAngularClientCodegen codegen = new TypeScriptAngularClientCodegen();
+        codegen.additionalProperties().put(TypeScriptAngularClientCodegen.FILE_NAMING, "kebab-case");
+        codegen.processOpts();
+
+        OpenAPI openAPI = TestUtils.createOpenAPIWithOneSchema("sample", schema);
+        codegen.setOpenAPI(openAPI);
+
+        final CodegenModel cm = codegen.fromModel("FooResponse__links", schema);
+        Assert.assertEquals(cm.getClassFilename(), "./foo-response-links", "The generated filename should not have a double hyphen.");
+    }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/utils/StringUtilsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/utils/StringUtilsTest.java
@@ -35,5 +35,7 @@ public class StringUtilsTest {
         Assert.assertEquals(dashize("abcd"), "abcd");
         Assert.assertEquals(dashize("some-value"), "some-value");
         Assert.assertEquals(dashize("some_value"), "some-value");
+        Assert.assertEquals(dashize("Foo_Response__links"), "foo-response-links");
+        Assert.assertEquals(dashize("Foo Response _links"), "foo-response-links");
     }
 }


### PR DESCRIPTION
When using "kebab-case" file names, the typescript-angular client generator would create model files with repeating dashes in the filenames, but the import statements would have single dashes. This was caused by the Inline Model Resolver naming the resolved models by concatenating the parent name to the child model name with an underscore separator; if the child model name had a leading underscore, this would cause a double underscore in the new model name. When this model name was converted to kebab case for the file name, each individual underscore was converted to a dash, resulting in a filename with repeated dashes.

To address, updated the `dashize` method in StringUtils to collapse multiple consecutive whitespace and/or underscores to a single dash. This _shouldn't_ be a breaking change, but if need be the fix could easily be amended to make the collapsing part of the operation optional using a boolean parameter and an overloaded method call.

Added test cases to the StringUtils unit tests, Angular Typescript client code gen tests, and Angular Typescript model tests. Ran all of the tests in the project using `mvn test`; no failures. There were no changes to the petstore APIs or templates.  Built the project and verified using the YML and commandline arguments from #5073 (yml included at bottom of PR).

Fixes #5073 

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@TiFu (2017/07) @taxpon (2017/07) @sebastianhaas (2017/07) @kenisteward (2017/07) @Vrolijkx (2017/09) @macjohnny (2018/01) @nicokoenig (2018/09) @topce (2018/10) @akehir (2019/07) @petejohansonxo (2019/11)

### Verification

Sample YML for verification (make sure to set fileNaming to "kebab-case"):

```yaml
openapi: 3.0.0
info:
  title: Example API
  description: An Example API
  version: "1.0"
paths:
  /hello:
    get:
      summary: Example endpoint
      operationId: get_hello
      responses:
        200:
          description: Example response
          content:
            application/json:
              schema:
                $ref: '#/components/schemas/FooResponse'
components:
  schemas:
    FooResponse:
      type: object
      properties:
        _links:
          required:
            - collection
            - self
          type: object
          properties:
            collection:
              type: string
              format: uri
            self:
              type: string
              format: uri
```

Previous behavior would generate files `./models/foo-response.ts` and `./models/foo-response--links.ts`. New behavior is to generate `./models/foo-response-links.ts` (other file unchanged).