### PR TITLE
Respect usenose for Python CI

### DIFF
--- a/modules/openapi-generator/src/main/resources/python/gitlab-ci.mustache
+++ b/modules/openapi-generator/src/main/resources/python/gitlab-ci.mustache
@@ -7,8 +7,13 @@ stages:
   stage: test
   script:
    - pip install -r requirements.txt
-   - pip install nose
+   - pip install -r test-requirements.txt
+   {{#useNose}}
    - nosetests
+   {{/useNose}}
+   {{^useNose}}
+   - pytest --cov={{{packageName}}}
+   {{/useNose}}
 
 nosetest-2.7:
   extends: .nosetest

--- a/modules/openapi-generator/src/main/resources/python/travis.mustache
+++ b/modules/openapi-generator/src/main/resources/python/travis.mustache
@@ -10,6 +10,13 @@ python:
   - "3.7"
   - "3.8"
 # command to install dependencies
-install: "pip install -r requirements.txt"
+install:
+  - "pip install -r requirements.txt"
+  - "pip install -r test-requirements.txt"
 # command to run tests
+{{#useNose}}
 script: nosetests
+{{/useNose}}
+{{^useNose}}
+script: pytest --cov={{{packageName}}}
+{{/useNose}}

--- a/samples/client/petstore/python-asyncio/.gitlab-ci.yml
+++ b/samples/client/petstore/python-asyncio/.gitlab-ci.yml
@@ -7,8 +7,8 @@ stages:
   stage: test
   script:
    - pip install -r requirements.txt
-   - pip install nose
-   - nosetests
+   - pip install -r test-requirements.txt
+   - pytest --cov=petstore_api
 
 nosetest-2.7:
   extends: .nosetest

--- a/samples/client/petstore/python-asyncio/.travis.yml
+++ b/samples/client/petstore/python-asyncio/.travis.yml
@@ -10,6 +10,8 @@ python:
   - "3.7"
   - "3.8"
 # command to install dependencies
-install: "pip install -r requirements.txt"
+install:
+  - "pip install -r requirements.txt"
+  - "pip install -r test-requirements.txt"
 # command to run tests
-script: nosetests
+script: pytest --cov=petstore_api

--- a/samples/client/petstore/python-experimental/.gitlab-ci.yml
+++ b/samples/client/petstore/python-experimental/.gitlab-ci.yml
@@ -7,8 +7,8 @@ stages:
   stage: test
   script:
    - pip install -r requirements.txt
-   - pip install nose
-   - nosetests
+   - pip install -r test-requirements.txt
+   - pytest --cov=petstore_api
 
 nosetest-2.7:
   extends: .nosetest

--- a/samples/client/petstore/python-experimental/.travis.yml
+++ b/samples/client/petstore/python-experimental/.travis.yml
@@ -10,6 +10,8 @@ python:
   - "3.7"
   - "3.8"
 # command to install dependencies
-install: "pip install -r requirements.txt"
+install:
+  - "pip install -r requirements.txt"
+  - "pip install -r test-requirements.txt"
 # command to run tests
-script: nosetests
+script: pytest --cov=petstore_api

--- a/samples/client/petstore/python-tornado/.gitlab-ci.yml
+++ b/samples/client/petstore/python-tornado/.gitlab-ci.yml
@@ -7,8 +7,8 @@ stages:
   stage: test
   script:
    - pip install -r requirements.txt
-   - pip install nose
-   - nosetests
+   - pip install -r test-requirements.txt
+   - pytest --cov=petstore_api
 
 nosetest-2.7:
   extends: .nosetest

--- a/samples/client/petstore/python-tornado/.travis.yml
+++ b/samples/client/petstore/python-tornado/.travis.yml
@@ -10,6 +10,8 @@ python:
   - "3.7"
   - "3.8"
 # command to install dependencies
-install: "pip install -r requirements.txt"
+install:
+  - "pip install -r requirements.txt"
+  - "pip install -r test-requirements.txt"
 # command to run tests
-script: nosetests
+script: pytest --cov=petstore_api

--- a/samples/client/petstore/python/.gitlab-ci.yml
+++ b/samples/client/petstore/python/.gitlab-ci.yml
@@ -7,8 +7,8 @@ stages:
   stage: test
   script:
    - pip install -r requirements.txt
-   - pip install nose
-   - nosetests
+   - pip install -r test-requirements.txt
+   - pytest --cov=petstore_api
 
 nosetest-2.7:
   extends: .nosetest

--- a/samples/client/petstore/python/.travis.yml
+++ b/samples/client/petstore/python/.travis.yml
@@ -10,6 +10,8 @@ python:
   - "3.7"
   - "3.8"
 # command to install dependencies
-install: "pip install -r requirements.txt"
+install:
+  - "pip install -r requirements.txt"
+  - "pip install -r test-requirements.txt"
 # command to run tests
-script: nosetests
+script: pytest --cov=petstore_api

--- a/samples/openapi3/client/petstore/python-experimental/.gitlab-ci.yml
+++ b/samples/openapi3/client/petstore/python-experimental/.gitlab-ci.yml
@@ -7,8 +7,8 @@ stages:
   stage: test
   script:
    - pip install -r requirements.txt
-   - pip install nose
-   - nosetests
+   - pip install -r test-requirements.txt
+   - pytest --cov=petstore_api
 
 nosetest-2.7:
   extends: .nosetest

--- a/samples/openapi3/client/petstore/python-experimental/.travis.yml
+++ b/samples/openapi3/client/petstore/python-experimental/.travis.yml
@@ -10,6 +10,8 @@ python:
   - "3.7"
   - "3.8"
 # command to install dependencies
-install: "pip install -r requirements.txt"
+install:
+  - "pip install -r requirements.txt"
+  - "pip install -r test-requirements.txt"
 # command to run tests
-script: nosetests
+script: pytest --cov=petstore_api

--- a/samples/openapi3/client/petstore/python/.gitlab-ci.yml
+++ b/samples/openapi3/client/petstore/python/.gitlab-ci.yml
@@ -7,8 +7,8 @@ stages:
   stage: test
   script:
    - pip install -r requirements.txt
-   - pip install nose
-   - nosetests
+   - pip install -r test-requirements.txt
+   - pytest --cov=petstore_api
 
 nosetest-2.7:
   extends: .nosetest

--- a/samples/openapi3/client/petstore/python/.travis.yml
+++ b/samples/openapi3/client/petstore/python/.travis.yml
@@ -10,6 +10,8 @@ python:
   - "3.7"
   - "3.8"
 # command to install dependencies
-install: "pip install -r requirements.txt"
+install:
+  - "pip install -r requirements.txt"
+  - "pip install -r test-requirements.txt"
 # command to run tests
-script: nosetests
+script: pytest --cov=petstore_api


### PR DESCRIPTION
As requested in [this comment](https://github.com/OpenAPITools/openapi-generator/pull/5342#issuecomment-587074732) of #5342 , this PR makes sure that the generated `.travis.yml` and `.gitlab-ci.yml` for python projects respect the "useNose" option passed to them from the CLI. The will switch to using either `nosetests` or `pytest`.

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

----------------------

Adding Python technical committee: @taxpon @frol @mbohlool @cbornet @kenjones-cisco @tomplus @Jyhess @slash-arun @spacether