### PR TITLE
[typescript] Add ReadonlyArray to native types

### DIFF
--- a/docs/generators/typescript-angular.md
+++ b/docs/generators/typescript-angular.md
@@ -60,6 +60,7 @@ sidebar_label: typescript-angular
 <li>Long</li>
 <li>Map</li>
 <li>Object</li>
+<li>ReadonlyArray</li>
 <li>String</li>
 <li>any</li>
 <li>boolean</li>

--- a/docs/generators/typescript-angularjs.md
+++ b/docs/generators/typescript-angularjs.md
@@ -43,6 +43,7 @@ sidebar_label: typescript-angularjs
 <li>Long</li>
 <li>Map</li>
 <li>Object</li>
+<li>ReadonlyArray</li>
 <li>String</li>
 <li>any</li>
 <li>boolean</li>

--- a/docs/generators/typescript-aurelia.md
+++ b/docs/generators/typescript-aurelia.md
@@ -46,6 +46,7 @@ sidebar_label: typescript-aurelia
 <li>Long</li>
 <li>Map</li>
 <li>Object</li>
+<li>ReadonlyArray</li>
 <li>String</li>
 <li>any</li>
 <li>boolean</li>

--- a/docs/generators/typescript-axios.md
+++ b/docs/generators/typescript-axios.md
@@ -50,6 +50,7 @@ sidebar_label: typescript-axios
 <li>Long</li>
 <li>Map</li>
 <li>Object</li>
+<li>ReadonlyArray</li>
 <li>String</li>
 <li>any</li>
 <li>boolean</li>

--- a/docs/generators/typescript-fetch.md
+++ b/docs/generators/typescript-fetch.md
@@ -51,6 +51,7 @@ sidebar_label: typescript-fetch
 <li>Long</li>
 <li>Map</li>
 <li>Object</li>
+<li>ReadonlyArray</li>
 <li>String</li>
 <li>any</li>
 <li>boolean</li>

--- a/docs/generators/typescript-inversify.md
+++ b/docs/generators/typescript-inversify.md
@@ -52,6 +52,7 @@ sidebar_label: typescript-inversify
 <li>Long</li>
 <li>Map</li>
 <li>Object</li>
+<li>ReadonlyArray</li>
 <li>String</li>
 <li>any</li>
 <li>boolean</li>

--- a/docs/generators/typescript-jquery.md
+++ b/docs/generators/typescript-jquery.md
@@ -48,6 +48,7 @@ sidebar_label: typescript-jquery
 <li>Long</li>
 <li>Map</li>
 <li>Object</li>
+<li>ReadonlyArray</li>
 <li>String</li>
 <li>any</li>
 <li>boolean</li>

--- a/docs/generators/typescript-node.md
+++ b/docs/generators/typescript-node.md
@@ -49,6 +49,7 @@ sidebar_label: typescript-node
 <li>Map</li>
 <li>Object</li>
 <li>ReadStream</li>
+<li>ReadonlyArray</li>
 <li>RequestDetailedFile</li>
 <li>RequestFile</li>
 <li>String</li>

--- a/docs/generators/typescript-redux-query.md
+++ b/docs/generators/typescript-redux-query.md
@@ -49,6 +49,7 @@ sidebar_label: typescript-redux-query
 <li>Long</li>
 <li>Map</li>
 <li>Object</li>
+<li>ReadonlyArray</li>
 <li>String</li>
 <li>any</li>
 <li>boolean</li>

--- a/docs/generators/typescript-rxjs.md
+++ b/docs/generators/typescript-rxjs.md
@@ -49,6 +49,7 @@ sidebar_label: typescript-rxjs
 <li>Long</li>
 <li>Map</li>
 <li>Object</li>
+<li>ReadonlyArray</li>
 <li>String</li>
 <li>any</li>
 <li>boolean</li>

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractTypeScriptClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractTypeScriptClientCodegen.java
@@ -126,6 +126,7 @@ public abstract class AbstractTypeScriptClientCodegen extends DefaultCodegen imp
                 "Float",
                 "Object",
                 "Array",
+                "ReadonlyArray",
                 "Date",
                 "number",
                 "any",


### PR DESCRIPTION
This allows mapping the array type to TypeScript's ReadonlyArray. If ReadonlyArray is not a native type, using --type-mappings array=ReadonlyArray causes erroneous attempts at importing ReadonlyArray from the generated code.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
