### PR TITLE
[swift][client] validate http status code

### DIFF
--- a/modules/openapi-generator/src/main/resources/swift5/Extensions.mustache
+++ b/modules/openapi-generator/src/main/resources/swift5/Extensions.mustache
@@ -173,6 +173,12 @@ extension KeyedDecodingContainerProtocol {
 
 }
 
+extension HTTPURLResponse {
+    var isStatusCodeSuccessful: Bool {
+        return Array(200 ..< 300).contains(statusCode)
+    }
+}
+
 {{#usePromiseKit}}extension RequestBuilder {
     {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} func execute() -> Promise<Response<T>>  {
         let deferred = Promise<Response<T>>.pending()

--- a/modules/openapi-generator/src/main/resources/swift5/Models.mustache
+++ b/modules/openapi-generator/src/main/resources/swift5/Models.mustache
@@ -25,6 +25,7 @@ protocol JSONEncodable {
 {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} enum DecodableRequestBuilderError: Error {
     case emptyDataResponse
     case nilHTTPResponse
+    case unsuccessfulHTTPStatusCode(Error?)
     case jsonDecoding(DecodingError)
     case generalError(Error)
 }

--- a/modules/openapi-generator/src/main/resources/swift5/libraries/urlsession/URLSessionImplementations.mustache
+++ b/modules/openapi-generator/src/main/resources/swift5/libraries/urlsession/URLSessionImplementations.mustache
@@ -181,7 +181,7 @@ private var urlSessionStore = SynchronizedDictionary<String, URLSession>()
     }
     
     fileprivate func processRequestResponse(urlRequest: URLRequest, data: Data?, response: URLResponse?, error: Error?, completion: @escaping (_ result: Result<Response<T>, Error>) -> Void) {
-        
+
         guard let httpResponse = response as? HTTPURLResponse else {
             completion(.failure(ErrorResponse.error(-2, nil, DecodableRequestBuilderError.nilHTTPResponse)))
             return
@@ -191,12 +191,12 @@ private var urlSessionStore = SynchronizedDictionary<String, URLSession>()
             completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, DecodableRequestBuilderError.unsuccessfulHTTPStatusCode(error))))
             return
         }
-        
+
         if let error = error {
             completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, error)))
             return
         }
-        
+
         switch T.self {
         case is String.Type:
             
@@ -313,7 +313,7 @@ private var urlSessionStore = SynchronizedDictionary<String, URLSession>()
 
 {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}open{{/nonPublicApi}} class URLSessionDecodableRequestBuilder<T:Decodable>: URLSessionRequestBuilder<T> {
     override fileprivate func processRequestResponse(urlRequest: URLRequest, data: Data?, response: URLResponse?, error: Error?, completion: @escaping (_ result: Result<Response<T>, Error>) -> Void) {
-        
+
         guard let httpResponse = response as? HTTPURLResponse else {
             completion(.failure(ErrorResponse.error(-2, nil, DecodableRequestBuilderError.nilHTTPResponse)))
             return

--- a/modules/openapi-generator/src/main/resources/swift5/libraries/urlsession/URLSessionImplementations.mustache
+++ b/modules/openapi-generator/src/main/resources/swift5/libraries/urlsession/URLSessionImplementations.mustache
@@ -186,14 +186,19 @@ private var urlSessionStore = SynchronizedDictionary<String, URLSession>()
             completion(.failure(ErrorResponse.error(-2, nil, DecodableRequestBuilderError.nilHTTPResponse)))
             return
         }
+
+        guard httpResponse.isStatusCodeSuccessful else {
+            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, DecodableRequestBuilderError.unsuccessfulHTTPStatusCode(error))))
+            return
+        }
+        
+        if let error = error {
+            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, error)))
+            return
+        }
         
         switch T.self {
         case is String.Type:
-            
-            if let error = error {
-                completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, error)))
-                return
-            }
             
             let body = data.flatMap { String(data: $0, encoding: .utf8) } ?? ""
             
@@ -236,19 +241,9 @@ private var urlSessionStore = SynchronizedDictionary<String, URLSession>()
             
         case is Void.Type:
             
-            if let error = error {
-                completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, error)))
-                return
-            }
-            
             completion(.success(Response(response: httpResponse, body: nil)))
             
         default:
-            
-            if let error = error {
-                completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, error)))
-                return
-            }
             
             completion(.success(Response(response: httpResponse, body: data as? T)))
         }
@@ -318,19 +313,24 @@ private var urlSessionStore = SynchronizedDictionary<String, URLSession>()
 
 {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}open{{/nonPublicApi}} class URLSessionDecodableRequestBuilder<T:Decodable>: URLSessionRequestBuilder<T> {
     override fileprivate func processRequestResponse(urlRequest: URLRequest, data: Data?, response: URLResponse?, error: Error?, completion: @escaping (_ result: Result<Response<T>, Error>) -> Void) {
-
+        
         guard let httpResponse = response as? HTTPURLResponse else {
             completion(.failure(ErrorResponse.error(-2, nil, DecodableRequestBuilderError.nilHTTPResponse)))
             return
         }
-        
+
+        guard httpResponse.isStatusCodeSuccessful else {
+            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, DecodableRequestBuilderError.unsuccessfulHTTPStatusCode(error))))
+            return
+        }
+
+        if let error = error {
+            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, error)))
+            return
+        }
+
         switch T.self {
         case is String.Type:
-            
-            if let error = error {
-                completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, error)))
-                return
-            }
             
             let body = data.flatMap { String(data: $0, encoding: .utf8) } ?? ""
             
@@ -338,28 +338,13 @@ private var urlSessionStore = SynchronizedDictionary<String, URLSession>()
             
         case is Void.Type:
             
-            if let error = error {
-                completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, error)))
-                return
-            }
-            
             completion(.success(Response(response: httpResponse, body: nil)))
             
         case is Data.Type:
             
-            if let error = error {
-                completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, error)))
-                return
-            }
-            
             completion(.success(Response(response: httpResponse, body: data as? T)))
             
         default:
-            
-            if let error = error {
-                completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, error)))
-                return
-            }
             
             guard let data = data, !data.isEmpty else {
                 completion(.failure(ErrorResponse.error(httpResponse.statusCode, nil, DecodableRequestBuilderError.emptyDataResponse)))

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Extensions.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Extensions.swift
@@ -171,3 +171,9 @@ extension KeyedDecodingContainerProtocol {
     }
 
 }
+
+extension HTTPURLResponse {
+    var isStatusCodeSuccessful: Bool {
+        return Array(200 ..< 300).contains(statusCode)
+    }
+}

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models.swift
@@ -25,6 +25,7 @@ public enum DownloadException: Error {
 public enum DecodableRequestBuilderError: Error {
     case emptyDataResponse
     case nilHTTPResponse
+    case unsuccessfulHTTPStatusCode(Error?)
     case jsonDecoding(DecodingError)
     case generalError(Error)
 }

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Extensions.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Extensions.swift
@@ -171,3 +171,9 @@ extension KeyedDecodingContainerProtocol {
     }
 
 }
+
+extension HTTPURLResponse {
+    var isStatusCodeSuccessful: Bool {
+        return Array(200 ..< 300).contains(statusCode)
+    }
+}

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models.swift
@@ -25,6 +25,7 @@ public enum DownloadException: Error {
 public enum DecodableRequestBuilderError: Error {
     case emptyDataResponse
     case nilHTTPResponse
+    case unsuccessfulHTTPStatusCode(Error?)
     case jsonDecoding(DecodingError)
     case generalError(Error)
 }

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
@@ -187,13 +187,18 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T> {
             return
         }
 
+        guard httpResponse.isStatusCodeSuccessful else {
+            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, DecodableRequestBuilderError.unsuccessfulHTTPStatusCode(error))))
+            return
+        }
+
+        if let error = error {
+            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, error)))
+            return
+        }
+
         switch T.self {
         case is String.Type:
-
-            if let error = error {
-                completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, error)))
-                return
-            }
 
             let body = data.flatMap { String(data: $0, encoding: .utf8) } ?? ""
 
@@ -236,19 +241,9 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T> {
 
         case is Void.Type:
 
-            if let error = error {
-                completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, error)))
-                return
-            }
-
             completion(.success(Response(response: httpResponse, body: nil)))
 
         default:
-
-            if let error = error {
-                completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, error)))
-                return
-            }
 
             completion(.success(Response(response: httpResponse, body: data as? T)))
         }
@@ -324,13 +319,18 @@ open class URLSessionDecodableRequestBuilder<T: Decodable>: URLSessionRequestBui
             return
         }
 
+        guard httpResponse.isStatusCodeSuccessful else {
+            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, DecodableRequestBuilderError.unsuccessfulHTTPStatusCode(error))))
+            return
+        }
+
+        if let error = error {
+            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, error)))
+            return
+        }
+
         switch T.self {
         case is String.Type:
-
-            if let error = error {
-                completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, error)))
-                return
-            }
 
             let body = data.flatMap { String(data: $0, encoding: .utf8) } ?? ""
 
@@ -338,28 +338,13 @@ open class URLSessionDecodableRequestBuilder<T: Decodable>: URLSessionRequestBui
 
         case is Void.Type:
 
-            if let error = error {
-                completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, error)))
-                return
-            }
-
             completion(.success(Response(response: httpResponse, body: nil)))
 
         case is Data.Type:
 
-            if let error = error {
-                completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, error)))
-                return
-            }
-
             completion(.success(Response(response: httpResponse, body: data as? T)))
 
         default:
-
-            if let error = error {
-                completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, error)))
-                return
-            }
 
             guard let data = data, !data.isEmpty else {
                 completion(.failure(ErrorResponse.error(httpResponse.statusCode, nil, DecodableRequestBuilderError.emptyDataResponse)))

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Extensions.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Extensions.swift
@@ -171,3 +171,9 @@ extension KeyedDecodingContainerProtocol {
     }
 
 }
+
+extension HTTPURLResponse {
+    var isStatusCodeSuccessful: Bool {
+        return Array(200 ..< 300).contains(statusCode)
+    }
+}

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models.swift
@@ -25,6 +25,7 @@ public enum DownloadException: Error {
 public enum DecodableRequestBuilderError: Error {
     case emptyDataResponse
     case nilHTTPResponse
+    case unsuccessfulHTTPStatusCode(Error?)
     case jsonDecoding(DecodingError)
     case generalError(Error)
 }

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
@@ -187,13 +187,18 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T> {
             return
         }
 
+        guard httpResponse.isStatusCodeSuccessful else {
+            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, DecodableRequestBuilderError.unsuccessfulHTTPStatusCode(error))))
+            return
+        }
+
+        if let error = error {
+            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, error)))
+            return
+        }
+
         switch T.self {
         case is String.Type:
-
-            if let error = error {
-                completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, error)))
-                return
-            }
 
             let body = data.flatMap { String(data: $0, encoding: .utf8) } ?? ""
 
@@ -236,19 +241,9 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T> {
 
         case is Void.Type:
 
-            if let error = error {
-                completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, error)))
-                return
-            }
-
             completion(.success(Response(response: httpResponse, body: nil)))
 
         default:
-
-            if let error = error {
-                completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, error)))
-                return
-            }
 
             completion(.success(Response(response: httpResponse, body: data as? T)))
         }
@@ -324,13 +319,18 @@ open class URLSessionDecodableRequestBuilder<T: Decodable>: URLSessionRequestBui
             return
         }
 
+        guard httpResponse.isStatusCodeSuccessful else {
+            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, DecodableRequestBuilderError.unsuccessfulHTTPStatusCode(error))))
+            return
+        }
+
+        if let error = error {
+            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, error)))
+            return
+        }
+
         switch T.self {
         case is String.Type:
-
-            if let error = error {
-                completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, error)))
-                return
-            }
 
             let body = data.flatMap { String(data: $0, encoding: .utf8) } ?? ""
 
@@ -338,28 +338,13 @@ open class URLSessionDecodableRequestBuilder<T: Decodable>: URLSessionRequestBui
 
         case is Void.Type:
 
-            if let error = error {
-                completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, error)))
-                return
-            }
-
             completion(.success(Response(response: httpResponse, body: nil)))
 
         case is Data.Type:
 
-            if let error = error {
-                completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, error)))
-                return
-            }
-
             completion(.success(Response(response: httpResponse, body: data as? T)))
 
         default:
-
-            if let error = error {
-                completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, error)))
-                return
-            }
 
             guard let data = data, !data.isEmpty else {
                 completion(.failure(ErrorResponse.error(httpResponse.statusCode, nil, DecodableRequestBuilderError.emptyDataResponse)))

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Extensions.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Extensions.swift
@@ -171,3 +171,9 @@ extension KeyedDecodingContainerProtocol {
     }
 
 }
+
+extension HTTPURLResponse {
+    var isStatusCodeSuccessful: Bool {
+        return Array(200 ..< 300).contains(statusCode)
+    }
+}

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models.swift
@@ -25,6 +25,7 @@ internal enum DownloadException: Error {
 internal enum DecodableRequestBuilderError: Error {
     case emptyDataResponse
     case nilHTTPResponse
+    case unsuccessfulHTTPStatusCode(Error?)
     case jsonDecoding(DecodingError)
     case generalError(Error)
 }

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
@@ -187,13 +187,18 @@ internal class URLSessionRequestBuilder<T>: RequestBuilder<T> {
             return
         }
 
+        guard httpResponse.isStatusCodeSuccessful else {
+            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, DecodableRequestBuilderError.unsuccessfulHTTPStatusCode(error))))
+            return
+        }
+
+        if let error = error {
+            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, error)))
+            return
+        }
+
         switch T.self {
         case is String.Type:
-
-            if let error = error {
-                completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, error)))
-                return
-            }
 
             let body = data.flatMap { String(data: $0, encoding: .utf8) } ?? ""
 
@@ -236,19 +241,9 @@ internal class URLSessionRequestBuilder<T>: RequestBuilder<T> {
 
         case is Void.Type:
 
-            if let error = error {
-                completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, error)))
-                return
-            }
-
             completion(.success(Response(response: httpResponse, body: nil)))
 
         default:
-
-            if let error = error {
-                completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, error)))
-                return
-            }
 
             completion(.success(Response(response: httpResponse, body: data as? T)))
         }
@@ -324,13 +319,18 @@ internal class URLSessionDecodableRequestBuilder<T: Decodable>: URLSessionReques
             return
         }
 
+        guard httpResponse.isStatusCodeSuccessful else {
+            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, DecodableRequestBuilderError.unsuccessfulHTTPStatusCode(error))))
+            return
+        }
+
+        if let error = error {
+            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, error)))
+            return
+        }
+
         switch T.self {
         case is String.Type:
-
-            if let error = error {
-                completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, error)))
-                return
-            }
 
             let body = data.flatMap { String(data: $0, encoding: .utf8) } ?? ""
 
@@ -338,28 +338,13 @@ internal class URLSessionDecodableRequestBuilder<T: Decodable>: URLSessionReques
 
         case is Void.Type:
 
-            if let error = error {
-                completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, error)))
-                return
-            }
-
             completion(.success(Response(response: httpResponse, body: nil)))
 
         case is Data.Type:
 
-            if let error = error {
-                completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, error)))
-                return
-            }
-
             completion(.success(Response(response: httpResponse, body: data as? T)))
 
         default:
-
-            if let error = error {
-                completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, error)))
-                return
-            }
 
             guard let data = data, !data.isEmpty else {
                 completion(.failure(ErrorResponse.error(httpResponse.statusCode, nil, DecodableRequestBuilderError.emptyDataResponse)))

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Extensions.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Extensions.swift
@@ -171,3 +171,9 @@ extension KeyedDecodingContainerProtocol {
     }
 
 }
+
+extension HTTPURLResponse {
+    var isStatusCodeSuccessful: Bool {
+        return Array(200 ..< 300).contains(statusCode)
+    }
+}

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models.swift
@@ -25,6 +25,7 @@ public enum DownloadException: Error {
 public enum DecodableRequestBuilderError: Error {
     case emptyDataResponse
     case nilHTTPResponse
+    case unsuccessfulHTTPStatusCode(Error?)
     case jsonDecoding(DecodingError)
     case generalError(Error)
 }

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
@@ -187,13 +187,18 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T> {
             return
         }
 
+        guard httpResponse.isStatusCodeSuccessful else {
+            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, DecodableRequestBuilderError.unsuccessfulHTTPStatusCode(error))))
+            return
+        }
+
+        if let error = error {
+            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, error)))
+            return
+        }
+
         switch T.self {
         case is String.Type:
-
-            if let error = error {
-                completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, error)))
-                return
-            }
 
             let body = data.flatMap { String(data: $0, encoding: .utf8) } ?? ""
 
@@ -236,19 +241,9 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T> {
 
         case is Void.Type:
 
-            if let error = error {
-                completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, error)))
-                return
-            }
-
             completion(.success(Response(response: httpResponse, body: nil)))
 
         default:
-
-            if let error = error {
-                completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, error)))
-                return
-            }
 
             completion(.success(Response(response: httpResponse, body: data as? T)))
         }
@@ -324,13 +319,18 @@ open class URLSessionDecodableRequestBuilder<T: Decodable>: URLSessionRequestBui
             return
         }
 
+        guard httpResponse.isStatusCodeSuccessful else {
+            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, DecodableRequestBuilderError.unsuccessfulHTTPStatusCode(error))))
+            return
+        }
+
+        if let error = error {
+            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, error)))
+            return
+        }
+
         switch T.self {
         case is String.Type:
-
-            if let error = error {
-                completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, error)))
-                return
-            }
 
             let body = data.flatMap { String(data: $0, encoding: .utf8) } ?? ""
 
@@ -338,28 +338,13 @@ open class URLSessionDecodableRequestBuilder<T: Decodable>: URLSessionRequestBui
 
         case is Void.Type:
 
-            if let error = error {
-                completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, error)))
-                return
-            }
-
             completion(.success(Response(response: httpResponse, body: nil)))
 
         case is Data.Type:
 
-            if let error = error {
-                completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, error)))
-                return
-            }
-
             completion(.success(Response(response: httpResponse, body: data as? T)))
 
         default:
-
-            if let error = error {
-                completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, error)))
-                return
-            }
 
             guard let data = data, !data.isEmpty else {
                 completion(.failure(ErrorResponse.error(httpResponse.statusCode, nil, DecodableRequestBuilderError.emptyDataResponse)))

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Extensions.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Extensions.swift
@@ -173,6 +173,12 @@ extension KeyedDecodingContainerProtocol {
 
 }
 
+extension HTTPURLResponse {
+    var isStatusCodeSuccessful: Bool {
+        return Array(200 ..< 300).contains(statusCode)
+    }
+}
+
 extension RequestBuilder {
     public func execute() -> Promise<Response<T>> {
         let deferred = Promise<Response<T>>.pending()

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models.swift
@@ -25,6 +25,7 @@ public enum DownloadException: Error {
 public enum DecodableRequestBuilderError: Error {
     case emptyDataResponse
     case nilHTTPResponse
+    case unsuccessfulHTTPStatusCode(Error?)
     case jsonDecoding(DecodingError)
     case generalError(Error)
 }

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
@@ -187,13 +187,18 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T> {
             return
         }
 
+        guard httpResponse.isStatusCodeSuccessful else {
+            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, DecodableRequestBuilderError.unsuccessfulHTTPStatusCode(error))))
+            return
+        }
+
+        if let error = error {
+            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, error)))
+            return
+        }
+
         switch T.self {
         case is String.Type:
-
-            if let error = error {
-                completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, error)))
-                return
-            }
 
             let body = data.flatMap { String(data: $0, encoding: .utf8) } ?? ""
 
@@ -236,19 +241,9 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T> {
 
         case is Void.Type:
 
-            if let error = error {
-                completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, error)))
-                return
-            }
-
             completion(.success(Response(response: httpResponse, body: nil)))
 
         default:
-
-            if let error = error {
-                completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, error)))
-                return
-            }
 
             completion(.success(Response(response: httpResponse, body: data as? T)))
         }
@@ -324,13 +319,18 @@ open class URLSessionDecodableRequestBuilder<T: Decodable>: URLSessionRequestBui
             return
         }
 
+        guard httpResponse.isStatusCodeSuccessful else {
+            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, DecodableRequestBuilderError.unsuccessfulHTTPStatusCode(error))))
+            return
+        }
+
+        if let error = error {
+            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, error)))
+            return
+        }
+
         switch T.self {
         case is String.Type:
-
-            if let error = error {
-                completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, error)))
-                return
-            }
 
             let body = data.flatMap { String(data: $0, encoding: .utf8) } ?? ""
 
@@ -338,28 +338,13 @@ open class URLSessionDecodableRequestBuilder<T: Decodable>: URLSessionRequestBui
 
         case is Void.Type:
 
-            if let error = error {
-                completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, error)))
-                return
-            }
-
             completion(.success(Response(response: httpResponse, body: nil)))
 
         case is Data.Type:
 
-            if let error = error {
-                completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, error)))
-                return
-            }
-
             completion(.success(Response(response: httpResponse, body: data as? T)))
 
         default:
-
-            if let error = error {
-                completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, error)))
-                return
-            }
 
             guard let data = data, !data.isEmpty else {
                 completion(.failure(ErrorResponse.error(httpResponse.statusCode, nil, DecodableRequestBuilderError.emptyDataResponse)))

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Extensions.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Extensions.swift
@@ -171,3 +171,9 @@ extension KeyedDecodingContainerProtocol {
     }
 
 }
+
+extension HTTPURLResponse {
+    var isStatusCodeSuccessful: Bool {
+        return Array(200 ..< 300).contains(statusCode)
+    }
+}

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models.swift
@@ -25,6 +25,7 @@ public enum DownloadException: Error {
 public enum DecodableRequestBuilderError: Error {
     case emptyDataResponse
     case nilHTTPResponse
+    case unsuccessfulHTTPStatusCode(Error?)
     case jsonDecoding(DecodingError)
     case generalError(Error)
 }

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
@@ -187,13 +187,18 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T> {
             return
         }
 
+        guard httpResponse.isStatusCodeSuccessful else {
+            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, DecodableRequestBuilderError.unsuccessfulHTTPStatusCode(error))))
+            return
+        }
+
+        if let error = error {
+            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, error)))
+            return
+        }
+
         switch T.self {
         case is String.Type:
-
-            if let error = error {
-                completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, error)))
-                return
-            }
 
             let body = data.flatMap { String(data: $0, encoding: .utf8) } ?? ""
 
@@ -236,19 +241,9 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T> {
 
         case is Void.Type:
 
-            if let error = error {
-                completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, error)))
-                return
-            }
-
             completion(.success(Response(response: httpResponse, body: nil)))
 
         default:
-
-            if let error = error {
-                completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, error)))
-                return
-            }
 
             completion(.success(Response(response: httpResponse, body: data as? T)))
         }
@@ -324,13 +319,18 @@ open class URLSessionDecodableRequestBuilder<T: Decodable>: URLSessionRequestBui
             return
         }
 
+        guard httpResponse.isStatusCodeSuccessful else {
+            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, DecodableRequestBuilderError.unsuccessfulHTTPStatusCode(error))))
+            return
+        }
+
+        if let error = error {
+            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, error)))
+            return
+        }
+
         switch T.self {
         case is String.Type:
-
-            if let error = error {
-                completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, error)))
-                return
-            }
 
             let body = data.flatMap { String(data: $0, encoding: .utf8) } ?? ""
 
@@ -338,28 +338,13 @@ open class URLSessionDecodableRequestBuilder<T: Decodable>: URLSessionRequestBui
 
         case is Void.Type:
 
-            if let error = error {
-                completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, error)))
-                return
-            }
-
             completion(.success(Response(response: httpResponse, body: nil)))
 
         case is Data.Type:
 
-            if let error = error {
-                completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, error)))
-                return
-            }
-
             completion(.success(Response(response: httpResponse, body: data as? T)))
 
         default:
-
-            if let error = error {
-                completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, error)))
-                return
-            }
 
             guard let data = data, !data.isEmpty else {
                 completion(.failure(ErrorResponse.error(httpResponse.statusCode, nil, DecodableRequestBuilderError.emptyDataResponse)))

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Extensions.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Extensions.swift
@@ -171,3 +171,9 @@ extension KeyedDecodingContainerProtocol {
     }
 
 }
+
+extension HTTPURLResponse {
+    var isStatusCodeSuccessful: Bool {
+        return Array(200 ..< 300).contains(statusCode)
+    }
+}

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models.swift
@@ -25,6 +25,7 @@ public enum DownloadException: Error {
 public enum DecodableRequestBuilderError: Error {
     case emptyDataResponse
     case nilHTTPResponse
+    case unsuccessfulHTTPStatusCode(Error?)
     case jsonDecoding(DecodingError)
     case generalError(Error)
 }

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
@@ -187,13 +187,18 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T> {
             return
         }
 
+        guard httpResponse.isStatusCodeSuccessful else {
+            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, DecodableRequestBuilderError.unsuccessfulHTTPStatusCode(error))))
+            return
+        }
+
+        if let error = error {
+            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, error)))
+            return
+        }
+
         switch T.self {
         case is String.Type:
-
-            if let error = error {
-                completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, error)))
-                return
-            }
 
             let body = data.flatMap { String(data: $0, encoding: .utf8) } ?? ""
 
@@ -236,19 +241,9 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T> {
 
         case is Void.Type:
 
-            if let error = error {
-                completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, error)))
-                return
-            }
-
             completion(.success(Response(response: httpResponse, body: nil)))
 
         default:
-
-            if let error = error {
-                completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, error)))
-                return
-            }
 
             completion(.success(Response(response: httpResponse, body: data as? T)))
         }
@@ -324,13 +319,18 @@ open class URLSessionDecodableRequestBuilder<T: Decodable>: URLSessionRequestBui
             return
         }
 
+        guard httpResponse.isStatusCodeSuccessful else {
+            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, DecodableRequestBuilderError.unsuccessfulHTTPStatusCode(error))))
+            return
+        }
+
+        if let error = error {
+            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, error)))
+            return
+        }
+
         switch T.self {
         case is String.Type:
-
-            if let error = error {
-                completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, error)))
-                return
-            }
 
             let body = data.flatMap { String(data: $0, encoding: .utf8) } ?? ""
 
@@ -338,28 +338,13 @@ open class URLSessionDecodableRequestBuilder<T: Decodable>: URLSessionRequestBui
 
         case is Void.Type:
 
-            if let error = error {
-                completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, error)))
-                return
-            }
-
             completion(.success(Response(response: httpResponse, body: nil)))
 
         case is Data.Type:
 
-            if let error = error {
-                completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, error)))
-                return
-            }
-
             completion(.success(Response(response: httpResponse, body: data as? T)))
 
         default:
-
-            if let error = error {
-                completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, error)))
-                return
-            }
 
             guard let data = data, !data.isEmpty else {
                 completion(.failure(ErrorResponse.error(httpResponse.statusCode, nil, DecodableRequestBuilderError.emptyDataResponse)))

--- a/samples/client/petstore/swift5/urlsessionLibrary/PetstoreClient/Classes/OpenAPIs/Extensions.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/PetstoreClient/Classes/OpenAPIs/Extensions.swift
@@ -171,3 +171,9 @@ extension KeyedDecodingContainerProtocol {
     }
 
 }
+
+extension HTTPURLResponse {
+    var isStatusCodeSuccessful: Bool {
+        return Array(200 ..< 300).contains(statusCode)
+    }
+}

--- a/samples/client/petstore/swift5/urlsessionLibrary/PetstoreClient/Classes/OpenAPIs/Models.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/PetstoreClient/Classes/OpenAPIs/Models.swift
@@ -25,6 +25,7 @@ public enum DownloadException: Error {
 public enum DecodableRequestBuilderError: Error {
     case emptyDataResponse
     case nilHTTPResponse
+    case unsuccessfulHTTPStatusCode(Error?)
     case jsonDecoding(DecodingError)
     case generalError(Error)
 }

--- a/samples/client/petstore/swift5/urlsessionLibrary/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
@@ -187,13 +187,18 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T> {
             return
         }
 
+        guard httpResponse.isStatusCodeSuccessful else {
+            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, DecodableRequestBuilderError.unsuccessfulHTTPStatusCode(error))))
+            return
+        }
+
+        if let error = error {
+            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, error)))
+            return
+        }
+
         switch T.self {
         case is String.Type:
-
-            if let error = error {
-                completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, error)))
-                return
-            }
 
             let body = data.flatMap { String(data: $0, encoding: .utf8) } ?? ""
 
@@ -236,19 +241,9 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T> {
 
         case is Void.Type:
 
-            if let error = error {
-                completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, error)))
-                return
-            }
-
             completion(.success(Response(response: httpResponse, body: nil)))
 
         default:
-
-            if let error = error {
-                completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, error)))
-                return
-            }
 
             completion(.success(Response(response: httpResponse, body: data as? T)))
         }
@@ -324,13 +319,18 @@ open class URLSessionDecodableRequestBuilder<T: Decodable>: URLSessionRequestBui
             return
         }
 
+        guard httpResponse.isStatusCodeSuccessful else {
+            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, DecodableRequestBuilderError.unsuccessfulHTTPStatusCode(error))))
+            return
+        }
+
+        if let error = error {
+            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, error)))
+            return
+        }
+
         switch T.self {
         case is String.Type:
-
-            if let error = error {
-                completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, error)))
-                return
-            }
 
             let body = data.flatMap { String(data: $0, encoding: .utf8) } ?? ""
 
@@ -338,28 +338,13 @@ open class URLSessionDecodableRequestBuilder<T: Decodable>: URLSessionRequestBui
 
         case is Void.Type:
 
-            if let error = error {
-                completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, error)))
-                return
-            }
-
             completion(.success(Response(response: httpResponse, body: nil)))
 
         case is Data.Type:
 
-            if let error = error {
-                completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, error)))
-                return
-            }
-
             completion(.success(Response(response: httpResponse, body: data as? T)))
 
         default:
-
-            if let error = error {
-                completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, error)))
-                return
-            }
 
             guard let data = data, !data.isEmpty else {
                 completion(.failure(ErrorResponse.error(httpResponse.statusCode, nil, DecodableRequestBuilderError.emptyDataResponse)))

--- a/samples/client/test/swift5/default/TestClient/Classes/OpenAPIs/Extensions.swift
+++ b/samples/client/test/swift5/default/TestClient/Classes/OpenAPIs/Extensions.swift
@@ -171,3 +171,9 @@ extension KeyedDecodingContainerProtocol {
     }
 
 }
+
+extension HTTPURLResponse {
+    var isStatusCodeSuccessful: Bool {
+        return Array(200 ..< 300).contains(statusCode)
+    }
+}

--- a/samples/client/test/swift5/default/TestClient/Classes/OpenAPIs/Models.swift
+++ b/samples/client/test/swift5/default/TestClient/Classes/OpenAPIs/Models.swift
@@ -25,6 +25,7 @@ public enum DownloadException: Error {
 public enum DecodableRequestBuilderError: Error {
     case emptyDataResponse
     case nilHTTPResponse
+    case unsuccessfulHTTPStatusCode(Error?)
     case jsonDecoding(DecodingError)
     case generalError(Error)
 }

--- a/samples/client/test/swift5/default/TestClient/Classes/OpenAPIs/URLSessionImplementations.swift
+++ b/samples/client/test/swift5/default/TestClient/Classes/OpenAPIs/URLSessionImplementations.swift
@@ -187,13 +187,18 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T> {
             return
         }
 
+        guard httpResponse.isStatusCodeSuccessful else {
+            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, DecodableRequestBuilderError.unsuccessfulHTTPStatusCode(error))))
+            return
+        }
+
+        if let error = error {
+            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, error)))
+            return
+        }
+
         switch T.self {
         case is String.Type:
-
-            if let error = error {
-                completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, error)))
-                return
-            }
 
             let body = data.flatMap { String(data: $0, encoding: .utf8) } ?? ""
 
@@ -236,19 +241,9 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T> {
 
         case is Void.Type:
 
-            if let error = error {
-                completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, error)))
-                return
-            }
-
             completion(.success(Response(response: httpResponse, body: nil)))
 
         default:
-
-            if let error = error {
-                completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, error)))
-                return
-            }
 
             completion(.success(Response(response: httpResponse, body: data as? T)))
         }
@@ -324,13 +319,18 @@ open class URLSessionDecodableRequestBuilder<T: Decodable>: URLSessionRequestBui
             return
         }
 
+        guard httpResponse.isStatusCodeSuccessful else {
+            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, DecodableRequestBuilderError.unsuccessfulHTTPStatusCode(error))))
+            return
+        }
+
+        if let error = error {
+            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, error)))
+            return
+        }
+
         switch T.self {
         case is String.Type:
-
-            if let error = error {
-                completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, error)))
-                return
-            }
 
             let body = data.flatMap { String(data: $0, encoding: .utf8) } ?? ""
 
@@ -338,28 +338,13 @@ open class URLSessionDecodableRequestBuilder<T: Decodable>: URLSessionRequestBui
 
         case is Void.Type:
 
-            if let error = error {
-                completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, error)))
-                return
-            }
-
             completion(.success(Response(response: httpResponse, body: nil)))
 
         case is Data.Type:
 
-            if let error = error {
-                completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, error)))
-                return
-            }
-
             completion(.success(Response(response: httpResponse, body: data as? T)))
 
         default:
-
-            if let error = error {
-                completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, error)))
-                return
-            }
 
             guard let data = data, !data.isEmpty else {
                 completion(.failure(ErrorResponse.error(httpResponse.statusCode, nil, DecodableRequestBuilderError.emptyDataResponse)))


### PR DESCRIPTION
Currently the requests made by URLSession don't validate the http status code, so it's returning success even when the server returns a http status code that is not 2XY.

This PR fixes that by checking if http status code is 2XY and returning an error in the other cases.

### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [X] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [X] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@jgavris (2017/07) @ehyche (2017/08) @Edubits (2017/09) @jaz-ah (2017/09) @4brunu (2019/11)