### PR TITLE
[hb] Honor supporting files when applying bundles

### DIFF
--- a/modules/openapi-generator-core/src/main/java/org/openapitools/codegen/api/TemplatingEngineAdapter.java
+++ b/modules/openapi-generator-core/src/main/java/org/openapitools/codegen/api/TemplatingEngineAdapter.java
@@ -16,7 +16,9 @@
 
 package org.openapitools.codegen.api;
 
-import java.io.*;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Locale;
@@ -25,73 +27,77 @@ import java.util.Map;
 /**
  * Each templating engine is called by an Adapter, selected at runtime
  */
-public interface TemplatingEngineAdapter{
+public interface TemplatingEngineAdapter {
 
-  /**
-   * Provides an identifier used to load the adapter. This could be a name, uuid, or any other string.
-   *
-   * @return A string identifier.
-   */
-  String getIdentifier();
+    /**
+     * Provides an identifier used to load the adapter. This could be a name, uuid, or any other string.
+     *
+     * @return A string identifier.
+     */
+    String getIdentifier();
 
-  /**
-   * Compiles a template into a string
-   *
-   * @param generator From where we can fetch the templates content (e.g. an instance of DefaultGenerator)
-   * @param bundle The map of values to pass to the template
-   * @param templateFile The name of the template (e.g. model.mustache )
-   * @return the processed template result
-   * @throws IOException an error ocurred in the template processing
-   */
-  String compileTemplate(TemplatingGenerator generator, Map<String, Object> bundle,
-                         String templateFile) throws IOException;
+    /**
+     * Compiles a template into a string
+     *
+     * @param generator    From where we can fetch the templates content (e.g. an instance of DefaultGenerator)
+     * @param bundle       The map of values to pass to the template
+     * @param templateFile The name of the template (e.g. model.mustache )
+     * @return the processed template result
+     * @throws IOException an error ocurred in the template processing
+     */
+    String compileTemplate(TemplatingGenerator generator, Map<String, Object> bundle,
+                           String templateFile) throws IOException;
 
-  /**
-   * During generation, if a supporting file has a file extension that is
-   * inside that array, then it is considered a templated supporting file
-   * and we use the templating engine adapter to generate it
-   * @return string array of the valid file extensions for this templating engine
-   */
-  String[] getFileExtensions();
+    /**
+     * During generation, if a supporting file has a file extension that is
+     * inside that array, then it is considered a templated supporting file
+     * and we use the templating engine adapter to generate it
+     *
+     * @return string array of the valid file extensions for this templating engine
+     */
+    String[] getFileExtensions();
 
-  /**
-   * Determines whether the template file with supported extensions exists. This may be on the filesystem,
-   * external filesystem, or classpath (implementation is up to TemplatingGenerator).
-   *
-   * @param generator The generator holding details about file resolution
-   * @param templateFile The original target filename
-   * @return True if the template is available in the template search path, false if it can not be found
-   */
-  default boolean templateExists(TemplatingGenerator generator, String templateFile) {
-    return Arrays.stream(getFileExtensions()).anyMatch(ext -> {
-      int idx = templateFile.lastIndexOf(".");
-      String baseName;
-      if (idx > 0 && idx < templateFile.length() - 1) {
-        baseName = templateFile.substring(0, idx);
-      } else {
-        baseName = templateFile;
-      }
+    /**
+     * Determines whether the template file with supported extensions exists. This may be on the filesystem,
+     * external filesystem, or classpath (implementation is up to TemplatingGenerator).
+     *
+     * @param generator    The generator holding details about file resolution
+     * @param templateFile The original target filename
+     * @return True if the template is available in the template search path, false if it can not be found
+     */
+    default boolean templateExists(TemplatingGenerator generator, String templateFile) {
+        return Arrays.stream(getFileExtensions()).anyMatch(ext -> {
+            int idx = templateFile.lastIndexOf(".");
+            String baseName;
+            if (idx > 0 && idx < templateFile.length() - 1) {
+                baseName = templateFile.substring(0, idx);
+            } else {
+                baseName = templateFile;
+            }
 
-      Path path = generator.getFullTemplatePath(String.format(Locale.ROOT, "%s.%s", baseName, ext));
+            Path path = generator.getFullTemplatePath(String.format(Locale.ROOT, "%s.%s", baseName, ext));
 
-      InputStream is = null;
-      try {
-        is = this.getClass().getClassLoader().getResourceAsStream(path.toString());
-        if (is == null) {
-          is = new FileInputStream(path.toFile());
-        }
+            InputStream is = null;
+            try {
+                String resourcePath = System.getProperty("os.name").startsWith("Windows") ?
+                        path.toString().replace("\\", "/") :
+                        path.toString();
+                is = this.getClass().getClassLoader().getResourceAsStream(resourcePath);
+                if (is == null) {
+                    is = new FileInputStream(path.toFile());
+                }
 
-        return is.available() > 0;
-      } catch (IOException e) {
-        // ignore
-      } finally {
-        try {
-          if (is != null) is.close();
-        } catch (IOException e) {
-          // ignore
-        }
-      }
-      return false;
-    });
-  }
+                return is.available() > 0;
+            } catch (IOException e) {
+                // ignore
+            } finally {
+                try {
+                    if (is != null) is.close();
+                } catch (IOException e) {
+                    // ignore
+                }
+            }
+            return false;
+        });
+    }
 }

--- a/modules/openapi-generator-core/src/main/java/org/openapitools/codegen/api/TemplatingGenerator.java
+++ b/modules/openapi-generator-core/src/main/java/org/openapitools/codegen/api/TemplatingGenerator.java
@@ -20,26 +20,24 @@ import java.nio.file.Path;
 
 /**
  * interface to the full template content
- *   implementers might take into account the -t cli option,
- *   look in the resources for a language specific template, etc
+ * implementers might take into account the -t cli option,
+ * look in the resources for a language specific template, etc
  */
 public interface TemplatingGenerator {
 
-  /**
-   * returns the template content by name
-   *
-   * @param name the template name (e.g. model.mustache)
-   *
-   * @return the contents of that template
-   */
-  String getFullTemplateContents(String name);
+    /**
+     * returns the template content by name
+     *
+     * @param name the template name (e.g. model.mustache)
+     * @return the contents of that template
+     */
+    String getFullTemplateContents(String name);
 
-  /**
-   * Returns the path of a template, allowing access to the template where consuming literal contents aren't desirable or possible.
-   *
-   * @param name the template name (e.g. model.mustache)
-   *
-   * @return The {@link Path} to the template
-   */
-  Path getFullTemplatePath(String name);
+    /**
+     * Returns the path of a template, allowing access to the template where consuming literal contents aren't desirable or possible.
+     *
+     * @param name the template name (e.g. model.mustache)
+     * @return The {@link Path} to the template
+     */
+    Path getFullTemplatePath(String name);
 }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
@@ -723,7 +723,9 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
                 }
 
                 if (ignoreProcessor.allowsFile(new File(outputFilename))) {
-                    if (Arrays.stream(templatingEngine.getFileExtensions()).anyMatch(templateFile::endsWith)) {
+                    // support.templateFile is the unmodified/original supporting file name (e.g. build.sh.mustache)
+                    // templatingEngine.templateExists dispatches resolution to this, performing template-engine specific inspect of support file extensions.
+                    if (templatingEngine.templateExists(this, support.templateFile)) {
                         String templateContent = templatingEngine.compileTemplate(this, bundle, support.templateFile);
                         writeToFile(outputFilename, templateContent);
                         File written = new File(outputFilename);

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/templating/HandlebarsEngineAdapter.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/templating/HandlebarsEngineAdapter.java
@@ -90,7 +90,7 @@ public class HandlebarsEngineAdapter extends AbstractTemplatingEngineAdapter {
             } catch (Exception ignored) {
             }
         }
-        throw new RuntimeException("couldnt find a subtemplate " + templateFile);
+        throw new TemplateNotFoundException(templateFile);
     }
 
     @Override

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/templating/MustacheEngineAdapter.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/templating/MustacheEngineAdapter.java
@@ -60,7 +60,7 @@ public class MustacheEngineAdapter implements TemplatingEngineAdapter {
             } catch (Exception ignored) {
             }
         }
-        throw new RuntimeException("couldnt find a subtemplate " + name);
+        throw new TemplateNotFoundException(name);
     }
 
     public Mustache.Compiler getCompiler() {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/templating/TemplateNotFoundException.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/templating/TemplateNotFoundException.java
@@ -1,0 +1,76 @@
+package org.openapitools.codegen.templating;
+
+public class TemplateNotFoundException extends RuntimeException {
+    /**
+     * Constructs a new runtime exception with {@code null} as its
+     * detail message.  The cause is not initialized, and may subsequently be
+     * initialized by a call to {@link #initCause}.
+     */
+    public TemplateNotFoundException() {
+    }
+
+    /**
+     * Constructs a new runtime exception with the specified detail message.
+     * The cause is not initialized, and may subsequently be initialized by a
+     * call to {@link #initCause}.
+     *
+     * @param message the detail message. The detail message is saved for
+     *                later retrieval by the {@link #getMessage()} method.
+     */
+    public TemplateNotFoundException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a new runtime exception with the specified detail message and
+     * cause.  <p>Note that the detail message associated with
+     * {@code cause} is <i>not</i> automatically incorporated in
+     * this runtime exception's detail message.
+     *
+     * @param message the detail message (which is saved for later retrieval
+     *                by the {@link #getMessage()} method).
+     * @param cause   the cause (which is saved for later retrieval by the
+     *                {@link #getCause()} method).  (A <tt>null</tt> value is
+     *                permitted, and indicates that the cause is nonexistent or
+     *                unknown.)
+     * @since 1.4
+     */
+    public TemplateNotFoundException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    /**
+     * Constructs a new runtime exception with the specified cause and a
+     * detail message of <tt>(cause==null ? null : cause.toString())</tt>
+     * (which typically contains the class and detail message of
+     * <tt>cause</tt>).  This constructor is useful for runtime exceptions
+     * that are little more than wrappers for other throwables.
+     *
+     * @param cause the cause (which is saved for later retrieval by the
+     *              {@link #getCause()} method).  (A <tt>null</tt> value is
+     *              permitted, and indicates that the cause is nonexistent or
+     *              unknown.)
+     * @since 1.4
+     */
+    public TemplateNotFoundException(Throwable cause) {
+        super(cause);
+    }
+
+    /**
+     * Constructs a new runtime exception with the specified detail
+     * message, cause, suppression enabled or disabled, and writable
+     * stack trace enabled or disabled.
+     *
+     * @param message            the detail message.
+     * @param cause              the cause.  (A {@code null} value is permitted,
+     *                           and indicates that the cause is nonexistent or unknown.)
+     * @param enableSuppression  whether or not suppression is enabled
+     *                           or disabled
+     * @param writableStackTrace whether or not the stack trace should
+     *                           be writable
+     * @since 1.7
+     */
+    public TemplateNotFoundException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+}

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/templating/TemplateNotFoundException.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/templating/TemplateNotFoundException.java
@@ -30,7 +30,7 @@ public class TemplateNotFoundException extends RuntimeException {
      * @param message the detail message (which is saved for later retrieval
      *                by the {@link #getMessage()} method).
      * @param cause   the cause (which is saved for later retrieval by the
-     *                {@link #getCause()} method).  (A <tt>null</tt> value is
+     *                {@link #getCause()} method).  (A <code>null</code> value is
      *                permitted, and indicates that the cause is nonexistent or
      *                unknown.)
      * @since 1.4
@@ -41,13 +41,13 @@ public class TemplateNotFoundException extends RuntimeException {
 
     /**
      * Constructs a new runtime exception with the specified cause and a
-     * detail message of <tt>(cause==null ? null : cause.toString())</tt>
+     * detail message of <code>(cause==null ? null : cause.toString())</code>
      * (which typically contains the class and detail message of
-     * <tt>cause</tt>).  This constructor is useful for runtime exceptions
+     * <code>cause</code>).  This constructor is useful for runtime exceptions
      * that are little more than wrappers for other throwables.
      *
      * @param cause the cause (which is saved for later retrieval by the
-     *              {@link #getCause()} method).  (A <tt>null</tt> value is
+     *              {@link #getCause()} method).  (A <code>null</code> value is
      *              permitted, and indicates that the cause is nonexistent or
      *              unknown.)
      * @since 1.4


### PR DESCRIPTION
Experimental handlebars template engine wasn't applying data bundle to supporting files. This fixes that.

Because this changes how default mustache supporting files are handled, and our samples directory overwrites existing files, I'd like someone to double-check generation of mustache. I'd deleted the whole `samples` directory before regeneration, but this results in ~1200 lines of git status. I switched over to master and had the same results

cc @OpenAPITools/generator-core-team 

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

closes #5320