### PR TITLE
[kotlin]Fix ktor doesn't generate nullable types

### DIFF
--- a/modules/openapi-generator/src/main/resources/kotlin-server/libraries/ktor/Paths.kt.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-server/libraries/ktor/Paths.kt.mustache
@@ -18,7 +18,7 @@ object Paths {
      {{#allParams}}* @param {{paramName}} {{description}} {{^required}}(optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}
      {{/allParams}}*/
     @KtorExperimentalLocationsAPI
-    @Location("{{path}}") class {{operationId}}({{#allParams}}val {{paramName}}: {{{dataType}}}{{^required}}? = null{{/required}}{{#hasMore}}, {{/hasMore}}{{/allParams}})
+    @Location("{{path}}") class {{operationId}}({{#allParams}}val {{paramName}}: {{{dataType}}}{{^required}}? = null{{/required}}{{#required}}{{#isNullable}}?{{/isNullable}}{{/required}}{{#hasMore}}, {{/hasMore}}{{/allParams}})
 
     {{/bodyAllowed}}
     {{/operation}}

--- a/modules/openapi-generator/src/main/resources/kotlin-server/libraries/ktor/Paths.kt.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-server/libraries/ktor/Paths.kt.mustache
@@ -18,7 +18,7 @@ object Paths {
      {{#allParams}}* @param {{paramName}} {{description}} {{^required}}(optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}
      {{/allParams}}*/
     @KtorExperimentalLocationsAPI
-    @Location("{{path}}") class {{operationId}}({{#allParams}}val {{paramName}}: {{{dataType}}}{{#hasMore}}, {{/hasMore}}{{/allParams}})
+    @Location("{{path}}") class {{operationId}}({{#allParams}}val {{paramName}}: {{{dataType}}}{{^required}}? = null{{/required}}{{#hasMore}}, {{/hasMore}}{{/allParams}})
 
     {{/bodyAllowed}}
     {{/operation}}

--- a/samples/server/petstore/kotlin-server/ktor/src/main/kotlin/org/openapitools/server/Paths.kt
+++ b/samples/server/petstore/kotlin-server/ktor/src/main/kotlin/org/openapitools/server/Paths.kt
@@ -22,7 +22,7 @@ object Paths {
      * @param apiKey  (optional)
      */
     @KtorExperimentalLocationsAPI
-    @Location("/pet/{petId}") class deletePet(val petId: kotlin.Long, val apiKey: kotlin.String)
+    @Location("/pet/{petId}") class deletePet(val petId: kotlin.Long, val apiKey: kotlin.String? = null)
 
     /**
      * Finds Pets by status


### PR DESCRIPTION
fixes #5198

Optional parameters have to annotated as nullable

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

I can't find `./bin/openapi3/kotlin-server-petstore.sh`:cry: