### PR TITLE
[cli][core] Add support for dry-run and display

### DIFF
--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -3,6 +3,76 @@ id: debugging
 title: Debugging
 ---
 
+## Generation
+
+As a user there may be times when generated outputs don't match your expectations it's unclear why. The CLI supports a `--dry-run` option which may be used to inspect the anticipated file operations without making changes to the file system.
+
+Suppose you generate using the `--minimal-update` option, and you notice on subsequent generations of a client that no files have changed. This is by design.
+
+For example, if you generate the aspnetcore generator passing `--minimal-update --dry-run` to the sample generation script in the code repository:
+
+```bash
+export JAVA_OPTS="-Dlog.level=off"
+./bin/aspnetcore-petstore-server.sh --minimal-update --dry-run
+```
+
+You'll see the output similar to the following:
+
+```
+# START SCRIPT: ./bin/aspnetcore-petstore-server.sh
+
+
+Dry Run Results:
+
+s /path/to/aspnetcore/.openapi-generator-ignore
+n /path/to/aspnetcore/.openapi-generator/VERSION
+n /path/to/aspnetcore/Org.OpenAPITools.sln
+n /path/to/aspnetcore/README.md
+n /path/to/aspnetcore/build.bat
+n /path/to/aspnetcore/build.sh
+w /path/to/aspnetcore/src/Org.OpenAPITools/.gitignore
+n /path/to/aspnetcore/src/Org.OpenAPITools/Attributes/ValidateModelStateAttribute.cs
+n /path/to/aspnetcore/src/Org.OpenAPITools/Authentication/ApiAuthentication.cs
+n /path/to/aspnetcore/src/Org.OpenAPITools/Controllers/PetApi.cs
+n /path/to/aspnetcore/src/Org.OpenAPITools/Controllers/StoreApi.cs
+n /path/to/aspnetcore/src/Org.OpenAPITools/Controllers/UserApi.cs
+n /path/to/aspnetcore/src/Org.OpenAPITools/Converters/CustomEnumConverter.cs
+n /path/to/aspnetcore/src/Org.OpenAPITools/Dockerfile
+n /path/to/aspnetcore/src/Org.OpenAPITools/Filters/BasePathFilter.cs
+n /path/to/aspnetcore/src/Org.OpenAPITools/Filters/GeneratePathParamsValidationFilter.cs
+n /path/to/aspnetcore/src/Org.OpenAPITools/Models/ApiResponse.cs
+n /path/to/aspnetcore/src/Org.OpenAPITools/Models/Category.cs
+n /path/to/aspnetcore/src/Org.OpenAPITools/Models/Order.cs
+n /path/to/aspnetcore/src/Org.OpenAPITools/Models/Pet.cs
+n /path/to/aspnetcore/src/Org.OpenAPITools/Models/Tag.cs
+n /path/to/aspnetcore/src/Org.OpenAPITools/Models/User.cs
+n /path/to/aspnetcore/src/Org.OpenAPITools/Org.OpenAPITools.csproj
+n /path/to/aspnetcore/src/Org.OpenAPITools/Program.cs
+w /path/to/aspnetcore/src/Org.OpenAPITools/Properties/launchSettings.json
+n /path/to/aspnetcore/src/Org.OpenAPITools/Startup.cs
+w /path/to/aspnetcore/src/Org.OpenAPITools/appsettings.json
+w /path/to/aspnetcore/src/Org.OpenAPITools/wwwroot/README.md
+w /path/to/aspnetcore/src/Org.OpenAPITools/wwwroot/index.html
+n /path/to/aspnetcore/src/Org.OpenAPITools/wwwroot/openapi-original.json
+w /path/to/aspnetcore/src/Org.OpenAPITools/wwwroot/web.config
+
+
+States:
+
+  - w Write
+  - n Write if New/Updated
+  - i Ignored
+  - s Skipped Overwrite
+  - k Skipped by user option(s)
+  - e Error evaluating file write state
+
+```
+
+The output lists the files which would be written in a normal run of the tool. Notice that we skip `.openapi-generator-ignore` because the file exists and we don't want to blow away the user's generation rules. Most of these files will overwrite output files only if the contents slated for write are different from those on the filesystem; this is denoted by an `n` preceding the filename. Some of the above lines begin with a `w`, meaning these files will _always_ result in a write operation.
+
+If you find an operation that you feel should result in a different state, please [open an issue](https://github.com/OpenAPITools/openapi-generator/issues/new/choose) or [submit a pull request](https://github.com/OpenAPITools/openapi-generator/compare) to change the behavior (we welcome all contributions).
+
+
 ## Templates
 
 Sometimes, you may have issues with variables in your templates. As discussed in the [templating](./templating.md) docs, we offer a variety of system properties for inspecting the models bound to templates.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -242,16 +242,16 @@ NAME
 SYNOPSIS
         openapi-generator-cli generate
                 [(-a <authorization> | --auth <authorization>)]
-                [--api-package <api package>] [--artifact-id <artifact id>]
-                [--artifact-version <artifact version>]
+                [--api-name-suffix <api name suffix>] [--api-package <api package>]
+                [--artifact-id <artifact id>] [--artifact-version <artifact version>]
                 [(-c <configuration file> | --config <configuration file>)]
-                [-D <system properties>...]
+                [-D <system properties>...] [--dry-run]
                 [(-e <templating engine> | --engine <templating engine>)]
                 [--enable-post-process-file]
                 [(-g <generator name> | --generator-name <generator name>)]
-                [--generate-alias-as-model] [--git-repo-id <git repo id>]
-                [--git-user-id <git user id>] [--group-id <group id>]
-                [--http-user-agent <http user agent>]
+                [--generate-alias-as-model] [--git-host <git host>]
+                [--git-repo-id <git repo id>] [--git-user-id <git user id>]
+                [--group-id <group id>] [--http-user-agent <http user agent>]
                 (-i <spec file> | --input-spec <spec file>)
                 [--ignore-file-override <ignore file override location>]
                 [--import-mappings <import mappings>...]
@@ -283,6 +283,11 @@ OPTIONS
             remotely. Pass in a URL-encoded string of name:header with a comma
             separating multiple values
 
+        --api-name-suffix <api name suffix>
+            Suffix that will be appended to all API names ('tags'). Default:
+            Api. e.g. Pet => PetApi. Note: Only ruby, python, jaxrs generators
+            suppport this feature at the moment.
+
         --api-package <api package>
             package for generated api classes
 
@@ -295,29 +300,35 @@ OPTIONS
             generated library's filename
 
         -c <configuration file>, --config <configuration file>
-            Path to configuration file configuration file. It can be json or
-            yaml.If file is json, the content should have the format
-            {"optionKey":"optionValue", "optionKey1":"optionValue1"...}.If file
-            is yaml, the content should have the format optionKey:
-            optionValueSupported options can be different for each language. Run
-            config-help -g {generator name} command for language specific config
-            options.
+            Path to configuration file. It can be JSON or YAML. If file is JSON,
+            the content should have the format {"optionKey":"optionValue",
+            "optionKey1":"optionValue1"...}. If file is YAML, the content should
+            have the format optionKey: optionValue. Supported options can be
+            different for each language. Run config-help -g {generator name}
+            command for language-specific config options.
 
         -D <system properties>
             sets specified system properties in the format of
             name=value,name=value (or multiple options, each with name=value)
 
+        --dry-run
+            Try things out and report on potential changes (without actually
+            making changes).
+
         -e <templating engine>, --engine <templating engine>
             templating engine: "mustache" (default) or "handlebars" (beta)
 
         --enable-post-process-file
-            enablePostProcessFile
+            Enable post-processing file using environment variables.
 
         -g <generator name>, --generator-name <generator name>
             generator to use (see list command for list)
 
         --generate-alias-as-model
             Generate alias to map, array as models
+
+        --git-host <git host>
+            Git host, e.g. gitlab.com.
 
         --git-repo-id <git repo id>
             Git repo ID, e.g. openapi-generator.
@@ -372,12 +383,10 @@ OPTIONS
             Only write output files that have changed.
 
         --model-name-prefix <model name prefix>
-            Prefix that will be prepended to all model names. Default is the
-            empty string.
+            Prefix that will be prepended to all model names.
 
         --model-name-suffix <model name suffix>
-            Suffix that will be appended to all model names. Default is the
-            empty string.
+            Suffix that will be appended to all model names.
 
         --model-package <model package>
             package for generated models
@@ -410,8 +419,8 @@ OPTIONS
             generation.
 
         --server-variables <server variables>
-            sets server variables for spec documents which support variable
-            templating of servers.
+            sets server variables overrides for spec documents which support
+            variable templating of servers.
 
         --skip-validate-spec
             Skips the default behavior of validating an input specification.

--- a/modules/openapi-generator-cli/src/main/java/org/openapitools/codegen/cmd/Generate.java
+++ b/modules/openapi-generator-cli/src/main/java/org/openapitools/codegen/cmd/Generate.java
@@ -91,6 +91,9 @@ public class Generate implements Runnable {
                     + "overwritten during the generation.")
     private Boolean skipOverwrite;
 
+    @Option(name = { "--dry-run" }, title = "Dry run",
+            description = "Try things out and report on potential changes (without actually making changes).")
+    private Boolean isDryRun;
 
     @Option(name = {"--package-name"}, title = "package name",
             description = CodegenConstants.PACKAGE_NAME_DESC)
@@ -416,7 +419,7 @@ public class Generate implements Runnable {
 
             // this null check allows us to inject for unit testing.
             if (generator == null) {
-                generator = new DefaultGenerator();
+                generator = new DefaultGenerator(isDryRun);
             }
 
             generator.opts(clientOptInput);

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/AbstractGenerator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/AbstractGenerator.java
@@ -17,7 +17,7 @@
 
 package org.openapitools.codegen;
 
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
 import java.util.Arrays;
@@ -28,12 +28,16 @@ import org.slf4j.LoggerFactory;
 
 import java.io.*;
 import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Scanner;
 import java.util.regex.Pattern;
 
 public abstract class AbstractGenerator implements TemplatingGenerator {
     private static final Logger LOGGER = LoggerFactory.getLogger(AbstractGenerator.class);
-    
+    protected boolean dryRun = false;
+    protected Map<String, DryRunStatus> dryRunStatusMap = new HashMap<>();
+
     /**
      * Is the minimal-file-update option enabled?
      * 
@@ -50,19 +54,19 @@ public abstract class AbstractGenerator implements TemplatingGenerator {
      * @throws IOException If file cannot be written.
      */
     public File writeToFile(String filename, String contents) throws IOException {
-        return writeToFile(filename, contents.getBytes(Charset.forName("UTF-8")));
+        return writeToFile(filename, contents.getBytes(StandardCharsets.UTF_8));
     }
 
     /**
      * Write bytes to a file
      * 
      * @param filename The name of file to write
-     * @param contents The contents bytes.  Typically this is a UTF-8 formatted string.
+     * @param contents The contents bytes.  Typically, this is a UTF-8 formatted string.
      * @return File representing the written file.
      * @throws IOException If file cannot be written.
      */
     @SuppressWarnings("static-method")
-    public File writeToFile(String filename, byte contents[]) throws IOException {
+    public File writeToFile(String filename, byte[] contents) throws IOException {
         if (getEnableMinimalUpdate()) {
             String tempFilename = filename + ".tmp";
             // Use Paths.get here to normalize path (for Windows file separator, space escaping on Linux/Mac, etc)

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DryRunStatus.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DryRunStatus.java
@@ -1,0 +1,160 @@
+package org.openapitools.codegen;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Locale;
+
+/**
+ * Holds details about a file's write status for display via the --dry-run option of CLI
+ */
+class DryRunStatus {
+    private Path path;
+    private State state;
+    private String reason;
+
+    /**
+     * Constructs a new instance of {@link DryRunStatus} for a given path and status of {@link State#Write}
+     *
+     * @param path The target path where the file would write
+     */
+    public DryRunStatus(Path path) {
+        this(path, State.Write);
+    }
+
+    /**
+     * Constructs a new instance of {@link DryRunStatus} for a path and a target state
+     *
+     * @param path  The target path where the file would write
+     * @param state The evaluated state as determined by the generation workflow
+     */
+    public DryRunStatus(Path path, State state) {
+        this.path = path;
+        setState(state);
+    }
+
+    /**
+     * Constructs a new instance of {@link DryRunStatus} for a path, target state, and presenting a specific reason for that state
+     *
+     * @param path   The target path where the file would write
+     * @param state  The evaluated state as determined by the generation workflow
+     * @param reason A reason for the state, beyond any generic reason
+     */
+    public DryRunStatus(Path path, State state, String reason) {
+        this.path = path;
+        this.state = state;
+        this.reason = reason;
+    }
+
+    /**
+     * Append a user display text to the {@link Appendable} instance
+     *
+     * @param appendable An object implementing {@link Appendable} (such as {@link StringBuilder}
+     * @throws IOException via contract of {@link Path#toAbsolutePath()}
+     */
+    public void appendTo(Appendable appendable) throws IOException {
+        appendable.append(String.format(Locale.ROOT, "%s %s", this.state.getShortDisplay(), this.path.toAbsolutePath()));
+    }
+
+    /**
+     * Gets the target path of the file write operation
+     *
+     * @return a {@link Path} instance
+     */
+    public Path getPath() {
+        return path;
+    }
+
+    /**
+     * Gets the reason for the file's {@link State}
+     *
+     * @return A human-readable string which explains why this file's dry-run resulted in the defined {@link State}
+     */
+    public String getReason() {
+        return reason;
+    }
+
+    /**
+     * Gets the {@link State} as determined by the generator's workflow
+     *
+     * @return A {@link State} enum detailing the expected operation of the generator's workflow
+     */
+    public State getState() {
+        return state;
+    }
+
+    /**
+     * Sets the {@link State} as determined by the generator's workflow.
+     * <p>
+     * This method will provide a default reason. To explicitly provide a reason for the {@link State}, use {@link DryRunStatus#DryRunStatus(Path, State, String)}
+     *
+     * @param state A {@link State} enum detailing the expected operation of the generator's workflow
+     */
+    public void setState(State state) {
+        if (state != this.state) {
+            switch (state) {
+                case Write:
+                    this.reason = "File will be written.";
+                    break;
+                case WriteIfNewer:
+                    this.reason = "File will be written only if it is new or if contents differ from an existing file.";
+                    break;
+                case Ignored:
+                    this.reason = "Ignored via rules defined in codegen ignore file.";
+                    break;
+                case SkippedOverwrite:
+                    this.reason = "File is configured not to overwrite an existing file of the same name.";
+                    break;
+                case Error:
+                    this.reason = "File error: template does not exist, or file is not accessible.";
+                    break;
+            }
+        }
+
+        this.state = state;
+    }
+
+    /**
+     * Represents the possible states of a file write operation as determined by the Generator
+     */
+    enum State {
+        Write("w", "Write"),
+        WriteIfNewer("n", "Write if New/Updated"),
+        Ignored("i", "Ignored"),
+        SkippedOverwrite("s", "Skipped Overwrite"),
+        Skipped("k", "Skipped by user option(s)"),
+        Error("e", "Error evaluating file write state");
+
+        private final String shortDisplay;
+        private final String description;
+
+        /**
+         * Constructs a new {@link State} with required short value and human-readable description
+         *
+         * @param shortDisplay The short value used for display
+         * @param description  A description of the state which is more human-readable than the enum's name
+         */
+        State(String shortDisplay, String description) {
+
+            this.shortDisplay = shortDisplay;
+            this.description = description;
+        }
+
+        /**
+         * Gets a description of the state which is more human-readable than the enum's name
+         *
+         * @return A human-readable description
+         */
+        public String getDescription() {
+            return description;
+        }
+
+        /**
+         * Gets the short value used for display
+         *
+         * @return A character representing this state
+         */
+        public String getShortDisplay() {
+            return shortDisplay;
+        }
+    }
+}

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/config/CodegenConfigurator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/config/CodegenConfigurator.java
@@ -439,6 +439,9 @@ public class CodegenConfigurator {
             GlobalSettings.setProperty("debugModels", "");
             GlobalSettings.setProperty("debugOperations", "");
             GlobalSettings.setProperty("debugSupportingFiles", "");
+            GlobalSettings.setProperty("verbose", "true");
+        } else {
+            GlobalSettings.setProperty("verbose", "false");
         }
 
         for (Map.Entry<String, String> entry : workflowSettings.getSystemProperties().entrySet()) {


### PR DESCRIPTION
CLI now supports `--dry-run`, which will output a file change status similar to git status --porcelain. This option aligns with #1811 for providing users and template authors more details about targeted outputs. This `--dry-run` option will be necessary in order to present users with vendor extensions which heavily rely on the generator inputs and often on logic defined by some generator implementations which is only evaluated during generation.

The user may also specify `--verbose` for a one-liner below each file explaining why the change operation might take place.

This PR also cleans up some lint warnings and improves general code cleanliness
of DefaultGenerator.

Specifically:

* logger strings are now using the built-in log formatter rather than
  constructing new strings regardless of log level.
* Diamond operators are used where possible
* Some long-unused commented code has been removed
* Lambdas are used where possible
* Redundant operations are merged (HashMap constructor used rather than
  subsequent putAll on a collection, for example)


<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

cc @OpenAPITools/generator-core-team 
