### PR TITLE
[RESOLVE] Added Spring JPA annotations support to SpringCodegen

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenModel.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenModel.java
@@ -74,6 +74,9 @@ public class CodegenModel implements IJsonSchemaValidationProperties {
 
     public Map<String, Object> vendorExtensions = new HashMap<String, Object>();
 
+    public boolean isJpaEntity = false;
+    public Set<String> additionalAnnotations = new TreeSet<String>();
+
     //The type of the value from additional properties. Used in map like objects.
     public String additionalPropertiesType;
 
@@ -97,6 +100,14 @@ public class CodegenModel implements IJsonSchemaValidationProperties {
 
     public void setAdditionalPropertiesType(String additionalPropertiesType) {
         this.additionalPropertiesType = additionalPropertiesType;
+    }
+
+    public Set<String> getAdditionalAnnotations() {
+        return additionalAnnotations;
+    }
+
+    public void setAdditionalAnnotations(Set<String> additionalAnnotations) {
+        this.additionalAnnotations = additionalAnnotations;
     }
 
     public Set<String> getAllMandatory() {
@@ -538,6 +549,7 @@ public class CodegenModel implements IJsonSchemaValidationProperties {
                 hasChildren == that.hasChildren &&
                 isMapModel == that.isMapModel &&
                 hasOnlyReadOnly == that.hasOnlyReadOnly &&
+                isJpaEntity == that.isJpaEntity &&
                 getUniqueItems() == that.getUniqueItems() &&
                 getExclusiveMinimum() == that.getExclusiveMinimum() &&
                 getExclusiveMaximum() == that.getExclusiveMaximum() &&
@@ -580,6 +592,7 @@ public class CodegenModel implements IJsonSchemaValidationProperties {
                 Objects.equals(externalDocumentation, that.externalDocumentation) &&
                 Objects.equals(vendorExtensions, that.vendorExtensions) &&
                 Objects.equals(additionalPropertiesType, that.additionalPropertiesType) &&
+                Objects.equals(getAdditionalAnnotations(), that.getAdditionalAnnotations()) &&
                 Objects.equals(getMaxProperties(), that.getMaxProperties()) &&
                 Objects.equals(getMinProperties(), that.getMinProperties()) &&
                 Objects.equals(getMaxItems(), that.getMaxItems()) &&
@@ -599,14 +612,14 @@ public class CodegenModel implements IJsonSchemaValidationProperties {
                 getInterfaceModels(), getChildren(), anyOf, oneOf, allOf, getName(), getClassname(), getTitle(),
                 getDescription(), getClassVarName(), getModelJson(), getDataType(), getXmlPrefix(), getXmlNamespace(),
                 getXmlName(), getClassFilename(), getUnescapedDescription(), getDiscriminator(), getDefaultValue(),
-                getArrayModelType(), isAlias, isString, isInteger, isLong, isNumber, isNumeric, isFloat, isDouble,
+                getArrayModelType(), isAlias, isString, isInteger, isLong, isNumber, isNumeric, isFloat, isDouble, isJpaEntity,
                 getVars(), getAllVars(), getRequiredVars(), getOptionalVars(), getReadOnlyVars(), getReadWriteVars(),
                 getParentVars(), getAllowableValues(), getMandatory(), getAllMandatory(), getImports(), hasVars,
                 isEmptyVars(), hasMoreModels, hasEnums, isEnum, isNullable, hasRequired, hasOptional, isArrayModel,
                 hasChildren, isMapModel, hasOnlyReadOnly, getExternalDocumentation(), getVendorExtensions(),
                 getAdditionalPropertiesType(), getMaxProperties(), getMinProperties(), getUniqueItems(), getMaxItems(),
                 getMinItems(), getMaxLength(), getMinLength(), getExclusiveMinimum(), getExclusiveMaximum(), getMinimum(),
-                getMaximum(), getPattern(), getMultipleOf());
+                getMaximum(), getPattern(), getMultipleOf(), getAdditionalAnnotations());
     }
 
     @Override
@@ -684,6 +697,8 @@ public class CodegenModel implements IJsonSchemaValidationProperties {
         sb.append(", maximum='").append(maximum).append('\'');
         sb.append(", pattern='").append(pattern).append('\'');
         sb.append(", multipleOf='").append(multipleOf).append('\'');
+        sb.append(", isJpaEntity=").append(isJpaEntity);
+        sb.append(", additionalAnnotations=").append(additionalAnnotations);
         sb.append('}');
         return sb.toString();
     }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenProperty.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenProperty.java
@@ -104,6 +104,9 @@ public class CodegenProperty implements Cloneable, IJsonSchemaValidationProperti
     private Integer minProperties;
     private boolean uniqueItems;
 
+    // JPA annotations
+    public List<String> additionalAnnotations = new ArrayList<>();
+
     // XML
     public boolean isXmlAttribute = false;
     public String xmlPrefix;
@@ -478,6 +481,9 @@ public class CodegenProperty implements Cloneable, IJsonSchemaValidationProperti
             if (this.vendorExtensions != null) {
                 cp.vendorExtensions = new HashMap<String, Object>(this.vendorExtensions);
             }
+            if (this.additionalAnnotations != null) {
+                cp.additionalAnnotations = new LinkedList<>(this.additionalAnnotations);
+            }
 
             return cp;
         } catch (CloneNotSupportedException e) {
@@ -604,6 +610,7 @@ public class CodegenProperty implements Cloneable, IJsonSchemaValidationProperti
         sb.append(", uniqueItems=").append(uniqueItems);
         sb.append(", multipleOf=").append(multipleOf);
         sb.append(", isXmlAttribute=").append(isXmlAttribute);
+        sb.append(", additionalAnnotations=").append(additionalAnnotations);
         sb.append(", xmlPrefix='").append(xmlPrefix).append('\'');
         sb.append(", xmlName='").append(xmlName).append('\'');
         sb.append(", xmlNamespace='").append(xmlNamespace).append('\'');
@@ -686,6 +693,7 @@ public class CodegenProperty implements Cloneable, IJsonSchemaValidationProperti
                 Objects.equals(items, that.items) &&
                 Objects.equals(mostInnerItems, that.mostInnerItems) &&
                 Objects.equals(vendorExtensions, that.vendorExtensions) &&
+                Objects.equals(additionalAnnotations, that.additionalAnnotations) &&
                 Objects.equals(discriminatorValue, that.discriminatorValue) &&
                 Objects.equals(nameInCamelCase, that.nameInCamelCase) &&
                 Objects.equals(nameInSnakeCase, that.nameInSnakeCase) &&
@@ -713,6 +721,6 @@ public class CodegenProperty implements Cloneable, IJsonSchemaValidationProperti
                 isSelfReference, isCircularReference, _enum, allowableValues, items, mostInnerItems,
                 vendorExtensions, hasValidation, isInherited, discriminatorValue, nameInCamelCase,
                 nameInSnakeCase, enumName, maxItems, minItems, isXmlAttribute, xmlPrefix, xmlName,
-                xmlNamespace, isXmlWrapped);
+                xmlNamespace, isXmlWrapped, additionalAnnotations);
     }
 }

--- a/modules/openapi-generator/src/main/resources/JavaSpring/libraries/spring-boot/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/libraries/spring-boot/pom.mustache
@@ -82,6 +82,12 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web{{#reactive}}flux{{/reactive}}</artifactId>
         </dependency>
+        {{#useSpringJpa}}
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+        {{/useSpringJpa}}
         {{#useSpringfox}}
         <!--SpringFox dependencies -->
         <dependency>

--- a/modules/openapi-generator/src/main/resources/JavaSpring/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/pojo.mustache
@@ -2,7 +2,8 @@
  * {{#description}}{{.}}{{/description}}{{^description}}{{classname}}{{/description}}
  */{{#description}}
 @ApiModel(description = "{{{description}}}"){{/description}}
-{{>generatedAnnotation}}{{#discriminator}}{{>typeInfoAnnotation}}{{/discriminator}}{{>xmlAnnotation}}{{>additionalModelTypeAnnotations}}
+{{>generatedAnnotation}}{{#discriminator}}{{>typeInfoAnnotation}}{{/discriminator}}{{>xmlAnnotation}}{{>additionalModelTypeAnnotations}}{{#isJpaEntity}}{{#additionalAnnotations}}
+{{{.}}}{{/additionalAnnotations}}{{/isJpaEntity}}
 public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}}{{^parent}}{{#hateoas}}extends RepresentationModel<{{classname}}> {{/hateoas}}{{/parent}} {{#serializableModel}}implements Serializable{{/serializableModel}} {
 {{#serializableModel}}
   private static final long serialVersionUID = 1L;
@@ -18,7 +19,8 @@ public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}}{{^parent}}
 {{>enumClass}}
     {{/mostInnerItems}}
     {{/isContainer}}
-    {{/isEnum}}
+    {{/isEnum}}{{#additionalAnnotations}}
+  {{{.}}}{{/additionalAnnotations}}
   {{#jackson}}
   @JsonProperty("{{baseName}}"){{#withXml}}
   @JacksonXmlProperty({{#isXmlAttribute}}isAttribute = true, {{/isXmlAttribute}}{{#xmlNamespace}}namespace="{{xmlNamespace}}", {{/xmlNamespace}}localName = "{{#xmlName}}{{xmlName}}{{/xmlName}}{{^xmlName}}{{baseName}}{{/xmlName}}"){{/withXml}}


### PR DESCRIPTION
Added Spring JPA annotations support to SpringCodegen.

Added `additionalAnnotations` to **CodegenModel**, **CodegenProperty**.
Added `isJpaEntity` to **CodegenModel**.
Added `useSpringJpa` config option to **SpringCodegen**.

Example: 

```yaml
User:
  type: object
  x-java-jpa-entity: true
  x-java-jpa-table: users
  properties:
    id:
      type: integer
      format: int64
      x-java-jpa-annotations:
        - "@Id"
        - "@GeneratedValue(strategy = GenerationType.IDENTITY)"
    firstName:
      type: string
    lastName:
      type: string
    username:
      type: string
    passwordHash:
      type: string
```

Would generate this class for you:

```java
/**
 * User
 */
@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2020-02-13T21:44:31.102132Z[Europe/London]")

@Entity // <---- makes this an Entity
@Table(name = "users") // <---- applies table name
public class User   {

  @Id // <---- adds annotations
  @GeneratedValue(strategy = GenerationType.IDENTITY)
  @JsonProperty("id")
  private Long id;


  @JsonProperty("firstName")
  private String firstName;


  @JsonProperty("lastName")
  private String lastName;


  @JsonProperty("username")
  private String username;


  @JsonProperty("passwordHash")
  private String passwordHash;

  public User id(Long id) {
    this.id = id;
    return this;
  }

  /**
   * Get id
   * @return id
  */
  @ApiModelProperty(value = "")


  public Long getId() {
    return id;
  }

  public void setId(Long id) {
    this.id = id;
  }

/// the rest of the file there
```

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04) @lwlee2608 (2019/10) @bkabrda (2020/01)
