### PR TITLE
[go] Fix filenames with $GOOS and $GOARCH sufixes

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractGoCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractGoCodegen.java
@@ -228,11 +228,28 @@ public abstract class AbstractGoCodegen extends DefaultCodegen implements Codege
         return camelize(toModel(name));
     }
 
+    protected boolean isReservedFilename(String name) {
+        String[] parts = name.split("_");
+        String suffix = parts[parts.length - 1];
+
+        reservedSuffixes = new HashSet<String>(Arrays.asList(
+                // Test
+                "test",
+                // $GOOS
+                "aix", "android", "darwin", "dragonfly", "freebsd", "illumos", "js", "linux", "netbsd", "openbsd",
+                "plan9", "solaris", "windows",
+                // $GOARCH
+                "386", "amd64", "arm", "arm64", "mips", "mips64", "mips64le", "mipsle", "ppc64", "ppc64le", "s390x",
+                "wasm"));
+        return name != null && reservedSuffixes.contains(name);
+    }
+
     @Override
     public String toModelFilename(String name) {
         name = toModel("model_" + name);
-        if (name.endsWith("_test")) {
-            LOGGER.warn(name + ".go with `_test.go` suffix (reserved word) cannot be used as filename. Renamed to " + name + "_.go");
+
+        if (isReservedFilename(name)) {
+            LOGGER.warn(name + ".go with suffix (reserved word) cannot be used as filename. Renamed to " + name + "_.go");
             name += "_";
         }
         return name;
@@ -279,8 +296,8 @@ public abstract class AbstractGoCodegen extends DefaultCodegen implements Codege
 
         // e.g. PetApi.go => pet_api.go
         name = "api_" + underscore(name);
-        if (name.endsWith("_test")) {
-            LOGGER.warn(name + ".go with `_test.go` suffix (reserved word) cannot be used as filename. Renamed to " + name + "_.go");
+        if (isReservedFilename(name)) {
+            LOGGER.warn(name + ".go with suffix (reserved word) cannot be used as filename. Renamed to " + name + "_.go");
             name += "_";
         }
         return name;
@@ -341,10 +358,10 @@ public abstract class AbstractGoCodegen extends DefaultCodegen implements Codege
             type = openAPIType;
         return type;
     }
-    
+
     /**
      * Determines the golang instantiation type of the specified schema.
-     * 
+     *
      * This function is called when the input schema is a map, and specifically
      * when the 'additionalProperties' attribute is present in the OAS specification.
      * Codegen invokes this function to resolve the "parent" association to
@@ -354,7 +371,7 @@ public abstract class AbstractGoCodegen extends DefaultCodegen implements Codege
      * - Indicate a polymorphic association with some other type (e.g. class inheritance).
      * - If the specification has a discriminator, cogegen create a “parent” based on the discriminator.
      * - Use of the 'additionalProperties' attribute in the OAS specification.
-     *   This is the specific scenario when codegen invokes this function. 
+     *   This is the specific scenario when codegen invokes this function.
      *
      * @param property the input schema
      *

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractGoCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractGoCodegen.java
@@ -241,7 +241,7 @@ public abstract class AbstractGoCodegen extends DefaultCodegen implements Codege
                 // $GOARCH
                 "386", "amd64", "arm", "arm64", "mips", "mips64", "mips64le", "mipsle", "ppc64", "ppc64le", "s390x",
                 "wasm"));
-        return name != null && reservedSuffixes.contains(name);
+        return reservedSuffixes.contains(suffix);
     }
 
     @Override

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractGoCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractGoCodegen.java
@@ -232,7 +232,7 @@ public abstract class AbstractGoCodegen extends DefaultCodegen implements Codege
         String[] parts = name.split("_");
         String suffix = parts[parts.length - 1];
 
-        reservedSuffixes = new HashSet<String>(Arrays.asList(
+        Set<String> reservedSuffixes = new HashSet<String>(Arrays.asList(
                 // Test
                 "test",
                 // $GOOS


### PR DESCRIPTION
Avoid using filename with sufixes with valid `$GOOS` or `$GOARCH` to avoid surprises.

❗️ **Huge thanks to @zippolyte for identifying this issue.** ❗️ 

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [ ] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [ ] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

--
@antihax (2017/11) @bvwells (2017/12) @grokify (2018/07) @kemokemo (2018/09) @bkabrda (2019/07)