### PR TITLE
[typescript] Don't hardcode the date type if user has mapped it

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractTypeScriptClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractTypeScriptClientCodegen.java
@@ -158,7 +158,7 @@ public abstract class AbstractTypeScriptClientCodegen extends DefaultCodegen imp
         typeMapping.put("Map", "any");
         typeMapping.put("map", "any");
         typeMapping.put("date", "string");
-        typeMapping.put("DateTime", "Date");
+        typeMapping.put("DateTime", "string");
         typeMapping.put("binary", "any");
         typeMapping.put("File", "any");
         typeMapping.put("file", "any");

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptAngularClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptAngularClientCodegen.java
@@ -86,6 +86,8 @@ public class TypeScriptAngularClientCodegen extends AbstractTypeScriptClientCode
         apiPackage = "api";
         modelPackage = "model";
 
+        typeMapping.put("DateTime", "Date");
+
         this.cliOptions.add(new CliOption(NPM_REPOSITORY,
                 "Use this property to set an url your private npmRepo in the package.json"));
         this.cliOptions.add(CliOption.newBoolean(WITH_INTERFACES,

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptAngularJsClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptAngularJsClientCodegen.java
@@ -34,6 +34,8 @@ public class TypeScriptAngularJsClientCodegen extends AbstractTypeScriptClientCo
         apiPackage = "api";
         modelPackage = "model";
 
+        typeMapping.put("DateTime", "Date");
+
         removeOption(NPM_NAME);
         removeOption(NPM_VERSION);
         removeOption(SNAPSHOT);

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptAureliaClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptAureliaClientCodegen.java
@@ -37,6 +37,7 @@ public class TypeScriptAureliaClientCodegen extends AbstractTypeScriptClientCode
         outputFolder = "generated-code/typescript-aurelia";
         embeddedTemplateDir = templateDir = "typescript-aurelia";
 
+        typeMapping.put("DateTime", "Date");
     }
 
     @Override

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptAxiosClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptAxiosClientCodegen.java
@@ -55,6 +55,8 @@ public class TypeScriptAxiosClientCodegen extends AbstractTypeScriptClientCodege
         outputFolder = "generated-code/typescript-axios";
         embeddedTemplateDir = templateDir = "typescript-axios";
 
+        typeMapping.put("DateTime", "Date");
+
         this.cliOptions.add(new CliOption(NPM_REPOSITORY, "Use this property to set an url of your private npmRepo in the package.json"));
         this.cliOptions.add(new CliOption(WITH_INTERFACES, "Setting this property to true will generate interfaces next to the default class implementations.", SchemaTypeUtil.BOOLEAN_TYPE).defaultValue(Boolean.FALSE.toString()));
         this.cliOptions.add(new CliOption(SEPARATE_MODELS_AND_API, "Put the model and api in separate folders and in separate classes", SchemaTypeUtil.BOOLEAN_TYPE).defaultValue(Boolean.FALSE.toString()));

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptFetchClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptFetchClientCodegen.java
@@ -134,15 +134,10 @@ public class TypeScriptFetchClientCodegen extends AbstractTypeScriptClientCodege
 
     @Override
     public String getTypeDeclaration(Schema p) {
-        String oasType = getSchemaType(p);
         if (ModelUtils.isFileSchema(p)) {
             return "Blob";
         } else if (ModelUtils.isBinarySchema(p)) {
             return "Blob";
-        } else if (ModelUtils.isDateSchema(p)) {
-            return typeMapping.containsKey("Date") ? typeMapping.get("Date") : "Date";
-        } else if (ModelUtils.isDateTimeSchema(p)) {
-            return typeMapping.containsKey("Date") ? typeMapping.get("Date") : "Date";
         }
         return super.getTypeDeclaration(p);
     }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptFetchClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptFetchClientCodegen.java
@@ -63,6 +63,9 @@ public class TypeScriptFetchClientCodegen extends AbstractTypeScriptClientCodege
         this.modelTemplateFiles.put("models.mustache", ".ts");
         this.addExtraReservedWords();
 
+        typeMapping.put("date", "Date");
+        typeMapping.put("DateTime", "Date");
+
         this.cliOptions.add(new CliOption(NPM_REPOSITORY, "Use this property to set an url your private npmRepo in the package.json"));
         this.cliOptions.add(new CliOption(WITH_INTERFACES, "Setting this property to true will generate interfaces next to the default class implementations.", SchemaTypeUtil.BOOLEAN_TYPE).defaultValue(Boolean.FALSE.toString()));
         this.cliOptions.add(new CliOption(USE_SINGLE_REQUEST_PARAMETER, "Setting this property to true will generate functions with a single argument containing all API endpoint parameters instead of one argument per parameter.", SchemaTypeUtil.BOOLEAN_TYPE).defaultValue(Boolean.TRUE.toString()));

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptFetchClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptFetchClientCodegen.java
@@ -134,14 +134,15 @@ public class TypeScriptFetchClientCodegen extends AbstractTypeScriptClientCodege
 
     @Override
     public String getTypeDeclaration(Schema p) {
+        String oasType = getSchemaType(p);
         if (ModelUtils.isFileSchema(p)) {
             return "Blob";
         } else if (ModelUtils.isBinarySchema(p)) {
             return "Blob";
         } else if (ModelUtils.isDateSchema(p)) {
-            return "Date";
+            return typeMapping.containsKey("Date") ? typeMapping.get("Date") : "Date";
         } else if (ModelUtils.isDateTimeSchema(p)) {
-            return "Date";
+            return typeMapping.containsKey("Date") ? typeMapping.get("Date") : "Date";
         }
         return super.getTypeDeclaration(p);
     }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptInversifyClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptInversifyClientCodegen.java
@@ -58,6 +58,8 @@ public class TypeScriptInversifyClientCodegen extends AbstractTypeScriptClientCo
         apiPackage = "api";
         modelPackage = "model";
 
+        typeMapping.put("DateTime", "Date");
+
         this.reservedWords.add("map");
 
         this.cliOptions.add(new CliOption(NPM_REPOSITORY,

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptJqueryClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptJqueryClientCodegen.java
@@ -53,6 +53,8 @@ public class TypeScriptJqueryClientCodegen extends AbstractTypeScriptClientCodeg
         outputFolder = "generated-code/typescript-jquery";
         embeddedTemplateDir = templateDir = "typescript-jquery";
 
+        typeMapping.put("DateTime", "Date");
+
         this.cliOptions.add(new CliOption(NPM_REPOSITORY, "Use this property to set an url your private npmRepo in the package.json"));
         this.cliOptions.add(new CliOption(JQUERY_ALREADY_IMPORTED,
                 "When using this in legacy app using mix of typescript and javascript, this will only declare jquery and not import it",

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptNodeClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptNodeClientCodegen.java
@@ -55,6 +55,8 @@ public class TypeScriptNodeClientCodegen extends AbstractTypeScriptClientCodegen
         // at the moment
         importMapping.clear();
 
+        typeMapping.put("DateTime", "Date");
+
         outputFolder = "generated-code/typescript-node";
         embeddedTemplateDir = templateDir = "typescript-node";
         modelTemplateFiles.put("model.mustache", ".ts");

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptReduxQueryClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptReduxQueryClientCodegen.java
@@ -103,14 +103,15 @@ public class TypeScriptReduxQueryClientCodegen extends AbstractTypeScriptClientC
 
     @Override
     public String getTypeDeclaration(Schema p) {
+        String oasType = getSchemaType(p);
         if (ModelUtils.isFileSchema(p)) {
             return "Blob";
         } else if (ModelUtils.isBinarySchema(p)) {
             return "Blob";
         } else if (ModelUtils.isDateSchema(p)) {
-            return "Date";
+            return typeMapping.containsKey("Date") ? typeMapping.get("Date") : "Date";
         } else if (ModelUtils.isDateTimeSchema(p)) {
-            return "Date";
+            return typeMapping.containsKey("Date") ? typeMapping.get("Date") : "Date";
         }
         return super.getTypeDeclaration(p);
     }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptReduxQueryClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptReduxQueryClientCodegen.java
@@ -103,15 +103,10 @@ public class TypeScriptReduxQueryClientCodegen extends AbstractTypeScriptClientC
 
     @Override
     public String getTypeDeclaration(Schema p) {
-        String oasType = getSchemaType(p);
         if (ModelUtils.isFileSchema(p)) {
             return "Blob";
         } else if (ModelUtils.isBinarySchema(p)) {
             return "Blob";
-        } else if (ModelUtils.isDateSchema(p)) {
-            return typeMapping.containsKey("Date") ? typeMapping.get("Date") : "Date";
-        } else if (ModelUtils.isDateTimeSchema(p)) {
-            return typeMapping.containsKey("Date") ? typeMapping.get("Date") : "Date";
         }
         return super.getTypeDeclaration(p);
     }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptReduxQueryClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptReduxQueryClientCodegen.java
@@ -58,6 +58,9 @@ public class TypeScriptReduxQueryClientCodegen extends AbstractTypeScriptClientC
         this.modelTemplateFiles.put("models.mustache", ".ts");
         this.addExtraReservedWords();
 
+        typeMapping.put("date", "Date");
+        typeMapping.put("DateTime", "Date");
+
         this.cliOptions.add(new CliOption(NPM_REPOSITORY, "Use this property to set an url your private npmRepo in the package.json"));
         this.cliOptions.add(new CliOption(WITH_INTERFACES, "Setting this property to true will generate interfaces next to the default class implementations.", SchemaTypeUtil.BOOLEAN_TYPE).defaultValue(Boolean.FALSE.toString()));
         this.cliOptions.add(new CliOption(USE_SINGLE_REQUEST_PARAMETER, "Setting this property to true will generate functions with a single argument containing all API endpoint parameters instead of one argument per parameter.", SchemaTypeUtil.BOOLEAN_TYPE).defaultValue(Boolean.TRUE.toString()));

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptRxjsClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptRxjsClientCodegen.java
@@ -58,6 +58,7 @@ public class TypeScriptRxjsClientCodegen extends AbstractTypeScriptClientCodegen
 
         languageSpecificPrimitives.add("Blob");
         typeMapping.put("file", "Blob");
+        typeMapping.put("DateTime", "Date");
 
         this.cliOptions.add(new CliOption(NPM_REPOSITORY, "Use this property to set an url your private npmRepo in the package.json"));
         this.cliOptions.add(new CliOption(WITH_INTERFACES, "Setting this property to true will generate interfaces next to the default class implementations.", SchemaTypeUtil.BOOLEAN_TYPE).defaultValue(Boolean.FALSE.toString()));
@@ -109,9 +110,7 @@ public class TypeScriptRxjsClientCodegen extends AbstractTypeScriptClientCodegen
 
     @Override
     public String getTypeDeclaration(Schema p) {
-        if (ModelUtils.isFileSchema(p)) {
-            return "Blob";
-        } else if (ModelUtils.isBinarySchema(p)) {
+        if (ModelUtils.isBinarySchema(p)) {
             return "Blob";
         }
         return super.getTypeDeclaration(p);

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptRxjsClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptRxjsClientCodegen.java
@@ -109,15 +109,10 @@ public class TypeScriptRxjsClientCodegen extends AbstractTypeScriptClientCodegen
 
     @Override
     public String getTypeDeclaration(Schema p) {
-        String oasType = getSchemaType(p);
         if (ModelUtils.isFileSchema(p)) {
             return "Blob";
         } else if (ModelUtils.isBinarySchema(p)) {
             return "Blob";
-        } else if (ModelUtils.isDateSchema(p)) {
-            return typeMapping.containsKey("Date") ? typeMapping.get("Date") : "Date";
-        } else if (ModelUtils.isDateTimeSchema(p)) {
-            return typeMapping.containsKey("Date") ? typeMapping.get("Date") : "Date";
         }
         return super.getTypeDeclaration(p);
     }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptRxjsClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptRxjsClientCodegen.java
@@ -109,14 +109,15 @@ public class TypeScriptRxjsClientCodegen extends AbstractTypeScriptClientCodegen
 
     @Override
     public String getTypeDeclaration(Schema p) {
+        String oasType = getSchemaType(p);
         if (ModelUtils.isFileSchema(p)) {
             return "Blob";
         } else if (ModelUtils.isBinarySchema(p)) {
             return "Blob";
         } else if (ModelUtils.isDateSchema(p)) {
-            return "Date";
+            return typeMapping.containsKey("Date") ? typeMapping.get("Date") : "Date";
         } else if (ModelUtils.isDateTimeSchema(p)) {
-            return "Date";
+            return typeMapping.containsKey("Date") ? typeMapping.get("Date") : "Date";
         }
         return super.getTypeDeclaration(p);
     }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/fetch/TypeScriptFetchModelTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/fetch/TypeScriptFetchModelTest.java
@@ -95,7 +95,7 @@ public class TypeScriptFetchModelTest {
         final CodegenProperty property4 = cm.vars.get(3);
         Assert.assertEquals(property4.baseName, "birthDate");
         Assert.assertEquals(property4.complexType, null);
-        Assert.assertEquals(property4.dataType, "Date");
+        Assert.assertEquals(property4.dataType, "string");
         Assert.assertEquals(property4.name, "birthDate");
         Assert.assertEquals(property4.defaultValue, "undefined");
         Assert.assertFalse(property4.hasMore);

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/fetch/TypeScriptFetchModelTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/fetch/TypeScriptFetchModelTest.java
@@ -95,7 +95,7 @@ public class TypeScriptFetchModelTest {
         final CodegenProperty property4 = cm.vars.get(3);
         Assert.assertEquals(property4.baseName, "birthDate");
         Assert.assertEquals(property4.complexType, null);
-        Assert.assertEquals(property4.dataType, "string");
+        Assert.assertEquals(property4.dataType, "Date");
         Assert.assertEquals(property4.name, "birthDate");
         Assert.assertEquals(property4.defaultValue, "undefined");
         Assert.assertFalse(property4.hasMore);


### PR DESCRIPTION
If the user has set --type-mappings Date=foo, respect this setting
instead of hardcoding the date type.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
