### PR TITLE
[Rust Server] Nullable fixes

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustServerCodegen.java
@@ -1157,28 +1157,32 @@ public class RustServerCodegen extends DefaultCodegen implements CodegenConfig {
 
     @Override
     public String toDefaultValue(Schema p) {
-        if (ModelUtils.isBooleanSchema(p)) {
+        String defaultValue = null;
+        if ((ModelUtils.isNullable(p)) && (p.getDefault() != null) && (p.getDefault().toString().equalsIgnoreCase("null")))
+            return "swagger::Nullable::Null";
+        else if (ModelUtils.isBooleanSchema(p)) {
             if (p.getDefault() != null) {
                 if (p.getDefault().toString().equalsIgnoreCase("false"))
-                    return "false";
+                    defaultValue = "false";
                 else
-                    return "true";
+                    defaultValue = "true";
             }
         } else if (ModelUtils.isNumberSchema(p)) {
             if (p.getDefault() != null) {
-                return p.getDefault().toString();
+                defaultValue = p.getDefault().toString();
             }
         } else if (ModelUtils.isIntegerSchema(p)) {
             if (p.getDefault() != null) {
-                return p.getDefault().toString();
+                defaultValue = p.getDefault().toString();
             }
         } else if (ModelUtils.isStringSchema(p)) {
             if (p.getDefault() != null) {
-                return "\"" + (String) p.getDefault() + "\".to_string()";
+                defaultValue = "\"" + (String) p.getDefault() + "\".to_string()";
             }
         }
-
-        return null;
+        if ((defaultValue != null) && (ModelUtils.isNullable(p)))
+            defaultValue = "swagger::Nullable::Present(" + defaultValue + ")";
+        return defaultValue;
     }
 
     @Override

--- a/modules/openapi-generator/src/main/resources/rust-server/models.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/models.mustache
@@ -299,7 +299,12 @@ impl ::std::string::ToString for {{{classname}}} {
 {{/isNullable}}
 {{/isListContainer}}
 {{#isListContainer}}
+{{#isNullable}}
+        params.push(self.{{{name}}}.as_ref().map_or(vec!["null".to_string()], |x| x.iter().map(|x| x.to_string()).collect::<Vec<_>>().join(",").to_string()));
+{{/isNullable}}
+{{^isNullable}}
         params.push(self.{{{name}}}.iter().map(|x| x.to_string()).collect::<Vec<_>>().join(",").to_string());
+{{/isNullable}}
 {{/isListContainer}}
 {{/required}}
 {{^required}}
@@ -314,7 +319,12 @@ impl ::std::string::ToString for {{{classname}}} {
 {{/isNullable}}
 {{/isListContainer}}
 {{#isListContainer}}
+{{#isNullable}}
+            params.push({{{name}}}.as_ref().map_or("null".to_string(), |x| x.iter().map(|x| x.to_string()).collect::<Vec<_>>().join(",").to_string()));
+{{/isNullable}}
+{{^isNullable}}
             params.push({{{name}}}.iter().map(|x| x.to_string()).collect::<Vec<_>>().join(",").to_string());
+{{/isNullable}}
 {{/isListContainer}}
         }
 {{/required}}
@@ -353,23 +363,29 @@ impl ::std::str::FromStr for {{{classname}}} {
 
             if let Some(key) = key_result {
                 match key {
-                    {{#vars}}
-                    {{#isBinary}}
+          {{#vars}}
+            {{#isBinary}}
                     "{{{baseName}}}" => return Err(()), // Parsing binary data in this style is not supported yet
-                    {{/isBinary}}
-                    {{#isByteArray}}
+            {{/isBinary}}
+            {{^isBinary}}
+              {{#isByteArray}}
                     "{{{baseName}}}" => return Err(()), // Parsing binary data in this style is not supported yet
-                    {{/isByteArray}}
-                    {{#isContainer}}
+              {{/isByteArray}}
+              {{^isByteArray}}
+                {{#isContainer}}
                     "{{{baseName}}}" => return Err(()), // Parsing a container in this style is not supported yet
-                    {{/isContainer}}
-                    {{#isNullable}}
+                {{/isContainer}}
+                {{^isContainer}}
+                  {{#isNullable}}
                     "{{{baseName}}}" => return Err(()), // Parsing a nullable type in this style is not supported yet
-                    {{/isNullable}}
-                    {{^isByteArray}}{{^isBinary}}{{^isContainer}}{{^isNullable}}
+                  {{/isNullable}}
+                  {{^isNullable}}
                     "{{{baseName}}}" => intermediate_rep.{{{name}}}.push({{{dataType}}}::from_str(val).map_err(|x| ())?),
-                    {{/isNullable}}{{/isContainer}}{{/isBinary}}{{/isByteArray}}
-                    {{/vars}}
+                  {{/isNullable}}
+                {{/isContainer}}
+              {{/isByteArray}}
+            {{/isBinary}}
+          {{/vars}}
                     _ => return Err(()) // Parse error - unexpected key
                 }
             }

--- a/modules/openapi-generator/src/test/resources/3_0/rust-server/openapi-v3.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/rust-server/openapi-v3.yaml
@@ -377,3 +377,27 @@ components:
       type: boolean
     OptionalObjectHeader:
       type: integer
+    NullableTest:
+      type: object
+      required:
+      - nullable
+      properties:
+        nullable:
+          type: string
+          nullable: true
+        nullableWithNullDefault:
+          type: string
+          nullable: true
+          default: null
+        nullableWithPresentDefault:
+          type: string
+          nullable: true
+          default: "default"
+        nullableWithNoDefault:
+          type: string
+          nullable: true
+        nullableArray:
+          type: array
+          items:
+            type: string
+          nullable: true

--- a/samples/server/petstore/rust-server/output/multipart-v3/src/models.rs
+++ b/samples/server/petstore/rust-server/output/multipart-v3/src/models.rs
@@ -99,13 +99,9 @@ impl ::std::str::FromStr for MultipartRelatedRequest {
 
             if let Some(key) = key_result {
                 match key {
-                    
                     "object_field" => intermediate_rep.object_field.push(models::MultipartRequestObjectField::from_str(val).map_err(|x| ())?),
-                    
                     "optional_binary_field" => return Err(()), // Parsing binary data in this style is not supported yet
-                    
                     "required_binary_field" => return Err(()), // Parsing binary data in this style is not supported yet
-                    
                     _ => return Err(()) // Parse error - unexpected key
                 }
             }
@@ -225,17 +221,10 @@ impl ::std::str::FromStr for MultipartRequest {
 
             if let Some(key) = key_result {
                 match key {
-                    
                     "string_field" => intermediate_rep.string_field.push(String::from_str(val).map_err(|x| ())?),
-                    
-                    
                     "optional_string_field" => intermediate_rep.optional_string_field.push(String::from_str(val).map_err(|x| ())?),
-                    
-                    
                     "object_field" => intermediate_rep.object_field.push(models::MultipartRequestObjectField::from_str(val).map_err(|x| ())?),
-                    
                     "binary_field" => return Err(()), // Parsing binary data in this style is not supported yet
-                    
                     _ => return Err(()) // Parse error - unexpected key
                 }
             }
@@ -340,11 +329,8 @@ impl ::std::str::FromStr for MultipartRequestObjectField {
 
             if let Some(key) = key_result {
                 match key {
-                    
                     "field_a" => intermediate_rep.field_a.push(String::from_str(val).map_err(|x| ())?),
-                    
                     "field_b" => return Err(()), // Parsing a container in this style is not supported yet
-                    
                     _ => return Err(()) // Parse error - unexpected key
                 }
             }

--- a/samples/server/petstore/rust-server/output/openapi-v3/README.md
+++ b/samples/server/petstore/rust-server/output/openapi-v3/README.md
@@ -134,6 +134,7 @@ Method | HTTP request | Description
  - [InlineResponse201](docs/InlineResponse201.md)
  - [MyId](docs/MyId.md)
  - [MyIdList](docs/MyIdList.md)
+ - [NullableTest](docs/NullableTest.md)
  - [ObjectHeader](docs/ObjectHeader.md)
  - [ObjectParam](docs/ObjectParam.md)
  - [ObjectUntypedProps](docs/ObjectUntypedProps.md)

--- a/samples/server/petstore/rust-server/output/openapi-v3/api/openapi.yaml
+++ b/samples/server/petstore/rust-server/output/openapi-v3/api/openapi.yaml
@@ -368,6 +368,30 @@ components:
       type: boolean
     OptionalObjectHeader:
       type: integer
+    NullableTest:
+      properties:
+        nullable:
+          nullable: true
+          type: string
+        nullableWithNullDefault:
+          default: "null"
+          nullable: true
+          type: string
+        nullableWithPresentDefault:
+          default: default
+          nullable: true
+          type: string
+        nullableWithNoDefault:
+          nullable: true
+          type: string
+        nullableArray:
+          items:
+            type: string
+          nullable: true
+          type: array
+      required:
+      - nullable
+      type: object
     inline_response_201:
       properties:
         foo:

--- a/samples/server/petstore/rust-server/output/openapi-v3/docs/NullableTest.md
+++ b/samples/server/petstore/rust-server/output/openapi-v3/docs/NullableTest.md
@@ -1,0 +1,14 @@
+# NullableTest
+
+## Properties
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**nullable** | **String** |  | 
+**nullable_with_null_default** | **String** |  | [optional] [default to Some(swagger::Nullable::Null)]
+**nullable_with_present_default** | **String** |  | [optional] [default to Some(swagger::Nullable::Present("default".to_string()))]
+**nullable_with_no_default** | **String** |  | [optional] [default to None]
+**nullable_array** | **Vec<String>** |  | [optional] [default to None]
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+
+

--- a/samples/server/petstore/rust-server/output/openapi-v3/src/models.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/src/models.rs
@@ -257,9 +257,7 @@ impl ::std::str::FromStr for AnotherXmlObject {
 
             if let Some(key) = key_result {
                 match key {
-                    
                     "inner_string" => intermediate_rep.inner_string.push(String::from_str(val).map_err(|x| ())?),
-                    
                     _ => return Err(()) // Parse error - unexpected key
                 }
             }
@@ -379,12 +377,8 @@ impl ::std::str::FromStr for DuplicateXmlObject {
 
             if let Some(key) = key_result {
                 match key {
-                    
                     "inner_string" => intermediate_rep.inner_string.push(String::from_str(val).map_err(|x| ())?),
-                    
-                    
                     "inner_array" => intermediate_rep.inner_array.push(models::XmlArray::from_str(val).map_err(|x| ())?),
-                    
                     _ => return Err(()) // Parse error - unexpected key
                 }
             }
@@ -543,9 +537,7 @@ impl ::std::str::FromStr for InlineResponse201 {
 
             if let Some(key) = key_result {
                 match key {
-                    
                     "foo" => intermediate_rep.foo.push(String::from_str(val).map_err(|x| ())?),
-                    
                     _ => return Err(()) // Parse error - unexpected key
                 }
             }
@@ -722,6 +714,168 @@ impl MyIdList {
     }
 }
 
+// Methods for converting between IntoHeaderValue<NullableTest> and HeaderValue
+
+impl From<IntoHeaderValue<NullableTest>> for HeaderValue {
+    fn from(hdr_value: IntoHeaderValue<NullableTest>) -> Self {
+        HeaderValue::from_str(&hdr_value.to_string()).unwrap()
+    }
+}
+
+impl From<HeaderValue> for IntoHeaderValue<NullableTest> {
+    fn from(hdr_value: HeaderValue) -> Self {
+        IntoHeaderValue(NullableTest::from_str(hdr_value.to_str().unwrap()).unwrap())
+    }
+}
+
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "conversion", derive(LabelledGeneric))]
+pub struct NullableTest {
+    #[serde(rename = "nullable")]
+    pub nullable: swagger::Nullable<String>,
+
+    #[serde(rename = "nullableWithNullDefault")]
+    #[serde(deserialize_with = "swagger::nullable_format::deserialize_optional_nullable")]
+    #[serde(default = "swagger::nullable_format::default_optional_nullable")]
+    #[serde(skip_serializing_if="Option::is_none")]
+    pub nullable_with_null_default: Option<swagger::Nullable<String>>,
+
+    #[serde(rename = "nullableWithPresentDefault")]
+    #[serde(deserialize_with = "swagger::nullable_format::deserialize_optional_nullable")]
+    #[serde(default = "swagger::nullable_format::default_optional_nullable")]
+    #[serde(skip_serializing_if="Option::is_none")]
+    pub nullable_with_present_default: Option<swagger::Nullable<String>>,
+
+    #[serde(rename = "nullableWithNoDefault")]
+    #[serde(deserialize_with = "swagger::nullable_format::deserialize_optional_nullable")]
+    #[serde(default = "swagger::nullable_format::default_optional_nullable")]
+    #[serde(skip_serializing_if="Option::is_none")]
+    pub nullable_with_no_default: Option<swagger::Nullable<String>>,
+
+    #[serde(rename = "nullableArray")]
+    #[serde(deserialize_with = "swagger::nullable_format::deserialize_optional_nullable")]
+    #[serde(default = "swagger::nullable_format::default_optional_nullable")]
+    #[serde(skip_serializing_if="Option::is_none")]
+    pub nullable_array: Option<swagger::Nullable<Vec<String>>>,
+
+}
+
+impl NullableTest {
+    pub fn new(nullable: swagger::Nullable<String>, ) -> NullableTest {
+        NullableTest {
+            nullable: nullable,
+            nullable_with_null_default: Some(swagger::Nullable::Null),
+            nullable_with_present_default: Some(swagger::Nullable::Present("default".to_string())),
+            nullable_with_no_default: None,
+            nullable_array: None,
+        }
+    }
+}
+
+/// Converts the NullableTest value to the Query Parameters representation (style=form, explode=false)
+/// specified in https://swagger.io/docs/specification/serialization/
+/// Should be implemented in a serde serializer
+impl ::std::string::ToString for NullableTest {
+    fn to_string(&self) -> String {
+        let mut params: Vec<String> = vec![];
+
+        params.push("nullable".to_string());
+        params.push(self.nullable.as_ref().map_or("null".to_string(), |x| x.to_string()));
+
+
+        if let Some(ref nullable_with_null_default) = self.nullable_with_null_default {
+            params.push("nullableWithNullDefault".to_string());
+            params.push(nullable_with_null_default.as_ref().map_or("null".to_string(), |x| x.to_string()));
+        }
+
+
+        if let Some(ref nullable_with_present_default) = self.nullable_with_present_default {
+            params.push("nullableWithPresentDefault".to_string());
+            params.push(nullable_with_present_default.as_ref().map_or("null".to_string(), |x| x.to_string()));
+        }
+
+
+        if let Some(ref nullable_with_no_default) = self.nullable_with_no_default {
+            params.push("nullableWithNoDefault".to_string());
+            params.push(nullable_with_no_default.as_ref().map_or("null".to_string(), |x| x.to_string()));
+        }
+
+
+        if let Some(ref nullable_array) = self.nullable_array {
+            params.push("nullableArray".to_string());
+            params.push(nullable_array.as_ref().map_or("null".to_string(), |x| x.iter().map(|x| x.to_string()).collect::<Vec<_>>().join(",").to_string()));
+        }
+
+        params.join(",").to_string()
+    }
+}
+
+/// Converts Query Parameters representation (style=form, explode=false) to a NullableTest value
+/// as specified in https://swagger.io/docs/specification/serialization/
+/// Should be implemented in a serde deserializer
+impl ::std::str::FromStr for NullableTest {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        #[derive(Default)]
+        // An intermediate representation of the struct to use for parsing.
+        struct IntermediateRep {
+            pub nullable: Vec<String>,
+            pub nullable_with_null_default: Vec<String>,
+            pub nullable_with_present_default: Vec<String>,
+            pub nullable_with_no_default: Vec<String>,
+            pub nullable_array: Vec<Vec<String>>,
+        }
+
+        let mut intermediate_rep = IntermediateRep::default();
+
+        // Parse into intermediate representation
+        let mut string_iter = s.split(',').into_iter();
+        let mut key_result = string_iter.next();
+
+        while key_result.is_some() {
+            let val = match string_iter.next() {
+                Some(x) => x,
+                None => return Err(())
+            };
+
+            if let Some(key) = key_result {
+                match key {
+                    "nullable" => return Err(()), // Parsing a nullable type in this style is not supported yet
+                    "nullableWithNullDefault" => return Err(()), // Parsing a nullable type in this style is not supported yet
+                    "nullableWithPresentDefault" => return Err(()), // Parsing a nullable type in this style is not supported yet
+                    "nullableWithNoDefault" => return Err(()), // Parsing a nullable type in this style is not supported yet
+                    "nullableArray" => return Err(()), // Parsing a container in this style is not supported yet
+                    _ => return Err(()) // Parse error - unexpected key
+                }
+            }
+
+            // Get the next key
+            key_result = string_iter.next();
+        }
+
+        // Use the intermediate representation to return the struct
+        Ok(NullableTest {
+            nullable: Err(())?,
+            nullable_with_null_default: Err(())?,
+            nullable_with_present_default: Err(())?,
+            nullable_with_no_default: Err(())?,
+            nullable_array: Err(())?,
+        })
+    }
+}
+
+
+impl NullableTest {
+    /// Helper function to allow us to convert this model to an XML string.
+    /// Will panic if serialisation fails.
+    #[allow(dead_code)]
+    pub(crate) fn to_xml(&self) -> String {
+        serde_xml_rs::to_string(&self).expect("impossible to fail to serialize")
+    }
+}
+
 // Methods for converting between IntoHeaderValue<ObjectHeader> and HeaderValue
 
 impl From<IntoHeaderValue<ObjectHeader>> for HeaderValue {
@@ -806,12 +960,8 @@ impl ::std::str::FromStr for ObjectHeader {
 
             if let Some(key) = key_result {
                 match key {
-                    
                     "requiredObjectHeader" => intermediate_rep.required_object_header.push(bool::from_str(val).map_err(|x| ())?),
-                    
-                    
                     "optionalObjectHeader" => intermediate_rep.optional_object_header.push(isize::from_str(val).map_err(|x| ())?),
-                    
                     _ => return Err(()) // Parse error - unexpected key
                 }
             }
@@ -922,12 +1072,8 @@ impl ::std::str::FromStr for ObjectParam {
 
             if let Some(key) = key_result {
                 match key {
-                    
                     "requiredParam" => intermediate_rep.required_param.push(bool::from_str(val).map_err(|x| ())?),
-                    
-                    
                     "optionalParam" => intermediate_rep.optional_param.push(isize::from_str(val).map_err(|x| ())?),
-                    
                     _ => return Err(()) // Parse error - unexpected key
                 }
             }
@@ -1047,18 +1193,10 @@ impl ::std::str::FromStr for ObjectUntypedProps {
 
             if let Some(key) = key_result {
                 match key {
-                    
                     "required_untyped" => intermediate_rep.required_untyped.push(serde_json::Value::from_str(val).map_err(|x| ())?),
-                    
-                    
                     "required_untyped_nullable" => intermediate_rep.required_untyped_nullable.push(serde_json::Value::from_str(val).map_err(|x| ())?),
-                    
-                    
                     "not_required_untyped" => intermediate_rep.not_required_untyped.push(serde_json::Value::from_str(val).map_err(|x| ())?),
-                    
-                    
                     "not_required_untyped_nullable" => intermediate_rep.not_required_untyped_nullable.push(serde_json::Value::from_str(val).map_err(|x| ())?),
-                    
                     _ => return Err(()) // Parse error - unexpected key
                 }
             }
@@ -1163,7 +1301,6 @@ impl ::std::str::FromStr for ObjectWithArrayOfObjects {
             if let Some(key) = key_result {
                 match key {
                     "objectArray" => return Err(()), // Parsing a container in this style is not supported yet
-                    
                     _ => return Err(()) // Parse error - unexpected key
                 }
             }
@@ -1612,12 +1749,8 @@ impl ::std::str::FromStr for XmlObject {
 
             if let Some(key) = key_result {
                 match key {
-                    
                     "innerString" => intermediate_rep.inner_string.push(String::from_str(val).map_err(|x| ())?),
-                    
-                    
                     "other_inner_rename" => intermediate_rep.other_inner_rename.push(isize::from_str(val).map_err(|x| ())?),
-                    
                     _ => return Err(()) // Parse error - unexpected key
                 }
             }

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/docs/NullableTest.md
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/docs/NullableTest.md
@@ -1,0 +1,14 @@
+# NullableTest
+
+## Properties
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**nullable** | **String** |  | 
+**nullable_with_null_default** | **String** |  | [optional] [default to None]
+**nullable_with_present_default** | **String** |  | [optional] [default to Some("default".to_string())]
+**nullable_with_no_default** | **String** |  | [optional] [default to None]
+**nullable_array** | **Vec<String>** |  | [optional] [default to None]
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+
+

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/src/models.rs
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/src/models.rs
@@ -94,9 +94,7 @@ impl ::std::str::FromStr for AdditionalPropertiesClass {
             if let Some(key) = key_result {
                 match key {
                     "map_property" => return Err(()), // Parsing a container in this style is not supported yet
-                    
                     "map_of_map_property" => return Err(()), // Parsing a container in this style is not supported yet
-                    
                     _ => return Err(()) // Parse error - unexpected key
                 }
             }
@@ -207,12 +205,8 @@ impl ::std::str::FromStr for Animal {
 
             if let Some(key) = key_result {
                 match key {
-                    
                     "className" => intermediate_rep.class_name.push(String::from_str(val).map_err(|x| ())?),
-                    
-                    
                     "color" => intermediate_rep.color.push(String::from_str(val).map_err(|x| ())?),
-                    
                     _ => return Err(()) // Parse error - unexpected key
                 }
             }
@@ -449,15 +443,9 @@ impl ::std::str::FromStr for ApiResponse {
 
             if let Some(key) = key_result {
                 match key {
-                    
                     "code" => intermediate_rep.code.push(i32::from_str(val).map_err(|x| ())?),
-                    
-                    
                     "type" => intermediate_rep._type.push(String::from_str(val).map_err(|x| ())?),
-                    
-                    
                     "message" => intermediate_rep.message.push(String::from_str(val).map_err(|x| ())?),
-                    
                     _ => return Err(()) // Parse error - unexpected key
                 }
             }
@@ -557,7 +545,6 @@ impl ::std::str::FromStr for ArrayOfArrayOfNumberOnly {
             if let Some(key) = key_result {
                 match key {
                     "ArrayArrayNumber" => return Err(()), // Parsing a container in this style is not supported yet
-                    
                     _ => return Err(()) // Parse error - unexpected key
                 }
             }
@@ -659,7 +646,6 @@ impl ::std::str::FromStr for ArrayOfNumberOnly {
             if let Some(key) = key_result {
                 match key {
                     "ArrayNumber" => return Err(()), // Parsing a container in this style is not supported yet
-                    
                     _ => return Err(()) // Parse error - unexpected key
                 }
             }
@@ -790,13 +776,9 @@ impl ::std::str::FromStr for ArrayTest {
             if let Some(key) = key_result {
                 match key {
                     "array_of_string" => return Err(()), // Parsing a container in this style is not supported yet
-                    
                     "array_array_of_integer" => return Err(()), // Parsing a container in this style is not supported yet
-                    
                     "array_array_of_model" => return Err(()), // Parsing a container in this style is not supported yet
-                    
                     "array_of_enum" => return Err(()), // Parsing a container in this style is not supported yet
-                    
                     _ => return Err(()) // Parse error - unexpected key
                 }
             }
@@ -961,24 +943,12 @@ impl ::std::str::FromStr for Capitalization {
 
             if let Some(key) = key_result {
                 match key {
-                    
                     "smallCamel" => intermediate_rep.small_camel.push(String::from_str(val).map_err(|x| ())?),
-                    
-                    
                     "CapitalCamel" => intermediate_rep.capital_camel.push(String::from_str(val).map_err(|x| ())?),
-                    
-                    
                     "small_Snake" => intermediate_rep.small_snake.push(String::from_str(val).map_err(|x| ())?),
-                    
-                    
                     "Capital_Snake" => intermediate_rep.capital_snake.push(String::from_str(val).map_err(|x| ())?),
-                    
-                    
                     "SCA_ETH_Flow_Points" => intermediate_rep.sca_eth_flow_points.push(String::from_str(val).map_err(|x| ())?),
-                    
-                    
                     "ATT_NAME" => intermediate_rep.att_name.push(String::from_str(val).map_err(|x| ())?),
-                    
                     _ => return Err(()) // Parse error - unexpected key
                 }
             }
@@ -1105,15 +1075,9 @@ impl ::std::str::FromStr for Cat {
 
             if let Some(key) = key_result {
                 match key {
-                    
                     "className" => intermediate_rep.class_name.push(String::from_str(val).map_err(|x| ())?),
-                    
-                    
                     "color" => intermediate_rep.color.push(String::from_str(val).map_err(|x| ())?),
-                    
-                    
                     "declawed" => intermediate_rep.declawed.push(bool::from_str(val).map_err(|x| ())?),
-                    
                     _ => return Err(()) // Parse error - unexpected key
                 }
             }
@@ -1216,9 +1180,7 @@ impl ::std::str::FromStr for CatAllOf {
 
             if let Some(key) = key_result {
                 match key {
-                    
                     "declawed" => intermediate_rep.declawed.push(bool::from_str(val).map_err(|x| ())?),
-                    
                     _ => return Err(()) // Parse error - unexpected key
                 }
             }
@@ -1332,12 +1294,8 @@ impl ::std::str::FromStr for Category {
 
             if let Some(key) = key_result {
                 match key {
-                    
                     "id" => intermediate_rep.id.push(i64::from_str(val).map_err(|x| ())?),
-                    
-                    
                     "name" => intermediate_rep.name.push(String::from_str(val).map_err(|x| ())?),
-                    
                     _ => return Err(()) // Parse error - unexpected key
                 }
             }
@@ -1440,9 +1398,7 @@ impl ::std::str::FromStr for ClassModel {
 
             if let Some(key) = key_result {
                 match key {
-                    
                     "_class" => intermediate_rep._class.push(String::from_str(val).map_err(|x| ())?),
-                    
                     _ => return Err(()) // Parse error - unexpected key
                 }
             }
@@ -1543,9 +1499,7 @@ impl ::std::str::FromStr for Client {
 
             if let Some(key) = key_result {
                 match key {
-                    
                     "client" => intermediate_rep.client.push(String::from_str(val).map_err(|x| ())?),
-                    
                     _ => return Err(()) // Parse error - unexpected key
                 }
             }
@@ -1667,15 +1621,9 @@ impl ::std::str::FromStr for Dog {
 
             if let Some(key) = key_result {
                 match key {
-                    
                     "className" => intermediate_rep.class_name.push(String::from_str(val).map_err(|x| ())?),
-                    
-                    
                     "color" => intermediate_rep.color.push(String::from_str(val).map_err(|x| ())?),
-                    
-                    
                     "breed" => intermediate_rep.breed.push(String::from_str(val).map_err(|x| ())?),
-                    
                     _ => return Err(()) // Parse error - unexpected key
                 }
             }
@@ -1778,9 +1726,7 @@ impl ::std::str::FromStr for DogAllOf {
 
             if let Some(key) = key_result {
                 match key {
-                    
                     "breed" => intermediate_rep.breed.push(String::from_str(val).map_err(|x| ())?),
-                    
                     _ => return Err(()) // Parse error - unexpected key
                 }
             }
@@ -1904,13 +1850,9 @@ impl ::std::str::FromStr for EnumArrays {
 
             if let Some(key) = key_result {
                 match key {
-                    
                     "just_symbol" => intermediate_rep.just_symbol.push(String::from_str(val).map_err(|x| ())?),
-                    
                     "array_enum" => return Err(()), // Parsing a container in this style is not supported yet
-                    
                     "array_array_enum" => return Err(()), // Parsing a container in this style is not supported yet
-                    
                     _ => return Err(()) // Parse error - unexpected key
                 }
             }
@@ -2105,21 +2047,11 @@ impl ::std::str::FromStr for EnumTest {
 
             if let Some(key) = key_result {
                 match key {
-                    
                     "enum_string" => intermediate_rep.enum_string.push(String::from_str(val).map_err(|x| ())?),
-                    
-                    
                     "enum_string_required" => intermediate_rep.enum_string_required.push(String::from_str(val).map_err(|x| ())?),
-                    
-                    
                     "enum_integer" => intermediate_rep.enum_integer.push(i32::from_str(val).map_err(|x| ())?),
-                    
-                    
                     "enum_number" => intermediate_rep.enum_number.push(f64::from_str(val).map_err(|x| ())?),
-                    
-                    
                     "outerEnum" => intermediate_rep.outer_enum.push(models::OuterEnum::from_str(val).map_err(|x| ())?),
-                    
                     _ => return Err(()) // Parse error - unexpected key
                 }
             }
@@ -2342,43 +2274,19 @@ impl ::std::str::FromStr for FormatTest {
 
             if let Some(key) = key_result {
                 match key {
-                    
                     "integer" => intermediate_rep.integer.push(u8::from_str(val).map_err(|x| ())?),
-                    
-                    
                     "int32" => intermediate_rep.int32.push(u32::from_str(val).map_err(|x| ())?),
-                    
-                    
                     "int64" => intermediate_rep.int64.push(i64::from_str(val).map_err(|x| ())?),
-                    
-                    
                     "number" => intermediate_rep.number.push(f64::from_str(val).map_err(|x| ())?),
-                    
-                    
                     "float" => intermediate_rep.float.push(f32::from_str(val).map_err(|x| ())?),
-                    
-                    
                     "double" => intermediate_rep.double.push(f64::from_str(val).map_err(|x| ())?),
-                    
-                    
                     "string" => intermediate_rep.string.push(String::from_str(val).map_err(|x| ())?),
-                    
                     "byte" => return Err(()), // Parsing binary data in this style is not supported yet
-                    
                     "binary" => return Err(()), // Parsing binary data in this style is not supported yet
-                    
-                    
                     "date" => intermediate_rep.date.push(chrono::DateTime::<chrono::Utc>::from_str(val).map_err(|x| ())?),
-                    
-                    
                     "dateTime" => intermediate_rep.date_time.push(chrono::DateTime::<chrono::Utc>::from_str(val).map_err(|x| ())?),
-                    
-                    
                     "uuid" => intermediate_rep.uuid.push(uuid::Uuid::from_str(val).map_err(|x| ())?),
-                    
-                    
                     "password" => intermediate_rep.password.push(String::from_str(val).map_err(|x| ())?),
-                    
                     _ => return Err(()) // Parse error - unexpected key
                 }
             }
@@ -2503,12 +2411,8 @@ impl ::std::str::FromStr for HasOnlyReadOnly {
 
             if let Some(key) = key_result {
                 match key {
-                    
                     "bar" => intermediate_rep.bar.push(String::from_str(val).map_err(|x| ())?),
-                    
-                    
                     "foo" => intermediate_rep.foo.push(String::from_str(val).map_err(|x| ())?),
-                    
                     _ => return Err(()) // Parse error - unexpected key
                 }
             }
@@ -2610,9 +2514,7 @@ impl ::std::str::FromStr for List {
 
             if let Some(key) = key_result {
                 match key {
-                    
                     "123-list" => intermediate_rep._123_list.push(String::from_str(val).map_err(|x| ())?),
-                    
                     _ => return Err(()) // Parse error - unexpected key
                 }
             }
@@ -2730,11 +2632,8 @@ impl ::std::str::FromStr for MapTest {
             if let Some(key) = key_result {
                 match key {
                     "map_map_of_string" => return Err(()), // Parsing a container in this style is not supported yet
-                    
                     "map_map_of_enum" => return Err(()), // Parsing a container in this style is not supported yet
-                    
                     "map_of_enum_string" => return Err(()), // Parsing a container in this style is not supported yet
-                    
                     _ => return Err(()) // Parse error - unexpected key
                 }
             }
@@ -2850,14 +2749,9 @@ impl ::std::str::FromStr for MixedPropertiesAndAdditionalPropertiesClass {
 
             if let Some(key) = key_result {
                 match key {
-                    
                     "uuid" => intermediate_rep.uuid.push(uuid::Uuid::from_str(val).map_err(|x| ())?),
-                    
-                    
                     "dateTime" => intermediate_rep.date_time.push(chrono::DateTime::<chrono::Utc>::from_str(val).map_err(|x| ())?),
-                    
                     "map" => return Err(()), // Parsing a container in this style is not supported yet
-                    
                     _ => return Err(()) // Parse error - unexpected key
                 }
             }
@@ -2974,12 +2868,8 @@ impl ::std::str::FromStr for Model200Response {
 
             if let Some(key) = key_result {
                 match key {
-                    
                     "name" => intermediate_rep.name.push(i32::from_str(val).map_err(|x| ())?),
-                    
-                    
                     "class" => intermediate_rep.class.push(String::from_str(val).map_err(|x| ())?),
-                    
                     _ => return Err(()) // Parse error - unexpected key
                 }
             }
@@ -3083,9 +2973,7 @@ impl ::std::str::FromStr for ModelReturn {
 
             if let Some(key) = key_result {
                 match key {
-                    
                     "return" => intermediate_rep._return.push(i32::from_str(val).map_err(|x| ())?),
-                    
                     _ => return Err(()) // Parse error - unexpected key
                 }
             }
@@ -3221,18 +3109,10 @@ impl ::std::str::FromStr for Name {
 
             if let Some(key) = key_result {
                 match key {
-                    
                     "name" => intermediate_rep.name.push(i32::from_str(val).map_err(|x| ())?),
-                    
-                    
                     "snake_case" => intermediate_rep.snake_case.push(i32::from_str(val).map_err(|x| ())?),
-                    
-                    
                     "property" => intermediate_rep.property.push(String::from_str(val).map_err(|x| ())?),
-                    
-                    
                     "123Number" => intermediate_rep._123_number.push(isize::from_str(val).map_err(|x| ())?),
-                    
                     _ => return Err(()) // Parse error - unexpected key
                 }
             }
@@ -3336,9 +3216,7 @@ impl ::std::str::FromStr for NumberOnly {
 
             if let Some(key) = key_result {
                 match key {
-                    
                     "JustNumber" => intermediate_rep.just_number.push(f64::from_str(val).map_err(|x| ())?),
-                    
                     _ => return Err(()) // Parse error - unexpected key
                 }
             }
@@ -3435,9 +3313,7 @@ impl ::std::str::FromStr for ObjectContainingObjectWithOnlyAdditionalProperties 
 
             if let Some(key) = key_result {
                 match key {
-                    
                     "inner" => intermediate_rep.inner.push(models::ObjectWithOnlyAdditionalProperties::from_str(val).map_err(|x| ())?),
-                    
                     _ => return Err(()) // Parse error - unexpected key
                 }
             }
@@ -3658,24 +3534,12 @@ impl ::std::str::FromStr for Order {
 
             if let Some(key) = key_result {
                 match key {
-                    
                     "id" => intermediate_rep.id.push(i64::from_str(val).map_err(|x| ())?),
-                    
-                    
                     "petId" => intermediate_rep.pet_id.push(i64::from_str(val).map_err(|x| ())?),
-                    
-                    
                     "quantity" => intermediate_rep.quantity.push(i32::from_str(val).map_err(|x| ())?),
-                    
-                    
                     "shipDate" => intermediate_rep.ship_date.push(chrono::DateTime::<chrono::Utc>::from_str(val).map_err(|x| ())?),
-                    
-                    
                     "status" => intermediate_rep.status.push(String::from_str(val).map_err(|x| ())?),
-                    
-                    
                     "complete" => intermediate_rep.complete.push(bool::from_str(val).map_err(|x| ())?),
-                    
                     _ => return Err(()) // Parse error - unexpected key
                 }
             }
@@ -3845,15 +3709,9 @@ impl ::std::str::FromStr for OuterComposite {
 
             if let Some(key) = key_result {
                 match key {
-                    
                     "my_number" => intermediate_rep.my_number.push(f64::from_str(val).map_err(|x| ())?),
-                    
-                    
                     "my_string" => intermediate_rep.my_string.push(String::from_str(val).map_err(|x| ())?),
-                    
-                    
                     "my_boolean" => intermediate_rep.my_boolean.push(bool::from_str(val).map_err(|x| ())?),
-                    
                     _ => return Err(()) // Parse error - unexpected key
                 }
             }
@@ -4138,22 +3996,12 @@ impl ::std::str::FromStr for Pet {
 
             if let Some(key) = key_result {
                 match key {
-                    
                     "id" => intermediate_rep.id.push(i64::from_str(val).map_err(|x| ())?),
-                    
-                    
                     "category" => intermediate_rep.category.push(models::Category::from_str(val).map_err(|x| ())?),
-                    
-                    
                     "name" => intermediate_rep.name.push(String::from_str(val).map_err(|x| ())?),
-                    
                     "photoUrls" => return Err(()), // Parsing a container in this style is not supported yet
-                    
                     "tags" => return Err(()), // Parsing a container in this style is not supported yet
-                    
-                    
                     "status" => intermediate_rep.status.push(String::from_str(val).map_err(|x| ())?),
-                    
                     _ => return Err(()) // Parse error - unexpected key
                 }
             }
@@ -4271,12 +4119,8 @@ impl ::std::str::FromStr for ReadOnlyFirst {
 
             if let Some(key) = key_result {
                 match key {
-                    
                     "bar" => intermediate_rep.bar.push(String::from_str(val).map_err(|x| ())?),
-                    
-                    
                     "baz" => intermediate_rep.baz.push(String::from_str(val).map_err(|x| ())?),
-                    
                     _ => return Err(()) // Parse error - unexpected key
                 }
             }
@@ -4379,9 +4223,7 @@ impl ::std::str::FromStr for SpecialModelName {
 
             if let Some(key) = key_result {
                 match key {
-                    
                     "$special[property.name]" => intermediate_rep.special_property_name.push(i64::from_str(val).map_err(|x| ())?),
-                    
                     _ => return Err(()) // Parse error - unexpected key
                 }
             }
@@ -4495,12 +4337,8 @@ impl ::std::str::FromStr for Tag {
 
             if let Some(key) = key_result {
                 match key {
-                    
                     "id" => intermediate_rep.id.push(i64::from_str(val).map_err(|x| ())?),
-                    
-                    
                     "name" => intermediate_rep.name.push(String::from_str(val).map_err(|x| ())?),
-                    
                     _ => return Err(()) // Parse error - unexpected key
                 }
             }
@@ -4688,30 +4526,14 @@ impl ::std::str::FromStr for User {
 
             if let Some(key) = key_result {
                 match key {
-                    
                     "id" => intermediate_rep.id.push(i64::from_str(val).map_err(|x| ())?),
-                    
-                    
                     "username" => intermediate_rep.username.push(String::from_str(val).map_err(|x| ())?),
-                    
-                    
                     "firstName" => intermediate_rep.first_name.push(String::from_str(val).map_err(|x| ())?),
-                    
-                    
                     "lastName" => intermediate_rep.last_name.push(String::from_str(val).map_err(|x| ())?),
-                    
-                    
                     "email" => intermediate_rep.email.push(String::from_str(val).map_err(|x| ())?),
-                    
-                    
                     "password" => intermediate_rep.password.push(String::from_str(val).map_err(|x| ())?),
-                    
-                    
                     "phone" => intermediate_rep.phone.push(String::from_str(val).map_err(|x| ())?),
-                    
-                    
                     "userStatus" => intermediate_rep.user_status.push(i32::from_str(val).map_err(|x| ())?),
-                    
                     _ => return Err(()) // Parse error - unexpected key
                 }
             }

--- a/samples/server/petstore/rust-server/output/rust-server-test/src/models.rs
+++ b/samples/server/petstore/rust-server/output/rust-server-test/src/models.rs
@@ -98,9 +98,7 @@ impl ::std::str::FromStr for ANullableContainer {
             if let Some(key) = key_result {
                 match key {
                     "NullableThing" => return Err(()), // Parsing a nullable type in this style is not supported yet
-                    
                     "RequiredNullableThing" => return Err(()), // Parsing a nullable type in this style is not supported yet
-                    
                     _ => return Err(()) // Parse error - unexpected key
                 }
             }
@@ -250,9 +248,7 @@ impl ::std::str::FromStr for GetYamlResponse {
 
             if let Some(key) = key_result {
                 match key {
-                    
                     "value" => intermediate_rep.value.push(String::from_str(val).map_err(|x| ())?),
-                    
                     _ => return Err(()) // Parse error - unexpected key
                 }
             }
@@ -354,12 +350,8 @@ impl ::std::str::FromStr for InlineObject {
 
             if let Some(key) = key_result {
                 match key {
-                    
                     "id" => intermediate_rep.id.push(String::from_str(val).map_err(|x| ())?),
-                    
-                    
                     "password" => intermediate_rep.password.push(String::from_str(val).map_err(|x| ())?),
-                    
                     _ => return Err(()) // Parse error - unexpected key
                 }
             }
@@ -450,9 +442,7 @@ impl ::std::str::FromStr for ObjectOfObjects {
 
             if let Some(key) = key_result {
                 match key {
-                    
                     "inner" => intermediate_rep.inner.push(models::ObjectOfObjectsInner::from_str(val).map_err(|x| ())?),
-                    
                     _ => return Err(()) // Parse error - unexpected key
                 }
             }
@@ -554,12 +544,8 @@ impl ::std::str::FromStr for ObjectOfObjectsInner {
 
             if let Some(key) = key_result {
                 match key {
-                    
                     "required_thing" => intermediate_rep.required_thing.push(String::from_str(val).map_err(|x| ())?),
-                    
-                    
                     "optional_thing" => intermediate_rep.optional_thing.push(isize::from_str(val).map_err(|x| ())?),
-                    
                     _ => return Err(()) // Parse error - unexpected key
                 }
             }


### PR DESCRIPTION
This fixes a number of bugs when nullable was used alongside optional or array types - primarily around either generating invalid default values or rendering them to string parameters incorrectly.  I've added tests for these and fixed the bugs.

This fix was contributed by @mirw and reviewed by myself, on behalf of of @Metaswitch.

### Rust Server Technical Committee

- @frol
- @farcaller 
- @bjgill

### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [X] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [X] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
