### PR TITLE
[go] Allow user overrides for generated outputs

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/GoGinServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/GoGinServerCodegen.java
@@ -131,16 +131,30 @@ public class GoGinServerCodegen extends AbstractGoCodegen {
             setPackageName((String) additionalProperties.get(CodegenConstants.PACKAGE_NAME));
         } else {
             setPackageName("openapi");
+            additionalProperties.put(CodegenConstants.PACKAGE_NAME, this.packageName);
         }
 
         /*
          * Additional Properties.  These values can be passed to the templates and
          * are available in models, apis, and supporting files
          */
-        additionalProperties.put("apiVersion", apiVersion);
-        additionalProperties.put("serverPort", serverPort);
-        additionalProperties.put("apiPath", apiPath);
-        additionalProperties.put(CodegenConstants.PACKAGE_NAME, packageName);
+        if (additionalProperties.containsKey("apiVersion")) {
+            this.apiVersion = (String)additionalProperties.get("apiVersion");
+        } else {
+            additionalProperties.put("apiVersion", apiVersion);
+        }
+
+        if (additionalProperties.containsKey("serverPort")) {
+            this.serverPort = Integer.parseInt((String)additionalProperties.get("serverPort"));
+        } else {
+            additionalProperties.put("serverPort", serverPort);
+        }
+
+        if (additionalProperties.containsKey("apiPath")) {
+            this.apiPath = (String)additionalProperties.get("apiPath");
+        } else {
+            additionalProperties.put("apiPath", apiPath);
+        }
 
         modelPackage = packageName;
         apiPackage = packageName;


### PR DESCRIPTION
`go-gin-server` previously didn't allow users to configure apiPath, serverPort, or apiVersion. This change only overwrites those values if they don't exist.

@antihax (2017/11) @bvwells (2017/12) @grokify (2018/07) @kemokemo (2018/09) @bkabrda (2019/07)

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
