### PR TITLE
[bug] Templates via classpath

### DIFF
--- a/docs/templating.md
+++ b/docs/templating.md
@@ -26,6 +26,29 @@ OpenAPI Generator supports user-defined templates. This approach is often the ea
 
 > **Note:** You cannot use this approach to create new templates, only override existing ones. If you'd like to create a new generator to contribute back to the project, see `new.sh` in the repository root. If you'd like to create a private generator for more templating control, see the [customization](./customization.md) docs.
 
+OpenAPI Generator not only supports local files for templating, but also templates defined on the classpath. This is a great option if you want to reuse templates across multiple projects. To load a template via classpath, you'll need to generate a little differently. For example, if you've created an artifact called `template-classpath-example` which contains extended templates for the `htmlDocs` generator with the following structure:
+
+```
+└── src
+    ├── main
+    │   ├── java
+    │   └── resources
+    │       └── templates
+    │           └── htmlDocs
+    │               ├── index.mustache
+    │               └── style.css.mustache
+``` 
+
+You can define your classpath to contain your JAR and the openapi-generator-cli _fat jar_, then invoke main class `org.openapitools.codegen.OpenAPIGenerator`. For instance,
+
+```sh
+java -cp /path/totemplate-classpath-example-1.0-SNAPSHOT.jar:modules/openapi-generator-cli/target/openapi-generator-cli.jar \
+    org.openapitools.codegen.OpenAPIGenerator generate -i https://raw.githubusercontent.com/OAI/OpenAPI-Specification/master/examples/v3.0/petstore.yaml \
+    -g html -o template-example -t templates/htmlDocs
+```
+
+Note that our template directory is relative to the resource directory of the JAR defined on the classpath.
+
 ### Custom Logic
 
 For this example, let's modify a Java client to use AOP via [jcabi/jcabi-aspects](https://github.com/jcabi/jcabi-aspects). We'll log API method execution at the `INFO` level. The jcabi-aspects project could also be used to implement method retries on failures; this would be a great exercise to further play around with templating.

--- a/modules/openapi-generator-maven-plugin/README.md
+++ b/modules/openapi-generator-maven-plugin/README.md
@@ -48,6 +48,7 @@ mvn clean compile
 | `generatorName` |  `openapi.generator.maven.plugin.generatorName` | target generator name
 | `output` |  `openapi.generator.maven.plugin.output` | target output path (default is `${project.build.directory}/generated-sources/openapi`. Can also be set globally through the `openapi.generator.maven.plugin.output` property)
 | `templateDirectory` |  `openapi.generator.maven.plugin.templateDirectory` | directory with mustache templates
+| `templateResourcePath` |  `openapi.generator.maven.plugin.templateResourcePath` | directory with mustache templates via resource path. This option will overwrite any option defined in `templateDirectory`. 
 | `addCompileSourceRoot` |  `openapi.generator.maven.plugin.addCompileSourceRoot` | add the output directory to the project as a source root (`true` by default)
 | `modelPackage` |  `openapi.generator.maven.plugin.modelPackage` | the package to use for generated model objects/classes
 | `apiPackage` |  `openapi.generator.maven.plugin.apiPackage` | the package to use for generated api objects/classes

--- a/modules/openapi-generator-maven-plugin/src/main/java/org/openapitools/codegen/plugin/CodeGenMojo.java
+++ b/modules/openapi-generator-maven-plugin/src/main/java/org/openapitools/codegen/plugin/CodeGenMojo.java
@@ -40,6 +40,7 @@ import java.util.Set;
 import com.google.common.io.ByteSource;
 import com.google.common.io.CharSource;
 import io.swagger.v3.parser.util.ClasspathHelper;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
@@ -132,6 +133,12 @@ public class CodeGenMojo extends AbstractMojo {
      */
     @Parameter(name = "templateDirectory", property = "openapi.generator.maven.plugin.templateDirectory")
     private File templateDirectory;
+
+    /**
+     * Resource path containing template files.
+     */
+    @Parameter(name = "templateResourcePath", property = "openapi.generator.maven.plugin.templateResourcePath")
+    private String templateResourcePath;
 
     /**
      * The name of templating engine to use, "mustache" (default) or "handlebars" (beta)
@@ -581,6 +588,13 @@ public class CodeGenMojo extends AbstractMojo {
 
             if (null != templateDirectory) {
                 configurator.setTemplateDir(templateDirectory.getAbsolutePath());
+            }
+
+            if (StringUtils.isNotEmpty(templateResourcePath)) {
+                if (null != templateDirectory) {
+                    LOGGER.warn("Both templateDirectory and templateResourcePath were configured. templateResourcePath overwrites templateDirectory.");
+                }
+                configurator.setTemplateDir(templateResourcePath);
             }
 
             if (null != engine) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/AbstractGenerator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/AbstractGenerator.java
@@ -161,14 +161,14 @@ public abstract class AbstractGenerator implements TemplatingGenerator {
         if (StringUtils.isNotEmpty(library)) {
             //look for the file in the library subfolder of the supplied template
             final String libTemplateFile = buildLibraryFilePath(config.templateDir(), library, templateFile);
-            if (new File(libTemplateFile).exists()) {
+            if (new File(libTemplateFile).exists() || this.getClass().getClassLoader().getResource(libTemplateFile) != null) {
                 return libTemplateFile;
             }
         }
 
         //check the supplied template main folder for the file
         final String template = config.templateDir() + File.separator + templateFile;
-        if (new File(template).exists()) {
+        if (new File(template).exists() || this.getClass().getClassLoader().getResource(template) != null) {
             return template;
         }
 


### PR DESCRIPTION
At one point, we supported loading templates via class path, but there were a few conditions in code which removed this behavior.

You can test with https://github.com/jimschubert/template-classpath-example, which uses [Bangers](https://fonts.google.com/specimen/Bangers?selection.family=Bangers) rather than the font used in the built-in template. The example demonstrates mustache templates loading relative template files rather than falling back to the embedded templates. In that repo:

```
gradle build publishToMavenLocal
```

In this repo:

```
mvn install
java -cp ~/.m2/repository/org/openapitools/samples/template-classpath-example/1.0-SNAPSHOT/template-classpath-example-1.0-SNAPSHOT.jar:modules/openapi-generator-cli/target/openapi-generator-cli.jar \
  org.openapitools.codegen.OpenAPIGenerator generate \
  -i https://raw.githubusercontent.com/OAI/OpenAPI-Specification/master/examples/v3.0/petstore.yaml \
  -g html \
  -o template-example3 \
  -t templates/htmlDocs
```

This pulls `templates/htmlDocs` from the example's jar on the class path. That example results in this beautiful custom html documentation output:

![image](https://user-images.githubusercontent.com/109659/73420773-ade15a00-42f1-11ea-8801-ea39c7155f26.png)


Fixes #5136 

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

cc @OpenAPITools/generator-core-team 
