### PR TITLE
typescript-angular: single request parameter documentation

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-angular/api.service.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-angular/api.service.mustache
@@ -44,7 +44,8 @@ import {
 {{#allParams.0}}
 export interface {{#prefixParameterInterfaces}}{{classname}}{{/prefixParameterInterfaces}}{{operationIdCamelCase}}RequestParams {
 {{#allParams}}
-    {{paramName}}{{^required}}?{{/required}}: {{{dataType}}}{{#isNullable}} | null{{/isNullable}};
+    {{#description}}/** {{description}} */
+    {{/description}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}{{#isNullable}} | null{{/isNullable}};
 {{/allParams}}
 }
 

--- a/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/single-request-parameter/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/single-request-parameter/api/pet.service.ts
@@ -25,39 +25,51 @@ import { Configuration }                                     from '../configurat
 
 
 export interface AddPetRequestParams {
+    /** Pet object that needs to be added to the store */
     body: Pet;
 }
 
 export interface DeletePetRequestParams {
+    /** Pet id to delete */
     petId: number;
     apiKey?: string;
 }
 
 export interface FindPetsByStatusRequestParams {
+    /** Status values that need to be considered for filter */
     status: Array<'available' | 'pending' | 'sold'>;
 }
 
 export interface FindPetsByTagsRequestParams {
+    /** Tags to filter by */
     tags: Array<string>;
 }
 
 export interface GetPetByIdRequestParams {
+    /** ID of pet to return */
     petId: number;
 }
 
 export interface UpdatePetRequestParams {
+    /** Pet object that needs to be added to the store */
     body: Pet;
 }
 
 export interface UpdatePetWithFormRequestParams {
+    /** ID of pet that needs to be updated */
     petId: number;
+    /** Updated name of the pet */
     name?: string;
+    /** Updated status of the pet */
     status?: string;
 }
 
 export interface UploadFileRequestParams {
+    /** ID of pet to update */
     petId: number;
+    /** Additional data to pass to server */
     additionalMetadata?: string;
+    /** file to upload */
     file?: Blob;
 }
 

--- a/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/single-request-parameter/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/single-request-parameter/api/store.service.ts
@@ -24,14 +24,17 @@ import { Configuration }                                     from '../configurat
 
 
 export interface DeleteOrderRequestParams {
+    /** ID of the order that needs to be deleted */
     orderId: string;
 }
 
 export interface GetOrderByIdRequestParams {
+    /** ID of pet that needs to be fetched */
     orderId: number;
 }
 
 export interface PlaceOrderRequestParams {
+    /** order placed for purchasing the pet */
     body: Order;
 }
 

--- a/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/single-request-parameter/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/single-request-parameter/api/user.service.ts
@@ -24,32 +24,41 @@ import { Configuration }                                     from '../configurat
 
 
 export interface CreateUserRequestParams {
+    /** Created user object */
     body: User;
 }
 
 export interface CreateUsersWithArrayInputRequestParams {
+    /** List of user object */
     body: Array<User>;
 }
 
 export interface CreateUsersWithListInputRequestParams {
+    /** List of user object */
     body: Array<User>;
 }
 
 export interface DeleteUserRequestParams {
+    /** The name that needs to be deleted */
     username: string;
 }
 
 export interface GetUserByNameRequestParams {
+    /** The name that needs to be fetched. Use user1 for testing. */
     username: string;
 }
 
 export interface LoginUserRequestParams {
+    /** The user name for login */
     username: string;
+    /** The password for login in clear text */
     password: string;
 }
 
 export interface UpdateUserRequestParams {
+    /** name that need to be deleted */
     username: string;
+    /** Updated user object */
     body: User;
 }
 


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
Fixes #5307 
If useSingleRequestParameter is activated for the Angular generator, a JSDoc comment is added to the generated request parameter interface members (if a description is given in the spec).

_Previously:_
```
export interface ExampleRequestParams {
  test: string;
}
```

_With this PR:_
```
export interface ExampleRequestParams {
  /** An example documentation of the request parameter test. */
  test: string;
}
```

<!-- Please check the completed items below -->
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [X] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [X] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Technical commitee
@TiFu (2017/07) @taxpon (2017/07) @sebastianhaas (2017/07) @kenisteward (2017/07) @Vrolijkx (2017/09) @macjohnny (2018/01) @nicokoenig (2018/09) @topce (2018/10) @akehir (2019/07) @petejohansonxo (2019/11) @amakhrov (2020/02)
