### PR TITLE
[Java][Spring][1975] Add OAuth2 Preauthorize annotations based on scope

### DIFF
--- a/modules/openapi-generator/src/main/resources/JavaSpring/api.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/api.mustache
@@ -17,6 +17,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 {{/jdk8-no-delegate}}
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 {{#useBeanValidation}}
 import org.springframework.validation.annotation.Validated;
 {{/useBeanValidation}}
@@ -122,6 +123,13 @@ public interface {{classname}} {
     {{/headerParams}}
     })
     {{/implicitHeaders}}
+    {{#hasAuthMethods}}
+        {{#authMethods}}
+            {{#isOAuth}}
+    @PreAuthorize("{{#scopes}}hasAuthority('SCOPE_{{scope}}'){{#hasMore}} and {{/hasMore}}{{/scopes}}")
+            {{/isOAuth}}
+        {{/authMethods}}
+    {{/hasAuthMethods}}
     @RequestMapping(value = "{{{path}}}",{{#singleContentTypes}}{{#hasProduces}}
         produces = "{{{vendorExtensions.x-accepts}}}", {{/hasProduces}}{{#hasConsumes}}
         consumes = "{{{vendorExtensions.x-contentType}}}",{{/hasConsumes}}{{/singleContentTypes}}{{^singleContentTypes}}{{#hasProduces}}

--- a/samples/client/petstore/spring-cloud-async/src/main/java/org/openapitools/api/PetApi.java
+++ b/samples/client/petstore/spring-cloud-async/src/main/java/org/openapitools/api/PetApi.java
@@ -12,6 +12,7 @@ import io.swagger.annotations.*;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -48,6 +49,7 @@ public interface PetApi {
     }, tags={ "pet", })
     @ApiResponses(value = { 
         @ApiResponse(code = 405, message = "Invalid input") })
+    @PreAuthorize("hasAuthority('SCOPE_write:pets') and hasAuthority('SCOPE_read:pets')")
     @RequestMapping(value = "/pet",
         consumes = "application/json",
         method = RequestMethod.POST)
@@ -69,6 +71,7 @@ public interface PetApi {
     }, tags={ "pet", })
     @ApiResponses(value = { 
         @ApiResponse(code = 400, message = "Invalid pet value") })
+    @PreAuthorize("hasAuthority('SCOPE_write:pets') and hasAuthority('SCOPE_read:pets')")
     @RequestMapping(value = "/pet/{petId}",
         method = RequestMethod.DELETE)
     CompletableFuture<ResponseEntity<Void>> deletePet(@ApiParam(value = "Pet id to delete",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "" ) @RequestHeader(value="api_key", required=false) String apiKey);
@@ -91,6 +94,7 @@ public interface PetApi {
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = Pet.class, responseContainer = "List"),
         @ApiResponse(code = 400, message = "Invalid status value") })
+    @PreAuthorize("hasAuthority('SCOPE_write:pets') and hasAuthority('SCOPE_read:pets')")
     @RequestMapping(value = "/pet/findByStatus",
         produces = "application/json", 
         method = RequestMethod.GET)
@@ -115,6 +119,7 @@ public interface PetApi {
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = Pet.class, responseContainer = "List"),
         @ApiResponse(code = 400, message = "Invalid tag value") })
+    @PreAuthorize("hasAuthority('SCOPE_write:pets') and hasAuthority('SCOPE_read:pets')")
     @RequestMapping(value = "/pet/findByTags",
         produces = "application/json", 
         method = RequestMethod.GET)
@@ -161,6 +166,7 @@ public interface PetApi {
         @ApiResponse(code = 400, message = "Invalid ID supplied"),
         @ApiResponse(code = 404, message = "Pet not found"),
         @ApiResponse(code = 405, message = "Validation exception") })
+    @PreAuthorize("hasAuthority('SCOPE_write:pets') and hasAuthority('SCOPE_read:pets')")
     @RequestMapping(value = "/pet",
         consumes = "application/json",
         method = RequestMethod.PUT)
@@ -183,6 +189,7 @@ public interface PetApi {
     }, tags={ "pet", })
     @ApiResponses(value = { 
         @ApiResponse(code = 405, message = "Invalid input") })
+    @PreAuthorize("hasAuthority('SCOPE_write:pets') and hasAuthority('SCOPE_read:pets')")
     @RequestMapping(value = "/pet/{petId}",
         consumes = "application/x-www-form-urlencoded",
         method = RequestMethod.POST)
@@ -205,6 +212,7 @@ public interface PetApi {
     }, tags={ "pet", })
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = ModelApiResponse.class) })
+    @PreAuthorize("hasAuthority('SCOPE_write:pets') and hasAuthority('SCOPE_read:pets')")
     @RequestMapping(value = "/pet/{petId}/uploadImage",
         produces = "application/json", 
         consumes = "multipart/form-data",

--- a/samples/client/petstore/spring-cloud-async/src/main/java/org/openapitools/api/StoreApi.java
+++ b/samples/client/petstore/spring-cloud-async/src/main/java/org/openapitools/api/StoreApi.java
@@ -11,6 +11,7 @@ import io.swagger.annotations.*;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;

--- a/samples/client/petstore/spring-cloud-async/src/main/java/org/openapitools/api/UserApi.java
+++ b/samples/client/petstore/spring-cloud-async/src/main/java/org/openapitools/api/UserApi.java
@@ -11,6 +11,7 @@ import io.swagger.annotations.*;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;

--- a/samples/client/petstore/spring-cloud/src/main/java/org/openapitools/api/PetApi.java
+++ b/samples/client/petstore/spring-cloud/src/main/java/org/openapitools/api/PetApi.java
@@ -12,6 +12,7 @@ import io.swagger.annotations.*;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -47,6 +48,7 @@ public interface PetApi {
     }, tags={ "pet", })
     @ApiResponses(value = { 
         @ApiResponse(code = 405, message = "Invalid input") })
+    @PreAuthorize("hasAuthority('SCOPE_write:pets') and hasAuthority('SCOPE_read:pets')")
     @RequestMapping(value = "/pet",
         consumes = "application/json",
         method = RequestMethod.POST)
@@ -68,6 +70,7 @@ public interface PetApi {
     }, tags={ "pet", })
     @ApiResponses(value = { 
         @ApiResponse(code = 400, message = "Invalid pet value") })
+    @PreAuthorize("hasAuthority('SCOPE_write:pets') and hasAuthority('SCOPE_read:pets')")
     @RequestMapping(value = "/pet/{petId}",
         method = RequestMethod.DELETE)
     com.netflix.hystrix.HystrixCommand<ResponseEntity<Void>> deletePet(@ApiParam(value = "Pet id to delete",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "" ) @RequestHeader(value="api_key", required=false) String apiKey);
@@ -90,6 +93,7 @@ public interface PetApi {
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = Pet.class, responseContainer = "List"),
         @ApiResponse(code = 400, message = "Invalid status value") })
+    @PreAuthorize("hasAuthority('SCOPE_write:pets') and hasAuthority('SCOPE_read:pets')")
     @RequestMapping(value = "/pet/findByStatus",
         produces = "application/json", 
         method = RequestMethod.GET)
@@ -114,6 +118,7 @@ public interface PetApi {
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = Pet.class, responseContainer = "List"),
         @ApiResponse(code = 400, message = "Invalid tag value") })
+    @PreAuthorize("hasAuthority('SCOPE_write:pets') and hasAuthority('SCOPE_read:pets')")
     @RequestMapping(value = "/pet/findByTags",
         produces = "application/json", 
         method = RequestMethod.GET)
@@ -160,6 +165,7 @@ public interface PetApi {
         @ApiResponse(code = 400, message = "Invalid ID supplied"),
         @ApiResponse(code = 404, message = "Pet not found"),
         @ApiResponse(code = 405, message = "Validation exception") })
+    @PreAuthorize("hasAuthority('SCOPE_write:pets') and hasAuthority('SCOPE_read:pets')")
     @RequestMapping(value = "/pet",
         consumes = "application/json",
         method = RequestMethod.PUT)
@@ -182,6 +188,7 @@ public interface PetApi {
     }, tags={ "pet", })
     @ApiResponses(value = { 
         @ApiResponse(code = 405, message = "Invalid input") })
+    @PreAuthorize("hasAuthority('SCOPE_write:pets') and hasAuthority('SCOPE_read:pets')")
     @RequestMapping(value = "/pet/{petId}",
         consumes = "application/x-www-form-urlencoded",
         method = RequestMethod.POST)
@@ -204,6 +211,7 @@ public interface PetApi {
     }, tags={ "pet", })
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = ModelApiResponse.class) })
+    @PreAuthorize("hasAuthority('SCOPE_write:pets') and hasAuthority('SCOPE_read:pets')")
     @RequestMapping(value = "/pet/{petId}/uploadImage",
         produces = "application/json", 
         consumes = "multipart/form-data",

--- a/samples/client/petstore/spring-cloud/src/main/java/org/openapitools/api/StoreApi.java
+++ b/samples/client/petstore/spring-cloud/src/main/java/org/openapitools/api/StoreApi.java
@@ -11,6 +11,7 @@ import io.swagger.annotations.*;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;

--- a/samples/client/petstore/spring-cloud/src/main/java/org/openapitools/api/UserApi.java
+++ b/samples/client/petstore/spring-cloud/src/main/java/org/openapitools/api/UserApi.java
@@ -11,6 +11,7 @@ import io.swagger.annotations.*;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;

--- a/samples/client/petstore/spring-stubs/src/main/java/org/openapitools/api/PetApi.java
+++ b/samples/client/petstore/spring-stubs/src/main/java/org/openapitools/api/PetApi.java
@@ -12,6 +12,7 @@ import io.swagger.annotations.*;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -51,6 +52,7 @@ public interface PetApi {
     }, tags={ "pet", })
     @ApiResponses(value = { 
         @ApiResponse(code = 405, message = "Invalid input") })
+    @PreAuthorize("hasAuthority('SCOPE_write:pets') and hasAuthority('SCOPE_read:pets')")
     @RequestMapping(value = "/pet",
         consumes = "application/json",
         method = RequestMethod.POST)
@@ -75,6 +77,7 @@ public interface PetApi {
     }, tags={ "pet", })
     @ApiResponses(value = { 
         @ApiResponse(code = 400, message = "Invalid pet value") })
+    @PreAuthorize("hasAuthority('SCOPE_write:pets') and hasAuthority('SCOPE_read:pets')")
     @RequestMapping(value = "/pet/{petId}",
         method = RequestMethod.DELETE)
     default ResponseEntity<Void> deletePet(@ApiParam(value = "Pet id to delete",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "" ) @RequestHeader(value="api_key", required=false) String apiKey) {
@@ -100,6 +103,7 @@ public interface PetApi {
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = Pet.class, responseContainer = "List"),
         @ApiResponse(code = 400, message = "Invalid status value") })
+    @PreAuthorize("hasAuthority('SCOPE_write:pets') and hasAuthority('SCOPE_read:pets')")
     @RequestMapping(value = "/pet/findByStatus",
         produces = "application/json", 
         method = RequestMethod.GET)
@@ -141,6 +145,7 @@ public interface PetApi {
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = Pet.class, responseContainer = "List"),
         @ApiResponse(code = 400, message = "Invalid tag value") })
+    @PreAuthorize("hasAuthority('SCOPE_write:pets') and hasAuthority('SCOPE_read:pets')")
     @RequestMapping(value = "/pet/findByTags",
         produces = "application/json", 
         method = RequestMethod.GET)
@@ -221,6 +226,7 @@ public interface PetApi {
         @ApiResponse(code = 400, message = "Invalid ID supplied"),
         @ApiResponse(code = 404, message = "Pet not found"),
         @ApiResponse(code = 405, message = "Validation exception") })
+    @PreAuthorize("hasAuthority('SCOPE_write:pets') and hasAuthority('SCOPE_read:pets')")
     @RequestMapping(value = "/pet",
         consumes = "application/json",
         method = RequestMethod.PUT)
@@ -246,6 +252,7 @@ public interface PetApi {
     }, tags={ "pet", })
     @ApiResponses(value = { 
         @ApiResponse(code = 405, message = "Invalid input") })
+    @PreAuthorize("hasAuthority('SCOPE_write:pets') and hasAuthority('SCOPE_read:pets')")
     @RequestMapping(value = "/pet/{petId}",
         consumes = "application/x-www-form-urlencoded",
         method = RequestMethod.POST)
@@ -271,6 +278,7 @@ public interface PetApi {
     }, tags={ "pet", })
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = ModelApiResponse.class) })
+    @PreAuthorize("hasAuthority('SCOPE_write:pets') and hasAuthority('SCOPE_read:pets')")
     @RequestMapping(value = "/pet/{petId}/uploadImage",
         produces = "application/json", 
         consumes = "multipart/form-data",

--- a/samples/client/petstore/spring-stubs/src/main/java/org/openapitools/api/StoreApi.java
+++ b/samples/client/petstore/spring-stubs/src/main/java/org/openapitools/api/StoreApi.java
@@ -11,6 +11,7 @@ import io.swagger.annotations.*;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;

--- a/samples/client/petstore/spring-stubs/src/main/java/org/openapitools/api/UserApi.java
+++ b/samples/client/petstore/spring-stubs/src/main/java/org/openapitools/api/UserApi.java
@@ -11,6 +11,7 @@ import io.swagger.annotations.*;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;

--- a/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/api/AnotherFakeApi.java
+++ b/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/api/AnotherFakeApi.java
@@ -10,6 +10,7 @@ import io.swagger.annotations.*;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;

--- a/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/api/FakeApi.java
+++ b/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/api/FakeApi.java
@@ -20,6 +20,7 @@ import io.swagger.annotations.*;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -383,6 +384,7 @@ public interface FakeApi {
     }, tags={ "pet", })
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = ModelApiResponse.class) })
+    @PreAuthorize("hasAuthority('SCOPE_write:pets') and hasAuthority('SCOPE_read:pets')")
     @RequestMapping(value = "/fake/{petId}/uploadImageWithRequiredFile",
         produces = { "application/json" }, 
         consumes = { "multipart/form-data" },

--- a/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/api/FakeClassnameTestApi.java
+++ b/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/api/FakeClassnameTestApi.java
@@ -10,6 +10,7 @@ import io.swagger.annotations.*;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;

--- a/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/api/PetApi.java
+++ b/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/api/PetApi.java
@@ -12,6 +12,7 @@ import io.swagger.annotations.*;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -54,6 +55,7 @@ public interface PetApi {
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation"),
         @ApiResponse(code = 405, message = "Invalid input") })
+    @PreAuthorize("hasAuthority('SCOPE_write:pets') and hasAuthority('SCOPE_read:pets')")
     @RequestMapping(value = "/pet",
         consumes = { "application/json", "application/xml" },
         method = RequestMethod.POST)
@@ -80,6 +82,7 @@ public interface PetApi {
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation"),
         @ApiResponse(code = 400, message = "Invalid pet value") })
+    @PreAuthorize("hasAuthority('SCOPE_write:pets') and hasAuthority('SCOPE_read:pets')")
     @RequestMapping(value = "/pet/{petId}",
         method = RequestMethod.DELETE)
     default CompletableFuture<ResponseEntity<Void>> deletePet(@ApiParam(value = "Pet id to delete",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "" ) @RequestHeader(value="api_key", required=false) String apiKey) {
@@ -105,6 +108,7 @@ public interface PetApi {
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = Pet.class, responseContainer = "List"),
         @ApiResponse(code = 400, message = "Invalid status value") })
+    @PreAuthorize("hasAuthority('SCOPE_write:pets') and hasAuthority('SCOPE_read:pets')")
     @RequestMapping(value = "/pet/findByStatus",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.GET)
@@ -148,6 +152,7 @@ public interface PetApi {
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = Pet.class, responseContainer = "List"),
         @ApiResponse(code = 400, message = "Invalid tag value") })
+    @PreAuthorize("hasAuthority('SCOPE_write:pets') and hasAuthority('SCOPE_read:pets')")
     @RequestMapping(value = "/pet/findByTags",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.GET)
@@ -234,6 +239,7 @@ public interface PetApi {
         @ApiResponse(code = 400, message = "Invalid ID supplied"),
         @ApiResponse(code = 404, message = "Pet not found"),
         @ApiResponse(code = 405, message = "Validation exception") })
+    @PreAuthorize("hasAuthority('SCOPE_write:pets') and hasAuthority('SCOPE_read:pets')")
     @RequestMapping(value = "/pet",
         consumes = { "application/json", "application/xml" },
         method = RequestMethod.PUT)
@@ -259,6 +265,7 @@ public interface PetApi {
     }, tags={ "pet", })
     @ApiResponses(value = { 
         @ApiResponse(code = 405, message = "Invalid input") })
+    @PreAuthorize("hasAuthority('SCOPE_write:pets') and hasAuthority('SCOPE_read:pets')")
     @RequestMapping(value = "/pet/{petId}",
         consumes = { "application/x-www-form-urlencoded" },
         method = RequestMethod.POST)
@@ -284,6 +291,7 @@ public interface PetApi {
     }, tags={ "pet", })
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = ModelApiResponse.class) })
+    @PreAuthorize("hasAuthority('SCOPE_write:pets') and hasAuthority('SCOPE_read:pets')")
     @RequestMapping(value = "/pet/{petId}/uploadImage",
         produces = { "application/json" }, 
         consumes = { "multipart/form-data" },

--- a/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/api/StoreApi.java
+++ b/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/api/StoreApi.java
@@ -11,6 +11,7 @@ import io.swagger.annotations.*;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;

--- a/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/api/UserApi.java
+++ b/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/api/UserApi.java
@@ -11,6 +11,7 @@ import io.swagger.annotations.*;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;

--- a/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/api/AnotherFakeApi.java
+++ b/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/api/AnotherFakeApi.java
@@ -10,6 +10,7 @@ import io.swagger.annotations.*;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;

--- a/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/api/FakeApi.java
+++ b/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/api/FakeApi.java
@@ -20,6 +20,7 @@ import io.swagger.annotations.*;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -378,6 +379,7 @@ public interface FakeApi {
     }, tags={ "pet", })
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = ModelApiResponse.class) })
+    @PreAuthorize("hasAuthority('SCOPE_write:pets') and hasAuthority('SCOPE_read:pets')")
     @RequestMapping(value = "/fake/{petId}/uploadImageWithRequiredFile",
         produces = { "application/json" }, 
         consumes = { "multipart/form-data" },

--- a/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/api/FakeClassnameTestApi.java
+++ b/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/api/FakeClassnameTestApi.java
@@ -10,6 +10,7 @@ import io.swagger.annotations.*;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;

--- a/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/api/PetApi.java
+++ b/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/api/PetApi.java
@@ -12,6 +12,7 @@ import io.swagger.annotations.*;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -53,6 +54,7 @@ public interface PetApi {
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation"),
         @ApiResponse(code = 405, message = "Invalid input") })
+    @PreAuthorize("hasAuthority('SCOPE_write:pets') and hasAuthority('SCOPE_read:pets')")
     @RequestMapping(value = "/pet",
         consumes = { "application/json", "application/xml" },
         method = RequestMethod.POST)
@@ -79,6 +81,7 @@ public interface PetApi {
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation"),
         @ApiResponse(code = 400, message = "Invalid pet value") })
+    @PreAuthorize("hasAuthority('SCOPE_write:pets') and hasAuthority('SCOPE_read:pets')")
     @RequestMapping(value = "/pet/{petId}",
         method = RequestMethod.DELETE)
     default ResponseEntity<Void> deletePet(@ApiParam(value = "Pet id to delete",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "" ) @RequestHeader(value="api_key", required=false) String apiKey) {
@@ -104,6 +107,7 @@ public interface PetApi {
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = Pet.class, responseContainer = "List"),
         @ApiResponse(code = 400, message = "Invalid status value") })
+    @PreAuthorize("hasAuthority('SCOPE_write:pets') and hasAuthority('SCOPE_read:pets')")
     @RequestMapping(value = "/pet/findByStatus",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.GET)
@@ -145,6 +149,7 @@ public interface PetApi {
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = Pet.class, responseContainer = "List"),
         @ApiResponse(code = 400, message = "Invalid tag value") })
+    @PreAuthorize("hasAuthority('SCOPE_write:pets') and hasAuthority('SCOPE_read:pets')")
     @RequestMapping(value = "/pet/findByTags",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.GET)
@@ -227,6 +232,7 @@ public interface PetApi {
         @ApiResponse(code = 400, message = "Invalid ID supplied"),
         @ApiResponse(code = 404, message = "Pet not found"),
         @ApiResponse(code = 405, message = "Validation exception") })
+    @PreAuthorize("hasAuthority('SCOPE_write:pets') and hasAuthority('SCOPE_read:pets')")
     @RequestMapping(value = "/pet",
         consumes = { "application/json", "application/xml" },
         method = RequestMethod.PUT)
@@ -252,6 +258,7 @@ public interface PetApi {
     }, tags={ "pet", })
     @ApiResponses(value = { 
         @ApiResponse(code = 405, message = "Invalid input") })
+    @PreAuthorize("hasAuthority('SCOPE_write:pets') and hasAuthority('SCOPE_read:pets')")
     @RequestMapping(value = "/pet/{petId}",
         consumes = { "application/x-www-form-urlencoded" },
         method = RequestMethod.POST)
@@ -277,6 +284,7 @@ public interface PetApi {
     }, tags={ "pet", })
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = ModelApiResponse.class) })
+    @PreAuthorize("hasAuthority('SCOPE_write:pets') and hasAuthority('SCOPE_read:pets')")
     @RequestMapping(value = "/pet/{petId}/uploadImage",
         produces = { "application/json" }, 
         consumes = { "multipart/form-data" },

--- a/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/api/StoreApi.java
+++ b/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/api/StoreApi.java
@@ -11,6 +11,7 @@ import io.swagger.annotations.*;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;

--- a/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/api/UserApi.java
+++ b/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/api/UserApi.java
@@ -11,6 +11,7 @@ import io.swagger.annotations.*;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;

--- a/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/api/AnotherFakeApi.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/api/AnotherFakeApi.java
@@ -8,6 +8,7 @@ package org.openapitools.api;
 import org.openapitools.model.Client;
 import io.swagger.annotations.*;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;

--- a/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/api/FakeApi.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/api/FakeApi.java
@@ -18,6 +18,7 @@ import org.openapitools.model.User;
 import org.openapitools.model.XmlItem;
 import io.swagger.annotations.*;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -310,6 +311,7 @@ public interface FakeApi {
     }, tags={ "pet", })
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = ModelApiResponse.class) })
+    @PreAuthorize("hasAuthority('SCOPE_write:pets') and hasAuthority('SCOPE_read:pets')")
     @RequestMapping(value = "/fake/{petId}/uploadImageWithRequiredFile",
         produces = { "application/json" }, 
         consumes = { "multipart/form-data" },

--- a/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/api/FakeClassnameTestApi.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/api/FakeClassnameTestApi.java
@@ -8,6 +8,7 @@ package org.openapitools.api;
 import org.openapitools.model.Client;
 import io.swagger.annotations.*;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;

--- a/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/api/PetApi.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/api/PetApi.java
@@ -10,6 +10,7 @@ import org.openapitools.model.Pet;
 import org.springframework.core.io.Resource;
 import io.swagger.annotations.*;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -45,6 +46,7 @@ public interface PetApi {
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation"),
         @ApiResponse(code = 405, message = "Invalid input") })
+    @PreAuthorize("hasAuthority('SCOPE_write:pets') and hasAuthority('SCOPE_read:pets')")
     @RequestMapping(value = "/pet",
         consumes = { "application/json", "application/xml" },
         method = RequestMethod.POST)
@@ -68,6 +70,7 @@ public interface PetApi {
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation"),
         @ApiResponse(code = 400, message = "Invalid pet value") })
+    @PreAuthorize("hasAuthority('SCOPE_write:pets') and hasAuthority('SCOPE_read:pets')")
     @RequestMapping(value = "/pet/{petId}",
         method = RequestMethod.DELETE)
     ResponseEntity<Void> deletePet(@ApiParam(value = "Pet id to delete",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "" ) @RequestHeader(value="api_key", required=false) String apiKey);
@@ -90,6 +93,7 @@ public interface PetApi {
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = Pet.class, responseContainer = "List"),
         @ApiResponse(code = 400, message = "Invalid status value") })
+    @PreAuthorize("hasAuthority('SCOPE_write:pets') and hasAuthority('SCOPE_read:pets')")
     @RequestMapping(value = "/pet/findByStatus",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.GET)
@@ -114,6 +118,7 @@ public interface PetApi {
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = Pet.class, responseContainer = "List"),
         @ApiResponse(code = 400, message = "Invalid tag value") })
+    @PreAuthorize("hasAuthority('SCOPE_write:pets') and hasAuthority('SCOPE_read:pets')")
     @RequestMapping(value = "/pet/findByTags",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.GET)
@@ -162,6 +167,7 @@ public interface PetApi {
         @ApiResponse(code = 400, message = "Invalid ID supplied"),
         @ApiResponse(code = 404, message = "Pet not found"),
         @ApiResponse(code = 405, message = "Validation exception") })
+    @PreAuthorize("hasAuthority('SCOPE_write:pets') and hasAuthority('SCOPE_read:pets')")
     @RequestMapping(value = "/pet",
         consumes = { "application/json", "application/xml" },
         method = RequestMethod.PUT)
@@ -184,6 +190,7 @@ public interface PetApi {
     }, tags={ "pet", })
     @ApiResponses(value = { 
         @ApiResponse(code = 405, message = "Invalid input") })
+    @PreAuthorize("hasAuthority('SCOPE_write:pets') and hasAuthority('SCOPE_read:pets')")
     @RequestMapping(value = "/pet/{petId}",
         consumes = { "application/x-www-form-urlencoded" },
         method = RequestMethod.POST)
@@ -206,6 +213,7 @@ public interface PetApi {
     }, tags={ "pet", })
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = ModelApiResponse.class) })
+    @PreAuthorize("hasAuthority('SCOPE_write:pets') and hasAuthority('SCOPE_read:pets')")
     @RequestMapping(value = "/pet/{petId}/uploadImage",
         produces = { "application/json" }, 
         consumes = { "multipart/form-data" },

--- a/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/api/StoreApi.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/api/StoreApi.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import org.openapitools.model.Order;
 import io.swagger.annotations.*;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;

--- a/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/api/UserApi.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/api/UserApi.java
@@ -9,6 +9,7 @@ import java.util.List;
 import org.openapitools.model.User;
 import io.swagger.annotations.*;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/api/AnotherFakeApi.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/api/AnotherFakeApi.java
@@ -8,6 +8,7 @@ package org.openapitools.api;
 import org.openapitools.model.Client;
 import io.swagger.annotations.*;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/api/FakeApi.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/api/FakeApi.java
@@ -18,6 +18,7 @@ import org.openapitools.model.User;
 import org.openapitools.model.XmlItem;
 import io.swagger.annotations.*;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -310,6 +311,7 @@ public interface FakeApi {
     }, tags={ "pet", })
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = ModelApiResponse.class) })
+    @PreAuthorize("hasAuthority('SCOPE_write:pets') and hasAuthority('SCOPE_read:pets')")
     @RequestMapping(value = "/fake/{petId}/uploadImageWithRequiredFile",
         produces = { "application/json" }, 
         consumes = { "multipart/form-data" },

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/api/FakeClassnameTestApi.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/api/FakeClassnameTestApi.java
@@ -8,6 +8,7 @@ package org.openapitools.api;
 import org.openapitools.model.Client;
 import io.swagger.annotations.*;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/api/PetApi.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/api/PetApi.java
@@ -10,6 +10,7 @@ import org.openapitools.model.Pet;
 import org.springframework.core.io.Resource;
 import io.swagger.annotations.*;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -45,6 +46,7 @@ public interface PetApi {
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation"),
         @ApiResponse(code = 405, message = "Invalid input") })
+    @PreAuthorize("hasAuthority('SCOPE_write:pets') and hasAuthority('SCOPE_read:pets')")
     @RequestMapping(value = "/pet",
         consumes = { "application/json", "application/xml" },
         method = RequestMethod.POST)
@@ -68,6 +70,7 @@ public interface PetApi {
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation"),
         @ApiResponse(code = 400, message = "Invalid pet value") })
+    @PreAuthorize("hasAuthority('SCOPE_write:pets') and hasAuthority('SCOPE_read:pets')")
     @RequestMapping(value = "/pet/{petId}",
         method = RequestMethod.DELETE)
     ResponseEntity<Void> deletePet(@ApiParam(value = "Pet id to delete",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "" ) @RequestHeader(value="api_key", required=false) String apiKey);
@@ -90,6 +93,7 @@ public interface PetApi {
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = Pet.class, responseContainer = "List"),
         @ApiResponse(code = 400, message = "Invalid status value") })
+    @PreAuthorize("hasAuthority('SCOPE_write:pets') and hasAuthority('SCOPE_read:pets')")
     @RequestMapping(value = "/pet/findByStatus",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.GET)
@@ -114,6 +118,7 @@ public interface PetApi {
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = Pet.class, responseContainer = "List"),
         @ApiResponse(code = 400, message = "Invalid tag value") })
+    @PreAuthorize("hasAuthority('SCOPE_write:pets') and hasAuthority('SCOPE_read:pets')")
     @RequestMapping(value = "/pet/findByTags",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.GET)
@@ -162,6 +167,7 @@ public interface PetApi {
         @ApiResponse(code = 400, message = "Invalid ID supplied"),
         @ApiResponse(code = 404, message = "Pet not found"),
         @ApiResponse(code = 405, message = "Validation exception") })
+    @PreAuthorize("hasAuthority('SCOPE_write:pets') and hasAuthority('SCOPE_read:pets')")
     @RequestMapping(value = "/pet",
         consumes = { "application/json", "application/xml" },
         method = RequestMethod.PUT)
@@ -184,6 +190,7 @@ public interface PetApi {
     }, tags={ "pet", })
     @ApiResponses(value = { 
         @ApiResponse(code = 405, message = "Invalid input") })
+    @PreAuthorize("hasAuthority('SCOPE_write:pets') and hasAuthority('SCOPE_read:pets')")
     @RequestMapping(value = "/pet/{petId}",
         consumes = { "application/x-www-form-urlencoded" },
         method = RequestMethod.POST)
@@ -206,6 +213,7 @@ public interface PetApi {
     }, tags={ "pet", })
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = ModelApiResponse.class) })
+    @PreAuthorize("hasAuthority('SCOPE_write:pets') and hasAuthority('SCOPE_read:pets')")
     @RequestMapping(value = "/pet/{petId}/uploadImage",
         produces = { "application/json" }, 
         consumes = { "multipart/form-data" },

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/api/StoreApi.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/api/StoreApi.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import org.openapitools.model.Order;
 import io.swagger.annotations.*;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/api/UserApi.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/api/UserApi.java
@@ -9,6 +9,7 @@ import java.util.List;
 import org.openapitools.model.User;
 import io.swagger.annotations.*;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/api/AnotherFakeApi.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/api/AnotherFakeApi.java
@@ -8,6 +8,7 @@ package org.openapitools.api;
 import org.openapitools.model.Client;
 import io.swagger.annotations.*;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/api/FakeApi.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/api/FakeApi.java
@@ -18,6 +18,7 @@ import org.openapitools.model.User;
 import org.openapitools.model.XmlItem;
 import io.swagger.annotations.*;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -342,6 +343,7 @@ public interface FakeApi {
     }, tags={ "pet", })
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = ModelApiResponse.class) })
+    @PreAuthorize("hasAuthority('SCOPE_write:pets') and hasAuthority('SCOPE_read:pets')")
     @RequestMapping(value = "/fake/{petId}/uploadImageWithRequiredFile",
         produces = { "application/json" }, 
         consumes = { "multipart/form-data" },

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/api/FakeClassnameTestApi.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/api/FakeClassnameTestApi.java
@@ -8,6 +8,7 @@ package org.openapitools.api;
 import org.openapitools.model.Client;
 import io.swagger.annotations.*;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/api/PetApi.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/api/PetApi.java
@@ -10,6 +10,7 @@ import org.openapitools.model.Pet;
 import org.springframework.core.io.Resource;
 import io.swagger.annotations.*;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -49,6 +50,7 @@ public interface PetApi {
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation"),
         @ApiResponse(code = 405, message = "Invalid input") })
+    @PreAuthorize("hasAuthority('SCOPE_write:pets') and hasAuthority('SCOPE_read:pets')")
     @RequestMapping(value = "/pet",
         consumes = { "application/json", "application/xml" },
         method = RequestMethod.POST)
@@ -74,6 +76,7 @@ public interface PetApi {
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation"),
         @ApiResponse(code = 400, message = "Invalid pet value") })
+    @PreAuthorize("hasAuthority('SCOPE_write:pets') and hasAuthority('SCOPE_read:pets')")
     @RequestMapping(value = "/pet/{petId}",
         method = RequestMethod.DELETE)
     default ResponseEntity<Void> deletePet(@ApiParam(value = "Pet id to delete",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "" ) @RequestHeader(value="api_key", required=false) String apiKey) {
@@ -98,6 +101,7 @@ public interface PetApi {
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = Pet.class, responseContainer = "List"),
         @ApiResponse(code = 400, message = "Invalid status value") })
+    @PreAuthorize("hasAuthority('SCOPE_write:pets') and hasAuthority('SCOPE_read:pets')")
     @RequestMapping(value = "/pet/findByStatus",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.GET)
@@ -124,6 +128,7 @@ public interface PetApi {
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = Pet.class, responseContainer = "List"),
         @ApiResponse(code = 400, message = "Invalid tag value") })
+    @PreAuthorize("hasAuthority('SCOPE_write:pets') and hasAuthority('SCOPE_read:pets')")
     @RequestMapping(value = "/pet/findByTags",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.GET)
@@ -176,6 +181,7 @@ public interface PetApi {
         @ApiResponse(code = 400, message = "Invalid ID supplied"),
         @ApiResponse(code = 404, message = "Pet not found"),
         @ApiResponse(code = 405, message = "Validation exception") })
+    @PreAuthorize("hasAuthority('SCOPE_write:pets') and hasAuthority('SCOPE_read:pets')")
     @RequestMapping(value = "/pet",
         consumes = { "application/json", "application/xml" },
         method = RequestMethod.PUT)
@@ -200,6 +206,7 @@ public interface PetApi {
     }, tags={ "pet", })
     @ApiResponses(value = { 
         @ApiResponse(code = 405, message = "Invalid input") })
+    @PreAuthorize("hasAuthority('SCOPE_write:pets') and hasAuthority('SCOPE_read:pets')")
     @RequestMapping(value = "/pet/{petId}",
         consumes = { "application/x-www-form-urlencoded" },
         method = RequestMethod.POST)
@@ -224,6 +231,7 @@ public interface PetApi {
     }, tags={ "pet", })
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = ModelApiResponse.class) })
+    @PreAuthorize("hasAuthority('SCOPE_write:pets') and hasAuthority('SCOPE_read:pets')")
     @RequestMapping(value = "/pet/{petId}/uploadImage",
         produces = { "application/json" }, 
         consumes = { "multipart/form-data" },

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/api/StoreApi.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/api/StoreApi.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import org.openapitools.model.Order;
 import io.swagger.annotations.*;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/api/UserApi.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/api/UserApi.java
@@ -9,6 +9,7 @@ import java.util.List;
 import org.openapitools.model.User;
 import io.swagger.annotations.*;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/api/AnotherFakeApi.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/api/AnotherFakeApi.java
@@ -8,6 +8,7 @@ package org.openapitools.api;
 import org.openapitools.model.Client;
 import io.swagger.annotations.*;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/api/FakeApi.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/api/FakeApi.java
@@ -18,6 +18,7 @@ import org.openapitools.model.User;
 import org.openapitools.model.XmlItem;
 import io.swagger.annotations.*;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -310,6 +311,7 @@ public interface FakeApi {
     }, tags={ "pet", })
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = ModelApiResponse.class) })
+    @PreAuthorize("hasAuthority('SCOPE_write:pets') and hasAuthority('SCOPE_read:pets')")
     @RequestMapping(value = "/fake/{petId}/uploadImageWithRequiredFile",
         produces = { "application/json" }, 
         consumes = { "multipart/form-data" },

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/api/FakeClassnameTestApi.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/api/FakeClassnameTestApi.java
@@ -8,6 +8,7 @@ package org.openapitools.api;
 import org.openapitools.model.Client;
 import io.swagger.annotations.*;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/api/PetApi.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/api/PetApi.java
@@ -10,6 +10,7 @@ import org.openapitools.model.Pet;
 import org.springframework.core.io.Resource;
 import io.swagger.annotations.*;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -45,6 +46,7 @@ public interface PetApi {
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation"),
         @ApiResponse(code = 405, message = "Invalid input") })
+    @PreAuthorize("hasAuthority('SCOPE_write:pets') and hasAuthority('SCOPE_read:pets')")
     @RequestMapping(value = "/pet",
         consumes = { "application/json", "application/xml" },
         method = RequestMethod.POST)
@@ -68,6 +70,7 @@ public interface PetApi {
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation"),
         @ApiResponse(code = 400, message = "Invalid pet value") })
+    @PreAuthorize("hasAuthority('SCOPE_write:pets') and hasAuthority('SCOPE_read:pets')")
     @RequestMapping(value = "/pet/{petId}",
         method = RequestMethod.DELETE)
     ResponseEntity<Void> deletePet(@ApiParam(value = "Pet id to delete",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "" ) @RequestHeader(value="api_key", required=false) String apiKey);
@@ -90,6 +93,7 @@ public interface PetApi {
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = Pet.class, responseContainer = "List"),
         @ApiResponse(code = 400, message = "Invalid status value") })
+    @PreAuthorize("hasAuthority('SCOPE_write:pets') and hasAuthority('SCOPE_read:pets')")
     @RequestMapping(value = "/pet/findByStatus",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.GET)
@@ -114,6 +118,7 @@ public interface PetApi {
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = Pet.class, responseContainer = "List"),
         @ApiResponse(code = 400, message = "Invalid tag value") })
+    @PreAuthorize("hasAuthority('SCOPE_write:pets') and hasAuthority('SCOPE_read:pets')")
     @RequestMapping(value = "/pet/findByTags",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.GET)
@@ -162,6 +167,7 @@ public interface PetApi {
         @ApiResponse(code = 400, message = "Invalid ID supplied"),
         @ApiResponse(code = 404, message = "Pet not found"),
         @ApiResponse(code = 405, message = "Validation exception") })
+    @PreAuthorize("hasAuthority('SCOPE_write:pets') and hasAuthority('SCOPE_read:pets')")
     @RequestMapping(value = "/pet",
         consumes = { "application/json", "application/xml" },
         method = RequestMethod.PUT)
@@ -184,6 +190,7 @@ public interface PetApi {
     }, tags={ "pet", })
     @ApiResponses(value = { 
         @ApiResponse(code = 405, message = "Invalid input") })
+    @PreAuthorize("hasAuthority('SCOPE_write:pets') and hasAuthority('SCOPE_read:pets')")
     @RequestMapping(value = "/pet/{petId}",
         consumes = { "application/x-www-form-urlencoded" },
         method = RequestMethod.POST)
@@ -206,6 +213,7 @@ public interface PetApi {
     }, tags={ "pet", })
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = ModelApiResponse.class) })
+    @PreAuthorize("hasAuthority('SCOPE_write:pets') and hasAuthority('SCOPE_read:pets')")
     @RequestMapping(value = "/pet/{petId}/uploadImage",
         produces = { "application/json" }, 
         consumes = { "multipart/form-data" },

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/api/StoreApi.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/api/StoreApi.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import org.openapitools.model.Order;
 import io.swagger.annotations.*;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/api/UserApi.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/api/UserApi.java
@@ -9,6 +9,7 @@ import java.util.List;
 import org.openapitools.model.User;
 import io.swagger.annotations.*;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/api/AnotherFakeApi.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/api/AnotherFakeApi.java
@@ -10,6 +10,7 @@ import io.swagger.annotations.*;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/api/FakeApi.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/api/FakeApi.java
@@ -20,6 +20,7 @@ import io.swagger.annotations.*;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -408,6 +409,7 @@ public interface FakeApi {
         @ApiResponse(code = 200, message = "successful operation", response = ModelApiResponse.class) })
     @ApiImplicitParams({
     })
+    @PreAuthorize("hasAuthority('SCOPE_write:pets') and hasAuthority('SCOPE_read:pets')")
     @RequestMapping(value = "/fake/{petId}/uploadImageWithRequiredFile",
         produces = { "application/json" }, 
         consumes = { "multipart/form-data" },

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/api/FakeClassnameTestApi.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/api/FakeClassnameTestApi.java
@@ -10,6 +10,7 @@ import io.swagger.annotations.*;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/api/PetApi.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/api/PetApi.java
@@ -12,6 +12,7 @@ import io.swagger.annotations.*;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -55,6 +56,7 @@ public interface PetApi {
         @ApiResponse(code = 405, message = "Invalid input") })
     @ApiImplicitParams({
     })
+    @PreAuthorize("hasAuthority('SCOPE_write:pets') and hasAuthority('SCOPE_read:pets')")
     @RequestMapping(value = "/pet",
         consumes = { "application/json", "application/xml" },
         method = RequestMethod.POST)
@@ -83,6 +85,7 @@ public interface PetApi {
     @ApiImplicitParams({
     @ApiImplicitParam(name = "apiKey", value = "",  dataType = "String", paramType = "header")
     })
+    @PreAuthorize("hasAuthority('SCOPE_write:pets') and hasAuthority('SCOPE_read:pets')")
     @RequestMapping(value = "/pet/{petId}",
         method = RequestMethod.DELETE)
     default ResponseEntity<Void> deletePet(@ApiParam(value = "Pet id to delete",required=true) @PathVariable("petId") Long petId) {
@@ -110,6 +113,7 @@ public interface PetApi {
         @ApiResponse(code = 400, message = "Invalid status value") })
     @ApiImplicitParams({
     })
+    @PreAuthorize("hasAuthority('SCOPE_write:pets') and hasAuthority('SCOPE_read:pets')")
     @RequestMapping(value = "/pet/findByStatus",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.GET)
@@ -153,6 +157,7 @@ public interface PetApi {
         @ApiResponse(code = 400, message = "Invalid tag value") })
     @ApiImplicitParams({
     })
+    @PreAuthorize("hasAuthority('SCOPE_write:pets') and hasAuthority('SCOPE_read:pets')")
     @RequestMapping(value = "/pet/findByTags",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.GET)
@@ -239,6 +244,7 @@ public interface PetApi {
         @ApiResponse(code = 405, message = "Validation exception") })
     @ApiImplicitParams({
     })
+    @PreAuthorize("hasAuthority('SCOPE_write:pets') and hasAuthority('SCOPE_read:pets')")
     @RequestMapping(value = "/pet",
         consumes = { "application/json", "application/xml" },
         method = RequestMethod.PUT)
@@ -266,6 +272,7 @@ public interface PetApi {
         @ApiResponse(code = 405, message = "Invalid input") })
     @ApiImplicitParams({
     })
+    @PreAuthorize("hasAuthority('SCOPE_write:pets') and hasAuthority('SCOPE_read:pets')")
     @RequestMapping(value = "/pet/{petId}",
         consumes = { "application/x-www-form-urlencoded" },
         method = RequestMethod.POST)
@@ -293,6 +300,7 @@ public interface PetApi {
         @ApiResponse(code = 200, message = "successful operation", response = ModelApiResponse.class) })
     @ApiImplicitParams({
     })
+    @PreAuthorize("hasAuthority('SCOPE_write:pets') and hasAuthority('SCOPE_read:pets')")
     @RequestMapping(value = "/pet/{petId}/uploadImage",
         produces = { "application/json" }, 
         consumes = { "multipart/form-data" },

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/api/StoreApi.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/api/StoreApi.java
@@ -11,6 +11,7 @@ import io.swagger.annotations.*;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/api/UserApi.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/api/UserApi.java
@@ -11,6 +11,7 @@ import io.swagger.annotations.*;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/AnotherFakeApi.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/AnotherFakeApi.java
@@ -8,6 +8,7 @@ package org.openapitools.api;
 import org.openapitools.model.Client;
 import io.swagger.annotations.*;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/FakeApi.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/FakeApi.java
@@ -18,6 +18,7 @@ import org.openapitools.model.User;
 import org.openapitools.model.XmlItem;
 import io.swagger.annotations.*;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -345,6 +346,7 @@ public interface FakeApi {
     }, tags={ "pet", })
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = ModelApiResponse.class) })
+    @PreAuthorize("hasAuthority('SCOPE_write:pets') and hasAuthority('SCOPE_read:pets')")
     @RequestMapping(value = "/fake/{petId}/uploadImageWithRequiredFile",
         produces = { "application/json" }, 
         consumes = { "multipart/form-data" },

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/FakeClassnameTestApi.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/FakeClassnameTestApi.java
@@ -8,6 +8,7 @@ package org.openapitools.api;
 import org.openapitools.model.Client;
 import io.swagger.annotations.*;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/PetApi.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/PetApi.java
@@ -10,6 +10,7 @@ import org.openapitools.model.Pet;
 import org.springframework.core.io.Resource;
 import io.swagger.annotations.*;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -52,6 +53,7 @@ public interface PetApi {
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation"),
         @ApiResponse(code = 405, message = "Invalid input") })
+    @PreAuthorize("hasAuthority('SCOPE_write:pets') and hasAuthority('SCOPE_read:pets')")
     @RequestMapping(value = "/pet",
         consumes = { "application/json", "application/xml" },
         method = RequestMethod.POST)
@@ -77,6 +79,7 @@ public interface PetApi {
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation"),
         @ApiResponse(code = 400, message = "Invalid pet value") })
+    @PreAuthorize("hasAuthority('SCOPE_write:pets') and hasAuthority('SCOPE_read:pets')")
     @RequestMapping(value = "/pet/{petId}",
         method = RequestMethod.DELETE)
     default Mono<ResponseEntity<Void>> deletePet(@ApiParam(value = "Pet id to delete",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "" ) @RequestHeader(value="api_key", required=false) String apiKey, ServerWebExchange exchange) {
@@ -101,6 +104,7 @@ public interface PetApi {
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = Pet.class, responseContainer = "List"),
         @ApiResponse(code = 400, message = "Invalid status value") })
+    @PreAuthorize("hasAuthority('SCOPE_write:pets') and hasAuthority('SCOPE_read:pets')")
     @RequestMapping(value = "/pet/findByStatus",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.GET)
@@ -127,6 +131,7 @@ public interface PetApi {
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = Pet.class, responseContainer = "List"),
         @ApiResponse(code = 400, message = "Invalid tag value") })
+    @PreAuthorize("hasAuthority('SCOPE_write:pets') and hasAuthority('SCOPE_read:pets')")
     @RequestMapping(value = "/pet/findByTags",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.GET)
@@ -179,6 +184,7 @@ public interface PetApi {
         @ApiResponse(code = 400, message = "Invalid ID supplied"),
         @ApiResponse(code = 404, message = "Pet not found"),
         @ApiResponse(code = 405, message = "Validation exception") })
+    @PreAuthorize("hasAuthority('SCOPE_write:pets') and hasAuthority('SCOPE_read:pets')")
     @RequestMapping(value = "/pet",
         consumes = { "application/json", "application/xml" },
         method = RequestMethod.PUT)
@@ -203,6 +209,7 @@ public interface PetApi {
     }, tags={ "pet", })
     @ApiResponses(value = { 
         @ApiResponse(code = 405, message = "Invalid input") })
+    @PreAuthorize("hasAuthority('SCOPE_write:pets') and hasAuthority('SCOPE_read:pets')")
     @RequestMapping(value = "/pet/{petId}",
         consumes = { "application/x-www-form-urlencoded" },
         method = RequestMethod.POST)
@@ -227,6 +234,7 @@ public interface PetApi {
     }, tags={ "pet", })
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = ModelApiResponse.class) })
+    @PreAuthorize("hasAuthority('SCOPE_write:pets') and hasAuthority('SCOPE_read:pets')")
     @RequestMapping(value = "/pet/{petId}/uploadImage",
         produces = { "application/json" }, 
         consumes = { "multipart/form-data" },

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/StoreApi.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/StoreApi.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import org.openapitools.model.Order;
 import io.swagger.annotations.*;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/UserApi.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/UserApi.java
@@ -9,6 +9,7 @@ import java.util.List;
 import org.openapitools.model.User;
 import io.swagger.annotations.*;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/api/AnotherFakeApi.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/api/AnotherFakeApi.java
@@ -10,6 +10,7 @@ import io.swagger.annotations.*;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/api/FakeApi.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/api/FakeApi.java
@@ -20,6 +20,7 @@ import io.swagger.annotations.*;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -378,6 +379,7 @@ public interface FakeApi {
     }, tags={ "pet", })
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = ModelApiResponse.class) })
+    @PreAuthorize("hasAuthority('SCOPE_write:pets') and hasAuthority('SCOPE_read:pets')")
     @RequestMapping(value = "/fake/{petId}/uploadImageWithRequiredFile",
         produces = { "application/json" }, 
         consumes = { "multipart/form-data" },

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/api/FakeClassnameTestApi.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/api/FakeClassnameTestApi.java
@@ -10,6 +10,7 @@ import io.swagger.annotations.*;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/api/PetApi.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/api/PetApi.java
@@ -12,6 +12,7 @@ import io.swagger.annotations.*;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -53,6 +54,7 @@ public interface PetApi {
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation"),
         @ApiResponse(code = 405, message = "Invalid input") })
+    @PreAuthorize("hasAuthority('SCOPE_write:pets') and hasAuthority('SCOPE_read:pets')")
     @RequestMapping(value = "/pet",
         consumes = { "application/json", "application/xml" },
         method = RequestMethod.POST)
@@ -79,6 +81,7 @@ public interface PetApi {
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation"),
         @ApiResponse(code = 400, message = "Invalid pet value") })
+    @PreAuthorize("hasAuthority('SCOPE_write:pets') and hasAuthority('SCOPE_read:pets')")
     @RequestMapping(value = "/pet/{petId}",
         method = RequestMethod.DELETE)
     default ResponseEntity<Void> deletePet(@ApiParam(value = "Pet id to delete",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "" ) @RequestHeader(value="api_key", required=false) Optional<String> apiKey) {
@@ -104,6 +107,7 @@ public interface PetApi {
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = Pet.class, responseContainer = "List"),
         @ApiResponse(code = 400, message = "Invalid status value") })
+    @PreAuthorize("hasAuthority('SCOPE_write:pets') and hasAuthority('SCOPE_read:pets')")
     @RequestMapping(value = "/pet/findByStatus",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.GET)
@@ -145,6 +149,7 @@ public interface PetApi {
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = Pet.class, responseContainer = "List"),
         @ApiResponse(code = 400, message = "Invalid tag value") })
+    @PreAuthorize("hasAuthority('SCOPE_write:pets') and hasAuthority('SCOPE_read:pets')")
     @RequestMapping(value = "/pet/findByTags",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.GET)
@@ -227,6 +232,7 @@ public interface PetApi {
         @ApiResponse(code = 400, message = "Invalid ID supplied"),
         @ApiResponse(code = 404, message = "Pet not found"),
         @ApiResponse(code = 405, message = "Validation exception") })
+    @PreAuthorize("hasAuthority('SCOPE_write:pets') and hasAuthority('SCOPE_read:pets')")
     @RequestMapping(value = "/pet",
         consumes = { "application/json", "application/xml" },
         method = RequestMethod.PUT)
@@ -252,6 +258,7 @@ public interface PetApi {
     }, tags={ "pet", })
     @ApiResponses(value = { 
         @ApiResponse(code = 405, message = "Invalid input") })
+    @PreAuthorize("hasAuthority('SCOPE_write:pets') and hasAuthority('SCOPE_read:pets')")
     @RequestMapping(value = "/pet/{petId}",
         consumes = { "application/x-www-form-urlencoded" },
         method = RequestMethod.POST)
@@ -277,6 +284,7 @@ public interface PetApi {
     }, tags={ "pet", })
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = ModelApiResponse.class) })
+    @PreAuthorize("hasAuthority('SCOPE_write:pets') and hasAuthority('SCOPE_read:pets')")
     @RequestMapping(value = "/pet/{petId}/uploadImage",
         produces = { "application/json" }, 
         consumes = { "multipart/form-data" },

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/api/StoreApi.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/api/StoreApi.java
@@ -11,6 +11,7 @@ import io.swagger.annotations.*;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/api/UserApi.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/api/UserApi.java
@@ -11,6 +11,7 @@ import io.swagger.annotations.*;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/api/AnotherFakeApi.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/api/AnotherFakeApi.java
@@ -12,6 +12,7 @@ import io.virtualan.annotation.VirtualService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/api/FakeApi.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/api/FakeApi.java
@@ -22,6 +22,7 @@ import io.virtualan.annotation.VirtualService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -396,6 +397,7 @@ public interface FakeApi {
     }, tags={ "pet", })
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = ModelApiResponse.class) })
+    @PreAuthorize("hasAuthority('SCOPE_write:pets') and hasAuthority('SCOPE_read:pets')")
     @RequestMapping(value = "/fake/{petId}/uploadImageWithRequiredFile",
         produces = { "application/json" }, 
         consumes = { "multipart/form-data" },

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/api/FakeClassnameTestApi.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/api/FakeClassnameTestApi.java
@@ -12,6 +12,7 @@ import io.virtualan.annotation.VirtualService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/api/PetApi.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/api/PetApi.java
@@ -14,6 +14,7 @@ import io.virtualan.annotation.VirtualService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -57,6 +58,7 @@ public interface PetApi {
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation"),
         @ApiResponse(code = 405, message = "Invalid input") })
+    @PreAuthorize("hasAuthority('SCOPE_write:pets') and hasAuthority('SCOPE_read:pets')")
     @RequestMapping(value = "/pet",
         consumes = { "application/json", "application/xml" },
         method = RequestMethod.POST)
@@ -84,6 +86,7 @@ public interface PetApi {
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation"),
         @ApiResponse(code = 400, message = "Invalid pet value") })
+    @PreAuthorize("hasAuthority('SCOPE_write:pets') and hasAuthority('SCOPE_read:pets')")
     @RequestMapping(value = "/pet/{petId}",
         method = RequestMethod.DELETE)
     default ResponseEntity<Void> deletePet(@ApiParam(value = "Pet id to delete",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "" ) @RequestHeader(value="api_key", required=false) String apiKey) {
@@ -110,6 +113,7 @@ public interface PetApi {
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = Pet.class, responseContainer = "List"),
         @ApiResponse(code = 400, message = "Invalid status value") })
+    @PreAuthorize("hasAuthority('SCOPE_write:pets') and hasAuthority('SCOPE_read:pets')")
     @RequestMapping(value = "/pet/findByStatus",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.GET)
@@ -152,6 +156,7 @@ public interface PetApi {
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = Pet.class, responseContainer = "List"),
         @ApiResponse(code = 400, message = "Invalid tag value") })
+    @PreAuthorize("hasAuthority('SCOPE_write:pets') and hasAuthority('SCOPE_read:pets')")
     @RequestMapping(value = "/pet/findByTags",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.GET)
@@ -236,6 +241,7 @@ public interface PetApi {
         @ApiResponse(code = 400, message = "Invalid ID supplied"),
         @ApiResponse(code = 404, message = "Pet not found"),
         @ApiResponse(code = 405, message = "Validation exception") })
+    @PreAuthorize("hasAuthority('SCOPE_write:pets') and hasAuthority('SCOPE_read:pets')")
     @RequestMapping(value = "/pet",
         consumes = { "application/json", "application/xml" },
         method = RequestMethod.PUT)
@@ -262,6 +268,7 @@ public interface PetApi {
     }, tags={ "pet", })
     @ApiResponses(value = { 
         @ApiResponse(code = 405, message = "Invalid input") })
+    @PreAuthorize("hasAuthority('SCOPE_write:pets') and hasAuthority('SCOPE_read:pets')")
     @RequestMapping(value = "/pet/{petId}",
         consumes = { "application/x-www-form-urlencoded" },
         method = RequestMethod.POST)
@@ -288,6 +295,7 @@ public interface PetApi {
     }, tags={ "pet", })
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = ModelApiResponse.class) })
+    @PreAuthorize("hasAuthority('SCOPE_write:pets') and hasAuthority('SCOPE_read:pets')")
     @RequestMapping(value = "/pet/{petId}/uploadImage",
         produces = { "application/json" }, 
         consumes = { "multipart/form-data" },

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/api/StoreApi.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/api/StoreApi.java
@@ -13,6 +13,7 @@ import io.virtualan.annotation.VirtualService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/api/UserApi.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/api/UserApi.java
@@ -13,6 +13,7 @@ import io.virtualan.annotation.VirtualService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/api/AnotherFakeApi.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/api/AnotherFakeApi.java
@@ -10,6 +10,7 @@ import io.swagger.annotations.*;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/api/FakeApi.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/api/FakeApi.java
@@ -20,6 +20,7 @@ import io.swagger.annotations.*;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -378,6 +379,7 @@ public interface FakeApi {
     }, tags={ "pet", })
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = ModelApiResponse.class) })
+    @PreAuthorize("hasAuthority('SCOPE_write:pets') and hasAuthority('SCOPE_read:pets')")
     @RequestMapping(value = "/fake/{petId}/uploadImageWithRequiredFile",
         produces = { "application/json" }, 
         consumes = { "multipart/form-data" },

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/api/FakeClassnameTestApi.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/api/FakeClassnameTestApi.java
@@ -10,6 +10,7 @@ import io.swagger.annotations.*;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/api/PetApi.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/api/PetApi.java
@@ -12,6 +12,7 @@ import io.swagger.annotations.*;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -53,6 +54,7 @@ public interface PetApi {
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation"),
         @ApiResponse(code = 405, message = "Invalid input") })
+    @PreAuthorize("hasAuthority('SCOPE_write:pets') and hasAuthority('SCOPE_read:pets')")
     @RequestMapping(value = "/pet",
         consumes = { "application/json", "application/xml" },
         method = RequestMethod.POST)
@@ -79,6 +81,7 @@ public interface PetApi {
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation"),
         @ApiResponse(code = 400, message = "Invalid pet value") })
+    @PreAuthorize("hasAuthority('SCOPE_write:pets') and hasAuthority('SCOPE_read:pets')")
     @RequestMapping(value = "/pet/{petId}",
         method = RequestMethod.DELETE)
     default ResponseEntity<Void> deletePet(@ApiParam(value = "Pet id to delete",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "" ) @RequestHeader(value="api_key", required=false) String apiKey) {
@@ -104,6 +107,7 @@ public interface PetApi {
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = Pet.class, responseContainer = "List"),
         @ApiResponse(code = 400, message = "Invalid status value") })
+    @PreAuthorize("hasAuthority('SCOPE_write:pets') and hasAuthority('SCOPE_read:pets')")
     @RequestMapping(value = "/pet/findByStatus",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.GET)
@@ -145,6 +149,7 @@ public interface PetApi {
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = Pet.class, responseContainer = "List"),
         @ApiResponse(code = 400, message = "Invalid tag value") })
+    @PreAuthorize("hasAuthority('SCOPE_write:pets') and hasAuthority('SCOPE_read:pets')")
     @RequestMapping(value = "/pet/findByTags",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.GET)
@@ -227,6 +232,7 @@ public interface PetApi {
         @ApiResponse(code = 400, message = "Invalid ID supplied"),
         @ApiResponse(code = 404, message = "Pet not found"),
         @ApiResponse(code = 405, message = "Validation exception") })
+    @PreAuthorize("hasAuthority('SCOPE_write:pets') and hasAuthority('SCOPE_read:pets')")
     @RequestMapping(value = "/pet",
         consumes = { "application/json", "application/xml" },
         method = RequestMethod.PUT)
@@ -252,6 +258,7 @@ public interface PetApi {
     }, tags={ "pet", })
     @ApiResponses(value = { 
         @ApiResponse(code = 405, message = "Invalid input") })
+    @PreAuthorize("hasAuthority('SCOPE_write:pets') and hasAuthority('SCOPE_read:pets')")
     @RequestMapping(value = "/pet/{petId}",
         consumes = { "application/x-www-form-urlencoded" },
         method = RequestMethod.POST)
@@ -277,6 +284,7 @@ public interface PetApi {
     }, tags={ "pet", })
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = ModelApiResponse.class) })
+    @PreAuthorize("hasAuthority('SCOPE_write:pets') and hasAuthority('SCOPE_read:pets')")
     @RequestMapping(value = "/pet/{petId}/uploadImage",
         produces = { "application/json" }, 
         consumes = { "multipart/form-data" },

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/api/StoreApi.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/api/StoreApi.java
@@ -11,6 +11,7 @@ import io.swagger.annotations.*;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/api/UserApi.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/api/UserApi.java
@@ -11,6 +11,7 @@ import io.swagger.annotations.*;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;


### PR DESCRIPTION
Fixes #1975 

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
