### PR TITLE
[C++][Pistache] Fix operator== for empty model structs

### DIFF
--- a/modules/openapi-generator/src/main/resources/cpp-pistache-server/model-struct-source.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-pistache-server/model-struct-source.mustache
@@ -23,7 +23,7 @@ nlohmann::json {{classname}}::to_json() const
 
 bool {{classname}}::operator==(const {{classname}}& other) const
 {
-    return {{#vars}}{{baseName}} == other.{{baseName}}{{#hasMore}} && {{/hasMore}}{{/vars}};
+    return true{{#vars}} && {{baseName}} == other.{{baseName}}{{/vars}};
 }
 
 bool {{classname}}::operator!=(const {{classname}}& other) const


### PR DESCRIPTION
When `useStructModel=true` is set and a model specifies no properties, then a generated struct will not compile.
```
(...) error: return-statement with no value, in function returning 'bool' [-fpermissive]
 bool NoProperties::operator==(const NoProperties& other) const { return; }
```

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [ ] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@ravinikam @stkrwork @etherealjoy @martindelille @muttleyxd

P.S. I refuse to run `bin/openapi3/cpp-pistache-server-petstore.sh` since the changes I get seem to be unrelated.