### PR TITLE
fix #5136 - adds templateResourcePath option to load custom templates from a configurable resource path instead from a directory.

### DIFF
--- a/docs/templating.md
+++ b/docs/templating.md
@@ -16,9 +16,9 @@ The transform logic needs to implement [CodegenConfig.java](https://github.com/o
 ## Modifying Templates
 
 > OpenAPI Generator applies user-defined templates via options:  
-> * CLI: `-t/--template` CLI options
-> * Maven Plugin: `templateDirectory`
-> * Gradle Plugin: `templateDir`
+> * CLI: `-t/--template` (or `-trp/--template-resource-path` for a classpath resource) CLI options 
+> * Maven Plugin: `templateDirectory` (or `templateResourcePath` for a classpath resource)
+> * Gradle Plugin: `templateDir` (or `templateResourcePath` for a classpath resource)
 
 Built-in templates are written in Mustache and processed by [jmustache](https://github.com/samskivert/jmustache). Beginning with version 4.0.0, we support experimental Handlebars and user-defined template engines via plugins.
 

--- a/modules/openapi-generator-cli/src/main/java/org/openapitools/codegen/cmd/Generate.java
+++ b/modules/openapi-generator-cli/src/main/java/org/openapitools/codegen/cmd/Generate.java
@@ -59,6 +59,10 @@ public class Generate implements Runnable {
             description = "folder containing the template files")
     private String templateDir;
 
+    @Option(name = {"-trp", "--template-resource-path"}, title = "template resource path",
+        description = "classpath resource containing the template files")
+    private String templateResourcePath;
+
     @Option(name = {"-e", "--engine"}, title = "templating engine",
             description = "templating engine: \"mustache\" (default) or \"handlebars\" (beta)")
     private String templatingEngine;
@@ -305,6 +309,10 @@ public class Generate implements Runnable {
 
         if (isNotEmpty(templateDir)) {
             configurator.setTemplateDir(templateDir);
+        }
+
+        if (isNotEmpty(templateResourcePath)) {
+          configurator.setTemplateResourcePath (templateResourcePath);
         }
 
         if (isNotEmpty(packageName)) {

--- a/modules/openapi-generator-core/src/main/java/org/openapitools/codegen/config/WorkflowSettings.java
+++ b/modules/openapi-generator-core/src/main/java/org/openapitools/codegen/config/WorkflowSettings.java
@@ -56,6 +56,7 @@ public class WorkflowSettings {
     private boolean enableMinimalUpdate = DEFAULT_ENABLE_MINIMAL_UPDATE;
     private boolean strictSpecBehavior = DEFAULT_STRICT_SPEC_BEHAVIOR;
     private String templateDir;
+    private String templateResourcePath;
     private String templatingEngineName = DEFAULT_TEMPLATING_ENGINE_NAME;
     private String ignoreFileOverride;
     private ImmutableMap<String, String> systemProperties = DEFAULT_SYSTEM_PROPERTIES;
@@ -72,6 +73,7 @@ public class WorkflowSettings {
         this.enableMinimalUpdate = builder.enableMinimalUpdate;
         this.strictSpecBehavior = builder.strictSpecBehavior;
         this.templateDir = builder.templateDir;
+        this.templateResourcePath = builder.templateResourcePath;
         this.templatingEngineName = builder.templatingEngineName;
         this.ignoreFileOverride = builder.ignoreFileOverride;
         this.systemProperties = ImmutableMap.copyOf(builder.systemProperties);
@@ -103,6 +105,7 @@ public class WorkflowSettings {
         builder.strictSpecBehavior = copy.isStrictSpecBehavior();
         builder.templatingEngineName = copy.getTemplatingEngineName();
         builder.ignoreFileOverride = copy.getIgnoreFileOverride();
+        builder.templateResourcePath = copy.getTemplateResourcePath ();
 
         // this, and any other collections, must be mutable in the builder.
         builder.systemProperties = new HashMap<>(copy.getSystemProperties());
@@ -228,6 +231,16 @@ public class WorkflowSettings {
     }
 
     /**
+     * Gets the classpath resource path holding templates used in generation. This option allows users to extend or modify built-in templates, or to write their own.
+     * If {@link #getTemplateDir()} is given templates in that directory take precedence over templates in the defined classpath resource path.
+     *
+     * @return the classpath template resource path
+     */
+    public String getTemplateResourcePath() {
+        return templateResourcePath;
+    }
+
+    /**
      * Gets the name of the templating engine to target. This option allows a user to target an engine which differs from the generator default, or to
      * refer to their own fully qualified type name of a custom template engine adapter.
      *
@@ -272,6 +285,7 @@ public class WorkflowSettings {
         private Boolean enableMinimalUpdate = DEFAULT_ENABLE_MINIMAL_UPDATE;
         private Boolean strictSpecBehavior = DEFAULT_STRICT_SPEC_BEHAVIOR;
         private String templateDir;
+        private String templateResourcePath;
         private String templatingEngineName = DEFAULT_TEMPLATING_ENGINE_NAME;
         private String ignoreFileOverride;
 
@@ -421,6 +435,20 @@ public class WorkflowSettings {
         }
 
         /**
+         * Sets the {@code templateResourcePath} and returns a reference to this Builder so that the methods can be chained together.
+         *
+         * @param templateResourcePath the {@code templateResourcePath} to set
+         * @return a reference to this Builder
+         */
+        public Builder withTemplateResourcePath(String templateResourcePath) {
+            if (templateResourcePath != null) {
+                this.templateResourcePath = templateResourcePath;
+            }
+
+            return this;
+        }
+
+        /**
          * Sets the {@code templatingEngineName} and returns a reference to this Builder so that the methods can be chained together.
          *
          * @param templatingEngineName the {@code templatingEngineName} to set
@@ -498,6 +526,7 @@ public class WorkflowSettings {
                 ", enableMinimalUpdate=" + enableMinimalUpdate +
                 ", strictSpecBehavior=" + strictSpecBehavior +
                 ", templateDir='" + templateDir + '\'' +
+                ", templateResourcePath='" + templateResourcePath + '\'' +
                 ", templatingEngineName='" + templatingEngineName + '\'' +
                 ", ignoreFileOverride='" + ignoreFileOverride + '\'' +
                 ", systemProperties=" + systemProperties +
@@ -520,6 +549,7 @@ public class WorkflowSettings {
                 Objects.equals(getInputSpec(), that.getInputSpec()) &&
                 Objects.equals(getOutputDir(), that.getOutputDir()) &&
                 Objects.equals(getTemplateDir(), that.getTemplateDir()) &&
+                Objects.equals(getTemplateResourcePath (), that.getTemplateResourcePath ()) &&
                 Objects.equals(getTemplatingEngineName(), that.getTemplatingEngineName()) &&
                 Objects.equals(getIgnoreFileOverride(), that.getIgnoreFileOverride()) &&
                 Objects.equals(getSystemProperties(), that.getSystemProperties());
@@ -539,6 +569,7 @@ public class WorkflowSettings {
                 isEnableMinimalUpdate(),
                 isStrictSpecBehavior(),
                 getTemplateDir(),
+                getTemplateResourcePath (),
                 getTemplatingEngineName(),
                 getIgnoreFileOverride(),
                 getSystemProperties()

--- a/modules/openapi-generator-maven-plugin/README.md
+++ b/modules/openapi-generator-maven-plugin/README.md
@@ -48,6 +48,7 @@ mvn clean compile
 | `generatorName` |  `openapi.generator.maven.plugin.generatorName` | target generator name
 | `output` |  `openapi.generator.maven.plugin.output` | target output path (default is `${project.build.directory}/generated-sources/openapi`. Can also be set globally through the `openapi.generator.maven.plugin.output` property)
 | `templateDirectory` |  `openapi.generator.maven.plugin.templateDirectory` | directory with mustache templates
+| `templateResourcePath` |  `openapi.generator.maven.plugin.templateResourcePath` | classpath resource path with mustache templates
 | `addCompileSourceRoot` |  `openapi.generator.maven.plugin.addCompileSourceRoot` | add the output directory to the project as a source root (`true` by default)
 | `modelPackage` |  `openapi.generator.maven.plugin.modelPackage` | the package to use for generated model objects/classes
 | `apiPackage` |  `openapi.generator.maven.plugin.apiPackage` | the package to use for generated api objects/classes

--- a/modules/openapi-generator-maven-plugin/src/main/java/org/openapitools/codegen/plugin/CodeGenMojo.java
+++ b/modules/openapi-generator-maven-plugin/src/main/java/org/openapitools/codegen/plugin/CodeGenMojo.java
@@ -134,6 +134,12 @@ public class CodeGenMojo extends AbstractMojo {
     private File templateDirectory;
 
     /**
+     * A classpath resource path containing the template files.
+     */
+    @Parameter(name = "templateResourcePath", property = "openapi.generator.maven.plugin.templateResourcePath")
+    private String templateResourcePath;
+
+    /**
      * The name of templating engine to use, "mustache" (default) or "handlebars" (beta)
      */
     @Parameter(name = "engine", defaultValue = "mustache", property="openapi.generator.maven.plugin.engine")
@@ -581,6 +587,10 @@ public class CodeGenMojo extends AbstractMojo {
 
             if (null != templateDirectory) {
                 configurator.setTemplateDir(templateDirectory.getAbsolutePath());
+            }
+
+            if (isNotEmpty (templateResourcePath)) {
+                configurator.setTemplateResourcePath (templateResourcePath);
             }
 
             if (null != engine) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConfig.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConfig.java
@@ -64,6 +64,8 @@ public interface CodegenConfig {
 
     String templateDir();
 
+    String templateResourcePath();
+
     String embeddedTemplateDir();
 
     String modelFileFolder();
@@ -123,9 +125,9 @@ public interface CodegenConfig {
     List<CodegenSecurity> fromSecurity(Map<String, SecurityScheme> schemas);
 
     List<CodegenServer> fromServers(List<Server> servers);
-  
+
     List<CodegenServerVariable> fromServerVariables(Map<String, ServerVariable> variables);
-    
+
     Set<String> defaultIncludes();
 
     Map<String, String> typeMapping();

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConstants.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConstants.java
@@ -44,6 +44,7 @@ public class CodegenConstants {
     public static final String MODEL_PACKAGE_DESC = "package for generated models";
 
     public static final String TEMPLATE_DIR = "templateDir";
+    public static final String TEMPLATE_RESOURCE_PATH = "templateResourcePath";
 
     public static final String ALLOW_UNICODE_IDENTIFIERS = "allowUnicodeIdentifiers";
     public static final String ALLOW_UNICODE_IDENTIFIERS_DESC = "boolean, toggles whether unicode identifiers are allowed in names or not, default is false";

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -148,6 +148,7 @@ public class DefaultCodegen implements CodegenConfig {
     protected Map<String, String> modelDocTemplateFiles = new HashMap<String, String>();
     protected Map<String, String> reservedWordsMappings = new HashMap<String, String>();
     protected String templateDir;
+    protected String templateResourcePath;
     protected String embeddedTemplateDir;
     protected String commonTemplateDir = "_common";
     protected Map<String, Object> additionalProperties = new HashMap<String, Object>();
@@ -204,6 +205,10 @@ public class DefaultCodegen implements CodegenConfig {
     public void processOpts() {
         if (additionalProperties.containsKey(CodegenConstants.TEMPLATE_DIR)) {
             this.setTemplateDir((String) additionalProperties.get(CodegenConstants.TEMPLATE_DIR));
+        }
+
+        if (additionalProperties.containsKey(CodegenConstants.TEMPLATE_RESOURCE_PATH)) {
+            this.setTemplateResourcePath ((String) additionalProperties.get(CodegenConstants.TEMPLATE_RESOURCE_PATH));
         }
 
         if (additionalProperties.containsKey(CodegenConstants.MODEL_PACKAGE)) {
@@ -781,6 +786,10 @@ public class DefaultCodegen implements CodegenConfig {
         return templateDir;
     }
 
+    public String templateResourcePath() {
+        return templateResourcePath;
+    }
+
     public String embeddedTemplateDir() {
         if (embeddedTemplateDir != null) {
             return embeddedTemplateDir;
@@ -887,6 +896,10 @@ public class DefaultCodegen implements CodegenConfig {
 
     public void setTemplateDir(String templateDir) {
         this.templateDir = templateDir;
+    }
+
+    public void setTemplateResourcePath(String templateResourcePath) {
+      this.templateResourcePath = templateResourcePath;
     }
 
     public void setModelPackage(String modelPackage) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/config/CodegenConfigurator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/config/CodegenConfigurator.java
@@ -390,6 +390,12 @@ public class CodegenConfigurator {
         return this;
     }
 
+    public CodegenConfigurator setTemplateResourcePath(String templateResourcePath) {
+        workflowSettingsBuilder.withTemplateResourcePath(templateResourcePath);
+        return this;
+    }
+
+
     public CodegenConfigurator setTemplatingEngineName(String templatingEngineName) {
         this.templatingEngineName = templatingEngineName;
         workflowSettingsBuilder.withTemplatingEngineName(templatingEngineName);
@@ -539,6 +545,10 @@ public class CodegenConfigurator {
         String templateDir = workflowSettings.getTemplateDir();
         if (templateDir != null) {
             config.additionalProperties().put(CodegenConstants.TEMPLATE_DIR, workflowSettings.getTemplateDir());
+        }
+        String templateResourcePath = workflowSettings.getTemplateResourcePath ();
+        if (templateResourcePath != null) {
+            config.additionalProperties ().put (CodegenConstants.TEMPLATE_RESOURCE_PATH, workflowSettings.getTemplateResourcePath ());
         }
 
         ClientOptInput input = new ClientOptInput()

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/config/CodegenConfiguratorTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/config/CodegenConfiguratorTest.java
@@ -84,6 +84,7 @@ public class CodegenConfiguratorTest {
                 .setPackageName("package-name")
                 .setReleaseNote("release-note")
                 .setTemplateDir(templateDir)
+                .setTemplateResourcePath ("templateresourcepath")
                 .setOutputDir(outDir);
 
         final ClientOptInput clientOptInput = configurator.toClientOptInput();
@@ -109,6 +110,7 @@ public class CodegenConfiguratorTest {
         want(props, CodegenConstants.ENABLE_POST_PROCESS_FILE, false);
         want(props, CodegenConstants.GENERATE_ALIAS_AS_MODEL, true);
         want(props, CodegenConstants.TEMPLATE_DIR, templateDir);
+        want(props, CodegenConstants.TEMPLATE_RESOURCE_PATH, "templateresourcepath");
         want(props, CodegenConstants.GIT_REPO_ID, "git");
         want(props, CodegenConstants.GIT_USER_ID, "user");
         want(props, CodegenConstants.GIT_HOST, "test.com");


### PR DESCRIPTION
Added a templateResourcePath option, see RFC 5136 for details.

