### PR TITLE
[BUG][typescript-rxjs] Fix nully type coalescing in Configuration getters

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-rxjs/runtime.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-rxjs/runtime.mustache
@@ -36,12 +36,18 @@ export class Configuration {
 
     get apiKey(): ((name: string) => string) | undefined {
         const apiKey = this.configuration.apiKey;
-        return apiKey && (typeof apiKey === 'function' ? apiKey : () => apiKey);
+        if (!apiKey) {
+            return undefined;
+        }
+        return typeof apiKey === 'string' ? () => apiKey : apiKey;
     }
 
     get accessToken(): ((name: string, scopes?: string[]) => string) | undefined {
         const accessToken = this.configuration.accessToken;
-        return accessToken && (typeof accessToken === 'function' ? accessToken : () => accessToken);
+        if (!accessToken) {
+            return undefined;
+        }
+        return typeof accessToken === 'string' ? () => accessToken : accessToken;
     }
 }
 

--- a/samples/client/petstore/typescript-rxjs/builds/default/runtime.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/default/runtime.ts
@@ -47,12 +47,18 @@ export class Configuration {
 
     get apiKey(): ((name: string) => string) | undefined {
         const apiKey = this.configuration.apiKey;
-        return apiKey && (typeof apiKey === 'function' ? apiKey : () => apiKey);
+        if (!apiKey) {
+            return undefined;
+        }
+        return typeof apiKey === 'string' ? () => apiKey : apiKey;
     }
 
     get accessToken(): ((name: string, scopes?: string[]) => string) | undefined {
         const accessToken = this.configuration.accessToken;
-        return accessToken && (typeof accessToken === 'function' ? accessToken : () => accessToken);
+        if (!accessToken) {
+            return undefined;
+        }
+        return typeof accessToken === 'string' ? () => accessToken : accessToken;
     }
 }
 

--- a/samples/client/petstore/typescript-rxjs/builds/es6-target/runtime.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/es6-target/runtime.ts
@@ -47,12 +47,18 @@ export class Configuration {
 
     get apiKey(): ((name: string) => string) | undefined {
         const apiKey = this.configuration.apiKey;
-        return apiKey && (typeof apiKey === 'function' ? apiKey : () => apiKey);
+        if (!apiKey) {
+            return undefined;
+        }
+        return typeof apiKey === 'string' ? () => apiKey : apiKey;
     }
 
     get accessToken(): ((name: string, scopes?: string[]) => string) | undefined {
         const accessToken = this.configuration.accessToken;
-        return accessToken && (typeof accessToken === 'function' ? accessToken : () => accessToken);
+        if (!accessToken) {
+            return undefined;
+        }
+        return typeof accessToken === 'string' ? () => accessToken : accessToken;
     }
 }
 

--- a/samples/client/petstore/typescript-rxjs/builds/with-interfaces/runtime.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/with-interfaces/runtime.ts
@@ -47,12 +47,18 @@ export class Configuration {
 
     get apiKey(): ((name: string) => string) | undefined {
         const apiKey = this.configuration.apiKey;
-        return apiKey && (typeof apiKey === 'function' ? apiKey : () => apiKey);
+        if (!apiKey) {
+            return undefined;
+        }
+        return typeof apiKey === 'string' ? () => apiKey : apiKey;
     }
 
     get accessToken(): ((name: string, scopes?: string[]) => string) | undefined {
         const accessToken = this.configuration.accessToken;
-        return accessToken && (typeof accessToken === 'function' ? accessToken : () => accessToken);
+        if (!accessToken) {
+            return undefined;
+        }
+        return typeof accessToken === 'string' ? () => accessToken : accessToken;
     }
 }
 

--- a/samples/client/petstore/typescript-rxjs/builds/with-npm-version/runtime.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/with-npm-version/runtime.ts
@@ -47,12 +47,18 @@ export class Configuration {
 
     get apiKey(): ((name: string) => string) | undefined {
         const apiKey = this.configuration.apiKey;
-        return apiKey && (typeof apiKey === 'function' ? apiKey : () => apiKey);
+        if (!apiKey) {
+            return undefined;
+        }
+        return typeof apiKey === 'string' ? () => apiKey : apiKey;
     }
 
     get accessToken(): ((name: string, scopes?: string[]) => string) | undefined {
         const accessToken = this.configuration.accessToken;
-        return accessToken && (typeof accessToken === 'function' ? accessToken : () => accessToken);
+        if (!accessToken) {
+            return undefined;
+        }
+        return typeof accessToken === 'string' ? () => accessToken : accessToken;
     }
 }
 


### PR DESCRIPTION
With Typescript 3.7.5 the `runtime.ts` template output produces the following error:

```ts
(50,9): Type ‘“” | ((name: string) => string) | undefined’ is not assignable to type ‘((name: string) => string) | undefined’.
      Type ‘“”’ is not assignable to type ‘((name: string) => string) | undefined’.
```
referring to the coalescing of the null `""` JS value in the following lines:
https://github.com/OpenAPITools/openapi-generator/blob/118b5e77473c80eb0e3cbea1413ecf27075c19e3/modules/openapi-generator/src/main/resources/typescript-rxjs/runtime.mustache#L39
https://github.com/OpenAPITools/openapi-generator/blob/118b5e77473c80eb0e3cbea1413ecf27075c19e3/modules/openapi-generator/src/main/resources/typescript-rxjs/runtime.mustache#L44

Additionally, the `typeof accessToken === 'function'` check opens the discussion about polymorphism, while checking against `"string"` is more obvious — thus capturing the string half of the union type and leaving the rest of it to the TS inference to make sense of.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@TiFu (2017/07) @taxpon (2017/07) @sebastianhaas (2017/07) @kenisteward (2017/07) @Vrolijkx (2017/09) @macjohnny (2018/01) @nicokoenig (2018/09) @topce (2018/10) @akehir (2019/07) @petejohansonxo (2019/11) @amakhrov (2020/02)
