### PR TITLE
[codegen] Add openAPI attribute to validation and recommendation

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/validations/oas/OpenApiParameterValidations.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/validations/oas/OpenApiParameterValidations.java
@@ -12,7 +12,7 @@ import java.util.Locale;
 /**
  * A standalone instance for evaluating rules and recommendations related to OAS {@link Parameter}
  */
-class OpenApiParameterValidations extends GenericValidator<Parameter> {
+class OpenApiParameterValidations extends GenericValidator<ParameterWrapper> {
     OpenApiParameterValidations(RuleConfiguration ruleConfiguration) {
         super(new ArrayList<>());
         if (ruleConfiguration.isEnableRecommendations()) {
@@ -32,7 +32,8 @@ class OpenApiParameterValidations extends GenericValidator<Parameter> {
      * @param parameter Any spec doc parameter. The method will handle {@link HeaderParameter} evaluation.
      * @return {@link ValidationRule.Pass} if the check succeeds, otherwise {@link ValidationRule.Fail} with details "[key] contains an underscore."
      */
-    private static ValidationRule.Result apacheNginxHeaderCheck(Parameter parameter) {
+    private static ValidationRule.Result apacheNginxHeaderCheck(ParameterWrapper parameterWrapper) {
+        Parameter parameter = parameterWrapper.getParameter();
         if (parameter == null || !parameter.getIn().equals("header")) return ValidationRule.Pass.empty();
         ValidationRule.Result result = ValidationRule.Pass.empty();
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/validations/oas/OpenApiSchemaValidations.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/validations/oas/OpenApiSchemaValidations.java
@@ -2,6 +2,8 @@ package org.openapitools.codegen.validations.oas;
 
 import io.swagger.v3.oas.models.media.ComposedSchema;
 import io.swagger.v3.oas.models.media.Schema;
+
+import org.openapitools.codegen.utils.ModelUtils;
 import org.openapitools.codegen.validation.GenericValidator;
 import org.openapitools.codegen.validation.ValidationRule;
 
@@ -10,7 +12,7 @@ import java.util.ArrayList;
 /**
  * A standalone instance for evaluating rules and recommendations related to OAS {@link Schema}
  */
-class OpenApiSchemaValidations extends GenericValidator<Schema> {
+class OpenApiSchemaValidations extends GenericValidator<SchemaWrapper> {
     OpenApiSchemaValidations(RuleConfiguration ruleConfiguration) {
         super(new ArrayList<>());
         if (ruleConfiguration.isEnableRecommendations()) {
@@ -34,10 +36,11 @@ class OpenApiSchemaValidations extends GenericValidator<Schema> {
      * Because of this ambiguity in the spec about what is non-standard about oneOf support, we'll warn as a recommendation that
      * properties on the schema defining oneOf relationships may not be intentional in the OpenAPI Specification.
      *
-     * @param schema An input schema, regardless of the type of schema
+     * @param schemaWrapper An input schema, regardless of the type of schema
      * @return {@link ValidationRule.Pass} if the check succeeds, otherwise {@link ValidationRule.Fail}
      */
-    private static ValidationRule.Result checkOneOfWithProperties(Schema schema) {
+    private static ValidationRule.Result checkOneOfWithProperties(SchemaWrapper schemaWrapper) {
+        Schema schema = schemaWrapper.getSchema();
         ValidationRule.Result result = ValidationRule.Pass.empty();
 
         if (schema instanceof ComposedSchema) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/validations/oas/OpenApiSecuritySchemeValidations.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/validations/oas/OpenApiSecuritySchemeValidations.java
@@ -1,6 +1,7 @@
 package org.openapitools.codegen.validations.oas;
 
 import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.OpenAPI;
 import org.apache.commons.lang3.StringUtils;
 import org.openapitools.codegen.validation.GenericValidator;
 import org.openapitools.codegen.validation.ValidationRule;
@@ -11,7 +12,7 @@ import java.util.Locale;
 /**
  * A standalone instance for evaluating rules and recommendations related to OAS {@link SecurityScheme}
  */
-class OpenApiSecuritySchemeValidations extends GenericValidator<SecurityScheme> {
+class OpenApiSecuritySchemeValidations extends GenericValidator<SecuritySchemeWrapper> {
     OpenApiSecuritySchemeValidations(RuleConfiguration ruleConfiguration) {
         super(new ArrayList<>());
         if (ruleConfiguration.isEnableRecommendations()) {
@@ -31,7 +32,8 @@ class OpenApiSecuritySchemeValidations extends GenericValidator<SecurityScheme> 
      * @param securityScheme Security schemes are often used as header parameters (e.g. APIKEY).
      * @return <code>true</code> if the check succeeds (header does not have an underscore, e.g. 'api_key')
      */
-    private static ValidationRule.Result apacheNginxHeaderCheck(SecurityScheme securityScheme) {
+    private static ValidationRule.Result apacheNginxHeaderCheck(SecuritySchemeWrapper securitySchemeWrapper) {
+        SecurityScheme securityScheme = securitySchemeWrapper.getSecurityScheme();
         if (securityScheme == null || securityScheme.getIn() != SecurityScheme.In.HEADER)
             return ValidationRule.Pass.empty();
         ValidationRule.Result result = ValidationRule.Pass.empty();

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/validations/oas/OperationWrapper.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/validations/oas/OperationWrapper.java
@@ -2,12 +2,14 @@ package org.openapitools.codegen.validations.oas;
 
 import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.PathItem;
+import io.swagger.v3.oas.models.OpenAPI;
 
 /**
  * Encapsulates an operation with its HTTP Method. In OAS, the {@link PathItem} structure contains more than what we'd
  * want to evaluate for operation-only checks.
  */
 public class OperationWrapper {
+    OpenAPI specification;
     private Operation operation;
     private PathItem.HttpMethod httpMethod;
 
@@ -17,7 +19,8 @@ public class OperationWrapper {
      * @param operation The operation instances to wrap
      * @param httpMethod The http method to wrap
      */
-    OperationWrapper(Operation operation, PathItem.HttpMethod httpMethod) {
+    OperationWrapper(OpenAPI specification, Operation operation, PathItem.HttpMethod httpMethod) {
+        this.specification = specification;
         this.operation = operation;
         this.httpMethod = httpMethod;
     }
@@ -38,5 +41,15 @@ public class OperationWrapper {
      */
     public PathItem.HttpMethod getHttpMethod() {
         return httpMethod;
+    }
+
+
+    /**
+     * Returns the OpenAPI specification.
+     *
+     * @return The the OpenAPI specification.
+     */
+    public OpenAPI getOpenAPI() {
+        return specification;
     }
 }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/validations/oas/ParameterWrapper.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/validations/oas/ParameterWrapper.java
@@ -1,0 +1,41 @@
+package org.openapitools.codegen.validations.oas;
+
+import io.swagger.v3.oas.models.parameters.Parameter;
+import io.swagger.v3.oas.models.OpenAPI;
+
+/**
+ * Encapsulates an OAS parameter.
+ */
+public class ParameterWrapper {
+    OpenAPI specification;
+    private Parameter parameter;
+
+    /**
+     * Constructs a new instance of {@link ParameterWrapper}
+     *
+     * @param specification The OAS specification
+     * @param parameter The OAS parameter
+     */
+    ParameterWrapper(OpenAPI specification, Parameter parameter) {
+        this.specification = specification;
+        this.parameter = parameter;
+    }
+
+    /**
+     * Return the OAS parameter
+     *
+     * @return the OAS parameter
+     */
+    public Parameter getParameter() {
+        return parameter;
+    }
+
+    /**
+     * Returns the OpenAPI specification.
+     *
+     * @return The the OpenAPI specification.
+     */
+    public OpenAPI getOpenAPI() {
+        return specification;
+    }
+}

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/validations/oas/SchemaWrapper.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/validations/oas/SchemaWrapper.java
@@ -1,0 +1,41 @@
+package org.openapitools.codegen.validations.oas;
+
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.OpenAPI;
+
+/**
+ * Encapsulates an OAS schema.
+ */
+public class SchemaWrapper {
+    OpenAPI specification;
+    private Schema schema;
+
+    /**
+     * Constructs a new instance of {@link SchemaWrapper}
+     *
+     * @param specification The OAS specification
+     * @param schema The OAS schema
+     */
+    SchemaWrapper(OpenAPI specification, Schema schema) {
+        this.specification = specification;
+        this.schema = schema;
+    }
+
+    /**
+     * Return the OAS schema
+     *
+     * @return the OAS schema
+     */
+    public Schema getSchema() {
+        return schema;
+    }
+
+    /**
+     * Returns the OpenAPI specification.
+     *
+     * @return The the OpenAPI specification.
+     */
+    public OpenAPI getOpenAPI() {
+        return specification;
+    }
+}

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/validations/oas/SecuritySchemeWrapper.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/validations/oas/SecuritySchemeWrapper.java
@@ -1,0 +1,41 @@
+package org.openapitools.codegen.validations.oas;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+
+/**
+ * Encapsulates an OAS parameter.
+ */
+public class SecuritySchemeWrapper {
+    OpenAPI specification;
+    private SecurityScheme securityScheme;
+
+    /**
+     * Constructs a new instance of {@link SecuritySchemeWrapper}
+     *
+     * @param specification The OAS specification
+     * @param securityScheme The OAS securityScheme
+     */
+    SecuritySchemeWrapper(OpenAPI specification, SecurityScheme securityScheme) {
+        this.specification = specification;
+        this.securityScheme = securityScheme;
+    }
+
+    /**
+     * Return the OAS securityScheme
+     *
+     * @return the OAS securityScheme
+     */
+    public SecurityScheme getSecurityScheme() {
+        return securityScheme;
+    }
+
+    /**
+     * Returns the OpenAPI specification.
+     *
+     * @return The the OpenAPI specification.
+     */
+    public OpenAPI getOpenAPI() {
+        return specification;
+    }
+}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/validations/oas/OpenApiOperationValidationsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/validations/oas/OpenApiOperationValidationsTest.java
@@ -47,7 +47,7 @@ public class OpenApiOperationValidationsTest {
             op.setRequestBody(body);
         }
 
-        ValidationResult result = validator.validate(new OperationWrapper(op, method));
+        ValidationResult result = validator.validate(new OperationWrapper(null, op, method));
         Assert.assertNotNull(result.getWarnings());
 
         List<Invalid> warnings = result.getWarnings().stream()
@@ -77,7 +77,7 @@ public class OpenApiOperationValidationsTest {
             op.setRequestBody(body);
         }
 
-        ValidationResult result = validator.validate(new OperationWrapper(op, method));
+        ValidationResult result = validator.validate(new OperationWrapper(null, op, method));
         Assert.assertNotNull(result.getWarnings());
 
         List<Invalid> warnings = result.getWarnings().stream()
@@ -103,7 +103,7 @@ public class OpenApiOperationValidationsTest {
             op.setRequestBody(body);
         }
 
-        ValidationResult result = validator.validate(new OperationWrapper(op, method));
+        ValidationResult result = validator.validate(new OperationWrapper(null, op, method));
         Assert.assertNotNull(result.getWarnings());
 
         List<Invalid> warnings = result.getWarnings().stream()

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/validations/oas/OpenApiParameterValidationsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/validations/oas/OpenApiParameterValidationsTest.java
@@ -22,7 +22,7 @@ public class OpenApiParameterValidationsTest {
         parameter.setIn(in);
         parameter.setName(key);
 
-        ValidationResult result = validator.validate(parameter);
+        ValidationResult result = validator.validate(new ParameterWrapper(null, parameter));
         Assert.assertNotNull(result.getWarnings());
 
         List<Invalid> warnings = result.getWarnings().stream()
@@ -43,7 +43,7 @@ public class OpenApiParameterValidationsTest {
         parameter.setIn(in);
         parameter.setName(key);
 
-        ValidationResult result = validator.validate(parameter);
+        ValidationResult result = validator.validate(new ParameterWrapper(null, parameter));
         Assert.assertNotNull(result.getWarnings());
 
         List<Invalid> warnings = result.getWarnings().stream()
@@ -64,7 +64,7 @@ public class OpenApiParameterValidationsTest {
         parameter.setIn(in);
         parameter.setName(key);
 
-        ValidationResult result = validator.validate(parameter);
+        ValidationResult result = validator.validate(new ParameterWrapper(null, parameter));
         Assert.assertNotNull(result.getWarnings());
 
         List<Invalid> warnings = result.getWarnings().stream()

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/validations/oas/OpenApiSchemaValidationsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/validations/oas/OpenApiSchemaValidationsTest.java
@@ -18,7 +18,7 @@ public class OpenApiSchemaValidationsTest {
         config.setEnableRecommendations(true);
         OpenApiSchemaValidations validator = new OpenApiSchemaValidations(config);
 
-        ValidationResult result = validator.validate(schema);
+        ValidationResult result = validator.validate(new SchemaWrapper(null, schema));
         Assert.assertNotNull(result.getWarnings());
 
         List<Invalid> warnings = result.getWarnings().stream()
@@ -39,7 +39,7 @@ public class OpenApiSchemaValidationsTest {
         config.setEnableRecommendations(false);
         OpenApiSchemaValidations validator = new OpenApiSchemaValidations(config);
 
-        ValidationResult result = validator.validate(schema);
+        ValidationResult result = validator.validate(new SchemaWrapper(null, schema));
         Assert.assertNotNull(result.getWarnings());
 
         List<Invalid> warnings = result.getWarnings().stream()
@@ -56,7 +56,7 @@ public class OpenApiSchemaValidationsTest {
         config.setEnableOneOfWithPropertiesRecommendation(false);
         OpenApiSchemaValidations validator = new OpenApiSchemaValidations(config);
 
-        ValidationResult result = validator.validate(schema);
+        ValidationResult result = validator.validate(new SchemaWrapper(null, schema));
         Assert.assertNotNull(result.getWarnings());
 
         List<Invalid> warnings = result.getWarnings().stream()

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/validations/oas/OpenApiSecuritySchemeValidationsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/validations/oas/OpenApiSecuritySchemeValidationsTest.java
@@ -20,7 +20,7 @@ public class OpenApiSecuritySchemeValidationsTest {
 
         SecurityScheme securityScheme = new SecurityScheme().in(in).name(key);
 
-        ValidationResult result = validator.validate(securityScheme);
+        ValidationResult result = validator.validate(new SecuritySchemeWrapper(null, securityScheme));
         Assert.assertNotNull(result.getWarnings());
 
         List<Invalid> warnings = result.getWarnings().stream()
@@ -39,7 +39,7 @@ public class OpenApiSecuritySchemeValidationsTest {
 
         SecurityScheme securityScheme = new SecurityScheme().in(in).name(key);
 
-        ValidationResult result = validator.validate(securityScheme);
+        ValidationResult result = validator.validate(new SecuritySchemeWrapper(null, securityScheme));
         Assert.assertNotNull(result.getWarnings());
 
         List<Invalid> warnings = result.getWarnings().stream()
@@ -58,7 +58,7 @@ public class OpenApiSecuritySchemeValidationsTest {
 
         SecurityScheme securityScheme = new SecurityScheme().in(in).name(key);
 
-        ValidationResult result = validator.validate(securityScheme);
+        ValidationResult result = validator.validate(new SecuritySchemeWrapper(null, securityScheme));
         Assert.assertNotNull(result.getWarnings());
 
         List<Invalid> warnings = result.getWarnings().stream()


### PR DESCRIPTION
* Add "OpenAPI" attribute such that validators can access the OpenAPI specification. For example, this is useful to determine the version of the OpenAPI spec, but this could also be useful potentially to perform cross attribute validation.
For example, I would like to be able to do something like this: https://github.com/CiscoM31/openapi-generator/pull/16/files#diff-74008c7d7a3f7e768ea177ffd70c334dR91

* Add code comments to existing method.

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [ ] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [ ] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
