### PR TITLE
[csharp-netcore] Fixed compiler null-check warning

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CSharpNetCoreClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CSharpNetCoreClientCodegen.java
@@ -420,7 +420,7 @@ public class CSharpNetCoreClientCodegen extends AbstractCSharpCodegen {
         super.postProcessModelProperty(model, property);
 
         if (!property.isContainer && (nullableType.contains(property.dataType) || property.isEnum)) {
-            property.vendorExtensions.put("x-value-type", true);
+            property.vendorExtensions.put("x-csharp-value-type", true);
         }
     }
 
@@ -461,7 +461,7 @@ public class CSharpNetCoreClientCodegen extends AbstractCSharpCodegen {
             if (!parameter.required) { //optional
                 parameter.dataType = parameter.dataType + "?";
             } else {
-                parameter.vendorExtensions.put("x-value-type", true);
+                parameter.vendorExtensions.put("x-csharp-value-type", true);
             }
         }
     }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CSharpNetCoreClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CSharpNetCoreClientCodegen.java
@@ -418,6 +418,10 @@ public class CSharpNetCoreClientCodegen extends AbstractCSharpCodegen {
         postProcessEmitDefaultValue(property.vendorExtensions);
 
         super.postProcessModelProperty(model, property);
+
+        if (!property.isContainer && (nullableType.contains(property.dataType) || property.isEnum)) {
+            property.vendorExtensions.put("x-value-type", true);
+        }
     }
 
     @Override
@@ -453,8 +457,12 @@ public class CSharpNetCoreClientCodegen extends AbstractCSharpCodegen {
         postProcessEmitDefaultValue(parameter.vendorExtensions);
         super.postProcessParameter(parameter);
 
-        if (!parameter.required && nullableType.contains(parameter.dataType)) { //optional
-            parameter.dataType = parameter.dataType + "?";
+        if (nullableType.contains(parameter.dataType)) {
+            if (!parameter.required) { //optional
+                parameter.dataType = parameter.dataType + "?";
+            } else {
+                parameter.vendorExtensions.put("x-value-type", true);
+            }
         }
     }
 

--- a/modules/openapi-generator/src/main/resources/csharp-netcore/api.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/api.mustache
@@ -226,12 +226,12 @@ namespace {{packageName}}.{{apiPackage}}
         {
             {{#allParams}}
             {{#required}}
-            {{^vendorExtensions.x-value-type}}
+            {{^vendorExtensions.x-csharp-value-type}}
             // verify the required parameter '{{paramName}}' is set
             if ({{paramName}} == null)
                 throw new {{packageName}}.Client.ApiException(400, "Missing required parameter '{{paramName}}' when calling {{classname}}->{{operationId}}");
 
-            {{/vendorExtensions.x-value-type}}
+            {{/vendorExtensions.x-csharp-value-type}}
             {{/required}}
             {{/allParams}}
             {{packageName}}.Client.RequestOptions localVarRequestOptions = new {{packageName}}.Client.RequestOptions();
@@ -256,16 +256,16 @@ namespace {{packageName}}.{{apiPackage}}
             if (localVarAccept != null) localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
 
             {{#pathParams}}
-            {{^vendorExtensions.x-value-type}}
+            {{^vendorExtensions.x-csharp-value-type}}
             if ({{paramName}} != null)
                 localVarRequestOptions.PathParameters.Add("{{baseName}}", {{packageName}}.Client.ClientUtils.ParameterToString({{paramName}})); // path parameter
-            {{/vendorExtensions.x-value-type}}
-            {{#vendorExtensions.x-value-type}}
+            {{/vendorExtensions.x-csharp-value-type}}
+            {{#vendorExtensions.x-csharp-value-type}}
             localVarRequestOptions.PathParameters.Add("{{baseName}}", {{packageName}}.Client.ClientUtils.ParameterToString({{paramName}})); // path parameter
-            {{/vendorExtensions.x-value-type}}
+            {{/vendorExtensions.x-csharp-value-type}}
             {{/pathParams}}
             {{#queryParams}}
-            {{^vendorExtensions.x-value-type}}
+            {{^vendorExtensions.x-csharp-value-type}}
             if ({{paramName}} != null)
             {
                 foreach (var _kvp in {{packageName}}.Client.ClientUtils.ParameterToMultiMap("{{#collectionFormat}}{{collectionFormat}}{{/collectionFormat}}", "{{baseName}}", {{paramName}}))
@@ -276,8 +276,8 @@ namespace {{packageName}}.{{apiPackage}}
                     }
                 }
             }
-            {{/vendorExtensions.x-value-type}}
-            {{#vendorExtensions.x-value-type}}
+            {{/vendorExtensions.x-csharp-value-type}}
+            {{#vendorExtensions.x-csharp-value-type}}
             foreach (var _kvp in {{packageName}}.Client.ClientUtils.ParameterToMultiMap("{{#collectionFormat}}{{collectionFormat}}{{/collectionFormat}}", "{{baseName}}", {{paramName}}))
             {
                 foreach (var _kvpValue in _kvp.Value)
@@ -285,19 +285,19 @@ namespace {{packageName}}.{{apiPackage}}
                     localVarRequestOptions.QueryParameters.Add(_kvp.Key, _kvpValue);
                 }
             }
-            {{/vendorExtensions.x-value-type}}
+            {{/vendorExtensions.x-csharp-value-type}}
             {{/queryParams}}
             {{#headerParams}}
-            {{^vendorExtensions.x-value-type}}
+            {{^vendorExtensions.x-csharp-value-type}}
             if ({{paramName}} != null)
                 localVarRequestOptions.HeaderParameters.Add("{{baseName}}", {{packageName}}.Client.ClientUtils.ParameterToString({{paramName}})); // header parameter
-            {{/vendorExtensions.x-value-type}}
-            {{#vendorExtensions.x-value-type}}
+            {{/vendorExtensions.x-csharp-value-type}}
+            {{#vendorExtensions.x-csharp-value-type}}
             localVarRequestOptions.HeaderParameters.Add("{{baseName}}", {{packageName}}.Client.ClientUtils.ParameterToString({{paramName}})); // header parameter
-            {{/vendorExtensions.x-value-type}}
+            {{/vendorExtensions.x-csharp-value-type}}
             {{/headerParams}}
             {{#formParams}}
-            {{^vendorExtensions.x-value-type}}
+            {{^vendorExtensions.x-csharp-value-type}}
             if ({{paramName}} != null)
             {
                 {{#isFile}}
@@ -307,15 +307,15 @@ namespace {{packageName}}.{{apiPackage}}
                 localVarRequestOptions.FormParameters.Add("{{baseName}}", {{packageName}}.Client.ClientUtils.ParameterToString({{paramName}})); // form parameter
                 {{/isFile}}
             }
-            {{/vendorExtensions.x-value-type}}
-            {{#vendorExtensions.x-value-type}}
+            {{/vendorExtensions.x-csharp-value-type}}
+            {{#vendorExtensions.x-csharp-value-type}}
             {{#isFile}}
             localVarRequestOptions.FileParameters.Add("{{baseName}}", {{paramName}});
             {{/isFile}}
             {{^isFile}}
             localVarRequestOptions.FormParameters.Add("{{baseName}}", {{packageName}}.Client.ClientUtils.ParameterToString({{paramName}})); // form parameter
             {{/isFile}}
-            {{/vendorExtensions.x-value-type}}
+            {{/vendorExtensions.x-csharp-value-type}}
             {{/formParams}}
             {{#bodyParam}}
             localVarRequestOptions.Data = {{paramName}};
@@ -395,12 +395,12 @@ namespace {{packageName}}.{{apiPackage}}
         {
             {{#allParams}}
             {{#required}}
-            {{^vendorExtensions.x-value-type}}
+            {{^vendorExtensions.x-csharp-value-type}}
             // verify the required parameter '{{paramName}}' is set
             if ({{paramName}} == null)
                 throw new {{packageName}}.Client.ApiException(400, "Missing required parameter '{{paramName}}' when calling {{classname}}->{{operationId}}");
 
-            {{/vendorExtensions.x-value-type}}
+            {{/vendorExtensions.x-csharp-value-type}}
             {{/required}}
             {{/allParams}}
 
@@ -426,16 +426,16 @@ namespace {{packageName}}.{{apiPackage}}
                 localVarRequestOptions.HeaderParameters.Add("Accept", _accept);
             
             {{#pathParams}}
-            {{^vendorExtensions.x-value-type}}
+            {{^vendorExtensions.x-csharp-value-type}}
             if ({{paramName}} != null)
                 localVarRequestOptions.PathParameters.Add("{{baseName}}", {{packageName}}.Client.ClientUtils.ParameterToString({{paramName}})); // path parameter
-            {{/vendorExtensions.x-value-type}}
-            {{#vendorExtensions.x-value-type}}
+            {{/vendorExtensions.x-csharp-value-type}}
+            {{#vendorExtensions.x-csharp-value-type}}
             localVarRequestOptions.PathParameters.Add("{{baseName}}", {{packageName}}.Client.ClientUtils.ParameterToString({{paramName}})); // path parameter
-            {{/vendorExtensions.x-value-type}}
+            {{/vendorExtensions.x-csharp-value-type}}
             {{/pathParams}}
             {{#queryParams}}
-            {{^vendorExtensions.x-value-type}}
+            {{^vendorExtensions.x-csharp-value-type}}
             if ({{paramName}} != null)
             {
                 foreach (var _kvp in {{packageName}}.Client.ClientUtils.ParameterToMultiMap("{{#collectionFormat}}{{collectionFormat}}{{/collectionFormat}}", "{{baseName}}", {{paramName}}))
@@ -446,8 +446,8 @@ namespace {{packageName}}.{{apiPackage}}
                     }
                 }
             }
-            {{/vendorExtensions.x-value-type}}
-            {{#vendorExtensions.x-value-type}}
+            {{/vendorExtensions.x-csharp-value-type}}
+            {{#vendorExtensions.x-csharp-value-type}}
             foreach (var _kvp in {{packageName}}.Client.ClientUtils.ParameterToMultiMap("{{#collectionFormat}}{{collectionFormat}}{{/collectionFormat}}", "{{baseName}}", {{paramName}}))
             {
                 foreach (var _kvpValue in _kvp.Value)
@@ -455,19 +455,19 @@ namespace {{packageName}}.{{apiPackage}}
                     localVarRequestOptions.QueryParameters.Add(_kvp.Key, _kvpValue);
                 }
             }
-            {{/vendorExtensions.x-value-type}}
+            {{/vendorExtensions.x-csharp-value-type}}
             {{/queryParams}}
             {{#headerParams}}
-            {{^vendorExtensions.x-value-type}}
+            {{^vendorExtensions.x-csharp-value-type}}
             if ({{paramName}} != null)
                 localVarRequestOptions.HeaderParameters.Add("{{baseName}}", {{packageName}}.Client.ClientUtils.ParameterToString({{paramName}})); // header parameter
-            {{/vendorExtensions.x-value-type}}
-            {{#vendorExtensions.x-value-type}}
+            {{/vendorExtensions.x-csharp-value-type}}
+            {{#vendorExtensions.x-csharp-value-type}}
             localVarRequestOptions.HeaderParameters.Add("{{baseName}}", {{packageName}}.Client.ClientUtils.ParameterToString({{paramName}})); // header parameter
-            {{/vendorExtensions.x-value-type}}
+            {{/vendorExtensions.x-csharp-value-type}}
             {{/headerParams}}
             {{#formParams}}
-            {{^vendorExtensions.x-value-type}}
+            {{^vendorExtensions.x-csharp-value-type}}
             if ({{paramName}} != null)
             {
                 {{#isFile}}
@@ -477,15 +477,15 @@ namespace {{packageName}}.{{apiPackage}}
                 localVarRequestOptions.FormParameters.Add("{{baseName}}", {{packageName}}.Client.ClientUtils.ParameterToString({{paramName}})); // form parameter
                 {{/isFile}}
             }
-            {{/vendorExtensions.x-value-type}}
-            {{#vendorExtensions.x-value-type}}
+            {{/vendorExtensions.x-csharp-value-type}}
+            {{#vendorExtensions.x-csharp-value-type}}
             {{#isFile}}
             localVarRequestOptions.FileParameters.Add("{{baseName}}", {{paramName}});
             {{/isFile}}
             {{^isFile}}
             localVarRequestOptions.FormParameters.Add("{{baseName}}", {{packageName}}.Client.ClientUtils.ParameterToString({{paramName}})); // form parameter
             {{/isFile}}
-            {{/vendorExtensions.x-value-type}}
+            {{/vendorExtensions.x-csharp-value-type}}
             {{/formParams}}
             {{#bodyParam}}
             localVarRequestOptions.Data = {{paramName}};

--- a/modules/openapi-generator/src/main/resources/csharp-netcore/api.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/api.mustache
@@ -225,14 +225,14 @@ namespace {{packageName}}.{{apiPackage}}
         public {{packageName}}.Client.ApiResponse<{{#returnType}} {{{returnType}}} {{/returnType}}{{^returnType}}Object{{/returnType}}> {{operationId}}WithHttpInfo ({{#allParams}}{{{dataType}}} {{paramName}}{{^required}}{{#optionalMethodArgument}} = default({{{dataType}}}){{/optionalMethodArgument}}{{/required}}{{#hasMore}}, {{/hasMore}}{{/allParams}})
         {
             {{#allParams}}
-            {{^isNullable}}
             {{#required}}
+            {{^vendorExtensions.x-value-type}}
             // verify the required parameter '{{paramName}}' is set
             if ({{paramName}} == null)
                 throw new {{packageName}}.Client.ApiException(400, "Missing required parameter '{{paramName}}' when calling {{classname}}->{{operationId}}");
 
+            {{/vendorExtensions.x-value-type}}
             {{/required}}
-            {{/isNullable}}
             {{/allParams}}
             {{packageName}}.Client.RequestOptions localVarRequestOptions = new {{packageName}}.Client.RequestOptions();
 
@@ -256,10 +256,16 @@ namespace {{packageName}}.{{apiPackage}}
             if (localVarAccept != null) localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
 
             {{#pathParams}}
+            {{^vendorExtensions.x-value-type}}
             if ({{paramName}} != null)
                 localVarRequestOptions.PathParameters.Add("{{baseName}}", {{packageName}}.Client.ClientUtils.ParameterToString({{paramName}})); // path parameter
+            {{/vendorExtensions.x-value-type}}
+            {{#vendorExtensions.x-value-type}}
+            localVarRequestOptions.PathParameters.Add("{{baseName}}", {{packageName}}.Client.ClientUtils.ParameterToString({{paramName}})); // path parameter
+            {{/vendorExtensions.x-value-type}}
             {{/pathParams}}
             {{#queryParams}}
+            {{^vendorExtensions.x-value-type}}
             if ({{paramName}} != null)
             {
                 foreach (var _kvp in {{packageName}}.Client.ClientUtils.ParameterToMultiMap("{{#collectionFormat}}{{collectionFormat}}{{/collectionFormat}}", "{{baseName}}", {{paramName}}))
@@ -270,12 +276,28 @@ namespace {{packageName}}.{{apiPackage}}
                     }
                 }
             }
+            {{/vendorExtensions.x-value-type}}
+            {{#vendorExtensions.x-value-type}}
+            foreach (var _kvp in {{packageName}}.Client.ClientUtils.ParameterToMultiMap("{{#collectionFormat}}{{collectionFormat}}{{/collectionFormat}}", "{{baseName}}", {{paramName}}))
+            {
+                foreach (var _kvpValue in _kvp.Value)
+                {
+                    localVarRequestOptions.QueryParameters.Add(_kvp.Key, _kvpValue);
+                }
+            }
+            {{/vendorExtensions.x-value-type}}
             {{/queryParams}}
             {{#headerParams}}
+            {{^vendorExtensions.x-value-type}}
             if ({{paramName}} != null)
                 localVarRequestOptions.HeaderParameters.Add("{{baseName}}", {{packageName}}.Client.ClientUtils.ParameterToString({{paramName}})); // header parameter
+            {{/vendorExtensions.x-value-type}}
+            {{#vendorExtensions.x-value-type}}
+            localVarRequestOptions.HeaderParameters.Add("{{baseName}}", {{packageName}}.Client.ClientUtils.ParameterToString({{paramName}})); // header parameter
+            {{/vendorExtensions.x-value-type}}
             {{/headerParams}}
             {{#formParams}}
+            {{^vendorExtensions.x-value-type}}
             if ({{paramName}} != null)
             {
                 {{#isFile}}
@@ -285,6 +307,15 @@ namespace {{packageName}}.{{apiPackage}}
                 localVarRequestOptions.FormParameters.Add("{{baseName}}", {{packageName}}.Client.ClientUtils.ParameterToString({{paramName}})); // form parameter
                 {{/isFile}}
             }
+            {{/vendorExtensions.x-value-type}}
+            {{#vendorExtensions.x-value-type}}
+            {{#isFile}}
+            localVarRequestOptions.FileParameters.Add("{{baseName}}", {{paramName}});
+            {{/isFile}}
+            {{^isFile}}
+            localVarRequestOptions.FormParameters.Add("{{baseName}}", {{packageName}}.Client.ClientUtils.ParameterToString({{paramName}})); // form parameter
+            {{/isFile}}
+            {{/vendorExtensions.x-value-type}}
             {{/formParams}}
             {{#bodyParam}}
             localVarRequestOptions.Data = {{paramName}};
@@ -363,14 +394,14 @@ namespace {{packageName}}.{{apiPackage}}
         public async System.Threading.Tasks.Task<{{packageName}}.Client.ApiResponse<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Object{{/returnType}}>> {{operationId}}AsyncWithHttpInfo ({{#allParams}}{{{dataType}}} {{paramName}}{{^required}}{{#optionalMethodArgument}} = default({{{dataType}}}){{/optionalMethodArgument}}{{/required}}{{#hasMore}}, {{/hasMore}}{{/allParams}})
         {
             {{#allParams}}
-            {{^isNullable}}
             {{#required}}
+            {{^vendorExtensions.x-value-type}}
             // verify the required parameter '{{paramName}}' is set
             if ({{paramName}} == null)
                 throw new {{packageName}}.Client.ApiException(400, "Missing required parameter '{{paramName}}' when calling {{classname}}->{{operationId}}");
 
+            {{/vendorExtensions.x-value-type}}
             {{/required}}
-            {{/isNullable}}
             {{/allParams}}
 
             {{packageName}}.Client.RequestOptions localVarRequestOptions = new {{packageName}}.Client.RequestOptions();
@@ -395,10 +426,16 @@ namespace {{packageName}}.{{apiPackage}}
                 localVarRequestOptions.HeaderParameters.Add("Accept", _accept);
             
             {{#pathParams}}
+            {{^vendorExtensions.x-value-type}}
             if ({{paramName}} != null)
                 localVarRequestOptions.PathParameters.Add("{{baseName}}", {{packageName}}.Client.ClientUtils.ParameterToString({{paramName}})); // path parameter
+            {{/vendorExtensions.x-value-type}}
+            {{#vendorExtensions.x-value-type}}
+            localVarRequestOptions.PathParameters.Add("{{baseName}}", {{packageName}}.Client.ClientUtils.ParameterToString({{paramName}})); // path parameter
+            {{/vendorExtensions.x-value-type}}
             {{/pathParams}}
             {{#queryParams}}
+            {{^vendorExtensions.x-value-type}}
             if ({{paramName}} != null)
             {
                 foreach (var _kvp in {{packageName}}.Client.ClientUtils.ParameterToMultiMap("{{#collectionFormat}}{{collectionFormat}}{{/collectionFormat}}", "{{baseName}}", {{paramName}}))
@@ -409,12 +446,28 @@ namespace {{packageName}}.{{apiPackage}}
                     }
                 }
             }
+            {{/vendorExtensions.x-value-type}}
+            {{#vendorExtensions.x-value-type}}
+            foreach (var _kvp in {{packageName}}.Client.ClientUtils.ParameterToMultiMap("{{#collectionFormat}}{{collectionFormat}}{{/collectionFormat}}", "{{baseName}}", {{paramName}}))
+            {
+                foreach (var _kvpValue in _kvp.Value)
+                {
+                    localVarRequestOptions.QueryParameters.Add(_kvp.Key, _kvpValue);
+                }
+            }
+            {{/vendorExtensions.x-value-type}}
             {{/queryParams}}
             {{#headerParams}}
+            {{^vendorExtensions.x-value-type}}
             if ({{paramName}} != null)
                 localVarRequestOptions.HeaderParameters.Add("{{baseName}}", {{packageName}}.Client.ClientUtils.ParameterToString({{paramName}})); // header parameter
+            {{/vendorExtensions.x-value-type}}
+            {{#vendorExtensions.x-value-type}}
+            localVarRequestOptions.HeaderParameters.Add("{{baseName}}", {{packageName}}.Client.ClientUtils.ParameterToString({{paramName}})); // header parameter
+            {{/vendorExtensions.x-value-type}}
             {{/headerParams}}
             {{#formParams}}
+            {{^vendorExtensions.x-value-type}}
             if ({{paramName}} != null)
             {
                 {{#isFile}}
@@ -424,6 +477,15 @@ namespace {{packageName}}.{{apiPackage}}
                 localVarRequestOptions.FormParameters.Add("{{baseName}}", {{packageName}}.Client.ClientUtils.ParameterToString({{paramName}})); // form parameter
                 {{/isFile}}
             }
+            {{/vendorExtensions.x-value-type}}
+            {{#vendorExtensions.x-value-type}}
+            {{#isFile}}
+            localVarRequestOptions.FileParameters.Add("{{baseName}}", {{paramName}});
+            {{/isFile}}
+            {{^isFile}}
+            localVarRequestOptions.FormParameters.Add("{{baseName}}", {{packageName}}.Client.ClientUtils.ParameterToString({{paramName}})); // form parameter
+            {{/isFile}}
+            {{/vendorExtensions.x-value-type}}
             {{/formParams}}
             {{#bodyParam}}
             localVarRequestOptions.Data = {{paramName}};

--- a/modules/openapi-generator/src/main/resources/csharp-netcore/modelGeneric.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/modelGeneric.mustache
@@ -61,13 +61,13 @@
             {{^isInherited}}
             {{^isReadOnly}}
             {{#required}}
-            {{^vendorExtensions.x-value-type}}
+            {{^vendorExtensions.x-csharp-value-type}}
             // to ensure "{{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}}" is required (not null)
             this.{{name}} = {{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}} ?? throw new ArgumentNullException("{{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}} is a required property for {{classname}} and cannot be null");;
-            {{/vendorExtensions.x-value-type}}
-            {{#vendorExtensions.x-value-type}}
+            {{/vendorExtensions.x-csharp-value-type}}
+            {{#vendorExtensions.x-csharp-value-type}}
             this.{{name}} = {{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}};
-            {{/vendorExtensions.x-value-type}}
+            {{/vendorExtensions.x-csharp-value-type}}
             {{/required}}
             {{/isReadOnly}}
             {{/isInherited}}
@@ -77,13 +77,13 @@
             {{^isReadOnly}}
             {{^required}}
             {{#defaultValue}}
-            {{^vendorExtensions.x-value-type}}
+            {{^vendorExtensions.x-csharp-value-type}}
             // use default value if no "{{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}}" provided
             this.{{name}} = {{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}} ?? {{{defaultValue}}};
-            {{/vendorExtensions.x-value-type}}
-            {{#vendorExtensions.x-value-type}}
+            {{/vendorExtensions.x-csharp-value-type}}
+            {{#vendorExtensions.x-csharp-value-type}}
             this.{{name}} = {{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}};
-            {{/vendorExtensions.x-value-type}}
+            {{/vendorExtensions.x-csharp-value-type}}
             {{/defaultValue}}
             {{^defaultValue}}
             this.{{name}} = {{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}};

--- a/modules/openapi-generator/src/main/resources/csharp-netcore/modelGeneric.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/modelGeneric.mustache
@@ -60,28 +60,15 @@
             {{#vars}}
             {{^isInherited}}
             {{^isReadOnly}}
-            {{^isNullable}}
             {{#required}}
-            {{^isEnum}}
+            {{^vendorExtensions.x-value-type}}
             // to ensure "{{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}}" is required (not null)
-            if ({{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}} == null)
-            {
-                throw new InvalidDataException("{{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}} is a required property for {{classname}} and cannot be null");
-            }
-            else
-            {
-                this.{{name}} = {{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}};
-            }
-
-            {{/isEnum}}
-            {{#isEnum}}
+            this.{{name}} = {{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}} ?? throw new ArgumentNullException("{{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}} is a required property for {{classname}} and cannot be null");;
+            {{/vendorExtensions.x-value-type}}
+            {{#vendorExtensions.x-value-type}}
             this.{{name}} = {{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}};
-            {{/isEnum}}
+            {{/vendorExtensions.x-value-type}}
             {{/required}}
-            {{/isNullable}}
-            {{#isNullable}}
-            this.{{name}} = {{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}};
-            {{/isNullable}}
             {{/isReadOnly}}
             {{/isInherited}}
             {{/vars}}
@@ -90,15 +77,13 @@
             {{^isReadOnly}}
             {{^required}}
             {{#defaultValue}}
+            {{^vendorExtensions.x-value-type}}
             // use default value if no "{{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}}" provided
-            if ({{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}} == null)
-            {
-                this.{{name}} = {{{defaultValue}}};
-            }
-            else
-            {
-                this.{{name}} = {{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}};
-            }
+            this.{{name}} = {{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}} ?? {{{defaultValue}}};
+            {{/vendorExtensions.x-value-type}}
+            {{#vendorExtensions.x-value-type}}
+            this.{{name}} = {{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}};
+            {{/vendorExtensions.x-value-type}}
             {{/defaultValue}}
             {{^defaultValue}}
             this.{{name}} = {{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}};

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Api/FakeApi.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Api/FakeApi.cs
@@ -1823,14 +1823,6 @@ namespace Org.OpenAPITools.Api
         /// <returns>ApiResponse of Object(void)</returns>
         public Org.OpenAPITools.Client.ApiResponse<Object> TestEndpointParametersWithHttpInfo (decimal number, double _double, string patternWithoutDelimiter, byte[] _byte, int? integer = default(int?), int? int32 = default(int?), long? int64 = default(long?), float? _float = default(float?), string _string = default(string), System.IO.Stream binary = default(System.IO.Stream), DateTime? date = default(DateTime?), DateTime? dateTime = default(DateTime?), string password = default(string), string callback = default(string))
         {
-            // verify the required parameter 'number' is set
-            if (number == null)
-                throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'number' when calling FakeApi->TestEndpointParameters");
-
-            // verify the required parameter '_double' is set
-            if (_double == null)
-                throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter '_double' when calling FakeApi->TestEndpointParameters");
-
             // verify the required parameter 'patternWithoutDelimiter' is set
             if (patternWithoutDelimiter == null)
                 throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'patternWithoutDelimiter' when calling FakeApi->TestEndpointParameters");
@@ -1867,18 +1859,12 @@ namespace Org.OpenAPITools.Api
             {
                 localVarRequestOptions.FormParameters.Add("int64", Org.OpenAPITools.Client.ClientUtils.ParameterToString(int64)); // form parameter
             }
-            if (number != null)
-            {
-                localVarRequestOptions.FormParameters.Add("number", Org.OpenAPITools.Client.ClientUtils.ParameterToString(number)); // form parameter
-            }
+            localVarRequestOptions.FormParameters.Add("number", Org.OpenAPITools.Client.ClientUtils.ParameterToString(number)); // form parameter
             if (_float != null)
             {
                 localVarRequestOptions.FormParameters.Add("float", Org.OpenAPITools.Client.ClientUtils.ParameterToString(_float)); // form parameter
             }
-            if (_double != null)
-            {
-                localVarRequestOptions.FormParameters.Add("double", Org.OpenAPITools.Client.ClientUtils.ParameterToString(_double)); // form parameter
-            }
+            localVarRequestOptions.FormParameters.Add("double", Org.OpenAPITools.Client.ClientUtils.ParameterToString(_double)); // form parameter
             if (_string != null)
             {
                 localVarRequestOptions.FormParameters.Add("string", Org.OpenAPITools.Client.ClientUtils.ParameterToString(_string)); // form parameter
@@ -1977,14 +1963,6 @@ namespace Org.OpenAPITools.Api
         /// <returns>Task of ApiResponse</returns>
         public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Object>> TestEndpointParametersAsyncWithHttpInfo (decimal number, double _double, string patternWithoutDelimiter, byte[] _byte, int? integer = default(int?), int? int32 = default(int?), long? int64 = default(long?), float? _float = default(float?), string _string = default(string), System.IO.Stream binary = default(System.IO.Stream), DateTime? date = default(DateTime?), DateTime? dateTime = default(DateTime?), string password = default(string), string callback = default(string))
         {
-            // verify the required parameter 'number' is set
-            if (number == null)
-                throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'number' when calling FakeApi->TestEndpointParameters");
-
-            // verify the required parameter '_double' is set
-            if (_double == null)
-                throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter '_double' when calling FakeApi->TestEndpointParameters");
-
             // verify the required parameter 'patternWithoutDelimiter' is set
             if (patternWithoutDelimiter == null)
                 throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'patternWithoutDelimiter' when calling FakeApi->TestEndpointParameters");
@@ -2022,18 +2000,12 @@ namespace Org.OpenAPITools.Api
             {
                 localVarRequestOptions.FormParameters.Add("int64", Org.OpenAPITools.Client.ClientUtils.ParameterToString(int64)); // form parameter
             }
-            if (number != null)
-            {
-                localVarRequestOptions.FormParameters.Add("number", Org.OpenAPITools.Client.ClientUtils.ParameterToString(number)); // form parameter
-            }
+            localVarRequestOptions.FormParameters.Add("number", Org.OpenAPITools.Client.ClientUtils.ParameterToString(number)); // form parameter
             if (_float != null)
             {
                 localVarRequestOptions.FormParameters.Add("float", Org.OpenAPITools.Client.ClientUtils.ParameterToString(_float)); // form parameter
             }
-            if (_double != null)
-            {
-                localVarRequestOptions.FormParameters.Add("double", Org.OpenAPITools.Client.ClientUtils.ParameterToString(_double)); // form parameter
-            }
+            localVarRequestOptions.FormParameters.Add("double", Org.OpenAPITools.Client.ClientUtils.ParameterToString(_double)); // form parameter
             if (_string != null)
             {
                 localVarRequestOptions.FormParameters.Add("string", Org.OpenAPITools.Client.ClientUtils.ParameterToString(_string)); // form parameter
@@ -2349,18 +2321,6 @@ namespace Org.OpenAPITools.Api
         /// <returns>ApiResponse of Object(void)</returns>
         public Org.OpenAPITools.Client.ApiResponse<Object> TestGroupParametersWithHttpInfo (int requiredStringGroup, bool requiredBooleanGroup, long requiredInt64Group, int? stringGroup = default(int?), bool? booleanGroup = default(bool?), long? int64Group = default(long?))
         {
-            // verify the required parameter 'requiredStringGroup' is set
-            if (requiredStringGroup == null)
-                throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'requiredStringGroup' when calling FakeApi->TestGroupParameters");
-
-            // verify the required parameter 'requiredBooleanGroup' is set
-            if (requiredBooleanGroup == null)
-                throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'requiredBooleanGroup' when calling FakeApi->TestGroupParameters");
-
-            // verify the required parameter 'requiredInt64Group' is set
-            if (requiredInt64Group == null)
-                throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'requiredInt64Group' when calling FakeApi->TestGroupParameters");
-
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
             String[] _contentTypes = new String[] {
@@ -2376,24 +2336,18 @@ namespace Org.OpenAPITools.Api
             var localVarAccept = Org.OpenAPITools.Client.ClientUtils.SelectHeaderAccept(_accepts);
             if (localVarAccept != null) localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
 
-            if (requiredStringGroup != null)
+            foreach (var _kvp in Org.OpenAPITools.Client.ClientUtils.ParameterToMultiMap("", "required_string_group", requiredStringGroup))
             {
-                foreach (var _kvp in Org.OpenAPITools.Client.ClientUtils.ParameterToMultiMap("", "required_string_group", requiredStringGroup))
+                foreach (var _kvpValue in _kvp.Value)
                 {
-                    foreach (var _kvpValue in _kvp.Value)
-                    {
-                        localVarRequestOptions.QueryParameters.Add(_kvp.Key, _kvpValue);
-                    }
+                    localVarRequestOptions.QueryParameters.Add(_kvp.Key, _kvpValue);
                 }
             }
-            if (requiredInt64Group != null)
+            foreach (var _kvp in Org.OpenAPITools.Client.ClientUtils.ParameterToMultiMap("", "required_int64_group", requiredInt64Group))
             {
-                foreach (var _kvp in Org.OpenAPITools.Client.ClientUtils.ParameterToMultiMap("", "required_int64_group", requiredInt64Group))
+                foreach (var _kvpValue in _kvp.Value)
                 {
-                    foreach (var _kvpValue in _kvp.Value)
-                    {
-                        localVarRequestOptions.QueryParameters.Add(_kvp.Key, _kvpValue);
-                    }
+                    localVarRequestOptions.QueryParameters.Add(_kvp.Key, _kvpValue);
                 }
             }
             if (stringGroup != null)
@@ -2416,8 +2370,7 @@ namespace Org.OpenAPITools.Api
                     }
                 }
             }
-            if (requiredBooleanGroup != null)
-                localVarRequestOptions.HeaderParameters.Add("required_boolean_group", Org.OpenAPITools.Client.ClientUtils.ParameterToString(requiredBooleanGroup)); // header parameter
+            localVarRequestOptions.HeaderParameters.Add("required_boolean_group", Org.OpenAPITools.Client.ClientUtils.ParameterToString(requiredBooleanGroup)); // header parameter
             if (booleanGroup != null)
                 localVarRequestOptions.HeaderParameters.Add("boolean_group", Org.OpenAPITools.Client.ClientUtils.ParameterToString(booleanGroup)); // header parameter
 
@@ -2464,18 +2417,6 @@ namespace Org.OpenAPITools.Api
         /// <returns>Task of ApiResponse</returns>
         public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Object>> TestGroupParametersAsyncWithHttpInfo (int requiredStringGroup, bool requiredBooleanGroup, long requiredInt64Group, int? stringGroup = default(int?), bool? booleanGroup = default(bool?), long? int64Group = default(long?))
         {
-            // verify the required parameter 'requiredStringGroup' is set
-            if (requiredStringGroup == null)
-                throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'requiredStringGroup' when calling FakeApi->TestGroupParameters");
-
-            // verify the required parameter 'requiredBooleanGroup' is set
-            if (requiredBooleanGroup == null)
-                throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'requiredBooleanGroup' when calling FakeApi->TestGroupParameters");
-
-            // verify the required parameter 'requiredInt64Group' is set
-            if (requiredInt64Group == null)
-                throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'requiredInt64Group' when calling FakeApi->TestGroupParameters");
-
 
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
@@ -2492,24 +2433,18 @@ namespace Org.OpenAPITools.Api
             foreach (var _accept in _accepts)
                 localVarRequestOptions.HeaderParameters.Add("Accept", _accept);
             
-            if (requiredStringGroup != null)
+            foreach (var _kvp in Org.OpenAPITools.Client.ClientUtils.ParameterToMultiMap("", "required_string_group", requiredStringGroup))
             {
-                foreach (var _kvp in Org.OpenAPITools.Client.ClientUtils.ParameterToMultiMap("", "required_string_group", requiredStringGroup))
+                foreach (var _kvpValue in _kvp.Value)
                 {
-                    foreach (var _kvpValue in _kvp.Value)
-                    {
-                        localVarRequestOptions.QueryParameters.Add(_kvp.Key, _kvpValue);
-                    }
+                    localVarRequestOptions.QueryParameters.Add(_kvp.Key, _kvpValue);
                 }
             }
-            if (requiredInt64Group != null)
+            foreach (var _kvp in Org.OpenAPITools.Client.ClientUtils.ParameterToMultiMap("", "required_int64_group", requiredInt64Group))
             {
-                foreach (var _kvp in Org.OpenAPITools.Client.ClientUtils.ParameterToMultiMap("", "required_int64_group", requiredInt64Group))
+                foreach (var _kvpValue in _kvp.Value)
                 {
-                    foreach (var _kvpValue in _kvp.Value)
-                    {
-                        localVarRequestOptions.QueryParameters.Add(_kvp.Key, _kvpValue);
-                    }
+                    localVarRequestOptions.QueryParameters.Add(_kvp.Key, _kvpValue);
                 }
             }
             if (stringGroup != null)
@@ -2532,8 +2467,7 @@ namespace Org.OpenAPITools.Api
                     }
                 }
             }
-            if (requiredBooleanGroup != null)
-                localVarRequestOptions.HeaderParameters.Add("required_boolean_group", Org.OpenAPITools.Client.ClientUtils.ParameterToString(requiredBooleanGroup)); // header parameter
+            localVarRequestOptions.HeaderParameters.Add("required_boolean_group", Org.OpenAPITools.Client.ClientUtils.ParameterToString(requiredBooleanGroup)); // header parameter
             if (booleanGroup != null)
                 localVarRequestOptions.HeaderParameters.Add("boolean_group", Org.OpenAPITools.Client.ClientUtils.ParameterToString(booleanGroup)); // header parameter
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Api/PetApi.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Api/PetApi.cs
@@ -708,10 +708,6 @@ namespace Org.OpenAPITools.Api
         /// <returns>ApiResponse of Object(void)</returns>
         public Org.OpenAPITools.Client.ApiResponse<Object> DeletePetWithHttpInfo (long petId, string apiKey = default(string))
         {
-            // verify the required parameter 'petId' is set
-            if (petId == null)
-                throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'petId' when calling PetApi->DeletePet");
-
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
             String[] _contentTypes = new String[] {
@@ -727,8 +723,7 @@ namespace Org.OpenAPITools.Api
             var localVarAccept = Org.OpenAPITools.Client.ClientUtils.SelectHeaderAccept(_accepts);
             if (localVarAccept != null) localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
 
-            if (petId != null)
-                localVarRequestOptions.PathParameters.Add("petId", Org.OpenAPITools.Client.ClientUtils.ParameterToString(petId)); // path parameter
+            localVarRequestOptions.PathParameters.Add("petId", Org.OpenAPITools.Client.ClientUtils.ParameterToString(petId)); // path parameter
             if (apiKey != null)
                 localVarRequestOptions.HeaderParameters.Add("api_key", Org.OpenAPITools.Client.ClientUtils.ParameterToString(apiKey)); // header parameter
 
@@ -773,10 +768,6 @@ namespace Org.OpenAPITools.Api
         /// <returns>Task of ApiResponse</returns>
         public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Object>> DeletePetAsyncWithHttpInfo (long petId, string apiKey = default(string))
         {
-            // verify the required parameter 'petId' is set
-            if (petId == null)
-                throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'petId' when calling PetApi->DeletePet");
-
 
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
@@ -793,8 +784,7 @@ namespace Org.OpenAPITools.Api
             foreach (var _accept in _accepts)
                 localVarRequestOptions.HeaderParameters.Add("Accept", _accept);
             
-            if (petId != null)
-                localVarRequestOptions.PathParameters.Add("petId", Org.OpenAPITools.Client.ClientUtils.ParameterToString(petId)); // path parameter
+            localVarRequestOptions.PathParameters.Add("petId", Org.OpenAPITools.Client.ClientUtils.ParameterToString(petId)); // path parameter
             if (apiKey != null)
                 localVarRequestOptions.HeaderParameters.Add("api_key", Org.OpenAPITools.Client.ClientUtils.ParameterToString(apiKey)); // header parameter
 
@@ -1128,10 +1118,6 @@ namespace Org.OpenAPITools.Api
         /// <returns>ApiResponse of Pet</returns>
         public Org.OpenAPITools.Client.ApiResponse< Pet > GetPetByIdWithHttpInfo (long petId)
         {
-            // verify the required parameter 'petId' is set
-            if (petId == null)
-                throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'petId' when calling PetApi->GetPetById");
-
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
             String[] _contentTypes = new String[] {
@@ -1149,8 +1135,7 @@ namespace Org.OpenAPITools.Api
             var localVarAccept = Org.OpenAPITools.Client.ClientUtils.SelectHeaderAccept(_accepts);
             if (localVarAccept != null) localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
 
-            if (petId != null)
-                localVarRequestOptions.PathParameters.Add("petId", Org.OpenAPITools.Client.ClientUtils.ParameterToString(petId)); // path parameter
+            localVarRequestOptions.PathParameters.Add("petId", Org.OpenAPITools.Client.ClientUtils.ParameterToString(petId)); // path parameter
 
             // authentication (api_key) required
             if (!String.IsNullOrEmpty(this.Configuration.GetApiKeyWithPrefix("api_key")))
@@ -1191,10 +1176,6 @@ namespace Org.OpenAPITools.Api
         /// <returns>Task of ApiResponse (Pet)</returns>
         public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Pet>> GetPetByIdAsyncWithHttpInfo (long petId)
         {
-            // verify the required parameter 'petId' is set
-            if (petId == null)
-                throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'petId' when calling PetApi->GetPetById");
-
 
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
@@ -1213,8 +1194,7 @@ namespace Org.OpenAPITools.Api
             foreach (var _accept in _accepts)
                 localVarRequestOptions.HeaderParameters.Add("Accept", _accept);
             
-            if (petId != null)
-                localVarRequestOptions.PathParameters.Add("petId", Org.OpenAPITools.Client.ClientUtils.ParameterToString(petId)); // path parameter
+            localVarRequestOptions.PathParameters.Add("petId", Org.OpenAPITools.Client.ClientUtils.ParameterToString(petId)); // path parameter
 
             // authentication (api_key) required
             if (!String.IsNullOrEmpty(this.Configuration.GetApiKeyWithPrefix("api_key")))
@@ -1383,10 +1363,6 @@ namespace Org.OpenAPITools.Api
         /// <returns>ApiResponse of Object(void)</returns>
         public Org.OpenAPITools.Client.ApiResponse<Object> UpdatePetWithFormWithHttpInfo (long petId, string name = default(string), string status = default(string))
         {
-            // verify the required parameter 'petId' is set
-            if (petId == null)
-                throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'petId' when calling PetApi->UpdatePetWithForm");
-
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
             String[] _contentTypes = new String[] {
@@ -1403,8 +1379,7 @@ namespace Org.OpenAPITools.Api
             var localVarAccept = Org.OpenAPITools.Client.ClientUtils.SelectHeaderAccept(_accepts);
             if (localVarAccept != null) localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
 
-            if (petId != null)
-                localVarRequestOptions.PathParameters.Add("petId", Org.OpenAPITools.Client.ClientUtils.ParameterToString(petId)); // path parameter
+            localVarRequestOptions.PathParameters.Add("petId", Org.OpenAPITools.Client.ClientUtils.ParameterToString(petId)); // path parameter
             if (name != null)
             {
                 localVarRequestOptions.FormParameters.Add("name", Org.OpenAPITools.Client.ClientUtils.ParameterToString(name)); // form parameter
@@ -1457,10 +1432,6 @@ namespace Org.OpenAPITools.Api
         /// <returns>Task of ApiResponse</returns>
         public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Object>> UpdatePetWithFormAsyncWithHttpInfo (long petId, string name = default(string), string status = default(string))
         {
-            // verify the required parameter 'petId' is set
-            if (petId == null)
-                throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'petId' when calling PetApi->UpdatePetWithForm");
-
 
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
@@ -1478,8 +1449,7 @@ namespace Org.OpenAPITools.Api
             foreach (var _accept in _accepts)
                 localVarRequestOptions.HeaderParameters.Add("Accept", _accept);
             
-            if (petId != null)
-                localVarRequestOptions.PathParameters.Add("petId", Org.OpenAPITools.Client.ClientUtils.ParameterToString(petId)); // path parameter
+            localVarRequestOptions.PathParameters.Add("petId", Org.OpenAPITools.Client.ClientUtils.ParameterToString(petId)); // path parameter
             if (name != null)
             {
                 localVarRequestOptions.FormParameters.Add("name", Org.OpenAPITools.Client.ClientUtils.ParameterToString(name)); // form parameter
@@ -1533,10 +1503,6 @@ namespace Org.OpenAPITools.Api
         /// <returns>ApiResponse of ApiResponse</returns>
         public Org.OpenAPITools.Client.ApiResponse< ApiResponse > UploadFileWithHttpInfo (long petId, string additionalMetadata = default(string), System.IO.Stream file = default(System.IO.Stream))
         {
-            // verify the required parameter 'petId' is set
-            if (petId == null)
-                throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'petId' when calling PetApi->UploadFile");
-
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
             String[] _contentTypes = new String[] {
@@ -1554,8 +1520,7 @@ namespace Org.OpenAPITools.Api
             var localVarAccept = Org.OpenAPITools.Client.ClientUtils.SelectHeaderAccept(_accepts);
             if (localVarAccept != null) localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
 
-            if (petId != null)
-                localVarRequestOptions.PathParameters.Add("petId", Org.OpenAPITools.Client.ClientUtils.ParameterToString(petId)); // path parameter
+            localVarRequestOptions.PathParameters.Add("petId", Org.OpenAPITools.Client.ClientUtils.ParameterToString(petId)); // path parameter
             if (additionalMetadata != null)
             {
                 localVarRequestOptions.FormParameters.Add("additionalMetadata", Org.OpenAPITools.Client.ClientUtils.ParameterToString(additionalMetadata)); // form parameter
@@ -1609,10 +1574,6 @@ namespace Org.OpenAPITools.Api
         /// <returns>Task of ApiResponse (ApiResponse)</returns>
         public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<ApiResponse>> UploadFileAsyncWithHttpInfo (long petId, string additionalMetadata = default(string), System.IO.Stream file = default(System.IO.Stream))
         {
-            // verify the required parameter 'petId' is set
-            if (petId == null)
-                throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'petId' when calling PetApi->UploadFile");
-
 
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
@@ -1631,8 +1592,7 @@ namespace Org.OpenAPITools.Api
             foreach (var _accept in _accepts)
                 localVarRequestOptions.HeaderParameters.Add("Accept", _accept);
             
-            if (petId != null)
-                localVarRequestOptions.PathParameters.Add("petId", Org.OpenAPITools.Client.ClientUtils.ParameterToString(petId)); // path parameter
+            localVarRequestOptions.PathParameters.Add("petId", Org.OpenAPITools.Client.ClientUtils.ParameterToString(petId)); // path parameter
             if (additionalMetadata != null)
             {
                 localVarRequestOptions.FormParameters.Add("additionalMetadata", Org.OpenAPITools.Client.ClientUtils.ParameterToString(additionalMetadata)); // form parameter
@@ -1686,10 +1646,6 @@ namespace Org.OpenAPITools.Api
         /// <returns>ApiResponse of ApiResponse</returns>
         public Org.OpenAPITools.Client.ApiResponse< ApiResponse > UploadFileWithRequiredFileWithHttpInfo (long petId, System.IO.Stream requiredFile, string additionalMetadata = default(string))
         {
-            // verify the required parameter 'petId' is set
-            if (petId == null)
-                throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'petId' when calling PetApi->UploadFileWithRequiredFile");
-
             // verify the required parameter 'requiredFile' is set
             if (requiredFile == null)
                 throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'requiredFile' when calling PetApi->UploadFileWithRequiredFile");
@@ -1711,8 +1667,7 @@ namespace Org.OpenAPITools.Api
             var localVarAccept = Org.OpenAPITools.Client.ClientUtils.SelectHeaderAccept(_accepts);
             if (localVarAccept != null) localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
 
-            if (petId != null)
-                localVarRequestOptions.PathParameters.Add("petId", Org.OpenAPITools.Client.ClientUtils.ParameterToString(petId)); // path parameter
+            localVarRequestOptions.PathParameters.Add("petId", Org.OpenAPITools.Client.ClientUtils.ParameterToString(petId)); // path parameter
             if (additionalMetadata != null)
             {
                 localVarRequestOptions.FormParameters.Add("additionalMetadata", Org.OpenAPITools.Client.ClientUtils.ParameterToString(additionalMetadata)); // form parameter
@@ -1766,10 +1721,6 @@ namespace Org.OpenAPITools.Api
         /// <returns>Task of ApiResponse (ApiResponse)</returns>
         public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<ApiResponse>> UploadFileWithRequiredFileAsyncWithHttpInfo (long petId, System.IO.Stream requiredFile, string additionalMetadata = default(string))
         {
-            // verify the required parameter 'petId' is set
-            if (petId == null)
-                throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'petId' when calling PetApi->UploadFileWithRequiredFile");
-
             // verify the required parameter 'requiredFile' is set
             if (requiredFile == null)
                 throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'requiredFile' when calling PetApi->UploadFileWithRequiredFile");
@@ -1792,8 +1743,7 @@ namespace Org.OpenAPITools.Api
             foreach (var _accept in _accepts)
                 localVarRequestOptions.HeaderParameters.Add("Accept", _accept);
             
-            if (petId != null)
-                localVarRequestOptions.PathParameters.Add("petId", Org.OpenAPITools.Client.ClientUtils.ParameterToString(petId)); // path parameter
+            localVarRequestOptions.PathParameters.Add("petId", Org.OpenAPITools.Client.ClientUtils.ParameterToString(petId)); // path parameter
             if (additionalMetadata != null)
             {
                 localVarRequestOptions.FormParameters.Add("additionalMetadata", Org.OpenAPITools.Client.ClientUtils.ParameterToString(additionalMetadata)); // form parameter

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Api/StoreApi.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Api/StoreApi.cs
@@ -560,10 +560,6 @@ namespace Org.OpenAPITools.Api
         /// <returns>ApiResponse of Order</returns>
         public Org.OpenAPITools.Client.ApiResponse< Order > GetOrderByIdWithHttpInfo (long orderId)
         {
-            // verify the required parameter 'orderId' is set
-            if (orderId == null)
-                throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'orderId' when calling StoreApi->GetOrderById");
-
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
             String[] _contentTypes = new String[] {
@@ -581,8 +577,7 @@ namespace Org.OpenAPITools.Api
             var localVarAccept = Org.OpenAPITools.Client.ClientUtils.SelectHeaderAccept(_accepts);
             if (localVarAccept != null) localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
 
-            if (orderId != null)
-                localVarRequestOptions.PathParameters.Add("order_id", Org.OpenAPITools.Client.ClientUtils.ParameterToString(orderId)); // path parameter
+            localVarRequestOptions.PathParameters.Add("order_id", Org.OpenAPITools.Client.ClientUtils.ParameterToString(orderId)); // path parameter
 
 
             // make the HTTP request
@@ -618,10 +613,6 @@ namespace Org.OpenAPITools.Api
         /// <returns>Task of ApiResponse (Order)</returns>
         public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Order>> GetOrderByIdAsyncWithHttpInfo (long orderId)
         {
-            // verify the required parameter 'orderId' is set
-            if (orderId == null)
-                throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'orderId' when calling StoreApi->GetOrderById");
-
 
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
@@ -640,8 +631,7 @@ namespace Org.OpenAPITools.Api
             foreach (var _accept in _accepts)
                 localVarRequestOptions.HeaderParameters.Add("Accept", _accept);
             
-            if (orderId != null)
-                localVarRequestOptions.PathParameters.Add("order_id", Org.OpenAPITools.Client.ClientUtils.ParameterToString(orderId)); // path parameter
+            localVarRequestOptions.PathParameters.Add("order_id", Org.OpenAPITools.Client.ClientUtils.ParameterToString(orderId)); // path parameter
 
 
             // make the HTTP request

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Animal.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Animal.cs
@@ -53,24 +53,9 @@ namespace Org.OpenAPITools.Model
         public Animal(string className = default(string), string color = "red")
         {
             // to ensure "className" is required (not null)
-            if (className == null)
-            {
-                throw new InvalidDataException("className is a required property for Animal and cannot be null");
-            }
-            else
-            {
-                this.ClassName = className;
-            }
-
+            this.ClassName = className ?? throw new ArgumentNullException("className is a required property for Animal and cannot be null");;
             // use default value if no "color" provided
-            if (color == null)
-            {
-                this.Color = "red";
-            }
-            else
-            {
-                this.Color = color;
-            }
+            this.Color = color ?? "red";
         }
         
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Category.cs
@@ -45,15 +45,7 @@ namespace Org.OpenAPITools.Model
         public Category(long id = default(long), string name = "default-name")
         {
             // to ensure "name" is required (not null)
-            if (name == null)
-            {
-                throw new InvalidDataException("name is a required property for Category and cannot be null");
-            }
-            else
-            {
-                this.Name = name;
-            }
-
+            this.Name = name ?? throw new ArgumentNullException("name is a required property for Category and cannot be null");;
             this.Id = id;
         }
         

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -56,46 +56,12 @@ namespace Org.OpenAPITools.Model
         /// <param name="bigDecimal">bigDecimal.</param>
         public FormatTest(int integer = default(int), int int32 = default(int), long int64 = default(long), decimal number = default(decimal), float _float = default(float), double _double = default(double), string _string = default(string), byte[] _byte = default(byte[]), System.IO.Stream binary = default(System.IO.Stream), DateTime date = default(DateTime), DateTime dateTime = default(DateTime), Guid uuid = default(Guid), string password = default(string), decimal bigDecimal = default(decimal))
         {
-            // to ensure "number" is required (not null)
-            if (number == null)
-            {
-                throw new InvalidDataException("number is a required property for FormatTest and cannot be null");
-            }
-            else
-            {
-                this.Number = number;
-            }
-
+            this.Number = number;
             // to ensure "_byte" is required (not null)
-            if (_byte == null)
-            {
-                throw new InvalidDataException("_byte is a required property for FormatTest and cannot be null");
-            }
-            else
-            {
-                this.Byte = _byte;
-            }
-
-            // to ensure "date" is required (not null)
-            if (date == null)
-            {
-                throw new InvalidDataException("date is a required property for FormatTest and cannot be null");
-            }
-            else
-            {
-                this.Date = date;
-            }
-
+            this.Byte = _byte ?? throw new ArgumentNullException("_byte is a required property for FormatTest and cannot be null");;
+            this.Date = date;
             // to ensure "password" is required (not null)
-            if (password == null)
-            {
-                throw new InvalidDataException("password is a required property for FormatTest and cannot be null");
-            }
-            else
-            {
-                this.Password = password;
-            }
-
+            this.Password = password ?? throw new ArgumentNullException("password is a required property for FormatTest and cannot be null");;
             this.Integer = integer;
             this.Int32 = int32;
             this.Int64 = int64;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Name.cs
@@ -44,16 +44,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="property">property.</param>
         public Name(int name = default(int), string property = default(string))
         {
-            // to ensure "name" is required (not null)
-            if (name == null)
-            {
-                throw new InvalidDataException("name is a required property for Name and cannot be null");
-            }
-            else
-            {
-                this._Name = name;
-            }
-
+            this._Name = name;
             this.Property = property;
         }
         

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Order.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Order.cs
@@ -81,15 +81,7 @@ namespace Org.OpenAPITools.Model
             this.Quantity = quantity;
             this.ShipDate = shipDate;
             this.Status = status;
-            // use default value if no "complete" provided
-            if (complete == null)
-            {
-                this.Complete = false;
-            }
-            else
-            {
-                this.Complete = complete;
-            }
+            this.Complete = complete;
         }
         
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Pet.cs
@@ -82,25 +82,9 @@ namespace Org.OpenAPITools.Model
         public Pet(long id = default(long), Category category = default(Category), string name = default(string), List<string> photoUrls = default(List<string>), List<Tag> tags = default(List<Tag>), StatusEnum? status = default(StatusEnum?))
         {
             // to ensure "name" is required (not null)
-            if (name == null)
-            {
-                throw new InvalidDataException("name is a required property for Pet and cannot be null");
-            }
-            else
-            {
-                this.Name = name;
-            }
-
+            this.Name = name ?? throw new ArgumentNullException("name is a required property for Pet and cannot be null");;
             // to ensure "photoUrls" is required (not null)
-            if (photoUrls == null)
-            {
-                throw new InvalidDataException("photoUrls is a required property for Pet and cannot be null");
-            }
-            else
-            {
-                this.PhotoUrls = photoUrls;
-            }
-
+            this.PhotoUrls = photoUrls ?? throw new ArgumentNullException("photoUrls is a required property for Pet and cannot be null");;
             this.Id = id;
             this.Category = category;
             this.Tags = tags;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/TypeHolderDefault.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/TypeHolderDefault.cs
@@ -48,55 +48,12 @@ namespace Org.OpenAPITools.Model
         public TypeHolderDefault(string stringItem = "what", decimal numberItem = default(decimal), int integerItem = default(int), bool boolItem = true, List<int> arrayItem = default(List<int>))
         {
             // to ensure "stringItem" is required (not null)
-            if (stringItem == null)
-            {
-                throw new InvalidDataException("stringItem is a required property for TypeHolderDefault and cannot be null");
-            }
-            else
-            {
-                this.StringItem = stringItem;
-            }
-
-            // to ensure "numberItem" is required (not null)
-            if (numberItem == null)
-            {
-                throw new InvalidDataException("numberItem is a required property for TypeHolderDefault and cannot be null");
-            }
-            else
-            {
-                this.NumberItem = numberItem;
-            }
-
-            // to ensure "integerItem" is required (not null)
-            if (integerItem == null)
-            {
-                throw new InvalidDataException("integerItem is a required property for TypeHolderDefault and cannot be null");
-            }
-            else
-            {
-                this.IntegerItem = integerItem;
-            }
-
-            // to ensure "boolItem" is required (not null)
-            if (boolItem == null)
-            {
-                throw new InvalidDataException("boolItem is a required property for TypeHolderDefault and cannot be null");
-            }
-            else
-            {
-                this.BoolItem = boolItem;
-            }
-
+            this.StringItem = stringItem ?? throw new ArgumentNullException("stringItem is a required property for TypeHolderDefault and cannot be null");;
+            this.NumberItem = numberItem;
+            this.IntegerItem = integerItem;
+            this.BoolItem = boolItem;
             // to ensure "arrayItem" is required (not null)
-            if (arrayItem == null)
-            {
-                throw new InvalidDataException("arrayItem is a required property for TypeHolderDefault and cannot be null");
-            }
-            else
-            {
-                this.ArrayItem = arrayItem;
-            }
-
+            this.ArrayItem = arrayItem ?? throw new ArgumentNullException("arrayItem is a required property for TypeHolderDefault and cannot be null");;
         }
         
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/TypeHolderExample.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/TypeHolderExample.cs
@@ -49,65 +49,13 @@ namespace Org.OpenAPITools.Model
         public TypeHolderExample(string stringItem = default(string), decimal numberItem = default(decimal), float floatItem = default(float), int integerItem = default(int), bool boolItem = default(bool), List<int> arrayItem = default(List<int>))
         {
             // to ensure "stringItem" is required (not null)
-            if (stringItem == null)
-            {
-                throw new InvalidDataException("stringItem is a required property for TypeHolderExample and cannot be null");
-            }
-            else
-            {
-                this.StringItem = stringItem;
-            }
-
-            // to ensure "numberItem" is required (not null)
-            if (numberItem == null)
-            {
-                throw new InvalidDataException("numberItem is a required property for TypeHolderExample and cannot be null");
-            }
-            else
-            {
-                this.NumberItem = numberItem;
-            }
-
-            // to ensure "floatItem" is required (not null)
-            if (floatItem == null)
-            {
-                throw new InvalidDataException("floatItem is a required property for TypeHolderExample and cannot be null");
-            }
-            else
-            {
-                this.FloatItem = floatItem;
-            }
-
-            // to ensure "integerItem" is required (not null)
-            if (integerItem == null)
-            {
-                throw new InvalidDataException("integerItem is a required property for TypeHolderExample and cannot be null");
-            }
-            else
-            {
-                this.IntegerItem = integerItem;
-            }
-
-            // to ensure "boolItem" is required (not null)
-            if (boolItem == null)
-            {
-                throw new InvalidDataException("boolItem is a required property for TypeHolderExample and cannot be null");
-            }
-            else
-            {
-                this.BoolItem = boolItem;
-            }
-
+            this.StringItem = stringItem ?? throw new ArgumentNullException("stringItem is a required property for TypeHolderExample and cannot be null");;
+            this.NumberItem = numberItem;
+            this.FloatItem = floatItem;
+            this.IntegerItem = integerItem;
+            this.BoolItem = boolItem;
             // to ensure "arrayItem" is required (not null)
-            if (arrayItem == null)
-            {
-                throw new InvalidDataException("arrayItem is a required property for TypeHolderExample and cannot be null");
-            }
-            else
-            {
-                this.ArrayItem = arrayItem;
-            }
-
+            this.ArrayItem = arrayItem ?? throw new ArgumentNullException("arrayItem is a required property for TypeHolderExample and cannot be null");;
         }
         
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Api/FakeApi.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Api/FakeApi.cs
@@ -1823,14 +1823,6 @@ namespace Org.OpenAPITools.Api
         /// <returns>ApiResponse of Object(void)</returns>
         public Org.OpenAPITools.Client.ApiResponse<Object> TestEndpointParametersWithHttpInfo (decimal number, double _double, string patternWithoutDelimiter, byte[] _byte, int? integer = default(int?), int? int32 = default(int?), long? int64 = default(long?), float? _float = default(float?), string _string = default(string), System.IO.Stream binary = default(System.IO.Stream), DateTime? date = default(DateTime?), DateTime? dateTime = default(DateTime?), string password = default(string), string callback = default(string))
         {
-            // verify the required parameter 'number' is set
-            if (number == null)
-                throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'number' when calling FakeApi->TestEndpointParameters");
-
-            // verify the required parameter '_double' is set
-            if (_double == null)
-                throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter '_double' when calling FakeApi->TestEndpointParameters");
-
             // verify the required parameter 'patternWithoutDelimiter' is set
             if (patternWithoutDelimiter == null)
                 throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'patternWithoutDelimiter' when calling FakeApi->TestEndpointParameters");
@@ -1867,18 +1859,12 @@ namespace Org.OpenAPITools.Api
             {
                 localVarRequestOptions.FormParameters.Add("int64", Org.OpenAPITools.Client.ClientUtils.ParameterToString(int64)); // form parameter
             }
-            if (number != null)
-            {
-                localVarRequestOptions.FormParameters.Add("number", Org.OpenAPITools.Client.ClientUtils.ParameterToString(number)); // form parameter
-            }
+            localVarRequestOptions.FormParameters.Add("number", Org.OpenAPITools.Client.ClientUtils.ParameterToString(number)); // form parameter
             if (_float != null)
             {
                 localVarRequestOptions.FormParameters.Add("float", Org.OpenAPITools.Client.ClientUtils.ParameterToString(_float)); // form parameter
             }
-            if (_double != null)
-            {
-                localVarRequestOptions.FormParameters.Add("double", Org.OpenAPITools.Client.ClientUtils.ParameterToString(_double)); // form parameter
-            }
+            localVarRequestOptions.FormParameters.Add("double", Org.OpenAPITools.Client.ClientUtils.ParameterToString(_double)); // form parameter
             if (_string != null)
             {
                 localVarRequestOptions.FormParameters.Add("string", Org.OpenAPITools.Client.ClientUtils.ParameterToString(_string)); // form parameter
@@ -1977,14 +1963,6 @@ namespace Org.OpenAPITools.Api
         /// <returns>Task of ApiResponse</returns>
         public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Object>> TestEndpointParametersAsyncWithHttpInfo (decimal number, double _double, string patternWithoutDelimiter, byte[] _byte, int? integer = default(int?), int? int32 = default(int?), long? int64 = default(long?), float? _float = default(float?), string _string = default(string), System.IO.Stream binary = default(System.IO.Stream), DateTime? date = default(DateTime?), DateTime? dateTime = default(DateTime?), string password = default(string), string callback = default(string))
         {
-            // verify the required parameter 'number' is set
-            if (number == null)
-                throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'number' when calling FakeApi->TestEndpointParameters");
-
-            // verify the required parameter '_double' is set
-            if (_double == null)
-                throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter '_double' when calling FakeApi->TestEndpointParameters");
-
             // verify the required parameter 'patternWithoutDelimiter' is set
             if (patternWithoutDelimiter == null)
                 throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'patternWithoutDelimiter' when calling FakeApi->TestEndpointParameters");
@@ -2022,18 +2000,12 @@ namespace Org.OpenAPITools.Api
             {
                 localVarRequestOptions.FormParameters.Add("int64", Org.OpenAPITools.Client.ClientUtils.ParameterToString(int64)); // form parameter
             }
-            if (number != null)
-            {
-                localVarRequestOptions.FormParameters.Add("number", Org.OpenAPITools.Client.ClientUtils.ParameterToString(number)); // form parameter
-            }
+            localVarRequestOptions.FormParameters.Add("number", Org.OpenAPITools.Client.ClientUtils.ParameterToString(number)); // form parameter
             if (_float != null)
             {
                 localVarRequestOptions.FormParameters.Add("float", Org.OpenAPITools.Client.ClientUtils.ParameterToString(_float)); // form parameter
             }
-            if (_double != null)
-            {
-                localVarRequestOptions.FormParameters.Add("double", Org.OpenAPITools.Client.ClientUtils.ParameterToString(_double)); // form parameter
-            }
+            localVarRequestOptions.FormParameters.Add("double", Org.OpenAPITools.Client.ClientUtils.ParameterToString(_double)); // form parameter
             if (_string != null)
             {
                 localVarRequestOptions.FormParameters.Add("string", Org.OpenAPITools.Client.ClientUtils.ParameterToString(_string)); // form parameter
@@ -2349,18 +2321,6 @@ namespace Org.OpenAPITools.Api
         /// <returns>ApiResponse of Object(void)</returns>
         public Org.OpenAPITools.Client.ApiResponse<Object> TestGroupParametersWithHttpInfo (int requiredStringGroup, bool requiredBooleanGroup, long requiredInt64Group, int? stringGroup = default(int?), bool? booleanGroup = default(bool?), long? int64Group = default(long?))
         {
-            // verify the required parameter 'requiredStringGroup' is set
-            if (requiredStringGroup == null)
-                throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'requiredStringGroup' when calling FakeApi->TestGroupParameters");
-
-            // verify the required parameter 'requiredBooleanGroup' is set
-            if (requiredBooleanGroup == null)
-                throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'requiredBooleanGroup' when calling FakeApi->TestGroupParameters");
-
-            // verify the required parameter 'requiredInt64Group' is set
-            if (requiredInt64Group == null)
-                throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'requiredInt64Group' when calling FakeApi->TestGroupParameters");
-
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
             String[] _contentTypes = new String[] {
@@ -2376,24 +2336,18 @@ namespace Org.OpenAPITools.Api
             var localVarAccept = Org.OpenAPITools.Client.ClientUtils.SelectHeaderAccept(_accepts);
             if (localVarAccept != null) localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
 
-            if (requiredStringGroup != null)
+            foreach (var _kvp in Org.OpenAPITools.Client.ClientUtils.ParameterToMultiMap("", "required_string_group", requiredStringGroup))
             {
-                foreach (var _kvp in Org.OpenAPITools.Client.ClientUtils.ParameterToMultiMap("", "required_string_group", requiredStringGroup))
+                foreach (var _kvpValue in _kvp.Value)
                 {
-                    foreach (var _kvpValue in _kvp.Value)
-                    {
-                        localVarRequestOptions.QueryParameters.Add(_kvp.Key, _kvpValue);
-                    }
+                    localVarRequestOptions.QueryParameters.Add(_kvp.Key, _kvpValue);
                 }
             }
-            if (requiredInt64Group != null)
+            foreach (var _kvp in Org.OpenAPITools.Client.ClientUtils.ParameterToMultiMap("", "required_int64_group", requiredInt64Group))
             {
-                foreach (var _kvp in Org.OpenAPITools.Client.ClientUtils.ParameterToMultiMap("", "required_int64_group", requiredInt64Group))
+                foreach (var _kvpValue in _kvp.Value)
                 {
-                    foreach (var _kvpValue in _kvp.Value)
-                    {
-                        localVarRequestOptions.QueryParameters.Add(_kvp.Key, _kvpValue);
-                    }
+                    localVarRequestOptions.QueryParameters.Add(_kvp.Key, _kvpValue);
                 }
             }
             if (stringGroup != null)
@@ -2416,8 +2370,7 @@ namespace Org.OpenAPITools.Api
                     }
                 }
             }
-            if (requiredBooleanGroup != null)
-                localVarRequestOptions.HeaderParameters.Add("required_boolean_group", Org.OpenAPITools.Client.ClientUtils.ParameterToString(requiredBooleanGroup)); // header parameter
+            localVarRequestOptions.HeaderParameters.Add("required_boolean_group", Org.OpenAPITools.Client.ClientUtils.ParameterToString(requiredBooleanGroup)); // header parameter
             if (booleanGroup != null)
                 localVarRequestOptions.HeaderParameters.Add("boolean_group", Org.OpenAPITools.Client.ClientUtils.ParameterToString(booleanGroup)); // header parameter
 
@@ -2464,18 +2417,6 @@ namespace Org.OpenAPITools.Api
         /// <returns>Task of ApiResponse</returns>
         public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Object>> TestGroupParametersAsyncWithHttpInfo (int requiredStringGroup, bool requiredBooleanGroup, long requiredInt64Group, int? stringGroup = default(int?), bool? booleanGroup = default(bool?), long? int64Group = default(long?))
         {
-            // verify the required parameter 'requiredStringGroup' is set
-            if (requiredStringGroup == null)
-                throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'requiredStringGroup' when calling FakeApi->TestGroupParameters");
-
-            // verify the required parameter 'requiredBooleanGroup' is set
-            if (requiredBooleanGroup == null)
-                throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'requiredBooleanGroup' when calling FakeApi->TestGroupParameters");
-
-            // verify the required parameter 'requiredInt64Group' is set
-            if (requiredInt64Group == null)
-                throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'requiredInt64Group' when calling FakeApi->TestGroupParameters");
-
 
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
@@ -2492,24 +2433,18 @@ namespace Org.OpenAPITools.Api
             foreach (var _accept in _accepts)
                 localVarRequestOptions.HeaderParameters.Add("Accept", _accept);
             
-            if (requiredStringGroup != null)
+            foreach (var _kvp in Org.OpenAPITools.Client.ClientUtils.ParameterToMultiMap("", "required_string_group", requiredStringGroup))
             {
-                foreach (var _kvp in Org.OpenAPITools.Client.ClientUtils.ParameterToMultiMap("", "required_string_group", requiredStringGroup))
+                foreach (var _kvpValue in _kvp.Value)
                 {
-                    foreach (var _kvpValue in _kvp.Value)
-                    {
-                        localVarRequestOptions.QueryParameters.Add(_kvp.Key, _kvpValue);
-                    }
+                    localVarRequestOptions.QueryParameters.Add(_kvp.Key, _kvpValue);
                 }
             }
-            if (requiredInt64Group != null)
+            foreach (var _kvp in Org.OpenAPITools.Client.ClientUtils.ParameterToMultiMap("", "required_int64_group", requiredInt64Group))
             {
-                foreach (var _kvp in Org.OpenAPITools.Client.ClientUtils.ParameterToMultiMap("", "required_int64_group", requiredInt64Group))
+                foreach (var _kvpValue in _kvp.Value)
                 {
-                    foreach (var _kvpValue in _kvp.Value)
-                    {
-                        localVarRequestOptions.QueryParameters.Add(_kvp.Key, _kvpValue);
-                    }
+                    localVarRequestOptions.QueryParameters.Add(_kvp.Key, _kvpValue);
                 }
             }
             if (stringGroup != null)
@@ -2532,8 +2467,7 @@ namespace Org.OpenAPITools.Api
                     }
                 }
             }
-            if (requiredBooleanGroup != null)
-                localVarRequestOptions.HeaderParameters.Add("required_boolean_group", Org.OpenAPITools.Client.ClientUtils.ParameterToString(requiredBooleanGroup)); // header parameter
+            localVarRequestOptions.HeaderParameters.Add("required_boolean_group", Org.OpenAPITools.Client.ClientUtils.ParameterToString(requiredBooleanGroup)); // header parameter
             if (booleanGroup != null)
                 localVarRequestOptions.HeaderParameters.Add("boolean_group", Org.OpenAPITools.Client.ClientUtils.ParameterToString(booleanGroup)); // header parameter
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Api/PetApi.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Api/PetApi.cs
@@ -708,10 +708,6 @@ namespace Org.OpenAPITools.Api
         /// <returns>ApiResponse of Object(void)</returns>
         public Org.OpenAPITools.Client.ApiResponse<Object> DeletePetWithHttpInfo (long petId, string apiKey = default(string))
         {
-            // verify the required parameter 'petId' is set
-            if (petId == null)
-                throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'petId' when calling PetApi->DeletePet");
-
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
             String[] _contentTypes = new String[] {
@@ -727,8 +723,7 @@ namespace Org.OpenAPITools.Api
             var localVarAccept = Org.OpenAPITools.Client.ClientUtils.SelectHeaderAccept(_accepts);
             if (localVarAccept != null) localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
 
-            if (petId != null)
-                localVarRequestOptions.PathParameters.Add("petId", Org.OpenAPITools.Client.ClientUtils.ParameterToString(petId)); // path parameter
+            localVarRequestOptions.PathParameters.Add("petId", Org.OpenAPITools.Client.ClientUtils.ParameterToString(petId)); // path parameter
             if (apiKey != null)
                 localVarRequestOptions.HeaderParameters.Add("api_key", Org.OpenAPITools.Client.ClientUtils.ParameterToString(apiKey)); // header parameter
 
@@ -773,10 +768,6 @@ namespace Org.OpenAPITools.Api
         /// <returns>Task of ApiResponse</returns>
         public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Object>> DeletePetAsyncWithHttpInfo (long petId, string apiKey = default(string))
         {
-            // verify the required parameter 'petId' is set
-            if (petId == null)
-                throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'petId' when calling PetApi->DeletePet");
-
 
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
@@ -793,8 +784,7 @@ namespace Org.OpenAPITools.Api
             foreach (var _accept in _accepts)
                 localVarRequestOptions.HeaderParameters.Add("Accept", _accept);
             
-            if (petId != null)
-                localVarRequestOptions.PathParameters.Add("petId", Org.OpenAPITools.Client.ClientUtils.ParameterToString(petId)); // path parameter
+            localVarRequestOptions.PathParameters.Add("petId", Org.OpenAPITools.Client.ClientUtils.ParameterToString(petId)); // path parameter
             if (apiKey != null)
                 localVarRequestOptions.HeaderParameters.Add("api_key", Org.OpenAPITools.Client.ClientUtils.ParameterToString(apiKey)); // header parameter
 
@@ -1128,10 +1118,6 @@ namespace Org.OpenAPITools.Api
         /// <returns>ApiResponse of Pet</returns>
         public Org.OpenAPITools.Client.ApiResponse< Pet > GetPetByIdWithHttpInfo (long petId)
         {
-            // verify the required parameter 'petId' is set
-            if (petId == null)
-                throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'petId' when calling PetApi->GetPetById");
-
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
             String[] _contentTypes = new String[] {
@@ -1149,8 +1135,7 @@ namespace Org.OpenAPITools.Api
             var localVarAccept = Org.OpenAPITools.Client.ClientUtils.SelectHeaderAccept(_accepts);
             if (localVarAccept != null) localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
 
-            if (petId != null)
-                localVarRequestOptions.PathParameters.Add("petId", Org.OpenAPITools.Client.ClientUtils.ParameterToString(petId)); // path parameter
+            localVarRequestOptions.PathParameters.Add("petId", Org.OpenAPITools.Client.ClientUtils.ParameterToString(petId)); // path parameter
 
             // authentication (api_key) required
             if (!String.IsNullOrEmpty(this.Configuration.GetApiKeyWithPrefix("api_key")))
@@ -1191,10 +1176,6 @@ namespace Org.OpenAPITools.Api
         /// <returns>Task of ApiResponse (Pet)</returns>
         public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Pet>> GetPetByIdAsyncWithHttpInfo (long petId)
         {
-            // verify the required parameter 'petId' is set
-            if (petId == null)
-                throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'petId' when calling PetApi->GetPetById");
-
 
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
@@ -1213,8 +1194,7 @@ namespace Org.OpenAPITools.Api
             foreach (var _accept in _accepts)
                 localVarRequestOptions.HeaderParameters.Add("Accept", _accept);
             
-            if (petId != null)
-                localVarRequestOptions.PathParameters.Add("petId", Org.OpenAPITools.Client.ClientUtils.ParameterToString(petId)); // path parameter
+            localVarRequestOptions.PathParameters.Add("petId", Org.OpenAPITools.Client.ClientUtils.ParameterToString(petId)); // path parameter
 
             // authentication (api_key) required
             if (!String.IsNullOrEmpty(this.Configuration.GetApiKeyWithPrefix("api_key")))
@@ -1383,10 +1363,6 @@ namespace Org.OpenAPITools.Api
         /// <returns>ApiResponse of Object(void)</returns>
         public Org.OpenAPITools.Client.ApiResponse<Object> UpdatePetWithFormWithHttpInfo (long petId, string name = default(string), string status = default(string))
         {
-            // verify the required parameter 'petId' is set
-            if (petId == null)
-                throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'petId' when calling PetApi->UpdatePetWithForm");
-
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
             String[] _contentTypes = new String[] {
@@ -1403,8 +1379,7 @@ namespace Org.OpenAPITools.Api
             var localVarAccept = Org.OpenAPITools.Client.ClientUtils.SelectHeaderAccept(_accepts);
             if (localVarAccept != null) localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
 
-            if (petId != null)
-                localVarRequestOptions.PathParameters.Add("petId", Org.OpenAPITools.Client.ClientUtils.ParameterToString(petId)); // path parameter
+            localVarRequestOptions.PathParameters.Add("petId", Org.OpenAPITools.Client.ClientUtils.ParameterToString(petId)); // path parameter
             if (name != null)
             {
                 localVarRequestOptions.FormParameters.Add("name", Org.OpenAPITools.Client.ClientUtils.ParameterToString(name)); // form parameter
@@ -1457,10 +1432,6 @@ namespace Org.OpenAPITools.Api
         /// <returns>Task of ApiResponse</returns>
         public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Object>> UpdatePetWithFormAsyncWithHttpInfo (long petId, string name = default(string), string status = default(string))
         {
-            // verify the required parameter 'petId' is set
-            if (petId == null)
-                throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'petId' when calling PetApi->UpdatePetWithForm");
-
 
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
@@ -1478,8 +1449,7 @@ namespace Org.OpenAPITools.Api
             foreach (var _accept in _accepts)
                 localVarRequestOptions.HeaderParameters.Add("Accept", _accept);
             
-            if (petId != null)
-                localVarRequestOptions.PathParameters.Add("petId", Org.OpenAPITools.Client.ClientUtils.ParameterToString(petId)); // path parameter
+            localVarRequestOptions.PathParameters.Add("petId", Org.OpenAPITools.Client.ClientUtils.ParameterToString(petId)); // path parameter
             if (name != null)
             {
                 localVarRequestOptions.FormParameters.Add("name", Org.OpenAPITools.Client.ClientUtils.ParameterToString(name)); // form parameter
@@ -1533,10 +1503,6 @@ namespace Org.OpenAPITools.Api
         /// <returns>ApiResponse of ApiResponse</returns>
         public Org.OpenAPITools.Client.ApiResponse< ApiResponse > UploadFileWithHttpInfo (long petId, string additionalMetadata = default(string), System.IO.Stream file = default(System.IO.Stream))
         {
-            // verify the required parameter 'petId' is set
-            if (petId == null)
-                throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'petId' when calling PetApi->UploadFile");
-
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
             String[] _contentTypes = new String[] {
@@ -1554,8 +1520,7 @@ namespace Org.OpenAPITools.Api
             var localVarAccept = Org.OpenAPITools.Client.ClientUtils.SelectHeaderAccept(_accepts);
             if (localVarAccept != null) localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
 
-            if (petId != null)
-                localVarRequestOptions.PathParameters.Add("petId", Org.OpenAPITools.Client.ClientUtils.ParameterToString(petId)); // path parameter
+            localVarRequestOptions.PathParameters.Add("petId", Org.OpenAPITools.Client.ClientUtils.ParameterToString(petId)); // path parameter
             if (additionalMetadata != null)
             {
                 localVarRequestOptions.FormParameters.Add("additionalMetadata", Org.OpenAPITools.Client.ClientUtils.ParameterToString(additionalMetadata)); // form parameter
@@ -1609,10 +1574,6 @@ namespace Org.OpenAPITools.Api
         /// <returns>Task of ApiResponse (ApiResponse)</returns>
         public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<ApiResponse>> UploadFileAsyncWithHttpInfo (long petId, string additionalMetadata = default(string), System.IO.Stream file = default(System.IO.Stream))
         {
-            // verify the required parameter 'petId' is set
-            if (petId == null)
-                throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'petId' when calling PetApi->UploadFile");
-
 
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
@@ -1631,8 +1592,7 @@ namespace Org.OpenAPITools.Api
             foreach (var _accept in _accepts)
                 localVarRequestOptions.HeaderParameters.Add("Accept", _accept);
             
-            if (petId != null)
-                localVarRequestOptions.PathParameters.Add("petId", Org.OpenAPITools.Client.ClientUtils.ParameterToString(petId)); // path parameter
+            localVarRequestOptions.PathParameters.Add("petId", Org.OpenAPITools.Client.ClientUtils.ParameterToString(petId)); // path parameter
             if (additionalMetadata != null)
             {
                 localVarRequestOptions.FormParameters.Add("additionalMetadata", Org.OpenAPITools.Client.ClientUtils.ParameterToString(additionalMetadata)); // form parameter
@@ -1686,10 +1646,6 @@ namespace Org.OpenAPITools.Api
         /// <returns>ApiResponse of ApiResponse</returns>
         public Org.OpenAPITools.Client.ApiResponse< ApiResponse > UploadFileWithRequiredFileWithHttpInfo (long petId, System.IO.Stream requiredFile, string additionalMetadata = default(string))
         {
-            // verify the required parameter 'petId' is set
-            if (petId == null)
-                throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'petId' when calling PetApi->UploadFileWithRequiredFile");
-
             // verify the required parameter 'requiredFile' is set
             if (requiredFile == null)
                 throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'requiredFile' when calling PetApi->UploadFileWithRequiredFile");
@@ -1711,8 +1667,7 @@ namespace Org.OpenAPITools.Api
             var localVarAccept = Org.OpenAPITools.Client.ClientUtils.SelectHeaderAccept(_accepts);
             if (localVarAccept != null) localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
 
-            if (petId != null)
-                localVarRequestOptions.PathParameters.Add("petId", Org.OpenAPITools.Client.ClientUtils.ParameterToString(petId)); // path parameter
+            localVarRequestOptions.PathParameters.Add("petId", Org.OpenAPITools.Client.ClientUtils.ParameterToString(petId)); // path parameter
             if (additionalMetadata != null)
             {
                 localVarRequestOptions.FormParameters.Add("additionalMetadata", Org.OpenAPITools.Client.ClientUtils.ParameterToString(additionalMetadata)); // form parameter
@@ -1766,10 +1721,6 @@ namespace Org.OpenAPITools.Api
         /// <returns>Task of ApiResponse (ApiResponse)</returns>
         public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<ApiResponse>> UploadFileWithRequiredFileAsyncWithHttpInfo (long petId, System.IO.Stream requiredFile, string additionalMetadata = default(string))
         {
-            // verify the required parameter 'petId' is set
-            if (petId == null)
-                throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'petId' when calling PetApi->UploadFileWithRequiredFile");
-
             // verify the required parameter 'requiredFile' is set
             if (requiredFile == null)
                 throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'requiredFile' when calling PetApi->UploadFileWithRequiredFile");
@@ -1792,8 +1743,7 @@ namespace Org.OpenAPITools.Api
             foreach (var _accept in _accepts)
                 localVarRequestOptions.HeaderParameters.Add("Accept", _accept);
             
-            if (petId != null)
-                localVarRequestOptions.PathParameters.Add("petId", Org.OpenAPITools.Client.ClientUtils.ParameterToString(petId)); // path parameter
+            localVarRequestOptions.PathParameters.Add("petId", Org.OpenAPITools.Client.ClientUtils.ParameterToString(petId)); // path parameter
             if (additionalMetadata != null)
             {
                 localVarRequestOptions.FormParameters.Add("additionalMetadata", Org.OpenAPITools.Client.ClientUtils.ParameterToString(additionalMetadata)); // form parameter

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Api/StoreApi.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Api/StoreApi.cs
@@ -560,10 +560,6 @@ namespace Org.OpenAPITools.Api
         /// <returns>ApiResponse of Order</returns>
         public Org.OpenAPITools.Client.ApiResponse< Order > GetOrderByIdWithHttpInfo (long orderId)
         {
-            // verify the required parameter 'orderId' is set
-            if (orderId == null)
-                throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'orderId' when calling StoreApi->GetOrderById");
-
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
             String[] _contentTypes = new String[] {
@@ -581,8 +577,7 @@ namespace Org.OpenAPITools.Api
             var localVarAccept = Org.OpenAPITools.Client.ClientUtils.SelectHeaderAccept(_accepts);
             if (localVarAccept != null) localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
 
-            if (orderId != null)
-                localVarRequestOptions.PathParameters.Add("order_id", Org.OpenAPITools.Client.ClientUtils.ParameterToString(orderId)); // path parameter
+            localVarRequestOptions.PathParameters.Add("order_id", Org.OpenAPITools.Client.ClientUtils.ParameterToString(orderId)); // path parameter
 
 
             // make the HTTP request
@@ -618,10 +613,6 @@ namespace Org.OpenAPITools.Api
         /// <returns>Task of ApiResponse (Order)</returns>
         public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Order>> GetOrderByIdAsyncWithHttpInfo (long orderId)
         {
-            // verify the required parameter 'orderId' is set
-            if (orderId == null)
-                throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'orderId' when calling StoreApi->GetOrderById");
-
 
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
@@ -640,8 +631,7 @@ namespace Org.OpenAPITools.Api
             foreach (var _accept in _accepts)
                 localVarRequestOptions.HeaderParameters.Add("Accept", _accept);
             
-            if (orderId != null)
-                localVarRequestOptions.PathParameters.Add("order_id", Org.OpenAPITools.Client.ClientUtils.ParameterToString(orderId)); // path parameter
+            localVarRequestOptions.PathParameters.Add("order_id", Org.OpenAPITools.Client.ClientUtils.ParameterToString(orderId)); // path parameter
 
 
             // make the HTTP request

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Animal.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Animal.cs
@@ -53,24 +53,9 @@ namespace Org.OpenAPITools.Model
         public Animal(string className = default(string), string color = "red")
         {
             // to ensure "className" is required (not null)
-            if (className == null)
-            {
-                throw new InvalidDataException("className is a required property for Animal and cannot be null");
-            }
-            else
-            {
-                this.ClassName = className;
-            }
-
+            this.ClassName = className ?? throw new ArgumentNullException("className is a required property for Animal and cannot be null");;
             // use default value if no "color" provided
-            if (color == null)
-            {
-                this.Color = "red";
-            }
-            else
-            {
-                this.Color = color;
-            }
+            this.Color = color ?? "red";
         }
         
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Category.cs
@@ -45,15 +45,7 @@ namespace Org.OpenAPITools.Model
         public Category(long id = default(long), string name = "default-name")
         {
             // to ensure "name" is required (not null)
-            if (name == null)
-            {
-                throw new InvalidDataException("name is a required property for Category and cannot be null");
-            }
-            else
-            {
-                this.Name = name;
-            }
-
+            this.Name = name ?? throw new ArgumentNullException("name is a required property for Category and cannot be null");;
             this.Id = id;
         }
         

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -56,46 +56,12 @@ namespace Org.OpenAPITools.Model
         /// <param name="bigDecimal">bigDecimal.</param>
         public FormatTest(int integer = default(int), int int32 = default(int), long int64 = default(long), decimal number = default(decimal), float _float = default(float), double _double = default(double), string _string = default(string), byte[] _byte = default(byte[]), System.IO.Stream binary = default(System.IO.Stream), DateTime date = default(DateTime), DateTime dateTime = default(DateTime), Guid uuid = default(Guid), string password = default(string), decimal bigDecimal = default(decimal))
         {
-            // to ensure "number" is required (not null)
-            if (number == null)
-            {
-                throw new InvalidDataException("number is a required property for FormatTest and cannot be null");
-            }
-            else
-            {
-                this.Number = number;
-            }
-
+            this.Number = number;
             // to ensure "_byte" is required (not null)
-            if (_byte == null)
-            {
-                throw new InvalidDataException("_byte is a required property for FormatTest and cannot be null");
-            }
-            else
-            {
-                this.Byte = _byte;
-            }
-
-            // to ensure "date" is required (not null)
-            if (date == null)
-            {
-                throw new InvalidDataException("date is a required property for FormatTest and cannot be null");
-            }
-            else
-            {
-                this.Date = date;
-            }
-
+            this.Byte = _byte ?? throw new ArgumentNullException("_byte is a required property for FormatTest and cannot be null");;
+            this.Date = date;
             // to ensure "password" is required (not null)
-            if (password == null)
-            {
-                throw new InvalidDataException("password is a required property for FormatTest and cannot be null");
-            }
-            else
-            {
-                this.Password = password;
-            }
-
+            this.Password = password ?? throw new ArgumentNullException("password is a required property for FormatTest and cannot be null");;
             this.Integer = integer;
             this.Int32 = int32;
             this.Int64 = int64;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Name.cs
@@ -44,16 +44,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="property">property.</param>
         public Name(int name = default(int), string property = default(string))
         {
-            // to ensure "name" is required (not null)
-            if (name == null)
-            {
-                throw new InvalidDataException("name is a required property for Name and cannot be null");
-            }
-            else
-            {
-                this._Name = name;
-            }
-
+            this._Name = name;
             this.Property = property;
         }
         

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Order.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Order.cs
@@ -81,15 +81,7 @@ namespace Org.OpenAPITools.Model
             this.Quantity = quantity;
             this.ShipDate = shipDate;
             this.Status = status;
-            // use default value if no "complete" provided
-            if (complete == null)
-            {
-                this.Complete = false;
-            }
-            else
-            {
-                this.Complete = complete;
-            }
+            this.Complete = complete;
         }
         
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Pet.cs
@@ -82,25 +82,9 @@ namespace Org.OpenAPITools.Model
         public Pet(long id = default(long), Category category = default(Category), string name = default(string), List<string> photoUrls = default(List<string>), List<Tag> tags = default(List<Tag>), StatusEnum? status = default(StatusEnum?))
         {
             // to ensure "name" is required (not null)
-            if (name == null)
-            {
-                throw new InvalidDataException("name is a required property for Pet and cannot be null");
-            }
-            else
-            {
-                this.Name = name;
-            }
-
+            this.Name = name ?? throw new ArgumentNullException("name is a required property for Pet and cannot be null");;
             // to ensure "photoUrls" is required (not null)
-            if (photoUrls == null)
-            {
-                throw new InvalidDataException("photoUrls is a required property for Pet and cannot be null");
-            }
-            else
-            {
-                this.PhotoUrls = photoUrls;
-            }
-
+            this.PhotoUrls = photoUrls ?? throw new ArgumentNullException("photoUrls is a required property for Pet and cannot be null");;
             this.Id = id;
             this.Category = category;
             this.Tags = tags;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/TypeHolderDefault.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/TypeHolderDefault.cs
@@ -48,55 +48,12 @@ namespace Org.OpenAPITools.Model
         public TypeHolderDefault(string stringItem = "what", decimal numberItem = default(decimal), int integerItem = default(int), bool boolItem = true, List<int> arrayItem = default(List<int>))
         {
             // to ensure "stringItem" is required (not null)
-            if (stringItem == null)
-            {
-                throw new InvalidDataException("stringItem is a required property for TypeHolderDefault and cannot be null");
-            }
-            else
-            {
-                this.StringItem = stringItem;
-            }
-
-            // to ensure "numberItem" is required (not null)
-            if (numberItem == null)
-            {
-                throw new InvalidDataException("numberItem is a required property for TypeHolderDefault and cannot be null");
-            }
-            else
-            {
-                this.NumberItem = numberItem;
-            }
-
-            // to ensure "integerItem" is required (not null)
-            if (integerItem == null)
-            {
-                throw new InvalidDataException("integerItem is a required property for TypeHolderDefault and cannot be null");
-            }
-            else
-            {
-                this.IntegerItem = integerItem;
-            }
-
-            // to ensure "boolItem" is required (not null)
-            if (boolItem == null)
-            {
-                throw new InvalidDataException("boolItem is a required property for TypeHolderDefault and cannot be null");
-            }
-            else
-            {
-                this.BoolItem = boolItem;
-            }
-
+            this.StringItem = stringItem ?? throw new ArgumentNullException("stringItem is a required property for TypeHolderDefault and cannot be null");;
+            this.NumberItem = numberItem;
+            this.IntegerItem = integerItem;
+            this.BoolItem = boolItem;
             // to ensure "arrayItem" is required (not null)
-            if (arrayItem == null)
-            {
-                throw new InvalidDataException("arrayItem is a required property for TypeHolderDefault and cannot be null");
-            }
-            else
-            {
-                this.ArrayItem = arrayItem;
-            }
-
+            this.ArrayItem = arrayItem ?? throw new ArgumentNullException("arrayItem is a required property for TypeHolderDefault and cannot be null");;
         }
         
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/TypeHolderExample.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/TypeHolderExample.cs
@@ -49,65 +49,13 @@ namespace Org.OpenAPITools.Model
         public TypeHolderExample(string stringItem = default(string), decimal numberItem = default(decimal), float floatItem = default(float), int integerItem = default(int), bool boolItem = default(bool), List<int> arrayItem = default(List<int>))
         {
             // to ensure "stringItem" is required (not null)
-            if (stringItem == null)
-            {
-                throw new InvalidDataException("stringItem is a required property for TypeHolderExample and cannot be null");
-            }
-            else
-            {
-                this.StringItem = stringItem;
-            }
-
-            // to ensure "numberItem" is required (not null)
-            if (numberItem == null)
-            {
-                throw new InvalidDataException("numberItem is a required property for TypeHolderExample and cannot be null");
-            }
-            else
-            {
-                this.NumberItem = numberItem;
-            }
-
-            // to ensure "floatItem" is required (not null)
-            if (floatItem == null)
-            {
-                throw new InvalidDataException("floatItem is a required property for TypeHolderExample and cannot be null");
-            }
-            else
-            {
-                this.FloatItem = floatItem;
-            }
-
-            // to ensure "integerItem" is required (not null)
-            if (integerItem == null)
-            {
-                throw new InvalidDataException("integerItem is a required property for TypeHolderExample and cannot be null");
-            }
-            else
-            {
-                this.IntegerItem = integerItem;
-            }
-
-            // to ensure "boolItem" is required (not null)
-            if (boolItem == null)
-            {
-                throw new InvalidDataException("boolItem is a required property for TypeHolderExample and cannot be null");
-            }
-            else
-            {
-                this.BoolItem = boolItem;
-            }
-
+            this.StringItem = stringItem ?? throw new ArgumentNullException("stringItem is a required property for TypeHolderExample and cannot be null");;
+            this.NumberItem = numberItem;
+            this.FloatItem = floatItem;
+            this.IntegerItem = integerItem;
+            this.BoolItem = boolItem;
             // to ensure "arrayItem" is required (not null)
-            if (arrayItem == null)
-            {
-                throw new InvalidDataException("arrayItem is a required property for TypeHolderExample and cannot be null");
-            }
-            else
-            {
-                this.ArrayItem = arrayItem;
-            }
-
+            this.ArrayItem = arrayItem ?? throw new ArgumentNullException("arrayItem is a required property for TypeHolderExample and cannot be null");;
         }
         
         /// <summary>


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
### PR detail

- Introduce `x-value-type` vendor extension
  - This property represents a C# ValueType
- Make template null check decisions respect `x-value-type`

This PR is closes #4604, closes #3693

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@mandrean @jimschubert @frankyjuang