### PR TITLE
[cli] Optional colorized outputs

### DIFF
--- a/modules/openapi-generator-cli/pom.xml
+++ b/modules/openapi-generator-cli/pom.xml
@@ -65,6 +65,16 @@
                                 <transformer
                                         implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
                             </transformers>
+                            <filters>
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
                         </configuration>
                     </execution>
                 </executions>
@@ -133,6 +143,11 @@
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
             <version>1.2.3</version>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.janino</groupId>
+            <artifactId>janino</artifactId>
+            <version>3.1.0</version>
         </dependency>
         <dependency>
             <groupId>org.testng</groupId>

--- a/modules/openapi-generator-cli/src/main/resources/logback.xml
+++ b/modules/openapi-generator-cli/src/main/resources/logback.xml
@@ -1,9 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
+
+    <!-- Prevent startup messages from Logback -->
+    <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
+
+    <!-- For those without color (the default) -->
+    <property name="noColorPattern"
+              value="[%thread] %-5level %logger{36} - %msg%n" />
+    <!-- For those with color (with -Dcolor set) -->
+    <property name="colorPattern"
+              value="[%thread] %highlight(%-5level) %logger{36} - %msg%n" />
+
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <target>System.out</target>
         <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
-            <pattern>[%thread] %-5level %logger{36} - %msg%n</pattern>
+            <pattern>${noColorPattern}</pattern>
         </encoder>
         <filter class="ch.qos.logback.classic.filter.LevelFilter">
             <level>ERROR</level>
@@ -14,21 +25,80 @@
     <appender name="STDERR" class="ch.qos.logback.core.ConsoleAppender">
         <target>System.err</target>
         <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
-            <pattern>[%thread] %-5level %logger{36} - %msg%n</pattern>
+            <pattern>${noColorPattern}</pattern>
         </encoder>
         <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
             <level>ERROR</level>
         </filter>
     </appender>
+    <appender name="STDOUT_COLOR" class="ch.qos.logback.core.ConsoleAppender">
+        <target>System.out</target>
+        <withJansi>true</withJansi>
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <pattern>${colorPattern}</pattern>
+        </encoder>
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>ERROR</level>
+            <onMatch>DENY</onMatch>
+            <onMismatch>NEUTRAL</onMismatch>
+        </filter>
+    </appender>
+    <appender name="STDERR_COLOR" class="ch.qos.logback.core.ConsoleAppender">
+        <target>System.err</target>
+        <withJansi>true</withJansi>
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <pattern>${colorPattern}</pattern>
+        </encoder>
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>ERROR</level>
+        </filter>
+    </appender>
+    <appender name="ONCELOGGER_COLOR" class="ch.qos.logback.core.ConsoleAppender">
+        <target>System.err</target>
+        <withJansi>true</withJansi>
+        <evaluator class="ch.qos.logback.classic.boolex.OnMarkerEvaluator">
+            <marker>ONCE</marker>
+        </evaluator>
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <pattern>[%thread] %highlight(%-5level) %logger{36} - %red(%msg)%n</pattern>
+        </encoder>
+    </appender>
+
     <logger name="io.swagger" level="warn">
-        <appender-ref ref="STDOUT"/>
-        <appender-ref ref="STDERR"/>
+        <!-- Colorize by passing -Dcolor -->
+        <if condition='isDefined("color")'>
+            <then>
+                <appender-ref ref="STDOUT_COLOR"/>
+                <appender-ref ref="STDERR_COLOR"/>
+            </then>
+            <else>
+                <appender-ref ref="STDOUT"/>
+                <appender-ref ref="STDERR"/>
+            </else>
+        </if>
     </logger>
     <logger name="org.openapitools" level="${log.level:-info}">
-        <appender-ref ref="STDOUT"/>
-        <appender-ref ref="STDERR"/>
+        <!-- Colorize by passing -Dcolor -->
+        <if condition='isDefined("color")'>
+            <then>
+                <appender-ref ref="STDOUT_COLOR"/>
+                <appender-ref ref="STDERR_COLOR"/>
+            </then>
+            <else>
+                <appender-ref ref="STDOUT"/>
+                <appender-ref ref="STDERR"/>
+            </else>
+        </if>
     </logger>
     <root level="error">
-        <appender-ref ref="STDERR"/>
+        <!-- Colorize by passing -Dcolor -->
+        <if condition='isDefined("color")'>
+            <then>
+                <appender-ref ref="STDERR_COLOR"/>
+            </then>
+            <else>
+                <appender-ref ref="STDERR"/>
+            </else>
+        </if>
     </root>
 </configuration>


### PR DESCRIPTION
Requested by @ybelenko in #4615

Trying this out: set `-Dcolor`

![image](https://user-images.githubusercontent.com/109659/73615254-3141ca80-45d4-11ea-83dc-dc2ca69b19e5.png)

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
