### PR TITLE
[python] Cleanup ThreadPool with atexit rather than __del__

### DIFF
--- a/modules/openapi-generator/src/main/resources/python/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/python/api_client.mustache
@@ -2,6 +2,7 @@
 {{>partial_header}}
 from __future__ import absolute_import
 
+import atexit
 import datetime
 from dateutil.parser import parse
 import json
@@ -75,11 +76,19 @@ class ApiClient(object):
         self.user_agent = '{{#httpUserAgent}}{{{.}}}{{/httpUserAgent}}{{^httpUserAgent}}OpenAPI-Generator/{{{packageVersion}}}/python{{/httpUserAgent}}'
         self.client_side_validation = configuration.client_side_validation
 
-    def __del__(self):
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.close()
+
+    def close(self):
         if self._pool:
             self._pool.close()
             self._pool.join()
             self._pool = None
+            if hasattr(atexit, 'unregister'):
+                atexit.unregister(self.close)
 
     @property
     def pool(self):
@@ -87,6 +96,7 @@ class ApiClient(object):
          avoids instantiating unused threadpool for blocking clients.
         """
         if self._pool is None:
+            atexit.register(self.close)
             self._pool = ThreadPool(self.pool_threads)
         return self._pool
 

--- a/modules/openapi-generator/src/main/resources/python/api_doc_example.mustache
+++ b/modules/openapi-generator/src/main/resources/python/api_doc_example.mustache
@@ -8,22 +8,26 @@ from pprint import pprint
 {{#hasAuthMethods}}
 # Defining host is optional and default to {{{basePath}}}
 configuration.host = "{{{basePath}}}"
-# Create an instance of the API class
-api_instance = {{{packageName}}}.{{{classname}}}({{{packageName}}}.ApiClient(configuration))
-{{#allParams}}{{paramName}} = {{{example}}} # {{{dataType}}} | {{{description}}}{{^required}} (optional){{/required}}{{#defaultValue}} (default to {{{.}}}){{/defaultValue}}
-{{/allParams}}
+# Enter a context with an instance of the API client
+with {{{packageName}}}.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = {{{packageName}}}.{{{classname}}}(api_client)
+    {{#allParams}}{{paramName}} = {{{example}}} # {{{dataType}}} | {{{description}}}{{^required}} (optional){{/required}}{{#defaultValue}} (default to {{{.}}}){{/defaultValue}}
+    {{/allParams}}
 {{/hasAuthMethods}}
 {{^hasAuthMethods}}
-# Create an instance of the API class
-api_instance = {{{packageName}}}.{{{classname}}}()
-{{#allParams}}{{paramName}} = {{{example}}} # {{{dataType}}} | {{{description}}}{{^required}} (optional){{/required}}{{#defaultValue}} (default to {{{.}}}){{/defaultValue}}
-{{/allParams}}
+# Enter a context with an instance of the API client
+with {{{packageName}}}.ApiClient() as api_client:
+    # Create an instance of the API class
+    api_instance = {{{packageName}}}.{{{classname}}}(api_client)
+    {{#allParams}}{{paramName}} = {{{example}}} # {{{dataType}}} | {{{description}}}{{^required}} (optional){{/required}}{{#defaultValue}} (default to {{{.}}}){{/defaultValue}}
+    {{/allParams}}
 {{/hasAuthMethods}}
 
-try:
-{{#summary}}    # {{{.}}}
-{{/summary}}    {{#returnType}}api_response = {{/returnType}}api_instance.{{{operationId}}}({{#allParams}}{{#required}}{{paramName}}{{/required}}{{^required}}{{paramName}}={{paramName}}{{/required}}{{#hasMore}}, {{/hasMore}}{{/allParams}}){{#returnType}}
-    pprint(api_response){{/returnType}}
-except ApiException as e:
-    print("Exception when calling {{classname}}->{{operationId}}: %s\n" % e)
+    try:
+    {{#summary}}    # {{{.}}}
+    {{/summary}}    {{#returnType}}api_response = {{/returnType}}api_instance.{{{operationId}}}({{#allParams}}{{#required}}{{paramName}}{{/required}}{{^required}}{{paramName}}={{paramName}}{{/required}}{{#hasMore}}, {{/hasMore}}{{/allParams}}){{#returnType}}
+        pprint(api_response){{/returnType}}
+    except ApiException as e:
+        print("Exception when calling {{classname}}->{{operationId}}: %s\n" % e)
 ```

--- a/modules/openapi-generator/src/main/resources/python/common_README.mustache
+++ b/modules/openapi-generator/src/main/resources/python/common_README.mustache
@@ -8,18 +8,20 @@ from pprint import pprint
 {{> python_doc_auth_partial}}
 # Defining host is optional and default to {{{basePath}}}
 configuration.host = "{{{basePath}}}"
-# Create an instance of the API class
-api_instance = {{{packageName}}}.{{{classname}}}({{{packageName}}}.ApiClient(configuration))
-{{#allParams}}{{paramName}} = {{{example}}} # {{{dataType}}} | {{{description}}}{{^required}} (optional){{/required}}{{#defaultValue}} (default to {{{.}}}){{/defaultValue}}
-{{/allParams}}
+# Enter a context with an instance of the API client
+with {{{packageName}}}.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = {{{packageName}}}.{{{classname}}}(api_client)
+    {{#allParams}}{{paramName}} = {{{example}}} # {{{dataType}}} | {{{description}}}{{^required}} (optional){{/required}}{{#defaultValue}} (default to {{{.}}}){{/defaultValue}}
+    {{/allParams}}
 
-try:
-{{#summary}}    # {{{.}}}
-{{/summary}}    {{#returnType}}api_response = {{/returnType}}api_instance.{{{operationId}}}({{#allParams}}{{#required}}{{paramName}}{{/required}}{{^required}}{{paramName}}={{paramName}}{{/required}}{{#hasMore}}, {{/hasMore}}{{/allParams}}){{#returnType}}
-    pprint(api_response){{/returnType}}
-except ApiException as e:
-    print("Exception when calling {{classname}}->{{operationId}}: %s\n" % e)
-{{/-first}}{{/operation}}{{/operations}}{{/-first}}{{/apis}}{{/apiInfo}}
+    try:
+    {{#summary}}    # {{{.}}}
+    {{/summary}}    {{#returnType}}api_response = {{/returnType}}api_instance.{{{operationId}}}({{#allParams}}{{#required}}{{paramName}}{{/required}}{{^required}}{{paramName}}={{paramName}}{{/required}}{{#hasMore}}, {{/hasMore}}{{/allParams}}){{#returnType}}
+        pprint(api_response){{/returnType}}
+    except ApiException as e:
+        print("Exception when calling {{classname}}->{{operationId}}: %s\n" % e)
+    {{/-first}}{{/operation}}{{/operations}}{{/-first}}{{/apis}}{{/apiInfo}}
 ```
 
 ## Documentation for API Endpoints

--- a/modules/openapi-generator/src/main/resources/python/python-experimental/README_common.mustache
+++ b/modules/openapi-generator/src/main/resources/python/python-experimental/README_common.mustache
@@ -7,18 +7,20 @@ from pprint import pprint
 {{> python_doc_auth_partial}}
 # Defining host is optional and default to {{{basePath}}}
 configuration.host = "{{{basePath}}}"
-# Create an instance of the API class
-api_instance = {{{packageName}}}.{{{classname}}}({{{packageName}}}.ApiClient(configuration))
-{{#allParams}}{{paramName}} = {{{example}}} # {{{dataType}}} | {{{description}}}{{^required}} (optional){{/required}}{{#defaultValue}} (default to {{{.}}}){{/defaultValue}}
-{{/allParams}}
+# Enter a context with an instance of the API client
+with {{{packageName}}}.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = {{{packageName}}}.{{{classname}}}(api_client)
+    {{#allParams}}{{paramName}} = {{{example}}} # {{{dataType}}} | {{{description}}}{{^required}} (optional){{/required}}{{#defaultValue}} (default to {{{.}}}){{/defaultValue}}
+    {{/allParams}}
 
-try:
-{{#summary}}    # {{{.}}}
-{{/summary}}    {{#returnType}}api_response = {{/returnType}}api_instance.{{{operationId}}}({{#allParams}}{{#required}}{{paramName}}{{/required}}{{^required}}{{paramName}}={{paramName}}{{/required}}{{#hasMore}}, {{/hasMore}}{{/allParams}}){{#returnType}}
-    pprint(api_response){{/returnType}}
-except {{{packageName}}}.ApiException as e:
-    print("Exception when calling {{classname}}->{{operationId}}: %s\n" % e)
-{{/-first}}{{/operation}}{{/operations}}{{/-first}}{{/apis}}{{/apiInfo}}
+    try:
+    {{#summary}}    # {{{.}}}
+    {{/summary}}    {{#returnType}}api_response = {{/returnType}}api_instance.{{{operationId}}}({{#allParams}}{{#required}}{{paramName}}{{/required}}{{^required}}{{paramName}}={{paramName}}{{/required}}{{#hasMore}}, {{/hasMore}}{{/allParams}}){{#returnType}}
+        pprint(api_response){{/returnType}}
+    except {{{packageName}}}.ApiException as e:
+        print("Exception when calling {{classname}}->{{operationId}}: %s\n" % e)
+    {{/-first}}{{/operation}}{{/operations}}{{/-first}}{{/apis}}{{/apiInfo}}
 ```
 
 ## Documentation for API Endpoints

--- a/modules/openapi-generator/src/main/resources/python/python-experimental/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/python/python-experimental/api_client.mustache
@@ -3,6 +3,7 @@
 from __future__ import absolute_import
 
 import json
+import atexit
 import mimetypes
 from multiprocessing.pool import ThreadPool
 import os
@@ -74,11 +75,19 @@ class ApiClient(object):
         # Set default User-Agent.
         self.user_agent = '{{#httpUserAgent}}{{{.}}}{{/httpUserAgent}}{{^httpUserAgent}}OpenAPI-Generator/{{{packageVersion}}}/python{{/httpUserAgent}}'
 
-    def __del__(self):
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.close()
+
+    def close(self):
         if self._pool:
             self._pool.close()
             self._pool.join()
             self._pool = None
+            if hasattr(atexit, 'unregister'):
+                atexit.unregister(self.close)
 
     @property
     def pool(self):
@@ -86,6 +95,7 @@ class ApiClient(object):
          avoids instantiating unused threadpool for blocking clients.
         """
         if self._pool is None:
+            atexit.register(self.close)
             self._pool = ThreadPool(self.pool_threads)
         return self._pool
 

--- a/modules/openapi-generator/src/main/resources/python/python-experimental/api_doc_example.mustache
+++ b/modules/openapi-generator/src/main/resources/python/python-experimental/api_doc_example.mustache
@@ -7,51 +7,55 @@ from pprint import pprint
 {{#hasAuthMethods}}
 # Defining host is optional and default to {{{basePath}}}
 configuration.host = "{{{basePath}}}"
-# Create an instance of the API class
-api_instance = {{{packageName}}}.{{{classname}}}({{{packageName}}}.ApiClient(configuration))
+# Enter a context with an instance of the API client
+with {{{packageName}}}.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = {{{packageName}}}.{{{classname}}}(api_client)
 {{/hasAuthMethods}}
 {{^hasAuthMethods}}
-# Create an instance of the API class
-api_instance = {{{packageName}}}.{{{classname}}}()
+# Enter a context with an instance of the API client
+with {{{packageName}}}.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = {{{packageName}}}.{{{classname}}}(api_client)
 {{/hasAuthMethods}}
-{{#requiredParams}}{{^defaultValue}}{{paramName}} = {{{example}}} # {{{dataType}}} | {{{description}}}
-{{/defaultValue}}{{/requiredParams}}{{#optionalParams}}{{paramName}} = {{{example}}} # {{{dataType}}} | {{{description}}}{{^required}} (optional){{/required}}{{#defaultValue}} if omitted the server will use the default value of {{{defaultValue}}}{{/defaultValue}}
-{{/optionalParams}}
-{{#requiredParams}}
-{{^hasMore}}
+    {{#requiredParams}}{{^defaultValue}}{{paramName}} = {{{example}}} # {{{dataType}}} | {{{description}}}
+    {{/defaultValue}}{{/requiredParams}}{{#optionalParams}}{{paramName}} = {{{example}}} # {{{dataType}}} | {{{description}}}{{^required}} (optional){{/required}}{{#defaultValue}} if omitted the server will use the default value of {{{defaultValue}}}{{/defaultValue}}
+    {{/optionalParams}}
+    {{#requiredParams}}
+    {{^hasMore}}
 
-# example passing only required values which don't have defaults set
-try:
-{{#summary}}    # {{{.}}}
-{{/summary}}    {{#returnType}}api_response = {{/returnType}}api_instance.{{{operationId}}}({{#requiredParams}}{{^defaultValue}}{{paramName}}{{#hasMore}}, {{/hasMore}}{{/defaultValue}}{{/requiredParams}}){{#returnType}}
-    pprint(api_response){{/returnType}}
-except {{{packageName}}}.ApiException as e:
-    print("Exception when calling {{classname}}->{{operationId}}: %s\n" % e)
-{{/hasMore}}
-{{/requiredParams}}
-{{#optionalParams}}
-{{^hasMore}}
+    # example passing only required values which don't have defaults set
+    try:
+    {{#summary}}    # {{{.}}}
+    {{/summary}}    {{#returnType}}api_response = {{/returnType}}api_instance.{{{operationId}}}({{#requiredParams}}{{^defaultValue}}{{paramName}}{{#hasMore}}, {{/hasMore}}{{/defaultValue}}{{/requiredParams}}){{#returnType}}
+        pprint(api_response){{/returnType}}
+    except {{{packageName}}}.ApiException as e:
+        print("Exception when calling {{classname}}->{{operationId}}: %s\n" % e)
+    {{/hasMore}}
+    {{/requiredParams}}
+    {{#optionalParams}}
+    {{^hasMore}}
 
-# example passing only required values which don't have defaults set
-# and optional values
-try:
-{{#summary}}    # {{{.}}}
-{{/summary}}    {{#returnType}}api_response = {{/returnType}}api_instance.{{{operationId}}}({{#requiredParams}}{{^defaultValue}}{{paramName}}, {{/defaultValue}}{{/requiredParams}}{{#optionalParams}}{{paramName}}={{paramName}}{{#hasMore}}, {{/hasMore}}{{/optionalParams}}){{#returnType}}
-    pprint(api_response){{/returnType}}
-except {{{packageName}}}.ApiException as e:
-    print("Exception when calling {{classname}}->{{operationId}}: %s\n" % e)
-{{/hasMore}}
-{{/optionalParams}}
-{{^requiredParams}}
-{{^optionalParams}}
+    # example passing only required values which don't have defaults set
+    # and optional values
+    try:
+    {{#summary}}    # {{{.}}}
+    {{/summary}}    {{#returnType}}api_response = {{/returnType}}api_instance.{{{operationId}}}({{#requiredParams}}{{^defaultValue}}{{paramName}}, {{/defaultValue}}{{/requiredParams}}{{#optionalParams}}{{paramName}}={{paramName}}{{#hasMore}}, {{/hasMore}}{{/optionalParams}}){{#returnType}}
+        pprint(api_response){{/returnType}}
+    except {{{packageName}}}.ApiException as e:
+        print("Exception when calling {{classname}}->{{operationId}}: %s\n" % e)
+    {{/hasMore}}
+    {{/optionalParams}}
+    {{^requiredParams}}
+    {{^optionalParams}}
 
-# example, this endpoint has no required or optional parameters
-try:
-{{#summary}}    # {{{.}}}
-{{/summary}}    {{#returnType}}api_response = {{/returnType}}api_instance.{{{operationId}}}(){{#returnType}}
-    pprint(api_response){{/returnType}}
-except {{{packageName}}}.ApiException as e:
-    print("Exception when calling {{classname}}->{{operationId}}: %s\n" % e)
-{{/optionalParams}}
-{{/requiredParams}}
+    # example, this endpoint has no required or optional parameters
+    try:
+    {{#summary}}    # {{{.}}}
+    {{/summary}}    {{#returnType}}api_response = {{/returnType}}api_instance.{{{operationId}}}(){{#returnType}}
+        pprint(api_response){{/returnType}}
+    except {{{packageName}}}.ApiException as e:
+        print("Exception when calling {{classname}}->{{operationId}}: %s\n" % e)
+    {{/optionalParams}}
+    {{/requiredParams}}
 ```

--- a/samples/client/petstore/python-asyncio/README.md
+++ b/samples/client/petstore/python-asyncio/README.md
@@ -54,17 +54,19 @@ from pprint import pprint
 
 # Defining host is optional and default to http://petstore.swagger.io:80/v2
 configuration.host = "http://petstore.swagger.io:80/v2"
-# Create an instance of the API class
-api_instance = petstore_api.AnotherFakeApi(petstore_api.ApiClient(configuration))
-body = petstore_api.Client() # Client | client model
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.AnotherFakeApi(api_client)
+    body = petstore_api.Client() # Client | client model
 
-try:
-    # To test special tags
-    api_response = api_instance.call_123_test_special_tags(body)
-    pprint(api_response)
-except ApiException as e:
-    print("Exception when calling AnotherFakeApi->call_123_test_special_tags: %s\n" % e)
-
+    try:
+        # To test special tags
+        api_response = api_instance.call_123_test_special_tags(body)
+        pprint(api_response)
+    except ApiException as e:
+        print("Exception when calling AnotherFakeApi->call_123_test_special_tags: %s\n" % e)
+    
 ```
 
 ## Documentation for API Endpoints

--- a/samples/client/petstore/python-asyncio/docs/AnotherFakeApi.md
+++ b/samples/client/petstore/python-asyncio/docs/AnotherFakeApi.md
@@ -23,16 +23,18 @@ import petstore_api
 from petstore_api.rest import ApiException
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.AnotherFakeApi()
-body = petstore_api.Client() # Client | client model
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient() as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.AnotherFakeApi(api_client)
+    body = petstore_api.Client() # Client | client model
 
-try:
-    # To test special tags
-    api_response = api_instance.call_123_test_special_tags(body)
-    pprint(api_response)
-except ApiException as e:
-    print("Exception when calling AnotherFakeApi->call_123_test_special_tags: %s\n" % e)
+    try:
+        # To test special tags
+        api_response = api_instance.call_123_test_special_tags(body)
+        pprint(api_response)
+    except ApiException as e:
+        print("Exception when calling AnotherFakeApi->call_123_test_special_tags: %s\n" % e)
 ```
 
 ### Parameters

--- a/samples/client/petstore/python-asyncio/docs/FakeApi.md
+++ b/samples/client/petstore/python-asyncio/docs/FakeApi.md
@@ -36,15 +36,17 @@ import petstore_api
 from petstore_api.rest import ApiException
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.FakeApi()
-xml_item = petstore_api.XmlItem() # XmlItem | XmlItem Body
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient() as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.FakeApi(api_client)
+    xml_item = petstore_api.XmlItem() # XmlItem | XmlItem Body
 
-try:
-    # creates an XmlItem
-    api_instance.create_xml_item(xml_item)
-except ApiException as e:
-    print("Exception when calling FakeApi->create_xml_item: %s\n" % e)
+    try:
+        # creates an XmlItem
+        api_instance.create_xml_item(xml_item)
+    except ApiException as e:
+        print("Exception when calling FakeApi->create_xml_item: %s\n" % e)
 ```
 
 ### Parameters
@@ -89,15 +91,17 @@ import petstore_api
 from petstore_api.rest import ApiException
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.FakeApi()
-body = True # bool | Input boolean as post body (optional)
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient() as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.FakeApi(api_client)
+    body = True # bool | Input boolean as post body (optional)
 
-try:
-    api_response = api_instance.fake_outer_boolean_serialize(body=body)
-    pprint(api_response)
-except ApiException as e:
-    print("Exception when calling FakeApi->fake_outer_boolean_serialize: %s\n" % e)
+    try:
+        api_response = api_instance.fake_outer_boolean_serialize(body=body)
+        pprint(api_response)
+    except ApiException as e:
+        print("Exception when calling FakeApi->fake_outer_boolean_serialize: %s\n" % e)
 ```
 
 ### Parameters
@@ -142,15 +146,17 @@ import petstore_api
 from petstore_api.rest import ApiException
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.FakeApi()
-body = petstore_api.OuterComposite() # OuterComposite | Input composite as post body (optional)
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient() as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.FakeApi(api_client)
+    body = petstore_api.OuterComposite() # OuterComposite | Input composite as post body (optional)
 
-try:
-    api_response = api_instance.fake_outer_composite_serialize(body=body)
-    pprint(api_response)
-except ApiException as e:
-    print("Exception when calling FakeApi->fake_outer_composite_serialize: %s\n" % e)
+    try:
+        api_response = api_instance.fake_outer_composite_serialize(body=body)
+        pprint(api_response)
+    except ApiException as e:
+        print("Exception when calling FakeApi->fake_outer_composite_serialize: %s\n" % e)
 ```
 
 ### Parameters
@@ -195,15 +201,17 @@ import petstore_api
 from petstore_api.rest import ApiException
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.FakeApi()
-body = 3.4 # float | Input number as post body (optional)
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient() as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.FakeApi(api_client)
+    body = 3.4 # float | Input number as post body (optional)
 
-try:
-    api_response = api_instance.fake_outer_number_serialize(body=body)
-    pprint(api_response)
-except ApiException as e:
-    print("Exception when calling FakeApi->fake_outer_number_serialize: %s\n" % e)
+    try:
+        api_response = api_instance.fake_outer_number_serialize(body=body)
+        pprint(api_response)
+    except ApiException as e:
+        print("Exception when calling FakeApi->fake_outer_number_serialize: %s\n" % e)
 ```
 
 ### Parameters
@@ -248,15 +256,17 @@ import petstore_api
 from petstore_api.rest import ApiException
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.FakeApi()
-body = 'body_example' # str | Input string as post body (optional)
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient() as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.FakeApi(api_client)
+    body = 'body_example' # str | Input string as post body (optional)
 
-try:
-    api_response = api_instance.fake_outer_string_serialize(body=body)
-    pprint(api_response)
-except ApiException as e:
-    print("Exception when calling FakeApi->fake_outer_string_serialize: %s\n" % e)
+    try:
+        api_response = api_instance.fake_outer_string_serialize(body=body)
+        pprint(api_response)
+    except ApiException as e:
+        print("Exception when calling FakeApi->fake_outer_string_serialize: %s\n" % e)
 ```
 
 ### Parameters
@@ -301,14 +311,16 @@ import petstore_api
 from petstore_api.rest import ApiException
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.FakeApi()
-body = petstore_api.FileSchemaTestClass() # FileSchemaTestClass | 
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient() as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.FakeApi(api_client)
+    body = petstore_api.FileSchemaTestClass() # FileSchemaTestClass | 
 
-try:
-    api_instance.test_body_with_file_schema(body)
-except ApiException as e:
-    print("Exception when calling FakeApi->test_body_with_file_schema: %s\n" % e)
+    try:
+        api_instance.test_body_with_file_schema(body)
+    except ApiException as e:
+        print("Exception when calling FakeApi->test_body_with_file_schema: %s\n" % e)
 ```
 
 ### Parameters
@@ -351,15 +363,17 @@ import petstore_api
 from petstore_api.rest import ApiException
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.FakeApi()
-query = 'query_example' # str | 
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient() as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.FakeApi(api_client)
+    query = 'query_example' # str | 
 body = petstore_api.User() # User | 
 
-try:
-    api_instance.test_body_with_query_params(query, body)
-except ApiException as e:
-    print("Exception when calling FakeApi->test_body_with_query_params: %s\n" % e)
+    try:
+        api_instance.test_body_with_query_params(query, body)
+    except ApiException as e:
+        print("Exception when calling FakeApi->test_body_with_query_params: %s\n" % e)
 ```
 
 ### Parameters
@@ -405,16 +419,18 @@ import petstore_api
 from petstore_api.rest import ApiException
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.FakeApi()
-body = petstore_api.Client() # Client | client model
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient() as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.FakeApi(api_client)
+    body = petstore_api.Client() # Client | client model
 
-try:
-    # To test \"client\" model
-    api_response = api_instance.test_client_model(body)
-    pprint(api_response)
-except ApiException as e:
-    print("Exception when calling FakeApi->test_client_model: %s\n" % e)
+    try:
+        # To test \"client\" model
+        api_response = api_instance.test_client_model(body)
+        pprint(api_response)
+    except ApiException as e:
+        print("Exception when calling FakeApi->test_client_model: %s\n" % e)
 ```
 
 ### Parameters
@@ -466,9 +482,11 @@ configuration.password = 'YOUR_PASSWORD'
 
 # Defining host is optional and default to http://petstore.swagger.io:80/v2
 configuration.host = "http://petstore.swagger.io:80/v2"
-# Create an instance of the API class
-api_instance = petstore_api.FakeApi(petstore_api.ApiClient(configuration))
-number = 3.4 # float | None
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.FakeApi(api_client)
+    number = 3.4 # float | None
 double = 3.4 # float | None
 pattern_without_delimiter = 'pattern_without_delimiter_example' # str | None
 byte = 'byte_example' # str | None
@@ -483,11 +501,11 @@ date_time = '2013-10-20T19:20:30+01:00' # datetime | None (optional)
 password = 'password_example' # str | None (optional)
 param_callback = 'param_callback_example' # str | None (optional)
 
-try:
-    # Fake endpoint for testing various parameters  假端點  偽のエンドポイント  가짜 엔드 포인트
-    api_instance.test_endpoint_parameters(number, double, pattern_without_delimiter, byte, integer=integer, int32=int32, int64=int64, float=float, string=string, binary=binary, date=date, date_time=date_time, password=password, param_callback=param_callback)
-except ApiException as e:
-    print("Exception when calling FakeApi->test_endpoint_parameters: %s\n" % e)
+    try:
+        # Fake endpoint for testing various parameters  假端點  偽のエンドポイント  가짜 엔드 포인트
+        api_instance.test_endpoint_parameters(number, double, pattern_without_delimiter, byte, integer=integer, int32=int32, int64=int64, float=float, string=string, binary=binary, date=date, date_time=date_time, password=password, param_callback=param_callback)
+    except ApiException as e:
+        print("Exception when calling FakeApi->test_endpoint_parameters: %s\n" % e)
 ```
 
 ### Parameters
@@ -546,9 +564,11 @@ import petstore_api
 from petstore_api.rest import ApiException
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.FakeApi()
-enum_header_string_array = ['enum_header_string_array_example'] # list[str] | Header parameter enum test (string array) (optional)
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient() as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.FakeApi(api_client)
+    enum_header_string_array = ['enum_header_string_array_example'] # list[str] | Header parameter enum test (string array) (optional)
 enum_header_string = '-efg' # str | Header parameter enum test (string) (optional) (default to '-efg')
 enum_query_string_array = ['enum_query_string_array_example'] # list[str] | Query parameter enum test (string array) (optional)
 enum_query_string = '-efg' # str | Query parameter enum test (string) (optional) (default to '-efg')
@@ -557,11 +577,11 @@ enum_query_double = 3.4 # float | Query parameter enum test (double) (optional)
 enum_form_string_array = '$' # list[str] | Form parameter enum test (string array) (optional) (default to '$')
 enum_form_string = '-efg' # str | Form parameter enum test (string) (optional) (default to '-efg')
 
-try:
-    # To test enum parameters
-    api_instance.test_enum_parameters(enum_header_string_array=enum_header_string_array, enum_header_string=enum_header_string, enum_query_string_array=enum_query_string_array, enum_query_string=enum_query_string, enum_query_integer=enum_query_integer, enum_query_double=enum_query_double, enum_form_string_array=enum_form_string_array, enum_form_string=enum_form_string)
-except ApiException as e:
-    print("Exception when calling FakeApi->test_enum_parameters: %s\n" % e)
+    try:
+        # To test enum parameters
+        api_instance.test_enum_parameters(enum_header_string_array=enum_header_string_array, enum_header_string=enum_header_string, enum_query_string_array=enum_query_string_array, enum_query_string=enum_query_string, enum_query_integer=enum_query_integer, enum_query_double=enum_query_double, enum_form_string_array=enum_form_string_array, enum_form_string=enum_form_string)
+    except ApiException as e:
+        print("Exception when calling FakeApi->test_enum_parameters: %s\n" % e)
 ```
 
 ### Parameters
@@ -614,20 +634,22 @@ import petstore_api
 from petstore_api.rest import ApiException
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.FakeApi()
-required_string_group = 56 # int | Required String in group parameters
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient() as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.FakeApi(api_client)
+    required_string_group = 56 # int | Required String in group parameters
 required_boolean_group = True # bool | Required Boolean in group parameters
 required_int64_group = 56 # int | Required Integer in group parameters
 string_group = 56 # int | String in group parameters (optional)
 boolean_group = True # bool | Boolean in group parameters (optional)
 int64_group = 56 # int | Integer in group parameters (optional)
 
-try:
-    # Fake endpoint to test group parameters (optional)
-    api_instance.test_group_parameters(required_string_group, required_boolean_group, required_int64_group, string_group=string_group, boolean_group=boolean_group, int64_group=int64_group)
-except ApiException as e:
-    print("Exception when calling FakeApi->test_group_parameters: %s\n" % e)
+    try:
+        # Fake endpoint to test group parameters (optional)
+        api_instance.test_group_parameters(required_string_group, required_boolean_group, required_int64_group, string_group=string_group, boolean_group=boolean_group, int64_group=int64_group)
+    except ApiException as e:
+        print("Exception when calling FakeApi->test_group_parameters: %s\n" % e)
 ```
 
 ### Parameters
@@ -675,15 +697,17 @@ import petstore_api
 from petstore_api.rest import ApiException
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.FakeApi()
-param = {'key': 'param_example'} # dict(str, str) | request body
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient() as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.FakeApi(api_client)
+    param = {'key': 'param_example'} # dict(str, str) | request body
 
-try:
-    # test inline additionalProperties
-    api_instance.test_inline_additional_properties(param)
-except ApiException as e:
-    print("Exception when calling FakeApi->test_inline_additional_properties: %s\n" % e)
+    try:
+        # test inline additionalProperties
+        api_instance.test_inline_additional_properties(param)
+    except ApiException as e:
+        print("Exception when calling FakeApi->test_inline_additional_properties: %s\n" % e)
 ```
 
 ### Parameters
@@ -726,16 +750,18 @@ import petstore_api
 from petstore_api.rest import ApiException
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.FakeApi()
-param = 'param_example' # str | field1
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient() as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.FakeApi(api_client)
+    param = 'param_example' # str | field1
 param2 = 'param2_example' # str | field2
 
-try:
-    # test json serialization of form data
-    api_instance.test_json_form_data(param, param2)
-except ApiException as e:
-    print("Exception when calling FakeApi->test_json_form_data: %s\n" % e)
+    try:
+        # test json serialization of form data
+        api_instance.test_json_form_data(param, param2)
+    except ApiException as e:
+        print("Exception when calling FakeApi->test_json_form_data: %s\n" % e)
 ```
 
 ### Parameters
@@ -781,18 +807,20 @@ import petstore_api
 from petstore_api.rest import ApiException
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.FakeApi()
-pipe = ['pipe_example'] # list[str] | 
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient() as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.FakeApi(api_client)
+    pipe = ['pipe_example'] # list[str] | 
 ioutil = ['ioutil_example'] # list[str] | 
 http = ['http_example'] # list[str] | 
 url = ['url_example'] # list[str] | 
 context = ['context_example'] # list[str] | 
 
-try:
-    api_instance.test_query_parameter_collection_format(pipe, ioutil, http, url, context)
-except ApiException as e:
-    print("Exception when calling FakeApi->test_query_parameter_collection_format: %s\n" % e)
+    try:
+        api_instance.test_query_parameter_collection_format(pipe, ioutil, http, url, context)
+    except ApiException as e:
+        print("Exception when calling FakeApi->test_query_parameter_collection_format: %s\n" % e)
 ```
 
 ### Parameters

--- a/samples/client/petstore/python-asyncio/docs/FakeClassnameTags123Api.md
+++ b/samples/client/petstore/python-asyncio/docs/FakeClassnameTags123Api.md
@@ -31,16 +31,18 @@ configuration.api_key['api_key_query'] = 'YOUR_API_KEY'
 
 # Defining host is optional and default to http://petstore.swagger.io:80/v2
 configuration.host = "http://petstore.swagger.io:80/v2"
-# Create an instance of the API class
-api_instance = petstore_api.FakeClassnameTags123Api(petstore_api.ApiClient(configuration))
-body = petstore_api.Client() # Client | client model
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.FakeClassnameTags123Api(api_client)
+    body = petstore_api.Client() # Client | client model
 
-try:
-    # To test class name in snake case
-    api_response = api_instance.test_classname(body)
-    pprint(api_response)
-except ApiException as e:
-    print("Exception when calling FakeClassnameTags123Api->test_classname: %s\n" % e)
+    try:
+        # To test class name in snake case
+        api_response = api_instance.test_classname(body)
+        pprint(api_response)
+    except ApiException as e:
+        print("Exception when calling FakeClassnameTags123Api->test_classname: %s\n" % e)
 ```
 
 ### Parameters

--- a/samples/client/petstore/python-asyncio/docs/PetApi.md
+++ b/samples/client/petstore/python-asyncio/docs/PetApi.md
@@ -35,15 +35,17 @@ configuration.access_token = 'YOUR_ACCESS_TOKEN'
 
 # Defining host is optional and default to http://petstore.swagger.io:80/v2
 configuration.host = "http://petstore.swagger.io:80/v2"
-# Create an instance of the API class
-api_instance = petstore_api.PetApi(petstore_api.ApiClient(configuration))
-body = petstore_api.Pet() # Pet | Pet object that needs to be added to the store
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.PetApi(api_client)
+    body = petstore_api.Pet() # Pet | Pet object that needs to be added to the store
 
-try:
-    # Add a new pet to the store
-    api_instance.add_pet(body)
-except ApiException as e:
-    print("Exception when calling PetApi->add_pet: %s\n" % e)
+    try:
+        # Add a new pet to the store
+        api_instance.add_pet(body)
+    except ApiException as e:
+        print("Exception when calling PetApi->add_pet: %s\n" % e)
 ```
 
 ### Parameters
@@ -93,16 +95,18 @@ configuration.access_token = 'YOUR_ACCESS_TOKEN'
 
 # Defining host is optional and default to http://petstore.swagger.io:80/v2
 configuration.host = "http://petstore.swagger.io:80/v2"
-# Create an instance of the API class
-api_instance = petstore_api.PetApi(petstore_api.ApiClient(configuration))
-pet_id = 56 # int | Pet id to delete
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.PetApi(api_client)
+    pet_id = 56 # int | Pet id to delete
 api_key = 'api_key_example' # str |  (optional)
 
-try:
-    # Deletes a pet
-    api_instance.delete_pet(pet_id, api_key=api_key)
-except ApiException as e:
-    print("Exception when calling PetApi->delete_pet: %s\n" % e)
+    try:
+        # Deletes a pet
+        api_instance.delete_pet(pet_id, api_key=api_key)
+    except ApiException as e:
+        print("Exception when calling PetApi->delete_pet: %s\n" % e)
 ```
 
 ### Parameters
@@ -155,16 +159,18 @@ configuration.access_token = 'YOUR_ACCESS_TOKEN'
 
 # Defining host is optional and default to http://petstore.swagger.io:80/v2
 configuration.host = "http://petstore.swagger.io:80/v2"
-# Create an instance of the API class
-api_instance = petstore_api.PetApi(petstore_api.ApiClient(configuration))
-status = ['status_example'] # list[str] | Status values that need to be considered for filter
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.PetApi(api_client)
+    status = ['status_example'] # list[str] | Status values that need to be considered for filter
 
-try:
-    # Finds Pets by status
-    api_response = api_instance.find_pets_by_status(status)
-    pprint(api_response)
-except ApiException as e:
-    print("Exception when calling PetApi->find_pets_by_status: %s\n" % e)
+    try:
+        # Finds Pets by status
+        api_response = api_instance.find_pets_by_status(status)
+        pprint(api_response)
+    except ApiException as e:
+        print("Exception when calling PetApi->find_pets_by_status: %s\n" % e)
 ```
 
 ### Parameters
@@ -216,16 +222,18 @@ configuration.access_token = 'YOUR_ACCESS_TOKEN'
 
 # Defining host is optional and default to http://petstore.swagger.io:80/v2
 configuration.host = "http://petstore.swagger.io:80/v2"
-# Create an instance of the API class
-api_instance = petstore_api.PetApi(petstore_api.ApiClient(configuration))
-tags = ['tags_example'] # list[str] | Tags to filter by
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.PetApi(api_client)
+    tags = ['tags_example'] # list[str] | Tags to filter by
 
-try:
-    # Finds Pets by tags
-    api_response = api_instance.find_pets_by_tags(tags)
-    pprint(api_response)
-except ApiException as e:
-    print("Exception when calling PetApi->find_pets_by_tags: %s\n" % e)
+    try:
+        # Finds Pets by tags
+        api_response = api_instance.find_pets_by_tags(tags)
+        pprint(api_response)
+    except ApiException as e:
+        print("Exception when calling PetApi->find_pets_by_tags: %s\n" % e)
 ```
 
 ### Parameters
@@ -279,16 +287,18 @@ configuration.api_key['api_key'] = 'YOUR_API_KEY'
 
 # Defining host is optional and default to http://petstore.swagger.io:80/v2
 configuration.host = "http://petstore.swagger.io:80/v2"
-# Create an instance of the API class
-api_instance = petstore_api.PetApi(petstore_api.ApiClient(configuration))
-pet_id = 56 # int | ID of pet to return
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.PetApi(api_client)
+    pet_id = 56 # int | ID of pet to return
 
-try:
-    # Find pet by ID
-    api_response = api_instance.get_pet_by_id(pet_id)
-    pprint(api_response)
-except ApiException as e:
-    print("Exception when calling PetApi->get_pet_by_id: %s\n" % e)
+    try:
+        # Find pet by ID
+        api_response = api_instance.get_pet_by_id(pet_id)
+        pprint(api_response)
+    except ApiException as e:
+        print("Exception when calling PetApi->get_pet_by_id: %s\n" % e)
 ```
 
 ### Parameters
@@ -339,15 +349,17 @@ configuration.access_token = 'YOUR_ACCESS_TOKEN'
 
 # Defining host is optional and default to http://petstore.swagger.io:80/v2
 configuration.host = "http://petstore.swagger.io:80/v2"
-# Create an instance of the API class
-api_instance = petstore_api.PetApi(petstore_api.ApiClient(configuration))
-body = petstore_api.Pet() # Pet | Pet object that needs to be added to the store
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.PetApi(api_client)
+    body = petstore_api.Pet() # Pet | Pet object that needs to be added to the store
 
-try:
-    # Update an existing pet
-    api_instance.update_pet(body)
-except ApiException as e:
-    print("Exception when calling PetApi->update_pet: %s\n" % e)
+    try:
+        # Update an existing pet
+        api_instance.update_pet(body)
+    except ApiException as e:
+        print("Exception when calling PetApi->update_pet: %s\n" % e)
 ```
 
 ### Parameters
@@ -399,17 +411,19 @@ configuration.access_token = 'YOUR_ACCESS_TOKEN'
 
 # Defining host is optional and default to http://petstore.swagger.io:80/v2
 configuration.host = "http://petstore.swagger.io:80/v2"
-# Create an instance of the API class
-api_instance = petstore_api.PetApi(petstore_api.ApiClient(configuration))
-pet_id = 56 # int | ID of pet that needs to be updated
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.PetApi(api_client)
+    pet_id = 56 # int | ID of pet that needs to be updated
 name = 'name_example' # str | Updated name of the pet (optional)
 status = 'status_example' # str | Updated status of the pet (optional)
 
-try:
-    # Updates a pet in the store with form data
-    api_instance.update_pet_with_form(pet_id, name=name, status=status)
-except ApiException as e:
-    print("Exception when calling PetApi->update_pet_with_form: %s\n" % e)
+    try:
+        # Updates a pet in the store with form data
+        api_instance.update_pet_with_form(pet_id, name=name, status=status)
+    except ApiException as e:
+        print("Exception when calling PetApi->update_pet_with_form: %s\n" % e)
 ```
 
 ### Parameters
@@ -460,18 +474,20 @@ configuration.access_token = 'YOUR_ACCESS_TOKEN'
 
 # Defining host is optional and default to http://petstore.swagger.io:80/v2
 configuration.host = "http://petstore.swagger.io:80/v2"
-# Create an instance of the API class
-api_instance = petstore_api.PetApi(petstore_api.ApiClient(configuration))
-pet_id = 56 # int | ID of pet to update
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.PetApi(api_client)
+    pet_id = 56 # int | ID of pet to update
 additional_metadata = 'additional_metadata_example' # str | Additional data to pass to server (optional)
 file = '/path/to/file' # file | file to upload (optional)
 
-try:
-    # uploads an image
-    api_response = api_instance.upload_file(pet_id, additional_metadata=additional_metadata, file=file)
-    pprint(api_response)
-except ApiException as e:
-    print("Exception when calling PetApi->upload_file: %s\n" % e)
+    try:
+        # uploads an image
+        api_response = api_instance.upload_file(pet_id, additional_metadata=additional_metadata, file=file)
+        pprint(api_response)
+    except ApiException as e:
+        print("Exception when calling PetApi->upload_file: %s\n" % e)
 ```
 
 ### Parameters
@@ -522,18 +538,20 @@ configuration.access_token = 'YOUR_ACCESS_TOKEN'
 
 # Defining host is optional and default to http://petstore.swagger.io:80/v2
 configuration.host = "http://petstore.swagger.io:80/v2"
-# Create an instance of the API class
-api_instance = petstore_api.PetApi(petstore_api.ApiClient(configuration))
-pet_id = 56 # int | ID of pet to update
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.PetApi(api_client)
+    pet_id = 56 # int | ID of pet to update
 required_file = '/path/to/file' # file | file to upload
 additional_metadata = 'additional_metadata_example' # str | Additional data to pass to server (optional)
 
-try:
-    # uploads an image (required)
-    api_response = api_instance.upload_file_with_required_file(pet_id, required_file, additional_metadata=additional_metadata)
-    pprint(api_response)
-except ApiException as e:
-    print("Exception when calling PetApi->upload_file_with_required_file: %s\n" % e)
+    try:
+        # uploads an image (required)
+        api_response = api_instance.upload_file_with_required_file(pet_id, required_file, additional_metadata=additional_metadata)
+        pprint(api_response)
+    except ApiException as e:
+        print("Exception when calling PetApi->upload_file_with_required_file: %s\n" % e)
 ```
 
 ### Parameters

--- a/samples/client/petstore/python-asyncio/docs/StoreApi.md
+++ b/samples/client/petstore/python-asyncio/docs/StoreApi.md
@@ -26,15 +26,17 @@ import petstore_api
 from petstore_api.rest import ApiException
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.StoreApi()
-order_id = 'order_id_example' # str | ID of the order that needs to be deleted
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient() as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.StoreApi(api_client)
+    order_id = 'order_id_example' # str | ID of the order that needs to be deleted
 
-try:
-    # Delete purchase order by ID
-    api_instance.delete_order(order_id)
-except ApiException as e:
-    print("Exception when calling StoreApi->delete_order: %s\n" % e)
+    try:
+        # Delete purchase order by ID
+        api_instance.delete_order(order_id)
+    except ApiException as e:
+        print("Exception when calling StoreApi->delete_order: %s\n" % e)
 ```
 
 ### Parameters
@@ -88,15 +90,17 @@ configuration.api_key['api_key'] = 'YOUR_API_KEY'
 
 # Defining host is optional and default to http://petstore.swagger.io:80/v2
 configuration.host = "http://petstore.swagger.io:80/v2"
-# Create an instance of the API class
-api_instance = petstore_api.StoreApi(petstore_api.ApiClient(configuration))
-
-try:
-    # Returns pet inventories by status
-    api_response = api_instance.get_inventory()
-    pprint(api_response)
-except ApiException as e:
-    print("Exception when calling StoreApi->get_inventory: %s\n" % e)
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.StoreApi(api_client)
+    
+    try:
+        # Returns pet inventories by status
+        api_response = api_instance.get_inventory()
+        pprint(api_response)
+    except ApiException as e:
+        print("Exception when calling StoreApi->get_inventory: %s\n" % e)
 ```
 
 ### Parameters
@@ -138,16 +142,18 @@ import petstore_api
 from petstore_api.rest import ApiException
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.StoreApi()
-order_id = 56 # int | ID of pet that needs to be fetched
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient() as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.StoreApi(api_client)
+    order_id = 56 # int | ID of pet that needs to be fetched
 
-try:
-    # Find purchase order by ID
-    api_response = api_instance.get_order_by_id(order_id)
-    pprint(api_response)
-except ApiException as e:
-    print("Exception when calling StoreApi->get_order_by_id: %s\n" % e)
+    try:
+        # Find purchase order by ID
+        api_response = api_instance.get_order_by_id(order_id)
+        pprint(api_response)
+    except ApiException as e:
+        print("Exception when calling StoreApi->get_order_by_id: %s\n" % e)
 ```
 
 ### Parameters
@@ -192,16 +198,18 @@ import petstore_api
 from petstore_api.rest import ApiException
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.StoreApi()
-body = petstore_api.Order() # Order | order placed for purchasing the pet
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient() as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.StoreApi(api_client)
+    body = petstore_api.Order() # Order | order placed for purchasing the pet
 
-try:
-    # Place an order for a pet
-    api_response = api_instance.place_order(body)
-    pprint(api_response)
-except ApiException as e:
-    print("Exception when calling StoreApi->place_order: %s\n" % e)
+    try:
+        # Place an order for a pet
+        api_response = api_instance.place_order(body)
+        pprint(api_response)
+    except ApiException as e:
+        print("Exception when calling StoreApi->place_order: %s\n" % e)
 ```
 
 ### Parameters

--- a/samples/client/petstore/python-asyncio/docs/UserApi.md
+++ b/samples/client/petstore/python-asyncio/docs/UserApi.md
@@ -30,15 +30,17 @@ import petstore_api
 from petstore_api.rest import ApiException
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.UserApi()
-body = petstore_api.User() # User | Created user object
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient() as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.UserApi(api_client)
+    body = petstore_api.User() # User | Created user object
 
-try:
-    # Create user
-    api_instance.create_user(body)
-except ApiException as e:
-    print("Exception when calling UserApi->create_user: %s\n" % e)
+    try:
+        # Create user
+        api_instance.create_user(body)
+    except ApiException as e:
+        print("Exception when calling UserApi->create_user: %s\n" % e)
 ```
 
 ### Parameters
@@ -81,15 +83,17 @@ import petstore_api
 from petstore_api.rest import ApiException
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.UserApi()
-body = [petstore_api.User()] # list[User] | List of user object
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient() as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.UserApi(api_client)
+    body = [petstore_api.User()] # list[User] | List of user object
 
-try:
-    # Creates list of users with given input array
-    api_instance.create_users_with_array_input(body)
-except ApiException as e:
-    print("Exception when calling UserApi->create_users_with_array_input: %s\n" % e)
+    try:
+        # Creates list of users with given input array
+        api_instance.create_users_with_array_input(body)
+    except ApiException as e:
+        print("Exception when calling UserApi->create_users_with_array_input: %s\n" % e)
 ```
 
 ### Parameters
@@ -132,15 +136,17 @@ import petstore_api
 from petstore_api.rest import ApiException
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.UserApi()
-body = [petstore_api.User()] # list[User] | List of user object
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient() as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.UserApi(api_client)
+    body = [petstore_api.User()] # list[User] | List of user object
 
-try:
-    # Creates list of users with given input array
-    api_instance.create_users_with_list_input(body)
-except ApiException as e:
-    print("Exception when calling UserApi->create_users_with_list_input: %s\n" % e)
+    try:
+        # Creates list of users with given input array
+        api_instance.create_users_with_list_input(body)
+    except ApiException as e:
+        print("Exception when calling UserApi->create_users_with_list_input: %s\n" % e)
 ```
 
 ### Parameters
@@ -185,15 +191,17 @@ import petstore_api
 from petstore_api.rest import ApiException
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.UserApi()
-username = 'username_example' # str | The name that needs to be deleted
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient() as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.UserApi(api_client)
+    username = 'username_example' # str | The name that needs to be deleted
 
-try:
-    # Delete user
-    api_instance.delete_user(username)
-except ApiException as e:
-    print("Exception when calling UserApi->delete_user: %s\n" % e)
+    try:
+        # Delete user
+        api_instance.delete_user(username)
+    except ApiException as e:
+        print("Exception when calling UserApi->delete_user: %s\n" % e)
 ```
 
 ### Parameters
@@ -237,16 +245,18 @@ import petstore_api
 from petstore_api.rest import ApiException
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.UserApi()
-username = 'username_example' # str | The name that needs to be fetched. Use user1 for testing.
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient() as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.UserApi(api_client)
+    username = 'username_example' # str | The name that needs to be fetched. Use user1 for testing.
 
-try:
-    # Get user by user name
-    api_response = api_instance.get_user_by_name(username)
-    pprint(api_response)
-except ApiException as e:
-    print("Exception when calling UserApi->get_user_by_name: %s\n" % e)
+    try:
+        # Get user by user name
+        api_response = api_instance.get_user_by_name(username)
+        pprint(api_response)
+    except ApiException as e:
+        print("Exception when calling UserApi->get_user_by_name: %s\n" % e)
 ```
 
 ### Parameters
@@ -291,17 +301,19 @@ import petstore_api
 from petstore_api.rest import ApiException
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.UserApi()
-username = 'username_example' # str | The user name for login
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient() as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.UserApi(api_client)
+    username = 'username_example' # str | The user name for login
 password = 'password_example' # str | The password for login in clear text
 
-try:
-    # Logs user into the system
-    api_response = api_instance.login_user(username, password)
-    pprint(api_response)
-except ApiException as e:
-    print("Exception when calling UserApi->login_user: %s\n" % e)
+    try:
+        # Logs user into the system
+        api_response = api_instance.login_user(username, password)
+        pprint(api_response)
+    except ApiException as e:
+        print("Exception when calling UserApi->login_user: %s\n" % e)
 ```
 
 ### Parameters
@@ -346,14 +358,16 @@ import petstore_api
 from petstore_api.rest import ApiException
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.UserApi()
-
-try:
-    # Logs out current logged in user session
-    api_instance.logout_user()
-except ApiException as e:
-    print("Exception when calling UserApi->logout_user: %s\n" % e)
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient() as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.UserApi(api_client)
+    
+    try:
+        # Logs out current logged in user session
+        api_instance.logout_user()
+    except ApiException as e:
+        print("Exception when calling UserApi->logout_user: %s\n" % e)
 ```
 
 ### Parameters
@@ -395,16 +409,18 @@ import petstore_api
 from petstore_api.rest import ApiException
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.UserApi()
-username = 'username_example' # str | name that need to be deleted
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient() as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.UserApi(api_client)
+    username = 'username_example' # str | name that need to be deleted
 body = petstore_api.User() # User | Updated user object
 
-try:
-    # Updated user
-    api_instance.update_user(username, body)
-except ApiException as e:
-    print("Exception when calling UserApi->update_user: %s\n" % e)
+    try:
+        # Updated user
+        api_instance.update_user(username, body)
+    except ApiException as e:
+        print("Exception when calling UserApi->update_user: %s\n" % e)
 ```
 
 ### Parameters

--- a/samples/client/petstore/python-asyncio/petstore_api/api_client.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/api_client.py
@@ -10,6 +10,7 @@
 
 from __future__ import absolute_import
 
+import atexit
 import datetime
 from dateutil.parser import parse
 import json
@@ -80,11 +81,19 @@ class ApiClient(object):
         self.user_agent = 'OpenAPI-Generator/1.0.0/python'
         self.client_side_validation = configuration.client_side_validation
 
-    def __del__(self):
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.close()
+
+    def close(self):
         if self._pool:
             self._pool.close()
             self._pool.join()
             self._pool = None
+            if hasattr(atexit, 'unregister'):
+                atexit.unregister(self.close)
 
     @property
     def pool(self):
@@ -92,6 +101,7 @@ class ApiClient(object):
          avoids instantiating unused threadpool for blocking clients.
         """
         if self._pool is None:
+            atexit.register(self.close)
             self._pool = ThreadPool(self.pool_threads)
         return self._pool
 

--- a/samples/client/petstore/python-experimental/README.md
+++ b/samples/client/petstore/python-experimental/README.md
@@ -53,17 +53,19 @@ from pprint import pprint
 
 # Defining host is optional and default to http://petstore.swagger.io:80/v2
 configuration.host = "http://petstore.swagger.io:80/v2"
-# Create an instance of the API class
-api_instance = petstore_api.AnotherFakeApi(petstore_api.ApiClient(configuration))
-body = petstore_api.Client() # client.Client | client model
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.AnotherFakeApi(api_client)
+    body = petstore_api.Client() # client.Client | client model
 
-try:
-    # To test special tags
-    api_response = api_instance.call_123_test_special_tags(body)
-    pprint(api_response)
-except petstore_api.ApiException as e:
-    print("Exception when calling AnotherFakeApi->call_123_test_special_tags: %s\n" % e)
-
+    try:
+        # To test special tags
+        api_response = api_instance.call_123_test_special_tags(body)
+        pprint(api_response)
+    except petstore_api.ApiException as e:
+        print("Exception when calling AnotherFakeApi->call_123_test_special_tags: %s\n" % e)
+    
 ```
 
 ## Documentation for API Endpoints

--- a/samples/client/petstore/python-experimental/docs/AnotherFakeApi.md
+++ b/samples/client/petstore/python-experimental/docs/AnotherFakeApi.md
@@ -22,17 +22,19 @@ import time
 import petstore_api
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.AnotherFakeApi()
-body = petstore_api.Client() # client.Client | client model
-
-# example passing only required values which don't have defaults set
-try:
-    # To test special tags
-    api_response = api_instance.call_123_test_special_tags(body)
-    pprint(api_response)
-except petstore_api.ApiException as e:
-    print("Exception when calling AnotherFakeApi->call_123_test_special_tags: %s\n" % e)
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.AnotherFakeApi(api_client)
+    body = petstore_api.Client() # client.Client | client model
+    
+    # example passing only required values which don't have defaults set
+    try:
+        # To test special tags
+        api_response = api_instance.call_123_test_special_tags(body)
+        pprint(api_response)
+    except petstore_api.ApiException as e:
+        print("Exception when calling AnotherFakeApi->call_123_test_special_tags: %s\n" % e)
 ```
 
 ### Parameters

--- a/samples/client/petstore/python-experimental/docs/FakeApi.md
+++ b/samples/client/petstore/python-experimental/docs/FakeApi.md
@@ -36,16 +36,18 @@ import time
 import petstore_api
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.FakeApi()
-xml_item = petstore_api.XmlItem() # xml_item.XmlItem | XmlItem Body
-
-# example passing only required values which don't have defaults set
-try:
-    # creates an XmlItem
-    api_instance.create_xml_item(xml_item)
-except petstore_api.ApiException as e:
-    print("Exception when calling FakeApi->create_xml_item: %s\n" % e)
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.FakeApi(api_client)
+    xml_item = petstore_api.XmlItem() # xml_item.XmlItem | XmlItem Body
+    
+    # example passing only required values which don't have defaults set
+    try:
+        # creates an XmlItem
+        api_instance.create_xml_item(xml_item)
+    except petstore_api.ApiException as e:
+        print("Exception when calling FakeApi->create_xml_item: %s\n" % e)
 ```
 
 ### Parameters
@@ -89,17 +91,19 @@ import time
 import petstore_api
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.FakeApi()
-body = True # bool | Input boolean as post body (optional)
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.FakeApi(api_client)
+    body = True # bool | Input boolean as post body (optional)
 
-# example passing only required values which don't have defaults set
-# and optional values
-try:
-    api_response = api_instance.fake_outer_boolean_serialize(body=body)
-    pprint(api_response)
-except petstore_api.ApiException as e:
-    print("Exception when calling FakeApi->fake_outer_boolean_serialize: %s\n" % e)
+    # example passing only required values which don't have defaults set
+    # and optional values
+    try:
+        api_response = api_instance.fake_outer_boolean_serialize(body=body)
+        pprint(api_response)
+    except petstore_api.ApiException as e:
+        print("Exception when calling FakeApi->fake_outer_boolean_serialize: %s\n" % e)
 ```
 
 ### Parameters
@@ -143,17 +147,19 @@ import time
 import petstore_api
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.FakeApi()
-body = petstore_api.OuterComposite() # outer_composite.OuterComposite | Input composite as post body (optional)
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.FakeApi(api_client)
+    body = petstore_api.OuterComposite() # outer_composite.OuterComposite | Input composite as post body (optional)
 
-# example passing only required values which don't have defaults set
-# and optional values
-try:
-    api_response = api_instance.fake_outer_composite_serialize(body=body)
-    pprint(api_response)
-except petstore_api.ApiException as e:
-    print("Exception when calling FakeApi->fake_outer_composite_serialize: %s\n" % e)
+    # example passing only required values which don't have defaults set
+    # and optional values
+    try:
+        api_response = api_instance.fake_outer_composite_serialize(body=body)
+        pprint(api_response)
+    except petstore_api.ApiException as e:
+        print("Exception when calling FakeApi->fake_outer_composite_serialize: %s\n" % e)
 ```
 
 ### Parameters
@@ -197,17 +203,19 @@ import time
 import petstore_api
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.FakeApi()
-body = petstore_api.OuterEnum("placed") # outer_enum.OuterEnum | Input enum as post body (optional)
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.FakeApi(api_client)
+    body = petstore_api.OuterEnum("placed") # outer_enum.OuterEnum | Input enum as post body (optional)
 
-# example passing only required values which don't have defaults set
-# and optional values
-try:
-    api_response = api_instance.fake_outer_enum_serialize(body=body)
-    pprint(api_response)
-except petstore_api.ApiException as e:
-    print("Exception when calling FakeApi->fake_outer_enum_serialize: %s\n" % e)
+    # example passing only required values which don't have defaults set
+    # and optional values
+    try:
+        api_response = api_instance.fake_outer_enum_serialize(body=body)
+        pprint(api_response)
+    except petstore_api.ApiException as e:
+        print("Exception when calling FakeApi->fake_outer_enum_serialize: %s\n" % e)
 ```
 
 ### Parameters
@@ -251,17 +259,19 @@ import time
 import petstore_api
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.FakeApi()
-body = petstore_api.OuterNumber(3.4) # outer_number.OuterNumber | Input number as post body (optional)
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.FakeApi(api_client)
+    body = petstore_api.OuterNumber(3.4) # outer_number.OuterNumber | Input number as post body (optional)
 
-# example passing only required values which don't have defaults set
-# and optional values
-try:
-    api_response = api_instance.fake_outer_number_serialize(body=body)
-    pprint(api_response)
-except petstore_api.ApiException as e:
-    print("Exception when calling FakeApi->fake_outer_number_serialize: %s\n" % e)
+    # example passing only required values which don't have defaults set
+    # and optional values
+    try:
+        api_response = api_instance.fake_outer_number_serialize(body=body)
+        pprint(api_response)
+    except petstore_api.ApiException as e:
+        print("Exception when calling FakeApi->fake_outer_number_serialize: %s\n" % e)
 ```
 
 ### Parameters
@@ -305,17 +315,19 @@ import time
 import petstore_api
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.FakeApi()
-body = 'body_example' # str | Input string as post body (optional)
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.FakeApi(api_client)
+    body = 'body_example' # str | Input string as post body (optional)
 
-# example passing only required values which don't have defaults set
-# and optional values
-try:
-    api_response = api_instance.fake_outer_string_serialize(body=body)
-    pprint(api_response)
-except petstore_api.ApiException as e:
-    print("Exception when calling FakeApi->fake_outer_string_serialize: %s\n" % e)
+    # example passing only required values which don't have defaults set
+    # and optional values
+    try:
+        api_response = api_instance.fake_outer_string_serialize(body=body)
+        pprint(api_response)
+    except petstore_api.ApiException as e:
+        print("Exception when calling FakeApi->fake_outer_string_serialize: %s\n" % e)
 ```
 
 ### Parameters
@@ -359,15 +371,17 @@ import time
 import petstore_api
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.FakeApi()
-body = petstore_api.FileSchemaTestClass() # file_schema_test_class.FileSchemaTestClass | 
-
-# example passing only required values which don't have defaults set
-try:
-    api_instance.test_body_with_file_schema(body)
-except petstore_api.ApiException as e:
-    print("Exception when calling FakeApi->test_body_with_file_schema: %s\n" % e)
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.FakeApi(api_client)
+    body = petstore_api.FileSchemaTestClass() # file_schema_test_class.FileSchemaTestClass | 
+    
+    # example passing only required values which don't have defaults set
+    try:
+        api_instance.test_body_with_file_schema(body)
+    except petstore_api.ApiException as e:
+        print("Exception when calling FakeApi->test_body_with_file_schema: %s\n" % e)
 ```
 
 ### Parameters
@@ -409,16 +423,18 @@ import time
 import petstore_api
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.FakeApi()
-query = 'query_example' # str | 
-body = petstore_api.User() # user.User | 
-
-# example passing only required values which don't have defaults set
-try:
-    api_instance.test_body_with_query_params(query, body)
-except petstore_api.ApiException as e:
-    print("Exception when calling FakeApi->test_body_with_query_params: %s\n" % e)
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.FakeApi(api_client)
+    query = 'query_example' # str | 
+    body = petstore_api.User() # user.User | 
+    
+    # example passing only required values which don't have defaults set
+    try:
+        api_instance.test_body_with_query_params(query, body)
+    except petstore_api.ApiException as e:
+        print("Exception when calling FakeApi->test_body_with_query_params: %s\n" % e)
 ```
 
 ### Parameters
@@ -463,17 +479,19 @@ import time
 import petstore_api
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.FakeApi()
-body = petstore_api.Client() # client.Client | client model
-
-# example passing only required values which don't have defaults set
-try:
-    # To test \"client\" model
-    api_response = api_instance.test_client_model(body)
-    pprint(api_response)
-except petstore_api.ApiException as e:
-    print("Exception when calling FakeApi->test_client_model: %s\n" % e)
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.FakeApi(api_client)
+    body = petstore_api.Client() # client.Client | client model
+    
+    # example passing only required values which don't have defaults set
+    try:
+        # To test \"client\" model
+        api_response = api_instance.test_client_model(body)
+        pprint(api_response)
+    except petstore_api.ApiException as e:
+        print("Exception when calling FakeApi->test_client_model: %s\n" % e)
 ```
 
 ### Parameters
@@ -517,14 +535,16 @@ import time
 import petstore_api
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.FakeApi()
-
-# example passing only required values which don't have defaults set
-try:
-    api_instance.test_endpoint_enums_length_one()
-except petstore_api.ApiException as e:
-    print("Exception when calling FakeApi->test_endpoint_enums_length_one: %s\n" % e)
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.FakeApi(api_client)
+    
+    # example passing only required values which don't have defaults set
+    try:
+        api_instance.test_endpoint_enums_length_one()
+    except petstore_api.ApiException as e:
+        print("Exception when calling FakeApi->test_endpoint_enums_length_one: %s\n" % e)
 ```
 
 ### Parameters
@@ -579,13 +599,15 @@ configuration.password = 'YOUR_PASSWORD'
 
 # Defining host is optional and default to http://petstore.swagger.io:80/v2
 configuration.host = "http://petstore.swagger.io:80/v2"
-# Create an instance of the API class
-api_instance = petstore_api.FakeApi(petstore_api.ApiClient(configuration))
-number = 3.4 # float | None
-double = 3.4 # float | None
-pattern_without_delimiter = 'pattern_without_delimiter_example' # str | None
-byte = 'byte_example' # str | None
-integer = 56 # int | None (optional)
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.FakeApi(api_client)
+    number = 3.4 # float | None
+    double = 3.4 # float | None
+    pattern_without_delimiter = 'pattern_without_delimiter_example' # str | None
+    byte = 'byte_example' # str | None
+    integer = 56 # int | None (optional)
 int32 = 56 # int | None (optional)
 int64 = 56 # int | None (optional)
 float = 3.4 # float | None (optional)
@@ -596,20 +618,20 @@ date_time = '2013-10-20T19:20:30+01:00' # datetime | None (optional)
 password = 'password_example' # str | None (optional)
 param_callback = 'param_callback_example' # str | None (optional)
 
-# example passing only required values which don't have defaults set
-try:
-    # Fake endpoint for testing various parameters  假端點  偽のエンドポイント  가짜 엔드 포인트
-    api_instance.test_endpoint_parameters(number, double, pattern_without_delimiter, byte)
-except petstore_api.ApiException as e:
-    print("Exception when calling FakeApi->test_endpoint_parameters: %s\n" % e)
+    # example passing only required values which don't have defaults set
+    try:
+        # Fake endpoint for testing various parameters  假端點  偽のエンドポイント  가짜 엔드 포인트
+        api_instance.test_endpoint_parameters(number, double, pattern_without_delimiter, byte)
+    except petstore_api.ApiException as e:
+        print("Exception when calling FakeApi->test_endpoint_parameters: %s\n" % e)
 
-# example passing only required values which don't have defaults set
-# and optional values
-try:
-    # Fake endpoint for testing various parameters  假端點  偽のエンドポイント  가짜 엔드 포인트
-    api_instance.test_endpoint_parameters(number, double, pattern_without_delimiter, byte, integer=integer, int32=int32, int64=int64, float=float, string=string, binary=binary, date=date, date_time=date_time, password=password, param_callback=param_callback)
-except petstore_api.ApiException as e:
-    print("Exception when calling FakeApi->test_endpoint_parameters: %s\n" % e)
+    # example passing only required values which don't have defaults set
+    # and optional values
+    try:
+        # Fake endpoint for testing various parameters  假端點  偽のエンドポイント  가짜 엔드 포인트
+        api_instance.test_endpoint_parameters(number, double, pattern_without_delimiter, byte, integer=integer, int32=int32, int64=int64, float=float, string=string, binary=binary, date=date, date_time=date_time, password=password, param_callback=param_callback)
+    except petstore_api.ApiException as e:
+        print("Exception when calling FakeApi->test_endpoint_parameters: %s\n" % e)
 ```
 
 ### Parameters
@@ -667,9 +689,11 @@ import time
 import petstore_api
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.FakeApi()
-enum_header_string_array = ['enum_header_string_array_example'] # [str] | Header parameter enum test (string array) (optional)
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.FakeApi(api_client)
+    enum_header_string_array = ['enum_header_string_array_example'] # [str] | Header parameter enum test (string array) (optional)
 enum_header_string = '-efg' # str | Header parameter enum test (string) (optional) if omitted the server will use the default value of '-efg'
 enum_query_string_array = ['enum_query_string_array_example'] # [str] | Query parameter enum test (string array) (optional)
 enum_query_string = '-efg' # str | Query parameter enum test (string) (optional) if omitted the server will use the default value of '-efg'
@@ -678,13 +702,13 @@ enum_query_double = 3.4 # float | Query parameter enum test (double) (optional)
 enum_form_string_array = '$' # [str] | Form parameter enum test (string array) (optional) if omitted the server will use the default value of '$'
 enum_form_string = '-efg' # str | Form parameter enum test (string) (optional) if omitted the server will use the default value of '-efg'
 
-# example passing only required values which don't have defaults set
-# and optional values
-try:
-    # To test enum parameters
-    api_instance.test_enum_parameters(enum_header_string_array=enum_header_string_array, enum_header_string=enum_header_string, enum_query_string_array=enum_query_string_array, enum_query_string=enum_query_string, enum_query_integer=enum_query_integer, enum_query_double=enum_query_double, enum_form_string_array=enum_form_string_array, enum_form_string=enum_form_string)
-except petstore_api.ApiException as e:
-    print("Exception when calling FakeApi->test_enum_parameters: %s\n" % e)
+    # example passing only required values which don't have defaults set
+    # and optional values
+    try:
+        # To test enum parameters
+        api_instance.test_enum_parameters(enum_header_string_array=enum_header_string_array, enum_header_string=enum_header_string, enum_query_string_array=enum_query_string_array, enum_query_string=enum_query_string, enum_query_integer=enum_query_integer, enum_query_double=enum_query_double, enum_form_string_array=enum_form_string_array, enum_form_string=enum_form_string)
+    except petstore_api.ApiException as e:
+        print("Exception when calling FakeApi->test_enum_parameters: %s\n" % e)
 ```
 
 ### Parameters
@@ -736,29 +760,31 @@ import time
 import petstore_api
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.FakeApi()
-required_string_group = 56 # int | Required String in group parameters
-required_boolean_group = True # bool | Required Boolean in group parameters
-required_int64_group = 56 # int | Required Integer in group parameters
-string_group = 56 # int | String in group parameters (optional)
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.FakeApi(api_client)
+    required_string_group = 56 # int | Required String in group parameters
+    required_boolean_group = True # bool | Required Boolean in group parameters
+    required_int64_group = 56 # int | Required Integer in group parameters
+    string_group = 56 # int | String in group parameters (optional)
 boolean_group = True # bool | Boolean in group parameters (optional)
 int64_group = 56 # int | Integer in group parameters (optional)
 
-# example passing only required values which don't have defaults set
-try:
-    # Fake endpoint to test group parameters (optional)
-    api_instance.test_group_parameters(required_string_group, required_boolean_group, required_int64_group)
-except petstore_api.ApiException as e:
-    print("Exception when calling FakeApi->test_group_parameters: %s\n" % e)
+    # example passing only required values which don't have defaults set
+    try:
+        # Fake endpoint to test group parameters (optional)
+        api_instance.test_group_parameters(required_string_group, required_boolean_group, required_int64_group)
+    except petstore_api.ApiException as e:
+        print("Exception when calling FakeApi->test_group_parameters: %s\n" % e)
 
-# example passing only required values which don't have defaults set
-# and optional values
-try:
-    # Fake endpoint to test group parameters (optional)
-    api_instance.test_group_parameters(required_string_group, required_boolean_group, required_int64_group, string_group=string_group, boolean_group=boolean_group, int64_group=int64_group)
-except petstore_api.ApiException as e:
-    print("Exception when calling FakeApi->test_group_parameters: %s\n" % e)
+    # example passing only required values which don't have defaults set
+    # and optional values
+    try:
+        # Fake endpoint to test group parameters (optional)
+        api_instance.test_group_parameters(required_string_group, required_boolean_group, required_int64_group, string_group=string_group, boolean_group=boolean_group, int64_group=int64_group)
+    except petstore_api.ApiException as e:
+        print("Exception when calling FakeApi->test_group_parameters: %s\n" % e)
 ```
 
 ### Parameters
@@ -805,16 +831,18 @@ import time
 import petstore_api
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.FakeApi()
-param = {'key': 'param_example'} # {str: (str,)} | request body
-
-# example passing only required values which don't have defaults set
-try:
-    # test inline additionalProperties
-    api_instance.test_inline_additional_properties(param)
-except petstore_api.ApiException as e:
-    print("Exception when calling FakeApi->test_inline_additional_properties: %s\n" % e)
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.FakeApi(api_client)
+    param = {'key': 'param_example'} # {str: (str,)} | request body
+    
+    # example passing only required values which don't have defaults set
+    try:
+        # test inline additionalProperties
+        api_instance.test_inline_additional_properties(param)
+    except petstore_api.ApiException as e:
+        print("Exception when calling FakeApi->test_inline_additional_properties: %s\n" % e)
 ```
 
 ### Parameters
@@ -856,17 +884,19 @@ import time
 import petstore_api
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.FakeApi()
-param = 'param_example' # str | field1
-param2 = 'param2_example' # str | field2
-
-# example passing only required values which don't have defaults set
-try:
-    # test json serialization of form data
-    api_instance.test_json_form_data(param, param2)
-except petstore_api.ApiException as e:
-    print("Exception when calling FakeApi->test_json_form_data: %s\n" % e)
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.FakeApi(api_client)
+    param = 'param_example' # str | field1
+    param2 = 'param2_example' # str | field2
+    
+    # example passing only required values which don't have defaults set
+    try:
+        # test json serialization of form data
+        api_instance.test_json_form_data(param, param2)
+    except petstore_api.ApiException as e:
+        print("Exception when calling FakeApi->test_json_form_data: %s\n" % e)
 ```
 
 ### Parameters

--- a/samples/client/petstore/python-experimental/docs/FakeClassnameTags123Api.md
+++ b/samples/client/petstore/python-experimental/docs/FakeClassnameTags123Api.md
@@ -30,17 +30,19 @@ configuration.api_key['api_key_query'] = 'YOUR_API_KEY'
 
 # Defining host is optional and default to http://petstore.swagger.io:80/v2
 configuration.host = "http://petstore.swagger.io:80/v2"
-# Create an instance of the API class
-api_instance = petstore_api.FakeClassnameTags123Api(petstore_api.ApiClient(configuration))
-body = petstore_api.Client() # client.Client | client model
-
-# example passing only required values which don't have defaults set
-try:
-    # To test class name in snake case
-    api_response = api_instance.test_classname(body)
-    pprint(api_response)
-except petstore_api.ApiException as e:
-    print("Exception when calling FakeClassnameTags123Api->test_classname: %s\n" % e)
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.FakeClassnameTags123Api(api_client)
+    body = petstore_api.Client() # client.Client | client model
+    
+    # example passing only required values which don't have defaults set
+    try:
+        # To test class name in snake case
+        api_response = api_instance.test_classname(body)
+        pprint(api_response)
+    except petstore_api.ApiException as e:
+        print("Exception when calling FakeClassnameTags123Api->test_classname: %s\n" % e)
 ```
 
 ### Parameters

--- a/samples/client/petstore/python-experimental/docs/PetApi.md
+++ b/samples/client/petstore/python-experimental/docs/PetApi.md
@@ -34,16 +34,18 @@ configuration.access_token = 'YOUR_ACCESS_TOKEN'
 
 # Defining host is optional and default to http://petstore.swagger.io:80/v2
 configuration.host = "http://petstore.swagger.io:80/v2"
-# Create an instance of the API class
-api_instance = petstore_api.PetApi(petstore_api.ApiClient(configuration))
-body = petstore_api.Pet() # pet.Pet | Pet object that needs to be added to the store
-
-# example passing only required values which don't have defaults set
-try:
-    # Add a new pet to the store
-    api_instance.add_pet(body)
-except petstore_api.ApiException as e:
-    print("Exception when calling PetApi->add_pet: %s\n" % e)
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.PetApi(api_client)
+    body = petstore_api.Pet() # pet.Pet | Pet object that needs to be added to the store
+    
+    # example passing only required values which don't have defaults set
+    try:
+        # Add a new pet to the store
+        api_instance.add_pet(body)
+    except petstore_api.ApiException as e:
+        print("Exception when calling PetApi->add_pet: %s\n" % e)
 ```
 
 ### Parameters
@@ -92,25 +94,27 @@ configuration.access_token = 'YOUR_ACCESS_TOKEN'
 
 # Defining host is optional and default to http://petstore.swagger.io:80/v2
 configuration.host = "http://petstore.swagger.io:80/v2"
-# Create an instance of the API class
-api_instance = petstore_api.PetApi(petstore_api.ApiClient(configuration))
-pet_id = 56 # int | Pet id to delete
-api_key = 'api_key_example' # str |  (optional)
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.PetApi(api_client)
+    pet_id = 56 # int | Pet id to delete
+    api_key = 'api_key_example' # str |  (optional)
 
-# example passing only required values which don't have defaults set
-try:
-    # Deletes a pet
-    api_instance.delete_pet(pet_id)
-except petstore_api.ApiException as e:
-    print("Exception when calling PetApi->delete_pet: %s\n" % e)
+    # example passing only required values which don't have defaults set
+    try:
+        # Deletes a pet
+        api_instance.delete_pet(pet_id)
+    except petstore_api.ApiException as e:
+        print("Exception when calling PetApi->delete_pet: %s\n" % e)
 
-# example passing only required values which don't have defaults set
-# and optional values
-try:
-    # Deletes a pet
-    api_instance.delete_pet(pet_id, api_key=api_key)
-except petstore_api.ApiException as e:
-    print("Exception when calling PetApi->delete_pet: %s\n" % e)
+    # example passing only required values which don't have defaults set
+    # and optional values
+    try:
+        # Deletes a pet
+        api_instance.delete_pet(pet_id, api_key=api_key)
+    except petstore_api.ApiException as e:
+        print("Exception when calling PetApi->delete_pet: %s\n" % e)
 ```
 
 ### Parameters
@@ -162,17 +166,19 @@ configuration.access_token = 'YOUR_ACCESS_TOKEN'
 
 # Defining host is optional and default to http://petstore.swagger.io:80/v2
 configuration.host = "http://petstore.swagger.io:80/v2"
-# Create an instance of the API class
-api_instance = petstore_api.PetApi(petstore_api.ApiClient(configuration))
-status = ['status_example'] # [str] | Status values that need to be considered for filter
-
-# example passing only required values which don't have defaults set
-try:
-    # Finds Pets by status
-    api_response = api_instance.find_pets_by_status(status)
-    pprint(api_response)
-except petstore_api.ApiException as e:
-    print("Exception when calling PetApi->find_pets_by_status: %s\n" % e)
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.PetApi(api_client)
+    status = ['status_example'] # [str] | Status values that need to be considered for filter
+    
+    # example passing only required values which don't have defaults set
+    try:
+        # Finds Pets by status
+        api_response = api_instance.find_pets_by_status(status)
+        pprint(api_response)
+    except petstore_api.ApiException as e:
+        print("Exception when calling PetApi->find_pets_by_status: %s\n" % e)
 ```
 
 ### Parameters
@@ -223,17 +229,19 @@ configuration.access_token = 'YOUR_ACCESS_TOKEN'
 
 # Defining host is optional and default to http://petstore.swagger.io:80/v2
 configuration.host = "http://petstore.swagger.io:80/v2"
-# Create an instance of the API class
-api_instance = petstore_api.PetApi(petstore_api.ApiClient(configuration))
-tags = ['tags_example'] # [str] | Tags to filter by
-
-# example passing only required values which don't have defaults set
-try:
-    # Finds Pets by tags
-    api_response = api_instance.find_pets_by_tags(tags)
-    pprint(api_response)
-except petstore_api.ApiException as e:
-    print("Exception when calling PetApi->find_pets_by_tags: %s\n" % e)
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.PetApi(api_client)
+    tags = ['tags_example'] # [str] | Tags to filter by
+    
+    # example passing only required values which don't have defaults set
+    try:
+        # Finds Pets by tags
+        api_response = api_instance.find_pets_by_tags(tags)
+        pprint(api_response)
+    except petstore_api.ApiException as e:
+        print("Exception when calling PetApi->find_pets_by_tags: %s\n" % e)
 ```
 
 ### Parameters
@@ -286,17 +294,19 @@ configuration.api_key['api_key'] = 'YOUR_API_KEY'
 
 # Defining host is optional and default to http://petstore.swagger.io:80/v2
 configuration.host = "http://petstore.swagger.io:80/v2"
-# Create an instance of the API class
-api_instance = petstore_api.PetApi(petstore_api.ApiClient(configuration))
-pet_id = 56 # int | ID of pet to return
-
-# example passing only required values which don't have defaults set
-try:
-    # Find pet by ID
-    api_response = api_instance.get_pet_by_id(pet_id)
-    pprint(api_response)
-except petstore_api.ApiException as e:
-    print("Exception when calling PetApi->get_pet_by_id: %s\n" % e)
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.PetApi(api_client)
+    pet_id = 56 # int | ID of pet to return
+    
+    # example passing only required values which don't have defaults set
+    try:
+        # Find pet by ID
+        api_response = api_instance.get_pet_by_id(pet_id)
+        pprint(api_response)
+    except petstore_api.ApiException as e:
+        print("Exception when calling PetApi->get_pet_by_id: %s\n" % e)
 ```
 
 ### Parameters
@@ -346,16 +356,18 @@ configuration.access_token = 'YOUR_ACCESS_TOKEN'
 
 # Defining host is optional and default to http://petstore.swagger.io:80/v2
 configuration.host = "http://petstore.swagger.io:80/v2"
-# Create an instance of the API class
-api_instance = petstore_api.PetApi(petstore_api.ApiClient(configuration))
-body = petstore_api.Pet() # pet.Pet | Pet object that needs to be added to the store
-
-# example passing only required values which don't have defaults set
-try:
-    # Update an existing pet
-    api_instance.update_pet(body)
-except petstore_api.ApiException as e:
-    print("Exception when calling PetApi->update_pet: %s\n" % e)
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.PetApi(api_client)
+    body = petstore_api.Pet() # pet.Pet | Pet object that needs to be added to the store
+    
+    # example passing only required values which don't have defaults set
+    try:
+        # Update an existing pet
+        api_instance.update_pet(body)
+    except petstore_api.ApiException as e:
+        print("Exception when calling PetApi->update_pet: %s\n" % e)
 ```
 
 ### Parameters
@@ -406,26 +418,28 @@ configuration.access_token = 'YOUR_ACCESS_TOKEN'
 
 # Defining host is optional and default to http://petstore.swagger.io:80/v2
 configuration.host = "http://petstore.swagger.io:80/v2"
-# Create an instance of the API class
-api_instance = petstore_api.PetApi(petstore_api.ApiClient(configuration))
-pet_id = 56 # int | ID of pet that needs to be updated
-name = 'name_example' # str | Updated name of the pet (optional)
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.PetApi(api_client)
+    pet_id = 56 # int | ID of pet that needs to be updated
+    name = 'name_example' # str | Updated name of the pet (optional)
 status = 'status_example' # str | Updated status of the pet (optional)
 
-# example passing only required values which don't have defaults set
-try:
-    # Updates a pet in the store with form data
-    api_instance.update_pet_with_form(pet_id)
-except petstore_api.ApiException as e:
-    print("Exception when calling PetApi->update_pet_with_form: %s\n" % e)
+    # example passing only required values which don't have defaults set
+    try:
+        # Updates a pet in the store with form data
+        api_instance.update_pet_with_form(pet_id)
+    except petstore_api.ApiException as e:
+        print("Exception when calling PetApi->update_pet_with_form: %s\n" % e)
 
-# example passing only required values which don't have defaults set
-# and optional values
-try:
-    # Updates a pet in the store with form data
-    api_instance.update_pet_with_form(pet_id, name=name, status=status)
-except petstore_api.ApiException as e:
-    print("Exception when calling PetApi->update_pet_with_form: %s\n" % e)
+    # example passing only required values which don't have defaults set
+    # and optional values
+    try:
+        # Updates a pet in the store with form data
+        api_instance.update_pet_with_form(pet_id, name=name, status=status)
+    except petstore_api.ApiException as e:
+        print("Exception when calling PetApi->update_pet_with_form: %s\n" % e)
 ```
 
 ### Parameters
@@ -475,29 +489,31 @@ configuration.access_token = 'YOUR_ACCESS_TOKEN'
 
 # Defining host is optional and default to http://petstore.swagger.io:80/v2
 configuration.host = "http://petstore.swagger.io:80/v2"
-# Create an instance of the API class
-api_instance = petstore_api.PetApi(petstore_api.ApiClient(configuration))
-pet_id = 56 # int | ID of pet to update
-additional_metadata = 'additional_metadata_example' # str | Additional data to pass to server (optional)
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.PetApi(api_client)
+    pet_id = 56 # int | ID of pet to update
+    additional_metadata = 'additional_metadata_example' # str | Additional data to pass to server (optional)
 file = open('/path/to/file', 'rb') # file_type | file to upload (optional)
 files = open('/path/to/file', 'rb') # [file_type] | files to upload (optional)
 
-# example passing only required values which don't have defaults set
-try:
-    # uploads an image
-    api_response = api_instance.upload_file(pet_id)
-    pprint(api_response)
-except petstore_api.ApiException as e:
-    print("Exception when calling PetApi->upload_file: %s\n" % e)
+    # example passing only required values which don't have defaults set
+    try:
+        # uploads an image
+        api_response = api_instance.upload_file(pet_id)
+        pprint(api_response)
+    except petstore_api.ApiException as e:
+        print("Exception when calling PetApi->upload_file: %s\n" % e)
 
-# example passing only required values which don't have defaults set
-# and optional values
-try:
-    # uploads an image
-    api_response = api_instance.upload_file(pet_id, additional_metadata=additional_metadata, file=file, files=files)
-    pprint(api_response)
-except petstore_api.ApiException as e:
-    print("Exception when calling PetApi->upload_file: %s\n" % e)
+    # example passing only required values which don't have defaults set
+    # and optional values
+    try:
+        # uploads an image
+        api_response = api_instance.upload_file(pet_id, additional_metadata=additional_metadata, file=file, files=files)
+        pprint(api_response)
+    except petstore_api.ApiException as e:
+        print("Exception when calling PetApi->upload_file: %s\n" % e)
 ```
 
 ### Parameters
@@ -548,28 +564,30 @@ configuration.access_token = 'YOUR_ACCESS_TOKEN'
 
 # Defining host is optional and default to http://petstore.swagger.io:80/v2
 configuration.host = "http://petstore.swagger.io:80/v2"
-# Create an instance of the API class
-api_instance = petstore_api.PetApi(petstore_api.ApiClient(configuration))
-pet_id = 56 # int | ID of pet to update
-required_file = open('/path/to/file', 'rb') # file_type | file to upload
-additional_metadata = 'additional_metadata_example' # str | Additional data to pass to server (optional)
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.PetApi(api_client)
+    pet_id = 56 # int | ID of pet to update
+    required_file = open('/path/to/file', 'rb') # file_type | file to upload
+    additional_metadata = 'additional_metadata_example' # str | Additional data to pass to server (optional)
 
-# example passing only required values which don't have defaults set
-try:
-    # uploads an image (required)
-    api_response = api_instance.upload_file_with_required_file(pet_id, required_file)
-    pprint(api_response)
-except petstore_api.ApiException as e:
-    print("Exception when calling PetApi->upload_file_with_required_file: %s\n" % e)
+    # example passing only required values which don't have defaults set
+    try:
+        # uploads an image (required)
+        api_response = api_instance.upload_file_with_required_file(pet_id, required_file)
+        pprint(api_response)
+    except petstore_api.ApiException as e:
+        print("Exception when calling PetApi->upload_file_with_required_file: %s\n" % e)
 
-# example passing only required values which don't have defaults set
-# and optional values
-try:
-    # uploads an image (required)
-    api_response = api_instance.upload_file_with_required_file(pet_id, required_file, additional_metadata=additional_metadata)
-    pprint(api_response)
-except petstore_api.ApiException as e:
-    print("Exception when calling PetApi->upload_file_with_required_file: %s\n" % e)
+    # example passing only required values which don't have defaults set
+    # and optional values
+    try:
+        # uploads an image (required)
+        api_response = api_instance.upload_file_with_required_file(pet_id, required_file, additional_metadata=additional_metadata)
+        pprint(api_response)
+    except petstore_api.ApiException as e:
+        print("Exception when calling PetApi->upload_file_with_required_file: %s\n" % e)
 ```
 
 ### Parameters

--- a/samples/client/petstore/python-experimental/docs/StoreApi.md
+++ b/samples/client/petstore/python-experimental/docs/StoreApi.md
@@ -25,16 +25,18 @@ import time
 import petstore_api
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.StoreApi()
-order_id = 'order_id_example' # str | ID of the order that needs to be deleted
-
-# example passing only required values which don't have defaults set
-try:
-    # Delete purchase order by ID
-    api_instance.delete_order(order_id)
-except petstore_api.ApiException as e:
-    print("Exception when calling StoreApi->delete_order: %s\n" % e)
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.StoreApi(api_client)
+    order_id = 'order_id_example' # str | ID of the order that needs to be deleted
+    
+    # example passing only required values which don't have defaults set
+    try:
+        # Delete purchase order by ID
+        api_instance.delete_order(order_id)
+    except petstore_api.ApiException as e:
+        print("Exception when calling StoreApi->delete_order: %s\n" % e)
 ```
 
 ### Parameters
@@ -87,16 +89,18 @@ configuration.api_key['api_key'] = 'YOUR_API_KEY'
 
 # Defining host is optional and default to http://petstore.swagger.io:80/v2
 configuration.host = "http://petstore.swagger.io:80/v2"
-# Create an instance of the API class
-api_instance = petstore_api.StoreApi(petstore_api.ApiClient(configuration))
-
-# example, this endpoint has no required or optional parameters
-try:
-    # Returns pet inventories by status
-    api_response = api_instance.get_inventory()
-    pprint(api_response)
-except petstore_api.ApiException as e:
-    print("Exception when calling StoreApi->get_inventory: %s\n" % e)
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.StoreApi(api_client)
+    
+    # example, this endpoint has no required or optional parameters
+    try:
+        # Returns pet inventories by status
+        api_response = api_instance.get_inventory()
+        pprint(api_response)
+    except petstore_api.ApiException as e:
+        print("Exception when calling StoreApi->get_inventory: %s\n" % e)
 ```
 
 ### Parameters
@@ -137,17 +141,19 @@ import time
 import petstore_api
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.StoreApi()
-order_id = 56 # int | ID of pet that needs to be fetched
-
-# example passing only required values which don't have defaults set
-try:
-    # Find purchase order by ID
-    api_response = api_instance.get_order_by_id(order_id)
-    pprint(api_response)
-except petstore_api.ApiException as e:
-    print("Exception when calling StoreApi->get_order_by_id: %s\n" % e)
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.StoreApi(api_client)
+    order_id = 56 # int | ID of pet that needs to be fetched
+    
+    # example passing only required values which don't have defaults set
+    try:
+        # Find purchase order by ID
+        api_response = api_instance.get_order_by_id(order_id)
+        pprint(api_response)
+    except petstore_api.ApiException as e:
+        print("Exception when calling StoreApi->get_order_by_id: %s\n" % e)
 ```
 
 ### Parameters
@@ -191,17 +197,19 @@ import time
 import petstore_api
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.StoreApi()
-body = petstore_api.Order() # order.Order | order placed for purchasing the pet
-
-# example passing only required values which don't have defaults set
-try:
-    # Place an order for a pet
-    api_response = api_instance.place_order(body)
-    pprint(api_response)
-except petstore_api.ApiException as e:
-    print("Exception when calling StoreApi->place_order: %s\n" % e)
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.StoreApi(api_client)
+    body = petstore_api.Order() # order.Order | order placed for purchasing the pet
+    
+    # example passing only required values which don't have defaults set
+    try:
+        # Place an order for a pet
+        api_response = api_instance.place_order(body)
+        pprint(api_response)
+    except petstore_api.ApiException as e:
+        print("Exception when calling StoreApi->place_order: %s\n" % e)
 ```
 
 ### Parameters

--- a/samples/client/petstore/python-experimental/docs/UserApi.md
+++ b/samples/client/petstore/python-experimental/docs/UserApi.md
@@ -29,16 +29,18 @@ import time
 import petstore_api
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.UserApi()
-body = petstore_api.User() # user.User | Created user object
-
-# example passing only required values which don't have defaults set
-try:
-    # Create user
-    api_instance.create_user(body)
-except petstore_api.ApiException as e:
-    print("Exception when calling UserApi->create_user: %s\n" % e)
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.UserApi(api_client)
+    body = petstore_api.User() # user.User | Created user object
+    
+    # example passing only required values which don't have defaults set
+    try:
+        # Create user
+        api_instance.create_user(body)
+    except petstore_api.ApiException as e:
+        print("Exception when calling UserApi->create_user: %s\n" % e)
 ```
 
 ### Parameters
@@ -80,16 +82,18 @@ import time
 import petstore_api
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.UserApi()
-body = [petstore_api.User()] # [user.User] | List of user object
-
-# example passing only required values which don't have defaults set
-try:
-    # Creates list of users with given input array
-    api_instance.create_users_with_array_input(body)
-except petstore_api.ApiException as e:
-    print("Exception when calling UserApi->create_users_with_array_input: %s\n" % e)
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.UserApi(api_client)
+    body = [petstore_api.User()] # [user.User] | List of user object
+    
+    # example passing only required values which don't have defaults set
+    try:
+        # Creates list of users with given input array
+        api_instance.create_users_with_array_input(body)
+    except petstore_api.ApiException as e:
+        print("Exception when calling UserApi->create_users_with_array_input: %s\n" % e)
 ```
 
 ### Parameters
@@ -131,16 +135,18 @@ import time
 import petstore_api
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.UserApi()
-body = [petstore_api.User()] # [user.User] | List of user object
-
-# example passing only required values which don't have defaults set
-try:
-    # Creates list of users with given input array
-    api_instance.create_users_with_list_input(body)
-except petstore_api.ApiException as e:
-    print("Exception when calling UserApi->create_users_with_list_input: %s\n" % e)
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.UserApi(api_client)
+    body = [petstore_api.User()] # [user.User] | List of user object
+    
+    # example passing only required values which don't have defaults set
+    try:
+        # Creates list of users with given input array
+        api_instance.create_users_with_list_input(body)
+    except petstore_api.ApiException as e:
+        print("Exception when calling UserApi->create_users_with_list_input: %s\n" % e)
 ```
 
 ### Parameters
@@ -184,16 +190,18 @@ import time
 import petstore_api
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.UserApi()
-username = 'username_example' # str | The name that needs to be deleted
-
-# example passing only required values which don't have defaults set
-try:
-    # Delete user
-    api_instance.delete_user(username)
-except petstore_api.ApiException as e:
-    print("Exception when calling UserApi->delete_user: %s\n" % e)
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.UserApi(api_client)
+    username = 'username_example' # str | The name that needs to be deleted
+    
+    # example passing only required values which don't have defaults set
+    try:
+        # Delete user
+        api_instance.delete_user(username)
+    except petstore_api.ApiException as e:
+        print("Exception when calling UserApi->delete_user: %s\n" % e)
 ```
 
 ### Parameters
@@ -236,17 +244,19 @@ import time
 import petstore_api
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.UserApi()
-username = 'username_example' # str | The name that needs to be fetched. Use user1 for testing.
-
-# example passing only required values which don't have defaults set
-try:
-    # Get user by user name
-    api_response = api_instance.get_user_by_name(username)
-    pprint(api_response)
-except petstore_api.ApiException as e:
-    print("Exception when calling UserApi->get_user_by_name: %s\n" % e)
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.UserApi(api_client)
+    username = 'username_example' # str | The name that needs to be fetched. Use user1 for testing.
+    
+    # example passing only required values which don't have defaults set
+    try:
+        # Get user by user name
+        api_response = api_instance.get_user_by_name(username)
+        pprint(api_response)
+    except petstore_api.ApiException as e:
+        print("Exception when calling UserApi->get_user_by_name: %s\n" % e)
 ```
 
 ### Parameters
@@ -290,18 +300,20 @@ import time
 import petstore_api
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.UserApi()
-username = 'username_example' # str | The user name for login
-password = 'password_example' # str | The password for login in clear text
-
-# example passing only required values which don't have defaults set
-try:
-    # Logs user into the system
-    api_response = api_instance.login_user(username, password)
-    pprint(api_response)
-except petstore_api.ApiException as e:
-    print("Exception when calling UserApi->login_user: %s\n" % e)
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.UserApi(api_client)
+    username = 'username_example' # str | The user name for login
+    password = 'password_example' # str | The password for login in clear text
+    
+    # example passing only required values which don't have defaults set
+    try:
+        # Logs user into the system
+        api_response = api_instance.login_user(username, password)
+        pprint(api_response)
+    except petstore_api.ApiException as e:
+        print("Exception when calling UserApi->login_user: %s\n" % e)
 ```
 
 ### Parameters
@@ -345,15 +357,17 @@ import time
 import petstore_api
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.UserApi()
-
-# example, this endpoint has no required or optional parameters
-try:
-    # Logs out current logged in user session
-    api_instance.logout_user()
-except petstore_api.ApiException as e:
-    print("Exception when calling UserApi->logout_user: %s\n" % e)
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.UserApi(api_client)
+    
+    # example, this endpoint has no required or optional parameters
+    try:
+        # Logs out current logged in user session
+        api_instance.logout_user()
+    except petstore_api.ApiException as e:
+        print("Exception when calling UserApi->logout_user: %s\n" % e)
 ```
 
 ### Parameters
@@ -394,17 +408,19 @@ import time
 import petstore_api
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.UserApi()
-username = 'username_example' # str | name that need to be deleted
-body = petstore_api.User() # user.User | Updated user object
-
-# example passing only required values which don't have defaults set
-try:
-    # Updated user
-    api_instance.update_user(username, body)
-except petstore_api.ApiException as e:
-    print("Exception when calling UserApi->update_user: %s\n" % e)
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.UserApi(api_client)
+    username = 'username_example' # str | name that need to be deleted
+    body = petstore_api.User() # user.User | Updated user object
+    
+    # example passing only required values which don't have defaults set
+    try:
+        # Updated user
+        api_instance.update_user(username, body)
+    except petstore_api.ApiException as e:
+        print("Exception when calling UserApi->update_user: %s\n" % e)
 ```
 
 ### Parameters

--- a/samples/client/petstore/python-experimental/petstore_api/api_client.py
+++ b/samples/client/petstore/python-experimental/petstore_api/api_client.py
@@ -11,6 +11,7 @@
 from __future__ import absolute_import
 
 import json
+import atexit
 import mimetypes
 from multiprocessing.pool import ThreadPool
 import os
@@ -79,11 +80,19 @@ class ApiClient(object):
         # Set default User-Agent.
         self.user_agent = 'OpenAPI-Generator/1.0.0/python'
 
-    def __del__(self):
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.close()
+
+    def close(self):
         if self._pool:
             self._pool.close()
             self._pool.join()
             self._pool = None
+            if hasattr(atexit, 'unregister'):
+                atexit.unregister(self.close)
 
     @property
     def pool(self):
@@ -91,6 +100,7 @@ class ApiClient(object):
          avoids instantiating unused threadpool for blocking clients.
         """
         if self._pool is None:
+            atexit.register(self.close)
             self._pool = ThreadPool(self.pool_threads)
         return self._pool
 

--- a/samples/client/petstore/python-tornado/README.md
+++ b/samples/client/petstore/python-tornado/README.md
@@ -54,17 +54,19 @@ from pprint import pprint
 
 # Defining host is optional and default to http://petstore.swagger.io:80/v2
 configuration.host = "http://petstore.swagger.io:80/v2"
-# Create an instance of the API class
-api_instance = petstore_api.AnotherFakeApi(petstore_api.ApiClient(configuration))
-body = petstore_api.Client() # Client | client model
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.AnotherFakeApi(api_client)
+    body = petstore_api.Client() # Client | client model
 
-try:
-    # To test special tags
-    api_response = api_instance.call_123_test_special_tags(body)
-    pprint(api_response)
-except ApiException as e:
-    print("Exception when calling AnotherFakeApi->call_123_test_special_tags: %s\n" % e)
-
+    try:
+        # To test special tags
+        api_response = api_instance.call_123_test_special_tags(body)
+        pprint(api_response)
+    except ApiException as e:
+        print("Exception when calling AnotherFakeApi->call_123_test_special_tags: %s\n" % e)
+    
 ```
 
 ## Documentation for API Endpoints

--- a/samples/client/petstore/python-tornado/docs/AnotherFakeApi.md
+++ b/samples/client/petstore/python-tornado/docs/AnotherFakeApi.md
@@ -23,16 +23,18 @@ import petstore_api
 from petstore_api.rest import ApiException
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.AnotherFakeApi()
-body = petstore_api.Client() # Client | client model
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient() as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.AnotherFakeApi(api_client)
+    body = petstore_api.Client() # Client | client model
 
-try:
-    # To test special tags
-    api_response = api_instance.call_123_test_special_tags(body)
-    pprint(api_response)
-except ApiException as e:
-    print("Exception when calling AnotherFakeApi->call_123_test_special_tags: %s\n" % e)
+    try:
+        # To test special tags
+        api_response = api_instance.call_123_test_special_tags(body)
+        pprint(api_response)
+    except ApiException as e:
+        print("Exception when calling AnotherFakeApi->call_123_test_special_tags: %s\n" % e)
 ```
 
 ### Parameters

--- a/samples/client/petstore/python-tornado/docs/FakeApi.md
+++ b/samples/client/petstore/python-tornado/docs/FakeApi.md
@@ -36,15 +36,17 @@ import petstore_api
 from petstore_api.rest import ApiException
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.FakeApi()
-xml_item = petstore_api.XmlItem() # XmlItem | XmlItem Body
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient() as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.FakeApi(api_client)
+    xml_item = petstore_api.XmlItem() # XmlItem | XmlItem Body
 
-try:
-    # creates an XmlItem
-    api_instance.create_xml_item(xml_item)
-except ApiException as e:
-    print("Exception when calling FakeApi->create_xml_item: %s\n" % e)
+    try:
+        # creates an XmlItem
+        api_instance.create_xml_item(xml_item)
+    except ApiException as e:
+        print("Exception when calling FakeApi->create_xml_item: %s\n" % e)
 ```
 
 ### Parameters
@@ -89,15 +91,17 @@ import petstore_api
 from petstore_api.rest import ApiException
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.FakeApi()
-body = True # bool | Input boolean as post body (optional)
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient() as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.FakeApi(api_client)
+    body = True # bool | Input boolean as post body (optional)
 
-try:
-    api_response = api_instance.fake_outer_boolean_serialize(body=body)
-    pprint(api_response)
-except ApiException as e:
-    print("Exception when calling FakeApi->fake_outer_boolean_serialize: %s\n" % e)
+    try:
+        api_response = api_instance.fake_outer_boolean_serialize(body=body)
+        pprint(api_response)
+    except ApiException as e:
+        print("Exception when calling FakeApi->fake_outer_boolean_serialize: %s\n" % e)
 ```
 
 ### Parameters
@@ -142,15 +146,17 @@ import petstore_api
 from petstore_api.rest import ApiException
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.FakeApi()
-body = petstore_api.OuterComposite() # OuterComposite | Input composite as post body (optional)
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient() as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.FakeApi(api_client)
+    body = petstore_api.OuterComposite() # OuterComposite | Input composite as post body (optional)
 
-try:
-    api_response = api_instance.fake_outer_composite_serialize(body=body)
-    pprint(api_response)
-except ApiException as e:
-    print("Exception when calling FakeApi->fake_outer_composite_serialize: %s\n" % e)
+    try:
+        api_response = api_instance.fake_outer_composite_serialize(body=body)
+        pprint(api_response)
+    except ApiException as e:
+        print("Exception when calling FakeApi->fake_outer_composite_serialize: %s\n" % e)
 ```
 
 ### Parameters
@@ -195,15 +201,17 @@ import petstore_api
 from petstore_api.rest import ApiException
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.FakeApi()
-body = 3.4 # float | Input number as post body (optional)
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient() as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.FakeApi(api_client)
+    body = 3.4 # float | Input number as post body (optional)
 
-try:
-    api_response = api_instance.fake_outer_number_serialize(body=body)
-    pprint(api_response)
-except ApiException as e:
-    print("Exception when calling FakeApi->fake_outer_number_serialize: %s\n" % e)
+    try:
+        api_response = api_instance.fake_outer_number_serialize(body=body)
+        pprint(api_response)
+    except ApiException as e:
+        print("Exception when calling FakeApi->fake_outer_number_serialize: %s\n" % e)
 ```
 
 ### Parameters
@@ -248,15 +256,17 @@ import petstore_api
 from petstore_api.rest import ApiException
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.FakeApi()
-body = 'body_example' # str | Input string as post body (optional)
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient() as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.FakeApi(api_client)
+    body = 'body_example' # str | Input string as post body (optional)
 
-try:
-    api_response = api_instance.fake_outer_string_serialize(body=body)
-    pprint(api_response)
-except ApiException as e:
-    print("Exception when calling FakeApi->fake_outer_string_serialize: %s\n" % e)
+    try:
+        api_response = api_instance.fake_outer_string_serialize(body=body)
+        pprint(api_response)
+    except ApiException as e:
+        print("Exception when calling FakeApi->fake_outer_string_serialize: %s\n" % e)
 ```
 
 ### Parameters
@@ -301,14 +311,16 @@ import petstore_api
 from petstore_api.rest import ApiException
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.FakeApi()
-body = petstore_api.FileSchemaTestClass() # FileSchemaTestClass | 
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient() as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.FakeApi(api_client)
+    body = petstore_api.FileSchemaTestClass() # FileSchemaTestClass | 
 
-try:
-    api_instance.test_body_with_file_schema(body)
-except ApiException as e:
-    print("Exception when calling FakeApi->test_body_with_file_schema: %s\n" % e)
+    try:
+        api_instance.test_body_with_file_schema(body)
+    except ApiException as e:
+        print("Exception when calling FakeApi->test_body_with_file_schema: %s\n" % e)
 ```
 
 ### Parameters
@@ -351,15 +363,17 @@ import petstore_api
 from petstore_api.rest import ApiException
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.FakeApi()
-query = 'query_example' # str | 
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient() as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.FakeApi(api_client)
+    query = 'query_example' # str | 
 body = petstore_api.User() # User | 
 
-try:
-    api_instance.test_body_with_query_params(query, body)
-except ApiException as e:
-    print("Exception when calling FakeApi->test_body_with_query_params: %s\n" % e)
+    try:
+        api_instance.test_body_with_query_params(query, body)
+    except ApiException as e:
+        print("Exception when calling FakeApi->test_body_with_query_params: %s\n" % e)
 ```
 
 ### Parameters
@@ -405,16 +419,18 @@ import petstore_api
 from petstore_api.rest import ApiException
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.FakeApi()
-body = petstore_api.Client() # Client | client model
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient() as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.FakeApi(api_client)
+    body = petstore_api.Client() # Client | client model
 
-try:
-    # To test \"client\" model
-    api_response = api_instance.test_client_model(body)
-    pprint(api_response)
-except ApiException as e:
-    print("Exception when calling FakeApi->test_client_model: %s\n" % e)
+    try:
+        # To test \"client\" model
+        api_response = api_instance.test_client_model(body)
+        pprint(api_response)
+    except ApiException as e:
+        print("Exception when calling FakeApi->test_client_model: %s\n" % e)
 ```
 
 ### Parameters
@@ -466,9 +482,11 @@ configuration.password = 'YOUR_PASSWORD'
 
 # Defining host is optional and default to http://petstore.swagger.io:80/v2
 configuration.host = "http://petstore.swagger.io:80/v2"
-# Create an instance of the API class
-api_instance = petstore_api.FakeApi(petstore_api.ApiClient(configuration))
-number = 3.4 # float | None
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.FakeApi(api_client)
+    number = 3.4 # float | None
 double = 3.4 # float | None
 pattern_without_delimiter = 'pattern_without_delimiter_example' # str | None
 byte = 'byte_example' # str | None
@@ -483,11 +501,11 @@ date_time = '2013-10-20T19:20:30+01:00' # datetime | None (optional)
 password = 'password_example' # str | None (optional)
 param_callback = 'param_callback_example' # str | None (optional)
 
-try:
-    # Fake endpoint for testing various parameters  假端點  偽のエンドポイント  가짜 엔드 포인트
-    api_instance.test_endpoint_parameters(number, double, pattern_without_delimiter, byte, integer=integer, int32=int32, int64=int64, float=float, string=string, binary=binary, date=date, date_time=date_time, password=password, param_callback=param_callback)
-except ApiException as e:
-    print("Exception when calling FakeApi->test_endpoint_parameters: %s\n" % e)
+    try:
+        # Fake endpoint for testing various parameters  假端點  偽のエンドポイント  가짜 엔드 포인트
+        api_instance.test_endpoint_parameters(number, double, pattern_without_delimiter, byte, integer=integer, int32=int32, int64=int64, float=float, string=string, binary=binary, date=date, date_time=date_time, password=password, param_callback=param_callback)
+    except ApiException as e:
+        print("Exception when calling FakeApi->test_endpoint_parameters: %s\n" % e)
 ```
 
 ### Parameters
@@ -546,9 +564,11 @@ import petstore_api
 from petstore_api.rest import ApiException
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.FakeApi()
-enum_header_string_array = ['enum_header_string_array_example'] # list[str] | Header parameter enum test (string array) (optional)
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient() as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.FakeApi(api_client)
+    enum_header_string_array = ['enum_header_string_array_example'] # list[str] | Header parameter enum test (string array) (optional)
 enum_header_string = '-efg' # str | Header parameter enum test (string) (optional) (default to '-efg')
 enum_query_string_array = ['enum_query_string_array_example'] # list[str] | Query parameter enum test (string array) (optional)
 enum_query_string = '-efg' # str | Query parameter enum test (string) (optional) (default to '-efg')
@@ -557,11 +577,11 @@ enum_query_double = 3.4 # float | Query parameter enum test (double) (optional)
 enum_form_string_array = '$' # list[str] | Form parameter enum test (string array) (optional) (default to '$')
 enum_form_string = '-efg' # str | Form parameter enum test (string) (optional) (default to '-efg')
 
-try:
-    # To test enum parameters
-    api_instance.test_enum_parameters(enum_header_string_array=enum_header_string_array, enum_header_string=enum_header_string, enum_query_string_array=enum_query_string_array, enum_query_string=enum_query_string, enum_query_integer=enum_query_integer, enum_query_double=enum_query_double, enum_form_string_array=enum_form_string_array, enum_form_string=enum_form_string)
-except ApiException as e:
-    print("Exception when calling FakeApi->test_enum_parameters: %s\n" % e)
+    try:
+        # To test enum parameters
+        api_instance.test_enum_parameters(enum_header_string_array=enum_header_string_array, enum_header_string=enum_header_string, enum_query_string_array=enum_query_string_array, enum_query_string=enum_query_string, enum_query_integer=enum_query_integer, enum_query_double=enum_query_double, enum_form_string_array=enum_form_string_array, enum_form_string=enum_form_string)
+    except ApiException as e:
+        print("Exception when calling FakeApi->test_enum_parameters: %s\n" % e)
 ```
 
 ### Parameters
@@ -614,20 +634,22 @@ import petstore_api
 from petstore_api.rest import ApiException
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.FakeApi()
-required_string_group = 56 # int | Required String in group parameters
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient() as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.FakeApi(api_client)
+    required_string_group = 56 # int | Required String in group parameters
 required_boolean_group = True # bool | Required Boolean in group parameters
 required_int64_group = 56 # int | Required Integer in group parameters
 string_group = 56 # int | String in group parameters (optional)
 boolean_group = True # bool | Boolean in group parameters (optional)
 int64_group = 56 # int | Integer in group parameters (optional)
 
-try:
-    # Fake endpoint to test group parameters (optional)
-    api_instance.test_group_parameters(required_string_group, required_boolean_group, required_int64_group, string_group=string_group, boolean_group=boolean_group, int64_group=int64_group)
-except ApiException as e:
-    print("Exception when calling FakeApi->test_group_parameters: %s\n" % e)
+    try:
+        # Fake endpoint to test group parameters (optional)
+        api_instance.test_group_parameters(required_string_group, required_boolean_group, required_int64_group, string_group=string_group, boolean_group=boolean_group, int64_group=int64_group)
+    except ApiException as e:
+        print("Exception when calling FakeApi->test_group_parameters: %s\n" % e)
 ```
 
 ### Parameters
@@ -675,15 +697,17 @@ import petstore_api
 from petstore_api.rest import ApiException
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.FakeApi()
-param = {'key': 'param_example'} # dict(str, str) | request body
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient() as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.FakeApi(api_client)
+    param = {'key': 'param_example'} # dict(str, str) | request body
 
-try:
-    # test inline additionalProperties
-    api_instance.test_inline_additional_properties(param)
-except ApiException as e:
-    print("Exception when calling FakeApi->test_inline_additional_properties: %s\n" % e)
+    try:
+        # test inline additionalProperties
+        api_instance.test_inline_additional_properties(param)
+    except ApiException as e:
+        print("Exception when calling FakeApi->test_inline_additional_properties: %s\n" % e)
 ```
 
 ### Parameters
@@ -726,16 +750,18 @@ import petstore_api
 from petstore_api.rest import ApiException
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.FakeApi()
-param = 'param_example' # str | field1
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient() as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.FakeApi(api_client)
+    param = 'param_example' # str | field1
 param2 = 'param2_example' # str | field2
 
-try:
-    # test json serialization of form data
-    api_instance.test_json_form_data(param, param2)
-except ApiException as e:
-    print("Exception when calling FakeApi->test_json_form_data: %s\n" % e)
+    try:
+        # test json serialization of form data
+        api_instance.test_json_form_data(param, param2)
+    except ApiException as e:
+        print("Exception when calling FakeApi->test_json_form_data: %s\n" % e)
 ```
 
 ### Parameters
@@ -781,18 +807,20 @@ import petstore_api
 from petstore_api.rest import ApiException
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.FakeApi()
-pipe = ['pipe_example'] # list[str] | 
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient() as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.FakeApi(api_client)
+    pipe = ['pipe_example'] # list[str] | 
 ioutil = ['ioutil_example'] # list[str] | 
 http = ['http_example'] # list[str] | 
 url = ['url_example'] # list[str] | 
 context = ['context_example'] # list[str] | 
 
-try:
-    api_instance.test_query_parameter_collection_format(pipe, ioutil, http, url, context)
-except ApiException as e:
-    print("Exception when calling FakeApi->test_query_parameter_collection_format: %s\n" % e)
+    try:
+        api_instance.test_query_parameter_collection_format(pipe, ioutil, http, url, context)
+    except ApiException as e:
+        print("Exception when calling FakeApi->test_query_parameter_collection_format: %s\n" % e)
 ```
 
 ### Parameters

--- a/samples/client/petstore/python-tornado/docs/FakeClassnameTags123Api.md
+++ b/samples/client/petstore/python-tornado/docs/FakeClassnameTags123Api.md
@@ -31,16 +31,18 @@ configuration.api_key['api_key_query'] = 'YOUR_API_KEY'
 
 # Defining host is optional and default to http://petstore.swagger.io:80/v2
 configuration.host = "http://petstore.swagger.io:80/v2"
-# Create an instance of the API class
-api_instance = petstore_api.FakeClassnameTags123Api(petstore_api.ApiClient(configuration))
-body = petstore_api.Client() # Client | client model
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.FakeClassnameTags123Api(api_client)
+    body = petstore_api.Client() # Client | client model
 
-try:
-    # To test class name in snake case
-    api_response = api_instance.test_classname(body)
-    pprint(api_response)
-except ApiException as e:
-    print("Exception when calling FakeClassnameTags123Api->test_classname: %s\n" % e)
+    try:
+        # To test class name in snake case
+        api_response = api_instance.test_classname(body)
+        pprint(api_response)
+    except ApiException as e:
+        print("Exception when calling FakeClassnameTags123Api->test_classname: %s\n" % e)
 ```
 
 ### Parameters

--- a/samples/client/petstore/python-tornado/docs/PetApi.md
+++ b/samples/client/petstore/python-tornado/docs/PetApi.md
@@ -35,15 +35,17 @@ configuration.access_token = 'YOUR_ACCESS_TOKEN'
 
 # Defining host is optional and default to http://petstore.swagger.io:80/v2
 configuration.host = "http://petstore.swagger.io:80/v2"
-# Create an instance of the API class
-api_instance = petstore_api.PetApi(petstore_api.ApiClient(configuration))
-body = petstore_api.Pet() # Pet | Pet object that needs to be added to the store
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.PetApi(api_client)
+    body = petstore_api.Pet() # Pet | Pet object that needs to be added to the store
 
-try:
-    # Add a new pet to the store
-    api_instance.add_pet(body)
-except ApiException as e:
-    print("Exception when calling PetApi->add_pet: %s\n" % e)
+    try:
+        # Add a new pet to the store
+        api_instance.add_pet(body)
+    except ApiException as e:
+        print("Exception when calling PetApi->add_pet: %s\n" % e)
 ```
 
 ### Parameters
@@ -93,16 +95,18 @@ configuration.access_token = 'YOUR_ACCESS_TOKEN'
 
 # Defining host is optional and default to http://petstore.swagger.io:80/v2
 configuration.host = "http://petstore.swagger.io:80/v2"
-# Create an instance of the API class
-api_instance = petstore_api.PetApi(petstore_api.ApiClient(configuration))
-pet_id = 56 # int | Pet id to delete
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.PetApi(api_client)
+    pet_id = 56 # int | Pet id to delete
 api_key = 'api_key_example' # str |  (optional)
 
-try:
-    # Deletes a pet
-    api_instance.delete_pet(pet_id, api_key=api_key)
-except ApiException as e:
-    print("Exception when calling PetApi->delete_pet: %s\n" % e)
+    try:
+        # Deletes a pet
+        api_instance.delete_pet(pet_id, api_key=api_key)
+    except ApiException as e:
+        print("Exception when calling PetApi->delete_pet: %s\n" % e)
 ```
 
 ### Parameters
@@ -155,16 +159,18 @@ configuration.access_token = 'YOUR_ACCESS_TOKEN'
 
 # Defining host is optional and default to http://petstore.swagger.io:80/v2
 configuration.host = "http://petstore.swagger.io:80/v2"
-# Create an instance of the API class
-api_instance = petstore_api.PetApi(petstore_api.ApiClient(configuration))
-status = ['status_example'] # list[str] | Status values that need to be considered for filter
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.PetApi(api_client)
+    status = ['status_example'] # list[str] | Status values that need to be considered for filter
 
-try:
-    # Finds Pets by status
-    api_response = api_instance.find_pets_by_status(status)
-    pprint(api_response)
-except ApiException as e:
-    print("Exception when calling PetApi->find_pets_by_status: %s\n" % e)
+    try:
+        # Finds Pets by status
+        api_response = api_instance.find_pets_by_status(status)
+        pprint(api_response)
+    except ApiException as e:
+        print("Exception when calling PetApi->find_pets_by_status: %s\n" % e)
 ```
 
 ### Parameters
@@ -216,16 +222,18 @@ configuration.access_token = 'YOUR_ACCESS_TOKEN'
 
 # Defining host is optional and default to http://petstore.swagger.io:80/v2
 configuration.host = "http://petstore.swagger.io:80/v2"
-# Create an instance of the API class
-api_instance = petstore_api.PetApi(petstore_api.ApiClient(configuration))
-tags = ['tags_example'] # list[str] | Tags to filter by
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.PetApi(api_client)
+    tags = ['tags_example'] # list[str] | Tags to filter by
 
-try:
-    # Finds Pets by tags
-    api_response = api_instance.find_pets_by_tags(tags)
-    pprint(api_response)
-except ApiException as e:
-    print("Exception when calling PetApi->find_pets_by_tags: %s\n" % e)
+    try:
+        # Finds Pets by tags
+        api_response = api_instance.find_pets_by_tags(tags)
+        pprint(api_response)
+    except ApiException as e:
+        print("Exception when calling PetApi->find_pets_by_tags: %s\n" % e)
 ```
 
 ### Parameters
@@ -279,16 +287,18 @@ configuration.api_key['api_key'] = 'YOUR_API_KEY'
 
 # Defining host is optional and default to http://petstore.swagger.io:80/v2
 configuration.host = "http://petstore.swagger.io:80/v2"
-# Create an instance of the API class
-api_instance = petstore_api.PetApi(petstore_api.ApiClient(configuration))
-pet_id = 56 # int | ID of pet to return
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.PetApi(api_client)
+    pet_id = 56 # int | ID of pet to return
 
-try:
-    # Find pet by ID
-    api_response = api_instance.get_pet_by_id(pet_id)
-    pprint(api_response)
-except ApiException as e:
-    print("Exception when calling PetApi->get_pet_by_id: %s\n" % e)
+    try:
+        # Find pet by ID
+        api_response = api_instance.get_pet_by_id(pet_id)
+        pprint(api_response)
+    except ApiException as e:
+        print("Exception when calling PetApi->get_pet_by_id: %s\n" % e)
 ```
 
 ### Parameters
@@ -339,15 +349,17 @@ configuration.access_token = 'YOUR_ACCESS_TOKEN'
 
 # Defining host is optional and default to http://petstore.swagger.io:80/v2
 configuration.host = "http://petstore.swagger.io:80/v2"
-# Create an instance of the API class
-api_instance = petstore_api.PetApi(petstore_api.ApiClient(configuration))
-body = petstore_api.Pet() # Pet | Pet object that needs to be added to the store
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.PetApi(api_client)
+    body = petstore_api.Pet() # Pet | Pet object that needs to be added to the store
 
-try:
-    # Update an existing pet
-    api_instance.update_pet(body)
-except ApiException as e:
-    print("Exception when calling PetApi->update_pet: %s\n" % e)
+    try:
+        # Update an existing pet
+        api_instance.update_pet(body)
+    except ApiException as e:
+        print("Exception when calling PetApi->update_pet: %s\n" % e)
 ```
 
 ### Parameters
@@ -399,17 +411,19 @@ configuration.access_token = 'YOUR_ACCESS_TOKEN'
 
 # Defining host is optional and default to http://petstore.swagger.io:80/v2
 configuration.host = "http://petstore.swagger.io:80/v2"
-# Create an instance of the API class
-api_instance = petstore_api.PetApi(petstore_api.ApiClient(configuration))
-pet_id = 56 # int | ID of pet that needs to be updated
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.PetApi(api_client)
+    pet_id = 56 # int | ID of pet that needs to be updated
 name = 'name_example' # str | Updated name of the pet (optional)
 status = 'status_example' # str | Updated status of the pet (optional)
 
-try:
-    # Updates a pet in the store with form data
-    api_instance.update_pet_with_form(pet_id, name=name, status=status)
-except ApiException as e:
-    print("Exception when calling PetApi->update_pet_with_form: %s\n" % e)
+    try:
+        # Updates a pet in the store with form data
+        api_instance.update_pet_with_form(pet_id, name=name, status=status)
+    except ApiException as e:
+        print("Exception when calling PetApi->update_pet_with_form: %s\n" % e)
 ```
 
 ### Parameters
@@ -460,18 +474,20 @@ configuration.access_token = 'YOUR_ACCESS_TOKEN'
 
 # Defining host is optional and default to http://petstore.swagger.io:80/v2
 configuration.host = "http://petstore.swagger.io:80/v2"
-# Create an instance of the API class
-api_instance = petstore_api.PetApi(petstore_api.ApiClient(configuration))
-pet_id = 56 # int | ID of pet to update
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.PetApi(api_client)
+    pet_id = 56 # int | ID of pet to update
 additional_metadata = 'additional_metadata_example' # str | Additional data to pass to server (optional)
 file = '/path/to/file' # file | file to upload (optional)
 
-try:
-    # uploads an image
-    api_response = api_instance.upload_file(pet_id, additional_metadata=additional_metadata, file=file)
-    pprint(api_response)
-except ApiException as e:
-    print("Exception when calling PetApi->upload_file: %s\n" % e)
+    try:
+        # uploads an image
+        api_response = api_instance.upload_file(pet_id, additional_metadata=additional_metadata, file=file)
+        pprint(api_response)
+    except ApiException as e:
+        print("Exception when calling PetApi->upload_file: %s\n" % e)
 ```
 
 ### Parameters
@@ -522,18 +538,20 @@ configuration.access_token = 'YOUR_ACCESS_TOKEN'
 
 # Defining host is optional and default to http://petstore.swagger.io:80/v2
 configuration.host = "http://petstore.swagger.io:80/v2"
-# Create an instance of the API class
-api_instance = petstore_api.PetApi(petstore_api.ApiClient(configuration))
-pet_id = 56 # int | ID of pet to update
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.PetApi(api_client)
+    pet_id = 56 # int | ID of pet to update
 required_file = '/path/to/file' # file | file to upload
 additional_metadata = 'additional_metadata_example' # str | Additional data to pass to server (optional)
 
-try:
-    # uploads an image (required)
-    api_response = api_instance.upload_file_with_required_file(pet_id, required_file, additional_metadata=additional_metadata)
-    pprint(api_response)
-except ApiException as e:
-    print("Exception when calling PetApi->upload_file_with_required_file: %s\n" % e)
+    try:
+        # uploads an image (required)
+        api_response = api_instance.upload_file_with_required_file(pet_id, required_file, additional_metadata=additional_metadata)
+        pprint(api_response)
+    except ApiException as e:
+        print("Exception when calling PetApi->upload_file_with_required_file: %s\n" % e)
 ```
 
 ### Parameters

--- a/samples/client/petstore/python-tornado/docs/StoreApi.md
+++ b/samples/client/petstore/python-tornado/docs/StoreApi.md
@@ -26,15 +26,17 @@ import petstore_api
 from petstore_api.rest import ApiException
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.StoreApi()
-order_id = 'order_id_example' # str | ID of the order that needs to be deleted
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient() as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.StoreApi(api_client)
+    order_id = 'order_id_example' # str | ID of the order that needs to be deleted
 
-try:
-    # Delete purchase order by ID
-    api_instance.delete_order(order_id)
-except ApiException as e:
-    print("Exception when calling StoreApi->delete_order: %s\n" % e)
+    try:
+        # Delete purchase order by ID
+        api_instance.delete_order(order_id)
+    except ApiException as e:
+        print("Exception when calling StoreApi->delete_order: %s\n" % e)
 ```
 
 ### Parameters
@@ -88,15 +90,17 @@ configuration.api_key['api_key'] = 'YOUR_API_KEY'
 
 # Defining host is optional and default to http://petstore.swagger.io:80/v2
 configuration.host = "http://petstore.swagger.io:80/v2"
-# Create an instance of the API class
-api_instance = petstore_api.StoreApi(petstore_api.ApiClient(configuration))
-
-try:
-    # Returns pet inventories by status
-    api_response = api_instance.get_inventory()
-    pprint(api_response)
-except ApiException as e:
-    print("Exception when calling StoreApi->get_inventory: %s\n" % e)
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.StoreApi(api_client)
+    
+    try:
+        # Returns pet inventories by status
+        api_response = api_instance.get_inventory()
+        pprint(api_response)
+    except ApiException as e:
+        print("Exception when calling StoreApi->get_inventory: %s\n" % e)
 ```
 
 ### Parameters
@@ -138,16 +142,18 @@ import petstore_api
 from petstore_api.rest import ApiException
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.StoreApi()
-order_id = 56 # int | ID of pet that needs to be fetched
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient() as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.StoreApi(api_client)
+    order_id = 56 # int | ID of pet that needs to be fetched
 
-try:
-    # Find purchase order by ID
-    api_response = api_instance.get_order_by_id(order_id)
-    pprint(api_response)
-except ApiException as e:
-    print("Exception when calling StoreApi->get_order_by_id: %s\n" % e)
+    try:
+        # Find purchase order by ID
+        api_response = api_instance.get_order_by_id(order_id)
+        pprint(api_response)
+    except ApiException as e:
+        print("Exception when calling StoreApi->get_order_by_id: %s\n" % e)
 ```
 
 ### Parameters
@@ -192,16 +198,18 @@ import petstore_api
 from petstore_api.rest import ApiException
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.StoreApi()
-body = petstore_api.Order() # Order | order placed for purchasing the pet
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient() as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.StoreApi(api_client)
+    body = petstore_api.Order() # Order | order placed for purchasing the pet
 
-try:
-    # Place an order for a pet
-    api_response = api_instance.place_order(body)
-    pprint(api_response)
-except ApiException as e:
-    print("Exception when calling StoreApi->place_order: %s\n" % e)
+    try:
+        # Place an order for a pet
+        api_response = api_instance.place_order(body)
+        pprint(api_response)
+    except ApiException as e:
+        print("Exception when calling StoreApi->place_order: %s\n" % e)
 ```
 
 ### Parameters

--- a/samples/client/petstore/python-tornado/docs/UserApi.md
+++ b/samples/client/petstore/python-tornado/docs/UserApi.md
@@ -30,15 +30,17 @@ import petstore_api
 from petstore_api.rest import ApiException
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.UserApi()
-body = petstore_api.User() # User | Created user object
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient() as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.UserApi(api_client)
+    body = petstore_api.User() # User | Created user object
 
-try:
-    # Create user
-    api_instance.create_user(body)
-except ApiException as e:
-    print("Exception when calling UserApi->create_user: %s\n" % e)
+    try:
+        # Create user
+        api_instance.create_user(body)
+    except ApiException as e:
+        print("Exception when calling UserApi->create_user: %s\n" % e)
 ```
 
 ### Parameters
@@ -81,15 +83,17 @@ import petstore_api
 from petstore_api.rest import ApiException
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.UserApi()
-body = [petstore_api.User()] # list[User] | List of user object
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient() as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.UserApi(api_client)
+    body = [petstore_api.User()] # list[User] | List of user object
 
-try:
-    # Creates list of users with given input array
-    api_instance.create_users_with_array_input(body)
-except ApiException as e:
-    print("Exception when calling UserApi->create_users_with_array_input: %s\n" % e)
+    try:
+        # Creates list of users with given input array
+        api_instance.create_users_with_array_input(body)
+    except ApiException as e:
+        print("Exception when calling UserApi->create_users_with_array_input: %s\n" % e)
 ```
 
 ### Parameters
@@ -132,15 +136,17 @@ import petstore_api
 from petstore_api.rest import ApiException
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.UserApi()
-body = [petstore_api.User()] # list[User] | List of user object
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient() as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.UserApi(api_client)
+    body = [petstore_api.User()] # list[User] | List of user object
 
-try:
-    # Creates list of users with given input array
-    api_instance.create_users_with_list_input(body)
-except ApiException as e:
-    print("Exception when calling UserApi->create_users_with_list_input: %s\n" % e)
+    try:
+        # Creates list of users with given input array
+        api_instance.create_users_with_list_input(body)
+    except ApiException as e:
+        print("Exception when calling UserApi->create_users_with_list_input: %s\n" % e)
 ```
 
 ### Parameters
@@ -185,15 +191,17 @@ import petstore_api
 from petstore_api.rest import ApiException
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.UserApi()
-username = 'username_example' # str | The name that needs to be deleted
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient() as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.UserApi(api_client)
+    username = 'username_example' # str | The name that needs to be deleted
 
-try:
-    # Delete user
-    api_instance.delete_user(username)
-except ApiException as e:
-    print("Exception when calling UserApi->delete_user: %s\n" % e)
+    try:
+        # Delete user
+        api_instance.delete_user(username)
+    except ApiException as e:
+        print("Exception when calling UserApi->delete_user: %s\n" % e)
 ```
 
 ### Parameters
@@ -237,16 +245,18 @@ import petstore_api
 from petstore_api.rest import ApiException
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.UserApi()
-username = 'username_example' # str | The name that needs to be fetched. Use user1 for testing.
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient() as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.UserApi(api_client)
+    username = 'username_example' # str | The name that needs to be fetched. Use user1 for testing.
 
-try:
-    # Get user by user name
-    api_response = api_instance.get_user_by_name(username)
-    pprint(api_response)
-except ApiException as e:
-    print("Exception when calling UserApi->get_user_by_name: %s\n" % e)
+    try:
+        # Get user by user name
+        api_response = api_instance.get_user_by_name(username)
+        pprint(api_response)
+    except ApiException as e:
+        print("Exception when calling UserApi->get_user_by_name: %s\n" % e)
 ```
 
 ### Parameters
@@ -291,17 +301,19 @@ import petstore_api
 from petstore_api.rest import ApiException
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.UserApi()
-username = 'username_example' # str | The user name for login
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient() as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.UserApi(api_client)
+    username = 'username_example' # str | The user name for login
 password = 'password_example' # str | The password for login in clear text
 
-try:
-    # Logs user into the system
-    api_response = api_instance.login_user(username, password)
-    pprint(api_response)
-except ApiException as e:
-    print("Exception when calling UserApi->login_user: %s\n" % e)
+    try:
+        # Logs user into the system
+        api_response = api_instance.login_user(username, password)
+        pprint(api_response)
+    except ApiException as e:
+        print("Exception when calling UserApi->login_user: %s\n" % e)
 ```
 
 ### Parameters
@@ -346,14 +358,16 @@ import petstore_api
 from petstore_api.rest import ApiException
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.UserApi()
-
-try:
-    # Logs out current logged in user session
-    api_instance.logout_user()
-except ApiException as e:
-    print("Exception when calling UserApi->logout_user: %s\n" % e)
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient() as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.UserApi(api_client)
+    
+    try:
+        # Logs out current logged in user session
+        api_instance.logout_user()
+    except ApiException as e:
+        print("Exception when calling UserApi->logout_user: %s\n" % e)
 ```
 
 ### Parameters
@@ -395,16 +409,18 @@ import petstore_api
 from petstore_api.rest import ApiException
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.UserApi()
-username = 'username_example' # str | name that need to be deleted
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient() as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.UserApi(api_client)
+    username = 'username_example' # str | name that need to be deleted
 body = petstore_api.User() # User | Updated user object
 
-try:
-    # Updated user
-    api_instance.update_user(username, body)
-except ApiException as e:
-    print("Exception when calling UserApi->update_user: %s\n" % e)
+    try:
+        # Updated user
+        api_instance.update_user(username, body)
+    except ApiException as e:
+        print("Exception when calling UserApi->update_user: %s\n" % e)
 ```
 
 ### Parameters

--- a/samples/client/petstore/python-tornado/petstore_api/api_client.py
+++ b/samples/client/petstore/python-tornado/petstore_api/api_client.py
@@ -10,6 +10,7 @@
 
 from __future__ import absolute_import
 
+import atexit
 import datetime
 from dateutil.parser import parse
 import json
@@ -81,11 +82,19 @@ class ApiClient(object):
         self.user_agent = 'OpenAPI-Generator/1.0.0/python'
         self.client_side_validation = configuration.client_side_validation
 
-    def __del__(self):
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.close()
+
+    def close(self):
         if self._pool:
             self._pool.close()
             self._pool.join()
             self._pool = None
+            if hasattr(atexit, 'unregister'):
+                atexit.unregister(self.close)
 
     @property
     def pool(self):
@@ -93,6 +102,7 @@ class ApiClient(object):
          avoids instantiating unused threadpool for blocking clients.
         """
         if self._pool is None:
+            atexit.register(self.close)
             self._pool = ThreadPool(self.pool_threads)
         return self._pool
 

--- a/samples/client/petstore/python/README.md
+++ b/samples/client/petstore/python/README.md
@@ -54,17 +54,19 @@ from pprint import pprint
 
 # Defining host is optional and default to http://petstore.swagger.io:80/v2
 configuration.host = "http://petstore.swagger.io:80/v2"
-# Create an instance of the API class
-api_instance = petstore_api.AnotherFakeApi(petstore_api.ApiClient(configuration))
-body = petstore_api.Client() # Client | client model
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.AnotherFakeApi(api_client)
+    body = petstore_api.Client() # Client | client model
 
-try:
-    # To test special tags
-    api_response = api_instance.call_123_test_special_tags(body)
-    pprint(api_response)
-except ApiException as e:
-    print("Exception when calling AnotherFakeApi->call_123_test_special_tags: %s\n" % e)
-
+    try:
+        # To test special tags
+        api_response = api_instance.call_123_test_special_tags(body)
+        pprint(api_response)
+    except ApiException as e:
+        print("Exception when calling AnotherFakeApi->call_123_test_special_tags: %s\n" % e)
+    
 ```
 
 ## Documentation for API Endpoints

--- a/samples/client/petstore/python/docs/AnotherFakeApi.md
+++ b/samples/client/petstore/python/docs/AnotherFakeApi.md
@@ -23,16 +23,18 @@ import petstore_api
 from petstore_api.rest import ApiException
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.AnotherFakeApi()
-body = petstore_api.Client() # Client | client model
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient() as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.AnotherFakeApi(api_client)
+    body = petstore_api.Client() # Client | client model
 
-try:
-    # To test special tags
-    api_response = api_instance.call_123_test_special_tags(body)
-    pprint(api_response)
-except ApiException as e:
-    print("Exception when calling AnotherFakeApi->call_123_test_special_tags: %s\n" % e)
+    try:
+        # To test special tags
+        api_response = api_instance.call_123_test_special_tags(body)
+        pprint(api_response)
+    except ApiException as e:
+        print("Exception when calling AnotherFakeApi->call_123_test_special_tags: %s\n" % e)
 ```
 
 ### Parameters

--- a/samples/client/petstore/python/docs/FakeApi.md
+++ b/samples/client/petstore/python/docs/FakeApi.md
@@ -36,15 +36,17 @@ import petstore_api
 from petstore_api.rest import ApiException
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.FakeApi()
-xml_item = petstore_api.XmlItem() # XmlItem | XmlItem Body
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient() as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.FakeApi(api_client)
+    xml_item = petstore_api.XmlItem() # XmlItem | XmlItem Body
 
-try:
-    # creates an XmlItem
-    api_instance.create_xml_item(xml_item)
-except ApiException as e:
-    print("Exception when calling FakeApi->create_xml_item: %s\n" % e)
+    try:
+        # creates an XmlItem
+        api_instance.create_xml_item(xml_item)
+    except ApiException as e:
+        print("Exception when calling FakeApi->create_xml_item: %s\n" % e)
 ```
 
 ### Parameters
@@ -89,15 +91,17 @@ import petstore_api
 from petstore_api.rest import ApiException
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.FakeApi()
-body = True # bool | Input boolean as post body (optional)
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient() as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.FakeApi(api_client)
+    body = True # bool | Input boolean as post body (optional)
 
-try:
-    api_response = api_instance.fake_outer_boolean_serialize(body=body)
-    pprint(api_response)
-except ApiException as e:
-    print("Exception when calling FakeApi->fake_outer_boolean_serialize: %s\n" % e)
+    try:
+        api_response = api_instance.fake_outer_boolean_serialize(body=body)
+        pprint(api_response)
+    except ApiException as e:
+        print("Exception when calling FakeApi->fake_outer_boolean_serialize: %s\n" % e)
 ```
 
 ### Parameters
@@ -142,15 +146,17 @@ import petstore_api
 from petstore_api.rest import ApiException
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.FakeApi()
-body = petstore_api.OuterComposite() # OuterComposite | Input composite as post body (optional)
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient() as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.FakeApi(api_client)
+    body = petstore_api.OuterComposite() # OuterComposite | Input composite as post body (optional)
 
-try:
-    api_response = api_instance.fake_outer_composite_serialize(body=body)
-    pprint(api_response)
-except ApiException as e:
-    print("Exception when calling FakeApi->fake_outer_composite_serialize: %s\n" % e)
+    try:
+        api_response = api_instance.fake_outer_composite_serialize(body=body)
+        pprint(api_response)
+    except ApiException as e:
+        print("Exception when calling FakeApi->fake_outer_composite_serialize: %s\n" % e)
 ```
 
 ### Parameters
@@ -195,15 +201,17 @@ import petstore_api
 from petstore_api.rest import ApiException
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.FakeApi()
-body = 3.4 # float | Input number as post body (optional)
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient() as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.FakeApi(api_client)
+    body = 3.4 # float | Input number as post body (optional)
 
-try:
-    api_response = api_instance.fake_outer_number_serialize(body=body)
-    pprint(api_response)
-except ApiException as e:
-    print("Exception when calling FakeApi->fake_outer_number_serialize: %s\n" % e)
+    try:
+        api_response = api_instance.fake_outer_number_serialize(body=body)
+        pprint(api_response)
+    except ApiException as e:
+        print("Exception when calling FakeApi->fake_outer_number_serialize: %s\n" % e)
 ```
 
 ### Parameters
@@ -248,15 +256,17 @@ import petstore_api
 from petstore_api.rest import ApiException
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.FakeApi()
-body = 'body_example' # str | Input string as post body (optional)
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient() as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.FakeApi(api_client)
+    body = 'body_example' # str | Input string as post body (optional)
 
-try:
-    api_response = api_instance.fake_outer_string_serialize(body=body)
-    pprint(api_response)
-except ApiException as e:
-    print("Exception when calling FakeApi->fake_outer_string_serialize: %s\n" % e)
+    try:
+        api_response = api_instance.fake_outer_string_serialize(body=body)
+        pprint(api_response)
+    except ApiException as e:
+        print("Exception when calling FakeApi->fake_outer_string_serialize: %s\n" % e)
 ```
 
 ### Parameters
@@ -301,14 +311,16 @@ import petstore_api
 from petstore_api.rest import ApiException
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.FakeApi()
-body = petstore_api.FileSchemaTestClass() # FileSchemaTestClass | 
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient() as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.FakeApi(api_client)
+    body = petstore_api.FileSchemaTestClass() # FileSchemaTestClass | 
 
-try:
-    api_instance.test_body_with_file_schema(body)
-except ApiException as e:
-    print("Exception when calling FakeApi->test_body_with_file_schema: %s\n" % e)
+    try:
+        api_instance.test_body_with_file_schema(body)
+    except ApiException as e:
+        print("Exception when calling FakeApi->test_body_with_file_schema: %s\n" % e)
 ```
 
 ### Parameters
@@ -351,15 +363,17 @@ import petstore_api
 from petstore_api.rest import ApiException
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.FakeApi()
-query = 'query_example' # str | 
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient() as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.FakeApi(api_client)
+    query = 'query_example' # str | 
 body = petstore_api.User() # User | 
 
-try:
-    api_instance.test_body_with_query_params(query, body)
-except ApiException as e:
-    print("Exception when calling FakeApi->test_body_with_query_params: %s\n" % e)
+    try:
+        api_instance.test_body_with_query_params(query, body)
+    except ApiException as e:
+        print("Exception when calling FakeApi->test_body_with_query_params: %s\n" % e)
 ```
 
 ### Parameters
@@ -405,16 +419,18 @@ import petstore_api
 from petstore_api.rest import ApiException
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.FakeApi()
-body = petstore_api.Client() # Client | client model
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient() as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.FakeApi(api_client)
+    body = petstore_api.Client() # Client | client model
 
-try:
-    # To test \"client\" model
-    api_response = api_instance.test_client_model(body)
-    pprint(api_response)
-except ApiException as e:
-    print("Exception when calling FakeApi->test_client_model: %s\n" % e)
+    try:
+        # To test \"client\" model
+        api_response = api_instance.test_client_model(body)
+        pprint(api_response)
+    except ApiException as e:
+        print("Exception when calling FakeApi->test_client_model: %s\n" % e)
 ```
 
 ### Parameters
@@ -466,9 +482,11 @@ configuration.password = 'YOUR_PASSWORD'
 
 # Defining host is optional and default to http://petstore.swagger.io:80/v2
 configuration.host = "http://petstore.swagger.io:80/v2"
-# Create an instance of the API class
-api_instance = petstore_api.FakeApi(petstore_api.ApiClient(configuration))
-number = 3.4 # float | None
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.FakeApi(api_client)
+    number = 3.4 # float | None
 double = 3.4 # float | None
 pattern_without_delimiter = 'pattern_without_delimiter_example' # str | None
 byte = 'byte_example' # str | None
@@ -483,11 +501,11 @@ date_time = '2013-10-20T19:20:30+01:00' # datetime | None (optional)
 password = 'password_example' # str | None (optional)
 param_callback = 'param_callback_example' # str | None (optional)
 
-try:
-    # Fake endpoint for testing various parameters  假端點  偽のエンドポイント  가짜 엔드 포인트
-    api_instance.test_endpoint_parameters(number, double, pattern_without_delimiter, byte, integer=integer, int32=int32, int64=int64, float=float, string=string, binary=binary, date=date, date_time=date_time, password=password, param_callback=param_callback)
-except ApiException as e:
-    print("Exception when calling FakeApi->test_endpoint_parameters: %s\n" % e)
+    try:
+        # Fake endpoint for testing various parameters  假端點  偽のエンドポイント  가짜 엔드 포인트
+        api_instance.test_endpoint_parameters(number, double, pattern_without_delimiter, byte, integer=integer, int32=int32, int64=int64, float=float, string=string, binary=binary, date=date, date_time=date_time, password=password, param_callback=param_callback)
+    except ApiException as e:
+        print("Exception when calling FakeApi->test_endpoint_parameters: %s\n" % e)
 ```
 
 ### Parameters
@@ -546,9 +564,11 @@ import petstore_api
 from petstore_api.rest import ApiException
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.FakeApi()
-enum_header_string_array = ['enum_header_string_array_example'] # list[str] | Header parameter enum test (string array) (optional)
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient() as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.FakeApi(api_client)
+    enum_header_string_array = ['enum_header_string_array_example'] # list[str] | Header parameter enum test (string array) (optional)
 enum_header_string = '-efg' # str | Header parameter enum test (string) (optional) (default to '-efg')
 enum_query_string_array = ['enum_query_string_array_example'] # list[str] | Query parameter enum test (string array) (optional)
 enum_query_string = '-efg' # str | Query parameter enum test (string) (optional) (default to '-efg')
@@ -557,11 +577,11 @@ enum_query_double = 3.4 # float | Query parameter enum test (double) (optional)
 enum_form_string_array = '$' # list[str] | Form parameter enum test (string array) (optional) (default to '$')
 enum_form_string = '-efg' # str | Form parameter enum test (string) (optional) (default to '-efg')
 
-try:
-    # To test enum parameters
-    api_instance.test_enum_parameters(enum_header_string_array=enum_header_string_array, enum_header_string=enum_header_string, enum_query_string_array=enum_query_string_array, enum_query_string=enum_query_string, enum_query_integer=enum_query_integer, enum_query_double=enum_query_double, enum_form_string_array=enum_form_string_array, enum_form_string=enum_form_string)
-except ApiException as e:
-    print("Exception when calling FakeApi->test_enum_parameters: %s\n" % e)
+    try:
+        # To test enum parameters
+        api_instance.test_enum_parameters(enum_header_string_array=enum_header_string_array, enum_header_string=enum_header_string, enum_query_string_array=enum_query_string_array, enum_query_string=enum_query_string, enum_query_integer=enum_query_integer, enum_query_double=enum_query_double, enum_form_string_array=enum_form_string_array, enum_form_string=enum_form_string)
+    except ApiException as e:
+        print("Exception when calling FakeApi->test_enum_parameters: %s\n" % e)
 ```
 
 ### Parameters
@@ -614,20 +634,22 @@ import petstore_api
 from petstore_api.rest import ApiException
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.FakeApi()
-required_string_group = 56 # int | Required String in group parameters
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient() as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.FakeApi(api_client)
+    required_string_group = 56 # int | Required String in group parameters
 required_boolean_group = True # bool | Required Boolean in group parameters
 required_int64_group = 56 # int | Required Integer in group parameters
 string_group = 56 # int | String in group parameters (optional)
 boolean_group = True # bool | Boolean in group parameters (optional)
 int64_group = 56 # int | Integer in group parameters (optional)
 
-try:
-    # Fake endpoint to test group parameters (optional)
-    api_instance.test_group_parameters(required_string_group, required_boolean_group, required_int64_group, string_group=string_group, boolean_group=boolean_group, int64_group=int64_group)
-except ApiException as e:
-    print("Exception when calling FakeApi->test_group_parameters: %s\n" % e)
+    try:
+        # Fake endpoint to test group parameters (optional)
+        api_instance.test_group_parameters(required_string_group, required_boolean_group, required_int64_group, string_group=string_group, boolean_group=boolean_group, int64_group=int64_group)
+    except ApiException as e:
+        print("Exception when calling FakeApi->test_group_parameters: %s\n" % e)
 ```
 
 ### Parameters
@@ -675,15 +697,17 @@ import petstore_api
 from petstore_api.rest import ApiException
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.FakeApi()
-param = {'key': 'param_example'} # dict(str, str) | request body
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient() as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.FakeApi(api_client)
+    param = {'key': 'param_example'} # dict(str, str) | request body
 
-try:
-    # test inline additionalProperties
-    api_instance.test_inline_additional_properties(param)
-except ApiException as e:
-    print("Exception when calling FakeApi->test_inline_additional_properties: %s\n" % e)
+    try:
+        # test inline additionalProperties
+        api_instance.test_inline_additional_properties(param)
+    except ApiException as e:
+        print("Exception when calling FakeApi->test_inline_additional_properties: %s\n" % e)
 ```
 
 ### Parameters
@@ -726,16 +750,18 @@ import petstore_api
 from petstore_api.rest import ApiException
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.FakeApi()
-param = 'param_example' # str | field1
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient() as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.FakeApi(api_client)
+    param = 'param_example' # str | field1
 param2 = 'param2_example' # str | field2
 
-try:
-    # test json serialization of form data
-    api_instance.test_json_form_data(param, param2)
-except ApiException as e:
-    print("Exception when calling FakeApi->test_json_form_data: %s\n" % e)
+    try:
+        # test json serialization of form data
+        api_instance.test_json_form_data(param, param2)
+    except ApiException as e:
+        print("Exception when calling FakeApi->test_json_form_data: %s\n" % e)
 ```
 
 ### Parameters
@@ -781,18 +807,20 @@ import petstore_api
 from petstore_api.rest import ApiException
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.FakeApi()
-pipe = ['pipe_example'] # list[str] | 
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient() as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.FakeApi(api_client)
+    pipe = ['pipe_example'] # list[str] | 
 ioutil = ['ioutil_example'] # list[str] | 
 http = ['http_example'] # list[str] | 
 url = ['url_example'] # list[str] | 
 context = ['context_example'] # list[str] | 
 
-try:
-    api_instance.test_query_parameter_collection_format(pipe, ioutil, http, url, context)
-except ApiException as e:
-    print("Exception when calling FakeApi->test_query_parameter_collection_format: %s\n" % e)
+    try:
+        api_instance.test_query_parameter_collection_format(pipe, ioutil, http, url, context)
+    except ApiException as e:
+        print("Exception when calling FakeApi->test_query_parameter_collection_format: %s\n" % e)
 ```
 
 ### Parameters

--- a/samples/client/petstore/python/docs/FakeClassnameTags123Api.md
+++ b/samples/client/petstore/python/docs/FakeClassnameTags123Api.md
@@ -31,16 +31,18 @@ configuration.api_key['api_key_query'] = 'YOUR_API_KEY'
 
 # Defining host is optional and default to http://petstore.swagger.io:80/v2
 configuration.host = "http://petstore.swagger.io:80/v2"
-# Create an instance of the API class
-api_instance = petstore_api.FakeClassnameTags123Api(petstore_api.ApiClient(configuration))
-body = petstore_api.Client() # Client | client model
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.FakeClassnameTags123Api(api_client)
+    body = petstore_api.Client() # Client | client model
 
-try:
-    # To test class name in snake case
-    api_response = api_instance.test_classname(body)
-    pprint(api_response)
-except ApiException as e:
-    print("Exception when calling FakeClassnameTags123Api->test_classname: %s\n" % e)
+    try:
+        # To test class name in snake case
+        api_response = api_instance.test_classname(body)
+        pprint(api_response)
+    except ApiException as e:
+        print("Exception when calling FakeClassnameTags123Api->test_classname: %s\n" % e)
 ```
 
 ### Parameters

--- a/samples/client/petstore/python/docs/PetApi.md
+++ b/samples/client/petstore/python/docs/PetApi.md
@@ -35,15 +35,17 @@ configuration.access_token = 'YOUR_ACCESS_TOKEN'
 
 # Defining host is optional and default to http://petstore.swagger.io:80/v2
 configuration.host = "http://petstore.swagger.io:80/v2"
-# Create an instance of the API class
-api_instance = petstore_api.PetApi(petstore_api.ApiClient(configuration))
-body = petstore_api.Pet() # Pet | Pet object that needs to be added to the store
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.PetApi(api_client)
+    body = petstore_api.Pet() # Pet | Pet object that needs to be added to the store
 
-try:
-    # Add a new pet to the store
-    api_instance.add_pet(body)
-except ApiException as e:
-    print("Exception when calling PetApi->add_pet: %s\n" % e)
+    try:
+        # Add a new pet to the store
+        api_instance.add_pet(body)
+    except ApiException as e:
+        print("Exception when calling PetApi->add_pet: %s\n" % e)
 ```
 
 ### Parameters
@@ -93,16 +95,18 @@ configuration.access_token = 'YOUR_ACCESS_TOKEN'
 
 # Defining host is optional and default to http://petstore.swagger.io:80/v2
 configuration.host = "http://petstore.swagger.io:80/v2"
-# Create an instance of the API class
-api_instance = petstore_api.PetApi(petstore_api.ApiClient(configuration))
-pet_id = 56 # int | Pet id to delete
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.PetApi(api_client)
+    pet_id = 56 # int | Pet id to delete
 api_key = 'api_key_example' # str |  (optional)
 
-try:
-    # Deletes a pet
-    api_instance.delete_pet(pet_id, api_key=api_key)
-except ApiException as e:
-    print("Exception when calling PetApi->delete_pet: %s\n" % e)
+    try:
+        # Deletes a pet
+        api_instance.delete_pet(pet_id, api_key=api_key)
+    except ApiException as e:
+        print("Exception when calling PetApi->delete_pet: %s\n" % e)
 ```
 
 ### Parameters
@@ -155,16 +159,18 @@ configuration.access_token = 'YOUR_ACCESS_TOKEN'
 
 # Defining host is optional and default to http://petstore.swagger.io:80/v2
 configuration.host = "http://petstore.swagger.io:80/v2"
-# Create an instance of the API class
-api_instance = petstore_api.PetApi(petstore_api.ApiClient(configuration))
-status = ['status_example'] # list[str] | Status values that need to be considered for filter
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.PetApi(api_client)
+    status = ['status_example'] # list[str] | Status values that need to be considered for filter
 
-try:
-    # Finds Pets by status
-    api_response = api_instance.find_pets_by_status(status)
-    pprint(api_response)
-except ApiException as e:
-    print("Exception when calling PetApi->find_pets_by_status: %s\n" % e)
+    try:
+        # Finds Pets by status
+        api_response = api_instance.find_pets_by_status(status)
+        pprint(api_response)
+    except ApiException as e:
+        print("Exception when calling PetApi->find_pets_by_status: %s\n" % e)
 ```
 
 ### Parameters
@@ -216,16 +222,18 @@ configuration.access_token = 'YOUR_ACCESS_TOKEN'
 
 # Defining host is optional and default to http://petstore.swagger.io:80/v2
 configuration.host = "http://petstore.swagger.io:80/v2"
-# Create an instance of the API class
-api_instance = petstore_api.PetApi(petstore_api.ApiClient(configuration))
-tags = ['tags_example'] # list[str] | Tags to filter by
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.PetApi(api_client)
+    tags = ['tags_example'] # list[str] | Tags to filter by
 
-try:
-    # Finds Pets by tags
-    api_response = api_instance.find_pets_by_tags(tags)
-    pprint(api_response)
-except ApiException as e:
-    print("Exception when calling PetApi->find_pets_by_tags: %s\n" % e)
+    try:
+        # Finds Pets by tags
+        api_response = api_instance.find_pets_by_tags(tags)
+        pprint(api_response)
+    except ApiException as e:
+        print("Exception when calling PetApi->find_pets_by_tags: %s\n" % e)
 ```
 
 ### Parameters
@@ -279,16 +287,18 @@ configuration.api_key['api_key'] = 'YOUR_API_KEY'
 
 # Defining host is optional and default to http://petstore.swagger.io:80/v2
 configuration.host = "http://petstore.swagger.io:80/v2"
-# Create an instance of the API class
-api_instance = petstore_api.PetApi(petstore_api.ApiClient(configuration))
-pet_id = 56 # int | ID of pet to return
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.PetApi(api_client)
+    pet_id = 56 # int | ID of pet to return
 
-try:
-    # Find pet by ID
-    api_response = api_instance.get_pet_by_id(pet_id)
-    pprint(api_response)
-except ApiException as e:
-    print("Exception when calling PetApi->get_pet_by_id: %s\n" % e)
+    try:
+        # Find pet by ID
+        api_response = api_instance.get_pet_by_id(pet_id)
+        pprint(api_response)
+    except ApiException as e:
+        print("Exception when calling PetApi->get_pet_by_id: %s\n" % e)
 ```
 
 ### Parameters
@@ -339,15 +349,17 @@ configuration.access_token = 'YOUR_ACCESS_TOKEN'
 
 # Defining host is optional and default to http://petstore.swagger.io:80/v2
 configuration.host = "http://petstore.swagger.io:80/v2"
-# Create an instance of the API class
-api_instance = petstore_api.PetApi(petstore_api.ApiClient(configuration))
-body = petstore_api.Pet() # Pet | Pet object that needs to be added to the store
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.PetApi(api_client)
+    body = petstore_api.Pet() # Pet | Pet object that needs to be added to the store
 
-try:
-    # Update an existing pet
-    api_instance.update_pet(body)
-except ApiException as e:
-    print("Exception when calling PetApi->update_pet: %s\n" % e)
+    try:
+        # Update an existing pet
+        api_instance.update_pet(body)
+    except ApiException as e:
+        print("Exception when calling PetApi->update_pet: %s\n" % e)
 ```
 
 ### Parameters
@@ -399,17 +411,19 @@ configuration.access_token = 'YOUR_ACCESS_TOKEN'
 
 # Defining host is optional and default to http://petstore.swagger.io:80/v2
 configuration.host = "http://petstore.swagger.io:80/v2"
-# Create an instance of the API class
-api_instance = petstore_api.PetApi(petstore_api.ApiClient(configuration))
-pet_id = 56 # int | ID of pet that needs to be updated
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.PetApi(api_client)
+    pet_id = 56 # int | ID of pet that needs to be updated
 name = 'name_example' # str | Updated name of the pet (optional)
 status = 'status_example' # str | Updated status of the pet (optional)
 
-try:
-    # Updates a pet in the store with form data
-    api_instance.update_pet_with_form(pet_id, name=name, status=status)
-except ApiException as e:
-    print("Exception when calling PetApi->update_pet_with_form: %s\n" % e)
+    try:
+        # Updates a pet in the store with form data
+        api_instance.update_pet_with_form(pet_id, name=name, status=status)
+    except ApiException as e:
+        print("Exception when calling PetApi->update_pet_with_form: %s\n" % e)
 ```
 
 ### Parameters
@@ -460,18 +474,20 @@ configuration.access_token = 'YOUR_ACCESS_TOKEN'
 
 # Defining host is optional and default to http://petstore.swagger.io:80/v2
 configuration.host = "http://petstore.swagger.io:80/v2"
-# Create an instance of the API class
-api_instance = petstore_api.PetApi(petstore_api.ApiClient(configuration))
-pet_id = 56 # int | ID of pet to update
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.PetApi(api_client)
+    pet_id = 56 # int | ID of pet to update
 additional_metadata = 'additional_metadata_example' # str | Additional data to pass to server (optional)
 file = '/path/to/file' # file | file to upload (optional)
 
-try:
-    # uploads an image
-    api_response = api_instance.upload_file(pet_id, additional_metadata=additional_metadata, file=file)
-    pprint(api_response)
-except ApiException as e:
-    print("Exception when calling PetApi->upload_file: %s\n" % e)
+    try:
+        # uploads an image
+        api_response = api_instance.upload_file(pet_id, additional_metadata=additional_metadata, file=file)
+        pprint(api_response)
+    except ApiException as e:
+        print("Exception when calling PetApi->upload_file: %s\n" % e)
 ```
 
 ### Parameters
@@ -522,18 +538,20 @@ configuration.access_token = 'YOUR_ACCESS_TOKEN'
 
 # Defining host is optional and default to http://petstore.swagger.io:80/v2
 configuration.host = "http://petstore.swagger.io:80/v2"
-# Create an instance of the API class
-api_instance = petstore_api.PetApi(petstore_api.ApiClient(configuration))
-pet_id = 56 # int | ID of pet to update
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.PetApi(api_client)
+    pet_id = 56 # int | ID of pet to update
 required_file = '/path/to/file' # file | file to upload
 additional_metadata = 'additional_metadata_example' # str | Additional data to pass to server (optional)
 
-try:
-    # uploads an image (required)
-    api_response = api_instance.upload_file_with_required_file(pet_id, required_file, additional_metadata=additional_metadata)
-    pprint(api_response)
-except ApiException as e:
-    print("Exception when calling PetApi->upload_file_with_required_file: %s\n" % e)
+    try:
+        # uploads an image (required)
+        api_response = api_instance.upload_file_with_required_file(pet_id, required_file, additional_metadata=additional_metadata)
+        pprint(api_response)
+    except ApiException as e:
+        print("Exception when calling PetApi->upload_file_with_required_file: %s\n" % e)
 ```
 
 ### Parameters

--- a/samples/client/petstore/python/docs/StoreApi.md
+++ b/samples/client/petstore/python/docs/StoreApi.md
@@ -26,15 +26,17 @@ import petstore_api
 from petstore_api.rest import ApiException
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.StoreApi()
-order_id = 'order_id_example' # str | ID of the order that needs to be deleted
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient() as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.StoreApi(api_client)
+    order_id = 'order_id_example' # str | ID of the order that needs to be deleted
 
-try:
-    # Delete purchase order by ID
-    api_instance.delete_order(order_id)
-except ApiException as e:
-    print("Exception when calling StoreApi->delete_order: %s\n" % e)
+    try:
+        # Delete purchase order by ID
+        api_instance.delete_order(order_id)
+    except ApiException as e:
+        print("Exception when calling StoreApi->delete_order: %s\n" % e)
 ```
 
 ### Parameters
@@ -88,15 +90,17 @@ configuration.api_key['api_key'] = 'YOUR_API_KEY'
 
 # Defining host is optional and default to http://petstore.swagger.io:80/v2
 configuration.host = "http://petstore.swagger.io:80/v2"
-# Create an instance of the API class
-api_instance = petstore_api.StoreApi(petstore_api.ApiClient(configuration))
-
-try:
-    # Returns pet inventories by status
-    api_response = api_instance.get_inventory()
-    pprint(api_response)
-except ApiException as e:
-    print("Exception when calling StoreApi->get_inventory: %s\n" % e)
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.StoreApi(api_client)
+    
+    try:
+        # Returns pet inventories by status
+        api_response = api_instance.get_inventory()
+        pprint(api_response)
+    except ApiException as e:
+        print("Exception when calling StoreApi->get_inventory: %s\n" % e)
 ```
 
 ### Parameters
@@ -138,16 +142,18 @@ import petstore_api
 from petstore_api.rest import ApiException
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.StoreApi()
-order_id = 56 # int | ID of pet that needs to be fetched
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient() as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.StoreApi(api_client)
+    order_id = 56 # int | ID of pet that needs to be fetched
 
-try:
-    # Find purchase order by ID
-    api_response = api_instance.get_order_by_id(order_id)
-    pprint(api_response)
-except ApiException as e:
-    print("Exception when calling StoreApi->get_order_by_id: %s\n" % e)
+    try:
+        # Find purchase order by ID
+        api_response = api_instance.get_order_by_id(order_id)
+        pprint(api_response)
+    except ApiException as e:
+        print("Exception when calling StoreApi->get_order_by_id: %s\n" % e)
 ```
 
 ### Parameters
@@ -192,16 +198,18 @@ import petstore_api
 from petstore_api.rest import ApiException
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.StoreApi()
-body = petstore_api.Order() # Order | order placed for purchasing the pet
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient() as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.StoreApi(api_client)
+    body = petstore_api.Order() # Order | order placed for purchasing the pet
 
-try:
-    # Place an order for a pet
-    api_response = api_instance.place_order(body)
-    pprint(api_response)
-except ApiException as e:
-    print("Exception when calling StoreApi->place_order: %s\n" % e)
+    try:
+        # Place an order for a pet
+        api_response = api_instance.place_order(body)
+        pprint(api_response)
+    except ApiException as e:
+        print("Exception when calling StoreApi->place_order: %s\n" % e)
 ```
 
 ### Parameters

--- a/samples/client/petstore/python/docs/UserApi.md
+++ b/samples/client/petstore/python/docs/UserApi.md
@@ -30,15 +30,17 @@ import petstore_api
 from petstore_api.rest import ApiException
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.UserApi()
-body = petstore_api.User() # User | Created user object
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient() as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.UserApi(api_client)
+    body = petstore_api.User() # User | Created user object
 
-try:
-    # Create user
-    api_instance.create_user(body)
-except ApiException as e:
-    print("Exception when calling UserApi->create_user: %s\n" % e)
+    try:
+        # Create user
+        api_instance.create_user(body)
+    except ApiException as e:
+        print("Exception when calling UserApi->create_user: %s\n" % e)
 ```
 
 ### Parameters
@@ -81,15 +83,17 @@ import petstore_api
 from petstore_api.rest import ApiException
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.UserApi()
-body = [petstore_api.User()] # list[User] | List of user object
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient() as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.UserApi(api_client)
+    body = [petstore_api.User()] # list[User] | List of user object
 
-try:
-    # Creates list of users with given input array
-    api_instance.create_users_with_array_input(body)
-except ApiException as e:
-    print("Exception when calling UserApi->create_users_with_array_input: %s\n" % e)
+    try:
+        # Creates list of users with given input array
+        api_instance.create_users_with_array_input(body)
+    except ApiException as e:
+        print("Exception when calling UserApi->create_users_with_array_input: %s\n" % e)
 ```
 
 ### Parameters
@@ -132,15 +136,17 @@ import petstore_api
 from petstore_api.rest import ApiException
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.UserApi()
-body = [petstore_api.User()] # list[User] | List of user object
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient() as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.UserApi(api_client)
+    body = [petstore_api.User()] # list[User] | List of user object
 
-try:
-    # Creates list of users with given input array
-    api_instance.create_users_with_list_input(body)
-except ApiException as e:
-    print("Exception when calling UserApi->create_users_with_list_input: %s\n" % e)
+    try:
+        # Creates list of users with given input array
+        api_instance.create_users_with_list_input(body)
+    except ApiException as e:
+        print("Exception when calling UserApi->create_users_with_list_input: %s\n" % e)
 ```
 
 ### Parameters
@@ -185,15 +191,17 @@ import petstore_api
 from petstore_api.rest import ApiException
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.UserApi()
-username = 'username_example' # str | The name that needs to be deleted
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient() as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.UserApi(api_client)
+    username = 'username_example' # str | The name that needs to be deleted
 
-try:
-    # Delete user
-    api_instance.delete_user(username)
-except ApiException as e:
-    print("Exception when calling UserApi->delete_user: %s\n" % e)
+    try:
+        # Delete user
+        api_instance.delete_user(username)
+    except ApiException as e:
+        print("Exception when calling UserApi->delete_user: %s\n" % e)
 ```
 
 ### Parameters
@@ -237,16 +245,18 @@ import petstore_api
 from petstore_api.rest import ApiException
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.UserApi()
-username = 'username_example' # str | The name that needs to be fetched. Use user1 for testing.
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient() as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.UserApi(api_client)
+    username = 'username_example' # str | The name that needs to be fetched. Use user1 for testing.
 
-try:
-    # Get user by user name
-    api_response = api_instance.get_user_by_name(username)
-    pprint(api_response)
-except ApiException as e:
-    print("Exception when calling UserApi->get_user_by_name: %s\n" % e)
+    try:
+        # Get user by user name
+        api_response = api_instance.get_user_by_name(username)
+        pprint(api_response)
+    except ApiException as e:
+        print("Exception when calling UserApi->get_user_by_name: %s\n" % e)
 ```
 
 ### Parameters
@@ -291,17 +301,19 @@ import petstore_api
 from petstore_api.rest import ApiException
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.UserApi()
-username = 'username_example' # str | The user name for login
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient() as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.UserApi(api_client)
+    username = 'username_example' # str | The user name for login
 password = 'password_example' # str | The password for login in clear text
 
-try:
-    # Logs user into the system
-    api_response = api_instance.login_user(username, password)
-    pprint(api_response)
-except ApiException as e:
-    print("Exception when calling UserApi->login_user: %s\n" % e)
+    try:
+        # Logs user into the system
+        api_response = api_instance.login_user(username, password)
+        pprint(api_response)
+    except ApiException as e:
+        print("Exception when calling UserApi->login_user: %s\n" % e)
 ```
 
 ### Parameters
@@ -346,14 +358,16 @@ import petstore_api
 from petstore_api.rest import ApiException
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.UserApi()
-
-try:
-    # Logs out current logged in user session
-    api_instance.logout_user()
-except ApiException as e:
-    print("Exception when calling UserApi->logout_user: %s\n" % e)
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient() as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.UserApi(api_client)
+    
+    try:
+        # Logs out current logged in user session
+        api_instance.logout_user()
+    except ApiException as e:
+        print("Exception when calling UserApi->logout_user: %s\n" % e)
 ```
 
 ### Parameters
@@ -395,16 +409,18 @@ import petstore_api
 from petstore_api.rest import ApiException
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.UserApi()
-username = 'username_example' # str | name that need to be deleted
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient() as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.UserApi(api_client)
+    username = 'username_example' # str | name that need to be deleted
 body = petstore_api.User() # User | Updated user object
 
-try:
-    # Updated user
-    api_instance.update_user(username, body)
-except ApiException as e:
-    print("Exception when calling UserApi->update_user: %s\n" % e)
+    try:
+        # Updated user
+        api_instance.update_user(username, body)
+    except ApiException as e:
+        print("Exception when calling UserApi->update_user: %s\n" % e)
 ```
 
 ### Parameters

--- a/samples/client/petstore/python/petstore_api/api_client.py
+++ b/samples/client/petstore/python/petstore_api/api_client.py
@@ -10,6 +10,7 @@
 
 from __future__ import absolute_import
 
+import atexit
 import datetime
 from dateutil.parser import parse
 import json
@@ -80,11 +81,19 @@ class ApiClient(object):
         self.user_agent = 'OpenAPI-Generator/1.0.0/python'
         self.client_side_validation = configuration.client_side_validation
 
-    def __del__(self):
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.close()
+
+    def close(self):
         if self._pool:
             self._pool.close()
             self._pool.join()
             self._pool = None
+            if hasattr(atexit, 'unregister'):
+                atexit.unregister(self.close)
 
     @property
     def pool(self):
@@ -92,6 +101,7 @@ class ApiClient(object):
          avoids instantiating unused threadpool for blocking clients.
         """
         if self._pool is None:
+            atexit.register(self.close)
             self._pool = ThreadPool(self.pool_threads)
         return self._pool
 

--- a/samples/client/petstore/python/tests/test_api_client.py
+++ b/samples/client/petstore/python/tests/test_api_client.py
@@ -11,6 +11,8 @@ $ nosetests -v
 
 import os
 import time
+import atexit
+import weakref
 import unittest
 from dateutil.parser import parse
 
@@ -169,3 +171,17 @@ class ApiClientTests(unittest.TestCase):
         data = [pet]
         result = self.api_client.sanitize_for_serialization(data)
         self.assertEqual(result, list_of_pet_dict)
+
+    def test_context_manager_closes_threadpool(self):
+        with petstore_api.ApiClient() as client:
+            self.assertIsNotNone(client.pool)
+            pool_ref = weakref.ref(client._pool)
+            self.assertIsNotNone(pool_ref())
+        self.assertIsNone(pool_ref())
+
+    def test_atexit_closes_threadpool(self):
+        client = petstore_api.ApiClient()
+        self.assertIsNotNone(client.pool)
+        self.assertIsNotNone(client._pool)
+        atexit._run_exitfuncs()
+        self.assertIsNone(client._pool)

--- a/samples/openapi3/client/petstore/python-experimental/README.md
+++ b/samples/openapi3/client/petstore/python-experimental/README.md
@@ -53,17 +53,19 @@ from pprint import pprint
 
 # Defining host is optional and default to http://petstore.swagger.io:80/v2
 configuration.host = "http://petstore.swagger.io:80/v2"
-# Create an instance of the API class
-api_instance = petstore_api.AnotherFakeApi(petstore_api.ApiClient(configuration))
-client_client = petstore_api.Client() # client.Client | client model
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.AnotherFakeApi(api_client)
+    client_client = petstore_api.Client() # client.Client | client model
 
-try:
-    # To test special tags
-    api_response = api_instance.call_123_test_special_tags(client_client)
-    pprint(api_response)
-except petstore_api.ApiException as e:
-    print("Exception when calling AnotherFakeApi->call_123_test_special_tags: %s\n" % e)
-
+    try:
+        # To test special tags
+        api_response = api_instance.call_123_test_special_tags(client_client)
+        pprint(api_response)
+    except petstore_api.ApiException as e:
+        print("Exception when calling AnotherFakeApi->call_123_test_special_tags: %s\n" % e)
+    
 ```
 
 ## Documentation for API Endpoints

--- a/samples/openapi3/client/petstore/python-experimental/docs/AnotherFakeApi.md
+++ b/samples/openapi3/client/petstore/python-experimental/docs/AnotherFakeApi.md
@@ -22,17 +22,19 @@ import time
 import petstore_api
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.AnotherFakeApi()
-client_client = petstore_api.Client() # client.Client | client model
-
-# example passing only required values which don't have defaults set
-try:
-    # To test special tags
-    api_response = api_instance.call_123_test_special_tags(client_client)
-    pprint(api_response)
-except petstore_api.ApiException as e:
-    print("Exception when calling AnotherFakeApi->call_123_test_special_tags: %s\n" % e)
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.AnotherFakeApi(api_client)
+    client_client = petstore_api.Client() # client.Client | client model
+    
+    # example passing only required values which don't have defaults set
+    try:
+        # To test special tags
+        api_response = api_instance.call_123_test_special_tags(client_client)
+        pprint(api_response)
+    except petstore_api.ApiException as e:
+        print("Exception when calling AnotherFakeApi->call_123_test_special_tags: %s\n" % e)
 ```
 
 ### Parameters

--- a/samples/openapi3/client/petstore/python-experimental/docs/DefaultApi.md
+++ b/samples/openapi3/client/petstore/python-experimental/docs/DefaultApi.md
@@ -20,15 +20,17 @@ import time
 import petstore_api
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.DefaultApi()
-
-# example, this endpoint has no required or optional parameters
-try:
-    api_response = api_instance.foo_get()
-    pprint(api_response)
-except petstore_api.ApiException as e:
-    print("Exception when calling DefaultApi->foo_get: %s\n" % e)
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.DefaultApi(api_client)
+    
+    # example, this endpoint has no required or optional parameters
+    try:
+        api_response = api_instance.foo_get()
+        pprint(api_response)
+    except petstore_api.ApiException as e:
+        print("Exception when calling DefaultApi->foo_get: %s\n" % e)
 ```
 
 ### Parameters

--- a/samples/openapi3/client/petstore/python-experimental/docs/FakeApi.md
+++ b/samples/openapi3/client/petstore/python-experimental/docs/FakeApi.md
@@ -33,16 +33,18 @@ import time
 import petstore_api
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.FakeApi()
-
-# example, this endpoint has no required or optional parameters
-try:
-    # Health check endpoint
-    api_response = api_instance.fake_health_get()
-    pprint(api_response)
-except petstore_api.ApiException as e:
-    print("Exception when calling FakeApi->fake_health_get: %s\n" % e)
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.FakeApi(api_client)
+    
+    # example, this endpoint has no required or optional parameters
+    try:
+        # Health check endpoint
+        api_response = api_instance.fake_health_get()
+        pprint(api_response)
+    except petstore_api.ApiException as e:
+        print("Exception when calling FakeApi->fake_health_get: %s\n" % e)
 ```
 
 ### Parameters
@@ -83,17 +85,19 @@ import time
 import petstore_api
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.FakeApi()
-body = True # bool | Input boolean as post body (optional)
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.FakeApi(api_client)
+    body = True # bool | Input boolean as post body (optional)
 
-# example passing only required values which don't have defaults set
-# and optional values
-try:
-    api_response = api_instance.fake_outer_boolean_serialize(body=body)
-    pprint(api_response)
-except petstore_api.ApiException as e:
-    print("Exception when calling FakeApi->fake_outer_boolean_serialize: %s\n" % e)
+    # example passing only required values which don't have defaults set
+    # and optional values
+    try:
+        api_response = api_instance.fake_outer_boolean_serialize(body=body)
+        pprint(api_response)
+    except petstore_api.ApiException as e:
+        print("Exception when calling FakeApi->fake_outer_boolean_serialize: %s\n" % e)
 ```
 
 ### Parameters
@@ -137,17 +141,19 @@ import time
 import petstore_api
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.FakeApi()
-outer_composite_outer_composite = petstore_api.OuterComposite() # outer_composite.OuterComposite | Input composite as post body (optional)
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.FakeApi(api_client)
+    outer_composite_outer_composite = petstore_api.OuterComposite() # outer_composite.OuterComposite | Input composite as post body (optional)
 
-# example passing only required values which don't have defaults set
-# and optional values
-try:
-    api_response = api_instance.fake_outer_composite_serialize(outer_composite_outer_composite=outer_composite_outer_composite)
-    pprint(api_response)
-except petstore_api.ApiException as e:
-    print("Exception when calling FakeApi->fake_outer_composite_serialize: %s\n" % e)
+    # example passing only required values which don't have defaults set
+    # and optional values
+    try:
+        api_response = api_instance.fake_outer_composite_serialize(outer_composite_outer_composite=outer_composite_outer_composite)
+        pprint(api_response)
+    except petstore_api.ApiException as e:
+        print("Exception when calling FakeApi->fake_outer_composite_serialize: %s\n" % e)
 ```
 
 ### Parameters
@@ -191,17 +197,19 @@ import time
 import petstore_api
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.FakeApi()
-body = 3.4 # float | Input number as post body (optional)
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.FakeApi(api_client)
+    body = 3.4 # float | Input number as post body (optional)
 
-# example passing only required values which don't have defaults set
-# and optional values
-try:
-    api_response = api_instance.fake_outer_number_serialize(body=body)
-    pprint(api_response)
-except petstore_api.ApiException as e:
-    print("Exception when calling FakeApi->fake_outer_number_serialize: %s\n" % e)
+    # example passing only required values which don't have defaults set
+    # and optional values
+    try:
+        api_response = api_instance.fake_outer_number_serialize(body=body)
+        pprint(api_response)
+    except petstore_api.ApiException as e:
+        print("Exception when calling FakeApi->fake_outer_number_serialize: %s\n" % e)
 ```
 
 ### Parameters
@@ -245,17 +253,19 @@ import time
 import petstore_api
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.FakeApi()
-body = 'body_example' # str | Input string as post body (optional)
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.FakeApi(api_client)
+    body = 'body_example' # str | Input string as post body (optional)
 
-# example passing only required values which don't have defaults set
-# and optional values
-try:
-    api_response = api_instance.fake_outer_string_serialize(body=body)
-    pprint(api_response)
-except petstore_api.ApiException as e:
-    print("Exception when calling FakeApi->fake_outer_string_serialize: %s\n" % e)
+    # example passing only required values which don't have defaults set
+    # and optional values
+    try:
+        api_response = api_instance.fake_outer_string_serialize(body=body)
+        pprint(api_response)
+    except petstore_api.ApiException as e:
+        print("Exception when calling FakeApi->fake_outer_string_serialize: %s\n" % e)
 ```
 
 ### Parameters
@@ -299,15 +309,17 @@ import time
 import petstore_api
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.FakeApi()
-file_schema_test_class_file_schema_test_class = petstore_api.FileSchemaTestClass() # file_schema_test_class.FileSchemaTestClass | 
-
-# example passing only required values which don't have defaults set
-try:
-    api_instance.test_body_with_file_schema(file_schema_test_class_file_schema_test_class)
-except petstore_api.ApiException as e:
-    print("Exception when calling FakeApi->test_body_with_file_schema: %s\n" % e)
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.FakeApi(api_client)
+    file_schema_test_class_file_schema_test_class = petstore_api.FileSchemaTestClass() # file_schema_test_class.FileSchemaTestClass | 
+    
+    # example passing only required values which don't have defaults set
+    try:
+        api_instance.test_body_with_file_schema(file_schema_test_class_file_schema_test_class)
+    except petstore_api.ApiException as e:
+        print("Exception when calling FakeApi->test_body_with_file_schema: %s\n" % e)
 ```
 
 ### Parameters
@@ -349,16 +361,18 @@ import time
 import petstore_api
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.FakeApi()
-query = 'query_example' # str | 
-user_user = petstore_api.User() # user.User | 
-
-# example passing only required values which don't have defaults set
-try:
-    api_instance.test_body_with_query_params(query, user_user)
-except petstore_api.ApiException as e:
-    print("Exception when calling FakeApi->test_body_with_query_params: %s\n" % e)
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.FakeApi(api_client)
+    query = 'query_example' # str | 
+    user_user = petstore_api.User() # user.User | 
+    
+    # example passing only required values which don't have defaults set
+    try:
+        api_instance.test_body_with_query_params(query, user_user)
+    except petstore_api.ApiException as e:
+        print("Exception when calling FakeApi->test_body_with_query_params: %s\n" % e)
 ```
 
 ### Parameters
@@ -403,17 +417,19 @@ import time
 import petstore_api
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.FakeApi()
-client_client = petstore_api.Client() # client.Client | client model
-
-# example passing only required values which don't have defaults set
-try:
-    # To test \"client\" model
-    api_response = api_instance.test_client_model(client_client)
-    pprint(api_response)
-except petstore_api.ApiException as e:
-    print("Exception when calling FakeApi->test_client_model: %s\n" % e)
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.FakeApi(api_client)
+    client_client = petstore_api.Client() # client.Client | client model
+    
+    # example passing only required values which don't have defaults set
+    try:
+        # To test \"client\" model
+        api_response = api_instance.test_client_model(client_client)
+        pprint(api_response)
+    except petstore_api.ApiException as e:
+        print("Exception when calling FakeApi->test_client_model: %s\n" % e)
 ```
 
 ### Parameters
@@ -464,13 +480,15 @@ configuration.password = 'YOUR_PASSWORD'
 
 # Defining host is optional and default to http://petstore.swagger.io:80/v2
 configuration.host = "http://petstore.swagger.io:80/v2"
-# Create an instance of the API class
-api_instance = petstore_api.FakeApi(petstore_api.ApiClient(configuration))
-number = 3.4 # float | None
-double = 3.4 # float | None
-pattern_without_delimiter = 'pattern_without_delimiter_example' # str | None
-byte = 'byte_example' # str | None
-integer = 56 # int | None (optional)
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.FakeApi(api_client)
+    number = 3.4 # float | None
+    double = 3.4 # float | None
+    pattern_without_delimiter = 'pattern_without_delimiter_example' # str | None
+    byte = 'byte_example' # str | None
+    integer = 56 # int | None (optional)
 int32 = 56 # int | None (optional)
 int64 = 56 # int | None (optional)
 float = 3.4 # float | None (optional)
@@ -481,20 +499,20 @@ date_time = '2013-10-20T19:20:30+01:00' # datetime | None (optional)
 password = 'password_example' # str | None (optional)
 param_callback = 'param_callback_example' # str | None (optional)
 
-# example passing only required values which don't have defaults set
-try:
-    # Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
-    api_instance.test_endpoint_parameters(number, double, pattern_without_delimiter, byte)
-except petstore_api.ApiException as e:
-    print("Exception when calling FakeApi->test_endpoint_parameters: %s\n" % e)
+    # example passing only required values which don't have defaults set
+    try:
+        # Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
+        api_instance.test_endpoint_parameters(number, double, pattern_without_delimiter, byte)
+    except petstore_api.ApiException as e:
+        print("Exception when calling FakeApi->test_endpoint_parameters: %s\n" % e)
 
-# example passing only required values which don't have defaults set
-# and optional values
-try:
-    # Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
-    api_instance.test_endpoint_parameters(number, double, pattern_without_delimiter, byte, integer=integer, int32=int32, int64=int64, float=float, string=string, binary=binary, date=date, date_time=date_time, password=password, param_callback=param_callback)
-except petstore_api.ApiException as e:
-    print("Exception when calling FakeApi->test_endpoint_parameters: %s\n" % e)
+    # example passing only required values which don't have defaults set
+    # and optional values
+    try:
+        # Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
+        api_instance.test_endpoint_parameters(number, double, pattern_without_delimiter, byte, integer=integer, int32=int32, int64=int64, float=float, string=string, binary=binary, date=date, date_time=date_time, password=password, param_callback=param_callback)
+    except petstore_api.ApiException as e:
+        print("Exception when calling FakeApi->test_endpoint_parameters: %s\n" % e)
 ```
 
 ### Parameters
@@ -552,9 +570,11 @@ import time
 import petstore_api
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.FakeApi()
-enum_header_string_array = ['enum_header_string_array_example'] # [str] | Header parameter enum test (string array) (optional)
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.FakeApi(api_client)
+    enum_header_string_array = ['enum_header_string_array_example'] # [str] | Header parameter enum test (string array) (optional)
 enum_header_string = '-efg' # str | Header parameter enum test (string) (optional) if omitted the server will use the default value of '-efg'
 enum_query_string_array = ['enum_query_string_array_example'] # [str] | Query parameter enum test (string array) (optional)
 enum_query_string = '-efg' # str | Query parameter enum test (string) (optional) if omitted the server will use the default value of '-efg'
@@ -563,13 +583,13 @@ enum_query_double = 3.4 # float | Query parameter enum test (double) (optional)
 enum_form_string_array = '$' # [str] | Form parameter enum test (string array) (optional) if omitted the server will use the default value of '$'
 enum_form_string = '-efg' # str | Form parameter enum test (string) (optional) if omitted the server will use the default value of '-efg'
 
-# example passing only required values which don't have defaults set
-# and optional values
-try:
-    # To test enum parameters
-    api_instance.test_enum_parameters(enum_header_string_array=enum_header_string_array, enum_header_string=enum_header_string, enum_query_string_array=enum_query_string_array, enum_query_string=enum_query_string, enum_query_integer=enum_query_integer, enum_query_double=enum_query_double, enum_form_string_array=enum_form_string_array, enum_form_string=enum_form_string)
-except petstore_api.ApiException as e:
-    print("Exception when calling FakeApi->test_enum_parameters: %s\n" % e)
+    # example passing only required values which don't have defaults set
+    # and optional values
+    try:
+        # To test enum parameters
+        api_instance.test_enum_parameters(enum_header_string_array=enum_header_string_array, enum_header_string=enum_header_string, enum_query_string_array=enum_query_string_array, enum_query_string=enum_query_string, enum_query_integer=enum_query_integer, enum_query_double=enum_query_double, enum_form_string_array=enum_form_string_array, enum_form_string=enum_form_string)
+    except petstore_api.ApiException as e:
+        print("Exception when calling FakeApi->test_enum_parameters: %s\n" % e)
 ```
 
 ### Parameters
@@ -627,29 +647,31 @@ configuration.access_token = 'YOUR_BEARER_TOKEN'
 
 # Defining host is optional and default to http://petstore.swagger.io:80/v2
 configuration.host = "http://petstore.swagger.io:80/v2"
-# Create an instance of the API class
-api_instance = petstore_api.FakeApi(petstore_api.ApiClient(configuration))
-required_string_group = 56 # int | Required String in group parameters
-required_boolean_group = True # bool | Required Boolean in group parameters
-required_int64_group = 56 # int | Required Integer in group parameters
-string_group = 56 # int | String in group parameters (optional)
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.FakeApi(api_client)
+    required_string_group = 56 # int | Required String in group parameters
+    required_boolean_group = True # bool | Required Boolean in group parameters
+    required_int64_group = 56 # int | Required Integer in group parameters
+    string_group = 56 # int | String in group parameters (optional)
 boolean_group = True # bool | Boolean in group parameters (optional)
 int64_group = 56 # int | Integer in group parameters (optional)
 
-# example passing only required values which don't have defaults set
-try:
-    # Fake endpoint to test group parameters (optional)
-    api_instance.test_group_parameters(required_string_group, required_boolean_group, required_int64_group)
-except petstore_api.ApiException as e:
-    print("Exception when calling FakeApi->test_group_parameters: %s\n" % e)
+    # example passing only required values which don't have defaults set
+    try:
+        # Fake endpoint to test group parameters (optional)
+        api_instance.test_group_parameters(required_string_group, required_boolean_group, required_int64_group)
+    except petstore_api.ApiException as e:
+        print("Exception when calling FakeApi->test_group_parameters: %s\n" % e)
 
-# example passing only required values which don't have defaults set
-# and optional values
-try:
-    # Fake endpoint to test group parameters (optional)
-    api_instance.test_group_parameters(required_string_group, required_boolean_group, required_int64_group, string_group=string_group, boolean_group=boolean_group, int64_group=int64_group)
-except petstore_api.ApiException as e:
-    print("Exception when calling FakeApi->test_group_parameters: %s\n" % e)
+    # example passing only required values which don't have defaults set
+    # and optional values
+    try:
+        # Fake endpoint to test group parameters (optional)
+        api_instance.test_group_parameters(required_string_group, required_boolean_group, required_int64_group, string_group=string_group, boolean_group=boolean_group, int64_group=int64_group)
+    except petstore_api.ApiException as e:
+        print("Exception when calling FakeApi->test_group_parameters: %s\n" % e)
 ```
 
 ### Parameters
@@ -696,16 +718,18 @@ import time
 import petstore_api
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.FakeApi()
-request_body = {'key': 'request_body_example'} # {str: (str,)} | request body
-
-# example passing only required values which don't have defaults set
-try:
-    # test inline additionalProperties
-    api_instance.test_inline_additional_properties(request_body)
-except petstore_api.ApiException as e:
-    print("Exception when calling FakeApi->test_inline_additional_properties: %s\n" % e)
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.FakeApi(api_client)
+    request_body = {'key': 'request_body_example'} # {str: (str,)} | request body
+    
+    # example passing only required values which don't have defaults set
+    try:
+        # test inline additionalProperties
+        api_instance.test_inline_additional_properties(request_body)
+    except petstore_api.ApiException as e:
+        print("Exception when calling FakeApi->test_inline_additional_properties: %s\n" % e)
 ```
 
 ### Parameters
@@ -747,17 +771,19 @@ import time
 import petstore_api
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.FakeApi()
-param = 'param_example' # str | field1
-param2 = 'param2_example' # str | field2
-
-# example passing only required values which don't have defaults set
-try:
-    # test json serialization of form data
-    api_instance.test_json_form_data(param, param2)
-except petstore_api.ApiException as e:
-    print("Exception when calling FakeApi->test_json_form_data: %s\n" % e)
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.FakeApi(api_client)
+    param = 'param_example' # str | field1
+    param2 = 'param2_example' # str | field2
+    
+    # example passing only required values which don't have defaults set
+    try:
+        # test json serialization of form data
+        api_instance.test_json_form_data(param, param2)
+    except petstore_api.ApiException as e:
+        print("Exception when calling FakeApi->test_json_form_data: %s\n" % e)
 ```
 
 ### Parameters
@@ -802,19 +828,21 @@ import time
 import petstore_api
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.FakeApi()
-pipe = ['pipe_example'] # [str] | 
-ioutil = ['ioutil_example'] # [str] | 
-http = ['http_example'] # [str] | 
-url = ['url_example'] # [str] | 
-context = ['context_example'] # [str] | 
-
-# example passing only required values which don't have defaults set
-try:
-    api_instance.test_query_parameter_collection_format(pipe, ioutil, http, url, context)
-except petstore_api.ApiException as e:
-    print("Exception when calling FakeApi->test_query_parameter_collection_format: %s\n" % e)
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.FakeApi(api_client)
+    pipe = ['pipe_example'] # [str] | 
+    ioutil = ['ioutil_example'] # [str] | 
+    http = ['http_example'] # [str] | 
+    url = ['url_example'] # [str] | 
+    context = ['context_example'] # [str] | 
+    
+    # example passing only required values which don't have defaults set
+    try:
+        api_instance.test_query_parameter_collection_format(pipe, ioutil, http, url, context)
+    except petstore_api.ApiException as e:
+        print("Exception when calling FakeApi->test_query_parameter_collection_format: %s\n" % e)
 ```
 
 ### Parameters

--- a/samples/openapi3/client/petstore/python-experimental/docs/FakeClassnameTags123Api.md
+++ b/samples/openapi3/client/petstore/python-experimental/docs/FakeClassnameTags123Api.md
@@ -30,17 +30,19 @@ configuration.api_key['api_key_query'] = 'YOUR_API_KEY'
 
 # Defining host is optional and default to http://petstore.swagger.io:80/v2
 configuration.host = "http://petstore.swagger.io:80/v2"
-# Create an instance of the API class
-api_instance = petstore_api.FakeClassnameTags123Api(petstore_api.ApiClient(configuration))
-client_client = petstore_api.Client() # client.Client | client model
-
-# example passing only required values which don't have defaults set
-try:
-    # To test class name in snake case
-    api_response = api_instance.test_classname(client_client)
-    pprint(api_response)
-except petstore_api.ApiException as e:
-    print("Exception when calling FakeClassnameTags123Api->test_classname: %s\n" % e)
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.FakeClassnameTags123Api(api_client)
+    client_client = petstore_api.Client() # client.Client | client model
+    
+    # example passing only required values which don't have defaults set
+    try:
+        # To test class name in snake case
+        api_response = api_instance.test_classname(client_client)
+        pprint(api_response)
+    except petstore_api.ApiException as e:
+        print("Exception when calling FakeClassnameTags123Api->test_classname: %s\n" % e)
 ```
 
 ### Parameters

--- a/samples/openapi3/client/petstore/python-experimental/docs/PetApi.md
+++ b/samples/openapi3/client/petstore/python-experimental/docs/PetApi.md
@@ -34,16 +34,18 @@ configuration.access_token = 'YOUR_ACCESS_TOKEN'
 
 # Defining host is optional and default to http://petstore.swagger.io:80/v2
 configuration.host = "http://petstore.swagger.io:80/v2"
-# Create an instance of the API class
-api_instance = petstore_api.PetApi(petstore_api.ApiClient(configuration))
-pet_pet = petstore_api.Pet() # pet.Pet | Pet object that needs to be added to the store
-
-# example passing only required values which don't have defaults set
-try:
-    # Add a new pet to the store
-    api_instance.add_pet(pet_pet)
-except petstore_api.ApiException as e:
-    print("Exception when calling PetApi->add_pet: %s\n" % e)
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.PetApi(api_client)
+    pet_pet = petstore_api.Pet() # pet.Pet | Pet object that needs to be added to the store
+    
+    # example passing only required values which don't have defaults set
+    try:
+        # Add a new pet to the store
+        api_instance.add_pet(pet_pet)
+    except petstore_api.ApiException as e:
+        print("Exception when calling PetApi->add_pet: %s\n" % e)
 ```
 
 ### Parameters
@@ -91,25 +93,27 @@ configuration.access_token = 'YOUR_ACCESS_TOKEN'
 
 # Defining host is optional and default to http://petstore.swagger.io:80/v2
 configuration.host = "http://petstore.swagger.io:80/v2"
-# Create an instance of the API class
-api_instance = petstore_api.PetApi(petstore_api.ApiClient(configuration))
-pet_id = 56 # int | Pet id to delete
-api_key = 'api_key_example' # str |  (optional)
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.PetApi(api_client)
+    pet_id = 56 # int | Pet id to delete
+    api_key = 'api_key_example' # str |  (optional)
 
-# example passing only required values which don't have defaults set
-try:
-    # Deletes a pet
-    api_instance.delete_pet(pet_id)
-except petstore_api.ApiException as e:
-    print("Exception when calling PetApi->delete_pet: %s\n" % e)
+    # example passing only required values which don't have defaults set
+    try:
+        # Deletes a pet
+        api_instance.delete_pet(pet_id)
+    except petstore_api.ApiException as e:
+        print("Exception when calling PetApi->delete_pet: %s\n" % e)
 
-# example passing only required values which don't have defaults set
-# and optional values
-try:
-    # Deletes a pet
-    api_instance.delete_pet(pet_id, api_key=api_key)
-except petstore_api.ApiException as e:
-    print("Exception when calling PetApi->delete_pet: %s\n" % e)
+    # example passing only required values which don't have defaults set
+    # and optional values
+    try:
+        # Deletes a pet
+        api_instance.delete_pet(pet_id, api_key=api_key)
+    except petstore_api.ApiException as e:
+        print("Exception when calling PetApi->delete_pet: %s\n" % e)
 ```
 
 ### Parameters
@@ -160,17 +164,19 @@ configuration.access_token = 'YOUR_ACCESS_TOKEN'
 
 # Defining host is optional and default to http://petstore.swagger.io:80/v2
 configuration.host = "http://petstore.swagger.io:80/v2"
-# Create an instance of the API class
-api_instance = petstore_api.PetApi(petstore_api.ApiClient(configuration))
-status = ['status_example'] # [str] | Status values that need to be considered for filter
-
-# example passing only required values which don't have defaults set
-try:
-    # Finds Pets by status
-    api_response = api_instance.find_pets_by_status(status)
-    pprint(api_response)
-except petstore_api.ApiException as e:
-    print("Exception when calling PetApi->find_pets_by_status: %s\n" % e)
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.PetApi(api_client)
+    status = ['status_example'] # [str] | Status values that need to be considered for filter
+    
+    # example passing only required values which don't have defaults set
+    try:
+        # Finds Pets by status
+        api_response = api_instance.find_pets_by_status(status)
+        pprint(api_response)
+    except petstore_api.ApiException as e:
+        print("Exception when calling PetApi->find_pets_by_status: %s\n" % e)
 ```
 
 ### Parameters
@@ -221,17 +227,19 @@ configuration.access_token = 'YOUR_ACCESS_TOKEN'
 
 # Defining host is optional and default to http://petstore.swagger.io:80/v2
 configuration.host = "http://petstore.swagger.io:80/v2"
-# Create an instance of the API class
-api_instance = petstore_api.PetApi(petstore_api.ApiClient(configuration))
-tags = ['tags_example'] # [str] | Tags to filter by
-
-# example passing only required values which don't have defaults set
-try:
-    # Finds Pets by tags
-    api_response = api_instance.find_pets_by_tags(tags)
-    pprint(api_response)
-except petstore_api.ApiException as e:
-    print("Exception when calling PetApi->find_pets_by_tags: %s\n" % e)
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.PetApi(api_client)
+    tags = ['tags_example'] # [str] | Tags to filter by
+    
+    # example passing only required values which don't have defaults set
+    try:
+        # Finds Pets by tags
+        api_response = api_instance.find_pets_by_tags(tags)
+        pprint(api_response)
+    except petstore_api.ApiException as e:
+        print("Exception when calling PetApi->find_pets_by_tags: %s\n" % e)
 ```
 
 ### Parameters
@@ -284,17 +292,19 @@ configuration.api_key['api_key'] = 'YOUR_API_KEY'
 
 # Defining host is optional and default to http://petstore.swagger.io:80/v2
 configuration.host = "http://petstore.swagger.io:80/v2"
-# Create an instance of the API class
-api_instance = petstore_api.PetApi(petstore_api.ApiClient(configuration))
-pet_id = 56 # int | ID of pet to return
-
-# example passing only required values which don't have defaults set
-try:
-    # Find pet by ID
-    api_response = api_instance.get_pet_by_id(pet_id)
-    pprint(api_response)
-except petstore_api.ApiException as e:
-    print("Exception when calling PetApi->get_pet_by_id: %s\n" % e)
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.PetApi(api_client)
+    pet_id = 56 # int | ID of pet to return
+    
+    # example passing only required values which don't have defaults set
+    try:
+        # Find pet by ID
+        api_response = api_instance.get_pet_by_id(pet_id)
+        pprint(api_response)
+    except petstore_api.ApiException as e:
+        print("Exception when calling PetApi->get_pet_by_id: %s\n" % e)
 ```
 
 ### Parameters
@@ -344,16 +354,18 @@ configuration.access_token = 'YOUR_ACCESS_TOKEN'
 
 # Defining host is optional and default to http://petstore.swagger.io:80/v2
 configuration.host = "http://petstore.swagger.io:80/v2"
-# Create an instance of the API class
-api_instance = petstore_api.PetApi(petstore_api.ApiClient(configuration))
-pet_pet = petstore_api.Pet() # pet.Pet | Pet object that needs to be added to the store
-
-# example passing only required values which don't have defaults set
-try:
-    # Update an existing pet
-    api_instance.update_pet(pet_pet)
-except petstore_api.ApiException as e:
-    print("Exception when calling PetApi->update_pet: %s\n" % e)
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.PetApi(api_client)
+    pet_pet = petstore_api.Pet() # pet.Pet | Pet object that needs to be added to the store
+    
+    # example passing only required values which don't have defaults set
+    try:
+        # Update an existing pet
+        api_instance.update_pet(pet_pet)
+    except petstore_api.ApiException as e:
+        print("Exception when calling PetApi->update_pet: %s\n" % e)
 ```
 
 ### Parameters
@@ -403,26 +415,28 @@ configuration.access_token = 'YOUR_ACCESS_TOKEN'
 
 # Defining host is optional and default to http://petstore.swagger.io:80/v2
 configuration.host = "http://petstore.swagger.io:80/v2"
-# Create an instance of the API class
-api_instance = petstore_api.PetApi(petstore_api.ApiClient(configuration))
-pet_id = 56 # int | ID of pet that needs to be updated
-name = 'name_example' # str | Updated name of the pet (optional)
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.PetApi(api_client)
+    pet_id = 56 # int | ID of pet that needs to be updated
+    name = 'name_example' # str | Updated name of the pet (optional)
 status = 'status_example' # str | Updated status of the pet (optional)
 
-# example passing only required values which don't have defaults set
-try:
-    # Updates a pet in the store with form data
-    api_instance.update_pet_with_form(pet_id)
-except petstore_api.ApiException as e:
-    print("Exception when calling PetApi->update_pet_with_form: %s\n" % e)
+    # example passing only required values which don't have defaults set
+    try:
+        # Updates a pet in the store with form data
+        api_instance.update_pet_with_form(pet_id)
+    except petstore_api.ApiException as e:
+        print("Exception when calling PetApi->update_pet_with_form: %s\n" % e)
 
-# example passing only required values which don't have defaults set
-# and optional values
-try:
-    # Updates a pet in the store with form data
-    api_instance.update_pet_with_form(pet_id, name=name, status=status)
-except petstore_api.ApiException as e:
-    print("Exception when calling PetApi->update_pet_with_form: %s\n" % e)
+    # example passing only required values which don't have defaults set
+    # and optional values
+    try:
+        # Updates a pet in the store with form data
+        api_instance.update_pet_with_form(pet_id, name=name, status=status)
+    except petstore_api.ApiException as e:
+        print("Exception when calling PetApi->update_pet_with_form: %s\n" % e)
 ```
 
 ### Parameters
@@ -472,28 +486,30 @@ configuration.access_token = 'YOUR_ACCESS_TOKEN'
 
 # Defining host is optional and default to http://petstore.swagger.io:80/v2
 configuration.host = "http://petstore.swagger.io:80/v2"
-# Create an instance of the API class
-api_instance = petstore_api.PetApi(petstore_api.ApiClient(configuration))
-pet_id = 56 # int | ID of pet to update
-additional_metadata = 'additional_metadata_example' # str | Additional data to pass to server (optional)
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.PetApi(api_client)
+    pet_id = 56 # int | ID of pet to update
+    additional_metadata = 'additional_metadata_example' # str | Additional data to pass to server (optional)
 file = open('/path/to/file', 'rb') # file_type | file to upload (optional)
 
-# example passing only required values which don't have defaults set
-try:
-    # uploads an image
-    api_response = api_instance.upload_file(pet_id)
-    pprint(api_response)
-except petstore_api.ApiException as e:
-    print("Exception when calling PetApi->upload_file: %s\n" % e)
+    # example passing only required values which don't have defaults set
+    try:
+        # uploads an image
+        api_response = api_instance.upload_file(pet_id)
+        pprint(api_response)
+    except petstore_api.ApiException as e:
+        print("Exception when calling PetApi->upload_file: %s\n" % e)
 
-# example passing only required values which don't have defaults set
-# and optional values
-try:
-    # uploads an image
-    api_response = api_instance.upload_file(pet_id, additional_metadata=additional_metadata, file=file)
-    pprint(api_response)
-except petstore_api.ApiException as e:
-    print("Exception when calling PetApi->upload_file: %s\n" % e)
+    # example passing only required values which don't have defaults set
+    # and optional values
+    try:
+        # uploads an image
+        api_response = api_instance.upload_file(pet_id, additional_metadata=additional_metadata, file=file)
+        pprint(api_response)
+    except petstore_api.ApiException as e:
+        print("Exception when calling PetApi->upload_file: %s\n" % e)
 ```
 
 ### Parameters
@@ -543,28 +559,30 @@ configuration.access_token = 'YOUR_ACCESS_TOKEN'
 
 # Defining host is optional and default to http://petstore.swagger.io:80/v2
 configuration.host = "http://petstore.swagger.io:80/v2"
-# Create an instance of the API class
-api_instance = petstore_api.PetApi(petstore_api.ApiClient(configuration))
-pet_id = 56 # int | ID of pet to update
-required_file = open('/path/to/file', 'rb') # file_type | file to upload
-additional_metadata = 'additional_metadata_example' # str | Additional data to pass to server (optional)
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.PetApi(api_client)
+    pet_id = 56 # int | ID of pet to update
+    required_file = open('/path/to/file', 'rb') # file_type | file to upload
+    additional_metadata = 'additional_metadata_example' # str | Additional data to pass to server (optional)
 
-# example passing only required values which don't have defaults set
-try:
-    # uploads an image (required)
-    api_response = api_instance.upload_file_with_required_file(pet_id, required_file)
-    pprint(api_response)
-except petstore_api.ApiException as e:
-    print("Exception when calling PetApi->upload_file_with_required_file: %s\n" % e)
+    # example passing only required values which don't have defaults set
+    try:
+        # uploads an image (required)
+        api_response = api_instance.upload_file_with_required_file(pet_id, required_file)
+        pprint(api_response)
+    except petstore_api.ApiException as e:
+        print("Exception when calling PetApi->upload_file_with_required_file: %s\n" % e)
 
-# example passing only required values which don't have defaults set
-# and optional values
-try:
-    # uploads an image (required)
-    api_response = api_instance.upload_file_with_required_file(pet_id, required_file, additional_metadata=additional_metadata)
-    pprint(api_response)
-except petstore_api.ApiException as e:
-    print("Exception when calling PetApi->upload_file_with_required_file: %s\n" % e)
+    # example passing only required values which don't have defaults set
+    # and optional values
+    try:
+        # uploads an image (required)
+        api_response = api_instance.upload_file_with_required_file(pet_id, required_file, additional_metadata=additional_metadata)
+        pprint(api_response)
+    except petstore_api.ApiException as e:
+        print("Exception when calling PetApi->upload_file_with_required_file: %s\n" % e)
 ```
 
 ### Parameters

--- a/samples/openapi3/client/petstore/python-experimental/docs/StoreApi.md
+++ b/samples/openapi3/client/petstore/python-experimental/docs/StoreApi.md
@@ -25,16 +25,18 @@ import time
 import petstore_api
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.StoreApi()
-order_id = 'order_id_example' # str | ID of the order that needs to be deleted
-
-# example passing only required values which don't have defaults set
-try:
-    # Delete purchase order by ID
-    api_instance.delete_order(order_id)
-except petstore_api.ApiException as e:
-    print("Exception when calling StoreApi->delete_order: %s\n" % e)
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.StoreApi(api_client)
+    order_id = 'order_id_example' # str | ID of the order that needs to be deleted
+    
+    # example passing only required values which don't have defaults set
+    try:
+        # Delete purchase order by ID
+        api_instance.delete_order(order_id)
+    except petstore_api.ApiException as e:
+        print("Exception when calling StoreApi->delete_order: %s\n" % e)
 ```
 
 ### Parameters
@@ -87,16 +89,18 @@ configuration.api_key['api_key'] = 'YOUR_API_KEY'
 
 # Defining host is optional and default to http://petstore.swagger.io:80/v2
 configuration.host = "http://petstore.swagger.io:80/v2"
-# Create an instance of the API class
-api_instance = petstore_api.StoreApi(petstore_api.ApiClient(configuration))
-
-# example, this endpoint has no required or optional parameters
-try:
-    # Returns pet inventories by status
-    api_response = api_instance.get_inventory()
-    pprint(api_response)
-except petstore_api.ApiException as e:
-    print("Exception when calling StoreApi->get_inventory: %s\n" % e)
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.StoreApi(api_client)
+    
+    # example, this endpoint has no required or optional parameters
+    try:
+        # Returns pet inventories by status
+        api_response = api_instance.get_inventory()
+        pprint(api_response)
+    except petstore_api.ApiException as e:
+        print("Exception when calling StoreApi->get_inventory: %s\n" % e)
 ```
 
 ### Parameters
@@ -137,17 +141,19 @@ import time
 import petstore_api
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.StoreApi()
-order_id = 56 # int | ID of pet that needs to be fetched
-
-# example passing only required values which don't have defaults set
-try:
-    # Find purchase order by ID
-    api_response = api_instance.get_order_by_id(order_id)
-    pprint(api_response)
-except petstore_api.ApiException as e:
-    print("Exception when calling StoreApi->get_order_by_id: %s\n" % e)
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.StoreApi(api_client)
+    order_id = 56 # int | ID of pet that needs to be fetched
+    
+    # example passing only required values which don't have defaults set
+    try:
+        # Find purchase order by ID
+        api_response = api_instance.get_order_by_id(order_id)
+        pprint(api_response)
+    except petstore_api.ApiException as e:
+        print("Exception when calling StoreApi->get_order_by_id: %s\n" % e)
 ```
 
 ### Parameters
@@ -191,17 +197,19 @@ import time
 import petstore_api
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.StoreApi()
-order_order = petstore_api.Order() # order.Order | order placed for purchasing the pet
-
-# example passing only required values which don't have defaults set
-try:
-    # Place an order for a pet
-    api_response = api_instance.place_order(order_order)
-    pprint(api_response)
-except petstore_api.ApiException as e:
-    print("Exception when calling StoreApi->place_order: %s\n" % e)
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.StoreApi(api_client)
+    order_order = petstore_api.Order() # order.Order | order placed for purchasing the pet
+    
+    # example passing only required values which don't have defaults set
+    try:
+        # Place an order for a pet
+        api_response = api_instance.place_order(order_order)
+        pprint(api_response)
+    except petstore_api.ApiException as e:
+        print("Exception when calling StoreApi->place_order: %s\n" % e)
 ```
 
 ### Parameters

--- a/samples/openapi3/client/petstore/python-experimental/docs/UserApi.md
+++ b/samples/openapi3/client/petstore/python-experimental/docs/UserApi.md
@@ -29,16 +29,18 @@ import time
 import petstore_api
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.UserApi()
-user_user = petstore_api.User() # user.User | Created user object
-
-# example passing only required values which don't have defaults set
-try:
-    # Create user
-    api_instance.create_user(user_user)
-except petstore_api.ApiException as e:
-    print("Exception when calling UserApi->create_user: %s\n" % e)
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.UserApi(api_client)
+    user_user = petstore_api.User() # user.User | Created user object
+    
+    # example passing only required values which don't have defaults set
+    try:
+        # Create user
+        api_instance.create_user(user_user)
+    except petstore_api.ApiException as e:
+        print("Exception when calling UserApi->create_user: %s\n" % e)
 ```
 
 ### Parameters
@@ -80,16 +82,18 @@ import time
 import petstore_api
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.UserApi()
-user_user = [petstore_api.User()] # [user.User] | List of user object
-
-# example passing only required values which don't have defaults set
-try:
-    # Creates list of users with given input array
-    api_instance.create_users_with_array_input(user_user)
-except petstore_api.ApiException as e:
-    print("Exception when calling UserApi->create_users_with_array_input: %s\n" % e)
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.UserApi(api_client)
+    user_user = [petstore_api.User()] # [user.User] | List of user object
+    
+    # example passing only required values which don't have defaults set
+    try:
+        # Creates list of users with given input array
+        api_instance.create_users_with_array_input(user_user)
+    except petstore_api.ApiException as e:
+        print("Exception when calling UserApi->create_users_with_array_input: %s\n" % e)
 ```
 
 ### Parameters
@@ -131,16 +135,18 @@ import time
 import petstore_api
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.UserApi()
-user_user = [petstore_api.User()] # [user.User] | List of user object
-
-# example passing only required values which don't have defaults set
-try:
-    # Creates list of users with given input array
-    api_instance.create_users_with_list_input(user_user)
-except petstore_api.ApiException as e:
-    print("Exception when calling UserApi->create_users_with_list_input: %s\n" % e)
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.UserApi(api_client)
+    user_user = [petstore_api.User()] # [user.User] | List of user object
+    
+    # example passing only required values which don't have defaults set
+    try:
+        # Creates list of users with given input array
+        api_instance.create_users_with_list_input(user_user)
+    except petstore_api.ApiException as e:
+        print("Exception when calling UserApi->create_users_with_list_input: %s\n" % e)
 ```
 
 ### Parameters
@@ -184,16 +190,18 @@ import time
 import petstore_api
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.UserApi()
-username = 'username_example' # str | The name that needs to be deleted
-
-# example passing only required values which don't have defaults set
-try:
-    # Delete user
-    api_instance.delete_user(username)
-except petstore_api.ApiException as e:
-    print("Exception when calling UserApi->delete_user: %s\n" % e)
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.UserApi(api_client)
+    username = 'username_example' # str | The name that needs to be deleted
+    
+    # example passing only required values which don't have defaults set
+    try:
+        # Delete user
+        api_instance.delete_user(username)
+    except petstore_api.ApiException as e:
+        print("Exception when calling UserApi->delete_user: %s\n" % e)
 ```
 
 ### Parameters
@@ -236,17 +244,19 @@ import time
 import petstore_api
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.UserApi()
-username = 'username_example' # str | The name that needs to be fetched. Use user1 for testing.
-
-# example passing only required values which don't have defaults set
-try:
-    # Get user by user name
-    api_response = api_instance.get_user_by_name(username)
-    pprint(api_response)
-except petstore_api.ApiException as e:
-    print("Exception when calling UserApi->get_user_by_name: %s\n" % e)
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.UserApi(api_client)
+    username = 'username_example' # str | The name that needs to be fetched. Use user1 for testing.
+    
+    # example passing only required values which don't have defaults set
+    try:
+        # Get user by user name
+        api_response = api_instance.get_user_by_name(username)
+        pprint(api_response)
+    except petstore_api.ApiException as e:
+        print("Exception when calling UserApi->get_user_by_name: %s\n" % e)
 ```
 
 ### Parameters
@@ -290,18 +300,20 @@ import time
 import petstore_api
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.UserApi()
-username = 'username_example' # str | The user name for login
-password = 'password_example' # str | The password for login in clear text
-
-# example passing only required values which don't have defaults set
-try:
-    # Logs user into the system
-    api_response = api_instance.login_user(username, password)
-    pprint(api_response)
-except petstore_api.ApiException as e:
-    print("Exception when calling UserApi->login_user: %s\n" % e)
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.UserApi(api_client)
+    username = 'username_example' # str | The user name for login
+    password = 'password_example' # str | The password for login in clear text
+    
+    # example passing only required values which don't have defaults set
+    try:
+        # Logs user into the system
+        api_response = api_instance.login_user(username, password)
+        pprint(api_response)
+    except petstore_api.ApiException as e:
+        print("Exception when calling UserApi->login_user: %s\n" % e)
 ```
 
 ### Parameters
@@ -345,15 +357,17 @@ import time
 import petstore_api
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.UserApi()
-
-# example, this endpoint has no required or optional parameters
-try:
-    # Logs out current logged in user session
-    api_instance.logout_user()
-except petstore_api.ApiException as e:
-    print("Exception when calling UserApi->logout_user: %s\n" % e)
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.UserApi(api_client)
+    
+    # example, this endpoint has no required or optional parameters
+    try:
+        # Logs out current logged in user session
+        api_instance.logout_user()
+    except petstore_api.ApiException as e:
+        print("Exception when calling UserApi->logout_user: %s\n" % e)
 ```
 
 ### Parameters
@@ -394,17 +408,19 @@ import time
 import petstore_api
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.UserApi()
-username = 'username_example' # str | name that need to be deleted
-user_user = petstore_api.User() # user.User | Updated user object
-
-# example passing only required values which don't have defaults set
-try:
-    # Updated user
-    api_instance.update_user(username, user_user)
-except petstore_api.ApiException as e:
-    print("Exception when calling UserApi->update_user: %s\n" % e)
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.UserApi(api_client)
+    username = 'username_example' # str | name that need to be deleted
+    user_user = petstore_api.User() # user.User | Updated user object
+    
+    # example passing only required values which don't have defaults set
+    try:
+        # Updated user
+        api_instance.update_user(username, user_user)
+    except petstore_api.ApiException as e:
+        print("Exception when calling UserApi->update_user: %s\n" % e)
 ```
 
 ### Parameters

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/api_client.py
@@ -11,6 +11,7 @@
 from __future__ import absolute_import
 
 import json
+import atexit
 import mimetypes
 from multiprocessing.pool import ThreadPool
 import os
@@ -79,11 +80,19 @@ class ApiClient(object):
         # Set default User-Agent.
         self.user_agent = 'OpenAPI-Generator/1.0.0/python'
 
-    def __del__(self):
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.close()
+
+    def close(self):
         if self._pool:
             self._pool.close()
             self._pool.join()
             self._pool = None
+            if hasattr(atexit, 'unregister'):
+                atexit.unregister(self.close)
 
     @property
     def pool(self):
@@ -91,6 +100,7 @@ class ApiClient(object):
          avoids instantiating unused threadpool for blocking clients.
         """
         if self._pool is None:
+            atexit.register(self.close)
             self._pool = ThreadPool(self.pool_threads)
         return self._pool
 

--- a/samples/openapi3/client/petstore/python/README.md
+++ b/samples/openapi3/client/petstore/python/README.md
@@ -54,17 +54,19 @@ from pprint import pprint
 
 # Defining host is optional and default to http://petstore.swagger.io:80/v2
 configuration.host = "http://petstore.swagger.io:80/v2"
-# Create an instance of the API class
-api_instance = petstore_api.AnotherFakeApi(petstore_api.ApiClient(configuration))
-client = petstore_api.Client() # Client | client model
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.AnotherFakeApi(api_client)
+    client = petstore_api.Client() # Client | client model
 
-try:
-    # To test special tags
-    api_response = api_instance.call_123_test_special_tags(client)
-    pprint(api_response)
-except ApiException as e:
-    print("Exception when calling AnotherFakeApi->call_123_test_special_tags: %s\n" % e)
-
+    try:
+        # To test special tags
+        api_response = api_instance.call_123_test_special_tags(client)
+        pprint(api_response)
+    except ApiException as e:
+        print("Exception when calling AnotherFakeApi->call_123_test_special_tags: %s\n" % e)
+    
 ```
 
 ## Documentation for API Endpoints

--- a/samples/openapi3/client/petstore/python/docs/AnotherFakeApi.md
+++ b/samples/openapi3/client/petstore/python/docs/AnotherFakeApi.md
@@ -23,16 +23,18 @@ import petstore_api
 from petstore_api.rest import ApiException
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.AnotherFakeApi()
-client = petstore_api.Client() # Client | client model
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient() as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.AnotherFakeApi(api_client)
+    client = petstore_api.Client() # Client | client model
 
-try:
-    # To test special tags
-    api_response = api_instance.call_123_test_special_tags(client)
-    pprint(api_response)
-except ApiException as e:
-    print("Exception when calling AnotherFakeApi->call_123_test_special_tags: %s\n" % e)
+    try:
+        # To test special tags
+        api_response = api_instance.call_123_test_special_tags(client)
+        pprint(api_response)
+    except ApiException as e:
+        print("Exception when calling AnotherFakeApi->call_123_test_special_tags: %s\n" % e)
 ```
 
 ### Parameters

--- a/samples/openapi3/client/petstore/python/docs/DefaultApi.md
+++ b/samples/openapi3/client/petstore/python/docs/DefaultApi.md
@@ -21,14 +21,16 @@ import petstore_api
 from petstore_api.rest import ApiException
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.DefaultApi()
-
-try:
-    api_response = api_instance.foo_get()
-    pprint(api_response)
-except ApiException as e:
-    print("Exception when calling DefaultApi->foo_get: %s\n" % e)
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient() as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.DefaultApi(api_client)
+    
+    try:
+        api_response = api_instance.foo_get()
+        pprint(api_response)
+    except ApiException as e:
+        print("Exception when calling DefaultApi->foo_get: %s\n" % e)
 ```
 
 ### Parameters

--- a/samples/openapi3/client/petstore/python/docs/FakeApi.md
+++ b/samples/openapi3/client/petstore/python/docs/FakeApi.md
@@ -34,15 +34,17 @@ import petstore_api
 from petstore_api.rest import ApiException
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.FakeApi()
-
-try:
-    # Health check endpoint
-    api_response = api_instance.fake_health_get()
-    pprint(api_response)
-except ApiException as e:
-    print("Exception when calling FakeApi->fake_health_get: %s\n" % e)
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient() as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.FakeApi(api_client)
+    
+    try:
+        # Health check endpoint
+        api_response = api_instance.fake_health_get()
+        pprint(api_response)
+    except ApiException as e:
+        print("Exception when calling FakeApi->fake_health_get: %s\n" % e)
 ```
 
 ### Parameters
@@ -84,15 +86,17 @@ import petstore_api
 from petstore_api.rest import ApiException
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.FakeApi()
-body = True # bool | Input boolean as post body (optional)
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient() as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.FakeApi(api_client)
+    body = True # bool | Input boolean as post body (optional)
 
-try:
-    api_response = api_instance.fake_outer_boolean_serialize(body=body)
-    pprint(api_response)
-except ApiException as e:
-    print("Exception when calling FakeApi->fake_outer_boolean_serialize: %s\n" % e)
+    try:
+        api_response = api_instance.fake_outer_boolean_serialize(body=body)
+        pprint(api_response)
+    except ApiException as e:
+        print("Exception when calling FakeApi->fake_outer_boolean_serialize: %s\n" % e)
 ```
 
 ### Parameters
@@ -137,15 +141,17 @@ import petstore_api
 from petstore_api.rest import ApiException
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.FakeApi()
-outer_composite = petstore_api.OuterComposite() # OuterComposite | Input composite as post body (optional)
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient() as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.FakeApi(api_client)
+    outer_composite = petstore_api.OuterComposite() # OuterComposite | Input composite as post body (optional)
 
-try:
-    api_response = api_instance.fake_outer_composite_serialize(outer_composite=outer_composite)
-    pprint(api_response)
-except ApiException as e:
-    print("Exception when calling FakeApi->fake_outer_composite_serialize: %s\n" % e)
+    try:
+        api_response = api_instance.fake_outer_composite_serialize(outer_composite=outer_composite)
+        pprint(api_response)
+    except ApiException as e:
+        print("Exception when calling FakeApi->fake_outer_composite_serialize: %s\n" % e)
 ```
 
 ### Parameters
@@ -190,15 +196,17 @@ import petstore_api
 from petstore_api.rest import ApiException
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.FakeApi()
-body = 3.4 # float | Input number as post body (optional)
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient() as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.FakeApi(api_client)
+    body = 3.4 # float | Input number as post body (optional)
 
-try:
-    api_response = api_instance.fake_outer_number_serialize(body=body)
-    pprint(api_response)
-except ApiException as e:
-    print("Exception when calling FakeApi->fake_outer_number_serialize: %s\n" % e)
+    try:
+        api_response = api_instance.fake_outer_number_serialize(body=body)
+        pprint(api_response)
+    except ApiException as e:
+        print("Exception when calling FakeApi->fake_outer_number_serialize: %s\n" % e)
 ```
 
 ### Parameters
@@ -243,15 +251,17 @@ import petstore_api
 from petstore_api.rest import ApiException
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.FakeApi()
-body = 'body_example' # str | Input string as post body (optional)
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient() as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.FakeApi(api_client)
+    body = 'body_example' # str | Input string as post body (optional)
 
-try:
-    api_response = api_instance.fake_outer_string_serialize(body=body)
-    pprint(api_response)
-except ApiException as e:
-    print("Exception when calling FakeApi->fake_outer_string_serialize: %s\n" % e)
+    try:
+        api_response = api_instance.fake_outer_string_serialize(body=body)
+        pprint(api_response)
+    except ApiException as e:
+        print("Exception when calling FakeApi->fake_outer_string_serialize: %s\n" % e)
 ```
 
 ### Parameters
@@ -296,14 +306,16 @@ import petstore_api
 from petstore_api.rest import ApiException
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.FakeApi()
-file_schema_test_class = petstore_api.FileSchemaTestClass() # FileSchemaTestClass | 
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient() as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.FakeApi(api_client)
+    file_schema_test_class = petstore_api.FileSchemaTestClass() # FileSchemaTestClass | 
 
-try:
-    api_instance.test_body_with_file_schema(file_schema_test_class)
-except ApiException as e:
-    print("Exception when calling FakeApi->test_body_with_file_schema: %s\n" % e)
+    try:
+        api_instance.test_body_with_file_schema(file_schema_test_class)
+    except ApiException as e:
+        print("Exception when calling FakeApi->test_body_with_file_schema: %s\n" % e)
 ```
 
 ### Parameters
@@ -346,15 +358,17 @@ import petstore_api
 from petstore_api.rest import ApiException
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.FakeApi()
-query = 'query_example' # str | 
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient() as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.FakeApi(api_client)
+    query = 'query_example' # str | 
 user = petstore_api.User() # User | 
 
-try:
-    api_instance.test_body_with_query_params(query, user)
-except ApiException as e:
-    print("Exception when calling FakeApi->test_body_with_query_params: %s\n" % e)
+    try:
+        api_instance.test_body_with_query_params(query, user)
+    except ApiException as e:
+        print("Exception when calling FakeApi->test_body_with_query_params: %s\n" % e)
 ```
 
 ### Parameters
@@ -400,16 +414,18 @@ import petstore_api
 from petstore_api.rest import ApiException
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.FakeApi()
-client = petstore_api.Client() # Client | client model
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient() as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.FakeApi(api_client)
+    client = petstore_api.Client() # Client | client model
 
-try:
-    # To test \"client\" model
-    api_response = api_instance.test_client_model(client)
-    pprint(api_response)
-except ApiException as e:
-    print("Exception when calling FakeApi->test_client_model: %s\n" % e)
+    try:
+        # To test \"client\" model
+        api_response = api_instance.test_client_model(client)
+        pprint(api_response)
+    except ApiException as e:
+        print("Exception when calling FakeApi->test_client_model: %s\n" % e)
 ```
 
 ### Parameters
@@ -461,9 +477,11 @@ configuration.password = 'YOUR_PASSWORD'
 
 # Defining host is optional and default to http://petstore.swagger.io:80/v2
 configuration.host = "http://petstore.swagger.io:80/v2"
-# Create an instance of the API class
-api_instance = petstore_api.FakeApi(petstore_api.ApiClient(configuration))
-number = 3.4 # float | None
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.FakeApi(api_client)
+    number = 3.4 # float | None
 double = 3.4 # float | None
 pattern_without_delimiter = 'pattern_without_delimiter_example' # str | None
 byte = 'byte_example' # str | None
@@ -478,11 +496,11 @@ date_time = '2013-10-20T19:20:30+01:00' # datetime | None (optional)
 password = 'password_example' # str | None (optional)
 param_callback = 'param_callback_example' # str | None (optional)
 
-try:
-    # Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
-    api_instance.test_endpoint_parameters(number, double, pattern_without_delimiter, byte, integer=integer, int32=int32, int64=int64, float=float, string=string, binary=binary, date=date, date_time=date_time, password=password, param_callback=param_callback)
-except ApiException as e:
-    print("Exception when calling FakeApi->test_endpoint_parameters: %s\n" % e)
+    try:
+        # Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
+        api_instance.test_endpoint_parameters(number, double, pattern_without_delimiter, byte, integer=integer, int32=int32, int64=int64, float=float, string=string, binary=binary, date=date, date_time=date_time, password=password, param_callback=param_callback)
+    except ApiException as e:
+        print("Exception when calling FakeApi->test_endpoint_parameters: %s\n" % e)
 ```
 
 ### Parameters
@@ -541,9 +559,11 @@ import petstore_api
 from petstore_api.rest import ApiException
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.FakeApi()
-enum_header_string_array = ['enum_header_string_array_example'] # list[str] | Header parameter enum test (string array) (optional)
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient() as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.FakeApi(api_client)
+    enum_header_string_array = ['enum_header_string_array_example'] # list[str] | Header parameter enum test (string array) (optional)
 enum_header_string = '-efg' # str | Header parameter enum test (string) (optional) (default to '-efg')
 enum_query_string_array = ['enum_query_string_array_example'] # list[str] | Query parameter enum test (string array) (optional)
 enum_query_string = '-efg' # str | Query parameter enum test (string) (optional) (default to '-efg')
@@ -552,11 +572,11 @@ enum_query_double = 3.4 # float | Query parameter enum test (double) (optional)
 enum_form_string_array = '$' # list[str] | Form parameter enum test (string array) (optional) (default to '$')
 enum_form_string = '-efg' # str | Form parameter enum test (string) (optional) (default to '-efg')
 
-try:
-    # To test enum parameters
-    api_instance.test_enum_parameters(enum_header_string_array=enum_header_string_array, enum_header_string=enum_header_string, enum_query_string_array=enum_query_string_array, enum_query_string=enum_query_string, enum_query_integer=enum_query_integer, enum_query_double=enum_query_double, enum_form_string_array=enum_form_string_array, enum_form_string=enum_form_string)
-except ApiException as e:
-    print("Exception when calling FakeApi->test_enum_parameters: %s\n" % e)
+    try:
+        # To test enum parameters
+        api_instance.test_enum_parameters(enum_header_string_array=enum_header_string_array, enum_header_string=enum_header_string, enum_query_string_array=enum_query_string_array, enum_query_string=enum_query_string, enum_query_integer=enum_query_integer, enum_query_double=enum_query_double, enum_form_string_array=enum_form_string_array, enum_form_string=enum_form_string)
+    except ApiException as e:
+        print("Exception when calling FakeApi->test_enum_parameters: %s\n" % e)
 ```
 
 ### Parameters
@@ -615,20 +635,22 @@ configuration.access_token = 'YOUR_BEARER_TOKEN'
 
 # Defining host is optional and default to http://petstore.swagger.io:80/v2
 configuration.host = "http://petstore.swagger.io:80/v2"
-# Create an instance of the API class
-api_instance = petstore_api.FakeApi(petstore_api.ApiClient(configuration))
-required_string_group = 56 # int | Required String in group parameters
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.FakeApi(api_client)
+    required_string_group = 56 # int | Required String in group parameters
 required_boolean_group = True # bool | Required Boolean in group parameters
 required_int64_group = 56 # int | Required Integer in group parameters
 string_group = 56 # int | String in group parameters (optional)
 boolean_group = True # bool | Boolean in group parameters (optional)
 int64_group = 56 # int | Integer in group parameters (optional)
 
-try:
-    # Fake endpoint to test group parameters (optional)
-    api_instance.test_group_parameters(required_string_group, required_boolean_group, required_int64_group, string_group=string_group, boolean_group=boolean_group, int64_group=int64_group)
-except ApiException as e:
-    print("Exception when calling FakeApi->test_group_parameters: %s\n" % e)
+    try:
+        # Fake endpoint to test group parameters (optional)
+        api_instance.test_group_parameters(required_string_group, required_boolean_group, required_int64_group, string_group=string_group, boolean_group=boolean_group, int64_group=int64_group)
+    except ApiException as e:
+        print("Exception when calling FakeApi->test_group_parameters: %s\n" % e)
 ```
 
 ### Parameters
@@ -676,15 +698,17 @@ import petstore_api
 from petstore_api.rest import ApiException
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.FakeApi()
-request_body = {'key': 'request_body_example'} # dict(str, str) | request body
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient() as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.FakeApi(api_client)
+    request_body = {'key': 'request_body_example'} # dict(str, str) | request body
 
-try:
-    # test inline additionalProperties
-    api_instance.test_inline_additional_properties(request_body)
-except ApiException as e:
-    print("Exception when calling FakeApi->test_inline_additional_properties: %s\n" % e)
+    try:
+        # test inline additionalProperties
+        api_instance.test_inline_additional_properties(request_body)
+    except ApiException as e:
+        print("Exception when calling FakeApi->test_inline_additional_properties: %s\n" % e)
 ```
 
 ### Parameters
@@ -727,16 +751,18 @@ import petstore_api
 from petstore_api.rest import ApiException
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.FakeApi()
-param = 'param_example' # str | field1
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient() as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.FakeApi(api_client)
+    param = 'param_example' # str | field1
 param2 = 'param2_example' # str | field2
 
-try:
-    # test json serialization of form data
-    api_instance.test_json_form_data(param, param2)
-except ApiException as e:
-    print("Exception when calling FakeApi->test_json_form_data: %s\n" % e)
+    try:
+        # test json serialization of form data
+        api_instance.test_json_form_data(param, param2)
+    except ApiException as e:
+        print("Exception when calling FakeApi->test_json_form_data: %s\n" % e)
 ```
 
 ### Parameters
@@ -782,18 +808,20 @@ import petstore_api
 from petstore_api.rest import ApiException
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.FakeApi()
-pipe = ['pipe_example'] # list[str] | 
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient() as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.FakeApi(api_client)
+    pipe = ['pipe_example'] # list[str] | 
 ioutil = ['ioutil_example'] # list[str] | 
 http = ['http_example'] # list[str] | 
 url = ['url_example'] # list[str] | 
 context = ['context_example'] # list[str] | 
 
-try:
-    api_instance.test_query_parameter_collection_format(pipe, ioutil, http, url, context)
-except ApiException as e:
-    print("Exception when calling FakeApi->test_query_parameter_collection_format: %s\n" % e)
+    try:
+        api_instance.test_query_parameter_collection_format(pipe, ioutil, http, url, context)
+    except ApiException as e:
+        print("Exception when calling FakeApi->test_query_parameter_collection_format: %s\n" % e)
 ```
 
 ### Parameters

--- a/samples/openapi3/client/petstore/python/docs/FakeClassnameTags123Api.md
+++ b/samples/openapi3/client/petstore/python/docs/FakeClassnameTags123Api.md
@@ -31,16 +31,18 @@ configuration.api_key['api_key_query'] = 'YOUR_API_KEY'
 
 # Defining host is optional and default to http://petstore.swagger.io:80/v2
 configuration.host = "http://petstore.swagger.io:80/v2"
-# Create an instance of the API class
-api_instance = petstore_api.FakeClassnameTags123Api(petstore_api.ApiClient(configuration))
-client = petstore_api.Client() # Client | client model
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.FakeClassnameTags123Api(api_client)
+    client = petstore_api.Client() # Client | client model
 
-try:
-    # To test class name in snake case
-    api_response = api_instance.test_classname(client)
-    pprint(api_response)
-except ApiException as e:
-    print("Exception when calling FakeClassnameTags123Api->test_classname: %s\n" % e)
+    try:
+        # To test class name in snake case
+        api_response = api_instance.test_classname(client)
+        pprint(api_response)
+    except ApiException as e:
+        print("Exception when calling FakeClassnameTags123Api->test_classname: %s\n" % e)
 ```
 
 ### Parameters

--- a/samples/openapi3/client/petstore/python/docs/PetApi.md
+++ b/samples/openapi3/client/petstore/python/docs/PetApi.md
@@ -35,15 +35,17 @@ configuration.access_token = 'YOUR_ACCESS_TOKEN'
 
 # Defining host is optional and default to http://petstore.swagger.io:80/v2
 configuration.host = "http://petstore.swagger.io:80/v2"
-# Create an instance of the API class
-api_instance = petstore_api.PetApi(petstore_api.ApiClient(configuration))
-pet = petstore_api.Pet() # Pet | Pet object that needs to be added to the store
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.PetApi(api_client)
+    pet = petstore_api.Pet() # Pet | Pet object that needs to be added to the store
 
-try:
-    # Add a new pet to the store
-    api_instance.add_pet(pet)
-except ApiException as e:
-    print("Exception when calling PetApi->add_pet: %s\n" % e)
+    try:
+        # Add a new pet to the store
+        api_instance.add_pet(pet)
+    except ApiException as e:
+        print("Exception when calling PetApi->add_pet: %s\n" % e)
 ```
 
 ### Parameters
@@ -92,16 +94,18 @@ configuration.access_token = 'YOUR_ACCESS_TOKEN'
 
 # Defining host is optional and default to http://petstore.swagger.io:80/v2
 configuration.host = "http://petstore.swagger.io:80/v2"
-# Create an instance of the API class
-api_instance = petstore_api.PetApi(petstore_api.ApiClient(configuration))
-pet_id = 56 # int | Pet id to delete
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.PetApi(api_client)
+    pet_id = 56 # int | Pet id to delete
 api_key = 'api_key_example' # str |  (optional)
 
-try:
-    # Deletes a pet
-    api_instance.delete_pet(pet_id, api_key=api_key)
-except ApiException as e:
-    print("Exception when calling PetApi->delete_pet: %s\n" % e)
+    try:
+        # Deletes a pet
+        api_instance.delete_pet(pet_id, api_key=api_key)
+    except ApiException as e:
+        print("Exception when calling PetApi->delete_pet: %s\n" % e)
 ```
 
 ### Parameters
@@ -153,16 +157,18 @@ configuration.access_token = 'YOUR_ACCESS_TOKEN'
 
 # Defining host is optional and default to http://petstore.swagger.io:80/v2
 configuration.host = "http://petstore.swagger.io:80/v2"
-# Create an instance of the API class
-api_instance = petstore_api.PetApi(petstore_api.ApiClient(configuration))
-status = ['status_example'] # list[str] | Status values that need to be considered for filter
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.PetApi(api_client)
+    status = ['status_example'] # list[str] | Status values that need to be considered for filter
 
-try:
-    # Finds Pets by status
-    api_response = api_instance.find_pets_by_status(status)
-    pprint(api_response)
-except ApiException as e:
-    print("Exception when calling PetApi->find_pets_by_status: %s\n" % e)
+    try:
+        # Finds Pets by status
+        api_response = api_instance.find_pets_by_status(status)
+        pprint(api_response)
+    except ApiException as e:
+        print("Exception when calling PetApi->find_pets_by_status: %s\n" % e)
 ```
 
 ### Parameters
@@ -214,16 +220,18 @@ configuration.access_token = 'YOUR_ACCESS_TOKEN'
 
 # Defining host is optional and default to http://petstore.swagger.io:80/v2
 configuration.host = "http://petstore.swagger.io:80/v2"
-# Create an instance of the API class
-api_instance = petstore_api.PetApi(petstore_api.ApiClient(configuration))
-tags = ['tags_example'] # list[str] | Tags to filter by
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.PetApi(api_client)
+    tags = ['tags_example'] # list[str] | Tags to filter by
 
-try:
-    # Finds Pets by tags
-    api_response = api_instance.find_pets_by_tags(tags)
-    pprint(api_response)
-except ApiException as e:
-    print("Exception when calling PetApi->find_pets_by_tags: %s\n" % e)
+    try:
+        # Finds Pets by tags
+        api_response = api_instance.find_pets_by_tags(tags)
+        pprint(api_response)
+    except ApiException as e:
+        print("Exception when calling PetApi->find_pets_by_tags: %s\n" % e)
 ```
 
 ### Parameters
@@ -277,16 +285,18 @@ configuration.api_key['api_key'] = 'YOUR_API_KEY'
 
 # Defining host is optional and default to http://petstore.swagger.io:80/v2
 configuration.host = "http://petstore.swagger.io:80/v2"
-# Create an instance of the API class
-api_instance = petstore_api.PetApi(petstore_api.ApiClient(configuration))
-pet_id = 56 # int | ID of pet to return
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.PetApi(api_client)
+    pet_id = 56 # int | ID of pet to return
 
-try:
-    # Find pet by ID
-    api_response = api_instance.get_pet_by_id(pet_id)
-    pprint(api_response)
-except ApiException as e:
-    print("Exception when calling PetApi->get_pet_by_id: %s\n" % e)
+    try:
+        # Find pet by ID
+        api_response = api_instance.get_pet_by_id(pet_id)
+        pprint(api_response)
+    except ApiException as e:
+        print("Exception when calling PetApi->get_pet_by_id: %s\n" % e)
 ```
 
 ### Parameters
@@ -337,15 +347,17 @@ configuration.access_token = 'YOUR_ACCESS_TOKEN'
 
 # Defining host is optional and default to http://petstore.swagger.io:80/v2
 configuration.host = "http://petstore.swagger.io:80/v2"
-# Create an instance of the API class
-api_instance = petstore_api.PetApi(petstore_api.ApiClient(configuration))
-pet = petstore_api.Pet() # Pet | Pet object that needs to be added to the store
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.PetApi(api_client)
+    pet = petstore_api.Pet() # Pet | Pet object that needs to be added to the store
 
-try:
-    # Update an existing pet
-    api_instance.update_pet(pet)
-except ApiException as e:
-    print("Exception when calling PetApi->update_pet: %s\n" % e)
+    try:
+        # Update an existing pet
+        api_instance.update_pet(pet)
+    except ApiException as e:
+        print("Exception when calling PetApi->update_pet: %s\n" % e)
 ```
 
 ### Parameters
@@ -396,17 +408,19 @@ configuration.access_token = 'YOUR_ACCESS_TOKEN'
 
 # Defining host is optional and default to http://petstore.swagger.io:80/v2
 configuration.host = "http://petstore.swagger.io:80/v2"
-# Create an instance of the API class
-api_instance = petstore_api.PetApi(petstore_api.ApiClient(configuration))
-pet_id = 56 # int | ID of pet that needs to be updated
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.PetApi(api_client)
+    pet_id = 56 # int | ID of pet that needs to be updated
 name = 'name_example' # str | Updated name of the pet (optional)
 status = 'status_example' # str | Updated status of the pet (optional)
 
-try:
-    # Updates a pet in the store with form data
-    api_instance.update_pet_with_form(pet_id, name=name, status=status)
-except ApiException as e:
-    print("Exception when calling PetApi->update_pet_with_form: %s\n" % e)
+    try:
+        # Updates a pet in the store with form data
+        api_instance.update_pet_with_form(pet_id, name=name, status=status)
+    except ApiException as e:
+        print("Exception when calling PetApi->update_pet_with_form: %s\n" % e)
 ```
 
 ### Parameters
@@ -457,18 +471,20 @@ configuration.access_token = 'YOUR_ACCESS_TOKEN'
 
 # Defining host is optional and default to http://petstore.swagger.io:80/v2
 configuration.host = "http://petstore.swagger.io:80/v2"
-# Create an instance of the API class
-api_instance = petstore_api.PetApi(petstore_api.ApiClient(configuration))
-pet_id = 56 # int | ID of pet to update
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.PetApi(api_client)
+    pet_id = 56 # int | ID of pet to update
 additional_metadata = 'additional_metadata_example' # str | Additional data to pass to server (optional)
 file = '/path/to/file' # file | file to upload (optional)
 
-try:
-    # uploads an image
-    api_response = api_instance.upload_file(pet_id, additional_metadata=additional_metadata, file=file)
-    pprint(api_response)
-except ApiException as e:
-    print("Exception when calling PetApi->upload_file: %s\n" % e)
+    try:
+        # uploads an image
+        api_response = api_instance.upload_file(pet_id, additional_metadata=additional_metadata, file=file)
+        pprint(api_response)
+    except ApiException as e:
+        print("Exception when calling PetApi->upload_file: %s\n" % e)
 ```
 
 ### Parameters
@@ -519,18 +535,20 @@ configuration.access_token = 'YOUR_ACCESS_TOKEN'
 
 # Defining host is optional and default to http://petstore.swagger.io:80/v2
 configuration.host = "http://petstore.swagger.io:80/v2"
-# Create an instance of the API class
-api_instance = petstore_api.PetApi(petstore_api.ApiClient(configuration))
-pet_id = 56 # int | ID of pet to update
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.PetApi(api_client)
+    pet_id = 56 # int | ID of pet to update
 required_file = '/path/to/file' # file | file to upload
 additional_metadata = 'additional_metadata_example' # str | Additional data to pass to server (optional)
 
-try:
-    # uploads an image (required)
-    api_response = api_instance.upload_file_with_required_file(pet_id, required_file, additional_metadata=additional_metadata)
-    pprint(api_response)
-except ApiException as e:
-    print("Exception when calling PetApi->upload_file_with_required_file: %s\n" % e)
+    try:
+        # uploads an image (required)
+        api_response = api_instance.upload_file_with_required_file(pet_id, required_file, additional_metadata=additional_metadata)
+        pprint(api_response)
+    except ApiException as e:
+        print("Exception when calling PetApi->upload_file_with_required_file: %s\n" % e)
 ```
 
 ### Parameters

--- a/samples/openapi3/client/petstore/python/docs/StoreApi.md
+++ b/samples/openapi3/client/petstore/python/docs/StoreApi.md
@@ -26,15 +26,17 @@ import petstore_api
 from petstore_api.rest import ApiException
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.StoreApi()
-order_id = 'order_id_example' # str | ID of the order that needs to be deleted
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient() as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.StoreApi(api_client)
+    order_id = 'order_id_example' # str | ID of the order that needs to be deleted
 
-try:
-    # Delete purchase order by ID
-    api_instance.delete_order(order_id)
-except ApiException as e:
-    print("Exception when calling StoreApi->delete_order: %s\n" % e)
+    try:
+        # Delete purchase order by ID
+        api_instance.delete_order(order_id)
+    except ApiException as e:
+        print("Exception when calling StoreApi->delete_order: %s\n" % e)
 ```
 
 ### Parameters
@@ -88,15 +90,17 @@ configuration.api_key['api_key'] = 'YOUR_API_KEY'
 
 # Defining host is optional and default to http://petstore.swagger.io:80/v2
 configuration.host = "http://petstore.swagger.io:80/v2"
-# Create an instance of the API class
-api_instance = petstore_api.StoreApi(petstore_api.ApiClient(configuration))
-
-try:
-    # Returns pet inventories by status
-    api_response = api_instance.get_inventory()
-    pprint(api_response)
-except ApiException as e:
-    print("Exception when calling StoreApi->get_inventory: %s\n" % e)
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.StoreApi(api_client)
+    
+    try:
+        # Returns pet inventories by status
+        api_response = api_instance.get_inventory()
+        pprint(api_response)
+    except ApiException as e:
+        print("Exception when calling StoreApi->get_inventory: %s\n" % e)
 ```
 
 ### Parameters
@@ -138,16 +142,18 @@ import petstore_api
 from petstore_api.rest import ApiException
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.StoreApi()
-order_id = 56 # int | ID of pet that needs to be fetched
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient() as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.StoreApi(api_client)
+    order_id = 56 # int | ID of pet that needs to be fetched
 
-try:
-    # Find purchase order by ID
-    api_response = api_instance.get_order_by_id(order_id)
-    pprint(api_response)
-except ApiException as e:
-    print("Exception when calling StoreApi->get_order_by_id: %s\n" % e)
+    try:
+        # Find purchase order by ID
+        api_response = api_instance.get_order_by_id(order_id)
+        pprint(api_response)
+    except ApiException as e:
+        print("Exception when calling StoreApi->get_order_by_id: %s\n" % e)
 ```
 
 ### Parameters
@@ -192,16 +198,18 @@ import petstore_api
 from petstore_api.rest import ApiException
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.StoreApi()
-order = petstore_api.Order() # Order | order placed for purchasing the pet
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient() as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.StoreApi(api_client)
+    order = petstore_api.Order() # Order | order placed for purchasing the pet
 
-try:
-    # Place an order for a pet
-    api_response = api_instance.place_order(order)
-    pprint(api_response)
-except ApiException as e:
-    print("Exception when calling StoreApi->place_order: %s\n" % e)
+    try:
+        # Place an order for a pet
+        api_response = api_instance.place_order(order)
+        pprint(api_response)
+    except ApiException as e:
+        print("Exception when calling StoreApi->place_order: %s\n" % e)
 ```
 
 ### Parameters

--- a/samples/openapi3/client/petstore/python/docs/UserApi.md
+++ b/samples/openapi3/client/petstore/python/docs/UserApi.md
@@ -30,15 +30,17 @@ import petstore_api
 from petstore_api.rest import ApiException
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.UserApi()
-user = petstore_api.User() # User | Created user object
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient() as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.UserApi(api_client)
+    user = petstore_api.User() # User | Created user object
 
-try:
-    # Create user
-    api_instance.create_user(user)
-except ApiException as e:
-    print("Exception when calling UserApi->create_user: %s\n" % e)
+    try:
+        # Create user
+        api_instance.create_user(user)
+    except ApiException as e:
+        print("Exception when calling UserApi->create_user: %s\n" % e)
 ```
 
 ### Parameters
@@ -81,15 +83,17 @@ import petstore_api
 from petstore_api.rest import ApiException
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.UserApi()
-user = [petstore_api.User()] # list[User] | List of user object
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient() as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.UserApi(api_client)
+    user = [petstore_api.User()] # list[User] | List of user object
 
-try:
-    # Creates list of users with given input array
-    api_instance.create_users_with_array_input(user)
-except ApiException as e:
-    print("Exception when calling UserApi->create_users_with_array_input: %s\n" % e)
+    try:
+        # Creates list of users with given input array
+        api_instance.create_users_with_array_input(user)
+    except ApiException as e:
+        print("Exception when calling UserApi->create_users_with_array_input: %s\n" % e)
 ```
 
 ### Parameters
@@ -132,15 +136,17 @@ import petstore_api
 from petstore_api.rest import ApiException
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.UserApi()
-user = [petstore_api.User()] # list[User] | List of user object
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient() as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.UserApi(api_client)
+    user = [petstore_api.User()] # list[User] | List of user object
 
-try:
-    # Creates list of users with given input array
-    api_instance.create_users_with_list_input(user)
-except ApiException as e:
-    print("Exception when calling UserApi->create_users_with_list_input: %s\n" % e)
+    try:
+        # Creates list of users with given input array
+        api_instance.create_users_with_list_input(user)
+    except ApiException as e:
+        print("Exception when calling UserApi->create_users_with_list_input: %s\n" % e)
 ```
 
 ### Parameters
@@ -185,15 +191,17 @@ import petstore_api
 from petstore_api.rest import ApiException
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.UserApi()
-username = 'username_example' # str | The name that needs to be deleted
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient() as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.UserApi(api_client)
+    username = 'username_example' # str | The name that needs to be deleted
 
-try:
-    # Delete user
-    api_instance.delete_user(username)
-except ApiException as e:
-    print("Exception when calling UserApi->delete_user: %s\n" % e)
+    try:
+        # Delete user
+        api_instance.delete_user(username)
+    except ApiException as e:
+        print("Exception when calling UserApi->delete_user: %s\n" % e)
 ```
 
 ### Parameters
@@ -237,16 +245,18 @@ import petstore_api
 from petstore_api.rest import ApiException
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.UserApi()
-username = 'username_example' # str | The name that needs to be fetched. Use user1 for testing.
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient() as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.UserApi(api_client)
+    username = 'username_example' # str | The name that needs to be fetched. Use user1 for testing.
 
-try:
-    # Get user by user name
-    api_response = api_instance.get_user_by_name(username)
-    pprint(api_response)
-except ApiException as e:
-    print("Exception when calling UserApi->get_user_by_name: %s\n" % e)
+    try:
+        # Get user by user name
+        api_response = api_instance.get_user_by_name(username)
+        pprint(api_response)
+    except ApiException as e:
+        print("Exception when calling UserApi->get_user_by_name: %s\n" % e)
 ```
 
 ### Parameters
@@ -291,17 +301,19 @@ import petstore_api
 from petstore_api.rest import ApiException
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.UserApi()
-username = 'username_example' # str | The user name for login
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient() as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.UserApi(api_client)
+    username = 'username_example' # str | The user name for login
 password = 'password_example' # str | The password for login in clear text
 
-try:
-    # Logs user into the system
-    api_response = api_instance.login_user(username, password)
-    pprint(api_response)
-except ApiException as e:
-    print("Exception when calling UserApi->login_user: %s\n" % e)
+    try:
+        # Logs user into the system
+        api_response = api_instance.login_user(username, password)
+        pprint(api_response)
+    except ApiException as e:
+        print("Exception when calling UserApi->login_user: %s\n" % e)
 ```
 
 ### Parameters
@@ -346,14 +358,16 @@ import petstore_api
 from petstore_api.rest import ApiException
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.UserApi()
-
-try:
-    # Logs out current logged in user session
-    api_instance.logout_user()
-except ApiException as e:
-    print("Exception when calling UserApi->logout_user: %s\n" % e)
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient() as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.UserApi(api_client)
+    
+    try:
+        # Logs out current logged in user session
+        api_instance.logout_user()
+    except ApiException as e:
+        print("Exception when calling UserApi->logout_user: %s\n" % e)
 ```
 
 ### Parameters
@@ -395,16 +409,18 @@ import petstore_api
 from petstore_api.rest import ApiException
 from pprint import pprint
 
-# Create an instance of the API class
-api_instance = petstore_api.UserApi()
-username = 'username_example' # str | name that need to be deleted
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient() as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.UserApi(api_client)
+    username = 'username_example' # str | name that need to be deleted
 user = petstore_api.User() # User | Updated user object
 
-try:
-    # Updated user
-    api_instance.update_user(username, user)
-except ApiException as e:
-    print("Exception when calling UserApi->update_user: %s\n" % e)
+    try:
+        # Updated user
+        api_instance.update_user(username, user)
+    except ApiException as e:
+        print("Exception when calling UserApi->update_user: %s\n" % e)
 ```
 
 ### Parameters

--- a/samples/openapi3/client/petstore/python/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api_client.py
@@ -10,6 +10,7 @@
 
 from __future__ import absolute_import
 
+import atexit
 import datetime
 from dateutil.parser import parse
 import json
@@ -80,11 +81,19 @@ class ApiClient(object):
         self.user_agent = 'OpenAPI-Generator/1.0.0/python'
         self.client_side_validation = configuration.client_side_validation
 
-    def __del__(self):
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.close()
+
+    def close(self):
         if self._pool:
             self._pool.close()
             self._pool.join()
             self._pool = None
+            if hasattr(atexit, 'unregister'):
+                atexit.unregister(self.close)
 
     @property
     def pool(self):
@@ -92,6 +101,7 @@ class ApiClient(object):
          avoids instantiating unused threadpool for blocking clients.
         """
         if self._pool is None:
+            atexit.register(self.close)
             self._pool = ThreadPool(self.pool_threads)
         return self._pool
 


### PR DESCRIPTION
This removes the `__del__` function from the generated Python client,
and replaces it with a `cleanup` function. When a ThreadPool is created,
the cleanup function is registered with the `atexit` module.

This fixes #5093, where the API client could hang indefinitely at
garbage collection.

Related to https://github.com/swagger-api/swagger-codegen/pull/10002
<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

cc @taxpon @frol @mbohlool @cbornet @kenjones-cisco @tomplus @Jyhess @slash-arun @spacether