### PR TITLE
[C++][Pistache] Add neutral discards to supress a potential -Wunused-parameter warning

### DIFF
--- a/modules/openapi-generator/src/main/resources/cpp-pistache-server/model-struct-source.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-pistache-server/model-struct-source.mustache
@@ -23,7 +23,7 @@ nlohmann::json {{classname}}::to_json() const
 
 bool {{classname}}::operator==(const {{classname}}& other) const
 {
-    return {{#vars}}{{baseName}} == other.{{baseName}}{{#hasMore}} && {{/hasMore}}{{/vars}};
+    return true{{#vars}} && {{baseName}} == other.{{baseName}}{{/vars}};
 }
 
 bool {{classname}}::operator!=(const {{classname}}& other) const

--- a/modules/openapi-generator/src/main/resources/cpp-pistache-server/model-struct-source.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-pistache-server/model-struct-source.mustache
@@ -23,6 +23,7 @@ nlohmann::json {{classname}}::to_json() const
 
 bool {{classname}}::operator==(const {{classname}}& other) const
 {
+    static_cast<void>(other);
     return true{{#vars}} && {{baseName}} == other.{{baseName}}{{/vars}};
 }
 
@@ -33,6 +34,8 @@ bool {{classname}}::operator!=(const {{classname}}& other) const
 
 void to_json(nlohmann::json& j, const {{classname}}& o)
 {
+    static_cast<void>(j);
+    static_cast<void>(o);
     {{#vars}}
     {{^required}}if (!o.{{baseName}}.isEmpty()){{/required}}
         j["{{baseName}}"] = o.{{baseName}}{{^required}}.get(){{/required}};
@@ -41,6 +44,8 @@ void to_json(nlohmann::json& j, const {{classname}}& o)
 
 void from_json(const nlohmann::json& j, {{classname}}& o)
 {
+    static_cast<void>(j);
+    static_cast<void>(o);
     {{#vars}}
     {{#required}}j.at("{{baseName}}").get_to(o.{{baseName}});{{/required}}
     {{^required}}if (j.find("{{baseName}}") != j.end()) {


### PR DESCRIPTION
**Note: this is dependent on #5124, so there is only one commit in this PR.**

When `useStructModel=true` is set and a model specifies no properties and assuming no compilation errors, then a generated struct will not produce -Wunused-parameter warnings.

Unfortunately, I didn't find a nice and clean solution. My ideas include:
- `(void) argument` or `static_cast<void>(argument)`
- conditionally specify only type like `const NoProperties&` instead of `const NoProperties& o`, however that means a messier template
- `__attribute__((unused))` but this isn't standard
- `[[maybe_unused]]` but it's C++17 so I guess it's a no-go
- `template <typename T> void ignore(T) {}`


So I decided to use the first option as it's a noop for compilers but I dunno. If you have any better idea, let me know.

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [ ] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@ravinikam @stkrwork @etherealjoy @martindelille @muttleyxd

P.S. I still :wink: refuse to run `bin/openapi3/cpp-pistache-server-petstore.sh` since the changes I get seem to be unrelated.