### PR TITLE
[gradle] Add recommendations to validate task

### DIFF
--- a/modules/openapi-generator-gradle-plugin/README.adoc
+++ b/modules/openapi-generator-gradle-plugin/README.adoc
@@ -377,6 +377,11 @@ openApiGenerate {
 |None
 |The input specification to validate. Supports all formats supported by the Parser.
 
+|recommend
+|Boolean
+|true
+|Whether or not to offer recommendations related to the validated specification document.
+
 |===
 
 === openApiMeta
@@ -521,6 +526,7 @@ BUILD SUCCESSFUL in 0s
 ----
 openApiValidate {
    inputSpec = "/src/openapi-generator/modules/openapi-generator/src/test/resources/3_0/petstore.yaml"
+   recommend = true
 }
 ----
 

--- a/modules/openapi-generator-gradle-plugin/gradle/wrapper/gradle-wrapper.properties
+++ b/modules/openapi-generator-gradle-plugin/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Thu Jan 30 22:14:34 EST 2020
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.2.1-all.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.2.1-bin.zip
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+zipStoreBase=GRADLE_USER_HOME

--- a/modules/openapi-generator-gradle-plugin/samples/local-spec/build.gradle
+++ b/modules/openapi-generator-gradle-plugin/samples/local-spec/build.gradle
@@ -28,6 +28,7 @@ openApiMeta {
 
 openApiValidate {
     inputSpec = "$rootDir/petstore-v3.0-invalid.yaml".toString()
+    recommend = true
 }
 
 // Builds a Kotlin client by default.

--- a/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/OpenApiGeneratorPlugin.kt
+++ b/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/OpenApiGeneratorPlugin.kt
@@ -84,6 +84,7 @@ class OpenApiGeneratorPlugin : Plugin<Project> {
                     description = "Validates an Open API 2.0 or 3.x specification document."
 
                     inputSpec.set(validate.inputSpec)
+                    recommend.set(validate.recommend)
                 }
 
                 create("openApiGenerate", GenerateTask::class.java) {

--- a/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/extensions/OpenApiGeneratorValidateExtension.kt
+++ b/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/extensions/OpenApiGeneratorValidateExtension.kt
@@ -29,4 +29,18 @@ open class OpenApiGeneratorValidateExtension(project: Project) {
      * The input specification to validate. Supports all formats supported by the Parser.
      */
     val inputSpec = project.objects.property<String>()
+
+    /**
+     * Whether or not to offer recommendations related to the validated specification document.
+     */
+    val recommend = project.objects.property<Boolean?>()
+
+    init {
+        applyDefaults()
+    }
+
+    @Suppress("MemberVisibilityCanBePrivate")
+    fun applyDefaults(){
+        recommend.set(true)
+    }
 }

--- a/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/tasks/ValidateTask.kt
+++ b/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/tasks/ValidateTask.kt
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+@file:Suppress("UnstableApiUsage")
+
 package org.openapitools.generator.gradle.plugin.tasks
 
 import io.swagger.parser.OpenAPIParser
@@ -22,9 +24,12 @@ import org.gradle.api.GradleException
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.options.Option
+import org.gradle.api.logging.Logging
 import org.gradle.internal.logging.text.StyledTextOutput
 import org.gradle.internal.logging.text.StyledTextOutputFactory
 import org.gradle.kotlin.dsl.property
+import org.openapitools.codegen.validations.oas.OpenApiEvaluator
+import org.openapitools.codegen.validations.oas.RuleConfiguration
 
 /**
  * A generator which validates an Open API spec. This task outputs a list of validation issues and errors.
@@ -46,6 +51,9 @@ open class ValidateTask : DefaultTask() {
     @get:Internal
     var inputSpec = project.objects.property<String>()
 
+    @get:Internal
+    var recommend = project.objects.property<Boolean?>()
+
     @Suppress("unused")
     @get:Internal
     @set:Option(option = "input", description = "The input specification.")
@@ -57,13 +65,35 @@ open class ValidateTask : DefaultTask() {
     @Suppress("unused")
     @TaskAction
     fun doWork() {
+        val logger = Logging.getLogger(javaClass)
+
         val spec = inputSpec.get()
+        val recommendations = recommend.get()
+
         logger.quiet("Validating spec $spec")
         val result = OpenAPIParser().readLocation(spec, null, null)
         val messages = result.messages.toSet()
         val out = services.get(StyledTextOutputFactory::class.java).create("openapi")
 
-        if (messages.isNotEmpty()) {
+
+        val ruleConfiguration = RuleConfiguration()
+        ruleConfiguration.isEnableRecommendations = recommendations
+
+        val evaluator = OpenApiEvaluator(ruleConfiguration)
+        val validationResult = evaluator.validate(result.openAPI)
+
+        if (validationResult.warnings.isNotEmpty()) {
+            out.withStyle(StyledTextOutput.Style.Info)
+            out.println("\nSpec has issues or recommendations.\nIssues:\n")
+
+            validationResult.warnings.forEach {
+                out.withStyle(StyledTextOutput.Style.Info)
+                out.println("\t${it.message}\n")
+                logger.debug("WARNING: ${it.message}|${it.details}")
+            }
+        }
+
+        if (messages.isNotEmpty() || validationResult.errors.isNotEmpty()) {
 
             out.withStyle(StyledTextOutput.Style.Error)
             out.println("\nSpec is invalid.\nIssues:\n")
@@ -71,11 +101,19 @@ open class ValidateTask : DefaultTask() {
             messages.forEach {
                 out.withStyle(StyledTextOutput.Style.Error)
                 out.println("\t$it\n")
+                logger.debug("ERROR: $it")
+            }
+
+            validationResult.errors.forEach {
+                out.withStyle(StyledTextOutput.Style.Error)
+                out.println("\t${it.message}\n")
+                logger.debug("ERROR: ${it.message}|${it.details}")
             }
 
             throw GradleException("Validation failed.")
         } else {
             out.withStyle(StyledTextOutput.Style.Success)
+            logger.debug("No error validations from swagger-parser or internal validations.")
             out.println("Spec is valid.")
         }
     }


### PR DESCRIPTION
Adds recommendation/validation to the validate task in the gradle plugin.
This fixes #335 although there's no addition to the maven plugin, because none of CLI/Gradle/Maven do custom recommendations or validation in the generate task.

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
