### PR TITLE
[Java] Error generating java due to a default for a date  #5086

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
@@ -831,7 +831,16 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
             return null;
         } else if (ModelUtils.isStringSchema(p)) {
             if (p.getDefault() != null) {
-                String _default = (String) p.getDefault();
+                String _default;
+                if (p.getDefault() instanceof Date){
+                    String stringBuilder = "LocalDate.parse(\"" +
+                            p.getDefault() +
+                            "\")";
+                    return String.format(Locale.ROOT, stringBuilder, "");
+                }
+                else{
+                    _default = (String) p.getDefault();
+                }
                 if (p.getEnum() == null) {
                     return "\"" + escapeText(_default) + "\"";
                 } else {
@@ -1493,7 +1502,7 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
      * @return SNAPSHOT version
      */
     private String buildSnapshotVersion(String version) {
-        if(version.endsWith("-SNAPSHOT")) {
+        if (version.endsWith("-SNAPSHOT")) {
             return version;
         }
         return version + "-SNAPSHOT";

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
@@ -758,9 +758,9 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
     }
 
     @Override
-    public String toDefaultValue(Schema p) {
-        p = ModelUtils.getReferencedSchema(this.openAPI, p);
-        if (ModelUtils.isArraySchema(p)) {
+    public String toDefaultValue(Schema schema) {
+        schema = ModelUtils.getReferencedSchema(this.openAPI, schema);
+        if (ModelUtils.isArraySchema(schema)) {
             final String pattern;
             if (fullJavaUtil) {
                 pattern = "new java.util.ArrayList<%s>()";
@@ -768,7 +768,7 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
                 pattern = "new ArrayList<%s>()";
             }
 
-            Schema<?> items = getSchemaItems((ArraySchema) p);
+            Schema<?> items = getSchemaItems((ArraySchema) schema);
 
             String typeDeclaration = getTypeDeclaration(items);
             Object java8obj = additionalProperties.get("java8");
@@ -780,18 +780,18 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
             }
 
             return String.format(Locale.ROOT, pattern, typeDeclaration);
-        } else if (ModelUtils.isMapSchema(p)) {
+        } else if (ModelUtils.isMapSchema(schema)) {
             final String pattern;
             if (fullJavaUtil) {
                 pattern = "new java.util.HashMap<%s>()";
             } else {
                 pattern = "new HashMap<%s>()";
             }
-            if (ModelUtils.getAdditionalProperties(p) == null) {
+            if (ModelUtils.getAdditionalProperties(schema) == null) {
                 return null;
             }
 
-            String typeDeclaration = String.format(Locale.ROOT, "String, %s", getTypeDeclaration(ModelUtils.getAdditionalProperties(p)));
+            String typeDeclaration = String.format(Locale.ROOT, "String, %s", getTypeDeclaration(ModelUtils.getAdditionalProperties(schema)));
             Object java8obj = additionalProperties.get("java8");
             if (java8obj != null) {
                 Boolean java8 = Boolean.valueOf(java8obj.toString());
@@ -801,47 +801,46 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
             }
 
             return String.format(Locale.ROOT, pattern, typeDeclaration);
-        } else if (ModelUtils.isIntegerSchema(p)) {
-            if (p.getDefault() != null) {
-                if (SchemaTypeUtil.INTEGER64_FORMAT.equals(p.getFormat())) {
-                    return p.getDefault().toString() + "l";
+        } else if (ModelUtils.isIntegerSchema(schema)) {
+            if (schema.getDefault() != null) {
+                if (SchemaTypeUtil.INTEGER64_FORMAT.equals(schema.getFormat())) {
+                    return schema.getDefault().toString() + "l";
                 } else {
-                    return p.getDefault().toString();
+                    return schema.getDefault().toString();
                 }
             }
             return null;
-        } else if (ModelUtils.isNumberSchema(p)) {
-            if (p.getDefault() != null) {
-                if (SchemaTypeUtil.FLOAT_FORMAT.equals(p.getFormat())) {
-                    return p.getDefault().toString() + "f";
+        } else if (ModelUtils.isNumberSchema(schema)) {
+            if (schema.getDefault() != null) {
+                if (SchemaTypeUtil.FLOAT_FORMAT.equals(schema.getFormat())) {
+                    return schema.getDefault().toString() + "f";
                 } else {
-                    return p.getDefault().toString() + "d";
+                    return schema.getDefault().toString() + "d";
                 }
             }
             return null;
-        } else if (ModelUtils.isBooleanSchema(p)) {
-            if (p.getDefault() != null) {
-                return p.getDefault().toString();
+        } else if (ModelUtils.isBooleanSchema(schema)) {
+            if (schema.getDefault() != null) {
+                return schema.getDefault().toString();
             }
             return null;
-        } else if (ModelUtils.isURISchema(p)) {
-            if (p.getDefault() != null) {
-                return "URI.create(\"" + escapeText((String) p.getDefault()) + "\")";
+        } else if (ModelUtils.isURISchema(schema)) {
+            if (schema.getDefault() != null) {
+                return "URI.create(\"" + escapeText((String) schema.getDefault()) + "\")";
             }
             return null;
-        } else if (ModelUtils.isStringSchema(p)) {
-            if (p.getDefault() != null) {
+        } else if (ModelUtils.isStringSchema(schema)) {
+            if (schema.getDefault() != null) {
                 String _default;
-                if (p.getDefault() instanceof Date){
+                if (schema.getDefault() instanceof Date){
                     String stringBuilder = "LocalDate.parse(\"" +
-                            p.getDefault() +
-                            "\")";
+                            schema.getDefault() +"\")";
                     return String.format(Locale.ROOT, stringBuilder, "");
                 }
                 else{
-                    _default = (String) p.getDefault();
+                    _default = (String) schema.getDefault();
                 }
-                if (p.getEnum() == null) {
+                if (schema.getEnum() == null) {
                     return "\"" + escapeText(_default) + "\"";
                 } else {
                     // convert to enum var name later in postProcessModels
@@ -849,14 +848,14 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
                 }
             }
             return null;
-        } else if (ModelUtils.isObjectSchema(p)) {
-            if (p.getDefault() != null) {
-                return super.toDefaultValue(p);
+        } else if (ModelUtils.isObjectSchema(schema)) {
+            if (schema.getDefault() != null) {
+                return super.toDefaultValue(schema);
             }
             return null;
         }
 
-        return super.toDefaultValue(p);
+        return super.toDefaultValue(schema);
     }
 
     @Override

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
@@ -26,6 +26,8 @@ import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.media.StringSchema;
 import io.swagger.v3.oas.models.servers.Server;
 import io.swagger.v3.parser.util.SchemaTypeUtil;
+import java.time.LocalDate;
+import java.time.ZoneId;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -833,9 +835,9 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
             if (schema.getDefault() != null) {
                 String _default;
                 if (schema.getDefault() instanceof Date){
-                    String stringBuilder = "LocalDate.parse(\"" +
-                            schema.getDefault() +"\")";
-                    return String.format(Locale.ROOT, stringBuilder, "");
+                    Date date = (Date) schema.getDefault();
+                    LocalDate localDate = date.toInstant().atZone(ZoneId.systemDefault()).toLocalDate();
+                    return String.format(Locale.ROOT, localDate.toString(), "");
                 }
                 else{
                     _default = (String) schema.getDefault();

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/AbstractJavaCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/AbstractJavaCodegenTest.java
@@ -21,6 +21,10 @@ import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.media.*;
 
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.Date;
 import org.openapitools.codegen.CodegenConstants;
 import org.openapitools.codegen.CodegenType;
 import org.openapitools.codegen.TestUtils;
@@ -411,6 +415,13 @@ public class AbstractJavaCodegenTest {
         Schema<?> schema = createObjectSchemaWithMinItems();
         String defaultValue = codegen.toDefaultValue(schema);
         Assert.assertNull(defaultValue);
+        DateSchema dateSchema = new DateSchema();
+        LocalDate defaultLocalDate = LocalDate.of(2019,2,15);
+        Date date = Date.from(defaultLocalDate.atStartOfDay(ZoneId.systemDefault()).toInstant());
+        dateSchema.setDefault(date);
+        defaultValue = codegen.toDefaultValue(dateSchema);
+        Assert.assertTrue(defaultValue.contains(defaultLocalDate.getYear()+""));
+        Assert.assertTrue(defaultValue.contains(defaultLocalDate.getDayOfMonth()+""));
     }
 
     @Test

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/AbstractJavaCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/AbstractJavaCodegenTest.java
@@ -420,8 +420,7 @@ public class AbstractJavaCodegenTest {
         Date date = Date.from(defaultLocalDate.atStartOfDay(ZoneId.systemDefault()).toInstant());
         dateSchema.setDefault(date);
         defaultValue = codegen.toDefaultValue(dateSchema);
-        Assert.assertTrue(defaultValue.contains(defaultLocalDate.getYear()+""));
-        Assert.assertTrue(defaultValue.contains(defaultLocalDate.getDayOfMonth()+""));
+        Assert.assertEquals(defaultLocalDate, LocalDate.parse(defaultValue));
     }
 
     @Test

--- a/modules/openapi-generator/src/test/resources/3_0/petstore.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/petstore.yaml
@@ -703,10 +703,6 @@ components:
         name:
           type: string
           example: doggie
-        birthday:
-          type: string
-          format: date
-          default: '2020-01-22'
         photoUrls:
           type: array
           xml:

--- a/modules/openapi-generator/src/test/resources/3_0/petstore.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/petstore.yaml
@@ -703,6 +703,10 @@ components:
         name:
           type: string
           example: doggie
+        birthday:
+          type: string
+          format: date
+          default: '2020-01-22'
         photoUrls:
           type: array
           xml:


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

-  handling examples of type date for openAPI 3 as localdate
- created test

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.


@bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04) @lwlee2608 (2019/10) @bkabrda (2020/01) @wing328  @jmini 