### PR TITLE
Removal of Encoding in the Query-Params in order to prevent double En…

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/webclient/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/webclient/ApiClient.mustache
@@ -555,23 +555,11 @@ public class ApiClient {
         updateParamsForAuth(authNames, queryParams, headerParams, cookieParams);
 
         final UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(basePath).path(path);
-        if (queryParams != null) {
-            //encode the query parameters in case they contain unsafe characters
-            for (List<String> values : queryParams.values()) {
-                if (values != null) {
-                    for (int i = 0; i < values.size(); i++) {
-                        try {
-                            values.set(i, URLEncoder.encode(values.get(i), "utf8"));
-                        } catch (UnsupportedEncodingException e) {
-
-                        }
-                    }
-                }
-            }
+        if (queryParams != null) {         
             builder.queryParams(queryParams);
         }
 
-        final WebClient.RequestBodySpec requestBuilder = webClient.method(method).uri(builder.encode().toUriString(), pathParams);
+        final WebClient.RequestBodySpec requestBuilder = webClient.method(method).uri(builder.build(false).toUriString(), pathParams);
         if(accept != null) {
             requestBuilder.accept(accept.toArray(new MediaType[accept.size()]));
         }


### PR DESCRIPTION
…coding.

This way letting WebClient do its Job in encoding the URL.
