### PR TITLE
[C-libcurl] Add object.c to CMakeLists to compile

### DIFF
--- a/modules/openapi-generator/src/main/resources/C-libcurl/CMakeLists.txt.mustache
+++ b/modules/openapi-generator/src/main/resources/C-libcurl/CMakeLists.txt.mustache
@@ -23,6 +23,7 @@ set(SRCS
     src/apiKey.c
     src/apiClient.c
     external/cJSON.c
+    model/object.c
 {{#models}}
 {{#model}}
     model/{{classname}}.c
@@ -43,6 +44,7 @@ set(HDRS
     include/list.h
     include/keyValuePair.h
     external/cJSON.h
+    model/object.h
 {{#models}}
 {{#model}}
     model/{{classname}}.h

--- a/samples/client/petstore/c/CMakeLists.txt
+++ b/samples/client/petstore/c/CMakeLists.txt
@@ -23,6 +23,7 @@ set(SRCS
     src/apiKey.c
     src/apiClient.c
     external/cJSON.c
+    model/object.c
     model/api_response.c
     model/category.c
     model/order.c
@@ -40,6 +41,7 @@ set(HDRS
     include/list.h
     include/keyValuePair.h
     external/cJSON.h
+    model/object.h
     model/api_response.h
     model/category.h
     model/order.h


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

After the C client library is generated,  I try to link it to my program. 

```shell
gcc main.c -g -I../../c_k8s_api_client/include -I../../c_k8s_api_client/model -I../../c_k8s_api_client/api -L../../c_k8s_api_client/build -lkubernetes -lpthread -lssl -lz -lcurl -o lsecretOutCluster
```
But there are some link errors:

```shell
../../c_k8s_api_client/build/libk8s.a(CoreV1API.c.o): In function `CoreV1API_patchCoreV1Namespace':
/root/c_k8s_api_client/api/CoreV1API.c:19072: undefined reference to `object_convertToJSON'
../../c_k8s_api_client/build/libk8s.a(CoreV1API.c.o): In function `CoreV1API_patchCoreV1NamespaceStatus':
/root/c_k8s_api_client/api/CoreV1API.c:19219: undefined reference to `object_convertToJSON'
...

``` 

The reason is : The source code file "object.c" is not compiled into the C client library (libkubernetes).


<!-- Please check the completed items below -->
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [X] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [X] File the PR against the [master](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [X] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@wing328 @zhemant