### PR TITLE
[go] Add Ptr method to const enum values

### DIFF
--- a/modules/openapi-generator/src/main/resources/go-experimental/model.mustache
+++ b/modules/openapi-generator/src/main/resources/go-experimental/model.mustache
@@ -25,6 +25,12 @@ const (
 	{{/enumVars}}
 	{{/allowableValues}}
 )
+
+// Ptr returns reference to {{{name}}} value
+func (v {{{classname}}}) Ptr() *{{{classname}}} {
+	return &v
+}
+
 {{/isEnum}}
 {{^isEnum}}
 // {{classname}}{{#description}} {{{description}}}{{/description}}{{^description}} struct for {{{classname}}}{{/description}}

--- a/samples/client/petstore/go-experimental/go-petstore/model_enum_class.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_enum_class.go
@@ -24,6 +24,12 @@ const (
 	XYZ EnumClass = "(xyz)"
 )
 
+// Ptr returns reference to EnumClass value
+func (v EnumClass) Ptr() *EnumClass {
+	return &v
+}
+
+
 type NullableEnumClass struct {
 	Value EnumClass
 	ExplicitNull bool

--- a/samples/client/petstore/go-experimental/go-petstore/model_outer_enum.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_outer_enum.go
@@ -24,6 +24,12 @@ const (
 	DELIVERED OuterEnum = "delivered"
 )
 
+// Ptr returns reference to OuterEnum value
+func (v OuterEnum) Ptr() *OuterEnum {
+	return &v
+}
+
+
 type NullableOuterEnum struct {
 	Value OuterEnum
 	ExplicitNull bool

--- a/samples/client/petstore/scala-gatling/bin/gatling/loginUser-queryParams.csv
+++ b/samples/client/petstore/scala-gatling/bin/gatling/loginUser-queryParams.csv
@@ -1,1 +1,1 @@
-username,password
+password,username

--- a/samples/client/petstore/scala-gatling/bin/gatling/org/openapitools/client/api/UserApiSimulation.scala
+++ b/samples/client/petstore/scala-gatling/bin/gatling/org/openapitools/client/api/UserApiSimulation.scala
@@ -147,8 +147,8 @@ class UserApiSimulation extends Simulation {
         .feed(loginUserQUERYFeeder)
         .exec(http("loginUser")
         .httpRequest("GET","/user/login")
-        .queryParam("username","${username}")
         .queryParam("password","${password}")
+        .queryParam("username","${username}")
 )
 
     // Run scnloginUser with warm up and reach a constant rate for entire duration

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_enum_class.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_enum_class.go
@@ -24,6 +24,12 @@ const (
 	ENUMCLASS_XYZ EnumClass = "(xyz)"
 )
 
+// Ptr returns reference to EnumClass value
+func (v EnumClass) Ptr() *EnumClass {
+	return &v
+}
+
+
 type NullableEnumClass struct {
 	Value EnumClass
 	ExplicitNull bool

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_outer_enum.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_outer_enum.go
@@ -24,6 +24,12 @@ const (
 	OUTERENUM_DELIVERED OuterEnum = "delivered"
 )
 
+// Ptr returns reference to OuterEnum value
+func (v OuterEnum) Ptr() *OuterEnum {
+	return &v
+}
+
+
 type NullableOuterEnum struct {
 	Value OuterEnum
 	ExplicitNull bool

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_outer_enum_default_value.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_outer_enum_default_value.go
@@ -24,6 +24,12 @@ const (
 	OUTERENUMDEFAULTVALUE_DELIVERED OuterEnumDefaultValue = "delivered"
 )
 
+// Ptr returns reference to OuterEnumDefaultValue value
+func (v OuterEnumDefaultValue) Ptr() *OuterEnumDefaultValue {
+	return &v
+}
+
+
 type NullableOuterEnumDefaultValue struct {
 	Value OuterEnumDefaultValue
 	ExplicitNull bool

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_outer_enum_integer.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_outer_enum_integer.go
@@ -24,6 +24,12 @@ const (
 	OUTERENUMINTEGER__2 OuterEnumInteger = 2
 )
 
+// Ptr returns reference to OuterEnumInteger value
+func (v OuterEnumInteger) Ptr() *OuterEnumInteger {
+	return &v
+}
+
+
 type NullableOuterEnumInteger struct {
 	Value OuterEnumInteger
 	ExplicitNull bool

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_outer_enum_integer_default_value.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_outer_enum_integer_default_value.go
@@ -24,6 +24,12 @@ const (
 	OUTERENUMINTEGERDEFAULTVALUE__2 OuterEnumIntegerDefaultValue = 2
 )
 
+// Ptr returns reference to OuterEnumIntegerDefaultValue value
+func (v OuterEnumIntegerDefaultValue) Ptr() *OuterEnumIntegerDefaultValue {
+	return &v
+}
+
+
 type NullableOuterEnumIntegerDefaultValue struct {
 	Value OuterEnumIntegerDefaultValue
 	ExplicitNull bool


### PR DESCRIPTION
Adds `Ptr` method that returns a reference to the constant enum value.

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.


---
@antihax (2017/11) @bvwells (2017/12) @grokify (2018/07) @kemokemo (2018/09) @bkabrda (2019/07)