### PR TITLE
[ci][test] Modifications to static analysis contribution via Tomasbjerre

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,8 @@ packages/
 .vagrant/
 .vscode/
 **/.vs
+bin
+.factorypath
 
 .settings
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.mvn/.gradle-enterprise/
 .scannerwork/
 .vscode
 *.iml

--- a/README.md
+++ b/README.md
@@ -252,6 +252,12 @@ If you don't have maven installed, you may directly use the included [maven wrap
 ./mvnw clean install
 ```
 
+The default build contains minimal static analysis (via CheckStyle). To run your build with PMD and Spotbugs, use the `static-analysis` profile:
+
+```sh
+mvn -Pstatic-analysis clean install
+```
+
 ### [1.5 - Homebrew](#table-of-contents)
 
 To install, run `brew install openapi-generator`

--- a/modules/openapi-generator-cli/pom.xml
+++ b/modules/openapi-generator-cli/pom.xml
@@ -28,6 +28,33 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <configuration>
+                    <configLocation>${project.basedir}/../../google_checkstyle.xml</configLocation>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>com.github.spotbugs</groupId>
+                <artifactId>spotbugs-maven-plugin</artifactId>
+                <configuration>
+                    <excludeFilterFile>${project.basedir}/../../spotbugs-exclude.xml</excludeFilterFile>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-pmd-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>se.bjurr.violations</groupId>
+                <artifactId>violations-maven-plugin</artifactId>
+                <configuration>
+                    <!-- Should be decreased continuousle as issues are fixed, and will eventually 
+                        reach 0. -->
+                    <maxViolations>274</maxViolations>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <configuration>
                     <archive>

--- a/modules/openapi-generator-cli/pom.xml
+++ b/modules/openapi-generator-cli/pom.xml
@@ -30,14 +30,14 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <configuration>
-                    <configLocation>${project.basedir}/../../google_checkstyle.xml</configLocation>
+                    <configLocation>${project.parent.basedir}${file.separator}google_checkstyle.xml</configLocation>
                 </configuration>
             </plugin>
             <plugin>
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-maven-plugin</artifactId>
                 <configuration>
-                    <excludeFilterFile>${project.basedir}/../../spotbugs-exclude.xml</excludeFilterFile>
+                    <excludeFilterFile>${project.parent.basedir}${file.separator}spotbugs-exclude.xml</excludeFilterFile>
                 </configuration>
             </plugin>
             <plugin>
@@ -47,11 +47,6 @@
             <plugin>
                 <groupId>se.bjurr.violations</groupId>
                 <artifactId>violations-maven-plugin</artifactId>
-                <configuration>
-                    <!-- Should be decreased continuousle as issues are fixed, and will eventually 
-                        reach 0. -->
-                    <maxViolations>274</maxViolations>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/modules/openapi-generator-cli/pom.xml
+++ b/modules/openapi-generator-cli/pom.xml
@@ -34,21 +34,6 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>com.github.spotbugs</groupId>
-                <artifactId>spotbugs-maven-plugin</artifactId>
-                <configuration>
-                    <excludeFilterFile>${project.parent.basedir}${file.separator}spotbugs-exclude.xml</excludeFilterFile>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-pmd-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>se.bjurr.violations</groupId>
-                <artifactId>violations-maven-plugin</artifactId>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <configuration>
@@ -94,6 +79,31 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>static-analysis</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.github.spotbugs</groupId>
+                        <artifactId>spotbugs-maven-plugin</artifactId>
+                        <configuration>
+                            <excludeFilterFile>${project.parent.basedir}${file.separator}spotbugs-exclude.xml</excludeFilterFile>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-pmd-plugin</artifactId>
+                    </plugin>
+                    <plugin>
+                        <groupId>se.bjurr.violations</groupId>
+                        <artifactId>violations-maven-plugin</artifactId>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
     <dependencies>
 

--- a/modules/openapi-generator-core/pom.xml
+++ b/modules/openapi-generator-core/pom.xml
@@ -22,14 +22,14 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
         <configuration>
-          <configLocation>${project.basedir}/../../google_checkstyle.xml</configLocation>
+          <configLocation>${project.parent.basedir}${file.separator}google_checkstyle.xml</configLocation>
         </configuration>
       </plugin>
       <plugin>
         <groupId>com.github.spotbugs</groupId>
         <artifactId>spotbugs-maven-plugin</artifactId>
         <configuration>
-          <excludeFilterFile>${project.basedir}/../../spotbugs-exclude.xml</excludeFilterFile>
+          <excludeFilterFile>${project.parent.basedir}${file.separator}spotbugs-exclude.xml</excludeFilterFile>
         </configuration>
       </plugin>
       <plugin>
@@ -39,11 +39,6 @@
       <plugin>
         <groupId>se.bjurr.violations</groupId>
         <artifactId>violations-maven-plugin</artifactId>
-        <configuration>
-          <!-- Should be decreased continuousle as issues are fixed, and will eventually
-            reach 0. -->
-          <maxViolations>571</maxViolations>
-        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/modules/openapi-generator-core/pom.xml
+++ b/modules/openapi-generator-core/pom.xml
@@ -25,21 +25,6 @@
           <configLocation>${project.parent.basedir}${file.separator}google_checkstyle.xml</configLocation>
         </configuration>
       </plugin>
-      <plugin>
-        <groupId>com.github.spotbugs</groupId>
-        <artifactId>spotbugs-maven-plugin</artifactId>
-        <configuration>
-          <excludeFilterFile>${project.parent.basedir}${file.separator}spotbugs-exclude.xml</excludeFilterFile>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-pmd-plugin</artifactId>
-      </plugin>
-      <plugin>
-        <groupId>se.bjurr.violations</groupId>
-        <artifactId>violations-maven-plugin</artifactId>
-      </plugin>
     </plugins>
   </build>
 
@@ -60,6 +45,31 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <profiles>
+    <profile>
+      <id>static-analysis</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>com.github.spotbugs</groupId>
+            <artifactId>spotbugs-maven-plugin</artifactId>
+            <configuration>
+              <excludeFilterFile>${project.parent.basedir}${file.separator}spotbugs-exclude.xml</excludeFilterFile>
+            </configuration>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-pmd-plugin</artifactId>
+          </plugin>
+          <plugin>
+            <groupId>se.bjurr.violations</groupId>
+            <artifactId>violations-maven-plugin</artifactId>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 
   <properties>
     <slf4j-version>1.7.12</slf4j-version>

--- a/modules/openapi-generator-core/pom.xml
+++ b/modules/openapi-generator-core/pom.xml
@@ -16,6 +16,38 @@
   <name>openapi-generator-core</name>
   <url>https://github.com/openapitools/openapi-generator</url>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+        <configuration>
+          <configLocation>${project.basedir}/../../google_checkstyle.xml</configLocation>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs-maven-plugin</artifactId>
+        <configuration>
+          <excludeFilterFile>${project.basedir}/../../spotbugs-exclude.xml</excludeFilterFile>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-pmd-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>se.bjurr.violations</groupId>
+        <artifactId>violations-maven-plugin</artifactId>
+        <configuration>
+          <!-- Should be decreased continuousle as issues are fixed, and will eventually
+            reach 0. -->
+          <maxViolations>571</maxViolations>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
   <dependencies>
     <dependency>
       <groupId>com.google.guava</groupId>

--- a/modules/openapi-generator-gradle-plugin/pom.xml
+++ b/modules/openapi-generator-gradle-plugin/pom.xml
@@ -65,6 +65,31 @@
         </pluginManagement>
 
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <configuration>
+                    <configLocation>${project.basedir}/../../google_checkstyle.xml</configLocation>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>com.github.spotbugs</groupId>
+                <artifactId>spotbugs-maven-plugin</artifactId>
+                <configuration>
+                    <excludeFilterFile>${project.basedir}/../../spotbugs-exclude.xml</excludeFilterFile>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-pmd-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>se.bjurr.violations</groupId>
+                <artifactId>violations-maven-plugin</artifactId>
+                <configuration>
+                    <maxViolations>0</maxViolations>
+                </configuration>
+            </plugin>
             <!-- 2) run gradle -->
             <plugin>
                 <groupId>org.fortasoft</groupId>

--- a/modules/openapi-generator-gradle-plugin/pom.xml
+++ b/modules/openapi-generator-gradle-plugin/pom.xml
@@ -72,21 +72,6 @@
                     <configLocation>${project.parent.basedir}${file.separator}google_checkstyle.xml</configLocation>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>com.github.spotbugs</groupId>
-                <artifactId>spotbugs-maven-plugin</artifactId>
-                <configuration>
-                    <excludeFilterFile>${project.parent.basedir}${file.separator}spotbugs-exclude.xml</excludeFilterFile>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-pmd-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>se.bjurr.violations</groupId>
-                <artifactId>violations-maven-plugin</artifactId>
-            </plugin>
             <!-- 2) run gradle -->
             <plugin>
                 <groupId>org.fortasoft</groupId>
@@ -126,4 +111,28 @@
         </plugins>
     </build>
 
+    <profiles>
+        <profile>
+            <id>static-analysis</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.github.spotbugs</groupId>
+                        <artifactId>spotbugs-maven-plugin</artifactId>
+                        <configuration>
+                            <excludeFilterFile>${project.parent.basedir}${file.separator}spotbugs-exclude.xml</excludeFilterFile>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-pmd-plugin</artifactId>
+                    </plugin>
+                    <plugin>
+                        <groupId>se.bjurr.violations</groupId>
+                        <artifactId>violations-maven-plugin</artifactId>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/modules/openapi-generator-gradle-plugin/pom.xml
+++ b/modules/openapi-generator-gradle-plugin/pom.xml
@@ -69,14 +69,14 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <configuration>
-                    <configLocation>${project.basedir}/../../google_checkstyle.xml</configLocation>
+                    <configLocation>${project.parent.basedir}${file.separator}google_checkstyle.xml</configLocation>
                 </configuration>
             </plugin>
             <plugin>
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-maven-plugin</artifactId>
                 <configuration>
-                    <excludeFilterFile>${project.basedir}/../../spotbugs-exclude.xml</excludeFilterFile>
+                    <excludeFilterFile>${project.parent.basedir}${file.separator}spotbugs-exclude.xml</excludeFilterFile>
                 </configuration>
             </plugin>
             <plugin>
@@ -86,9 +86,6 @@
             <plugin>
                 <groupId>se.bjurr.violations</groupId>
                 <artifactId>violations-maven-plugin</artifactId>
-                <configuration>
-                    <maxViolations>0</maxViolations>
-                </configuration>
             </plugin>
             <!-- 2) run gradle -->
             <plugin>

--- a/modules/openapi-generator-maven-plugin/pom.xml
+++ b/modules/openapi-generator-maven-plugin/pom.xml
@@ -93,14 +93,14 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <configuration>
-                    <configLocation>${project.basedir}/../../google_checkstyle.xml</configLocation>
+                    <configLocation>${project.parent.basedir}${file.separator}google_checkstyle.xml</configLocation>
                 </configuration>
             </plugin>
             <plugin>
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-maven-plugin</artifactId>
                 <configuration>
-                    <excludeFilterFile>${project.basedir}/../../spotbugs-exclude.xml</excludeFilterFile>
+                    <excludeFilterFile>${project.parent.basedir}${file.separator}spotbugs-exclude.xml</excludeFilterFile>
                 </configuration>
             </plugin>
             <plugin>
@@ -110,11 +110,6 @@
             <plugin>
                 <groupId>se.bjurr.violations</groupId>
                 <artifactId>violations-maven-plugin</artifactId>
-                <configuration>
-                    <!-- Should be decreased continuousle as issues are fixed, and will eventually 
-                        reach 0. -->
-                    <maxViolations>329</maxViolations>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>net.revelc.code</groupId>

--- a/modules/openapi-generator-maven-plugin/pom.xml
+++ b/modules/openapi-generator-maven-plugin/pom.xml
@@ -97,21 +97,6 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>com.github.spotbugs</groupId>
-                <artifactId>spotbugs-maven-plugin</artifactId>
-                <configuration>
-                    <excludeFilterFile>${project.parent.basedir}${file.separator}spotbugs-exclude.xml</excludeFilterFile>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-pmd-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>se.bjurr.violations</groupId>
-                <artifactId>violations-maven-plugin</artifactId>
-            </plugin>
-            <plugin>
                 <groupId>net.revelc.code</groupId>
                 <artifactId>formatter-maven-plugin</artifactId>
                 <configuration>
@@ -121,4 +106,29 @@
             </plugin>
         </plugins>
     </build>
+    <profiles>
+
+        <profile>
+            <id>static-analysis</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.github.spotbugs</groupId>
+                        <artifactId>spotbugs-maven-plugin</artifactId>
+                        <configuration>
+                            <excludeFilterFile>${project.parent.basedir}${file.separator}spotbugs-exclude.xml</excludeFilterFile>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-pmd-plugin</artifactId>
+                    </plugin>
+                    <plugin>
+                        <groupId>se.bjurr.violations</groupId>
+                        <artifactId>violations-maven-plugin</artifactId>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/modules/openapi-generator-maven-plugin/pom.xml
+++ b/modules/openapi-generator-maven-plugin/pom.xml
@@ -90,6 +90,33 @@
         </pluginManagement>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <configuration>
+                    <configLocation>${project.basedir}/../../google_checkstyle.xml</configLocation>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>com.github.spotbugs</groupId>
+                <artifactId>spotbugs-maven-plugin</artifactId>
+                <configuration>
+                    <excludeFilterFile>${project.basedir}/../../spotbugs-exclude.xml</excludeFilterFile>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-pmd-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>se.bjurr.violations</groupId>
+                <artifactId>violations-maven-plugin</artifactId>
+                <configuration>
+                    <!-- Should be decreased continuousle as issues are fixed, and will eventually 
+                        reach 0. -->
+                    <maxViolations>329</maxViolations>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>net.revelc.code</groupId>
                 <artifactId>formatter-maven-plugin</artifactId>
                 <configuration>

--- a/modules/openapi-generator-online/pom.xml
+++ b/modules/openapi-generator-online/pom.xml
@@ -46,14 +46,14 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <configuration>
-                    <configLocation>${project.basedir}/../../google_checkstyle.xml</configLocation>
+                    <configLocation>${project.parent.basedir}${file.separator}google_checkstyle.xml</configLocation>
                 </configuration>
             </plugin>
             <plugin>
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-maven-plugin</artifactId>
                 <configuration>
-                    <excludeFilterFile>${project.basedir}/../../spotbugs-exclude.xml</excludeFilterFile>
+                    <excludeFilterFile>${project.parent.basedir}${file.separator}spotbugs-exclude.xml</excludeFilterFile>
                 </configuration>
             </plugin>
             <plugin>
@@ -66,7 +66,7 @@
                 <configuration>
                     <!-- Should be decreased continuousle as issues are fixed, and will eventually 
                         reach 0. -->
-                    <maxViolations>153</maxViolations>
+                    <maxViolations>3</maxViolations>
                 </configuration>
             </plugin>
             <plugin>

--- a/modules/openapi-generator-online/pom.xml
+++ b/modules/openapi-generator-online/pom.xml
@@ -50,26 +50,6 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>com.github.spotbugs</groupId>
-                <artifactId>spotbugs-maven-plugin</artifactId>
-                <configuration>
-                    <excludeFilterFile>${project.parent.basedir}${file.separator}spotbugs-exclude.xml</excludeFilterFile>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-pmd-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>se.bjurr.violations</groupId>
-                <artifactId>violations-maven-plugin</artifactId>
-                <configuration>
-                    <!-- Should be decreased continuousle as issues are fixed, and will eventually 
-                        reach 0. -->
-                    <maxViolations>3</maxViolations>
-                </configuration>
-            </plugin>
-            <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
                 <version>${spring-boot-version}</version>
@@ -83,6 +63,35 @@
             </plugin>
         </plugins>
     </build>
+    <profiles>
+
+        <profile>
+            <id>static-analysis</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.github.spotbugs</groupId>
+                        <artifactId>spotbugs-maven-plugin</artifactId>
+                        <configuration>
+                            <excludeFilterFile>${project.parent.basedir}${file.separator}spotbugs-exclude.xml</excludeFilterFile>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-pmd-plugin</artifactId>
+                    </plugin>
+                    <plugin>
+                        <groupId>se.bjurr.violations</groupId>
+                        <artifactId>violations-maven-plugin</artifactId>
+                        <configuration>
+                            <!-- Should be decreased regularly down to 0 as issues are fixed. -->
+                            <maxViolations>3</maxViolations>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/modules/openapi-generator-online/pom.xml
+++ b/modules/openapi-generator-online/pom.xml
@@ -43,6 +43,33 @@
         </resources>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <configuration>
+                    <configLocation>${project.basedir}/../../google_checkstyle.xml</configLocation>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>com.github.spotbugs</groupId>
+                <artifactId>spotbugs-maven-plugin</artifactId>
+                <configuration>
+                    <excludeFilterFile>${project.basedir}/../../spotbugs-exclude.xml</excludeFilterFile>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-pmd-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>se.bjurr.violations</groupId>
+                <artifactId>violations-maven-plugin</artifactId>
+                <configuration>
+                    <!-- Should be decreased continuousle as issues are fixed, and will eventually 
+                        reach 0. -->
+                    <maxViolations>153</maxViolations>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
                 <version>${spring-boot-version}</version>

--- a/modules/openapi-generator/pom.xml
+++ b/modules/openapi-generator/pom.xml
@@ -51,26 +51,6 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>com.github.spotbugs</groupId>
-                <artifactId>spotbugs-maven-plugin</artifactId>
-                <configuration>
-                    <excludeFilterFile>${project.parent.basedir}${file.separator}spotbugs-exclude.xml</excludeFilterFile>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-pmd-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>se.bjurr.violations</groupId>
-                <artifactId>violations-maven-plugin</artifactId>
-                <configuration>
-                    <!-- Should be decreased continuousle as issues are fixed, and will eventually 
-                        reach 0. -->
-                    <maxViolations>65</maxViolations>
-                </configuration>
-            </plugin>
-            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
                 <version>1.6.0</version>
@@ -178,6 +158,33 @@
                                 </goals>
                             </execution>
                         </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>static-analysis</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.github.spotbugs</groupId>
+                        <artifactId>spotbugs-maven-plugin</artifactId>
+                        <configuration>
+                            <excludeFilterFile>${project.parent.basedir}${file.separator}spotbugs-exclude.xml</excludeFilterFile>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-pmd-plugin</artifactId>
+                    </plugin>
+                    <plugin>
+                        <groupId>se.bjurr.violations</groupId>
+                        <artifactId>violations-maven-plugin</artifactId>
+                        <configuration>
+                            <!-- Should be decreased continuousle as issues are fixed, and will eventually
+                                reach 0. -->
+                            <maxViolations>65</maxViolations>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/modules/openapi-generator/pom.xml
+++ b/modules/openapi-generator/pom.xml
@@ -44,6 +44,33 @@
         <finalName>${project.artifactId}-${project.version}</finalName>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <configuration>
+                    <configLocation>${project.basedir}/../../google_checkstyle.xml</configLocation>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>com.github.spotbugs</groupId>
+                <artifactId>spotbugs-maven-plugin</artifactId>
+                <configuration>
+                    <excludeFilterFile>${project.basedir}/../../spotbugs-exclude.xml</excludeFilterFile>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-pmd-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>se.bjurr.violations</groupId>
+                <artifactId>violations-maven-plugin</artifactId>
+                <configuration>
+                    <!-- Should be decreased continuousle as issues are fixed, and will eventually 
+                        reach 0. -->
+                    <maxViolations>12089</maxViolations>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
                 <version>1.6.0</version>

--- a/modules/openapi-generator/pom.xml
+++ b/modules/openapi-generator/pom.xml
@@ -47,14 +47,14 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <configuration>
-                    <configLocation>${project.basedir}/../../google_checkstyle.xml</configLocation>
+                    <configLocation>${project.parent.basedir}${file.separator}google_checkstyle.xml</configLocation>
                 </configuration>
             </plugin>
             <plugin>
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-maven-plugin</artifactId>
                 <configuration>
-                    <excludeFilterFile>${project.basedir}/../../spotbugs-exclude.xml</excludeFilterFile>
+                    <excludeFilterFile>${project.parent.basedir}${file.separator}spotbugs-exclude.xml</excludeFilterFile>
                 </configuration>
             </plugin>
             <plugin>
@@ -67,7 +67,7 @@
                 <configuration>
                     <!-- Should be decreased continuousle as issues are fixed, and will eventually 
                         reach 0. -->
-                    <maxViolations>12089</maxViolations>
+                    <maxViolations>65</maxViolations>
                 </configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>3.1.0</version>
+                <version>${checkstyle.plugin.version}</version>
                 <configuration>
                     <consoleOutput>false</consoleOutput>
                     <failsOnError>false</failsOnError>
@@ -112,50 +112,6 @@
                 <executions>
                     <execution>
                         <id>checkstyle-check</id>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                        <phase>verify</phase>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>com.github.spotbugs</groupId>
-                <artifactId>spotbugs-maven-plugin</artifactId>
-                <version>3.1.12.2</version>
-                <configuration>
-                    <failOnError>false</failOnError>
-                    <!-- https://spotbugs.readthedocs.io/en/stable/effort.html -->
-                    <effort>min</effort>
-                    <excludes>**/samples/*.java</excludes>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>spotbugs-check</id>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                        <phase>verify</phase>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-pmd-plugin</artifactId>
-                <version>3.12.0</version>
-                <configuration>
-                    <failOnViolation>false</failOnViolation>
-                    <printFailingErrors>false</printFailingErrors>
-                    <rulesets>
-                        <ruleset>category/java/errorprone.xml</ruleset>
-                    </rulesets>
-                    <excludes>
-                    	<exclude>**/samples/*.java</exclude>
-                    </excludes>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>pmd-check</id>
                         <goals>
                             <goal>check</goal>
                         </goals>
@@ -426,7 +382,7 @@
                 <plugin>
                     <groupId>se.bjurr.violations</groupId>
                     <artifactId>violations-maven-plugin</artifactId>
-                    <version>1.34</version>
+                    <version>${violations-maven.plugin.version}</version>
                     <configuration>
                         <maxViolations>0</maxViolations>
                         <detailLevel>VERBOSE</detailLevel>
@@ -465,6 +421,21 @@
                     <groupId>net.revelc.code</groupId>
                     <artifactId>formatter-maven-plugin</artifactId>
                     <version>0.5.2</version>
+                </plugin>
+                <plugin>
+                    <groupId>com.github.spotbugs</groupId>
+                    <artifactId>spotbugs-maven-plugin</artifactId>
+                    <version>${spotbugs.plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-pmd-plugin</artifactId>
+                    <version>${pmd.plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-checkstyle-plugin</artifactId>
+                    <version>${checkstyle.plugin.version}</version>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -570,6 +541,73 @@
                     </plugin>
                 </plugins>
             </build>
+        </profile>
+        <!-- CI related -->
+        <profile>
+            <!-- This profile will run much more in-depth static analysis checks. -->
+            <id>static-analysis</id>
+            <properties>
+                <skipTests>true</skipTests>
+                <maven.javadoc.skip>true</maven.javadoc.skip>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.github.spotbugs</groupId>
+                        <artifactId>spotbugs-maven-plugin</artifactId>
+                        <version>${spotbugs.plugin.version}</version>
+                        <configuration>
+                            <failOnError>false</failOnError>
+                            <!-- https://spotbugs.readthedocs.io/en/stable/effort.html -->
+                            <effort>min</effort>
+                            <excludeFilterFile>${project.basedir}${file.separator}spotbugs-exclude.xml</excludeFilterFile>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>spotbugs-check</id>
+                                <goals>
+                                    <goal>check</goal>
+                                </goals>
+                                <phase>verify</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-pmd-plugin</artifactId>
+                        <version>${pmd.plugin.version}</version>
+                        <configuration>
+                            <sourceEncoding>${project.build.sourceEncoding}</sourceEncoding>
+                            <failOnViolation>false</failOnViolation>
+                            <printFailingErrors>false</printFailingErrors>
+                            <rulesets>
+                                <ruleset>category/java/errorprone.xml</ruleset>
+                            </rulesets>
+                            <excludes>
+                                <exclude>**/samples/**/*</exclude>
+                            </excludes>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>pmd-check</id>
+                                <goals>
+                                    <goal>check</goal>
+                                </goals>
+                                <phase>verify</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+            <reporting>
+                <plugins>
+                    <plugin>
+                        <groupId>com.github.spotbugs</groupId>
+                        <artifactId>spotbugs-maven-plugin</artifactId>
+                        <version>${spotbugs.plugin.version}</version>
+                    </plugin>
+                </plugins>
+            </reporting>
         </profile>
         <!-- Samples -->
         <profile>
@@ -1565,5 +1603,9 @@
         <reflections-version>0.9.10</reflections-version>
         <mockito-version>3.2.0</mockito-version>
         <jacoco.version>0.8.5</jacoco.version>
+        <spotbugs.plugin.version>3.1.12.2</spotbugs.plugin.version>
+        <pmd.plugin.version>3.12.0</pmd.plugin.version>
+        <violations-maven.plugin.version>1.34</violations-maven.plugin.version>
+        <checkstyle.plugin.version>3.1.0</checkstyle.plugin.version>
     </properties>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,66 @@
         <finalName>${project.artifactId}-${project.version}</finalName>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <version>3.1.0</version>
+                <configuration>
+                    <consoleOutput>false</consoleOutput>
+                    <failsOnError>false</failsOnError>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>checkstyle-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <phase>verify</phase>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>com.github.spotbugs</groupId>
+                <artifactId>spotbugs-maven-plugin</artifactId>
+                <version>3.1.12.2</version>
+                <configuration>
+                    <failOnError>false</failOnError>
+                    <effort>max</effort>
+                    <excludes>
+                        <exclude>**/generated/*.java</exclude>
+                    </excludes>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>spotbugs-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <phase>verify</phase>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-pmd-plugin</artifactId>
+                <version>3.12.0</version>
+                <configuration>
+                    <failOnViolation>false</failOnViolation>
+                    <printFailingErrors>false</printFailingErrors>
+                    <rulesets>
+                        <ruleset>category/java/errorprone.xml</ruleset>
+                    </rulesets>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>pmd-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <phase>verify</phase>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>net.revelc.code</groupId>
                 <artifactId>formatter-maven-plugin</artifactId>
                 <!-- Uncomment this to format before checkstyle -->
@@ -360,6 +420,43 @@
         </plugins>
         <pluginManagement>
             <plugins>
+                <plugin>
+                    <groupId>se.bjurr.violations</groupId>
+                    <artifactId>violations-maven-plugin</artifactId>
+                    <version>1.33</version>
+                    <configuration>
+                        <maxViolations>0</maxViolations>
+                        <detailLevel>VERBOSE</detailLevel>
+                        <violations>
+                            <violation>
+                                <parser>FINDBUGS</parser>
+                                <reporter>Spotbugs</reporter>
+                                <folder>${project.basedir}</folder>
+                                <pattern>.*/spotbugsXml\.xml$</pattern>
+                            </violation>
+                            <violation>
+                                <parser>PMD</parser>
+                                <reporter>PMD</reporter>
+                                <folder>${project.basedir}</folder>
+                                <pattern>.*/pmd\.xml$</pattern>
+                            </violation>
+                            <violation>
+                                <parser>CHECKSTYLE</parser>
+                                <reporter>Checkstyle</reporter>
+                                <folder>${project.basedir}</folder>
+                                <pattern>.*/checkstyle-result\.xml$</pattern>
+                            </violation>
+                        </violations>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <phase>verify</phase>
+                            <goals>
+                                <goal>violations</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
                 <plugin>
                     <groupId>net.revelc.code</groupId>
                     <artifactId>formatter-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -107,6 +107,7 @@
                 <configuration>
                     <consoleOutput>false</consoleOutput>
                     <failsOnError>false</failsOnError>
+                    <excludes>**/samples/*.java</excludes>
                 </configuration>
                 <executions>
                     <execution>
@@ -124,10 +125,9 @@
                 <version>3.1.12.2</version>
                 <configuration>
                     <failOnError>false</failOnError>
-                    <effort>max</effort>
-                    <excludes>
-                        <exclude>**/generated/*.java</exclude>
-                    </excludes>
+                    <!-- https://spotbugs.readthedocs.io/en/stable/effort.html -->
+                    <effort>min</effort>
+                    <excludes>**/samples/*.java</excludes>
                 </configuration>
                 <executions>
                     <execution>
@@ -149,6 +149,9 @@
                     <rulesets>
                         <ruleset>category/java/errorprone.xml</ruleset>
                     </rulesets>
+                    <excludes>
+                    	<exclude>**/samples/*.java</exclude>
+                    </excludes>
                 </configuration>
                 <executions>
                     <execution>
@@ -423,10 +426,11 @@
                 <plugin>
                     <groupId>se.bjurr.violations</groupId>
                     <artifactId>violations-maven-plugin</artifactId>
-                    <version>1.33</version>
+                    <version>1.34</version>
                     <configuration>
                         <maxViolations>0</maxViolations>
                         <detailLevel>VERBOSE</detailLevel>
+                        <minSeverity>ERROR</minSeverity>
                         <violations>
                             <violation>
                                 <parser>FINDBUGS</parser>

--- a/spotbugs-exclude.xml
+++ b/spotbugs-exclude.xml
@@ -1,0 +1,25 @@
+<FindBugsFilter>
+
+	<Match>
+		<Bug pattern="RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE" />
+	</Match>
+
+	<Match>
+		<Bug pattern="URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD" />
+	</Match>
+
+	<Match>
+		<Bug pattern="RV_RETURN_VALUE_IGNORED_BAD_PRACTICE" />
+	</Match>
+
+	<Match>
+		<Bug pattern="URF_UNREAD_FIELD" />
+		<Or>
+			<And>
+				<Class name="io.undertow.server.protocol.ajp.AjpRequestParseState" />
+				<Field name="dataSize" />
+			</And>
+		</Or>
+	</Match>
+
+</FindBugsFilter>

--- a/spotbugs-exclude.xml
+++ b/spotbugs-exclude.xml
@@ -22,4 +22,13 @@
 		</Or>
 	</Match>
 
+	<!-- For source/class naming, see https://spotbugs.readthedocs.io/en/stable/filter.html#java-element-name-matching -->
+	<Match>
+		<!-- Ignore all source files with samples in path name -->
+		<Source name="~.*\samples\.*"/>
+	</Match>
+	<Match>
+		<!-- Ignore all bugs in any test classes -->
+		<Class name="~.*\.*Test" />
+	</Match>
 </FindBugsFilter>


### PR DESCRIPTION
This extends on submission by @tomasbjerre in #5040 by moving the PMD and Spotbugs  plugin execution to a separate profile `static-analysis`. This keeps CheckStyle in the default build because it added a very minimal amount of time to execution.

Once merged, I'd like to extend the Sonar CI GitHub Action to be a static analysis action which caches the xml reports generated by these plugins as build artifacts.  This will give us SonarCloud as a means for evaluating the static analysis, and allow for contributors to download the `*.xml` reports from the action. Once the GitHub action is updated, we can also close #33 as well.

Core contributors may run static analysis with:

```
mvn -Pstatic-analysis install
```

The analysis is separated from default functionality to reduce impact to community contributions. SpotBugs/PMD may add a non-trivial amount of time to builds on some machines.

cc @OpenAPITools/generator-core-team 

Closes #5040

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
