### PR TITLE
[C-libcurl] Guard memory free for query parameters to avoid coredump

### DIFF
--- a/modules/openapi-generator/src/main/resources/C-libcurl/api-body.mustache
+++ b/modules/openapi-generator/src/main/resources/C-libcurl/api-body.mustache
@@ -131,8 +131,8 @@
 
     // query parameters
     {{^isListContainer}}
-    char *keyQuery_{{{paramName}}};
-    {{#isPrimitiveType}}{{#isNumber}}{{{dataType}}}{{/isNumber}}{{#isLong}}{{{dataType}}}{{/isLong}}{{#isInteger}}{{{dataType}}}{{/isInteger}}{{#isDouble}}{{{dataType}}}{{/isDouble}}{{#isFloat}}{{{dataType}}}{{/isFloat}}{{#isBoolean}}{{{dataType}}}{{/isBoolean}}{{#isEnum}}{{#isString}}{{{baseName}}}_e{{/isString}}{{/isEnum}}{{^isEnum}}{{#isString}}{{{dataType}}} *{{/isString}}{{/isEnum}}{{#isByteArray}}{{{dataType}}}{{/isByteArray}}{{#isDate}}{{{dataType}}}{{/isDate}}{{#isDateTime}}{{{dataType}}}{{/isDateTime}}{{#isFile}}{{{dataType}}}{{/isFile}}{{/isPrimitiveType}}{{^isPrimitiveType}}{{#isModel}}{{#isEnum}}{{datatypeWithEnum}}_e{{/isEnum}}{{^isEnum}}{{{dataType}}}_t *{{/isEnum}}{{/isModel}}{{^isModel}}{{#isEnum}}{{datatypeWithEnum}}_e{{/isEnum}}{{/isModel}}{{#isUuid}}{{dataType}} *{{/isUuid}}{{#isEmail}}{{dataType}}{{/isEmail}}{{/isPrimitiveType}} valueQuery_{{{paramName}}};
+    char *keyQuery_{{{paramName}}} = NULL;
+    {{#isPrimitiveType}}{{#isNumber}}{{{dataType}}}{{/isNumber}}{{#isLong}}{{{dataType}}}{{/isLong}}{{#isInteger}}{{{dataType}}}{{/isInteger}}{{#isDouble}}{{{dataType}}}{{/isDouble}}{{#isFloat}}{{{dataType}}}{{/isFloat}}{{#isBoolean}}{{{dataType}}}{{/isBoolean}}{{#isEnum}}{{#isString}}{{{baseName}}}_e{{/isString}}{{/isEnum}}{{^isEnum}}{{#isString}}{{{dataType}}} *{{/isString}}{{/isEnum}}{{#isByteArray}}{{{dataType}}}{{/isByteArray}}{{#isDate}}{{{dataType}}}{{/isDate}}{{#isDateTime}}{{{dataType}}}{{/isDateTime}}{{#isFile}}{{{dataType}}}{{/isFile}}{{/isPrimitiveType}}{{^isPrimitiveType}}{{#isModel}}{{#isEnum}}{{datatypeWithEnum}}_e{{/isEnum}}{{^isEnum}}{{{dataType}}}_t *{{/isEnum}}{{/isModel}}{{^isModel}}{{#isEnum}}{{datatypeWithEnum}}_e{{/isEnum}}{{/isModel}}{{#isUuid}}{{dataType}} *{{/isUuid}}{{#isEmail}}{{dataType}}{{/isEmail}}{{/isPrimitiveType}} valueQuery_{{{paramName}}} {{#isString}}{{^isEnum}}= NULL{{/isEnum}}{{/isString}};
     keyValuePair_t *keyPairQuery_{{paramName}} = 0;
     {{/isListContainer}}
     if ({{paramName}})
@@ -330,13 +330,28 @@
     {{#queryParams}}
     {{^isListContainer}}
     {{#isString}}
-    free(keyQuery_{{{paramName}}});
-    free(valueQuery_{{{paramName}}});
-    keyValuePair_free(keyPairQuery_{{{paramName}}});
+    if(keyQuery_{{{paramName}}}){
+        free(keyQuery_{{{paramName}}});
+        keyQuery_{{{paramName}}} = NULL;
+    }
+    if(valueQuery_{{{paramName}}}){
+        free(valueQuery_{{{paramName}}});
+        valueQuery_{{{paramName}}} = NULL;
+    }
+    if(keyPairQuery_{{{paramName}}}){
+        keyValuePair_free(keyPairQuery_{{{paramName}}});
+        keyPairQuery_{{{paramName}}} = NULL;
+    }
     {{/isString}}
     {{^isString}}
-    free(keyQuery_{{{paramName}}});
-    keyValuePair_free(keyPairQuery_{{{paramName}}});
+    if(keyQuery_{{{paramName}}}){
+        free(keyQuery_{{{paramName}}});
+        keyQuery_{{{paramName}}} = NULL;
+    }
+    if(keyPairQuery_{{{paramName}}}){
+        keyValuePair_free(keyPairQuery_{{{paramName}}});
+        keyPairQuery_{{{paramName}}} = NULL;
+    }
     {{/isString}}
     {{/isListContainer}}
     {{/queryParams}}
@@ -403,13 +418,28 @@ end:
     {{#queryParams}}
     {{^isListContainer}}
     {{#isString}}
-    free(keyQuery_{{{paramName}}});
-    free(valueQuery_{{{paramName}}});
-    keyValuePair_free(keyPairQuery_{{{paramName}}});
+    if(keyQuery_{{{paramName}}}){
+        free(keyQuery_{{{paramName}}});
+        keyQuery_{{{paramName}}} = NULL;
+    }
+    if(valueQuery_{{{paramName}}}){
+        free(valueQuery_{{{paramName}}});
+        valueQuery_{{{paramName}}} = NULL;
+    }
+    if(keyPairQuery_{{{paramName}}}){
+        keyValuePair_free(keyPairQuery_{{{paramName}}});
+        keyPairQuery_{{{paramName}}} = NULL;
+    }
     {{/isString}}
     {{#isString}}
-    free(keyQuery_{{{paramName}}});
-    keyValuePair_free(keyPairQuery_{{{paramName}}});
+    if(){
+        free(keyQuery_{{{paramName}}});
+        keyQuery_{{{paramName}}} = NULL;
+    }
+    if(){
+        keyValuePair_free(keyPairQuery_{{{paramName}}});
+        keyPairQuery_{{{paramName}}} = NULL;
+    }
     {{/isString}}
     {{/isListContainer}}
     {{/queryParams}}

--- a/modules/openapi-generator/src/main/resources/C-libcurl/api-body.mustache
+++ b/modules/openapi-generator/src/main/resources/C-libcurl/api-body.mustache
@@ -432,11 +432,11 @@ end:
     }
     {{/isString}}
     {{#isString}}
-    if(){
+    if(keyQuery_{{{paramName}}}){
         free(keyQuery_{{{paramName}}});
         keyQuery_{{{paramName}}} = NULL;
     }
-    if(){
+    if(keyPairQuery_{{{paramName}}}){
         keyValuePair_free(keyPairQuery_{{{paramName}}});
         keyPairQuery_{{{paramName}}} = NULL;
     }


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

After generating a C-libcurl client for kubernetes and linking with my program,  a coredump will happen due to deleting an un-allocated memory

```
Program received signal SIGSEGV, Segmentation fault.
__GI___libc_free (mem=0x3000000030) at malloc.c:2951
2951    malloc.c: No such file or directory.
(gdb) bt
#0  __GI___libc_free (mem=0x3000000030) at malloc.c:2951
#1  0x00000000004290a0 in CoreV1API_listCoreV1NamespacedSecret (apiClient=0x6b4570, namespace=0x488489 "default", 
    pretty=0x0, allowWatchBookmarks=0, _continue=0x0, fieldSelector=0x0, labelSelector=0x0, limit=0, 
    resourceVersion=0x0, timeoutSeconds=1000, watch=0) at /root/c_k8s_api_client/api/CoreV1API.c:16598
#2  0x0000000000401532 in listSecret () at main.c:77
#3  0x000000000040179f in main (argc=2, argv=0x7fffffffe0a8) at main.c:159
```

The coredump happens at:

```
    free(keyQuery_pretty);
```
But actually,  keyQuery_pretty is not allocated.

So I added some guards for the query parameters before memory free.

<!-- Please check the completed items below -->
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [X] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [X] File the PR against the [master](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [X] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@wing328 @zhemant