### PR TITLE
[erlang] Do not export function if not defined.

### DIFF
--- a/modules/openapi-generator/src/main/resources/erlang-server/logic_handler.mustache
+++ b/modules/openapi-generator/src/main/resources/erlang-server/logic_handler.mustache
@@ -1,7 +1,14 @@
 -module({{packageName}}_logic_handler).
 
 -export([handle_request/4]).
+{{#authMethods}}
+	{{#isApiKey}}
 -export([authorize_api_key/3]).
+	{{/isApiKey}}
+{{/authMethods}}
+{{^authMethods}}
+-export([authorize_api_key/3]).
+{{/authMethods}}
 -type context() :: #{binary() => any()}.
 -type handler_response() ::{
     Status :: cowboy:http_status(),


### PR DESCRIPTION
Logic added to logic_handler.mustache so that it does not export authorize_api_key/3 when the function is not defined, leading to compilation error of *_logic_handler.erl, where * is openapi by default. 

```rebar3 shell``` under the root directory of the code stub can be run to compile.