### PR TITLE
[C++] [Qt5] Add request compression and handling identity

### DIFF
--- a/modules/openapi-generator/src/main/resources/cpp-qt5-client/HttpRequest.cpp.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-client/HttpRequest.cpp.mustache
@@ -289,12 +289,8 @@ void {{prefix}}HttpRequestWorker::execute({{prefix}}HttpRequestInput *input) {
     if (input->request_body.size() > 0) {
         qDebug() << "got a request body";
         request_content.clear();
-        if(!isFormData && (input->var_layout != MULTIPART)){
-            if(isRequestCompressionEnabled){
-                request_content.append(compress(input->request_body, 7, {{prefix}}CompressionType::Gzip));
-            } else {
-                request_content.append(input->request_body);
-            }
+        if(!isFormData && (input->var_layout != MULTIPART) && isRequestCompressionEnabled){
+            request_content.append(compress(input->request_body, 7, {{prefix}}CompressionType::Gzip));
         } else {
             request_content.append(input->request_body);
         }
@@ -325,6 +321,8 @@ void {{prefix}}HttpRequestWorker::execute({{prefix}}HttpRequestInput *input) {
 
     if(isResponseCompressionEnabled){
         request.setRawHeader("Accept-Encoding", "gzip");
+    } else {
+        request.setRawHeader("Accept-Encoding", "identity");
     }
 
     if (input->http_method == "GET") {
@@ -452,14 +450,14 @@ QByteArray {{prefix}}HttpRequestWorker::decompress(const QByteArray& data){
 
 QByteArray {{prefix}}HttpRequestWorker::compress(const QByteArray& input, int level, {{prefix}}CompressionType compressType) {
     {{#contentCompression}}QByteArray output;
-    static const int GZIP_WINDOWS_BIT = 15+16;
-    static const int ZLIB_WINDOWS_BIT = 15;
+    static const int GZIP_WINDOW_BIT = 15+16;
+    static const int ZLIB_WINDOW_BIT = 15;
     static const int CHUNK_SIZE = 8*1024;
-    int windowsBits;
+    int windowBits;
     if( compressType == {{prefix}}CompressionType::Gzip ){
-        windowsBits = GZIP_WINDOWS_BIT;
+        windowBits = GZIP_WINDOW_BIT;
     } else if ( compressType == {{prefix}}CompressionType::Zlib ){
-        windowsBits = ZLIB_WINDOWS_BIT;
+        windowBits = ZLIB_WINDOW_BIT;
     }
     do{
         int flush = 0, ret = 0;
@@ -468,7 +466,7 @@ QByteArray {{prefix}}HttpRequestWorker::compress(const QByteArray& input, int le
         if(input.length() <= 0) {
             break;
         }
-        if (deflateInit2(&strm, qMax(-1, qMin(9, level)), Z_DEFLATED, windowsBits, 8, Z_DEFAULT_STRATEGY) != Z_OK){
+        if (deflateInit2(&strm, qMax(-1, qMin(9, level)), Z_DEFLATED, windowBits, 8, Z_DEFAULT_STRATEGY) != Z_OK){
             break;
         }
         output.clear();

--- a/modules/openapi-generator/src/main/resources/cpp-qt5-client/HttpRequest.cpp.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-client/HttpRequest.cpp.mustache
@@ -96,8 +96,12 @@ void {{prefix}}HttpRequestWorker::setWorkingDirectory(const QString &path) {
     }
 }
 
-void {{prefix}}HttpRequestWorker::setCompressionEnabled(bool enable) {
-    isCompressionEnabled = enable;
+void {{prefix}}HttpRequestWorker::setResponseCompressionEnabled(bool enable) {
+    isResponseCompressionEnabled = enable;
+}
+
+void {{prefix}}HttpRequestWorker::setRequestCompressionEnabled(bool enable) {
+    isRequestCompressionEnabled = enable;
 }
 
 QString {{prefix}}HttpRequestWorker::http_attribute_encode(QString attribute_name, QString input) {
@@ -285,7 +289,15 @@ void {{prefix}}HttpRequestWorker::execute({{prefix}}HttpRequestInput *input) {
     if (input->request_body.size() > 0) {
         qDebug() << "got a request body";
         request_content.clear();
-        request_content.append(input->request_body);
+        if(!isFormData && (input->var_layout != MULTIPART)){
+            if(isRequestCompressionEnabled){
+                request_content.append(compress(input->request_body, 7, {{prefix}}CompressionType::Gzip));
+            } else {
+                request_content.append(input->request_body);
+            }
+        } else {
+            request_content.append(input->request_body);
+        }
     }
     // prepare connection
 
@@ -302,14 +314,17 @@ void {{prefix}}HttpRequestWorker::execute({{prefix}}HttpRequestInput *input) {
         } else {
             request.setHeader(QNetworkRequest::ContentTypeHeader, input->headers.value("Content-Type"));
         }
+        if(isRequestCompressionEnabled){
+            request.setRawHeader("Content-Encoding", "gzip");
+        }
     } else if (input->var_layout == URL_ENCODED) {
         request.setHeader(QNetworkRequest::ContentTypeHeader, "application/x-www-form-urlencoded");
     } else if (input->var_layout == MULTIPART) {
         request.setHeader(QNetworkRequest::ContentTypeHeader, "multipart/form-data; boundary=" + boundary);
     }
 
-    if(isCompressionEnabled){
-        request.setRawHeader("Accept-Encoding", "deflate, gzip");
+    if(isResponseCompressionEnabled){
+        request.setRawHeader("Accept-Encoding", "gzip");
     }
 
     if (input->http_method == "GET") {
@@ -391,6 +406,8 @@ void {{prefix}}HttpRequestWorker::process_response(QNetworkReply *reply) {
                     auto compressionTypes = encoding.first().split(',', QString::SkipEmptyParts);
                     if(compressionTypes.contains("gzip", Qt::CaseInsensitive) || compressionTypes.contains("deflate", Qt::CaseInsensitive)){
                         response = decompress(reply->readAll());
+                    } else if(compressionTypes.contains("identity", Qt::CaseInsensitive)){
+                        response = reply->readAll();
                     }
                 }
             }
@@ -402,11 +419,11 @@ void {{prefix}}HttpRequestWorker::process_response(QNetworkReply *reply) {
 }
 
 QByteArray {{prefix}}HttpRequestWorker::decompress(const QByteArray& data){
-    QByteArray result;
-    bool sts = false;{{#contentCompression}}
+    {{#contentCompression}}QByteArray result;
+    bool sts = false;
     do{
         z_stream strm{};
-        static const int CHUNK_SIZE = 2048;
+        static const int CHUNK_SIZE = 8*1024;
         char out[CHUNK_SIZE];
         if (data.size() <= 4) {
             break;
@@ -427,8 +444,65 @@ QByteArray {{prefix}}HttpRequestWorker::decompress(const QByteArray& data){
             sts = true;
         } while (strm.avail_out == 0);
         inflateEnd(&strm);
-    } while(false);{{/contentCompression}}
-    return sts ? result : QByteArray();
+    } while(false);
+    return sts ? result : QByteArray();{{/contentCompression}}{{^contentCompression}}
+    Q_UNUSED(data);
+    return QByteArray();{{/contentCompression}}
+}
+
+QByteArray {{prefix}}HttpRequestWorker::compress(const QByteArray& input, int level, {{prefix}}CompressionType compressType) {
+    {{#contentCompression}}QByteArray output;
+    static const int GZIP_WINDOWS_BIT = 15+16;
+    static const int ZLIB_WINDOWS_BIT = 15;
+    static const int CHUNK_SIZE = 8*1024;
+    int windowsBits;
+    if( compressType == {{prefix}}CompressionType::Gzip ){
+        windowsBits = GZIP_WINDOWS_BIT;
+    } else if ( compressType == {{prefix}}CompressionType::Zlib ){
+        windowsBits = ZLIB_WINDOWS_BIT;
+    }
+    do{
+        int flush = 0, ret = 0;
+        bool error_sts = false;
+        z_stream strm{};
+        if(input.length() <= 0) {
+            break;
+        }
+        if (deflateInit2(&strm, qMax(-1, qMin(9, level)), Z_DEFLATED, windowsBits, 8, Z_DEFAULT_STRATEGY) != Z_OK){
+            break;
+        }
+        output.clear();
+        auto input_data = input.data();
+        int input_data_left = input.length();
+        do {
+            int chunk_size = qMin(CHUNK_SIZE, input_data_left);
+            strm.next_in = (unsigned char*)input_data;
+            strm.avail_in = chunk_size;
+            input_data += chunk_size;
+            input_data_left -= chunk_size;
+            flush = (input_data_left <= 0 ? Z_FINISH : Z_NO_FLUSH);
+            do {
+                char out[CHUNK_SIZE];
+                strm.next_out = (unsigned char*)out;
+                strm.avail_out = CHUNK_SIZE;
+                ret = deflate(&strm, flush);
+                if(ret == Z_STREAM_ERROR) {
+                    error_sts = true;
+                    break;
+                }
+                auto have = (CHUNK_SIZE - strm.avail_out);
+                if(have > 0){
+                    output.append((char*)out, have);
+                }
+            } while (strm.avail_out == 0);
+        } while ((flush != Z_FINISH) && !(error_sts));
+        deflateEnd(&strm);
+    } while(false);
+    return output;{{/contentCompression}}{{^contentCompression}}
+    Q_UNUSED(input);
+    Q_UNUSED(level);
+    Q_UNUSED(compressType);        
+    return QByteArray();{{/contentCompression}}
 }
 
 QSslConfiguration *{{prefix}}HttpRequestWorker::sslDefaultConfiguration;

--- a/modules/openapi-generator/src/main/resources/cpp-qt5-client/HttpRequest.h.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-client/HttpRequest.h.mustache
@@ -63,21 +63,28 @@ public:
     void setWorkingDirectory(const QString &path);
     {{prefix}}HttpFileElement getHttpFileElement(const QString &fieldname = QString());
     QByteArray *getMultiPartField(const QString &fieldname = QString());
-    void setCompressionEnabled(bool enable);
+    void setResponseCompressionEnabled(bool enable);
+    void setRequestCompressionEnabled(bool enable);
 signals:
     void on_execution_finished({{prefix}}HttpRequestWorker *worker);
 
 private:
+    enum {{prefix}}CompressionType{
+        Zlib,
+        Gzip
+    };
     QNetworkAccessManager *manager;
     QMap<QString, QString> headers;
     QMap<QString, {{prefix}}HttpFileElement> files;
     QMap<QString, QByteArray *> multiPartFields;
     QString workingDirectory;
     int _timeOut;
-    bool isCompressionEnabled;
+    bool isResponseCompressionEnabled;
+    bool isRequestCompressionEnabled;
     void on_manager_timeout(QNetworkReply *reply);
     void process_response(QNetworkReply *reply);
     QByteArray decompress(const QByteArray& data);
+    QByteArray compress(const QByteArray& input, int level, {{prefix}}CompressionType compressType); 
 private slots:
     void on_manager_finished(QNetworkReply *reply);
 };

--- a/modules/openapi-generator/src/main/resources/cpp-qt5-client/api-body.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-client/api-body.mustache
@@ -15,7 +15,8 @@ namespace {{this}} {
       _port(port),
       _basePath(basePath),
       _timeOut(timeOut),
-      _compress(false) {}
+      isResponseCompressionEnabled(false),
+      isRequestCompressionEnabled(false) {}
 
 {{classname}}::~{{classname}}() {
 }
@@ -48,8 +49,12 @@ void {{classname}}::addHeaders(const QString &key, const QString &value) {
     defaultHeaders.insert(key, value);
 }
 
-void {{classname}}::enableContentCompression() {
-    _compress = true;
+void {{classname}}::enableRequestCompression() {
+    isRequestCompressionEnabled = true;
+}
+
+void {{classname}}::enableResponseCompression() {
+    isResponseCompressionEnabled = true;
 }
 
 {{#operations}}
@@ -113,8 +118,9 @@ void {{classname}}::{{nickname}}({{#allParams}}const {{{dataType}}} &{{paramName
 {{/collectionFormat}}{{/queryParams}}
     {{prefix}}HttpRequestWorker *worker = new {{prefix}}HttpRequestWorker(this);
     worker->setTimeOut(_timeOut);
-    worker->setWorkingDirectory(_workingDirectory);
-    worker->setCompressionEnabled(_compress);
+    worker->setWorkingDirectory(_workingDirectory);{{#contentCompression}}
+    worker->setResponseCompressionEnabled(isResponseCompressionEnabled);
+    worker->setRequestCompressionEnabled(isRequestCompressionEnabled);{{/contentCompression}}
     {{prefix}}HttpRequestInput input(fullPath, "{{httpMethod}}");
 {{#formParams}}{{^isFile}}
     input.add_var("{{baseName}}", ::{{cppNamespace}}::toStringValue({{paramName}}));{{/isFile}}{{#isFile}}

--- a/modules/openapi-generator/src/main/resources/cpp-qt5-client/api-header.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-client/api-header.mustache
@@ -27,7 +27,8 @@ public:
     void setTimeOut(const int timeOut);
     void setWorkingDirectory(const QString &path);
     void addHeaders(const QString &key, const QString &value);
-    void enableContentCompression();
+    void enableRequestCompression();
+    void enableResponseCompression();
 {{#operations}}{{#operation}}
     void {{nickname}}({{#allParams}}const {{{dataType}}} &{{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}});{{/operation}}{{/operations}}
 
@@ -38,7 +39,8 @@ private:
     int _timeOut;
     QString _workingDirectory;
     QMap<QString, QString> defaultHeaders;
-    bool _compress;
+    bool isResponseCompressionEnabled;
+    bool isRequestCompressionEnabled;
 {{#operations}}{{#operation}}
     void {{nickname}}Callback({{prefix}}HttpRequestWorker *worker);{{/operation}}{{/operations}}
 

--- a/samples/client/petstore/cpp-qt5/client/PFXHttpRequest.cpp
+++ b/samples/client/petstore/cpp-qt5/client/PFXHttpRequest.cpp
@@ -103,8 +103,12 @@ void PFXHttpRequestWorker::setWorkingDirectory(const QString &path) {
     }
 }
 
-void PFXHttpRequestWorker::setCompressionEnabled(bool enable) {
-    isCompressionEnabled = enable;
+void PFXHttpRequestWorker::setResponseCompressionEnabled(bool enable) {
+    isResponseCompressionEnabled = enable;
+}
+
+void PFXHttpRequestWorker::setRequestCompressionEnabled(bool enable) {
+    isRequestCompressionEnabled = enable;
 }
 
 QString PFXHttpRequestWorker::http_attribute_encode(QString attribute_name, QString input) {
@@ -292,7 +296,15 @@ void PFXHttpRequestWorker::execute(PFXHttpRequestInput *input) {
     if (input->request_body.size() > 0) {
         qDebug() << "got a request body";
         request_content.clear();
-        request_content.append(input->request_body);
+        if(!isFormData && (input->var_layout != MULTIPART)){
+            if(isRequestCompressionEnabled){
+                request_content.append(compress(input->request_body, 7, PFXCompressionType::Gzip));
+            } else {
+                request_content.append(input->request_body);
+            }
+        } else {
+            request_content.append(input->request_body);
+        }
     }
     // prepare connection
 
@@ -309,14 +321,17 @@ void PFXHttpRequestWorker::execute(PFXHttpRequestInput *input) {
         } else {
             request.setHeader(QNetworkRequest::ContentTypeHeader, input->headers.value("Content-Type"));
         }
+        if(isRequestCompressionEnabled){
+            request.setRawHeader("Content-Encoding", "gzip");
+        }
     } else if (input->var_layout == URL_ENCODED) {
         request.setHeader(QNetworkRequest::ContentTypeHeader, "application/x-www-form-urlencoded");
     } else if (input->var_layout == MULTIPART) {
         request.setHeader(QNetworkRequest::ContentTypeHeader, "multipart/form-data; boundary=" + boundary);
     }
 
-    if(isCompressionEnabled){
-        request.setRawHeader("Accept-Encoding", "deflate, gzip");
+    if(isResponseCompressionEnabled){
+        request.setRawHeader("Accept-Encoding", "gzip");
     }
 
     if (input->http_method == "GET") {
@@ -398,6 +413,8 @@ void PFXHttpRequestWorker::process_response(QNetworkReply *reply) {
                     auto compressionTypes = encoding.first().split(',', QString::SkipEmptyParts);
                     if(compressionTypes.contains("gzip", Qt::CaseInsensitive) || compressionTypes.contains("deflate", Qt::CaseInsensitive)){
                         response = decompress(reply->readAll());
+                    } else if(compressionTypes.contains("identity", Qt::CaseInsensitive)){
+                        response = reply->readAll();
                     }
                 }
             }
@@ -409,9 +426,17 @@ void PFXHttpRequestWorker::process_response(QNetworkReply *reply) {
 }
 
 QByteArray PFXHttpRequestWorker::decompress(const QByteArray& data){
-    QByteArray result;
-    bool sts = false;
-    return sts ? result : QByteArray();
+    
+    Q_UNUSED(data);
+    return QByteArray();
+}
+
+QByteArray PFXHttpRequestWorker::compress(const QByteArray& input, int level, PFXCompressionType compressType) {
+    
+    Q_UNUSED(input);
+    Q_UNUSED(level);
+    Q_UNUSED(compressType);        
+    return QByteArray();
 }
 
 QSslConfiguration *PFXHttpRequestWorker::sslDefaultConfiguration;

--- a/samples/client/petstore/cpp-qt5/client/PFXHttpRequest.cpp
+++ b/samples/client/petstore/cpp-qt5/client/PFXHttpRequest.cpp
@@ -296,12 +296,8 @@ void PFXHttpRequestWorker::execute(PFXHttpRequestInput *input) {
     if (input->request_body.size() > 0) {
         qDebug() << "got a request body";
         request_content.clear();
-        if(!isFormData && (input->var_layout != MULTIPART)){
-            if(isRequestCompressionEnabled){
-                request_content.append(compress(input->request_body, 7, PFXCompressionType::Gzip));
-            } else {
-                request_content.append(input->request_body);
-            }
+        if(!isFormData && (input->var_layout != MULTIPART) && isRequestCompressionEnabled){
+            request_content.append(compress(input->request_body, 7, PFXCompressionType::Gzip));
         } else {
             request_content.append(input->request_body);
         }
@@ -332,6 +328,8 @@ void PFXHttpRequestWorker::execute(PFXHttpRequestInput *input) {
 
     if(isResponseCompressionEnabled){
         request.setRawHeader("Accept-Encoding", "gzip");
+    } else {
+        request.setRawHeader("Accept-Encoding", "identity");
     }
 
     if (input->http_method == "GET") {

--- a/samples/client/petstore/cpp-qt5/client/PFXHttpRequest.h
+++ b/samples/client/petstore/cpp-qt5/client/PFXHttpRequest.h
@@ -71,21 +71,28 @@ public:
     void setWorkingDirectory(const QString &path);
     PFXHttpFileElement getHttpFileElement(const QString &fieldname = QString());
     QByteArray *getMultiPartField(const QString &fieldname = QString());
-    void setCompressionEnabled(bool enable);
+    void setResponseCompressionEnabled(bool enable);
+    void setRequestCompressionEnabled(bool enable);
 signals:
     void on_execution_finished(PFXHttpRequestWorker *worker);
 
 private:
+    enum PFXCompressionType{
+        Zlib,
+        Gzip
+    };
     QNetworkAccessManager *manager;
     QMap<QString, QString> headers;
     QMap<QString, PFXHttpFileElement> files;
     QMap<QString, QByteArray *> multiPartFields;
     QString workingDirectory;
     int _timeOut;
-    bool isCompressionEnabled;
+    bool isResponseCompressionEnabled;
+    bool isRequestCompressionEnabled;
     void on_manager_timeout(QNetworkReply *reply);
     void process_response(QNetworkReply *reply);
     QByteArray decompress(const QByteArray& data);
+    QByteArray compress(const QByteArray& input, int level, PFXCompressionType compressType); 
 private slots:
     void on_manager_finished(QNetworkReply *reply);
 };

--- a/samples/client/petstore/cpp-qt5/client/PFXPetApi.cpp
+++ b/samples/client/petstore/cpp-qt5/client/PFXPetApi.cpp
@@ -23,7 +23,8 @@ PFXPetApi::PFXPetApi(const QString &scheme, const QString &host, int port, const
       _port(port),
       _basePath(basePath),
       _timeOut(timeOut),
-      _compress(false) {}
+      isResponseCompressionEnabled(false),
+      isRequestCompressionEnabled(false) {}
 
 PFXPetApi::~PFXPetApi() {
 }
@@ -56,8 +57,12 @@ void PFXPetApi::addHeaders(const QString &key, const QString &value) {
     defaultHeaders.insert(key, value);
 }
 
-void PFXPetApi::enableContentCompression() {
-    _compress = true;
+void PFXPetApi::enableRequestCompression() {
+    isRequestCompressionEnabled = true;
+}
+
+void PFXPetApi::enableResponseCompression() {
+    isResponseCompressionEnabled = true;
 }
 
 void PFXPetApi::addPet(const PFXPet &body) {
@@ -71,7 +76,6 @@ void PFXPetApi::addPet(const PFXPet &body) {
     PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this);
     worker->setTimeOut(_timeOut);
     worker->setWorkingDirectory(_workingDirectory);
-    worker->setCompressionEnabled(_compress);
     PFXHttpRequestInput input(fullPath, "POST");
 
     QString output = body.asJson();
@@ -120,7 +124,6 @@ void PFXPetApi::deletePet(const qint64 &pet_id, const QString &api_key) {
     PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this);
     worker->setTimeOut(_timeOut);
     worker->setWorkingDirectory(_workingDirectory);
-    worker->setCompressionEnabled(_compress);
     PFXHttpRequestInput input(fullPath, "DELETE");
 
     if (api_key != nullptr) {
@@ -205,7 +208,6 @@ void PFXPetApi::findPetsByStatus(const QList<QString> &status) {
     PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this);
     worker->setTimeOut(_timeOut);
     worker->setWorkingDirectory(_workingDirectory);
-    worker->setCompressionEnabled(_compress);
     PFXHttpRequestInput input(fullPath, "GET");
 
     foreach (QString key, this->defaultHeaders.keys()) { input.headers.insert(key, this->defaultHeaders.value(key)); }
@@ -296,7 +298,6 @@ void PFXPetApi::findPetsByTags(const QList<QString> &tags) {
     PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this);
     worker->setTimeOut(_timeOut);
     worker->setWorkingDirectory(_workingDirectory);
-    worker->setCompressionEnabled(_compress);
     PFXHttpRequestInput input(fullPath, "GET");
 
     foreach (QString key, this->defaultHeaders.keys()) { input.headers.insert(key, this->defaultHeaders.value(key)); }
@@ -352,7 +353,6 @@ void PFXPetApi::getPetById(const qint64 &pet_id) {
     PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this);
     worker->setTimeOut(_timeOut);
     worker->setWorkingDirectory(_workingDirectory);
-    worker->setCompressionEnabled(_compress);
     PFXHttpRequestInput input(fullPath, "GET");
 
     foreach (QString key, this->defaultHeaders.keys()) { input.headers.insert(key, this->defaultHeaders.value(key)); }
@@ -396,7 +396,6 @@ void PFXPetApi::updatePet(const PFXPet &body) {
     PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this);
     worker->setTimeOut(_timeOut);
     worker->setWorkingDirectory(_workingDirectory);
-    worker->setCompressionEnabled(_compress);
     PFXHttpRequestInput input(fullPath, "PUT");
 
     QString output = body.asJson();
@@ -445,7 +444,6 @@ void PFXPetApi::updatePetWithForm(const qint64 &pet_id, const QString &name, con
     PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this);
     worker->setTimeOut(_timeOut);
     worker->setWorkingDirectory(_workingDirectory);
-    worker->setCompressionEnabled(_compress);
     PFXHttpRequestInput input(fullPath, "POST");
 
     input.add_var("name", ::test_namespace::toStringValue(name));
@@ -493,7 +491,6 @@ void PFXPetApi::uploadFile(const qint64 &pet_id, const QString &additional_metad
     PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this);
     worker->setTimeOut(_timeOut);
     worker->setWorkingDirectory(_workingDirectory);
-    worker->setCompressionEnabled(_compress);
     PFXHttpRequestInput input(fullPath, "POST");
 
     input.add_var("additionalMetadata", ::test_namespace::toStringValue(additional_metadata));

--- a/samples/client/petstore/cpp-qt5/client/PFXPetApi.h
+++ b/samples/client/petstore/cpp-qt5/client/PFXPetApi.h
@@ -37,7 +37,8 @@ public:
     void setTimeOut(const int timeOut);
     void setWorkingDirectory(const QString &path);
     void addHeaders(const QString &key, const QString &value);
-    void enableContentCompression();
+    void enableRequestCompression();
+    void enableResponseCompression();
 
     void addPet(const PFXPet &body);
     void deletePet(const qint64 &pet_id, const QString &api_key);
@@ -55,7 +56,8 @@ private:
     int _timeOut;
     QString _workingDirectory;
     QMap<QString, QString> defaultHeaders;
-    bool _compress;
+    bool isResponseCompressionEnabled;
+    bool isRequestCompressionEnabled;
 
     void addPetCallback(PFXHttpRequestWorker *worker);
     void deletePetCallback(PFXHttpRequestWorker *worker);

--- a/samples/client/petstore/cpp-qt5/client/PFXStoreApi.cpp
+++ b/samples/client/petstore/cpp-qt5/client/PFXStoreApi.cpp
@@ -23,7 +23,8 @@ PFXStoreApi::PFXStoreApi(const QString &scheme, const QString &host, int port, c
       _port(port),
       _basePath(basePath),
       _timeOut(timeOut),
-      _compress(false) {}
+      isResponseCompressionEnabled(false),
+      isRequestCompressionEnabled(false) {}
 
 PFXStoreApi::~PFXStoreApi() {
 }
@@ -56,8 +57,12 @@ void PFXStoreApi::addHeaders(const QString &key, const QString &value) {
     defaultHeaders.insert(key, value);
 }
 
-void PFXStoreApi::enableContentCompression() {
-    _compress = true;
+void PFXStoreApi::enableRequestCompression() {
+    isRequestCompressionEnabled = true;
+}
+
+void PFXStoreApi::enableResponseCompression() {
+    isResponseCompressionEnabled = true;
 }
 
 void PFXStoreApi::deleteOrder(const QString &order_id) {
@@ -74,7 +79,6 @@ void PFXStoreApi::deleteOrder(const QString &order_id) {
     PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this);
     worker->setTimeOut(_timeOut);
     worker->setWorkingDirectory(_workingDirectory);
-    worker->setCompressionEnabled(_compress);
     PFXHttpRequestInput input(fullPath, "DELETE");
 
     foreach (QString key, this->defaultHeaders.keys()) { input.headers.insert(key, this->defaultHeaders.value(key)); }
@@ -117,7 +121,6 @@ void PFXStoreApi::getInventory() {
     PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this);
     worker->setTimeOut(_timeOut);
     worker->setWorkingDirectory(_workingDirectory);
-    worker->setCompressionEnabled(_compress);
     PFXHttpRequestInput input(fullPath, "GET");
 
     foreach (QString key, this->defaultHeaders.keys()) { input.headers.insert(key, this->defaultHeaders.value(key)); }
@@ -173,7 +176,6 @@ void PFXStoreApi::getOrderById(const qint64 &order_id) {
     PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this);
     worker->setTimeOut(_timeOut);
     worker->setWorkingDirectory(_workingDirectory);
-    worker->setCompressionEnabled(_compress);
     PFXHttpRequestInput input(fullPath, "GET");
 
     foreach (QString key, this->defaultHeaders.keys()) { input.headers.insert(key, this->defaultHeaders.value(key)); }
@@ -217,7 +219,6 @@ void PFXStoreApi::placeOrder(const PFXOrder &body) {
     PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this);
     worker->setTimeOut(_timeOut);
     worker->setWorkingDirectory(_workingDirectory);
-    worker->setCompressionEnabled(_compress);
     PFXHttpRequestInput input(fullPath, "POST");
 
     QString output = body.asJson();

--- a/samples/client/petstore/cpp-qt5/client/PFXStoreApi.h
+++ b/samples/client/petstore/cpp-qt5/client/PFXStoreApi.h
@@ -36,7 +36,8 @@ public:
     void setTimeOut(const int timeOut);
     void setWorkingDirectory(const QString &path);
     void addHeaders(const QString &key, const QString &value);
-    void enableContentCompression();
+    void enableRequestCompression();
+    void enableResponseCompression();
 
     void deleteOrder(const QString &order_id);
     void getInventory();
@@ -50,7 +51,8 @@ private:
     int _timeOut;
     QString _workingDirectory;
     QMap<QString, QString> defaultHeaders;
-    bool _compress;
+    bool isResponseCompressionEnabled;
+    bool isRequestCompressionEnabled;
 
     void deleteOrderCallback(PFXHttpRequestWorker *worker);
     void getInventoryCallback(PFXHttpRequestWorker *worker);

--- a/samples/client/petstore/cpp-qt5/client/PFXUserApi.cpp
+++ b/samples/client/petstore/cpp-qt5/client/PFXUserApi.cpp
@@ -23,7 +23,8 @@ PFXUserApi::PFXUserApi(const QString &scheme, const QString &host, int port, con
       _port(port),
       _basePath(basePath),
       _timeOut(timeOut),
-      _compress(false) {}
+      isResponseCompressionEnabled(false),
+      isRequestCompressionEnabled(false) {}
 
 PFXUserApi::~PFXUserApi() {
 }
@@ -56,8 +57,12 @@ void PFXUserApi::addHeaders(const QString &key, const QString &value) {
     defaultHeaders.insert(key, value);
 }
 
-void PFXUserApi::enableContentCompression() {
-    _compress = true;
+void PFXUserApi::enableRequestCompression() {
+    isRequestCompressionEnabled = true;
+}
+
+void PFXUserApi::enableResponseCompression() {
+    isResponseCompressionEnabled = true;
 }
 
 void PFXUserApi::createUser(const PFXUser &body) {
@@ -71,7 +76,6 @@ void PFXUserApi::createUser(const PFXUser &body) {
     PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this);
     worker->setTimeOut(_timeOut);
     worker->setWorkingDirectory(_workingDirectory);
-    worker->setCompressionEnabled(_compress);
     PFXHttpRequestInput input(fullPath, "POST");
 
     QString output = body.asJson();
@@ -117,7 +121,6 @@ void PFXUserApi::createUsersWithArrayInput(const QList<PFXUser> &body) {
     PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this);
     worker->setTimeOut(_timeOut);
     worker->setWorkingDirectory(_workingDirectory);
-    worker->setCompressionEnabled(_compress);
     PFXHttpRequestInput input(fullPath, "POST");
 
     QJsonDocument doc(::test_namespace::toJsonValue(body).toArray());
@@ -164,7 +167,6 @@ void PFXUserApi::createUsersWithListInput(const QList<PFXUser> &body) {
     PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this);
     worker->setTimeOut(_timeOut);
     worker->setWorkingDirectory(_workingDirectory);
-    worker->setCompressionEnabled(_compress);
     PFXHttpRequestInput input(fullPath, "POST");
 
     QJsonDocument doc(::test_namespace::toJsonValue(body).toArray());
@@ -214,7 +216,6 @@ void PFXUserApi::deleteUser(const QString &username) {
     PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this);
     worker->setTimeOut(_timeOut);
     worker->setWorkingDirectory(_workingDirectory);
-    worker->setCompressionEnabled(_compress);
     PFXHttpRequestInput input(fullPath, "DELETE");
 
     foreach (QString key, this->defaultHeaders.keys()) { input.headers.insert(key, this->defaultHeaders.value(key)); }
@@ -260,7 +261,6 @@ void PFXUserApi::getUserByName(const QString &username) {
     PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this);
     worker->setTimeOut(_timeOut);
     worker->setWorkingDirectory(_workingDirectory);
-    worker->setCompressionEnabled(_compress);
     PFXHttpRequestInput input(fullPath, "GET");
 
     foreach (QString key, this->defaultHeaders.keys()) { input.headers.insert(key, this->defaultHeaders.value(key)); }
@@ -316,7 +316,6 @@ void PFXUserApi::loginUser(const QString &username, const QString &password) {
     PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this);
     worker->setTimeOut(_timeOut);
     worker->setWorkingDirectory(_workingDirectory);
-    worker->setCompressionEnabled(_compress);
     PFXHttpRequestInput input(fullPath, "GET");
 
     foreach (QString key, this->defaultHeaders.keys()) { input.headers.insert(key, this->defaultHeaders.value(key)); }
@@ -361,7 +360,6 @@ void PFXUserApi::logoutUser() {
     PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this);
     worker->setTimeOut(_timeOut);
     worker->setWorkingDirectory(_workingDirectory);
-    worker->setCompressionEnabled(_compress);
     PFXHttpRequestInput input(fullPath, "GET");
 
     foreach (QString key, this->defaultHeaders.keys()) { input.headers.insert(key, this->defaultHeaders.value(key)); }
@@ -407,7 +405,6 @@ void PFXUserApi::updateUser(const QString &username, const PFXUser &body) {
     PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this);
     worker->setTimeOut(_timeOut);
     worker->setWorkingDirectory(_workingDirectory);
-    worker->setCompressionEnabled(_compress);
     PFXHttpRequestInput input(fullPath, "PUT");
 
     QString output = body.asJson();

--- a/samples/client/petstore/cpp-qt5/client/PFXUserApi.h
+++ b/samples/client/petstore/cpp-qt5/client/PFXUserApi.h
@@ -36,7 +36,8 @@ public:
     void setTimeOut(const int timeOut);
     void setWorkingDirectory(const QString &path);
     void addHeaders(const QString &key, const QString &value);
-    void enableContentCompression();
+    void enableRequestCompression();
+    void enableResponseCompression();
 
     void createUser(const PFXUser &body);
     void createUsersWithArrayInput(const QList<PFXUser> &body);
@@ -54,7 +55,8 @@ private:
     int _timeOut;
     QString _workingDirectory;
     QMap<QString, QString> defaultHeaders;
-    bool _compress;
+    bool isResponseCompressionEnabled;
+    bool isRequestCompressionEnabled;
 
     void createUserCallback(PFXHttpRequestWorker *worker);
     void createUsersWithArrayInputCallback(PFXHttpRequestWorker *worker);


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
**Summay**
Support request compression and improve response compression support in Qt5 client.

*Changes*
- Split response and request compression
- Add request compression 
- Add handling of *identity* *Content-Encoding*
- Default **gzip** for requests and response compression

*Sample Test spec*

```yaml
---
# This is a sample Swagger spec, describing a simple API as a starting point.

swagger: "2.0"
info:
  description: Application Test Description
  version: 1.0.0
  title: ApplicationTemplate

host: 0.0.0.0:8080
basePath: /api
schemes:
- http

tags:
- name : CompressionTestServices
  x-displayName : "CompressionTestServices"
  description : |
    "Test Services offered by the application"

paths:
  /simpleEndpoint:
    post:
      tags:
        - CompressionTestServices
      summary: provide a list of Notifications
      operationId: setGetCompressedData
      consumes:
        - application/json
      produces:
        - application/json
      parameters:
        - name: reqBody
          in: body
          required: true
          schema:
            $ref: '#/definitions/Message'
      responses:
        '200':
          description: Success
          schema:
            $ref: '#/definitions/Message'
        '400':
          description: Bad Request
          schema:
            $ref: '#/definitions/Message'
            
definitions:
  Message:
    description: Type to be used to inform about errors happening while executing a command.
    type: object
    properties:
      content:
        description: Provide a list of all errors happened
        type: string
```

*Usage*
```C++
#include <QCoreApplication>
#include <QObject>
#include <QtGlobal>
#include <QFile>
#include <QString>

#include "OAICompressionTestServicesApi.h"

using namespace OpenAPI;
int main(int argc, char *argv[]) {
    QCoreApplication a(argc, argv);
    auto api = new OAICompressionTestServicesApi();
    api->setHost(QString("127.0.0.1"));
    api->setPort(8080);
    api->enableRequestCompression();
    api->enableResponseCompression();
    QFile file("request.txt");
    QByteArray bArray;
    if (file.exists()) {
        file.open(QIODevice::ReadOnly);
        bArray = file.readAll();
        file.close();
    }
    QObject::connect(api, &OAICompressionTestServicesApi::setGetCompressedDataSignalFull, [] \
(OAIHttpRequestWorker *worker, OAIMessage summary){
        Q_UNUSED(worker);
        QFile file("response.txt");
        if (file.exists()) {
            file.remove();
        }
        file.open(QIODevice::WriteOnly);
        file.write(summary.getContent().toUtf8());
        file.close();
    });
    OAIMessage msg;
    msg.setContent(QString(bArray));
    api->setGetCompressedData(msg);
    a.exec();
}
```
*Server*
- ASP.NET core with response and request compression

*Verification*
- Open wireshark and check the data transferred during the request and response before and after
   `api->enableRequestCompression();`/`api->enableResponseCompression();` are called.

*References*
- https://zlib.net/manual.html
- https://zlib.net/zlib_how.html

@muttleyxd @ravinikam @stkrwork @MartinDelille 

<!-- Please check the completed items below -->
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [X] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [X] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.


