### PR TITLE
[core] Log some things in model/url utils once

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
@@ -39,6 +39,8 @@ import java.util.*;
 import java.util.Map.Entry;
 import java.util.stream.Collectors;
 
+import static org.openapitools.codegen.utils.OnceLogger.once;
+
 public class ModelUtils {
     private static final Logger LOGGER = LoggerFactory.getLogger(ModelUtils.class);
 
@@ -248,7 +250,7 @@ public class ModelUtils {
                     }
                     visitContent(openAPI, parameter.getContent(), visitor, visitedSchemas);
                 } else {
-                    LOGGER.warn("Unreferenced parameter found.");
+                    once(LOGGER).warn("Unreferenced parameter(s) found.");
                 }
             }
         }
@@ -329,7 +331,7 @@ public class ModelUtils {
         } else if (ref.startsWith("#/definitions/")) {
             ref = ref.substring(ref.lastIndexOf("/") + 1);
         } else {
-            LOGGER.warn("Failed to get the schema name: {}", ref);
+            once(LOGGER).warn("Failed to get the schema name: {}", ref);
             //throw new RuntimeException("Failed to get the schema: " + ref);
             return null;
 
@@ -561,7 +563,8 @@ public class ModelUtils {
      */
     public static boolean isModel(Schema schema) {
         if (schema == null) {
-            LOGGER.error("Schema cannot be null in isModel check");
+            // TODO: Is this message necessary? A null schema is not a model, so the result is correct.
+            once(LOGGER).error("Schema cannot be null in isModel check");
             return false;
         }
 
@@ -571,11 +574,7 @@ public class ModelUtils {
         }
 
         // composed schema is a model
-        if (schema instanceof ComposedSchema) {
-            return true;
-        }
-
-        return false;
+        return schema instanceof ComposedSchema;
     }
 
     /**
@@ -586,7 +585,8 @@ public class ModelUtils {
      */
     public static boolean isFreeFormObject(Schema schema) {
         if (schema == null) {
-            LOGGER.error("Schema cannot be null in isFreeFormObject check");
+            // TODO: Is this message necessary? A null schema is not a free-form object, so the result is correct.
+            once(LOGGER).error("Schema cannot be null in isFreeFormObject check");
             return false;
         }
 
@@ -841,7 +841,7 @@ public class ModelUtils {
         if (schema != null && StringUtils.isNotEmpty(schema.get$ref())) {
             Schema ref = allSchemas.get(ModelUtils.getSimpleRef(schema.get$ref()));
             if (ref == null) {
-                LOGGER.warn("{} is not defined", schema.get$ref());
+                once(LOGGER).warn("{} is not defined", schema.get$ref());
                 return schema;
             } else if (ref.getEnum() != null && !ref.getEnum().isEmpty()) {
                 // top-level enum class

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/URLPathUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/URLPathUtils.java
@@ -33,6 +33,8 @@ import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static org.openapitools.codegen.utils.OnceLogger.once;
+
 public class URLPathUtils {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(URLPathUtils.class);
@@ -43,7 +45,7 @@ public class URLPathUtils {
     public static URL getServerURL(OpenAPI openAPI, Map<String, String> userDefinedVariables) {
         final List<Server> servers = openAPI.getServers();
         if (servers == null || servers.isEmpty()) {
-            LOGGER.warn("Server information seems not defined in the spec. Default to {}.", LOCAL_HOST);
+            once(LOGGER).warn("Server information seems not defined in the spec. Default to {}.", LOCAL_HOST);
             return getDefaultUrl();
         }
         // TODO need a way to obtain all server URLs
@@ -66,7 +68,7 @@ public class URLPathUtils {
             try {
                 return new URL(url);
             } catch (MalformedURLException e) {
-                LOGGER.warn("Not valid URL: {}. Default to {}.", server.getUrl(), LOCAL_HOST);
+                once(LOGGER).warn("Not valid URL: {}. Default to {}.", server.getUrl(), LOCAL_HOST);
             }
         }
         return getDefaultUrl();
@@ -205,10 +207,10 @@ public class URLPathUtils {
         if (url != null) {
             if (url.startsWith("//")) {
                 url = "http:" + url;
-                LOGGER.warn("'scheme' not defined in the spec (2.0). Default to [http] for server URL [{}]", url);
+                once(LOGGER).warn("'scheme' not defined in the spec (2.0). Default to [http] for server URL [{}]", url);
             } else if (url.startsWith("/")) {
                 url = LOCAL_HOST + url;
-                LOGGER.warn("'host' (OAS 2.0) or 'servers' (OAS 3.0) not defined in the spec. Default to [{}] for server URL [{}]", LOCAL_HOST, url);
+                once(LOGGER).warn("'host' (OAS 2.0) or 'servers' (OAS 3.0) not defined in the spec. Default to [{}] for server URL [{}]", LOCAL_HOST, url);
             } else if (!url.matches("[a-zA-Z][0-9a-zA-Z.+\\-]+://.+")) {
                 // Add http scheme for urls without a scheme.
                 // 2.0 spec is restricted to the following schemes: "http", "https", "ws", "wss"
@@ -217,7 +219,7 @@ public class URLPathUtils {
                 // can have alpha-numeric characters and [.+-]. Examples are here:
                 // https://www.iana.org/assignments/uri-schemes/uri-schemes.xhtml
                 url = "http://" + url;
-                LOGGER.warn("'scheme' not defined in the spec (2.0). Default to [http] for server URL [{}]", url);
+                once(LOGGER).warn("'scheme' not defined in the spec (2.0). Default to [http] for server URL [{}]", url);
             }
         }
         return url;


### PR DESCRIPTION
Some operational messages are iterated multiple times during some generations and should only be logged once.

This uses the cache I recently added to debounce some log messages. By default the messages `once`'d here will only display a most once per 2 seconds, and is configurable (see OnceLogger for details).

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@OpenAPITools/generator-core-team fyi