### PR TITLE
[maven] improve documentation regarding depedencies issues

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -43,7 +43,7 @@ For full details of all options, see the [plugin README](https://github.com/Open
 
 ### Dependencies
 
-The models generated use annotations like `@ApiModelProperty` the dependency commonly used is:
+The generated models use commonly use Swagger v2 annotations like `@ApiModelProperty`. A user may add Swagger v3 annotations:
 
 ```xml
 <dependency>

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -41,6 +41,28 @@ mvn clean compile
 
 For full details of all options, see the [plugin README](https://github.com/OpenAPITools/openapi-generator/tree/master/modules/openapi-generator-maven-plugin).
 
+### Dependencies
+
+The models generated use annotations like `@ApiModelProperty` the dependency commonly used is:
+
+```xml
+<dependency>
+    <groupId>io.swagger.core.v3</groupId>
+    <artifactId>swagger-annotations</artifactId>
+</dependency>
+```
+
+But this will not work. This depedency does not contains the package neither the classes needed. The resulting code it will fail to compile.
+
+As alternative instead use the following dependency:
+
+```xml
+<dependency>
+    <groupId>io.swagger.parser.v3</groupId>
+    <artifactId>swagger-parser</artifactId>
+</dependency>
+```
+
 ## Gradle
 
 This gradle plugin offers a declarative DSL via extensions (these are Gradle project extensions). These map almost fully 1:1 with the options you’d pass to the CLI or Maven plugin. The plugin maps the extensions to a task of the same name to provide a clean API. If you’re interested in the extension/task mapping concept from a high-level, you can check out [Gradle’s docs](https://docs.gradle.org/current/userguide/custom_plugins.html#sec:mapping_extension_properties_to_task_properties).

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -52,7 +52,7 @@ The generated models use commonly use Swagger v2 annotations like `@ApiModelProp
 </dependency>
 ```
 
-But this will not work. This depedency does not contains the package neither the classes needed. The resulting code it will fail to compile.
+But this will not work. This dependency is not binary compatible with Swagger v2 annotations. The resulting code will fail to compile.
 
 As alternative instead use the following dependency:
 


### PR DESCRIPTION
While working with a OpenAPI with Maven plugin had some trouble with the dependencies for the generated Models.
Updating the docs to help others that may face the same issues in the future.

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [ ] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04) @lwlee2608 (2019/10) @bkabrda (2020/01)
