### PR TITLE
[bug] fix null pointer exception while evaluating recommend…

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/validations/oas/OpenApiEvaluator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/validations/oas/OpenApiEvaluator.java
@@ -87,7 +87,10 @@ public class OpenApiEvaluator implements Validator<OpenAPI> {
             }
         }
 
-        parameters.forEach(parameter -> validationResult.consume(parameterValidations.validate(parameter)));
+        parameters.forEach(parameter -> {
+            parameter = ModelUtils.getReferencedParameter(specification, parameter);
+            validationResult.consume(parameterValidations.validate(parameter));
+        });
 
         return validationResult;
     }


### PR DESCRIPTION
A null pointer exception occurs when invoking --validate --recommend if at least one of the parameters in the OAS spec is a $ref.

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [ ] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
