### PR TITLE
[Kotlin][Client] Enum toString handling

### DIFF
--- a/modules/openapi-generator/src/main/resources/kotlin-client/enum_class.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/enum_class.mustache
@@ -41,6 +41,14 @@ import kotlinx.serialization.internal.CommonEnumSerializer
 
 {{/enumVars}}{{/allowableValues}}
 
+	/**
+	This override toString avoids using the enum var name and uses the actual api value instead.
+	In cases the var name and value are different, the client would send incorrect enums to the server.
+	**/
+	override fun toString(): String {
+        return value
+    }
+
 {{#multiplatform}}
     {{#nonPublicApi}}internal {{/nonPublicApi}}object Serializer : CommonEnumSerializer<{{classname}}>("{{classname}}", values(), values().map { it.value.toString() }.toTypedArray())
 {{/multiplatform}}

--- a/modules/openapi-generator/src/main/resources/kotlin-client/enum_class.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/enum_class.mustache
@@ -46,7 +46,7 @@ import kotlinx.serialization.internal.CommonEnumSerializer
 	In cases the var name and value are different, the client would send incorrect enums to the server.
 	**/
 	override fun toString(): String {
-        return value
+        return value{{^isString}}.toString(){{/isString}}
     }
 
 {{#multiplatform}}


### PR DESCRIPTION
I have noticed that in certain cases, the enum usage for path parameter and url query parameter is incorrectly implemented. 

In the case I have an enum with MY_ENUM("MyEnum") and I am using the enum as a path parameter. The path would look like that "myPath/.../MY_ENUM/...". This request would always fail. That is due to the different enum value than the server would expect.

To fix this issue, I suggest we add a custom toString to every enum class so that we will not use the enum var name but the value. That way the path would look like this "myPath/.../MyEnum/...".

Changes made with this PR:
- Added custom toString to the enum class script.

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@jimschubert (2017/09) ❤️, @dr4ke616 (2018/08) @karismann (2019/03) @Zomzog (2019/04) @andrewemery (2019/10) @4brunu (2019/11)