### PR TITLE
Typescript axios: remove use of btoa

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-axios/apiInner.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-axios/apiInner.mustache
@@ -78,7 +78,7 @@ export const {{classname}}AxiosParamCreator = function (configuration?: Configur
             {{#isBasicBasic}}
             // http basic authentication required
             if (configuration && (configuration.username || configuration.password)) {
-                localVarHeaderParameter["Authorization"] = "Basic " + btoa(configuration.username + ":" + configuration.password);
+                localVarRequestOptions["auth"] = { username: configuration.username, password: configuration.password }; 
             }
             {{/isBasicBasic}}
             {{#isBasicBearer}}


### PR DESCRIPTION
btoa (binary to ascii), is a javascript function to base64 encode a
string.

Axios is usable both from node and from the browser. But the btoa
function is available only in the browser.

This meant that any client that used basic auth was broken in node.
Axios has its own method of encoding basic auth credentials. This method
works in both the browser and node.
https://github.com/axios/axios/blame/v0.19.2/README.md#L318

By using this method, the generated client works in node and in the
browser.

This solves this comment on this issue.
https://github.com/OpenAPITools/openapi-generator/issues/3049#issuecomment-498278966

I have validated this change within a personal project:
https://github.com/ccouzens/create-vdc-with-edge-portal-api-demo/commit/df8b552f5f8b7528bd0b003b1c5b5558dd05eabf#diff-e91249994e03dd6af8c6bee4ff7d8381

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [ ] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
