### PR TITLE
[python] add method to set/get default configuration

### DIFF
--- a/modules/openapi-generator/src/main/resources/python/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/python/api_client.mustache
@@ -63,7 +63,7 @@ class ApiClient(object):
     def __init__(self, configuration=None, header_name=None, header_value=None,
                  cookie=None, pool_threads=1):
         if configuration is None:
-            configuration = Configuration()
+            configuration = Configuration.get_instance()
         self.configuration = configuration
         self.pool_threads = pool_threads
 

--- a/modules/openapi-generator/src/main/resources/python/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/python/api_client.mustache
@@ -63,7 +63,7 @@ class ApiClient(object):
     def __init__(self, configuration=None, header_name=None, header_value=None,
                  cookie=None, pool_threads=1):
         if configuration is None:
-            configuration = Configuration.get_instance()
+            configuration = Configuration.new_instance()
         self.configuration = configuration
         self.pool_threads = pool_threads
 

--- a/modules/openapi-generator/src/main/resources/python/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/python/api_client.mustache
@@ -63,7 +63,7 @@ class ApiClient(object):
     def __init__(self, configuration=None, header_name=None, header_value=None,
                  cookie=None, pool_threads=1):
         if configuration is None:
-            configuration = Configuration.new_instance()
+            configuration = Configuration.get_default_copy()
         self.configuration = configuration
         self.pool_threads = pool_threads
 

--- a/modules/openapi-generator/src/main/resources/python/configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/python/configuration.mustache
@@ -4,6 +4,7 @@
 
 from __future__ import absolute_import
 
+import copy
 import logging
 {{^asyncio}}
 import multiprocessing
@@ -116,6 +117,8 @@ class Configuration(object):
 {{/hasHttpSignatureMethods}}
 {{/hasAuthMethods}}
     """
+
+    _default = None
 
     def __init__(self, host="{{{basePath}}}",
                  api_key=None, api_key_prefix=None,
@@ -240,6 +243,31 @@ class Configuration(object):
         """
         # Disable client side validation
         self.client_side_validation = True
+
+    @classmethod
+    def set_default(cls, default):
+        """Set default instance of configuration.
+
+        It stores default configuration, which can be
+        returned by get_instance method.
+
+        :param default: object of Configuration
+        """
+        cls._default = copy.copy(default)
+
+    @classmethod
+    def get_instance(cls):
+        """Return new instance of configuration.
+
+        This method returns newly created, based on default constructor,
+        object of Configuration class or returns a copy of default
+        configuration passed by the set_default method.
+
+        :return: The configuration object.
+        """
+        if cls._default is not None:
+            return copy.copy(cls._default)
+        return Configuration()
 
     @property
     def logger_file(self):

--- a/modules/openapi-generator/src/main/resources/python/configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/python/configuration.mustache
@@ -245,18 +245,27 @@ class Configuration(object):
         self.client_side_validation = True
 
     @classmethod
+    def copy(cls, source):
+        if source is None:
+            return None
+        ret = copy.copy(source)
+        ret.api_key = copy.copy(source.api_key)
+        ret.api_key_prefix = copy.copy(source.api_key_prefix)
+        return ret
+
+    @classmethod
     def set_default(cls, default):
         """Set default instance of configuration.
 
         It stores default configuration, which can be
-        returned by get_instance method.
+        returned by new_instance method.
 
         :param default: object of Configuration
         """
-        cls._default = copy.copy(default)
+        cls._default = Configuration.copy(default)
 
     @classmethod
-    def get_instance(cls):
+    def new_instance(cls):
         """Return new instance of configuration.
 
         This method returns newly created, based on default constructor,
@@ -266,7 +275,7 @@ class Configuration(object):
         :return: The configuration object.
         """
         if cls._default is not None:
-            return copy.copy(cls._default)
+            return Configuration.copy(cls._default)
         return Configuration()
 
     @property

--- a/modules/openapi-generator/src/main/resources/python/configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/python/configuration.mustache
@@ -244,28 +244,33 @@ class Configuration(object):
         # Disable client side validation
         self.client_side_validation = True
 
-    @classmethod
-    def copy(cls, source):
-        if source is None:
-            return None
-        ret = copy.copy(source)
-        ret.api_key = copy.copy(source.api_key)
-        ret.api_key_prefix = copy.copy(source.api_key_prefix)
-        return ret
+    def __deepcopy__(self, memo):
+        cls = self.__class__
+        result = cls.__new__(cls)
+        memo[id(self)] = result
+        for k, v in self.__dict__.items():
+            if k not in ('logger', 'logger_file_handler'):
+                setattr(result, k, copy.deepcopy(v, memo))
+        # shallow copy of loggers
+        result.logger = copy.copy(self.logger)
+        # use setters to configure loggers
+        result.logger_file = self.logger_file
+        result.debug = self.debug
+        return result
 
     @classmethod
     def set_default(cls, default):
         """Set default instance of configuration.
 
         It stores default configuration, which can be
-        returned by new_instance method.
+        returned by get_default_copy method.
 
         :param default: object of Configuration
         """
-        cls._default = Configuration.copy(default)
+        cls._default = copy.deepcopy(default)
 
     @classmethod
-    def new_instance(cls):
+    def get_default_copy(cls):
         """Return new instance of configuration.
 
         This method returns newly created, based on default constructor,
@@ -275,7 +280,7 @@ class Configuration(object):
         :return: The configuration object.
         """
         if cls._default is not None:
-            return Configuration.copy(cls._default)
+            return copy.deepcopy(cls._default)
         return Configuration()
 
     @property

--- a/samples/client/petstore/python-asyncio/petstore_api/api_client.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/api_client.py
@@ -68,7 +68,7 @@ class ApiClient(object):
     def __init__(self, configuration=None, header_name=None, header_value=None,
                  cookie=None, pool_threads=1):
         if configuration is None:
-            configuration = Configuration()
+            configuration = Configuration.get_instance()
         self.configuration = configuration
         self.pool_threads = pool_threads
 

--- a/samples/client/petstore/python-asyncio/petstore_api/api_client.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/api_client.py
@@ -68,7 +68,7 @@ class ApiClient(object):
     def __init__(self, configuration=None, header_name=None, header_value=None,
                  cookie=None, pool_threads=1):
         if configuration is None:
-            configuration = Configuration.new_instance()
+            configuration = Configuration.get_default_copy()
         self.configuration = configuration
         self.pool_threads = pool_threads
 

--- a/samples/client/petstore/python-asyncio/petstore_api/api_client.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/api_client.py
@@ -68,7 +68,7 @@ class ApiClient(object):
     def __init__(self, configuration=None, header_name=None, header_value=None,
                  cookie=None, pool_threads=1):
         if configuration is None:
-            configuration = Configuration.get_instance()
+            configuration = Configuration.new_instance()
         self.configuration = configuration
         self.pool_threads = pool_threads
 

--- a/samples/client/petstore/python-asyncio/petstore_api/configuration.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/configuration.py
@@ -168,28 +168,33 @@ class Configuration(object):
         # Disable client side validation
         self.client_side_validation = True
 
-    @classmethod
-    def copy(cls, source):
-        if source is None:
-            return None
-        ret = copy.copy(source)
-        ret.api_key = copy.copy(source.api_key)
-        ret.api_key_prefix = copy.copy(source.api_key_prefix)
-        return ret
+    def __deepcopy__(self, memo):
+        cls = self.__class__
+        result = cls.__new__(cls)
+        memo[id(self)] = result
+        for k, v in self.__dict__.items():
+            if k not in ('logger', 'logger_file_handler'):
+                setattr(result, k, copy.deepcopy(v, memo))
+        # shallow copy of loggers
+        result.logger = copy.copy(self.logger)
+        # use setters to configure loggers
+        result.logger_file = self.logger_file
+        result.debug = self.debug
+        return result
 
     @classmethod
     def set_default(cls, default):
         """Set default instance of configuration.
 
         It stores default configuration, which can be
-        returned by new_instance method.
+        returned by get_default_copy method.
 
         :param default: object of Configuration
         """
-        cls._default = Configuration.copy(default)
+        cls._default = copy.deepcopy(default)
 
     @classmethod
-    def new_instance(cls):
+    def get_default_copy(cls):
         """Return new instance of configuration.
 
         This method returns newly created, based on default constructor,
@@ -199,7 +204,7 @@ class Configuration(object):
         :return: The configuration object.
         """
         if cls._default is not None:
-            return Configuration.copy(cls._default)
+            return copy.deepcopy(cls._default)
         return Configuration()
 
     @property

--- a/samples/client/petstore/python-asyncio/petstore_api/configuration.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/configuration.py
@@ -169,18 +169,27 @@ class Configuration(object):
         self.client_side_validation = True
 
     @classmethod
+    def copy(cls, source):
+        if source is None:
+            return None
+        ret = copy.copy(source)
+        ret.api_key = copy.copy(source.api_key)
+        ret.api_key_prefix = copy.copy(source.api_key_prefix)
+        return ret
+
+    @classmethod
     def set_default(cls, default):
         """Set default instance of configuration.
 
         It stores default configuration, which can be
-        returned by get_instance method.
+        returned by new_instance method.
 
         :param default: object of Configuration
         """
-        cls._default = copy.copy(default)
+        cls._default = Configuration.copy(default)
 
     @classmethod
-    def get_instance(cls):
+    def new_instance(cls):
         """Return new instance of configuration.
 
         This method returns newly created, based on default constructor,
@@ -190,7 +199,7 @@ class Configuration(object):
         :return: The configuration object.
         """
         if cls._default is not None:
-            return copy.copy(cls._default)
+            return Configuration.copy(cls._default)
         return Configuration()
 
     @property

--- a/samples/client/petstore/python-asyncio/petstore_api/configuration.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/configuration.py
@@ -12,6 +12,7 @@
 
 from __future__ import absolute_import
 
+import copy
 import logging
 import sys
 import urllib3
@@ -70,6 +71,8 @@ class Configuration(object):
           password='the-password',
       )
     """
+
+    _default = None
 
     def __init__(self, host="http://petstore.swagger.io:80/v2",
                  api_key=None, api_key_prefix=None,
@@ -164,6 +167,31 @@ class Configuration(object):
         """
         # Disable client side validation
         self.client_side_validation = True
+
+    @classmethod
+    def set_default(cls, default):
+        """Set default instance of configuration.
+
+        It stores default configuration, which can be
+        returned by get_instance method.
+
+        :param default: object of Configuration
+        """
+        cls._default = copy.copy(default)
+
+    @classmethod
+    def get_instance(cls):
+        """Return new instance of configuration.
+
+        This method returns newly created, based on default constructor,
+        object of Configuration class or returns a copy of default
+        configuration passed by the set_default method.
+
+        :return: The configuration object.
+        """
+        if cls._default is not None:
+            return copy.copy(cls._default)
+        return Configuration()
 
     @property
     def logger_file(self):

--- a/samples/client/petstore/python-experimental/petstore_api/configuration.py
+++ b/samples/client/petstore/python-experimental/petstore_api/configuration.py
@@ -173,18 +173,27 @@ class Configuration(object):
         self.client_side_validation = True
 
     @classmethod
+    def copy(cls, source):
+        if source is None:
+            return None
+        ret = copy.copy(source)
+        ret.api_key = copy.copy(source.api_key)
+        ret.api_key_prefix = copy.copy(source.api_key_prefix)
+        return ret
+
+    @classmethod
     def set_default(cls, default):
         """Set default instance of configuration.
 
         It stores default configuration, which can be
-        returned by get_instance method.
+        returned by new_instance method.
 
         :param default: object of Configuration
         """
-        cls._default = copy.copy(default)
+        cls._default = Configuration.copy(default)
 
     @classmethod
-    def get_instance(cls):
+    def new_instance(cls):
         """Return new instance of configuration.
 
         This method returns newly created, based on default constructor,
@@ -194,7 +203,7 @@ class Configuration(object):
         :return: The configuration object.
         """
         if cls._default is not None:
-            return copy.copy(cls._default)
+            return Configuration.copy(cls._default)
         return Configuration()
 
     @property

--- a/samples/client/petstore/python-experimental/petstore_api/configuration.py
+++ b/samples/client/petstore/python-experimental/petstore_api/configuration.py
@@ -12,6 +12,7 @@
 
 from __future__ import absolute_import
 
+import copy
 import logging
 import multiprocessing
 import sys
@@ -71,6 +72,8 @@ class Configuration(object):
           password='the-password',
       )
     """
+
+    _default = None
 
     def __init__(self, host="http://petstore.swagger.io:80/v2",
                  api_key=None, api_key_prefix=None,
@@ -168,6 +171,31 @@ class Configuration(object):
         """
         # Disable client side validation
         self.client_side_validation = True
+
+    @classmethod
+    def set_default(cls, default):
+        """Set default instance of configuration.
+
+        It stores default configuration, which can be
+        returned by get_instance method.
+
+        :param default: object of Configuration
+        """
+        cls._default = copy.copy(default)
+
+    @classmethod
+    def get_instance(cls):
+        """Return new instance of configuration.
+
+        This method returns newly created, based on default constructor,
+        object of Configuration class or returns a copy of default
+        configuration passed by the set_default method.
+
+        :return: The configuration object.
+        """
+        if cls._default is not None:
+            return copy.copy(cls._default)
+        return Configuration()
 
     @property
     def logger_file(self):

--- a/samples/client/petstore/python-tornado/petstore_api/api_client.py
+++ b/samples/client/petstore/python-tornado/petstore_api/api_client.py
@@ -69,7 +69,7 @@ class ApiClient(object):
     def __init__(self, configuration=None, header_name=None, header_value=None,
                  cookie=None, pool_threads=1):
         if configuration is None:
-            configuration = Configuration.get_instance()
+            configuration = Configuration.new_instance()
         self.configuration = configuration
         self.pool_threads = pool_threads
 

--- a/samples/client/petstore/python-tornado/petstore_api/api_client.py
+++ b/samples/client/petstore/python-tornado/petstore_api/api_client.py
@@ -69,7 +69,7 @@ class ApiClient(object):
     def __init__(self, configuration=None, header_name=None, header_value=None,
                  cookie=None, pool_threads=1):
         if configuration is None:
-            configuration = Configuration.new_instance()
+            configuration = Configuration.get_default_copy()
         self.configuration = configuration
         self.pool_threads = pool_threads
 

--- a/samples/client/petstore/python-tornado/petstore_api/api_client.py
+++ b/samples/client/petstore/python-tornado/petstore_api/api_client.py
@@ -69,7 +69,7 @@ class ApiClient(object):
     def __init__(self, configuration=None, header_name=None, header_value=None,
                  cookie=None, pool_threads=1):
         if configuration is None:
-            configuration = Configuration()
+            configuration = Configuration.get_instance()
         self.configuration = configuration
         self.pool_threads = pool_threads
 

--- a/samples/client/petstore/python-tornado/petstore_api/configuration.py
+++ b/samples/client/petstore/python-tornado/petstore_api/configuration.py
@@ -173,18 +173,27 @@ class Configuration(object):
         self.client_side_validation = True
 
     @classmethod
+    def copy(cls, source):
+        if source is None:
+            return None
+        ret = copy.copy(source)
+        ret.api_key = copy.copy(source.api_key)
+        ret.api_key_prefix = copy.copy(source.api_key_prefix)
+        return ret
+
+    @classmethod
     def set_default(cls, default):
         """Set default instance of configuration.
 
         It stores default configuration, which can be
-        returned by get_instance method.
+        returned by new_instance method.
 
         :param default: object of Configuration
         """
-        cls._default = copy.copy(default)
+        cls._default = Configuration.copy(default)
 
     @classmethod
-    def get_instance(cls):
+    def new_instance(cls):
         """Return new instance of configuration.
 
         This method returns newly created, based on default constructor,
@@ -194,7 +203,7 @@ class Configuration(object):
         :return: The configuration object.
         """
         if cls._default is not None:
-            return copy.copy(cls._default)
+            return Configuration.copy(cls._default)
         return Configuration()
 
     @property

--- a/samples/client/petstore/python-tornado/petstore_api/configuration.py
+++ b/samples/client/petstore/python-tornado/petstore_api/configuration.py
@@ -12,6 +12,7 @@
 
 from __future__ import absolute_import
 
+import copy
 import logging
 import multiprocessing
 import sys
@@ -71,6 +72,8 @@ class Configuration(object):
           password='the-password',
       )
     """
+
+    _default = None
 
     def __init__(self, host="http://petstore.swagger.io:80/v2",
                  api_key=None, api_key_prefix=None,
@@ -168,6 +171,31 @@ class Configuration(object):
         """
         # Disable client side validation
         self.client_side_validation = True
+
+    @classmethod
+    def set_default(cls, default):
+        """Set default instance of configuration.
+
+        It stores default configuration, which can be
+        returned by get_instance method.
+
+        :param default: object of Configuration
+        """
+        cls._default = copy.copy(default)
+
+    @classmethod
+    def get_instance(cls):
+        """Return new instance of configuration.
+
+        This method returns newly created, based on default constructor,
+        object of Configuration class or returns a copy of default
+        configuration passed by the set_default method.
+
+        :return: The configuration object.
+        """
+        if cls._default is not None:
+            return copy.copy(cls._default)
+        return Configuration()
 
     @property
     def logger_file(self):

--- a/samples/client/petstore/python/petstore_api/api_client.py
+++ b/samples/client/petstore/python/petstore_api/api_client.py
@@ -68,7 +68,7 @@ class ApiClient(object):
     def __init__(self, configuration=None, header_name=None, header_value=None,
                  cookie=None, pool_threads=1):
         if configuration is None:
-            configuration = Configuration()
+            configuration = Configuration.get_instance()
         self.configuration = configuration
         self.pool_threads = pool_threads
 

--- a/samples/client/petstore/python/petstore_api/api_client.py
+++ b/samples/client/petstore/python/petstore_api/api_client.py
@@ -68,7 +68,7 @@ class ApiClient(object):
     def __init__(self, configuration=None, header_name=None, header_value=None,
                  cookie=None, pool_threads=1):
         if configuration is None:
-            configuration = Configuration.new_instance()
+            configuration = Configuration.get_default_copy()
         self.configuration = configuration
         self.pool_threads = pool_threads
 

--- a/samples/client/petstore/python/petstore_api/api_client.py
+++ b/samples/client/petstore/python/petstore_api/api_client.py
@@ -68,7 +68,7 @@ class ApiClient(object):
     def __init__(self, configuration=None, header_name=None, header_value=None,
                  cookie=None, pool_threads=1):
         if configuration is None:
-            configuration = Configuration.get_instance()
+            configuration = Configuration.new_instance()
         self.configuration = configuration
         self.pool_threads = pool_threads
 

--- a/samples/client/petstore/python/petstore_api/configuration.py
+++ b/samples/client/petstore/python/petstore_api/configuration.py
@@ -173,18 +173,27 @@ class Configuration(object):
         self.client_side_validation = True
 
     @classmethod
+    def copy(cls, source):
+        if source is None:
+            return None
+        ret = copy.copy(source)
+        ret.api_key = copy.copy(source.api_key)
+        ret.api_key_prefix = copy.copy(source.api_key_prefix)
+        return ret
+
+    @classmethod
     def set_default(cls, default):
         """Set default instance of configuration.
 
         It stores default configuration, which can be
-        returned by get_instance method.
+        returned by new_instance method.
 
         :param default: object of Configuration
         """
-        cls._default = copy.copy(default)
+        cls._default = Configuration.copy(default)
 
     @classmethod
-    def get_instance(cls):
+    def new_instance(cls):
         """Return new instance of configuration.
 
         This method returns newly created, based on default constructor,
@@ -194,7 +203,7 @@ class Configuration(object):
         :return: The configuration object.
         """
         if cls._default is not None:
-            return copy.copy(cls._default)
+            return Configuration.copy(cls._default)
         return Configuration()
 
     @property

--- a/samples/client/petstore/python/petstore_api/configuration.py
+++ b/samples/client/petstore/python/petstore_api/configuration.py
@@ -12,6 +12,7 @@
 
 from __future__ import absolute_import
 
+import copy
 import logging
 import multiprocessing
 import sys
@@ -71,6 +72,8 @@ class Configuration(object):
           password='the-password',
       )
     """
+
+    _default = None
 
     def __init__(self, host="http://petstore.swagger.io:80/v2",
                  api_key=None, api_key_prefix=None,
@@ -168,6 +171,31 @@ class Configuration(object):
         """
         # Disable client side validation
         self.client_side_validation = True
+
+    @classmethod
+    def set_default(cls, default):
+        """Set default instance of configuration.
+
+        It stores default configuration, which can be
+        returned by get_instance method.
+
+        :param default: object of Configuration
+        """
+        cls._default = copy.copy(default)
+
+    @classmethod
+    def get_instance(cls):
+        """Return new instance of configuration.
+
+        This method returns newly created, based on default constructor,
+        object of Configuration class or returns a copy of default
+        configuration passed by the set_default method.
+
+        :return: The configuration object.
+        """
+        if cls._default is not None:
+            return copy.copy(cls._default)
+        return Configuration()
 
     @property
     def logger_file(self):

--- a/samples/client/petstore/python/tests/test_configuration.py
+++ b/samples/client/petstore/python/tests/test_configuration.py
@@ -36,11 +36,13 @@ class TestConfiguration(unittest.TestCase):
 
         # prepare default configuration
         c1 = petstore_api.Configuration(host="example.com")
+        c1.debug = True
         petstore_api.Configuration.set_default(c1)
 
         # get default configuration
-        c2 = petstore_api.Configuration.new_instance()
+        c2 = petstore_api.Configuration.get_default_copy()
         self.assertEqual(c2.host, "example.com")
+        self.assertTrue(c2.debug)
 
         self.assertNotEqual(id(c1.api_key), id(c2.api_key))
         self.assertNotEqual(id(c1.api_key_prefix), id(c2.api_key_prefix))

--- a/samples/client/petstore/python/tests/test_configuration.py
+++ b/samples/client/petstore/python/tests/test_configuration.py
@@ -22,14 +22,25 @@ class TestConfiguration(unittest.TestCase):
         pass
 
     def tearDown(self):
-        pass
+        # reset Configuration
+        petstore_api.Configuration.set_default(None)
 
     def testConfiguration(self):
         # check that different instances use different dictionaries
         c1 = petstore_api.Configuration()
         c2 = petstore_api.Configuration()
-        assert id(c1.api_key) != id(c2.api_key)
-        assert id(c1.api_key_prefix) != id(c2.api_key_prefix)
+        self.assertNotEqual(id(c1.api_key), id(c2.api_key))
+        self.assertNotEqual(id(c1.api_key_prefix), id(c2.api_key_prefix))
+
+    def testDefaultConfiguration(self):
+
+        # prepare default configuration
+        c1 = petstore_api.Configuration(host="example.com")
+        petstore_api.Configuration.set_default(c1)
+
+        # get default configuration
+        c2 = petstore_api.Configuration.get_instance()
+        self.assertEqual(c2.host, "example.com")
 
 
 if __name__ == '__main__':

--- a/samples/client/petstore/python/tests/test_configuration.py
+++ b/samples/client/petstore/python/tests/test_configuration.py
@@ -39,8 +39,11 @@ class TestConfiguration(unittest.TestCase):
         petstore_api.Configuration.set_default(c1)
 
         # get default configuration
-        c2 = petstore_api.Configuration.get_instance()
+        c2 = petstore_api.Configuration.new_instance()
         self.assertEqual(c2.host, "example.com")
+
+        self.assertNotEqual(id(c1.api_key), id(c2.api_key))
+        self.assertNotEqual(id(c1.api_key_prefix), id(c2.api_key_prefix))
 
 
 if __name__ == '__main__':

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/configuration.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/configuration.py
@@ -219,19 +219,33 @@ class Configuration(object):
         # Disable client side validation
         self.client_side_validation = True
 
+    def __deepcopy__(self, memo):
+        cls = self.__class__
+        result = cls.__new__(cls)
+        memo[id(self)] = result
+        for k, v in self.__dict__.items():
+            if k not in ('logger', 'logger_file_handler'):
+                setattr(result, k, copy.deepcopy(v, memo))
+        # shallow copy of loggers
+        result.logger = copy.copy(self.logger)
+        # use setters to configure loggers
+        result.logger_file = self.logger_file
+        result.debug = self.debug
+        return result
+
     @classmethod
     def set_default(cls, default):
         """Set default instance of configuration.
 
         It stores default configuration, which can be
-        returned by get_instance method.
+        returned by get_default_copy method.
 
         :param default: object of Configuration
         """
-        cls._default = copy.copy(default)
+        cls._default = copy.deepcopy(default)
 
     @classmethod
-    def get_instance(cls):
+    def get_default_copy(cls):
         """Return new instance of configuration.
 
         This method returns newly created, based on default constructor,
@@ -241,7 +255,7 @@ class Configuration(object):
         :return: The configuration object.
         """
         if cls._default is not None:
-            return copy.copy(cls._default)
+            return copy.deepcopy(cls._default)
         return Configuration()
 
     @property

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/configuration.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/configuration.py
@@ -12,6 +12,7 @@
 
 from __future__ import absolute_import
 
+import copy
 import logging
 import multiprocessing
 import sys
@@ -112,6 +113,8 @@ class Configuration(object):
         )
       )
     """
+
+    _default = None
 
     def __init__(self, host="http://petstore.swagger.io:80/v2",
                  api_key=None, api_key_prefix=None,
@@ -215,6 +218,31 @@ class Configuration(object):
         """
         # Disable client side validation
         self.client_side_validation = True
+
+    @classmethod
+    def set_default(cls, default):
+        """Set default instance of configuration.
+
+        It stores default configuration, which can be
+        returned by get_instance method.
+
+        :param default: object of Configuration
+        """
+        cls._default = copy.copy(default)
+
+    @classmethod
+    def get_instance(cls):
+        """Return new instance of configuration.
+
+        This method returns newly created, based on default constructor,
+        object of Configuration class or returns a copy of default
+        configuration passed by the set_default method.
+
+        :return: The configuration object.
+        """
+        if cls._default is not None:
+            return copy.copy(cls._default)
+        return Configuration()
 
     @property
     def logger_file(self):

--- a/samples/openapi3/client/petstore/python/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api_client.py
@@ -68,7 +68,7 @@ class ApiClient(object):
     def __init__(self, configuration=None, header_name=None, header_value=None,
                  cookie=None, pool_threads=1):
         if configuration is None:
-            configuration = Configuration()
+            configuration = Configuration.get_instance()
         self.configuration = configuration
         self.pool_threads = pool_threads
 

--- a/samples/openapi3/client/petstore/python/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api_client.py
@@ -68,7 +68,7 @@ class ApiClient(object):
     def __init__(self, configuration=None, header_name=None, header_value=None,
                  cookie=None, pool_threads=1):
         if configuration is None:
-            configuration = Configuration.get_instance()
+            configuration = Configuration.get_default_copy()
         self.configuration = configuration
         self.pool_threads = pool_threads
 

--- a/samples/openapi3/client/petstore/python/petstore_api/configuration.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/configuration.py
@@ -172,19 +172,33 @@ class Configuration(object):
         # Disable client side validation
         self.client_side_validation = True
 
+    def __deepcopy__(self, memo):
+        cls = self.__class__
+        result = cls.__new__(cls)
+        memo[id(self)] = result
+        for k, v in self.__dict__.items():
+            if k not in ('logger', 'logger_file_handler'):
+                setattr(result, k, copy.deepcopy(v, memo))
+        # shallow copy of loggers
+        result.logger = copy.copy(self.logger)
+        # use setters to configure loggers
+        result.logger_file = self.logger_file
+        result.debug = self.debug
+        return result
+
     @classmethod
     def set_default(cls, default):
         """Set default instance of configuration.
 
         It stores default configuration, which can be
-        returned by get_instance method.
+        returned by get_default_copy method.
 
         :param default: object of Configuration
         """
-        cls._default = copy.copy(default)
+        cls._default = copy.deepcopy(default)
 
     @classmethod
-    def get_instance(cls):
+    def get_default_copy(cls):
         """Return new instance of configuration.
 
         This method returns newly created, based on default constructor,
@@ -194,7 +208,7 @@ class Configuration(object):
         :return: The configuration object.
         """
         if cls._default is not None:
-            return copy.copy(cls._default)
+            return copy.deepcopy(cls._default)
         return Configuration()
 
     @property

--- a/samples/openapi3/client/petstore/python/petstore_api/configuration.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/configuration.py
@@ -12,6 +12,7 @@
 
 from __future__ import absolute_import
 
+import copy
 import logging
 import multiprocessing
 import sys
@@ -71,6 +72,8 @@ class Configuration(object):
           password='the-password',
       )
     """
+
+    _default = None
 
     def __init__(self, host="http://petstore.swagger.io:80/v2",
                  api_key=None, api_key_prefix=None,
@@ -168,6 +171,31 @@ class Configuration(object):
         """
         # Disable client side validation
         self.client_side_validation = True
+
+    @classmethod
+    def set_default(cls, default):
+        """Set default instance of configuration.
+
+        It stores default configuration, which can be
+        returned by get_instance method.
+
+        :param default: object of Configuration
+        """
+        cls._default = copy.copy(default)
+
+    @classmethod
+    def get_instance(cls):
+        """Return new instance of configuration.
+
+        This method returns newly created, based on default constructor,
+        object of Configuration class or returns a copy of default
+        configuration passed by the set_default method.
+
+        :return: The configuration object.
+        """
+        if cls._default is not None:
+            return copy.copy(cls._default)
+        return Configuration()
 
     @property
     def logger_file(self):


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

As a follow up the discussion https://github.com/OpenAPITools/openapi-generator/pull/4485#issuecomment-584915749 I'd like to recovery an option to set default configuration. I prepared very simple solution which provides the same API as we had before.

Thanks for reviewing it.

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@taxpon (2017/07) @frol (2017/07) @mbohlool (2017/07) @cbornet (2017/09) @kenjones-cisco (2017/11) @tomplus (2018/10) @Jyhess (2019/01) @slash-arun (2019/11) @spacether (2019/11)