### PR TITLE
[HttpBasicAuth] Use positive isBasicBasic tag instead of negative isBasicBearer

### DIFF
--- a/modules/openapi-generator/src/main/resources/Javascript/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Javascript/ApiClient.mustache
@@ -43,9 +43,9 @@
 {{/emitJSDoc}}{{=< >=}}    this.authentications = {
 <#authMethods>
 <#isBasic>
-<^isBasicBearer>
+<#isBasicBasic>
       '<name>': {type: 'basic'}<^-last>,</-last>
-</isBasicBearer>
+</isBasicBasic>
 <#isBasicBearer>
       '<name>': {type: 'bearer'}<^-last>,</-last><#bearerFormat> // <&.></bearerFormat>
 </isBasicBearer>

--- a/modules/openapi-generator/src/main/resources/Javascript/README.mustache
+++ b/modules/openapi-generator/src/main/resources/Javascript/README.mustache
@@ -100,12 +100,12 @@ var {{{moduleName}}} = require('{{{projectName}}}');
 var defaultClient = {{{moduleName}}}.ApiClient.instance;
 {{#authMethods}}
 {{#isBasic}}
-{{^isBasicBearer}}
+{{#isBasicBasic}}
 // Configure HTTP basic authorization: {{{name}}}
 var {{{name}}} = defaultClient.authentications['{{{name}}}'];
 {{{name}}}.username = 'YOUR USERNAME'
 {{{name}}}.password = 'YOUR PASSWORD'
-{{/isBasicBearer}}
+{{/isBasicBasic}}
 {{#isBasicBearer}}
 // Configure Bearer{{#bearerFormat}} ({{{.}}}){{/bearerFormat}} access token for authorization: {{{name}}}
 var {{{name}}} = defaultClient.authentications['{{{name}}}'];
@@ -192,10 +192,10 @@ All endpoints do not require authorization.
 - **Location**: {{#isKeyInQuery}}URL query string{{/isKeyInQuery}}{{#isKeyInHeader}}HTTP header{{/isKeyInHeader}}
 {{/isApiKey}}
 {{#isBasic}}
-{{^isBasicBearer}}
+{{#isBasicBasic}}
 
 - **Type**: HTTP basic authentication
-{{/isBasicBearer}}
+{{/isBasicBasic}}
 {{#isBasicBearer}}
 
 - **Type**: Bearer authentication{{#bearerFormat}} ({{{.}}}){{/bearerFormat}}

--- a/modules/openapi-generator/src/main/resources/Javascript/api_doc.mustache
+++ b/modules/openapi-generator/src/main/resources/Javascript/api_doc.mustache
@@ -28,12 +28,12 @@ var {{{moduleName}}} = require('{{{projectName}}}');
 var defaultClient = {{{moduleName}}}.ApiClient.instance;
 {{#authMethods}}
 {{#isBasic}}
-{{^isBasicBearer}}
+{{#isBasicBasic}}
 // Configure HTTP basic authorization: {{{name}}}
 var {{{name}}} = defaultClient.authentications['{{{name}}}'];
 {{{name}}}.username = 'YOUR USERNAME';
 {{{name}}}.password = 'YOUR PASSWORD';
-{{/isBasicBearer}}
+{{/isBasicBasic}}
 {{#isBasicBearer}}
 // Configure Bearer{{#bearerFormat}} ({{{.}}}){{/bearerFormat}} access token for authorization: {{{name}}}
 var {{{name}}} = defaultClient.authentications['{{{name}}}'];

--- a/modules/openapi-generator/src/main/resources/Javascript/es6/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Javascript/es6/ApiClient.mustache
@@ -31,9 +31,9 @@ class ApiClient {
         this.authentications = {
 <#authMethods>
 <#isBasic>
-<^isBasicBearer>
+<#isBasicBasic>
             '<name>': {type: 'basic'}<^-last>,</-last>
-</isBasicBearer>
+</isBasicBasic>
 <#isBasicBearer>
             '<name>': {type: 'bearer'}<^-last>,</-last><#bearerFormat> // <&.></bearerFormat>
 </isBasicBearer>

--- a/modules/openapi-generator/src/main/resources/Javascript/es6/README.mustache
+++ b/modules/openapi-generator/src/main/resources/Javascript/es6/README.mustache
@@ -112,12 +112,12 @@ var {{{moduleName}}} = require('{{{projectName}}}');
 var defaultClient = {{{moduleName}}}.ApiClient.instance;
 {{#authMethods}}
 {{#isBasic}}
-{{^isBasicBearer}}
+{{#isBasicBasic}}
 // Configure HTTP basic authorization: {{{name}}}
 var {{{name}}} = defaultClient.authentications['{{{name}}}'];
 {{{name}}}.username = 'YOUR USERNAME'
 {{{name}}}.password = 'YOUR PASSWORD'
-{{/isBasicBearer}}
+{{/isBasicBasic}}
 {{#isBasicBearer}}
 // Configure Bearer{{#bearerFormat}} ({{{.}}}){{/bearerFormat}} access token for authorization: {{{name}}}
 var {{{name}}} = defaultClient.authentications['{{{name}}}'];
@@ -206,9 +206,9 @@ All endpoints do not require authorization.
 - **Location**: {{#isKeyInQuery}}URL query string{{/isKeyInQuery}}{{#isKeyInHeader}}HTTP header{{/isKeyInHeader}}
 {{/isApiKey}}
 {{#isBasic}}
-{{^isBasicBearer}}
+{{#isBasicBasic}}
 - **Type**: HTTP basic authentication
-{{/isBasicBearer}}
+{{/isBasicBasic}}
 {{#isBasicBearer}}
 - **Type**: Bearer authentication{{#bearerFormat}} ({{{.}}}){{/bearerFormat}}
 {{/isBasicBearer}}

--- a/modules/openapi-generator/src/main/resources/Javascript/es6/api_doc.mustache
+++ b/modules/openapi-generator/src/main/resources/Javascript/es6/api_doc.mustache
@@ -28,12 +28,12 @@ import {{{moduleName}}} from '{{{projectName}}}';
 let defaultClient = {{{moduleName}}}.ApiClient.instance;
 {{#authMethods}}
 {{#isBasic}}
-{{^isBasicBearer}}
+{{#isBasicBasic}}
 // Configure HTTP basic authorization: {{{name}}}
 let {{{name}}} = defaultClient.authentications['{{{name}}}'];
 {{{name}}}.username = 'YOUR USERNAME';
 {{{name}}}.password = 'YOUR PASSWORD';
-{{/isBasicBearer}}
+{{/isBasicBasic}}
 {{#isBasicBearer}}
 // Configure Bearer{{#bearerFormat}} ({{{.}}}){{/bearerFormat}} access token for authorization: {{{name}}}
 let {{{name}}} = defaultClient.authentications['{{{name}}}'];

--- a/modules/openapi-generator/src/main/resources/asciidoc-documentation/index.mustache
+++ b/modules/openapi-generator/src/main/resources/asciidoc-documentation/index.mustache
@@ -25,7 +25,7 @@
 
 {{#authMethods}}
 {{#isBasic}}
-{{^isBasicBearer}}* *HTTP Basic* Authentication _{{{name}}}_{{/isBasicBearer}}
+{{#isBasicBasic}}* *HTTP Basic* Authentication _{{{name}}}_{{/isBasicBasic}}
 {{#isBasicBearer}}* *Bearer* Authentication {{/isBasicBearer}}
 {{/isBasic}}
 {{#isOAuth}}* *OAuth*  AuthorizationUrl: _{{authorizationUrl}}_, TokenUrl:   _{{tokenUrl}}_ {{/isOAuth}}

--- a/modules/openapi-generator/src/main/resources/kotlin-client/api_doc.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/api_doc.mustache
@@ -62,11 +62,11 @@ Configure {{name}}:
     ApiClient.apiKeyPrefix["{{keyParamName}}"] = ""
 {{/isApiKey}}
 {{#isBasic}}
-{{^isBasicBearer}}
+{{#isBasicBasic}}
 Configure {{name}}:
     ApiClient.username = ""
     ApiClient.password = ""
-{{/isBasicBearer}}
+{{/isBasicBasic}}
 {{#isBasicBearer}}
 Configure {{name}}:
     ApiClient.accessToken = ""

--- a/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-okhttp/infrastructure/ApiClient.kt.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-okhttp/infrastructure/ApiClient.kt.mustache
@@ -134,7 +134,7 @@ import java.io.File
         }
         {{/isApiKey}}
         {{#isBasic}}
-        {{^isBasicBearer}}
+        {{#isBasicBasic}}
         if (requestConfig.headers[Authorization].isNullOrEmpty()) {
             username?.let { username ->
                 password?.let { password ->
@@ -142,7 +142,7 @@ import java.io.File
                 }
             }
         }
-        {{/isBasicBearer}}
+        {{/isBasicBasic}}
         {{#isBasicBearer}}
         if (requestConfig.headers[Authorization].isNullOrEmpty()) {
             accessToken?.let { accessToken ->

--- a/modules/openapi-generator/src/main/resources/perl/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/perl/ApiClient.mustache
@@ -340,11 +340,11 @@ sub update_params_for_auth {
             {{/isKeyInQuery}}
             {{/isApiKey}}
             {{#isBasic}}
-            {{^isBasicBearer}}
+            {{#isBasicBasic}}
             if ($self->{config}{username} || $self->{config}{password}) {
                 $header_params->{'Authorization'} = 'Basic ' . encode_base64($self->{config}{username} . ":" . $self->{config}{password});
             }
-            {{/isBasicBearer}}
+            {{/isBasicBasic}}
             {{#isBasicBearer}}
             // this endpoint requires Bearer{{#bearerFormat}} ({{{.}}}){{/bearerFormat}} authentication (access token)
             if ($self->{config}{access_token}) {

--- a/modules/openapi-generator/src/main/resources/perl/api_doc.mustache
+++ b/modules/openapi-generator/src/main/resources/perl/api_doc.mustache
@@ -29,10 +29,10 @@ use {{moduleName}}::{{classname}};
 my $api_instance = {{moduleName}}::{{classname}}->new(
 {{#hasAuthMethods}}{{#authMethods}}{{#isBasic}}
     # Configure HTTP basic authorization: {{{name}}}
-    {{^isBasicBearer}}
+    {{#isBasicBasic}}
     username => 'YOUR_USERNAME',
     password => 'YOUR_PASSWORD',
-    {{/isBasicBearer}}
+    {{/isBasicBasic}}
     {{#isBasicBearer}}
     # Configure bearer access token for authorization: {{{name}}}
     access_token => 'YOUR_BEARER_TOKEN',

--- a/modules/openapi-generator/src/main/resources/php/README.mustache
+++ b/modules/openapi-generator/src/main/resources/php/README.mustache
@@ -122,10 +122,10 @@ All endpoints do not require authorization.
 
 {{/isApiKey}}
 {{#isBasic}}
-{{^isBasicBearer}}
+{{#isBasicBasic}}
 
 - **Type**: HTTP basic authentication
-{{/isBasicBearer}}
+{{/isBasicBasic}}
 {{#isBasicBearer}}
 
 - **Type**: Bearer authentication{{#bearerFormat}} ({{{.}}}){{/bearerFormat}}

--- a/modules/openapi-generator/src/main/resources/php/api.mustache
+++ b/modules/openapi-generator/src/main/resources/php/api.mustache
@@ -579,12 +579,12 @@ use {{invokerPackage}}\ObjectSerializer;
         }
         {{/isApiKey}}
         {{#isBasic}}
-        {{^isBasicBearer}}
+        {{#isBasicBasic}}
         // this endpoint requires HTTP basic authentication
         if (!empty($this->config->getUsername()) || !(empty($this->config->getPassword()))) {
             $headers['Authorization'] = 'Basic ' . base64_encode($this->config->getUsername() . ":" . $this->config->getPassword());
         }
-        {{/isBasicBearer}}
+        {{/isBasicBasic}}
         {{#isBasicBearer}}
         // this endpoint requires Bearer{{#bearerFormat}} ({{{.}}}){{/bearerFormat}} authentication (access token)
         if ($this->config->getAccessToken() !== null) {

--- a/modules/openapi-generator/src/main/resources/php/php_doc_auth_partial.mustache
+++ b/modules/openapi-generator/src/main/resources/php/php_doc_auth_partial.mustache
@@ -2,12 +2,12 @@
 
 {{#authMethods}}
 {{#isBasic}}
-{{^isBasicBearer}}
+{{#isBasicBasic}}
 // Configure HTTP basic authorization: {{{name}}}
 $config = {{{invokerPackage}}}\Configuration::getDefaultConfiguration()
               ->setUsername('YOUR_USERNAME')
               ->setPassword('YOUR_PASSWORD');
-{{/isBasicBearer}}
+{{/isBasicBasic}}
 {{#isBasicBearer}}
 // Configure Bearer{{#bearerFormat}} ({{{.}}}){{/bearerFormat}} authorization: {{{name}}}
 $config = {{{invokerPackage}}}\Configuration::getDefaultConfiguration()->setAccessToken('YOUR_ACCESS_TOKEN');

--- a/modules/openapi-generator/src/main/resources/python/api_doc.mustache
+++ b/modules/openapi-generator/src/main/resources/python/api_doc.mustache
@@ -22,9 +22,9 @@ Method | HTTP request | Description
 {{#hasAuthMethods}}
 {{#authMethods}}
 {{#isBasic}}
-{{^isBasicBearer}}
+{{#isBasicBasic}}
 * Basic Authentication ({{name}}):
-{{/isBasicBearer}}
+{{/isBasicBasic}}
 {{#isBasicBearer}}
 * Bearer{{#bearerFormat}} ({{{.}}}){{/bearerFormat}} Authentication ({{name}}):
 {{/isBasicBearer}}

--- a/modules/openapi-generator/src/main/resources/python/common_README.mustache
+++ b/modules/openapi-generator/src/main/resources/python/common_README.mustache
@@ -51,9 +51,9 @@ Class | Method | HTTP request | Description
 - **Location**: {{#isKeyInQuery}}URL query string{{/isKeyInQuery}}{{#isKeyInHeader}}HTTP header{{/isKeyInHeader}}
 {{/isApiKey}}
 {{#isBasic}}
-{{^isBasicBearer}}
+{{#isBasicBasic}}
 - **Type**: HTTP basic authentication
-{{/isBasicBearer}}
+{{/isBasicBasic}}
 {{#isBasicBearer}}
 - **Type**: Bearer authentication{{#bearerFormat}} ({{{.}}}){{/bearerFormat}}
 {{/isBasicBearer}}

--- a/modules/openapi-generator/src/main/resources/python/configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/python/configuration.mustache
@@ -297,7 +297,7 @@ class Configuration(object):
             }
 {{/isApiKey}}
 {{#isBasic}}
-  {{^isBasicBearer}}
+  {{#isBasicBasic}}
         if self.username is not None and self.password is not None:
             auth['{{name}}'] = {
                 'type': 'basic',
@@ -305,7 +305,7 @@ class Configuration(object):
                 'key': 'Authorization',
                 'value': self.get_basic_auth_token()
             }
-  {{/isBasicBearer}}
+  {{/isBasicBasic}}
   {{#isBasicBearer}}
         if self.access_token is not None:
             auth['{{name}}'] = {

--- a/modules/openapi-generator/src/main/resources/python/python-experimental/README_common.mustache
+++ b/modules/openapi-generator/src/main/resources/python/python-experimental/README_common.mustache
@@ -50,9 +50,9 @@ Class | Method | HTTP request | Description
 - **Location**: {{#isKeyInQuery}}URL query string{{/isKeyInQuery}}{{#isKeyInHeader}}HTTP header{{/isKeyInHeader}}
 {{/isApiKey}}
 {{#isBasic}}
-{{^isBasicBearer}}
+{{#isBasicBasic}}
 - **Type**: HTTP basic authentication
-{{/isBasicBearer}}
+{{/isBasicBasic}}
 {{#isBasicBearer}}
 - **Type**: Bearer authentication{{#bearerFormat}} ({{{.}}}){{/bearerFormat}}
 {{/isBasicBearer}}

--- a/modules/openapi-generator/src/main/resources/python/python-experimental/api_doc.mustache
+++ b/modules/openapi-generator/src/main/resources/python/python-experimental/api_doc.mustache
@@ -22,9 +22,9 @@ Method | HTTP request | Description
 {{#hasAuthMethods}}
 {{#authMethods}}
 {{#isBasic}}
-{{^isBasicBearer}}
+{{#isBasicBasic}}
 * Basic Authentication ({{name}}):
-{{/isBasicBearer}}
+{{/isBasicBasic}}
 {{#isBasicBearer}}
 * Bearer{{#bearerFormat}} ({{{.}}}){{/bearerFormat}} Authentication ({{name}}):
 {{/isBasicBearer}}

--- a/modules/openapi-generator/src/main/resources/python/python_doc_auth_partial.mustache
+++ b/modules/openapi-generator/src/main/resources/python/python_doc_auth_partial.mustache
@@ -2,11 +2,11 @@
 {{#authMethods}}
 configuration = {{{packageName}}}.Configuration()
 {{#isBasic}}
-{{^isBasicBearer}}
+{{#isBasicBasic}}
 # Configure HTTP basic authorization: {{{name}}}
 configuration.username = 'YOUR_USERNAME'
 configuration.password = 'YOUR_PASSWORD'
-{{/isBasicBearer}}
+{{/isBasicBasic}}
 {{#isBasicBearer}}
 # Configure Bearer authorization{{#bearerFormat}} ({{{.}}}){{/bearerFormat}}: {{{name}}}
 configuration.access_token = 'YOUR_BEARER_TOKEN'

--- a/modules/openapi-generator/src/main/resources/ruby-client/README.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/README.mustache
@@ -65,10 +65,10 @@ Please follow the [installation](#installation) procedure and then run the follo
 require '{{{gemName}}}'
 {{#apiInfo}}{{#apis}}{{#-first}}{{#operations}}{{#operation}}{{#-first}}{{#hasAuthMethods}}
 # Setup authorization
-{{{moduleName}}}.configure do |config|{{#authMethods}}{{#isBasic}}{{^isBasicBearer}}
+{{{moduleName}}}.configure do |config|{{#authMethods}}{{#isBasic}}{{#isBasicBasic}}
   # Configure HTTP basic authorization: {{{name}}}
   config.username = 'YOUR_USERNAME'
-  config.password = 'YOUR_PASSWORD'{{/isBasicBearer}}{{#isBasicBearer}}
+  config.password = 'YOUR_PASSWORD'{{/isBasicBasic}}{{#isBasicBearer}}
   # Configure Bearer authorization{{#bearerFormat}} ({{{.}}}){{/bearerFormat}}: {{{name}}}
   config.access_token = 'YOUR_BEARER_TOKEN'{{/isBasicBearer}}{{/isBasic}}{{#isApiKey}}
   # Configure API key authorization: {{{name}}}
@@ -131,8 +131,8 @@ Class | Method | HTTP request | Description
 - **Location**: {{#isKeyInQuery}}URL query string{{/isKeyInQuery}}{{#isKeyInHeader}}HTTP header{{/isKeyInHeader}}
 {{/isApiKey}}
 {{#isBasic}}
-{{^isBasicBearer}}- **Type**: HTTP basic authentication
-{{/isBasicBearer}}{{#isBasicBearer}}- **Type**: Bearer authentication{{#bearerFormat}} ({{{.}}}){{/bearerFormat}}
+{{#isBasicBasic}}- **Type**: HTTP basic authentication
+{{/isBasicBasic}}{{#isBasicBearer}}- **Type**: Bearer authentication{{#bearerFormat}} ({{{.}}}){{/bearerFormat}}
 {{/isBasicBearer}}
 {{/isBasic}}
 {{#isOAuth}}

--- a/modules/openapi-generator/src/main/resources/ruby-client/api_doc.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/api_doc.mustache
@@ -27,10 +27,10 @@ Method | HTTP request | Description
 require '{{{gemName}}}'
 {{#hasAuthMethods}}
 # setup authorization
-{{{moduleName}}}.configure do |config|{{#authMethods}}{{#isBasic}}{{^isBasicBearer}}
+{{{moduleName}}}.configure do |config|{{#authMethods}}{{#isBasic}}{{#isBasicBasic}}
   # Configure HTTP basic authorization: {{{name}}}
   config.username = 'YOUR USERNAME'
-  config.password = 'YOUR PASSWORD'{{/isBasicBearer}}{{#isBasicBearer}}
+  config.password = 'YOUR PASSWORD'{{/isBasicBasic}}{{#isBasicBearer}}
   # Configure Bearer authorization{{#bearerFormat}} ({{{.}}}){{/bearerFormat}}: {{{name}}}
   config.access_token = 'YOUR_BEARER_TOKEN'{{/isBasicBearer}}{{/isBasic}}{{#isApiKey}}
   # Configure API key authorization: {{{name}}}

--- a/modules/openapi-generator/src/main/resources/ruby-client/configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/configuration.mustache
@@ -176,7 +176,7 @@ module {{moduleName}}
           },
 {{/isApiKey}}
 {{#isBasic}}
-{{^isBasicBearer}}
+{{#isBasicBasic}}
         '{{name}}' =>
           {
             type: 'basic',
@@ -184,7 +184,7 @@ module {{moduleName}}
             key: 'Authorization',
             value: basic_auth_token
           },
-{{/isBasicBearer}}
+{{/isBasicBasic}}
 {{#isBasicBearer}}
         '{{name}}' =>
           {

--- a/modules/openapi-generator/src/main/resources/rust/reqwest/api.mustache
+++ b/modules/openapi-generator/src/main/resources/rust/reqwest/api.mustache
@@ -102,11 +102,11 @@ impl {{{classname}}} for {{{classname}}}Client {
         {{/isKeyInHeader}}
         {{/isApiKey}}
         {{#isBasic}}
-        {{^isBasicBearer}}
+        {{#isBasicBasic}}
         if let Some(ref auth_conf) = configuration.basic_auth {
             req_builder = req_builder.basic_auth(auth_conf.0.to_owned(), auth_conf.1.to_owned());
         };
-        {{/isBasicBearer}}
+        {{/isBasicBasic}}
         {{#isBasicBearer}}
         if let Some(ref token) = configuration.bearer_access_token {
             req_builder = req_builder.bearer_auth(token.to_owned());

--- a/modules/openapi-generator/src/main/resources/typescript-angular/api.service.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-angular/api.service.mustache
@@ -258,11 +258,11 @@ export class {{classname}} {
 {{/isKeyInQuery}}
 {{/isApiKey}}
 {{#isBasic}}
-    {{^isBasicBearer}}
+    {{#isBasicBasic}}
         if (this.configuration.username || this.configuration.password) {
             {{#useHttpClient}}headers = {{/useHttpClient}}headers.set('Authorization', 'Basic ' + btoa(this.configuration.username + ':' + this.configuration.password));
         }
-    {{/isBasicBearer}}
+    {{/isBasicBasic}}
     {{#isBasicBearer}}
         if (this.configuration.accessToken) {
             const accessToken = typeof this.configuration.accessToken === 'function'


### PR DESCRIPTION
For HTTP basic auth, many mustache templates use a convention to negate the isBasicBearer tag, i.e. the case for HTTP basic auth is the negation of isBasicBearer. The problem is this only works when there are two possible HTTP auth, 1) basic auth and 2) bearer token. To support more http auth methods, we should stop using the negation of "isBasicBearer".

```
...
{{^isBasicBearer}}
   // do stuff for HTTP basic authentication
{{/isBasicBearer}}
{{#isBasicBearer}}
   // do stuff for bearer authentication
{{/isBasicBearer}}
....
```

I am proposing that instead, we change the templates as follows:
```
{{#isBasicBasic}}
   // do stuff for HTTP basic authentication
{{/isBasicBasic}}
{{#isBasicBearer}}
   // do stuff for bearer authentication
{{/isBasicBearer}}
....
```

I started making the change for Javascript. If that seems a reasonable change to reviewers, I can make the change everywhere.

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [ ] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
