### PR TITLE
[Python-experimental] fix name of generated python class for composed schema

### DIFF
--- a/modules/openapi-generator/src/main/resources/python/python-experimental/model_templates/model_composed.mustache
+++ b/modules/openapi-generator/src/main/resources/python/python-experimental/model_templates/model_composed.mustache
@@ -38,17 +38,17 @@ class {{unescapedDescription}}(ModelComposed):
         return {
           'anyOf': [
 {{#anyOf}}
-              {{{.}}},
+              {{unescapedDescription}},
 {{/anyOf}}
           ],
           'allOf': [
 {{#allOf}}
-              {{{.}}},
+              {{unescapedDescription}},
 {{/allOf}}
           ],
           'oneOf': [
 {{#oneOf}}
-              {{{.}}},
+              {{unescapedDescription}},
 {{/oneOf}}
           ],
         }{{#discriminator}}


### PR DESCRIPTION
In some cases there is a mismatch in the name of the generated Python class.
The python-experimental/model_templates/model_composed.mustache template is used to generate a Python class when the corresponding OAS model is a composed schema, i.e. oneOf, anyOf, allAll. The name of the class uses the {{unescapedDescription}} tag, whereas the composed elements used {{.}}, which may not yield the same results.

The name of the class may not match the name of the referenced class in the generated _composed_schemas() function.

Note: The use of "unescapedDescription" as a holder for the name of the Python class is very confusing. I saw the comments indicating there are no other fields that can be used, but still imo it's not a pretty workaround.
https://github.com/OpenAPITools/openapi-generator/blob/master/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonClientExperimentalCodegen.java#L753

The problem occurs in the following scenario:
```yaml
components:
  schemas:
   os.Install:
      allOf:
        - '#/components/schemas/os.AbstractXYZ'
        - type: object
           properties:
               ...
```

The name of the generated class is "OsIntall", but the code generator also creates a reference to the "OSInstall" type.

Update: the PR as is does not work. @spacether , do you have a suggestion on how to change the template such that the compose schema references will match the unescapedDescription tag?


<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [ ] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [ ] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
