### PR TITLE
[BUG][TYPESCRIPT-RXJS] Format Date is converted to Date-Time

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-rxjs/apis.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-rxjs/apis.mustache
@@ -108,7 +108,7 @@ export class {{classname}} extends BaseAPI {
             {{/isDateTime}}
             {{^isDateTime}}
             {{#isDate}}
-            '{{baseName}}': ({{> paramNamePartial}} as any).toISOString(),
+            '{{baseName}}': ({{> paramNamePartial}} as any).toISOString().split('T')[0],
             {{/isDate}}
             {{^isDate}}
             '{{baseName}}': {{> paramNamePartial}},
@@ -137,7 +137,7 @@ export class {{classname}} extends BaseAPI {
         {{/isDateTime}}
         {{^isDateTime}}
         {{#isDate}}
-        if ({{> paramNamePartial}} != null) { query['{{baseName}}'] = ({{> paramNamePartial}} as any).toISOString(); }
+        if ({{> paramNamePartial}} != null) { query['{{baseName}}'] = ({{> paramNamePartial}} as any).toISOString().split('T')[0]; }
         {{/isDate}}
         {{^isDate}}
         if ({{> paramNamePartial}} != null) { query['{{baseName}}'] = {{> paramNamePartial}}; }


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

This PR fixes the wrong formatting of format 'date' for the typescript rxjs generator. It was falsely converted to 'date-time' (e.g. '2019-12-10T17:56:56.999Z') but should look like '2019-12-10'.

Fix #4763

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@TiFu (2017/07) @taxpon (2017/07) @sebastianhaas (2017/07) @kenisteward (2017/07) @Vrolijkx (2017/09) @macjohnny (2018/01) @nicokoenig (2018/09) @topce (2018/10) @akehir (2019/07) @petejohansonxo (2019/11) @amakhrov (2020/02)
