### PR TITLE
Fix for #4840 [BUG][JAVA][spring-mvc] Generated Code for Map of Maps …

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/SpringCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/SpringCodegen.java
@@ -652,7 +652,7 @@ public class SpringCodegen extends AbstractJavaCodegen
         } else if (rt.startsWith("Map")) {
             int end = rt.lastIndexOf(">");
             if (end > 0) {
-                dataTypeAssigner.setReturnType(rt.substring("Map<".length(), end).split(",")[1].trim());
+                dataTypeAssigner.setReturnType(rt.substring("Map<".length(), end).split(",", 2)[1].trim());
                 dataTypeAssigner.setReturnContainer("Map");
             }
         } else if (rt.startsWith("Set")) {


### PR DESCRIPTION
Fix for https://github.com/OpenAPITools/openapi-generator/issues/4840 
The Java-Code (spring-mvc) generated from OpenAPI-YAML for a Map of Maps ist not syntactically correct.

This is caused by SpringCodegen.java not handling Maps of Maps return types correctly. Its a simple mistake in applying String.split() to extract the Key-Type of the outer Map.

The following Unit Test shows the problem.

 ```
 @Test
    public void doDataTypeAssignmentNestedMapReturnType() {
         final SpringCodegen codegen = new SpringCodegen();
         codegen.doDataTypeAssignment("Map<String, Map<String, String>>", new SpringCodegen.DataTypeAssigner() {
             @Override
             public void setReturnType(String returnType) {
                assertEquals(returnType,"Map<String, String>");
             }

             @Override
             public void setReturnContainer(String returnContainer) {
                 assertEquals(returnContainer, "Map");
             }
         });
     }
```
Unfortunately, the visibility of doDataTypeAssignment() and DataTypeAssigner is private, so I can't check in the Test.


<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist

- [x ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [ ] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x ] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language. 
@bbdouglas  @sreeshas  @jfiala @lukoyanov @cbornet ( @jeff9finger  @karismann  @Zomzog  @lwlee2608 @bkabrda 
