### PR TITLE
[core][typescript][perl] Ensure model.parent is also added to model.allParents with multiple inheritance

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
@@ -972,7 +972,8 @@ public class ModelUtils {
     public static String getParentName(ComposedSchema composedSchema, Map<String, Schema> allSchemas) {
         List<Schema> interfaces = getInterfaces(composedSchema);
 
-        List<String> refedParentNames = new ArrayList<>();
+        List<String> refedWithoutDiscriminator = new ArrayList<>();
+
         if (interfaces != null && !interfaces.isEmpty()) {
             for (Schema schema : interfaces) {
                 // get the actual schema
@@ -986,9 +987,8 @@ public class ModelUtils {
                         // discriminator.propertyName is used
                         return parentName;
                     } else {
-                        LOGGER.debug("Not a parent since discriminator.propertyName is not set {}", s.get$ref());
                         // not a parent since discriminator.propertyName is not set
-                        refedParentNames.add(parentName);
+                        refedWithoutDiscriminator.add(parentName);
                     }
                 } else {
                     // not a ref, doing nothing
@@ -997,11 +997,11 @@ public class ModelUtils {
         }
 
         // parent name only makes sense when there is a single obvious parent
-        if (refedParentNames.size() == 1) {
+        if (refedWithoutDiscriminator.size() == 1) {
             LOGGER.warn("[deprecated] inheritance without use of 'discriminator.propertyName' is deprecated " +
                 "and will be removed in a future release. Generating model for composed schema name: {}. Title: {}",
                 composedSchema.getName(), composedSchema.getTitle());
-            return refedParentNames.get(0);
+            return refedWithoutDiscriminator.get(0);
         }
 
         return null;
@@ -1018,7 +1018,7 @@ public class ModelUtils {
     public static List<String> getAllParentsName(ComposedSchema composedSchema, Map<String, Schema> allSchemas, boolean includeAncestors) {
         List<Schema> interfaces = getInterfaces(composedSchema);
         List<String> names = new ArrayList<String>();
-        List<String> refedParentNames = new ArrayList<>();
+        List<String> refedWithoutDiscriminator = new ArrayList<>();
 
         if (interfaces != null && !interfaces.isEmpty()) {
             for (Schema schema : interfaces) {
@@ -1036,9 +1036,8 @@ public class ModelUtils {
                             names.addAll(getAllParentsName((ComposedSchema) s, allSchemas, true));
                         }
                     } else {
-                        LOGGER.debug("Not a parent since discriminator.propertyName is not set {}", s.get$ref());
                         // not a parent since discriminator.propertyName is not set
-                        refedParentNames.add(parentName);
+                        refedWithoutDiscriminator.add(parentName);
                     }
                 } else {
                     // not a ref, doing nothing
@@ -1046,10 +1045,10 @@ public class ModelUtils {
             }
         }
 
-        if (names.size() == 0 && refedParentNames.size() == 1) {
+        if (names.size() == 0 && refedWithoutDiscriminator.size() == 1) {
             LOGGER.warn("[deprecated] inheritance without use of 'discriminator.propertyName' is deprecated " +
-                    "and will be removed in a future release. Generating model for {}", composedSchema.getName());
-            return refedParentNames;
+                    "and will be removed in a future release. Generating model for {}. Title: {}", composedSchema.getName(), composedSchema.getTitle());
+            return refedWithoutDiscriminator;
         }
 
         return names;

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
@@ -1018,6 +1018,7 @@ public class ModelUtils {
     public static List<String> getAllParentsName(ComposedSchema composedSchema, Map<String, Schema> allSchemas, boolean includeAncestors) {
         List<Schema> interfaces = getInterfaces(composedSchema);
         List<String> names = new ArrayList<String>();
+        List<String> refedParentNames = new ArrayList<>();
 
         if (interfaces != null && !interfaces.isEmpty()) {
             for (Schema schema : interfaces) {
@@ -1037,11 +1038,18 @@ public class ModelUtils {
                     } else {
                         LOGGER.debug("Not a parent since discriminator.propertyName is not set {}", s.get$ref());
                         // not a parent since discriminator.propertyName is not set
+                        refedParentNames.add(parentName);
                     }
                 } else {
                     // not a ref, doing nothing
                 }
             }
+        }
+
+        if (names.size() == 0 && refedParentNames.size() == 1) {
+            LOGGER.warn("[deprecated] inheritance without use of 'discriminator.propertyName' is deprecated " +
+                    "and will be removed in a future release. Generating model for {}", composedSchema.getName());
+            return refedParentNames;
         }
 
         return names;

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
@@ -541,8 +541,7 @@ public class DefaultCodegenTest {
         CodegenModel model = codegen.fromModel("NewMessageEventCoreNoOwnProps", schema);
         Assert.assertEquals(getNames(model.getVars()), Collections.emptyList());
         Assert.assertEquals(model.parent, "MessageEventCore");
-        // this is legacy behavior that causes issues
-        Assert.assertEquals(model.allParents, Collections.emptyList());
+        Assert.assertEquals(model.allParents, Collections.singletonList("MessageEventCore"));
     }
 
     class CodegenWithMultipleInheritance extends DefaultCodegen {

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
@@ -528,7 +528,7 @@ public class DefaultCodegenTest {
         Schema child = openAPI.getComponents().getSchemas().get("clubForCreation");
         codegen.setOpenAPI(openAPI);
         CodegenModel childModel = codegen.fromModel("clubForCreation", child);
-        showVars(childModel);
+        Assert.assertEquals(getRequiredVars(childModel), Collections.singletonList("name"));
     }
 
     @Test
@@ -539,22 +539,20 @@ public class DefaultCodegenTest {
 
         Schema person = openAPI.getComponents().getSchemas().get("person");
         CodegenModel personModel = codegen.fromModel("person", person);
-        showVars(personModel);
+        Assert.assertEquals(getRequiredVars(personModel), Arrays.asList("firstName", "name", "email", "id"));
 
         Schema personForCreation = openAPI.getComponents().getSchemas().get("personForCreation");
         CodegenModel personForCreationModel = codegen.fromModel("personForCreation", personForCreation);
-        showVars(personForCreationModel);
+        Assert.assertEquals(getRequiredVars(personForCreationModel), Arrays.asList("firstName", "name", "email"));
 
         Schema personForUpdate = openAPI.getComponents().getSchemas().get("personForUpdate");
         CodegenModel personForUpdateModel = codegen.fromModel("personForUpdate", personForUpdate);
-        showVars(personForUpdateModel);
+        Assert.assertEquals(getRequiredVars(personForUpdateModel), Collections.emptyList());
     }
 
-    private void showVars(CodegenModel model) {
-        if(model.getRequiredVars() != null) {
-
-            System.out.println(model.getRequiredVars().stream().map(v -> v.name).collect(Collectors.toList()));
-        }
+    private List<String> getRequiredVars(CodegenModel model) {
+        if(model.getRequiredVars() == null) return null;
+        return model.getRequiredVars().stream().map(v -> v.name).collect(Collectors.toList());
     }
 
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
@@ -532,6 +532,29 @@ public class DefaultCodegenTest {
     }
 
     @Test
+    public void testAllOfSingleRefNoOwnProps() {
+        final OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/2_0/composed-allof.yaml");
+        final DefaultCodegen codegen = new CodegenWithMultipleInheritance();
+
+        Schema schema = openAPI.getComponents().getSchemas().get("NewMessageEventCoreNoOwnProps");
+        codegen.setOpenAPI(openAPI);
+        CodegenModel model = codegen.fromModel("NewMessageEventCoreNoOwnProps", schema);
+        Assert.assertEquals(getNames(model.getVars()), Collections.emptyList());
+        Assert.assertEquals(model.parent, "MessageEventCore");
+        // this is legacy behavior that causes issues
+        Assert.assertEquals(model.allParents, Collections.emptyList());
+    }
+
+    class CodegenWithMultipleInheritance extends DefaultCodegen {
+        public CodegenWithMultipleInheritance() {
+            super();
+            supportsInheritance = true;
+            supportsMultipleInheritance = true;
+        }
+    }
+
+
+    @Test
     public void testAllOfParent() {
         final OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/allOf-required-parent.yaml");
         DefaultCodegen codegen = new DefaultCodegen();
@@ -551,10 +574,13 @@ public class DefaultCodegenTest {
     }
 
     private List<String> getRequiredVars(CodegenModel model) {
-        if(model.getRequiredVars() == null) return null;
-        return model.getRequiredVars().stream().map(v -> v.name).collect(Collectors.toList());
+        return getNames(model.getRequiredVars());
     }
 
+    private List<String> getNames(List<CodegenProperty> props) {
+        if(props == null) return null;
+        return props.stream().map(v -> v.name).collect(Collectors.toList());
+    }
 
     @Test
     public void testCallbacks() {

--- a/modules/openapi-generator/src/test/resources/2_0/composed-allof.yaml
+++ b/modules/openapi-generator/src/test/resources/2_0/composed-allof.yaml
@@ -51,3 +51,8 @@ definitions:
         type: string
       p2:
         type: string
+
+  NewMessageEventCoreNoOwnProps:
+    type: object
+    allOf:
+      - $ref: "#/definitions/MessageEventCore"


### PR DESCRIPTION
Fixes https://github.com/OpenAPITools/openapi-generator/issues/4770

Turned out that generator still supports a deprecated inheritance case with a single oneOf ref without a discriminator. The behavior in this case is to treat it as inheritance rather than composition.

Now, the problem is that even though `model.parent` is properly populated with the referenced model in this situation, `model.allParents` (**used with multiple inheritance**) stays empty. It looks like a bug in the implementation rather than intended behavior - but of course correct me if I'm wrong.

This PR makes sure the same logic supporting the deprecated inheritance case applies both to `parent` and `allParents`.

I also cleaned up a few tests for DefaultCodegen that are related to `allOf` composition - just to give me a bit more safety assurance of the change (better than nothing)

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

Typescript generators family use multiple inheritance, hence copying them here:
@TiFu @taxpon @sebastianhaas @kenisteward @Vrolijkx @macjohnny @nicokoenig @topce @akehir @petejohansonxo

And also Perl (another representative of multiple inheritance supporting generator):
@wing328  @yue9944882 