### PR TITLE
Add return types to getter and fluent setter

### DIFF
--- a/modules/openapi-generator/src/main/resources/php-symfony/model_generic.mustache
+++ b/modules/openapi-generator/src/main/resources/php-symfony/model_generic.mustache
@@ -23,7 +23,7 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}} {{/parentSchema}}
      *
      * @return {{{vendorExtensions.x-comment-type}}}{{^required}}|null{{/required}}
      */
-    public function {{getter}}()
+    public function {{getter}}(){{#vendorExtensions.x-parameter-type}}: {{^required}}?{{/required}}{{vendorExtensions.x-parameter-type}}{{/vendorExtensions.x-parameter-type}}
     {
         return $this->{{name}};
     }
@@ -35,7 +35,7 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}} {{/parentSchema}}
      *
      * @return $this
      */
-    public function {{setter}}({{#vendorExtensions.x-parameter-type}}{{vendorExtensions.x-parameter-type}} {{/vendorExtensions.x-parameter-type}}${{name}}{{^required}} = null{{/required}})
+    public function {{setter}}({{#vendorExtensions.x-parameter-type}}{{vendorExtensions.x-parameter-type}} {{/vendorExtensions.x-parameter-type}}${{name}}{{^required}} = null{{/required}}){{#vendorExtensions.x-parameter-type}}: {{^required}}?{{/required}}{{vendorExtensions.x-parameter-type}}{{/vendorExtensions.x-parameter-type}}
     {
         $this->{{name}} = ${{name}};
 

--- a/samples/server/petstore/php-symfony/SymfonyBundle-php/Model/Order.php
+++ b/samples/server/petstore/php-symfony/SymfonyBundle-php/Model/Order.php
@@ -185,7 +185,7 @@ class Order
      *
      * @return \DateTime|null
      */
-    public function getShipDate()
+    public function getShipDate(): ?\DateTime
     {
         return $this->shipDate;
     }
@@ -197,7 +197,7 @@ class Order
      *
      * @return $this
      */
-    public function setShipDate(\DateTime $shipDate = null)
+    public function setShipDate(\DateTime $shipDate = null): ?\DateTime
     {
         $this->shipDate = $shipDate;
 

--- a/samples/server/petstore/php-symfony/SymfonyBundle-php/Model/Pet.php
+++ b/samples/server/petstore/php-symfony/SymfonyBundle-php/Model/Pet.php
@@ -143,7 +143,7 @@ class Pet
      *
      * @return OpenAPI\Server\Model\Category|null
      */
-    public function getCategory()
+    public function getCategory(): ?Category
     {
         return $this->category;
     }
@@ -155,7 +155,7 @@ class Pet
      *
      * @return $this
      */
-    public function setCategory(Category $category = null)
+    public function setCategory(Category $category = null): ?Category
     {
         $this->category = $category;
 
@@ -191,7 +191,7 @@ class Pet
      *
      * @return string[]
      */
-    public function getPhotoUrls()
+    public function getPhotoUrls(): array
     {
         return $this->photoUrls;
     }
@@ -203,7 +203,7 @@ class Pet
      *
      * @return $this
      */
-    public function setPhotoUrls(array $photoUrls)
+    public function setPhotoUrls(array $photoUrls): array
     {
         $this->photoUrls = $photoUrls;
 
@@ -215,7 +215,7 @@ class Pet
      *
      * @return OpenAPI\Server\Model\Tag[]|null
      */
-    public function getTags()
+    public function getTags(): ?array
     {
         return $this->tags;
     }
@@ -227,7 +227,7 @@ class Pet
      *
      * @return $this
      */
-    public function setTags(array $tags = null)
+    public function setTags(array $tags = null): ?array
     {
         $this->tags = $tags;
 


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

As it is possible to add types to the generated code (method argument types), it seems it is also wise to add types at the return value. This is wat this MR does.

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language. (@jebentier (2017/07), @dkarlovi (2017/07), @mandrean (2017/08), @jfastnacht (2017/09), @ackintosh (2017/09) ❤️, @ybelenko (2018/07), @renepardon (2018/12))
