### PR TITLE
[C-libcurl] Support HTTPS/SSL for the C client

### DIFF
--- a/modules/openapi-generator/src/main/resources/C-libcurl/apiClient.c.mustache
+++ b/modules/openapi-generator/src/main/resources/C-libcurl/apiClient.c.mustache
@@ -13,6 +13,7 @@ apiClient_t *apiClient_create() {
     curl_global_init(CURL_GLOBAL_ALL);
     apiClient_t *apiClient = malloc(sizeof(apiClient_t));
     apiClient->basePath = strdup("{{{basePath}}}");
+    apiClient->caPath = NULL;
     apiClient->dataReceived = NULL;
     apiClient->response_code = 0;
     {{#hasAuthMethods}}
@@ -34,6 +35,7 @@ apiClient_t *apiClient_create() {
 }
 
 apiClient_t *apiClient_create_with_base_path(const char *basePath
+, const char *caPath
 {{#hasAuthMethods}}
 {{#authMethods}}
 {{#isApiKey}}
@@ -49,6 +51,13 @@ apiClient_t *apiClient_create_with_base_path(const char *basePath
     }else{
         apiClient->basePath = strdup("{{{basePath}}}");
     }
+
+    if(caPath){
+        apiClient->caPath = strdup(caPath);
+    }else{
+        apiClient->caPath = NULL;
+    }
+
     apiClient->dataReceived = NULL;
     apiClient->response_code = 0;
     {{#hasAuthMethods}}
@@ -82,6 +91,9 @@ apiClient_t *apiClient_create_with_base_path(const char *basePath
 void apiClient_free(apiClient_t *apiClient) {
     if(apiClient->basePath) {
         free(apiClient->basePath);
+    }
+    if(apiClient->caPath) {
+        free(apiClient->caPath);
     }
     {{#hasAuthMethods}}
     {{#authMethods}}
@@ -375,6 +387,17 @@ void apiClient_invoke(apiClient_t    *apiClient,
                 free(headerValueToWrite);
             }
         }
+
+        if( strstr(apiClient->basePath, "https") != NULL ){
+            if (apiClient->caPath) {
+                curl_easy_setopt(handle, CURLOPT_SSL_VERIFYPEER, true);
+                curl_easy_setopt(handle, CURLOPT_CAINFO, apiClient->caPath);
+            } else {
+                curl_easy_setopt(handle, CURLOPT_SSL_VERIFYPEER, false);
+                curl_easy_setopt(handle, CURLOPT_SSL_VERIFYHOST, false);
+            }
+        }
+
         {{#hasAuthMethods}}
         {{#authMethods}}
         {{#isApiKey}}

--- a/modules/openapi-generator/src/main/resources/C-libcurl/apiClient.h.mustache
+++ b/modules/openapi-generator/src/main/resources/C-libcurl/apiClient.h.mustache
@@ -11,6 +11,7 @@
 
 typedef struct apiClient_t {
     char *basePath;
+    char *caPath;
     void *dataReceived;
     long response_code;
     {{#hasAuthMethods}}
@@ -38,6 +39,7 @@ typedef struct binary_t
 apiClient_t* apiClient_create();
 
 apiClient_t* apiClient_create_with_base_path(const char *basePath
+, const char *caPath
 {{#hasAuthMethods}}
 {{#authMethods}}
 {{#isApiKey}}


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->


Support https/SSL for the C libcurl client

<!-- Please check the completed items below -->
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [X] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [X] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@wing328 @zhemant