### PR TITLE
[JavaScript] Avoid setting Content-Type header if body is not used

### DIFF
--- a/modules/openapi-generator/src/main/resources/Javascript/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Javascript/ApiClient.mustache
@@ -459,8 +459,6 @@
       if(contentType != 'multipart/form-data') {
         request.type(contentType);
       }
-    } else if (!request.header['Content-Type']) {
-      request.type('application/json');
     }
 
     if (contentType === 'application/x-www-form-urlencoded') {
@@ -478,6 +476,9 @@
         }
       }
     } else if (bodyParam !== null && bodyParam !== undefined) {
+      if (!request.header['Content-Type']) {
+          request.type('application/json');
+      }
       request.send(bodyParam);
     }
 

--- a/modules/openapi-generator/src/main/resources/Javascript/es6/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Javascript/es6/ApiClient.mustache
@@ -421,8 +421,6 @@ class ApiClient {
             if(contentType != 'multipart/form-data') {
                 request.type(contentType);
             }
-        } else if (!request.header['Content-Type']) {
-            request.type('application/json');
         }
 
         if (contentType === 'application/x-www-form-urlencoded') {
@@ -440,6 +438,9 @@ class ApiClient {
                 }
             }
         } else if (bodyParam !== null && bodyParam !== undefined) {
+            if (!request.header['Content-Type']) {
+                request.type('application/json');
+            }
             request.send(bodyParam);
         }
 

--- a/samples/client/petstore/javascript-es6/src/ApiClient.js
+++ b/samples/client/petstore/javascript-es6/src/ApiClient.js
@@ -408,8 +408,6 @@ class ApiClient {
             if(contentType != 'multipart/form-data') {
                 request.type(contentType);
             }
-        } else if (!request.header['Content-Type']) {
-            request.type('application/json');
         }
 
         if (contentType === 'application/x-www-form-urlencoded') {
@@ -427,6 +425,9 @@ class ApiClient {
                 }
             }
         } else if (bodyParam !== null && bodyParam !== undefined) {
+            if (!request.header['Content-Type']) {
+                request.type('application/json');
+            }
             request.send(bodyParam);
         }
 

--- a/samples/client/petstore/javascript-promise-es6/src/ApiClient.js
+++ b/samples/client/petstore/javascript-promise-es6/src/ApiClient.js
@@ -400,8 +400,6 @@ class ApiClient {
             if(contentType != 'multipart/form-data') {
                 request.type(contentType);
             }
-        } else if (!request.header['Content-Type']) {
-            request.type('application/json');
         }
 
         if (contentType === 'application/x-www-form-urlencoded') {
@@ -419,6 +417,9 @@ class ApiClient {
                 }
             }
         } else if (bodyParam !== null && bodyParam !== undefined) {
+            if (!request.header['Content-Type']) {
+                request.type('application/json');
+            }
             request.send(bodyParam);
         }
 

--- a/samples/client/petstore/javascript-promise/src/ApiClient.js
+++ b/samples/client/petstore/javascript-promise/src/ApiClient.js
@@ -449,8 +449,6 @@
       if(contentType != 'multipart/form-data') {
         request.type(contentType);
       }
-    } else if (!request.header['Content-Type']) {
-      request.type('application/json');
     }
 
     if (contentType === 'application/x-www-form-urlencoded') {
@@ -468,6 +466,9 @@
         }
       }
     } else if (bodyParam !== null && bodyParam !== undefined) {
+      if (!request.header['Content-Type']) {
+          request.type('application/json');
+      }
       request.send(bodyParam);
     }
 

--- a/samples/client/petstore/javascript/src/ApiClient.js
+++ b/samples/client/petstore/javascript/src/ApiClient.js
@@ -458,8 +458,6 @@
       if(contentType != 'multipart/form-data') {
         request.type(contentType);
       }
-    } else if (!request.header['Content-Type']) {
-      request.type('application/json');
     }
 
     if (contentType === 'application/x-www-form-urlencoded') {
@@ -477,6 +475,9 @@
         }
       }
     } else if (bodyParam !== null && bodyParam !== undefined) {
+      if (!request.header['Content-Type']) {
+          request.type('application/json');
+      }
       request.send(bodyParam);
     }
 

--- a/samples/openapi3/client/petstore/javascript-es6/src/ApiClient.js
+++ b/samples/openapi3/client/petstore/javascript-es6/src/ApiClient.js
@@ -409,8 +409,6 @@ class ApiClient {
             if(contentType != 'multipart/form-data') {
                 request.type(contentType);
             }
-        } else if (!request.header['Content-Type']) {
-            request.type('application/json');
         }
 
         if (contentType === 'application/x-www-form-urlencoded') {
@@ -428,6 +426,9 @@ class ApiClient {
                 }
             }
         } else if (bodyParam !== null && bodyParam !== undefined) {
+            if (!request.header['Content-Type']) {
+                request.type('application/json');
+            }
             request.send(bodyParam);
         }
 


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

Avoid setting `Content-Type` header if body is not used. Currently, it's set to `application/json` by default even if no body is used.

This is important in that it makes request [simple](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#Simple_requests) to avoid triggerring a CORS preflight, which may not be supported by server since the sever does not expect it.


<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@CodeNinjai (2017/07) @frol (2017/07) @cliffano (2017/07)