### PR TITLE
always use @JacksonXmlElementWrapper and read xml data from reference…

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -3027,14 +3027,6 @@ public class DefaultCodegen implements CodegenConfig {
             property.isNullable = p.getNullable();
         }
 
-        if (p.getXml() != null) {
-            if (p.getXml().getAttribute() != null) {
-                property.isXmlAttribute = p.getXml().getAttribute();
-            }
-            property.xmlPrefix = p.getXml().getPrefix();
-            property.xmlName = p.getXml().getName();
-            property.xmlNamespace = p.getXml().getNamespace();
-        }
         if (p.getExtensions() != null && !p.getExtensions().isEmpty()) {
             property.getVendorExtensions().putAll(p.getExtensions());
         }
@@ -3199,6 +3191,32 @@ public class DefaultCodegen implements CodegenConfig {
             property.isNullable = referencedSchema.getNullable();
         }
 
+        final XML referencedSchemaXml = referencedSchema.getXml();
+
+        if (referencedSchemaXml != null) {
+            property.xmlName = referencedSchemaXml.getName();
+            property.xmlNamespace = referencedSchemaXml.getNamespace();
+            property.xmlPrefix = referencedSchemaXml.getPrefix();
+            if (referencedSchemaXml.getAttribute() != null) {
+                property.isXmlAttribute = referencedSchemaXml.getAttribute();
+            }
+            if (referencedSchemaXml.getWrapped() != null) {
+                property.isXmlWrapped = referencedSchemaXml.getWrapped();
+            }
+        }
+
+        if (p.getXml() != null) {
+            if (p.getXml().getAttribute() != null) {
+                property.isXmlAttribute = p.getXml().getAttribute();
+            }
+            if (p.getXml().getWrapped() != null) {
+                property.isXmlWrapped = p.getXml().getWrapped();
+            }
+            property.xmlPrefix = p.getXml().getPrefix();
+            property.xmlName = p.getXml().getName();
+            property.xmlNamespace = p.getXml().getNamespace();
+        }
+
         property.dataType = getTypeDeclaration(p);
         property.dataFormat = p.getFormat();
         property.baseType = getSchemaType(p);
@@ -3220,12 +3238,6 @@ public class DefaultCodegen implements CodegenConfig {
                 property.containerType = "array";
             }
             property.baseType = getSchemaType(p);
-            if (p.getXml() != null) {
-                property.isXmlWrapped = p.getXml().getWrapped() == null ? false : p.getXml().getWrapped();
-                property.xmlPrefix = p.getXml().getPrefix();
-                property.xmlNamespace = p.getXml().getNamespace();
-                property.xmlName = p.getXml().getName();
-            }
 
             // handle inner property
             property.maxItems = p.getMaxItems();

--- a/modules/openapi-generator/src/main/resources/Java/jackson_annotations.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/jackson_annotations.mustache
@@ -11,9 +11,8 @@
   @JacksonXmlProperty({{#isXmlAttribute}}isAttribute = true, {{/isXmlAttribute}}{{#xmlNamespace}}namespace="{{xmlNamespace}}", {{/xmlNamespace}}localName = "{{#xmlName}}{{xmlName}}{{/xmlName}}{{^xmlName}}{{baseName}}{{/xmlName}}")
     {{/isContainer}}
     {{#isContainer}}
-      {{#isXmlWrapped}}
   // items.xmlName={{items.xmlName}}
-  @JacksonXmlElementWrapper(useWrapping = {{isXmlWrapped}}, {{#xmlNamespace}}namespace="{{xmlNamespace}}", {{/xmlNamespace}}localName = "{{#items.xmlName}}{{items.xmlName}}{{/items.xmlName}}{{^items.xmlName}}{{items.baseName}}{{/items.xmlName}}")
-      {{/isXmlWrapped}}
+  @JacksonXmlProperty({{#xmlNamespace}}namespace="{{xmlNamespace}}", {{/xmlNamespace}}localName = "{{#items.xmlName}}{{items.xmlName}}{{/items.xmlName}}{{^items.xmlName}}{{items.baseName}}{{/items.xmlName}}")
+  @JacksonXmlElementWrapper(useWrapping = {{isXmlWrapped}}{{#xmlNamespace}}, namespace="{{xmlNamespace}}"{{/xmlNamespace}}{{#isXmlWrapped}}, localName = "{{#xmlName}}{{xmlName}}{{/xmlName}}{{^xmlName}}{{baseName}}{{/xmlName}}"{{/isXmlWrapped}})
     {{/isContainer}}
   {{/withXml}}

--- a/modules/openapi-generator/src/main/resources/Java/jackson_annotations.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/jackson_annotations.mustache
@@ -12,7 +12,7 @@
     {{/isContainer}}
     {{#isContainer}}
   // items.xmlName={{items.xmlName}}
-  @JacksonXmlProperty({{#xmlNamespace}}namespace="{{xmlNamespace}}", {{/xmlNamespace}}localName = "{{#items.xmlName}}{{items.xmlName}}{{/items.xmlName}}{{^items.xmlName}}{{items.baseName}}{{/items.xmlName}}")
+  @JacksonXmlProperty({{#xmlNamespace}}namespace="{{xmlNamespace}}", {{/xmlNamespace}}localName = "{{#items.xmlName}}{{items.xmlName}}{{/items.xmlName}}{{^items.xmlName}}{{#xmlName}}{{xmlName}}{{/xmlName}}{{^xmlName}}{{baseName}}{{/xmlName}}{{/items.xmlName}}")
   @JacksonXmlElementWrapper(useWrapping = {{isXmlWrapped}}{{#xmlNamespace}}, namespace="{{xmlNamespace}}"{{/xmlNamespace}}{{#isXmlWrapped}}, localName = "{{#xmlName}}{{xmlName}}{{/xmlName}}{{^xmlName}}{{baseName}}{{/xmlName}}"{{/isXmlWrapped}})
     {{/isContainer}}
   {{/withXml}}

--- a/modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml
+++ b/modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml
@@ -1238,14 +1238,15 @@ definitions:
         type: array
         uniqueItems: true
         xml:
-          name: photoUrl
           wrapped: true
         items:
           type: string
+          xml:
+            name: photoUrl
       tags:
         type: array
         xml:
-          name: tag
+          name: tags
           wrapped: true
         items:
           $ref: '#/definitions/Tag'

--- a/samples/client/petstore/go-experimental/go-petstore/api/openapi.yaml
+++ b/samples/client/petstore/go-experimental/go-petstore/api/openapi.yaml
@@ -1325,17 +1325,18 @@ components:
         photoUrls:
           items:
             type: string
+            xml:
+              name: photoUrl
           type: array
           uniqueItems: true
           xml:
-            name: photoUrl
             wrapped: true
         tags:
           items:
             $ref: '#/components/schemas/Tag'
           type: array
           xml:
-            name: tag
+            name: tags
             wrapped: true
         status:
           description: pet status in the store

--- a/samples/client/petstore/go/go-petstore-withXml/api/openapi.yaml
+++ b/samples/client/petstore/go/go-petstore-withXml/api/openapi.yaml
@@ -1325,17 +1325,18 @@ components:
         photoUrls:
           items:
             type: string
+            xml:
+              name: photoUrl
           type: array
           uniqueItems: true
           xml:
-            name: photoUrl
             wrapped: true
         tags:
           items:
             $ref: '#/components/schemas/Tag'
           type: array
           xml:
-            name: tag
+            name: tags
             wrapped: true
         status:
           description: pet status in the store

--- a/samples/client/petstore/go/go-petstore/api/openapi.yaml
+++ b/samples/client/petstore/go/go-petstore/api/openapi.yaml
@@ -1325,17 +1325,18 @@ components:
         photoUrls:
           items:
             type: string
+            xml:
+              name: photoUrl
           type: array
           uniqueItems: true
           xml:
-            name: photoUrl
             wrapped: true
         tags:
           items:
             $ref: '#/components/schemas/Tag'
           type: array
           xml:
-            name: tag
+            name: tags
             wrapped: true
         status:
           description: pet status in the store

--- a/samples/client/petstore/haskell-http-client/openapi.yaml
+++ b/samples/client/petstore/haskell-http-client/openapi.yaml
@@ -1325,17 +1325,18 @@ components:
         photoUrls:
           items:
             type: string
+            xml:
+              name: photoUrl
           type: array
           uniqueItems: true
           xml:
-            name: photoUrl
             wrapped: true
         tags:
           items:
             $ref: '#/components/schemas/Tag'
           type: array
           xml:
-            name: tag
+            name: tags
             wrapped: true
         status:
           description: pet status in the store

--- a/samples/client/petstore/java/feign/api/openapi.yaml
+++ b/samples/client/petstore/java/feign/api/openapi.yaml
@@ -1386,17 +1386,18 @@ components:
         photoUrls:
           items:
             type: string
+            xml:
+              name: photoUrl
           type: array
           uniqueItems: true
           xml:
-            name: photoUrl
             wrapped: true
         tags:
           items:
             $ref: '#/components/schemas/Tag'
           type: array
           xml:
-            name: tag
+            name: tags
             wrapped: true
         status:
           description: pet status in the store

--- a/samples/client/petstore/java/google-api-client/api/openapi.yaml
+++ b/samples/client/petstore/java/google-api-client/api/openapi.yaml
@@ -1386,17 +1386,18 @@ components:
         photoUrls:
           items:
             type: string
+            xml:
+              name: photoUrl
           type: array
           uniqueItems: true
           xml:
-            name: photoUrl
             wrapped: true
         tags:
           items:
             $ref: '#/components/schemas/Tag'
           type: array
           xml:
-            name: tag
+            name: tags
             wrapped: true
         status:
           description: pet status in the store

--- a/samples/client/petstore/java/jersey1/api/openapi.yaml
+++ b/samples/client/petstore/java/jersey1/api/openapi.yaml
@@ -1386,17 +1386,18 @@ components:
         photoUrls:
           items:
             type: string
+            xml:
+              name: photoUrl
           type: array
           uniqueItems: true
           xml:
-            name: photoUrl
             wrapped: true
         tags:
           items:
             $ref: '#/components/schemas/Tag'
           type: array
           xml:
-            name: tag
+            name: tags
             wrapped: true
         status:
           description: pet status in the store

--- a/samples/client/petstore/java/jersey2-java8/api/openapi.yaml
+++ b/samples/client/petstore/java/jersey2-java8/api/openapi.yaml
@@ -1386,17 +1386,18 @@ components:
         photoUrls:
           items:
             type: string
+            xml:
+              name: photoUrl
           type: array
           uniqueItems: true
           xml:
-            name: photoUrl
             wrapped: true
         tags:
           items:
             $ref: '#/components/schemas/Tag'
           type: array
           xml:
-            name: tag
+            name: tags
             wrapped: true
         status:
           description: pet status in the store

--- a/samples/client/petstore/java/native-async/api/openapi.yaml
+++ b/samples/client/petstore/java/native-async/api/openapi.yaml
@@ -1386,17 +1386,18 @@ components:
         photoUrls:
           items:
             type: string
+            xml:
+              name: photoUrl
           type: array
           uniqueItems: true
           xml:
-            name: photoUrl
             wrapped: true
         tags:
           items:
             $ref: '#/components/schemas/Tag'
           type: array
           xml:
-            name: tag
+            name: tags
             wrapped: true
         status:
           description: pet status in the store

--- a/samples/client/petstore/java/native/api/openapi.yaml
+++ b/samples/client/petstore/java/native/api/openapi.yaml
@@ -1386,17 +1386,18 @@ components:
         photoUrls:
           items:
             type: string
+            xml:
+              name: photoUrl
           type: array
           uniqueItems: true
           xml:
-            name: photoUrl
             wrapped: true
         tags:
           items:
             $ref: '#/components/schemas/Tag'
           type: array
           xml:
-            name: tag
+            name: tags
             wrapped: true
         status:
           description: pet status in the store

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/api/openapi.yaml
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/api/openapi.yaml
@@ -1386,17 +1386,18 @@ components:
         photoUrls:
           items:
             type: string
+            xml:
+              name: photoUrl
           type: array
           uniqueItems: true
           xml:
-            name: photoUrl
             wrapped: true
         tags:
           items:
             $ref: '#/components/schemas/Tag'
           type: array
           xml:
-            name: tag
+            name: tags
             wrapped: true
         status:
           description: pet status in the store

--- a/samples/client/petstore/java/okhttp-gson/api/openapi.yaml
+++ b/samples/client/petstore/java/okhttp-gson/api/openapi.yaml
@@ -1386,17 +1386,18 @@ components:
         photoUrls:
           items:
             type: string
+            xml:
+              name: photoUrl
           type: array
           uniqueItems: true
           xml:
-            name: photoUrl
             wrapped: true
         tags:
           items:
             $ref: '#/components/schemas/Tag'
           type: array
           xml:
-            name: tag
+            name: tags
             wrapped: true
         status:
           description: pet status in the store

--- a/samples/client/petstore/java/rest-assured-jackson/api/openapi.yaml
+++ b/samples/client/petstore/java/rest-assured-jackson/api/openapi.yaml
@@ -1386,17 +1386,18 @@ components:
         photoUrls:
           items:
             type: string
+            xml:
+              name: photoUrl
           type: array
           uniqueItems: true
           xml:
-            name: photoUrl
             wrapped: true
         tags:
           items:
             $ref: '#/components/schemas/Tag'
           type: array
           xml:
-            name: tag
+            name: tags
             wrapped: true
         status:
           description: pet status in the store

--- a/samples/client/petstore/java/rest-assured/api/openapi.yaml
+++ b/samples/client/petstore/java/rest-assured/api/openapi.yaml
@@ -1386,17 +1386,18 @@ components:
         photoUrls:
           items:
             type: string
+            xml:
+              name: photoUrl
           type: array
           uniqueItems: true
           xml:
-            name: photoUrl
             wrapped: true
         tags:
           items:
             $ref: '#/components/schemas/Tag'
           type: array
           xml:
-            name: tag
+            name: tags
             wrapped: true
         status:
           description: pet status in the store

--- a/samples/client/petstore/java/resteasy/api/openapi.yaml
+++ b/samples/client/petstore/java/resteasy/api/openapi.yaml
@@ -1386,17 +1386,18 @@ components:
         photoUrls:
           items:
             type: string
+            xml:
+              name: photoUrl
           type: array
           uniqueItems: true
           xml:
-            name: photoUrl
             wrapped: true
         tags:
           items:
             $ref: '#/components/schemas/Tag'
           type: array
           xml:
-            name: tag
+            name: tags
             wrapped: true
         status:
           description: pet status in the store

--- a/samples/client/petstore/java/resttemplate-withXml/api/openapi.yaml
+++ b/samples/client/petstore/java/resttemplate-withXml/api/openapi.yaml
@@ -1386,17 +1386,18 @@ components:
         photoUrls:
           items:
             type: string
+            xml:
+              name: photoUrl
           type: array
           uniqueItems: true
           xml:
-            name: photoUrl
             wrapped: true
         tags:
           items:
             $ref: '#/components/schemas/Tag'
           type: array
           xml:
-            name: tag
+            name: tags
             wrapped: true
         status:
           description: pet status in the store

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -143,6 +143,9 @@ public class AdditionalPropertiesClass {
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_MAP_STRING)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  // items.xmlName=
+  @JacksonXmlProperty(localName = "map_string")
+  @JacksonXmlElementWrapper(useWrapping = false)
 
   public Map<String, String> getMapString() {
     return mapString;
@@ -176,6 +179,9 @@ public class AdditionalPropertiesClass {
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_MAP_NUMBER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  // items.xmlName=
+  @JacksonXmlProperty(localName = "map_number")
+  @JacksonXmlElementWrapper(useWrapping = false)
 
   public Map<String, BigDecimal> getMapNumber() {
     return mapNumber;
@@ -209,6 +215,9 @@ public class AdditionalPropertiesClass {
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_MAP_INTEGER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  // items.xmlName=
+  @JacksonXmlProperty(localName = "map_integer")
+  @JacksonXmlElementWrapper(useWrapping = false)
 
   public Map<String, Integer> getMapInteger() {
     return mapInteger;
@@ -242,6 +251,9 @@ public class AdditionalPropertiesClass {
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_MAP_BOOLEAN)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  // items.xmlName=
+  @JacksonXmlProperty(localName = "map_boolean")
+  @JacksonXmlElementWrapper(useWrapping = false)
 
   public Map<String, Boolean> getMapBoolean() {
     return mapBoolean;
@@ -275,6 +287,9 @@ public class AdditionalPropertiesClass {
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_MAP_ARRAY_INTEGER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  // items.xmlName=
+  @JacksonXmlProperty(localName = "map_array_integer")
+  @JacksonXmlElementWrapper(useWrapping = false)
 
   public Map<String, List<Integer>> getMapArrayInteger() {
     return mapArrayInteger;
@@ -308,6 +323,9 @@ public class AdditionalPropertiesClass {
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_MAP_ARRAY_ANYTYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  // items.xmlName=
+  @JacksonXmlProperty(localName = "map_array_anytype")
+  @JacksonXmlElementWrapper(useWrapping = false)
 
   public Map<String, List<Object>> getMapArrayAnytype() {
     return mapArrayAnytype;
@@ -341,6 +359,9 @@ public class AdditionalPropertiesClass {
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_MAP_MAP_STRING)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  // items.xmlName=
+  @JacksonXmlProperty(localName = "map_map_string")
+  @JacksonXmlElementWrapper(useWrapping = false)
 
   public Map<String, Map<String, String>> getMapMapString() {
     return mapMapString;
@@ -374,6 +395,9 @@ public class AdditionalPropertiesClass {
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_MAP_MAP_ANYTYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  // items.xmlName=
+  @JacksonXmlProperty(localName = "map_map_anytype")
+  @JacksonXmlElementWrapper(useWrapping = false)
 
   public Map<String, Map<String, Object>> getMapMapAnytype() {
     return mapMapAnytype;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -71,6 +71,9 @@ public class ArrayOfArrayOfNumberOnly {
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_NUMBER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  // items.xmlName=
+  @JacksonXmlProperty(localName = "ArrayArrayNumber")
+  @JacksonXmlElementWrapper(useWrapping = false)
 
   public List<List<BigDecimal>> getArrayArrayNumber() {
     return arrayArrayNumber;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -71,6 +71,9 @@ public class ArrayOfNumberOnly {
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_ARRAY_NUMBER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  // items.xmlName=
+  @JacksonXmlProperty(localName = "ArrayNumber")
+  @JacksonXmlElementWrapper(useWrapping = false)
 
   public List<BigDecimal> getArrayNumber() {
     return arrayNumber;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -87,6 +87,9 @@ public class ArrayTest {
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_ARRAY_OF_STRING)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  // items.xmlName=
+  @JacksonXmlProperty(localName = "array_of_string")
+  @JacksonXmlElementWrapper(useWrapping = false)
 
   public List<String> getArrayOfString() {
     return arrayOfString;
@@ -120,6 +123,9 @@ public class ArrayTest {
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_INTEGER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  // items.xmlName=
+  @JacksonXmlProperty(localName = "array_array_of_integer")
+  @JacksonXmlElementWrapper(useWrapping = false)
 
   public List<List<Long>> getArrayArrayOfInteger() {
     return arrayArrayOfInteger;
@@ -153,6 +159,9 @@ public class ArrayTest {
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_MODEL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  // items.xmlName=
+  @JacksonXmlProperty(localName = "array_array_of_model")
+  @JacksonXmlElementWrapper(useWrapping = false)
 
   public List<List<ReadOnlyFirst>> getArrayArrayOfModel() {
     return arrayArrayOfModel;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -171,6 +171,9 @@ public class EnumArrays {
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_ARRAY_ENUM)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  // items.xmlName=
+  @JacksonXmlProperty(localName = "array_enum")
+  @JacksonXmlElementWrapper(useWrapping = false)
 
   public List<ArrayEnumEnum> getArrayEnum() {
     return arrayEnum;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -101,6 +101,9 @@ public class FileSchemaTestClass {
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_FILES)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  // items.xmlName=
+  @JacksonXmlProperty(localName = "files")
+  @JacksonXmlElementWrapper(useWrapping = false)
 
   public List<java.io.File> getFiles() {
     return files;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/MapTest.java
@@ -130,6 +130,9 @@ public class MapTest {
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_MAP_MAP_OF_STRING)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  // items.xmlName=
+  @JacksonXmlProperty(localName = "map_map_of_string")
+  @JacksonXmlElementWrapper(useWrapping = false)
 
   public Map<String, Map<String, String>> getMapMapOfString() {
     return mapMapOfString;
@@ -163,6 +166,9 @@ public class MapTest {
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_MAP_OF_ENUM_STRING)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  // items.xmlName=
+  @JacksonXmlProperty(localName = "map_of_enum_string")
+  @JacksonXmlElementWrapper(useWrapping = false)
 
   public Map<String, InnerEnum> getMapOfEnumString() {
     return mapOfEnumString;
@@ -196,6 +202,9 @@ public class MapTest {
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_DIRECT_MAP)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  // items.xmlName=
+  @JacksonXmlProperty(localName = "direct_map")
+  @JacksonXmlElementWrapper(useWrapping = false)
 
   public Map<String, Boolean> getDirectMap() {
     return directMap;
@@ -229,6 +238,9 @@ public class MapTest {
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_INDIRECT_MAP)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  // items.xmlName=
+  @JacksonXmlProperty(localName = "indirect_map")
+  @JacksonXmlElementWrapper(useWrapping = false)
 
   public Map<String, Boolean> getIndirectMap() {
     return indirectMap;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -136,6 +136,9 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_MAP)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  // items.xmlName=
+  @JacksonXmlProperty(localName = "map")
+  @JacksonXmlElementWrapper(useWrapping = false)
 
   public Map<String, Animal> getMap() {
     return map;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Pet.java
@@ -54,7 +54,7 @@ public class Pet {
   private Long id;
 
   public static final String JSON_PROPERTY_CATEGORY = "category";
-  @XmlElement(name = "category")
+  @XmlElement(name = "Category")
   private Category category;
 
   public static final String JSON_PROPERTY_NAME = "name";
@@ -63,18 +63,18 @@ public class Pet {
 
   public static final String JSON_PROPERTY_PHOTO_URLS = "photoUrls";
   // Is a container wrapped=true
-  // items.name=photoUrls items.baseName=photoUrls items.xmlName= items.xmlNamespace=
+  // items.name=photoUrls items.baseName=photoUrls items.xmlName=photoUrl items.xmlNamespace=
   // items.example= items.type=String
-  @XmlElement(name = "photoUrls")
-  @XmlElementWrapper(name = "photoUrl")
+  @XmlElement(name = "photoUrl")
+  @XmlElementWrapper(name = "photoUrls")
   private Set<String> photoUrls = new LinkedHashSet<String>();
 
   public static final String JSON_PROPERTY_TAGS = "tags";
   // Is a container wrapped=true
-  // items.name=tags items.baseName=tags items.xmlName= items.xmlNamespace=
+  // items.name=tags items.baseName=tags items.xmlName=Tag items.xmlNamespace=
   // items.example= items.type=Tag
-  @XmlElement(name = "tags")
-  @XmlElementWrapper(name = "tag")
+  @XmlElement(name = "Tag")
+  @XmlElementWrapper(name = "tags")
   private List<Tag> tags = null;
 
   /**
@@ -159,7 +159,7 @@ public class Pet {
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CATEGORY)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
-  @JacksonXmlProperty(localName = "category")
+  @JacksonXmlProperty(localName = "Category")
 
   public Category getCategory() {
     return category;
@@ -214,7 +214,8 @@ public class Pet {
   @ApiModelProperty(required = true, value = "")
   @JsonProperty(JSON_PROPERTY_PHOTO_URLS)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
-  // items.xmlName=
+  // items.xmlName=photoUrl
+  @JacksonXmlProperty(localName = "photoUrl")
   @JacksonXmlElementWrapper(useWrapping = true, localName = "photoUrls")
 
   public Set<String> getPhotoUrls() {
@@ -249,7 +250,8 @@ public class Pet {
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_TAGS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
-  // items.xmlName=
+  // items.xmlName=Tag
+  @JacksonXmlProperty(localName = "Tag")
   @JacksonXmlElementWrapper(useWrapping = true, localName = "tags")
 
   public List<Tag> getTags() {

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -187,6 +187,9 @@ public class TypeHolderDefault {
   @ApiModelProperty(required = true, value = "")
   @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
+  // items.xmlName=
+  @JacksonXmlProperty(localName = "array_item")
+  @JacksonXmlElementWrapper(useWrapping = false)
 
   public List<Integer> getArrayItem() {
     return arrayItem;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -217,6 +217,9 @@ public class TypeHolderExample {
   @ApiModelProperty(example = "[0, 1, 2, 3]", required = true, value = "")
   @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
+  // items.xmlName=
+  @JacksonXmlProperty(localName = "array_item")
+  @JacksonXmlElementWrapper(useWrapping = false)
 
   public List<Integer> getArrayItem() {
     return arrayItem;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -345,7 +345,8 @@ public class XmlItem {
   @JsonProperty(JSON_PROPERTY_WRAPPED_ARRAY)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   // items.xmlName=
-  @JacksonXmlElementWrapper(useWrapping = true, localName = "wrappedArray")
+  @JacksonXmlProperty(localName = "wrapped_array")
+  @JacksonXmlElementWrapper(useWrapping = true, localName = "wrapped_array")
 
   public List<Integer> getWrappedArray() {
     return wrappedArray;
@@ -483,6 +484,9 @@ public class XmlItem {
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_NAME_ARRAY)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  // items.xmlName=xml_name_array_item
+  @JacksonXmlProperty(localName = "xml_name_array_item")
+  @JacksonXmlElementWrapper(useWrapping = false)
 
   public List<Integer> getNameArray() {
     return nameArray;
@@ -517,7 +521,8 @@ public class XmlItem {
   @JsonProperty(JSON_PROPERTY_NAME_WRAPPED_ARRAY)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   // items.xmlName=xml_name_wrapped_array_item
-  @JacksonXmlElementWrapper(useWrapping = true, localName = "xml_name_wrapped_array_item")
+  @JacksonXmlProperty(localName = "xml_name_wrapped_array_item")
+  @JacksonXmlElementWrapper(useWrapping = true, localName = "xml_name_wrapped_array")
 
   public List<Integer> getNameWrappedArray() {
     return nameWrappedArray;
@@ -655,6 +660,9 @@ public class XmlItem {
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_PREFIX_ARRAY)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  // items.xmlName=
+  @JacksonXmlProperty(localName = "prefix_array")
+  @JacksonXmlElementWrapper(useWrapping = false)
 
   public List<Integer> getPrefixArray() {
     return prefixArray;
@@ -689,7 +697,8 @@ public class XmlItem {
   @JsonProperty(JSON_PROPERTY_PREFIX_WRAPPED_ARRAY)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   // items.xmlName=
-  @JacksonXmlElementWrapper(useWrapping = true, localName = "prefixWrappedArray")
+  @JacksonXmlProperty(localName = "prefix_wrapped_array")
+  @JacksonXmlElementWrapper(useWrapping = true, localName = "prefix_wrapped_array")
 
   public List<Integer> getPrefixWrappedArray() {
     return prefixWrappedArray;
@@ -827,6 +836,9 @@ public class XmlItem {
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_NAMESPACE_ARRAY)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  // items.xmlName=
+  @JacksonXmlProperty(localName = "namespace_array")
+  @JacksonXmlElementWrapper(useWrapping = false)
 
   public List<Integer> getNamespaceArray() {
     return namespaceArray;
@@ -861,7 +873,8 @@ public class XmlItem {
   @JsonProperty(JSON_PROPERTY_NAMESPACE_WRAPPED_ARRAY)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   // items.xmlName=
-  @JacksonXmlElementWrapper(useWrapping = true, namespace="http://f.com/schema", localName = "namespaceWrappedArray")
+  @JacksonXmlProperty(namespace="http://f.com/schema", localName = "namespace_wrapped_array")
+  @JacksonXmlElementWrapper(useWrapping = true, namespace="http://f.com/schema", localName = "namespace_wrapped_array")
 
   public List<Integer> getNamespaceWrappedArray() {
     return namespaceWrappedArray;
@@ -999,6 +1012,9 @@ public class XmlItem {
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_PREFIX_NS_ARRAY)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  // items.xmlName=
+  @JacksonXmlProperty(localName = "prefix_ns_array")
+  @JacksonXmlElementWrapper(useWrapping = false)
 
   public List<Integer> getPrefixNsArray() {
     return prefixNsArray;
@@ -1033,7 +1049,8 @@ public class XmlItem {
   @JsonProperty(JSON_PROPERTY_PREFIX_NS_WRAPPED_ARRAY)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   // items.xmlName=
-  @JacksonXmlElementWrapper(useWrapping = true, namespace="http://f.com/schema", localName = "prefixNsWrappedArray")
+  @JacksonXmlProperty(namespace="http://f.com/schema", localName = "prefix_ns_wrapped_array")
+  @JacksonXmlElementWrapper(useWrapping = true, namespace="http://f.com/schema", localName = "prefix_ns_wrapped_array")
 
   public List<Integer> getPrefixNsWrappedArray() {
     return prefixNsWrappedArray;

--- a/samples/client/petstore/java/resttemplate/api/openapi.yaml
+++ b/samples/client/petstore/java/resttemplate/api/openapi.yaml
@@ -1386,17 +1386,18 @@ components:
         photoUrls:
           items:
             type: string
+            xml:
+              name: photoUrl
           type: array
           uniqueItems: true
           xml:
-            name: photoUrl
             wrapped: true
         tags:
           items:
             $ref: '#/components/schemas/Tag'
           type: array
           xml:
-            name: tag
+            name: tags
             wrapped: true
         status:
           description: pet status in the store

--- a/samples/client/petstore/java/retrofit2-play26/api/openapi.yaml
+++ b/samples/client/petstore/java/retrofit2-play26/api/openapi.yaml
@@ -1386,17 +1386,18 @@ components:
         photoUrls:
           items:
             type: string
+            xml:
+              name: photoUrl
           type: array
           uniqueItems: true
           xml:
-            name: photoUrl
             wrapped: true
         tags:
           items:
             $ref: '#/components/schemas/Tag'
           type: array
           xml:
-            name: tag
+            name: tags
             wrapped: true
         status:
           description: pet status in the store

--- a/samples/client/petstore/java/retrofit2/api/openapi.yaml
+++ b/samples/client/petstore/java/retrofit2/api/openapi.yaml
@@ -1386,17 +1386,18 @@ components:
         photoUrls:
           items:
             type: string
+            xml:
+              name: photoUrl
           type: array
           uniqueItems: true
           xml:
-            name: photoUrl
             wrapped: true
         tags:
           items:
             $ref: '#/components/schemas/Tag'
           type: array
           xml:
-            name: tag
+            name: tags
             wrapped: true
         status:
           description: pet status in the store

--- a/samples/client/petstore/java/retrofit2rx2/api/openapi.yaml
+++ b/samples/client/petstore/java/retrofit2rx2/api/openapi.yaml
@@ -1386,17 +1386,18 @@ components:
         photoUrls:
           items:
             type: string
+            xml:
+              name: photoUrl
           type: array
           uniqueItems: true
           xml:
-            name: photoUrl
             wrapped: true
         tags:
           items:
             $ref: '#/components/schemas/Tag'
           type: array
           xml:
-            name: tag
+            name: tags
             wrapped: true
         status:
           description: pet status in the store

--- a/samples/client/petstore/java/retrofit2rx3/api/openapi.yaml
+++ b/samples/client/petstore/java/retrofit2rx3/api/openapi.yaml
@@ -1386,17 +1386,18 @@ components:
         photoUrls:
           items:
             type: string
+            xml:
+              name: photoUrl
           type: array
           uniqueItems: true
           xml:
-            name: photoUrl
             wrapped: true
         tags:
           items:
             $ref: '#/components/schemas/Tag'
           type: array
           xml:
-            name: tag
+            name: tags
             wrapped: true
         status:
           description: pet status in the store

--- a/samples/client/petstore/java/vertx/api/openapi.yaml
+++ b/samples/client/petstore/java/vertx/api/openapi.yaml
@@ -1386,17 +1386,18 @@ components:
         photoUrls:
           items:
             type: string
+            xml:
+              name: photoUrl
           type: array
           uniqueItems: true
           xml:
-            name: photoUrl
             wrapped: true
         tags:
           items:
             $ref: '#/components/schemas/Tag'
           type: array
           xml:
-            name: tag
+            name: tags
             wrapped: true
         status:
           description: pet status in the store

--- a/samples/client/petstore/java/webclient/api/openapi.yaml
+++ b/samples/client/petstore/java/webclient/api/openapi.yaml
@@ -1386,17 +1386,18 @@ components:
         photoUrls:
           items:
             type: string
+            xml:
+              name: photoUrl
           type: array
           uniqueItems: true
           xml:
-            name: photoUrl
             wrapped: true
         tags:
           items:
             $ref: '#/components/schemas/Tag'
           type: array
           xml:
-            name: tag
+            name: tags
             wrapped: true
         status:
           description: pet status in the store

--- a/samples/server/petstore/java-play-framework-fake-endpoints/public/openapi.json
+++ b/samples/server/petstore/java-play-framework-fake-endpoints/public/openapi.json
@@ -1797,12 +1797,14 @@
           },
           "photoUrls" : {
             "items" : {
-              "type" : "string"
+              "type" : "string",
+              "xml" : {
+                "name" : "photoUrl"
+              }
             },
             "type" : "array",
             "uniqueItems" : true,
             "xml" : {
-              "name" : "photoUrl",
               "wrapped" : true
             }
           },
@@ -1812,7 +1814,7 @@
             },
             "type" : "array",
             "xml" : {
-              "name" : "tag",
+              "name" : "tags",
               "wrapped" : true
             }
           },

--- a/samples/server/petstore/jaxrs-spec-interface/src/main/openapi/openapi.yaml
+++ b/samples/server/petstore/jaxrs-spec-interface/src/main/openapi/openapi.yaml
@@ -1460,17 +1460,18 @@ components:
         photoUrls:
           items:
             type: string
+            xml:
+              name: photoUrl
           type: array
           uniqueItems: true
           xml:
-            name: photoUrl
             wrapped: true
         tags:
           items:
             $ref: '#/components/schemas/Tag'
           type: array
           xml:
-            name: tag
+            name: tags
             wrapped: true
         status:
           description: pet status in the store

--- a/samples/server/petstore/jaxrs-spec/src/main/openapi/openapi.yaml
+++ b/samples/server/petstore/jaxrs-spec/src/main/openapi/openapi.yaml
@@ -1460,17 +1460,18 @@ components:
         photoUrls:
           items:
             type: string
+            xml:
+              name: photoUrl
           type: array
           uniqueItems: true
           xml:
-            name: photoUrl
             wrapped: true
         tags:
           items:
             $ref: '#/components/schemas/Tag'
           type: array
           xml:
-            name: tag
+            name: tags
             wrapped: true
         status:
           description: pet status in the store

--- a/samples/server/petstore/springboot-reactive/src/main/resources/openapi.yaml
+++ b/samples/server/petstore/springboot-reactive/src/main/resources/openapi.yaml
@@ -1460,17 +1460,18 @@ components:
         photoUrls:
           items:
             type: string
+            xml:
+              name: photoUrl
           type: array
           uniqueItems: true
           xml:
-            name: photoUrl
             wrapped: true
         tags:
           items:
             $ref: '#/components/schemas/Tag'
           type: array
           xml:
-            name: tag
+            name: tags
             wrapped: true
         status:
           description: pet status in the store


### PR DESCRIPTION
Hello All,

This pull request adds:
- always writes JacksonXmlElementWrapper even if xml.wrapped is false, because useWrapping is true from Jackson 2.1
- get xml properties from referenced schema.

Here is example of yaml:

```yaml
openapi: 3.0.0
info:
  title: API
  version: 1.0.0

paths:
  /:
    post:
      requestBody:
        required: true
        content:
          application/xml:
            schema:
              $ref: '#/components/schemas/Request'
      responses:
        '200':
          description: OK

components:
  schemas:
    Request:
      type: object
      properties:
        simpleAttribute:
          type: string
          xml:
            attribute: true
            name: ATTR
        refAttribute:
          $ref: '#/components/schemas/RefAttribute'
        simpleNode:
          type: object
          properties:
            prop1:
              type: string
            prop2:
              type: string
          xml:
            name: NODE
        refNode:
          $ref: '#/components/schemas/RefNode'
        simpleArray:
          type: array
          items:
            type: string
            xml:
              name: ARR_ITEM
        simpleWrappedArray:
          type: array
          items:
            type: string
            xml:
              name: ARR_ITEM
          xml:
            wrapped: true
            name: WRAPPED_ARRAY
        nodeArray:
          type: array
          items:
            $ref: '#/components/schemas/RefNode'
        wrappedNodeArray:
          type: array
          items:
            $ref: '#/components/schemas/RefNode'
          xml:
            wrapped: true
            name: WRAPPED_NODE_ARRAY
      xml:
        name: Request

    RefAttribute:
      type: string
      enum: [A, B, C]
      xml:
        name: REF_ATTR
        attribute: true

    RefNode:
      type: object
      properties:
        prop1:
          type: string
        prop2:
          type: string
      xml:
        name: REF_NODE

   
```

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
@bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04) @lwlee2608 (2019/10) @bkabrda (2020/01)
