### PR TITLE
[go-experimental] Fix nullable support

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/GoClientExperimentalCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/GoClientExperimentalCodegen.java
@@ -151,6 +151,11 @@ public class GoClientExperimentalCodegen extends GoClientCodegen {
 
     @Override
     public Map<String, Object> postProcessModels(Map<String, Object> objs) {
+        // The superclass determines the list of required golang imports. The actual list of imports
+        // depends on which types are used, some of which are changed in the code below (but then preserved
+        // and used through x-basetype in templates). So super.postProcessModels
+        // must be invoked at the beginning of this method.
+        objs = super.postProcessModels(objs);
 
         List<Map<String, Object>> models = (List<Map<String, Object>>) objs.get("models");
         for (Map<String, Object> m : models) {
@@ -162,6 +167,7 @@ public class GoClientExperimentalCodegen extends GoClientCodegen {
                 }
 
                 for (CodegenProperty param : model.vars) {
+                    param.vendorExtensions.put("x-basetype", param.dataType);
                     if (!param.isNullable || param.isMapContainer || param.isListContainer) {
                         continue;
                     }
@@ -178,11 +184,6 @@ public class GoClientExperimentalCodegen extends GoClientCodegen {
                 }
             }
         }
-
-        // The superclass determines the list of required golang imports. The actual list of imports
-        // depends on which types are used, which is done in the code above. So super.postProcessModels
-        // must be invoked at the end of this method.
-        objs = super.postProcessModels(objs);
         return objs;
     }
 

--- a/modules/openapi-generator/src/main/resources/go-experimental/model.mustache
+++ b/modules/openapi-generator/src/main/resources/go-experimental/model.mustache
@@ -105,6 +105,9 @@ func New{{classname}}WithDefaults() *{{classname}} {
 {{#vars}}
 {{#required}}
 // Get{{name}} returns the {{name}} field value
+{{#isNullable}}
+// If the value is explicit nil, the zero value for {{vendorExtensions.x-basetype}} will be returned
+{{/isNullable}}
 func (o *{{classname}}) Get{{name}}() {{vendorExtensions.x-basetype}} {
 	if o == nil {{#isNullable}}{{^isContainer}}|| o.{{name}}.Get() == nil{{/isContainer}}{{/isNullable}} {
 		var ret {{vendorExtensions.x-basetype}}

--- a/modules/openapi-generator/src/main/resources/go-experimental/model.mustache
+++ b/modules/openapi-generator/src/main/resources/go-experimental/model.mustache
@@ -262,7 +262,7 @@ func (v Nullable{{classname}}) Get() *{{classname}} {
 	return v.value
 }
 
-func (v Nullable{{classname}}) Set(val *{{classname}}) {
+func (v *Nullable{{classname}}) Set(val *{{classname}}) {
 	v.value = val
 	v.isSet = true
 }
@@ -271,7 +271,7 @@ func (v Nullable{{classname}}) IsSet() bool {
 	return v.isSet
 }
 
-func (v Nullable{{classname}}) Unset() {
+func (v *Nullable{{classname}}) Unset() {
 	v.value = nil
 	v.isSet = false
 }

--- a/modules/openapi-generator/src/main/resources/go-experimental/model.mustache
+++ b/modules/openapi-generator/src/main/resources/go-experimental/model.mustache
@@ -138,7 +138,7 @@ func (o *{{classname}}) Get{{name}}Ok() ({{dataType}}, bool) {
 		return ret, false
 	}
 {{#isNullable}}
-    return o.{{name}}, o.{{name}}.IsSet()
+    return o.{{name}}, {{#isContainer}}o.{{name}} == nil{{/isContainer}}{{^isContainer}}o.{{name}}.IsSet(){{/isContainer}}
 {{/isNullable}}
 {{^isNullable}}
     return *o.{{name}}, true
@@ -147,7 +147,7 @@ func (o *{{classname}}) Get{{name}}Ok() ({{dataType}}, bool) {
 
 // Has{{name}} returns a boolean if a field has been set.
 func (o *{{classname}}) Has{{name}}() bool {
-	if o != nil && {{^isNullable}}o.{{name}} != nil{{/isNullable}}{{#isNullable}}o.{{name}}.IsSet(){{/isNullable}} {
+    if o != nil && {{^isNullable}}o.{{name}} != nil{{/isNullable}}{{#isNullable}}{{#isContainer}}o.{{name}} != nil{{/isContainer}}{{^isContainer}}o.{{name}}.IsSet(){{/isContainer}}{{/isNullable}} {
 		return true
 	}
 
@@ -162,14 +162,33 @@ func (o *{{classname}}) Set{{name}}(v {{dataType}}) {
 {{/required}}
 {{/vars}}
 func (o {{classname}}) MarshalJSON() ([]byte, error) {
-    //TODO: serialize parents?
     toSerialize := map[string]interface{}{}
+    {{#parent}}
+    {{^isMapModel}}
+    serialized{{parent}}, err{{parent}} := json.Marshal(o.{{parent}})
+    if err{{parent}} != nil {
+        return []byte{}, err{{parent}}
+    }
+    err{{parent}} = json.Unmarshal([]byte(serialized{{parent}}), &toSerialize)
+    if err{{parent}} != nil {
+       return []byte{}, err{{parent}}
+    }
+    {{/isMapModel}}
+    {{/parent}}
     {{#vars}}
     {{! if argument is nullable, only serialize it if it is set}}
     {{#isNullable}}
+    {{#isContainer}}
+    {{! support for container fields is not ideal at this point because of lack of Nullable* types}}
+    if o.{{name}} != nil {
+        toSerialize["{{baseName}}"] = o.{{name}}
+    }
+    {{/isContainer}}
+    {{^isContainer}}
     if {{#required}}true{{/required}}{{^required}}o.{{name}}.IsSet(){{/required}} {
         toSerialize["{{baseName}}"] = o.{{name}}.Get()
     }
+    {{/isContainer}}
     {{/isNullable}}
     {{! if argument is not nullable, don't set it if it is nil}}
     {{^isNullable}}

--- a/modules/openapi-generator/src/main/resources/go-experimental/model.mustache
+++ b/modules/openapi-generator/src/main/resources/go-experimental/model.mustache
@@ -202,7 +202,7 @@ func (o {{classname}}) MarshalJSON() ([]byte, error) {
 
 {{/vendorExtensions.x-is-one-of-interface}}
 {{#vendorExtensions.x-is-one-of-interface}}
-func (s *{{classname}}) MarshalJSON() ([]byte, error) {
+func (s {{classname}}) MarshalJSON() ([]byte, error) {
     return json.Marshal(s.{{classname}}Interface)
 }
 

--- a/modules/openapi-generator/src/main/resources/go-experimental/model.mustache
+++ b/modules/openapi-generator/src/main/resources/go-experimental/model.mustache
@@ -29,7 +29,7 @@ const (
 // {{classname}}{{#description}} {{{description}}}{{/description}}{{^description}} struct for {{{classname}}}{{/description}}
 type {{classname}} struct {
 {{#vendorExtensions.x-is-one-of-interface}}
-    {{classname}}Interface interface { {{#discriminator}}{{propertyGetter}}() {{propertyType}}{{/discriminator}} }
+	{{classname}}Interface interface { {{#discriminator}}{{propertyGetter}}() {{propertyType}}{{/discriminator}} }
 {{/vendorExtensions.x-is-one-of-interface}}
 {{^vendorExtensions.x-is-one-of-interface}}
 {{#parent}}
@@ -56,10 +56,10 @@ type {{classname}} struct {
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
 func New{{classname}}({{#vars}}{{#required}}{{nameInCamelCase}} {{dataType}}, {{/required}}{{/vars}}) *{{classname}} {
-    this := {{classname}}{}
+	this := {{classname}}{}
 {{#vars}}
 {{#required}}
-    this.{{name}} = {{nameInCamelCase}}
+	this.{{name}} = {{nameInCamelCase}}
 {{/required}}
 {{^required}}
 {{#defaultValue}}
@@ -76,14 +76,14 @@ func New{{classname}}({{#vars}}{{#required}}{{nameInCamelCase}} {{dataType}}, {{
 {{/defaultValue}}
 {{/required}}
 {{/vars}}
-    return &this
+	return &this
 }
 
 // New{{classname}}WithDefaults instantiates a new {{classname}} object
 // This constructor will only assign default values to properties that have it defined,
 // but it doesn't guarantee that properties required by API are set
 func New{{classname}}WithDefaults() *{{classname}} {
-    this := {{classname}}{}
+	this := {{classname}}{}
 {{#vars}}
 {{#defaultValue}}
 {{^isContainer}}
@@ -99,49 +99,108 @@ func New{{classname}}WithDefaults() *{{classname}} {
 {{/isContainer}}
 {{/defaultValue}}
 {{/vars}}
-    return &this
+	return &this
 }
 
 {{#vars}}
 {{#required}}
 // Get{{name}} returns the {{name}} field value
-func (o *{{classname}}) Get{{name}}() {{dataType}} {
-	if o == nil {
-		var ret {{dataType}}
+func (o *{{classname}}) Get{{name}}() {{vendorExtensions.x-basetype}} {
+	if o == nil {{#isNullable}}{{^isContainer}}|| o.{{name}}.Get() == nil{{/isContainer}}{{/isNullable}} {
+		var ret {{vendorExtensions.x-basetype}}
 		return ret
 	}
 
+{{#isNullable}}
+{{#isContainer}}
 	return o.{{name}}
+{{/isContainer}}
+{{^isContainer}}
+	return *o.{{name}}.Get()
+{{/isContainer}}
+{{/isNullable}}
+{{^isNullable}}
+	return o.{{name}}
+{{/isNullable}}
+}
+
+// Get{{name}}Ok returns a tuple with the {{name}} field value
+// and a boolean to check if the value has been set.
+{{#isNullable}}
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+{{/isNullable}}
+func (o *{{classname}}) Get{{name}}Ok() (*{{vendorExtensions.x-basetype}}, bool) {
+	if o == nil {{#isNullable}}{{#isContainer}}|| o.{{name}} == nil{{/isContainer}}{{/isNullable}} {
+		return nil, false
+	}
+{{#isNullable}}
+{{#isContainer}}
+	return &o.{{name}}, true
+{{/isContainer}}
+{{^isContainer}}
+	return o.{{name}}.Get(), o.{{name}}.IsSet()
+{{/isContainer}}
+{{/isNullable}}
+{{^isNullable}}
+	return &o.{{name}}, true
+{{/isNullable}}
 }
 
 // Set{{name}} sets field value
-func (o *{{classname}}) Set{{name}}(v {{dataType}}) {
+func (o *{{classname}}) Set{{name}}(v {{vendorExtensions.x-basetype}}) {
+{{#isNullable}}
+{{#isContainer}}
 	o.{{name}} = v
+{{/isContainer}}
+{{^isContainer}}
+	o.{{name}}.Set(&v)
+{{/isContainer}}
+{{/isNullable}}
+{{^isNullable}}
+	o.{{name}} = v
+{{/isNullable}}
 }
 
 {{/required}}
 {{^required}}
-// Get{{name}} returns the {{name}} field value if set, zero value otherwise.
-func (o *{{classname}}) Get{{name}}() {{dataType}} {
-	if o == nil {{^isNullable}}|| o.{{name}} == nil{{/isNullable}} {
-		var ret {{dataType}}
+// Get{{name}} returns the {{name}} field value if set, zero value otherwise{{#isNullable}} (both if not set or set to explicit null){{/isNullable}}.
+func (o *{{classname}}) Get{{name}}() {{vendorExtensions.x-basetype}} {
+	if o == nil {{^isNullable}}|| o.{{name}} == nil{{/isNullable}}{{#isNullable}}{{^isContainer}}|| o.{{name}}.Get() == nil{{/isContainer}}{{/isNullable}} {
+		var ret {{vendorExtensions.x-basetype}}
 		return ret
 	}
-	return {{^isNullable}}*{{/isNullable}}o.{{name}}
-}
-
-// Get{{name}}Ok returns a tuple with the {{name}} field value if set, zero value otherwise
-// and a boolean to check if the value has been set.
-func (o *{{classname}}) Get{{name}}Ok() ({{dataType}}, bool) {
-	if o == nil {{^isNullable}}|| o.{{name}} == nil{{/isNullable}} {
-		var ret {{dataType}}
-		return ret, false
-	}
 {{#isNullable}}
-	return o.{{name}}, {{#isContainer}}o.{{name}} == nil{{/isContainer}}{{^isContainer}}o.{{name}}.IsSet(){{/isContainer}}
+{{#isContainer}}
+	return o.{{name}}
+{{/isContainer}}
+{{^isContainer}}
+	return *o.{{name}}.Get()
+{{/isContainer}}
 {{/isNullable}}
 {{^isNullable}}
-	return *o.{{name}}, true
+	return *o.{{name}}
+{{/isNullable}}
+}
+
+// Get{{name}}Ok returns a tuple with the {{name}} field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+{{#isNullable}}
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+{{/isNullable}}
+func (o *{{classname}}) Get{{name}}Ok() (*{{vendorExtensions.x-basetype}}, bool) {
+	if o == nil {{^isNullable}}|| o.{{name}} == nil{{/isNullable}}{{#isNullable}}{{#isContainer}}|| o.{{name}} == nil{{/isContainer}}{{/isNullable}} {
+		return nil, false
+	}
+{{#isNullable}}
+{{#isContainer}}
+	return &o.{{name}}, true
+{{/isContainer}}
+{{^isContainer}}
+	return o.{{name}}.Get(), o.{{name}}.IsSet()
+{{/isContainer}}
+{{/isNullable}}
+{{^isNullable}}
+	return o.{{name}}, true
 {{/isNullable}}
 }
 
@@ -155,9 +214,32 @@ func (o *{{classname}}) Has{{name}}() bool {
 }
 
 // Set{{name}} gets a reference to the given {{dataType}} and assigns it to the {{name}} field.
-func (o *{{classname}}) Set{{name}}(v {{dataType}}) {
-	o.{{name}} = {{^isNullable}}&{{/isNullable}}v
+func (o *{{classname}}) Set{{name}}(v {{vendorExtensions.x-basetype}}) {
+{{#isNullable}}
+{{#isContainer}}
+	o.{{name}} = v
+{{/isContainer}}
+{{^isContainer}}
+	o.{{name}}.Set(&v)
+{{/isContainer}}
+{{/isNullable}}
+{{^isNullable}}
+	o.{{name}} = &v
+{{/isNullable}}
 }
+{{#isNullable}}
+{{^isContainer}}
+// Set{{name}}Nil sets the value for {{name}} to be an explicit nil
+func (o *{{classname}}) Set{{name}}Nil() {
+	o.{{name}}.Set(nil)
+}
+
+// Unset{{name}} ensures that no value is present for {{name}}, not even an explicit nil
+func (o *{{classname}}) Unset{{name}}() {
+	o.{{name}}.Unset()
+}
+{{/isContainer}}
+{{/isNullable}}
 
 {{/required}}
 {{/vars}}
@@ -203,53 +285,53 @@ func (o {{classname}}) MarshalJSON() ([]byte, error) {
 {{/vendorExtensions.x-is-one-of-interface}}
 {{#vendorExtensions.x-is-one-of-interface}}
 func (s {{classname}}) MarshalJSON() ([]byte, error) {
-    return json.Marshal(s.{{classname}}Interface)
+	return json.Marshal(s.{{classname}}Interface)
 }
 
 func (s *{{classname}}) UnmarshalJSON(src []byte) error {
-    var err error
-    {{#discriminator}}
-    var unmarshaled map[string]interface{}
-    err = json.Unmarshal(src, &unmarshaled)
-    if err != nil {
-        return err
-    }
-    if v, ok := unmarshaled["{{discriminator.propertyBaseName}}"]; ok {
-        switch v {
-        {{#discriminator.mappedModels}}
-            case "{{mappingName}}":
-                var result *{{modelName}} = &{{modelName}}{}
-                err = json.Unmarshal(src, result)
-                if err != nil {
-                    return err
-                }
-                s.{{classname}}Interface = result
-                return nil
-        {{/discriminator.mappedModels}}
-            default:
-                return fmt.Errorf("No oneOf model has '{{discriminator.propertyBaseName}}' equal to %s", v)
-        }
-    } else {
-        return fmt.Errorf("Discriminator property '{{discriminator.propertyBaseName}}' not found in unmarshaled payload: %+v", unmarshaled)
-    }
-    {{/discriminator}}
-    {{^discriminator}}
-    {{#oneOf}}
-    var unmarshaled{{{.}}} *{{{.}}} = &{{{.}}}{}
-    err = json.Unmarshal(src, unmarshaled{{{.}}})
-    if err == nil {
-        s.{{classname}}Interface = unmarshaled{{{.}}}
-        return nil
-    }
-    {{/oneOf}}
-    return fmt.Errorf("No oneOf model could be deserialized from payload: %s", string(src))
-    {{/discriminator}}
+	var err error
+	{{#discriminator}}
+	var unmarshaled map[string]interface{}
+	err = json.Unmarshal(src, &unmarshaled)
+	if err != nil {
+		return err
+	}
+	if v, ok := unmarshaled["{{discriminator.propertyBaseName}}"]; ok {
+		switch v {
+		{{#discriminator.mappedModels}}
+			case "{{mappingName}}":
+				var result *{{modelName}} = &{{modelName}}{}
+				err = json.Unmarshal(src, result)
+				if err != nil {
+					return err
+				}
+				s.{{classname}}Interface = result
+				return nil
+		{{/discriminator.mappedModels}}
+			default:
+				return fmt.Errorf("No oneOf model has '{{discriminator.propertyBaseName}}' equal to %s", v)
+		}
+	} else {
+		return fmt.Errorf("Discriminator property '{{discriminator.propertyBaseName}}' not found in unmarshaled payload: %+v", unmarshaled)
+	}
+	{{/discriminator}}
+	{{^discriminator}}
+	{{#oneOf}}
+	var unmarshaled{{{.}}} *{{{.}}} = &{{{.}}}{}
+	err = json.Unmarshal(src, unmarshaled{{{.}}})
+	if err == nil {
+		s.{{classname}}Interface = unmarshaled{{{.}}}
+		return nil
+	}
+	{{/oneOf}}
+	return fmt.Errorf("No oneOf model could be deserialized from payload: %s", string(src))
+	{{/discriminator}}
 }
 {{/vendorExtensions.x-is-one-of-interface}}
 {{#vendorExtensions.x-implements}}
 // As{{{.}}} wraps this instance of {{classname}} in {{{.}}}
 func (s *{{classname}}) As{{{.}}}() {{{.}}} {
-    return {{{.}}}{ {{{.}}}Interface: s }
+	return {{{.}}}{ {{{.}}}Interface: s }
 }
 {{/vendorExtensions.x-implements}}
 {{/isEnum}}

--- a/modules/openapi-generator/src/main/resources/go-experimental/model.mustache
+++ b/modules/openapi-generator/src/main/resources/go-experimental/model.mustache
@@ -3,7 +3,6 @@ package {{packageName}}
 
 {{#models}}
 import (
-	"bytes"
 	"encoding/json"
 {{#imports}}
 	"{{import}}"
@@ -44,7 +43,7 @@ type {{classname}} struct {
 {{#description}}
 	// {{{description}}}
 {{/description}}
-	{{name}} {{^required}}*{{/required}}{{{dataType}}} `json:"{{baseName}}{{^required}},omitempty{{/required}}"{{#withXml}} xml:"{{baseName}}{{#isXmlAttribute}},attr{{/isXmlAttribute}}"{{/withXml}}{{#vendorExtensions.x-go-custom-tag}} {{{.}}}{{/vendorExtensions.x-go-custom-tag}}`
+	{{name}} {{^required}}{{^isNullable}}*{{/isNullable}}{{/required}}{{{dataType}}} `json:"{{baseName}}{{^required}},omitempty{{/required}}"{{#withXml}} xml:"{{baseName}}{{#isXmlAttribute}},attr{{/isXmlAttribute}}"{{/withXml}}{{#vendorExtensions.x-go-custom-tag}} {{{.}}}{{/vendorExtensions.x-go-custom-tag}}`
 {{/vars}}
 {{/vendorExtensions.x-is-one-of-interface}}
 }
@@ -65,8 +64,14 @@ func New{{classname}}({{#vars}}{{#required}}{{nameInCamelCase}} {{dataType}}, {{
 {{^required}}
 {{#defaultValue}}
 {{^isContainer}}
-    var {{nameInCamelCase}} {{{dataType}}} = {{#isNullable}}{{{dataType}}}{Value: {{/isNullable}}{{{.}}}{{#isNullable}} }{{/isNullable}}
-    this.{{name}} = {{^required}}&{{/required}}{{nameInCamelCase}}
+{{#isNullable}}
+    var {{nameInCamelCase}} {{{datatypeWithEnum}}} = {{{.}}}
+    this.{{name}} = *New{{{dataType}}}(&{{nameInCamelCase}})
+{{/isNullable}}
+{{^isNullable}}
+    var {{nameInCamelCase}} {{{dataType}}} = {{{.}}}
+    this.{{name}} = &{{nameInCamelCase}}
+{{/isNullable}}
 {{/isContainer}}
 {{/defaultValue}}
 {{/required}}
@@ -82,8 +87,15 @@ func New{{classname}}WithDefaults() *{{classname}} {
 {{#vars}}
 {{#defaultValue}}
 {{^isContainer}}
-    var {{nameInCamelCase}} {{{dataType}}} = {{#isNullable}}{{{dataType}}}{Value: {{/isNullable}}{{{.}}}{{#isNullable}} }{{/isNullable}}
+{{#isNullable}}
+{{!we use datatypeWithEnum here, since it will represent the non-nullable name of the datatype, e.g. int64 for NullableInt64}}
+    var {{nameInCamelCase}} {{{datatypeWithEnum}}} = {{{.}}}
+    this.{{name}} = *New{{{dataType}}}(&{{nameInCamelCase}})
+{{/isNullable}}
+{{^isNullable}}
+    var {{nameInCamelCase}} {{{dataType}}} = {{{.}}}
     this.{{name}} = {{^required}}&{{/required}}{{nameInCamelCase}}
+{{/isNullable}}
 {{/isContainer}}
 {{/defaultValue}}
 {{/vars}}
@@ -111,26 +123,31 @@ func (o *{{classname}}) Set{{name}}(v {{dataType}}) {
 {{^required}}
 // Get{{name}} returns the {{name}} field value if set, zero value otherwise.
 func (o *{{classname}}) Get{{name}}() {{dataType}} {
-	if o == nil || o.{{name}} == nil {
+	if o == nil {{^isNullable}}|| o.{{name}} == nil{{/isNullable}} {
 		var ret {{dataType}}
 		return ret
 	}
-	return *o.{{name}}
+	return {{^isNullable}}*{{/isNullable}}o.{{name}}
 }
 
 // Get{{name}}Ok returns a tuple with the {{name}} field value if set, zero value otherwise
 // and a boolean to check if the value has been set.
 func (o *{{classname}}) Get{{name}}Ok() ({{dataType}}, bool) {
-	if o == nil || o.{{name}} == nil {
+	if o == nil {{^isNullable}}|| o.{{name}} == nil{{/isNullable}} {
 		var ret {{dataType}}
 		return ret, false
 	}
-	return *o.{{name}}, true
+{{#isNullable}}
+    return o.{{name}}, o.{{name}}.IsSet()
+{{/isNullable}}
+{{^isNullable}}
+    return *o.{{name}}, true
+{{/isNullable}}
 }
 
 // Has{{name}} returns a boolean if a field has been set.
 func (o *{{classname}}) Has{{name}}() bool {
-	if o != nil && o.{{name}} != nil {
+	if o != nil && {{^isNullable}}o.{{name}} != nil{{/isNullable}}{{#isNullable}}o.{{name}}.IsSet(){{/isNullable}} {
 		return true
 	}
 
@@ -139,11 +156,31 @@ func (o *{{classname}}) Has{{name}}() bool {
 
 // Set{{name}} gets a reference to the given {{dataType}} and assigns it to the {{name}} field.
 func (o *{{classname}}) Set{{name}}(v {{dataType}}) {
-	o.{{name}} = &v
+	o.{{name}} = {{^isNullable}}&{{/isNullable}}v
 }
 
 {{/required}}
 {{/vars}}
+func (o {{classname}}) MarshalJSON() ([]byte, error) {
+    //TODO: serialize parents?
+    toSerialize := map[string]interface{}{}
+    {{#vars}}
+    {{! if argument is nullable, only serialize it if it is set}}
+    {{#isNullable}}
+    if {{#required}}true{{/required}}{{^required}}o.{{name}}.IsSet(){{/required}} {
+        toSerialize["{{baseName}}"] = o.{{name}}.Get()
+    }
+    {{/isNullable}}
+    {{! if argument is not nullable, don't set it if it is nil}}
+    {{^isNullable}}
+    if {{#required}}true{{/required}}{{^required}}o.{{name}} != nil{{/required}} {
+        toSerialize["{{baseName}}"] = o.{{name}}
+    }
+    {{/isNullable}}
+    {{/vars}}
+    return json.Marshal(toSerialize)
+}
+
 {{/vendorExtensions.x-is-one-of-interface}}
 {{#vendorExtensions.x-is-one-of-interface}}
 func (s *{{classname}}) MarshalJSON() ([]byte, error) {
@@ -198,26 +235,39 @@ func (s *{{classname}}) As{{{.}}}() {{{.}}} {
 {{/vendorExtensions.x-implements}}
 {{/isEnum}}
 type Nullable{{{classname}}} struct {
-	Value {{{classname}}}
-	ExplicitNull bool
+	value *{{{classname}}}
+	isSet bool
+}
+
+func (v Nullable{{classname}}) Get() *{{classname}} {
+    return v.value
+}
+
+func (v Nullable{{classname}}) Set(val *{{classname}}) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v Nullable{{classname}}) IsSet() bool {
+    return v.isSet
+}
+
+func (v Nullable{{classname}}) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullable{{classname}}(val *{{classname}}) *Nullable{{classname}} {
+    return &Nullable{{classname}}{value: val, isSet: true}
 }
 
 func (v Nullable{{{classname}}}) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-		return json.Marshal(v.Value)
-	}
+    return json.Marshal(v.value)
 }
 
 func (v *Nullable{{{classname}}}) UnmarshalJSON(src []byte) error {
-	if bytes.Equal(src, []byte("null")) {
-		v.ExplicitNull = true
-		return nil
-	}
-
-	return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }
 {{/model}}
 {{/models}}

--- a/modules/openapi-generator/src/main/resources/go-experimental/model.mustache
+++ b/modules/openapi-generator/src/main/resources/go-experimental/model.mustache
@@ -65,12 +65,12 @@ func New{{classname}}({{#vars}}{{#required}}{{nameInCamelCase}} {{dataType}}, {{
 {{#defaultValue}}
 {{^isContainer}}
 {{#isNullable}}
-    var {{nameInCamelCase}} {{{datatypeWithEnum}}} = {{{.}}}
-    this.{{name}} = *New{{{dataType}}}(&{{nameInCamelCase}})
+	var {{nameInCamelCase}} {{{datatypeWithEnum}}} = {{{.}}}
+	this.{{name}} = *New{{{dataType}}}(&{{nameInCamelCase}})
 {{/isNullable}}
 {{^isNullable}}
-    var {{nameInCamelCase}} {{{dataType}}} = {{{.}}}
-    this.{{name}} = &{{nameInCamelCase}}
+	var {{nameInCamelCase}} {{{dataType}}} = {{{.}}}
+	this.{{name}} = &{{nameInCamelCase}}
 {{/isNullable}}
 {{/isContainer}}
 {{/defaultValue}}
@@ -89,12 +89,12 @@ func New{{classname}}WithDefaults() *{{classname}} {
 {{^isContainer}}
 {{#isNullable}}
 {{!we use datatypeWithEnum here, since it will represent the non-nullable name of the datatype, e.g. int64 for NullableInt64}}
-    var {{nameInCamelCase}} {{{datatypeWithEnum}}} = {{{.}}}
-    this.{{name}} = *New{{{dataType}}}(&{{nameInCamelCase}})
+	var {{nameInCamelCase}} {{{datatypeWithEnum}}} = {{{.}}}
+	this.{{name}} = *New{{{dataType}}}(&{{nameInCamelCase}})
 {{/isNullable}}
 {{^isNullable}}
-    var {{nameInCamelCase}} {{{dataType}}} = {{{.}}}
-    this.{{name}} = {{^required}}&{{/required}}{{nameInCamelCase}}
+	var {{nameInCamelCase}} {{{dataType}}} = {{{.}}}
+	this.{{name}} = {{^required}}&{{/required}}{{nameInCamelCase}}
 {{/isNullable}}
 {{/isContainer}}
 {{/defaultValue}}
@@ -138,16 +138,16 @@ func (o *{{classname}}) Get{{name}}Ok() ({{dataType}}, bool) {
 		return ret, false
 	}
 {{#isNullable}}
-    return o.{{name}}, {{#isContainer}}o.{{name}} == nil{{/isContainer}}{{^isContainer}}o.{{name}}.IsSet(){{/isContainer}}
+	return o.{{name}}, {{#isContainer}}o.{{name}} == nil{{/isContainer}}{{^isContainer}}o.{{name}}.IsSet(){{/isContainer}}
 {{/isNullable}}
 {{^isNullable}}
-    return *o.{{name}}, true
+	return *o.{{name}}, true
 {{/isNullable}}
 }
 
 // Has{{name}} returns a boolean if a field has been set.
 func (o *{{classname}}) Has{{name}}() bool {
-    if o != nil && {{^isNullable}}o.{{name}} != nil{{/isNullable}}{{#isNullable}}{{#isContainer}}o.{{name}} != nil{{/isContainer}}{{^isContainer}}o.{{name}}.IsSet(){{/isContainer}}{{/isNullable}} {
+	if o != nil && {{^isNullable}}o.{{name}} != nil{{/isNullable}}{{#isNullable}}{{#isContainer}}o.{{name}} != nil{{/isContainer}}{{^isContainer}}o.{{name}}.IsSet(){{/isContainer}}{{/isNullable}} {
 		return true
 	}
 
@@ -162,42 +162,42 @@ func (o *{{classname}}) Set{{name}}(v {{dataType}}) {
 {{/required}}
 {{/vars}}
 func (o {{classname}}) MarshalJSON() ([]byte, error) {
-    toSerialize := map[string]interface{}{}
-    {{#parent}}
-    {{^isMapModel}}
-    serialized{{parent}}, err{{parent}} := json.Marshal(o.{{parent}})
-    if err{{parent}} != nil {
-        return []byte{}, err{{parent}}
-    }
-    err{{parent}} = json.Unmarshal([]byte(serialized{{parent}}), &toSerialize)
-    if err{{parent}} != nil {
-       return []byte{}, err{{parent}}
-    }
-    {{/isMapModel}}
-    {{/parent}}
-    {{#vars}}
-    {{! if argument is nullable, only serialize it if it is set}}
-    {{#isNullable}}
-    {{#isContainer}}
-    {{! support for container fields is not ideal at this point because of lack of Nullable* types}}
-    if o.{{name}} != nil {
-        toSerialize["{{baseName}}"] = o.{{name}}
-    }
-    {{/isContainer}}
-    {{^isContainer}}
-    if {{#required}}true{{/required}}{{^required}}o.{{name}}.IsSet(){{/required}} {
-        toSerialize["{{baseName}}"] = o.{{name}}.Get()
-    }
-    {{/isContainer}}
-    {{/isNullable}}
-    {{! if argument is not nullable, don't set it if it is nil}}
-    {{^isNullable}}
-    if {{#required}}true{{/required}}{{^required}}o.{{name}} != nil{{/required}} {
-        toSerialize["{{baseName}}"] = o.{{name}}
-    }
-    {{/isNullable}}
-    {{/vars}}
-    return json.Marshal(toSerialize)
+	toSerialize := map[string]interface{}{}
+	{{#parent}}
+	{{^isMapModel}}
+	serialized{{parent}}, err{{parent}} := json.Marshal(o.{{parent}})
+	if err{{parent}} != nil {
+		return []byte{}, err{{parent}}
+	}
+	err{{parent}} = json.Unmarshal([]byte(serialized{{parent}}), &toSerialize)
+	if err{{parent}} != nil {
+		return []byte{}, err{{parent}}
+	}
+	{{/isMapModel}}
+	{{/parent}}
+	{{#vars}}
+	{{! if argument is nullable, only serialize it if it is set}}
+	{{#isNullable}}
+	{{#isContainer}}
+	{{! support for container fields is not ideal at this point because of lack of Nullable* types}}
+	if o.{{name}} != nil {
+		toSerialize["{{baseName}}"] = o.{{name}}
+	}
+	{{/isContainer}}
+	{{^isContainer}}
+	if {{#required}}true{{/required}}{{^required}}o.{{name}}.IsSet(){{/required}} {
+		toSerialize["{{baseName}}"] = o.{{name}}.Get()
+	}
+	{{/isContainer}}
+	{{/isNullable}}
+	{{! if argument is not nullable, don't set it if it is nil}}
+	{{^isNullable}}
+	if {{#required}}true{{/required}}{{^required}}o.{{name}} != nil{{/required}} {
+		toSerialize["{{baseName}}"] = o.{{name}}
+	}
+	{{/isNullable}}
+	{{/vars}}
+	return json.Marshal(toSerialize)
 }
 
 {{/vendorExtensions.x-is-one-of-interface}}
@@ -259,33 +259,33 @@ type Nullable{{{classname}}} struct {
 }
 
 func (v Nullable{{classname}}) Get() *{{classname}} {
-    return v.value
+	return v.value
 }
 
 func (v Nullable{{classname}}) Set(val *{{classname}}) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v Nullable{{classname}}) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v Nullable{{classname}}) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullable{{classname}}(val *{{classname}}) *Nullable{{classname}} {
-    return &Nullable{{classname}}{value: val, isSet: true}
+	return &Nullable{{classname}}{value: val, isSet: true}
 }
 
 func (v Nullable{{{classname}}}) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *Nullable{{{classname}}}) UnmarshalJSON(src []byte) error {
-    v.isSet = true
+	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }
 {{/model}}

--- a/modules/openapi-generator/src/main/resources/go-experimental/model_doc.mustache
+++ b/modules/openapi-generator/src/main/resources/go-experimental/model_doc.mustache
@@ -36,37 +36,40 @@ but it doesn't guarantee that properties required by API are set
 {{#vars}}
 ### Get{{name}}
 
-`func (o *{{classname}}) Get{{name}}() {{dataType}}`
+`func (o *{{classname}}) Get{{name}}() {{vendorExtensions.x-basetype}}`
 
 Get{{name}} returns the {{name}} field if non-nil, zero value otherwise.
 
 ### Get{{name}}Ok
 
-`func (o *{{classname}}) Get{{name}}Ok() ({{dataType}}, bool)`
+`func (o *{{classname}}) Get{{name}}Ok() (*{{vendorExtensions.x-basetype}}, bool)`
 
 Get{{name}}Ok returns a tuple with the {{name}} field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
+### Set{{name}}
+
+`func (o *{{classname}}) Set{{name}}(v {{vendorExtensions.x-basetype}})`
+
+Set{{name}} sets {{name}} field to given value.
+
+{{#isNullable}}
 ### Has{{name}}
 
 `func (o *{{classname}}) Has{{name}}() bool`
 
 Has{{name}} returns a boolean if a field has been set.
 
-### Set{{name}}
+### Set{{name}}Nil
 
-`func (o *{{classname}}) Set{{name}}(v {{dataType}})`
+`func (o *{{classname}}) Set{{name}}Nil(b bool)`
 
-Set{{name}} gets a reference to the given {{dataType}} and assigns it to the {{name}} field.
+ Set{{name}}Nil sets the value for {{name}} to be an explicit nil
 
-{{#isNullable}}
-### Set{{name}}ExplicitNull
+### Unset{{name}}
+`func (o *{{classname}}) Unset{{name}}()`
 
-`func (o *{{classname}}) Set{{name}}ExplicitNull(b bool)`
-
-Set{{name}}ExplicitNull (un)sets {{name}} to be considered as explicit "null" value
-when serializing to JSON (pass true as argument to set this, false to unset)
-The {{name}} value is set to nil even if false is passed
+Unset{{name}} ensures that no value is present for {{name}}, not even an explicit nil
 {{/isNullable}}
 {{/vars}}
 {{#vendorExtensions.x-implements}}

--- a/modules/openapi-generator/src/main/resources/go-experimental/model_doc.mustache
+++ b/modules/openapi-generator/src/main/resources/go-experimental/model_doc.mustache
@@ -53,13 +53,15 @@ and a boolean to check if the value has been set.
 
 Set{{name}} sets {{name}} field to given value.
 
-{{#isNullable}}
+{{^required}}
 ### Has{{name}}
 
 `func (o *{{classname}}) Has{{name}}() bool`
 
 Has{{name}} returns a boolean if a field has been set.
+{{/required}}
 
+{{#isNullable}}
 ### Set{{name}}Nil
 
 `func (o *{{classname}}) Set{{name}}Nil(b bool)`

--- a/modules/openapi-generator/src/main/resources/go-experimental/utils.mustache
+++ b/modules/openapi-generator/src/main/resources/go-experimental/utils.mustache
@@ -2,13 +2,9 @@
 package {{packageName}}
 
 import (
-    "bytes"
     "encoding/json"
-    "errors"
     "time"
 )
-
-var ErrInvalidNullable = errors.New("nullable cannot have non-zero Value and ExplicitNull simultaneously")
 
 // PtrBool is a helper routine that returns a pointer to given integer value.
 func PtrBool(v bool) *bool { return &v }
@@ -35,202 +31,296 @@ func PtrString(v string) *string { return &v }
 func PtrTime(v time.Time) *time.Time { return &v }
 
 type NullableBool struct {
-    Value bool
-    ExplicitNull bool
+    value *bool
+    isSet bool
+}
+
+func (v NullableBool) Get() *bool {
+    return v.value
+}
+
+func (v NullableBool) Set(val *bool) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableBool) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableBool) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableBool(val *bool) *NullableBool {
+    return &NullableBool{value: val, isSet: true}
 }
 
 func (v NullableBool) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull && v.Value:
-        return nil, ErrInvalidNullable
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-        return json.Marshal(v.Value)
-    }
+    return json.Marshal(v.value)
 }
 
 func (v *NullableBool) UnmarshalJSON(src []byte) error {
-    if bytes.Equal(src, []byte("null")) {
-        v.ExplicitNull = true
-        return nil
-    }
-
-    return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+    return json.Unmarshal(src, &v.value)
 }
 
+
 type NullableInt struct {
-    Value int
-    ExplicitNull bool
+    value *int
+    isSet bool
+}
+
+func (v NullableInt) Get() *int {
+    return v.value
+}
+
+func (v NullableInt) Set(val *int) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableInt) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableInt) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableInt(val *int) *NullableInt {
+    return &NullableInt{value: val, isSet: true}
 }
 
 func (v NullableInt) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull && v.Value != 0:
-        return nil, ErrInvalidNullable
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-        return json.Marshal(v.Value)
-    }
+    return json.Marshal(v.value)
 }
-
 
 func (v *NullableInt) UnmarshalJSON(src []byte) error {
-    if bytes.Equal(src, []byte("null")) {
-        v.ExplicitNull = true
-        return nil
-    }
-
-    return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+    return json.Unmarshal(src, &v.value)
 }
 
+
 type NullableInt32 struct {
-    Value int32
-    ExplicitNull bool
+    value *int32
+    isSet bool
+}
+
+func (v NullableInt32) Get() *int32 {
+    return v.value
+}
+
+func (v NullableInt32) Set(val *int32) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableInt32) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableInt32) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableInt32(val *int32) *NullableInt32 {
+    return &NullableInt32{value: val, isSet: true}
 }
 
 func (v NullableInt32) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull && v.Value != 0:
-        return nil, ErrInvalidNullable
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-        return json.Marshal(v.Value)
-    }
+    return json.Marshal(v.value)
 }
 
 func (v *NullableInt32) UnmarshalJSON(src []byte) error {
-    if bytes.Equal(src, []byte("null")) {
-        v.ExplicitNull = true
-        return nil
-    }
-
-    return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+    return json.Unmarshal(src, &v.value)
 }
 
+
 type NullableInt64 struct {
-    Value int64
-    ExplicitNull bool
+    value *int64
+    isSet bool
+}
+
+func (v NullableInt64) Get() *int64 {
+    return v.value
+}
+
+func (v NullableInt64) Set(val *int64) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableInt64) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableInt64) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableInt64(val *int64) *NullableInt64 {
+    return &NullableInt64{value: val, isSet: true}
 }
 
 func (v NullableInt64) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull && v.Value != 0:
-        return nil, ErrInvalidNullable
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-        return json.Marshal(v.Value)
-    }
+    return json.Marshal(v.value)
 }
 
 func (v *NullableInt64) UnmarshalJSON(src []byte) error {
-    if bytes.Equal(src, []byte("null")) {
-        v.ExplicitNull = true
-        return nil
-    }
-
-    return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+    return json.Unmarshal(src, &v.value)
 }
 
+
 type NullableFloat32 struct {
-    Value float32
-    ExplicitNull bool
+    value *float32
+    isSet bool
+}
+
+func (v NullableFloat32) Get() *float32 {
+    return v.value
+}
+
+func (v NullableFloat32) Set(val *float32) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableFloat32) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableFloat32) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableFloat32(val *float32) *NullableFloat32 {
+    return &NullableFloat32{value: val, isSet: true}
 }
 
 func (v NullableFloat32) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull && v.Value != 0.0:
-        return nil, ErrInvalidNullable
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-        return json.Marshal(v.Value)
-    }
+    return json.Marshal(v.value)
 }
 
 func (v *NullableFloat32) UnmarshalJSON(src []byte) error {
-    if bytes.Equal(src, []byte("null")) {
-        v.ExplicitNull = true
-        return nil
-    }
-
-    return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+    return json.Unmarshal(src, &v.value)
 }
 
+
 type NullableFloat64 struct {
-    Value float64
-    ExplicitNull bool
+    value *float64
+    isSet bool
+}
+
+func (v NullableFloat64) Get() *float64 {
+    return v.value
+}
+
+func (v NullableFloat64) Set(val *float64) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableFloat64) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableFloat64) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableFloat64(val *float64) *NullableFloat64 {
+    return &NullableFloat64{value: val, isSet: true}
 }
 
 func (v NullableFloat64) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull && v.Value != 0.0:
-        return nil, ErrInvalidNullable
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-        return json.Marshal(v.Value)
-    }
+    return json.Marshal(v.value)
 }
 
 func (v *NullableFloat64) UnmarshalJSON(src []byte) error {
-    if bytes.Equal(src, []byte("null")) {
-        v.ExplicitNull = true
-        return nil
-    }
-
-    return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+    return json.Unmarshal(src, &v.value)
 }
 
+
 type NullableString struct {
-    Value string
-    ExplicitNull bool
+    value *string
+    isSet bool
+}
+
+func (v NullableString) Get() *string {
+    return v.value
+}
+
+func (v NullableString) Set(val *string) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableString) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableString) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableString(val *string) *NullableString {
+    return &NullableString{value: val, isSet: true}
 }
 
 func (v NullableString) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull && v.Value != "":
-        return nil, ErrInvalidNullable
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-        return json.Marshal(v.Value)
-    }
+    return json.Marshal(v.value)
 }
 
 func (v *NullableString) UnmarshalJSON(src []byte) error {
-    if bytes.Equal(src, []byte("null")) {
-        v.ExplicitNull = true
-        return nil
-    }
-
-    return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+    return json.Unmarshal(src, &v.value)
 }
 
+
 type NullableTime struct {
-    Value time.Time
-    ExplicitNull bool
+    value *time.Time
+    isSet bool
+}
+
+func (v NullableTime) Get() *time.Time {
+    return v.value
+}
+
+func (v NullableTime) Set(val *time.Time) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableTime) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableTime) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableTime(val *time.Time) *NullableTime {
+    return &NullableTime{value: val, isSet: true}
 }
 
 func (v NullableTime) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull && !v.Value.IsZero():
-        return nil, ErrInvalidNullable
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-        return v.Value.MarshalJSON()
-    }
+    return v.value.MarshalJSON()
 }
 
 func (v *NullableTime) UnmarshalJSON(src []byte) error {
-    if bytes.Equal(src, []byte("null")) {
-        v.ExplicitNull = true
-        return nil
-    }
-
-    return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+    return json.Unmarshal(src, &v.value)
 }

--- a/modules/openapi-generator/src/main/resources/go-experimental/utils.mustache
+++ b/modules/openapi-generator/src/main/resources/go-experimental/utils.mustache
@@ -2,8 +2,8 @@
 package {{packageName}}
 
 import (
-    "encoding/json"
-    "time"
+	"encoding/json"
+	"time"
 )
 
 // PtrBool is a helper routine that returns a pointer to given integer value.
@@ -31,296 +31,296 @@ func PtrString(v string) *string { return &v }
 func PtrTime(v time.Time) *time.Time { return &v }
 
 type NullableBool struct {
-    value *bool
-    isSet bool
+	value *bool
+	isSet bool
 }
 
 func (v NullableBool) Get() *bool {
-    return v.value
+	return v.value
 }
 
 func (v NullableBool) Set(val *bool) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableBool) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableBool) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableBool(val *bool) *NullableBool {
-    return &NullableBool{value: val, isSet: true}
+	return &NullableBool{value: val, isSet: true}
 }
 
 func (v NullableBool) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableBool) UnmarshalJSON(src []byte) error {
-    v.isSet = true
-    return json.Unmarshal(src, &v.value)
+	v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }
 
 
 type NullableInt struct {
-    value *int
-    isSet bool
+	value *int
+	isSet bool
 }
 
 func (v NullableInt) Get() *int {
-    return v.value
+	return v.value
 }
 
 func (v NullableInt) Set(val *int) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableInt) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableInt) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableInt(val *int) *NullableInt {
-    return &NullableInt{value: val, isSet: true}
+	return &NullableInt{value: val, isSet: true}
 }
 
 func (v NullableInt) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableInt) UnmarshalJSON(src []byte) error {
-    v.isSet = true
-    return json.Unmarshal(src, &v.value)
+	v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }
 
 
 type NullableInt32 struct {
-    value *int32
-    isSet bool
+	value *int32
+	isSet bool
 }
 
 func (v NullableInt32) Get() *int32 {
-    return v.value
+	return v.value
 }
 
 func (v NullableInt32) Set(val *int32) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableInt32) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableInt32) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableInt32(val *int32) *NullableInt32 {
-    return &NullableInt32{value: val, isSet: true}
+	return &NullableInt32{value: val, isSet: true}
 }
 
 func (v NullableInt32) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableInt32) UnmarshalJSON(src []byte) error {
-    v.isSet = true
-    return json.Unmarshal(src, &v.value)
+	v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }
 
 
 type NullableInt64 struct {
-    value *int64
-    isSet bool
+	value *int64
+	isSet bool
 }
 
 func (v NullableInt64) Get() *int64 {
-    return v.value
+	return v.value
 }
 
 func (v NullableInt64) Set(val *int64) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableInt64) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableInt64) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableInt64(val *int64) *NullableInt64 {
-    return &NullableInt64{value: val, isSet: true}
+	return &NullableInt64{value: val, isSet: true}
 }
 
 func (v NullableInt64) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableInt64) UnmarshalJSON(src []byte) error {
-    v.isSet = true
-    return json.Unmarshal(src, &v.value)
+	v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }
 
 
 type NullableFloat32 struct {
-    value *float32
-    isSet bool
+	value *float32
+	isSet bool
 }
 
 func (v NullableFloat32) Get() *float32 {
-    return v.value
+	return v.value
 }
 
 func (v NullableFloat32) Set(val *float32) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableFloat32) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableFloat32) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableFloat32(val *float32) *NullableFloat32 {
-    return &NullableFloat32{value: val, isSet: true}
+	return &NullableFloat32{value: val, isSet: true}
 }
 
 func (v NullableFloat32) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableFloat32) UnmarshalJSON(src []byte) error {
-    v.isSet = true
-    return json.Unmarshal(src, &v.value)
+	v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }
 
 
 type NullableFloat64 struct {
-    value *float64
-    isSet bool
+	value *float64
+	isSet bool
 }
 
 func (v NullableFloat64) Get() *float64 {
-    return v.value
+	return v.value
 }
 
 func (v NullableFloat64) Set(val *float64) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableFloat64) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableFloat64) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableFloat64(val *float64) *NullableFloat64 {
-    return &NullableFloat64{value: val, isSet: true}
+	return &NullableFloat64{value: val, isSet: true}
 }
 
 func (v NullableFloat64) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableFloat64) UnmarshalJSON(src []byte) error {
-    v.isSet = true
-    return json.Unmarshal(src, &v.value)
+	v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }
 
 
 type NullableString struct {
-    value *string
-    isSet bool
+	value *string
+	isSet bool
 }
 
 func (v NullableString) Get() *string {
-    return v.value
+	return v.value
 }
 
 func (v NullableString) Set(val *string) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableString) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableString) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableString(val *string) *NullableString {
-    return &NullableString{value: val, isSet: true}
+	return &NullableString{value: val, isSet: true}
 }
 
 func (v NullableString) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableString) UnmarshalJSON(src []byte) error {
-    v.isSet = true
-    return json.Unmarshal(src, &v.value)
+	v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }
 
 
 type NullableTime struct {
-    value *time.Time
-    isSet bool
+	value *time.Time
+	isSet bool
 }
 
 func (v NullableTime) Get() *time.Time {
-    return v.value
+	return v.value
 }
 
 func (v NullableTime) Set(val *time.Time) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableTime) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableTime) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableTime(val *time.Time) *NullableTime {
-    return &NullableTime{value: val, isSet: true}
+	return &NullableTime{value: val, isSet: true}
 }
 
 func (v NullableTime) MarshalJSON() ([]byte, error) {
-    return v.value.MarshalJSON()
+	return v.value.MarshalJSON()
 }
 
 func (v *NullableTime) UnmarshalJSON(src []byte) error {
-    v.isSet = true
-    return json.Unmarshal(src, &v.value)
+	v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }

--- a/modules/openapi-generator/src/main/resources/go-experimental/utils.mustache
+++ b/modules/openapi-generator/src/main/resources/go-experimental/utils.mustache
@@ -39,7 +39,7 @@ func (v NullableBool) Get() *bool {
 	return v.value
 }
 
-func (v NullableBool) Set(val *bool) {
+func (v *NullableBool) Set(val *bool) {
 	v.value = val
 	v.isSet = true
 }
@@ -48,7 +48,7 @@ func (v NullableBool) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableBool) Unset() {
+func (v *NullableBool) Unset() {
 	v.value = nil
 	v.isSet = false
 }
@@ -76,7 +76,7 @@ func (v NullableInt) Get() *int {
 	return v.value
 }
 
-func (v NullableInt) Set(val *int) {
+func (v *NullableInt) Set(val *int) {
 	v.value = val
 	v.isSet = true
 }
@@ -85,7 +85,7 @@ func (v NullableInt) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableInt) Unset() {
+func (v *NullableInt) Unset() {
 	v.value = nil
 	v.isSet = false
 }
@@ -113,7 +113,7 @@ func (v NullableInt32) Get() *int32 {
 	return v.value
 }
 
-func (v NullableInt32) Set(val *int32) {
+func (v *NullableInt32) Set(val *int32) {
 	v.value = val
 	v.isSet = true
 }
@@ -122,7 +122,7 @@ func (v NullableInt32) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableInt32) Unset() {
+func (v *NullableInt32) Unset() {
 	v.value = nil
 	v.isSet = false
 }
@@ -150,7 +150,7 @@ func (v NullableInt64) Get() *int64 {
 	return v.value
 }
 
-func (v NullableInt64) Set(val *int64) {
+func (v *NullableInt64) Set(val *int64) {
 	v.value = val
 	v.isSet = true
 }
@@ -159,7 +159,7 @@ func (v NullableInt64) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableInt64) Unset() {
+func (v *NullableInt64) Unset() {
 	v.value = nil
 	v.isSet = false
 }
@@ -187,7 +187,7 @@ func (v NullableFloat32) Get() *float32 {
 	return v.value
 }
 
-func (v NullableFloat32) Set(val *float32) {
+func (v *NullableFloat32) Set(val *float32) {
 	v.value = val
 	v.isSet = true
 }
@@ -196,7 +196,7 @@ func (v NullableFloat32) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableFloat32) Unset() {
+func (v *NullableFloat32) Unset() {
 	v.value = nil
 	v.isSet = false
 }
@@ -224,7 +224,7 @@ func (v NullableFloat64) Get() *float64 {
 	return v.value
 }
 
-func (v NullableFloat64) Set(val *float64) {
+func (v *NullableFloat64) Set(val *float64) {
 	v.value = val
 	v.isSet = true
 }
@@ -233,7 +233,7 @@ func (v NullableFloat64) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableFloat64) Unset() {
+func (v *NullableFloat64) Unset() {
 	v.value = nil
 	v.isSet = false
 }
@@ -261,7 +261,7 @@ func (v NullableString) Get() *string {
 	return v.value
 }
 
-func (v NullableString) Set(val *string) {
+func (v *NullableString) Set(val *string) {
 	v.value = val
 	v.isSet = true
 }
@@ -270,7 +270,7 @@ func (v NullableString) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableString) Unset() {
+func (v *NullableString) Unset() {
 	v.value = nil
 	v.isSet = false
 }
@@ -298,7 +298,7 @@ func (v NullableTime) Get() *time.Time {
 	return v.value
 }
 
-func (v NullableTime) Set(val *time.Time) {
+func (v *NullableTime) Set(val *time.Time) {
 	v.value = val
 	v.isSet = true
 }
@@ -307,7 +307,7 @@ func (v NullableTime) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableTime) Unset() {
+func (v *NullableTime) Unset() {
 	v.value = nil
 	v.isSet = false
 }

--- a/samples/client/petstore/go-experimental/go-petstore/docs/AdditionalPropertiesAnyType.md
+++ b/samples/client/petstore/go-experimental/go-petstore/docs/AdditionalPropertiesAnyType.md
@@ -33,22 +33,16 @@ GetName returns the Name field if non-nil, zero value otherwise.
 
 ### GetNameOk
 
-`func (o *AdditionalPropertiesAnyType) GetNameOk() (string, bool)`
+`func (o *AdditionalPropertiesAnyType) GetNameOk() (*string, bool)`
 
 GetNameOk returns a tuple with the Name field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasName
-
-`func (o *AdditionalPropertiesAnyType) HasName() bool`
-
-HasName returns a boolean if a field has been set.
 
 ### SetName
 
 `func (o *AdditionalPropertiesAnyType) SetName(v string)`
 
-SetName gets a reference to the given string and assigns it to the Name field.
+SetName sets Name field to given value.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/go-experimental/go-petstore/docs/AdditionalPropertiesAnyType.md
+++ b/samples/client/petstore/go-experimental/go-petstore/docs/AdditionalPropertiesAnyType.md
@@ -44,6 +44,12 @@ and a boolean to check if the value has been set.
 
 SetName sets Name field to given value.
 
+### HasName
+
+`func (o *AdditionalPropertiesAnyType) HasName() bool`
+
+HasName returns a boolean if a field has been set.
+
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/go-experimental/go-petstore/docs/AdditionalPropertiesArray.md
+++ b/samples/client/petstore/go-experimental/go-petstore/docs/AdditionalPropertiesArray.md
@@ -33,22 +33,16 @@ GetName returns the Name field if non-nil, zero value otherwise.
 
 ### GetNameOk
 
-`func (o *AdditionalPropertiesArray) GetNameOk() (string, bool)`
+`func (o *AdditionalPropertiesArray) GetNameOk() (*string, bool)`
 
 GetNameOk returns a tuple with the Name field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasName
-
-`func (o *AdditionalPropertiesArray) HasName() bool`
-
-HasName returns a boolean if a field has been set.
 
 ### SetName
 
 `func (o *AdditionalPropertiesArray) SetName(v string)`
 
-SetName gets a reference to the given string and assigns it to the Name field.
+SetName sets Name field to given value.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/go-experimental/go-petstore/docs/AdditionalPropertiesArray.md
+++ b/samples/client/petstore/go-experimental/go-petstore/docs/AdditionalPropertiesArray.md
@@ -44,6 +44,12 @@ and a boolean to check if the value has been set.
 
 SetName sets Name field to given value.
 
+### HasName
+
+`func (o *AdditionalPropertiesArray) HasName() bool`
+
+HasName returns a boolean if a field has been set.
+
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/go-experimental/go-petstore/docs/AdditionalPropertiesBoolean.md
+++ b/samples/client/petstore/go-experimental/go-petstore/docs/AdditionalPropertiesBoolean.md
@@ -33,22 +33,16 @@ GetName returns the Name field if non-nil, zero value otherwise.
 
 ### GetNameOk
 
-`func (o *AdditionalPropertiesBoolean) GetNameOk() (string, bool)`
+`func (o *AdditionalPropertiesBoolean) GetNameOk() (*string, bool)`
 
 GetNameOk returns a tuple with the Name field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasName
-
-`func (o *AdditionalPropertiesBoolean) HasName() bool`
-
-HasName returns a boolean if a field has been set.
 
 ### SetName
 
 `func (o *AdditionalPropertiesBoolean) SetName(v string)`
 
-SetName gets a reference to the given string and assigns it to the Name field.
+SetName sets Name field to given value.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/go-experimental/go-petstore/docs/AdditionalPropertiesBoolean.md
+++ b/samples/client/petstore/go-experimental/go-petstore/docs/AdditionalPropertiesBoolean.md
@@ -44,6 +44,12 @@ and a boolean to check if the value has been set.
 
 SetName sets Name field to given value.
 
+### HasName
+
+`func (o *AdditionalPropertiesBoolean) HasName() bool`
+
+HasName returns a boolean if a field has been set.
+
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/go-experimental/go-petstore/docs/AdditionalPropertiesClass.md
+++ b/samples/client/petstore/go-experimental/go-petstore/docs/AdditionalPropertiesClass.md
@@ -43,22 +43,16 @@ GetMapString returns the MapString field if non-nil, zero value otherwise.
 
 ### GetMapStringOk
 
-`func (o *AdditionalPropertiesClass) GetMapStringOk() (map[string]string, bool)`
+`func (o *AdditionalPropertiesClass) GetMapStringOk() (*map[string]string, bool)`
 
 GetMapStringOk returns a tuple with the MapString field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasMapString
-
-`func (o *AdditionalPropertiesClass) HasMapString() bool`
-
-HasMapString returns a boolean if a field has been set.
 
 ### SetMapString
 
 `func (o *AdditionalPropertiesClass) SetMapString(v map[string]string)`
 
-SetMapString gets a reference to the given map[string]string and assigns it to the MapString field.
+SetMapString sets MapString field to given value.
 
 ### GetMapNumber
 
@@ -68,22 +62,16 @@ GetMapNumber returns the MapNumber field if non-nil, zero value otherwise.
 
 ### GetMapNumberOk
 
-`func (o *AdditionalPropertiesClass) GetMapNumberOk() (map[string]float32, bool)`
+`func (o *AdditionalPropertiesClass) GetMapNumberOk() (*map[string]float32, bool)`
 
 GetMapNumberOk returns a tuple with the MapNumber field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasMapNumber
-
-`func (o *AdditionalPropertiesClass) HasMapNumber() bool`
-
-HasMapNumber returns a boolean if a field has been set.
 
 ### SetMapNumber
 
 `func (o *AdditionalPropertiesClass) SetMapNumber(v map[string]float32)`
 
-SetMapNumber gets a reference to the given map[string]float32 and assigns it to the MapNumber field.
+SetMapNumber sets MapNumber field to given value.
 
 ### GetMapInteger
 
@@ -93,22 +81,16 @@ GetMapInteger returns the MapInteger field if non-nil, zero value otherwise.
 
 ### GetMapIntegerOk
 
-`func (o *AdditionalPropertiesClass) GetMapIntegerOk() (map[string]int32, bool)`
+`func (o *AdditionalPropertiesClass) GetMapIntegerOk() (*map[string]int32, bool)`
 
 GetMapIntegerOk returns a tuple with the MapInteger field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasMapInteger
-
-`func (o *AdditionalPropertiesClass) HasMapInteger() bool`
-
-HasMapInteger returns a boolean if a field has been set.
 
 ### SetMapInteger
 
 `func (o *AdditionalPropertiesClass) SetMapInteger(v map[string]int32)`
 
-SetMapInteger gets a reference to the given map[string]int32 and assigns it to the MapInteger field.
+SetMapInteger sets MapInteger field to given value.
 
 ### GetMapBoolean
 
@@ -118,22 +100,16 @@ GetMapBoolean returns the MapBoolean field if non-nil, zero value otherwise.
 
 ### GetMapBooleanOk
 
-`func (o *AdditionalPropertiesClass) GetMapBooleanOk() (map[string]bool, bool)`
+`func (o *AdditionalPropertiesClass) GetMapBooleanOk() (*map[string]bool, bool)`
 
 GetMapBooleanOk returns a tuple with the MapBoolean field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasMapBoolean
-
-`func (o *AdditionalPropertiesClass) HasMapBoolean() bool`
-
-HasMapBoolean returns a boolean if a field has been set.
 
 ### SetMapBoolean
 
 `func (o *AdditionalPropertiesClass) SetMapBoolean(v map[string]bool)`
 
-SetMapBoolean gets a reference to the given map[string]bool and assigns it to the MapBoolean field.
+SetMapBoolean sets MapBoolean field to given value.
 
 ### GetMapArrayInteger
 
@@ -143,22 +119,16 @@ GetMapArrayInteger returns the MapArrayInteger field if non-nil, zero value othe
 
 ### GetMapArrayIntegerOk
 
-`func (o *AdditionalPropertiesClass) GetMapArrayIntegerOk() (map[string][]int32, bool)`
+`func (o *AdditionalPropertiesClass) GetMapArrayIntegerOk() (*map[string][]int32, bool)`
 
 GetMapArrayIntegerOk returns a tuple with the MapArrayInteger field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasMapArrayInteger
-
-`func (o *AdditionalPropertiesClass) HasMapArrayInteger() bool`
-
-HasMapArrayInteger returns a boolean if a field has been set.
 
 ### SetMapArrayInteger
 
 `func (o *AdditionalPropertiesClass) SetMapArrayInteger(v map[string][]int32)`
 
-SetMapArrayInteger gets a reference to the given map[string][]int32 and assigns it to the MapArrayInteger field.
+SetMapArrayInteger sets MapArrayInteger field to given value.
 
 ### GetMapArrayAnytype
 
@@ -168,22 +138,16 @@ GetMapArrayAnytype returns the MapArrayAnytype field if non-nil, zero value othe
 
 ### GetMapArrayAnytypeOk
 
-`func (o *AdditionalPropertiesClass) GetMapArrayAnytypeOk() (map[string][]map[string]interface{}, bool)`
+`func (o *AdditionalPropertiesClass) GetMapArrayAnytypeOk() (*map[string][]map[string]interface{}, bool)`
 
 GetMapArrayAnytypeOk returns a tuple with the MapArrayAnytype field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasMapArrayAnytype
-
-`func (o *AdditionalPropertiesClass) HasMapArrayAnytype() bool`
-
-HasMapArrayAnytype returns a boolean if a field has been set.
 
 ### SetMapArrayAnytype
 
 `func (o *AdditionalPropertiesClass) SetMapArrayAnytype(v map[string][]map[string]interface{})`
 
-SetMapArrayAnytype gets a reference to the given map[string][]map[string]interface{} and assigns it to the MapArrayAnytype field.
+SetMapArrayAnytype sets MapArrayAnytype field to given value.
 
 ### GetMapMapString
 
@@ -193,22 +157,16 @@ GetMapMapString returns the MapMapString field if non-nil, zero value otherwise.
 
 ### GetMapMapStringOk
 
-`func (o *AdditionalPropertiesClass) GetMapMapStringOk() (map[string]map[string]string, bool)`
+`func (o *AdditionalPropertiesClass) GetMapMapStringOk() (*map[string]map[string]string, bool)`
 
 GetMapMapStringOk returns a tuple with the MapMapString field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasMapMapString
-
-`func (o *AdditionalPropertiesClass) HasMapMapString() bool`
-
-HasMapMapString returns a boolean if a field has been set.
 
 ### SetMapMapString
 
 `func (o *AdditionalPropertiesClass) SetMapMapString(v map[string]map[string]string)`
 
-SetMapMapString gets a reference to the given map[string]map[string]string and assigns it to the MapMapString field.
+SetMapMapString sets MapMapString field to given value.
 
 ### GetMapMapAnytype
 
@@ -218,22 +176,16 @@ GetMapMapAnytype returns the MapMapAnytype field if non-nil, zero value otherwis
 
 ### GetMapMapAnytypeOk
 
-`func (o *AdditionalPropertiesClass) GetMapMapAnytypeOk() (map[string]map[string]map[string]interface{}, bool)`
+`func (o *AdditionalPropertiesClass) GetMapMapAnytypeOk() (*map[string]map[string]map[string]interface{}, bool)`
 
 GetMapMapAnytypeOk returns a tuple with the MapMapAnytype field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasMapMapAnytype
-
-`func (o *AdditionalPropertiesClass) HasMapMapAnytype() bool`
-
-HasMapMapAnytype returns a boolean if a field has been set.
 
 ### SetMapMapAnytype
 
 `func (o *AdditionalPropertiesClass) SetMapMapAnytype(v map[string]map[string]map[string]interface{})`
 
-SetMapMapAnytype gets a reference to the given map[string]map[string]map[string]interface{} and assigns it to the MapMapAnytype field.
+SetMapMapAnytype sets MapMapAnytype field to given value.
 
 ### GetAnytype1
 
@@ -243,22 +195,16 @@ GetAnytype1 returns the Anytype1 field if non-nil, zero value otherwise.
 
 ### GetAnytype1Ok
 
-`func (o *AdditionalPropertiesClass) GetAnytype1Ok() (map[string]interface{}, bool)`
+`func (o *AdditionalPropertiesClass) GetAnytype1Ok() (*map[string]interface{}, bool)`
 
 GetAnytype1Ok returns a tuple with the Anytype1 field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasAnytype1
-
-`func (o *AdditionalPropertiesClass) HasAnytype1() bool`
-
-HasAnytype1 returns a boolean if a field has been set.
 
 ### SetAnytype1
 
 `func (o *AdditionalPropertiesClass) SetAnytype1(v map[string]interface{})`
 
-SetAnytype1 gets a reference to the given map[string]interface{} and assigns it to the Anytype1 field.
+SetAnytype1 sets Anytype1 field to given value.
 
 ### GetAnytype2
 
@@ -268,22 +214,16 @@ GetAnytype2 returns the Anytype2 field if non-nil, zero value otherwise.
 
 ### GetAnytype2Ok
 
-`func (o *AdditionalPropertiesClass) GetAnytype2Ok() (map[string]interface{}, bool)`
+`func (o *AdditionalPropertiesClass) GetAnytype2Ok() (*map[string]interface{}, bool)`
 
 GetAnytype2Ok returns a tuple with the Anytype2 field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasAnytype2
-
-`func (o *AdditionalPropertiesClass) HasAnytype2() bool`
-
-HasAnytype2 returns a boolean if a field has been set.
 
 ### SetAnytype2
 
 `func (o *AdditionalPropertiesClass) SetAnytype2(v map[string]interface{})`
 
-SetAnytype2 gets a reference to the given map[string]interface{} and assigns it to the Anytype2 field.
+SetAnytype2 sets Anytype2 field to given value.
 
 ### GetAnytype3
 
@@ -293,22 +233,16 @@ GetAnytype3 returns the Anytype3 field if non-nil, zero value otherwise.
 
 ### GetAnytype3Ok
 
-`func (o *AdditionalPropertiesClass) GetAnytype3Ok() (map[string]interface{}, bool)`
+`func (o *AdditionalPropertiesClass) GetAnytype3Ok() (*map[string]interface{}, bool)`
 
 GetAnytype3Ok returns a tuple with the Anytype3 field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasAnytype3
-
-`func (o *AdditionalPropertiesClass) HasAnytype3() bool`
-
-HasAnytype3 returns a boolean if a field has been set.
 
 ### SetAnytype3
 
 `func (o *AdditionalPropertiesClass) SetAnytype3(v map[string]interface{})`
 
-SetAnytype3 gets a reference to the given map[string]interface{} and assigns it to the Anytype3 field.
+SetAnytype3 sets Anytype3 field to given value.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/go-experimental/go-petstore/docs/AdditionalPropertiesClass.md
+++ b/samples/client/petstore/go-experimental/go-petstore/docs/AdditionalPropertiesClass.md
@@ -54,6 +54,12 @@ and a boolean to check if the value has been set.
 
 SetMapString sets MapString field to given value.
 
+### HasMapString
+
+`func (o *AdditionalPropertiesClass) HasMapString() bool`
+
+HasMapString returns a boolean if a field has been set.
+
 ### GetMapNumber
 
 `func (o *AdditionalPropertiesClass) GetMapNumber() map[string]float32`
@@ -72,6 +78,12 @@ and a boolean to check if the value has been set.
 `func (o *AdditionalPropertiesClass) SetMapNumber(v map[string]float32)`
 
 SetMapNumber sets MapNumber field to given value.
+
+### HasMapNumber
+
+`func (o *AdditionalPropertiesClass) HasMapNumber() bool`
+
+HasMapNumber returns a boolean if a field has been set.
 
 ### GetMapInteger
 
@@ -92,6 +104,12 @@ and a boolean to check if the value has been set.
 
 SetMapInteger sets MapInteger field to given value.
 
+### HasMapInteger
+
+`func (o *AdditionalPropertiesClass) HasMapInteger() bool`
+
+HasMapInteger returns a boolean if a field has been set.
+
 ### GetMapBoolean
 
 `func (o *AdditionalPropertiesClass) GetMapBoolean() map[string]bool`
@@ -110,6 +128,12 @@ and a boolean to check if the value has been set.
 `func (o *AdditionalPropertiesClass) SetMapBoolean(v map[string]bool)`
 
 SetMapBoolean sets MapBoolean field to given value.
+
+### HasMapBoolean
+
+`func (o *AdditionalPropertiesClass) HasMapBoolean() bool`
+
+HasMapBoolean returns a boolean if a field has been set.
 
 ### GetMapArrayInteger
 
@@ -130,6 +154,12 @@ and a boolean to check if the value has been set.
 
 SetMapArrayInteger sets MapArrayInteger field to given value.
 
+### HasMapArrayInteger
+
+`func (o *AdditionalPropertiesClass) HasMapArrayInteger() bool`
+
+HasMapArrayInteger returns a boolean if a field has been set.
+
 ### GetMapArrayAnytype
 
 `func (o *AdditionalPropertiesClass) GetMapArrayAnytype() map[string][]map[string]interface{}`
@@ -148,6 +178,12 @@ and a boolean to check if the value has been set.
 `func (o *AdditionalPropertiesClass) SetMapArrayAnytype(v map[string][]map[string]interface{})`
 
 SetMapArrayAnytype sets MapArrayAnytype field to given value.
+
+### HasMapArrayAnytype
+
+`func (o *AdditionalPropertiesClass) HasMapArrayAnytype() bool`
+
+HasMapArrayAnytype returns a boolean if a field has been set.
 
 ### GetMapMapString
 
@@ -168,6 +204,12 @@ and a boolean to check if the value has been set.
 
 SetMapMapString sets MapMapString field to given value.
 
+### HasMapMapString
+
+`func (o *AdditionalPropertiesClass) HasMapMapString() bool`
+
+HasMapMapString returns a boolean if a field has been set.
+
 ### GetMapMapAnytype
 
 `func (o *AdditionalPropertiesClass) GetMapMapAnytype() map[string]map[string]map[string]interface{}`
@@ -186,6 +228,12 @@ and a boolean to check if the value has been set.
 `func (o *AdditionalPropertiesClass) SetMapMapAnytype(v map[string]map[string]map[string]interface{})`
 
 SetMapMapAnytype sets MapMapAnytype field to given value.
+
+### HasMapMapAnytype
+
+`func (o *AdditionalPropertiesClass) HasMapMapAnytype() bool`
+
+HasMapMapAnytype returns a boolean if a field has been set.
 
 ### GetAnytype1
 
@@ -206,6 +254,12 @@ and a boolean to check if the value has been set.
 
 SetAnytype1 sets Anytype1 field to given value.
 
+### HasAnytype1
+
+`func (o *AdditionalPropertiesClass) HasAnytype1() bool`
+
+HasAnytype1 returns a boolean if a field has been set.
+
 ### GetAnytype2
 
 `func (o *AdditionalPropertiesClass) GetAnytype2() map[string]interface{}`
@@ -225,6 +279,12 @@ and a boolean to check if the value has been set.
 
 SetAnytype2 sets Anytype2 field to given value.
 
+### HasAnytype2
+
+`func (o *AdditionalPropertiesClass) HasAnytype2() bool`
+
+HasAnytype2 returns a boolean if a field has been set.
+
 ### GetAnytype3
 
 `func (o *AdditionalPropertiesClass) GetAnytype3() map[string]interface{}`
@@ -243,6 +303,12 @@ and a boolean to check if the value has been set.
 `func (o *AdditionalPropertiesClass) SetAnytype3(v map[string]interface{})`
 
 SetAnytype3 sets Anytype3 field to given value.
+
+### HasAnytype3
+
+`func (o *AdditionalPropertiesClass) HasAnytype3() bool`
+
+HasAnytype3 returns a boolean if a field has been set.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/go-experimental/go-petstore/docs/AdditionalPropertiesInteger.md
+++ b/samples/client/petstore/go-experimental/go-petstore/docs/AdditionalPropertiesInteger.md
@@ -33,22 +33,16 @@ GetName returns the Name field if non-nil, zero value otherwise.
 
 ### GetNameOk
 
-`func (o *AdditionalPropertiesInteger) GetNameOk() (string, bool)`
+`func (o *AdditionalPropertiesInteger) GetNameOk() (*string, bool)`
 
 GetNameOk returns a tuple with the Name field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasName
-
-`func (o *AdditionalPropertiesInteger) HasName() bool`
-
-HasName returns a boolean if a field has been set.
 
 ### SetName
 
 `func (o *AdditionalPropertiesInteger) SetName(v string)`
 
-SetName gets a reference to the given string and assigns it to the Name field.
+SetName sets Name field to given value.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/go-experimental/go-petstore/docs/AdditionalPropertiesInteger.md
+++ b/samples/client/petstore/go-experimental/go-petstore/docs/AdditionalPropertiesInteger.md
@@ -44,6 +44,12 @@ and a boolean to check if the value has been set.
 
 SetName sets Name field to given value.
 
+### HasName
+
+`func (o *AdditionalPropertiesInteger) HasName() bool`
+
+HasName returns a boolean if a field has been set.
+
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/go-experimental/go-petstore/docs/AdditionalPropertiesNumber.md
+++ b/samples/client/petstore/go-experimental/go-petstore/docs/AdditionalPropertiesNumber.md
@@ -44,6 +44,12 @@ and a boolean to check if the value has been set.
 
 SetName sets Name field to given value.
 
+### HasName
+
+`func (o *AdditionalPropertiesNumber) HasName() bool`
+
+HasName returns a boolean if a field has been set.
+
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/go-experimental/go-petstore/docs/AdditionalPropertiesNumber.md
+++ b/samples/client/petstore/go-experimental/go-petstore/docs/AdditionalPropertiesNumber.md
@@ -33,22 +33,16 @@ GetName returns the Name field if non-nil, zero value otherwise.
 
 ### GetNameOk
 
-`func (o *AdditionalPropertiesNumber) GetNameOk() (string, bool)`
+`func (o *AdditionalPropertiesNumber) GetNameOk() (*string, bool)`
 
 GetNameOk returns a tuple with the Name field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasName
-
-`func (o *AdditionalPropertiesNumber) HasName() bool`
-
-HasName returns a boolean if a field has been set.
 
 ### SetName
 
 `func (o *AdditionalPropertiesNumber) SetName(v string)`
 
-SetName gets a reference to the given string and assigns it to the Name field.
+SetName sets Name field to given value.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/go-experimental/go-petstore/docs/AdditionalPropertiesObject.md
+++ b/samples/client/petstore/go-experimental/go-petstore/docs/AdditionalPropertiesObject.md
@@ -33,22 +33,16 @@ GetName returns the Name field if non-nil, zero value otherwise.
 
 ### GetNameOk
 
-`func (o *AdditionalPropertiesObject) GetNameOk() (string, bool)`
+`func (o *AdditionalPropertiesObject) GetNameOk() (*string, bool)`
 
 GetNameOk returns a tuple with the Name field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasName
-
-`func (o *AdditionalPropertiesObject) HasName() bool`
-
-HasName returns a boolean if a field has been set.
 
 ### SetName
 
 `func (o *AdditionalPropertiesObject) SetName(v string)`
 
-SetName gets a reference to the given string and assigns it to the Name field.
+SetName sets Name field to given value.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/go-experimental/go-petstore/docs/AdditionalPropertiesObject.md
+++ b/samples/client/petstore/go-experimental/go-petstore/docs/AdditionalPropertiesObject.md
@@ -44,6 +44,12 @@ and a boolean to check if the value has been set.
 
 SetName sets Name field to given value.
 
+### HasName
+
+`func (o *AdditionalPropertiesObject) HasName() bool`
+
+HasName returns a boolean if a field has been set.
+
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/go-experimental/go-petstore/docs/AdditionalPropertiesString.md
+++ b/samples/client/petstore/go-experimental/go-petstore/docs/AdditionalPropertiesString.md
@@ -44,6 +44,12 @@ and a boolean to check if the value has been set.
 
 SetName sets Name field to given value.
 
+### HasName
+
+`func (o *AdditionalPropertiesString) HasName() bool`
+
+HasName returns a boolean if a field has been set.
+
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/go-experimental/go-petstore/docs/AdditionalPropertiesString.md
+++ b/samples/client/petstore/go-experimental/go-petstore/docs/AdditionalPropertiesString.md
@@ -33,22 +33,16 @@ GetName returns the Name field if non-nil, zero value otherwise.
 
 ### GetNameOk
 
-`func (o *AdditionalPropertiesString) GetNameOk() (string, bool)`
+`func (o *AdditionalPropertiesString) GetNameOk() (*string, bool)`
 
 GetNameOk returns a tuple with the Name field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasName
-
-`func (o *AdditionalPropertiesString) HasName() bool`
-
-HasName returns a boolean if a field has been set.
 
 ### SetName
 
 `func (o *AdditionalPropertiesString) SetName(v string)`
 
-SetName gets a reference to the given string and assigns it to the Name field.
+SetName sets Name field to given value.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/go-experimental/go-petstore/docs/Animal.md
+++ b/samples/client/petstore/go-experimental/go-petstore/docs/Animal.md
@@ -34,22 +34,16 @@ GetClassName returns the ClassName field if non-nil, zero value otherwise.
 
 ### GetClassNameOk
 
-`func (o *Animal) GetClassNameOk() (string, bool)`
+`func (o *Animal) GetClassNameOk() (*string, bool)`
 
 GetClassNameOk returns a tuple with the ClassName field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasClassName
-
-`func (o *Animal) HasClassName() bool`
-
-HasClassName returns a boolean if a field has been set.
 
 ### SetClassName
 
 `func (o *Animal) SetClassName(v string)`
 
-SetClassName gets a reference to the given string and assigns it to the ClassName field.
+SetClassName sets ClassName field to given value.
 
 ### GetColor
 
@@ -59,22 +53,16 @@ GetColor returns the Color field if non-nil, zero value otherwise.
 
 ### GetColorOk
 
-`func (o *Animal) GetColorOk() (string, bool)`
+`func (o *Animal) GetColorOk() (*string, bool)`
 
 GetColorOk returns a tuple with the Color field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasColor
-
-`func (o *Animal) HasColor() bool`
-
-HasColor returns a boolean if a field has been set.
 
 ### SetColor
 
 `func (o *Animal) SetColor(v string)`
 
-SetColor gets a reference to the given string and assigns it to the Color field.
+SetColor sets Color field to given value.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/go-experimental/go-petstore/docs/Animal.md
+++ b/samples/client/petstore/go-experimental/go-petstore/docs/Animal.md
@@ -45,6 +45,7 @@ and a boolean to check if the value has been set.
 
 SetClassName sets ClassName field to given value.
 
+
 ### GetColor
 
 `func (o *Animal) GetColor() string`
@@ -63,6 +64,12 @@ and a boolean to check if the value has been set.
 `func (o *Animal) SetColor(v string)`
 
 SetColor sets Color field to given value.
+
+### HasColor
+
+`func (o *Animal) HasColor() bool`
+
+HasColor returns a boolean if a field has been set.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/go-experimental/go-petstore/docs/ApiResponse.md
+++ b/samples/client/petstore/go-experimental/go-petstore/docs/ApiResponse.md
@@ -35,22 +35,16 @@ GetCode returns the Code field if non-nil, zero value otherwise.
 
 ### GetCodeOk
 
-`func (o *ApiResponse) GetCodeOk() (int32, bool)`
+`func (o *ApiResponse) GetCodeOk() (*int32, bool)`
 
 GetCodeOk returns a tuple with the Code field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasCode
-
-`func (o *ApiResponse) HasCode() bool`
-
-HasCode returns a boolean if a field has been set.
 
 ### SetCode
 
 `func (o *ApiResponse) SetCode(v int32)`
 
-SetCode gets a reference to the given int32 and assigns it to the Code field.
+SetCode sets Code field to given value.
 
 ### GetType
 
@@ -60,22 +54,16 @@ GetType returns the Type field if non-nil, zero value otherwise.
 
 ### GetTypeOk
 
-`func (o *ApiResponse) GetTypeOk() (string, bool)`
+`func (o *ApiResponse) GetTypeOk() (*string, bool)`
 
 GetTypeOk returns a tuple with the Type field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasType
-
-`func (o *ApiResponse) HasType() bool`
-
-HasType returns a boolean if a field has been set.
 
 ### SetType
 
 `func (o *ApiResponse) SetType(v string)`
 
-SetType gets a reference to the given string and assigns it to the Type field.
+SetType sets Type field to given value.
 
 ### GetMessage
 
@@ -85,22 +73,16 @@ GetMessage returns the Message field if non-nil, zero value otherwise.
 
 ### GetMessageOk
 
-`func (o *ApiResponse) GetMessageOk() (string, bool)`
+`func (o *ApiResponse) GetMessageOk() (*string, bool)`
 
 GetMessageOk returns a tuple with the Message field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasMessage
-
-`func (o *ApiResponse) HasMessage() bool`
-
-HasMessage returns a boolean if a field has been set.
 
 ### SetMessage
 
 `func (o *ApiResponse) SetMessage(v string)`
 
-SetMessage gets a reference to the given string and assigns it to the Message field.
+SetMessage sets Message field to given value.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/go-experimental/go-petstore/docs/ApiResponse.md
+++ b/samples/client/petstore/go-experimental/go-petstore/docs/ApiResponse.md
@@ -46,6 +46,12 @@ and a boolean to check if the value has been set.
 
 SetCode sets Code field to given value.
 
+### HasCode
+
+`func (o *ApiResponse) HasCode() bool`
+
+HasCode returns a boolean if a field has been set.
+
 ### GetType
 
 `func (o *ApiResponse) GetType() string`
@@ -65,6 +71,12 @@ and a boolean to check if the value has been set.
 
 SetType sets Type field to given value.
 
+### HasType
+
+`func (o *ApiResponse) HasType() bool`
+
+HasType returns a boolean if a field has been set.
+
 ### GetMessage
 
 `func (o *ApiResponse) GetMessage() string`
@@ -83,6 +95,12 @@ and a boolean to check if the value has been set.
 `func (o *ApiResponse) SetMessage(v string)`
 
 SetMessage sets Message field to given value.
+
+### HasMessage
+
+`func (o *ApiResponse) HasMessage() bool`
+
+HasMessage returns a boolean if a field has been set.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/go-experimental/go-petstore/docs/ArrayOfArrayOfNumberOnly.md
+++ b/samples/client/petstore/go-experimental/go-petstore/docs/ArrayOfArrayOfNumberOnly.md
@@ -44,6 +44,12 @@ and a boolean to check if the value has been set.
 
 SetArrayArrayNumber sets ArrayArrayNumber field to given value.
 
+### HasArrayArrayNumber
+
+`func (o *ArrayOfArrayOfNumberOnly) HasArrayArrayNumber() bool`
+
+HasArrayArrayNumber returns a boolean if a field has been set.
+
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/go-experimental/go-petstore/docs/ArrayOfArrayOfNumberOnly.md
+++ b/samples/client/petstore/go-experimental/go-petstore/docs/ArrayOfArrayOfNumberOnly.md
@@ -33,22 +33,16 @@ GetArrayArrayNumber returns the ArrayArrayNumber field if non-nil, zero value ot
 
 ### GetArrayArrayNumberOk
 
-`func (o *ArrayOfArrayOfNumberOnly) GetArrayArrayNumberOk() ([][]float32, bool)`
+`func (o *ArrayOfArrayOfNumberOnly) GetArrayArrayNumberOk() (*[][]float32, bool)`
 
 GetArrayArrayNumberOk returns a tuple with the ArrayArrayNumber field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasArrayArrayNumber
-
-`func (o *ArrayOfArrayOfNumberOnly) HasArrayArrayNumber() bool`
-
-HasArrayArrayNumber returns a boolean if a field has been set.
 
 ### SetArrayArrayNumber
 
 `func (o *ArrayOfArrayOfNumberOnly) SetArrayArrayNumber(v [][]float32)`
 
-SetArrayArrayNumber gets a reference to the given [][]float32 and assigns it to the ArrayArrayNumber field.
+SetArrayArrayNumber sets ArrayArrayNumber field to given value.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/go-experimental/go-petstore/docs/ArrayOfNumberOnly.md
+++ b/samples/client/petstore/go-experimental/go-petstore/docs/ArrayOfNumberOnly.md
@@ -33,22 +33,16 @@ GetArrayNumber returns the ArrayNumber field if non-nil, zero value otherwise.
 
 ### GetArrayNumberOk
 
-`func (o *ArrayOfNumberOnly) GetArrayNumberOk() ([]float32, bool)`
+`func (o *ArrayOfNumberOnly) GetArrayNumberOk() (*[]float32, bool)`
 
 GetArrayNumberOk returns a tuple with the ArrayNumber field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasArrayNumber
-
-`func (o *ArrayOfNumberOnly) HasArrayNumber() bool`
-
-HasArrayNumber returns a boolean if a field has been set.
 
 ### SetArrayNumber
 
 `func (o *ArrayOfNumberOnly) SetArrayNumber(v []float32)`
 
-SetArrayNumber gets a reference to the given []float32 and assigns it to the ArrayNumber field.
+SetArrayNumber sets ArrayNumber field to given value.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/go-experimental/go-petstore/docs/ArrayOfNumberOnly.md
+++ b/samples/client/petstore/go-experimental/go-petstore/docs/ArrayOfNumberOnly.md
@@ -44,6 +44,12 @@ and a boolean to check if the value has been set.
 
 SetArrayNumber sets ArrayNumber field to given value.
 
+### HasArrayNumber
+
+`func (o *ArrayOfNumberOnly) HasArrayNumber() bool`
+
+HasArrayNumber returns a boolean if a field has been set.
+
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/go-experimental/go-petstore/docs/ArrayTest.md
+++ b/samples/client/petstore/go-experimental/go-petstore/docs/ArrayTest.md
@@ -35,22 +35,16 @@ GetArrayOfString returns the ArrayOfString field if non-nil, zero value otherwis
 
 ### GetArrayOfStringOk
 
-`func (o *ArrayTest) GetArrayOfStringOk() ([]string, bool)`
+`func (o *ArrayTest) GetArrayOfStringOk() (*[]string, bool)`
 
 GetArrayOfStringOk returns a tuple with the ArrayOfString field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasArrayOfString
-
-`func (o *ArrayTest) HasArrayOfString() bool`
-
-HasArrayOfString returns a boolean if a field has been set.
 
 ### SetArrayOfString
 
 `func (o *ArrayTest) SetArrayOfString(v []string)`
 
-SetArrayOfString gets a reference to the given []string and assigns it to the ArrayOfString field.
+SetArrayOfString sets ArrayOfString field to given value.
 
 ### GetArrayArrayOfInteger
 
@@ -60,22 +54,16 @@ GetArrayArrayOfInteger returns the ArrayArrayOfInteger field if non-nil, zero va
 
 ### GetArrayArrayOfIntegerOk
 
-`func (o *ArrayTest) GetArrayArrayOfIntegerOk() ([][]int64, bool)`
+`func (o *ArrayTest) GetArrayArrayOfIntegerOk() (*[][]int64, bool)`
 
 GetArrayArrayOfIntegerOk returns a tuple with the ArrayArrayOfInteger field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasArrayArrayOfInteger
-
-`func (o *ArrayTest) HasArrayArrayOfInteger() bool`
-
-HasArrayArrayOfInteger returns a boolean if a field has been set.
 
 ### SetArrayArrayOfInteger
 
 `func (o *ArrayTest) SetArrayArrayOfInteger(v [][]int64)`
 
-SetArrayArrayOfInteger gets a reference to the given [][]int64 and assigns it to the ArrayArrayOfInteger field.
+SetArrayArrayOfInteger sets ArrayArrayOfInteger field to given value.
 
 ### GetArrayArrayOfModel
 
@@ -85,22 +73,16 @@ GetArrayArrayOfModel returns the ArrayArrayOfModel field if non-nil, zero value 
 
 ### GetArrayArrayOfModelOk
 
-`func (o *ArrayTest) GetArrayArrayOfModelOk() ([][]ReadOnlyFirst, bool)`
+`func (o *ArrayTest) GetArrayArrayOfModelOk() (*[][]ReadOnlyFirst, bool)`
 
 GetArrayArrayOfModelOk returns a tuple with the ArrayArrayOfModel field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasArrayArrayOfModel
-
-`func (o *ArrayTest) HasArrayArrayOfModel() bool`
-
-HasArrayArrayOfModel returns a boolean if a field has been set.
 
 ### SetArrayArrayOfModel
 
 `func (o *ArrayTest) SetArrayArrayOfModel(v [][]ReadOnlyFirst)`
 
-SetArrayArrayOfModel gets a reference to the given [][]ReadOnlyFirst and assigns it to the ArrayArrayOfModel field.
+SetArrayArrayOfModel sets ArrayArrayOfModel field to given value.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/go-experimental/go-petstore/docs/ArrayTest.md
+++ b/samples/client/petstore/go-experimental/go-petstore/docs/ArrayTest.md
@@ -46,6 +46,12 @@ and a boolean to check if the value has been set.
 
 SetArrayOfString sets ArrayOfString field to given value.
 
+### HasArrayOfString
+
+`func (o *ArrayTest) HasArrayOfString() bool`
+
+HasArrayOfString returns a boolean if a field has been set.
+
 ### GetArrayArrayOfInteger
 
 `func (o *ArrayTest) GetArrayArrayOfInteger() [][]int64`
@@ -65,6 +71,12 @@ and a boolean to check if the value has been set.
 
 SetArrayArrayOfInteger sets ArrayArrayOfInteger field to given value.
 
+### HasArrayArrayOfInteger
+
+`func (o *ArrayTest) HasArrayArrayOfInteger() bool`
+
+HasArrayArrayOfInteger returns a boolean if a field has been set.
+
 ### GetArrayArrayOfModel
 
 `func (o *ArrayTest) GetArrayArrayOfModel() [][]ReadOnlyFirst`
@@ -83,6 +95,12 @@ and a boolean to check if the value has been set.
 `func (o *ArrayTest) SetArrayArrayOfModel(v [][]ReadOnlyFirst)`
 
 SetArrayArrayOfModel sets ArrayArrayOfModel field to given value.
+
+### HasArrayArrayOfModel
+
+`func (o *ArrayTest) HasArrayArrayOfModel() bool`
+
+HasArrayArrayOfModel returns a boolean if a field has been set.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/go-experimental/go-petstore/docs/BigCat.md
+++ b/samples/client/petstore/go-experimental/go-petstore/docs/BigCat.md
@@ -44,6 +44,12 @@ and a boolean to check if the value has been set.
 
 SetKind sets Kind field to given value.
 
+### HasKind
+
+`func (o *BigCat) HasKind() bool`
+
+HasKind returns a boolean if a field has been set.
+
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/go-experimental/go-petstore/docs/BigCat.md
+++ b/samples/client/petstore/go-experimental/go-petstore/docs/BigCat.md
@@ -33,22 +33,16 @@ GetKind returns the Kind field if non-nil, zero value otherwise.
 
 ### GetKindOk
 
-`func (o *BigCat) GetKindOk() (string, bool)`
+`func (o *BigCat) GetKindOk() (*string, bool)`
 
 GetKindOk returns a tuple with the Kind field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasKind
-
-`func (o *BigCat) HasKind() bool`
-
-HasKind returns a boolean if a field has been set.
 
 ### SetKind
 
 `func (o *BigCat) SetKind(v string)`
 
-SetKind gets a reference to the given string and assigns it to the Kind field.
+SetKind sets Kind field to given value.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/go-experimental/go-petstore/docs/BigCatAllOf.md
+++ b/samples/client/petstore/go-experimental/go-petstore/docs/BigCatAllOf.md
@@ -33,22 +33,16 @@ GetKind returns the Kind field if non-nil, zero value otherwise.
 
 ### GetKindOk
 
-`func (o *BigCatAllOf) GetKindOk() (string, bool)`
+`func (o *BigCatAllOf) GetKindOk() (*string, bool)`
 
 GetKindOk returns a tuple with the Kind field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasKind
-
-`func (o *BigCatAllOf) HasKind() bool`
-
-HasKind returns a boolean if a field has been set.
 
 ### SetKind
 
 `func (o *BigCatAllOf) SetKind(v string)`
 
-SetKind gets a reference to the given string and assigns it to the Kind field.
+SetKind sets Kind field to given value.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/go-experimental/go-petstore/docs/BigCatAllOf.md
+++ b/samples/client/petstore/go-experimental/go-petstore/docs/BigCatAllOf.md
@@ -44,6 +44,12 @@ and a boolean to check if the value has been set.
 
 SetKind sets Kind field to given value.
 
+### HasKind
+
+`func (o *BigCatAllOf) HasKind() bool`
+
+HasKind returns a boolean if a field has been set.
+
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/go-experimental/go-petstore/docs/Capitalization.md
+++ b/samples/client/petstore/go-experimental/go-petstore/docs/Capitalization.md
@@ -49,6 +49,12 @@ and a boolean to check if the value has been set.
 
 SetSmallCamel sets SmallCamel field to given value.
 
+### HasSmallCamel
+
+`func (o *Capitalization) HasSmallCamel() bool`
+
+HasSmallCamel returns a boolean if a field has been set.
+
 ### GetCapitalCamel
 
 `func (o *Capitalization) GetCapitalCamel() string`
@@ -67,6 +73,12 @@ and a boolean to check if the value has been set.
 `func (o *Capitalization) SetCapitalCamel(v string)`
 
 SetCapitalCamel sets CapitalCamel field to given value.
+
+### HasCapitalCamel
+
+`func (o *Capitalization) HasCapitalCamel() bool`
+
+HasCapitalCamel returns a boolean if a field has been set.
 
 ### GetSmallSnake
 
@@ -87,6 +99,12 @@ and a boolean to check if the value has been set.
 
 SetSmallSnake sets SmallSnake field to given value.
 
+### HasSmallSnake
+
+`func (o *Capitalization) HasSmallSnake() bool`
+
+HasSmallSnake returns a boolean if a field has been set.
+
 ### GetCapitalSnake
 
 `func (o *Capitalization) GetCapitalSnake() string`
@@ -105,6 +123,12 @@ and a boolean to check if the value has been set.
 `func (o *Capitalization) SetCapitalSnake(v string)`
 
 SetCapitalSnake sets CapitalSnake field to given value.
+
+### HasCapitalSnake
+
+`func (o *Capitalization) HasCapitalSnake() bool`
+
+HasCapitalSnake returns a boolean if a field has been set.
 
 ### GetSCAETHFlowPoints
 
@@ -125,6 +149,12 @@ and a boolean to check if the value has been set.
 
 SetSCAETHFlowPoints sets SCAETHFlowPoints field to given value.
 
+### HasSCAETHFlowPoints
+
+`func (o *Capitalization) HasSCAETHFlowPoints() bool`
+
+HasSCAETHFlowPoints returns a boolean if a field has been set.
+
 ### GetATT_NAME
 
 `func (o *Capitalization) GetATT_NAME() string`
@@ -143,6 +173,12 @@ and a boolean to check if the value has been set.
 `func (o *Capitalization) SetATT_NAME(v string)`
 
 SetATT_NAME sets ATT_NAME field to given value.
+
+### HasATT_NAME
+
+`func (o *Capitalization) HasATT_NAME() bool`
+
+HasATT_NAME returns a boolean if a field has been set.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/go-experimental/go-petstore/docs/Capitalization.md
+++ b/samples/client/petstore/go-experimental/go-petstore/docs/Capitalization.md
@@ -38,22 +38,16 @@ GetSmallCamel returns the SmallCamel field if non-nil, zero value otherwise.
 
 ### GetSmallCamelOk
 
-`func (o *Capitalization) GetSmallCamelOk() (string, bool)`
+`func (o *Capitalization) GetSmallCamelOk() (*string, bool)`
 
 GetSmallCamelOk returns a tuple with the SmallCamel field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasSmallCamel
-
-`func (o *Capitalization) HasSmallCamel() bool`
-
-HasSmallCamel returns a boolean if a field has been set.
 
 ### SetSmallCamel
 
 `func (o *Capitalization) SetSmallCamel(v string)`
 
-SetSmallCamel gets a reference to the given string and assigns it to the SmallCamel field.
+SetSmallCamel sets SmallCamel field to given value.
 
 ### GetCapitalCamel
 
@@ -63,22 +57,16 @@ GetCapitalCamel returns the CapitalCamel field if non-nil, zero value otherwise.
 
 ### GetCapitalCamelOk
 
-`func (o *Capitalization) GetCapitalCamelOk() (string, bool)`
+`func (o *Capitalization) GetCapitalCamelOk() (*string, bool)`
 
 GetCapitalCamelOk returns a tuple with the CapitalCamel field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasCapitalCamel
-
-`func (o *Capitalization) HasCapitalCamel() bool`
-
-HasCapitalCamel returns a boolean if a field has been set.
 
 ### SetCapitalCamel
 
 `func (o *Capitalization) SetCapitalCamel(v string)`
 
-SetCapitalCamel gets a reference to the given string and assigns it to the CapitalCamel field.
+SetCapitalCamel sets CapitalCamel field to given value.
 
 ### GetSmallSnake
 
@@ -88,22 +76,16 @@ GetSmallSnake returns the SmallSnake field if non-nil, zero value otherwise.
 
 ### GetSmallSnakeOk
 
-`func (o *Capitalization) GetSmallSnakeOk() (string, bool)`
+`func (o *Capitalization) GetSmallSnakeOk() (*string, bool)`
 
 GetSmallSnakeOk returns a tuple with the SmallSnake field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasSmallSnake
-
-`func (o *Capitalization) HasSmallSnake() bool`
-
-HasSmallSnake returns a boolean if a field has been set.
 
 ### SetSmallSnake
 
 `func (o *Capitalization) SetSmallSnake(v string)`
 
-SetSmallSnake gets a reference to the given string and assigns it to the SmallSnake field.
+SetSmallSnake sets SmallSnake field to given value.
 
 ### GetCapitalSnake
 
@@ -113,22 +95,16 @@ GetCapitalSnake returns the CapitalSnake field if non-nil, zero value otherwise.
 
 ### GetCapitalSnakeOk
 
-`func (o *Capitalization) GetCapitalSnakeOk() (string, bool)`
+`func (o *Capitalization) GetCapitalSnakeOk() (*string, bool)`
 
 GetCapitalSnakeOk returns a tuple with the CapitalSnake field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasCapitalSnake
-
-`func (o *Capitalization) HasCapitalSnake() bool`
-
-HasCapitalSnake returns a boolean if a field has been set.
 
 ### SetCapitalSnake
 
 `func (o *Capitalization) SetCapitalSnake(v string)`
 
-SetCapitalSnake gets a reference to the given string and assigns it to the CapitalSnake field.
+SetCapitalSnake sets CapitalSnake field to given value.
 
 ### GetSCAETHFlowPoints
 
@@ -138,22 +114,16 @@ GetSCAETHFlowPoints returns the SCAETHFlowPoints field if non-nil, zero value ot
 
 ### GetSCAETHFlowPointsOk
 
-`func (o *Capitalization) GetSCAETHFlowPointsOk() (string, bool)`
+`func (o *Capitalization) GetSCAETHFlowPointsOk() (*string, bool)`
 
 GetSCAETHFlowPointsOk returns a tuple with the SCAETHFlowPoints field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasSCAETHFlowPoints
-
-`func (o *Capitalization) HasSCAETHFlowPoints() bool`
-
-HasSCAETHFlowPoints returns a boolean if a field has been set.
 
 ### SetSCAETHFlowPoints
 
 `func (o *Capitalization) SetSCAETHFlowPoints(v string)`
 
-SetSCAETHFlowPoints gets a reference to the given string and assigns it to the SCAETHFlowPoints field.
+SetSCAETHFlowPoints sets SCAETHFlowPoints field to given value.
 
 ### GetATT_NAME
 
@@ -163,22 +133,16 @@ GetATT_NAME returns the ATT_NAME field if non-nil, zero value otherwise.
 
 ### GetATT_NAMEOk
 
-`func (o *Capitalization) GetATT_NAMEOk() (string, bool)`
+`func (o *Capitalization) GetATT_NAMEOk() (*string, bool)`
 
 GetATT_NAMEOk returns a tuple with the ATT_NAME field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasATT_NAME
-
-`func (o *Capitalization) HasATT_NAME() bool`
-
-HasATT_NAME returns a boolean if a field has been set.
 
 ### SetATT_NAME
 
 `func (o *Capitalization) SetATT_NAME(v string)`
 
-SetATT_NAME gets a reference to the given string and assigns it to the ATT_NAME field.
+SetATT_NAME sets ATT_NAME field to given value.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/go-experimental/go-petstore/docs/Cat.md
+++ b/samples/client/petstore/go-experimental/go-petstore/docs/Cat.md
@@ -33,22 +33,16 @@ GetDeclawed returns the Declawed field if non-nil, zero value otherwise.
 
 ### GetDeclawedOk
 
-`func (o *Cat) GetDeclawedOk() (bool, bool)`
+`func (o *Cat) GetDeclawedOk() (*bool, bool)`
 
 GetDeclawedOk returns a tuple with the Declawed field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasDeclawed
-
-`func (o *Cat) HasDeclawed() bool`
-
-HasDeclawed returns a boolean if a field has been set.
 
 ### SetDeclawed
 
 `func (o *Cat) SetDeclawed(v bool)`
 
-SetDeclawed gets a reference to the given bool and assigns it to the Declawed field.
+SetDeclawed sets Declawed field to given value.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/go-experimental/go-petstore/docs/Cat.md
+++ b/samples/client/petstore/go-experimental/go-petstore/docs/Cat.md
@@ -44,6 +44,12 @@ and a boolean to check if the value has been set.
 
 SetDeclawed sets Declawed field to given value.
 
+### HasDeclawed
+
+`func (o *Cat) HasDeclawed() bool`
+
+HasDeclawed returns a boolean if a field has been set.
+
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/go-experimental/go-petstore/docs/CatAllOf.md
+++ b/samples/client/petstore/go-experimental/go-petstore/docs/CatAllOf.md
@@ -44,6 +44,12 @@ and a boolean to check if the value has been set.
 
 SetDeclawed sets Declawed field to given value.
 
+### HasDeclawed
+
+`func (o *CatAllOf) HasDeclawed() bool`
+
+HasDeclawed returns a boolean if a field has been set.
+
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/go-experimental/go-petstore/docs/CatAllOf.md
+++ b/samples/client/petstore/go-experimental/go-petstore/docs/CatAllOf.md
@@ -33,22 +33,16 @@ GetDeclawed returns the Declawed field if non-nil, zero value otherwise.
 
 ### GetDeclawedOk
 
-`func (o *CatAllOf) GetDeclawedOk() (bool, bool)`
+`func (o *CatAllOf) GetDeclawedOk() (*bool, bool)`
 
 GetDeclawedOk returns a tuple with the Declawed field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasDeclawed
-
-`func (o *CatAllOf) HasDeclawed() bool`
-
-HasDeclawed returns a boolean if a field has been set.
 
 ### SetDeclawed
 
 `func (o *CatAllOf) SetDeclawed(v bool)`
 
-SetDeclawed gets a reference to the given bool and assigns it to the Declawed field.
+SetDeclawed sets Declawed field to given value.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/go-experimental/go-petstore/docs/Category.md
+++ b/samples/client/petstore/go-experimental/go-petstore/docs/Category.md
@@ -34,22 +34,16 @@ GetId returns the Id field if non-nil, zero value otherwise.
 
 ### GetIdOk
 
-`func (o *Category) GetIdOk() (int64, bool)`
+`func (o *Category) GetIdOk() (*int64, bool)`
 
 GetIdOk returns a tuple with the Id field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasId
-
-`func (o *Category) HasId() bool`
-
-HasId returns a boolean if a field has been set.
 
 ### SetId
 
 `func (o *Category) SetId(v int64)`
 
-SetId gets a reference to the given int64 and assigns it to the Id field.
+SetId sets Id field to given value.
 
 ### GetName
 
@@ -59,22 +53,16 @@ GetName returns the Name field if non-nil, zero value otherwise.
 
 ### GetNameOk
 
-`func (o *Category) GetNameOk() (string, bool)`
+`func (o *Category) GetNameOk() (*string, bool)`
 
 GetNameOk returns a tuple with the Name field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasName
-
-`func (o *Category) HasName() bool`
-
-HasName returns a boolean if a field has been set.
 
 ### SetName
 
 `func (o *Category) SetName(v string)`
 
-SetName gets a reference to the given string and assigns it to the Name field.
+SetName sets Name field to given value.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/go-experimental/go-petstore/docs/Category.md
+++ b/samples/client/petstore/go-experimental/go-petstore/docs/Category.md
@@ -45,6 +45,12 @@ and a boolean to check if the value has been set.
 
 SetId sets Id field to given value.
 
+### HasId
+
+`func (o *Category) HasId() bool`
+
+HasId returns a boolean if a field has been set.
+
 ### GetName
 
 `func (o *Category) GetName() string`
@@ -63,6 +69,7 @@ and a boolean to check if the value has been set.
 `func (o *Category) SetName(v string)`
 
 SetName sets Name field to given value.
+
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/go-experimental/go-petstore/docs/ClassModel.md
+++ b/samples/client/petstore/go-experimental/go-petstore/docs/ClassModel.md
@@ -33,22 +33,16 @@ GetClass returns the Class field if non-nil, zero value otherwise.
 
 ### GetClassOk
 
-`func (o *ClassModel) GetClassOk() (string, bool)`
+`func (o *ClassModel) GetClassOk() (*string, bool)`
 
 GetClassOk returns a tuple with the Class field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasClass
-
-`func (o *ClassModel) HasClass() bool`
-
-HasClass returns a boolean if a field has been set.
 
 ### SetClass
 
 `func (o *ClassModel) SetClass(v string)`
 
-SetClass gets a reference to the given string and assigns it to the Class field.
+SetClass sets Class field to given value.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/go-experimental/go-petstore/docs/ClassModel.md
+++ b/samples/client/petstore/go-experimental/go-petstore/docs/ClassModel.md
@@ -44,6 +44,12 @@ and a boolean to check if the value has been set.
 
 SetClass sets Class field to given value.
 
+### HasClass
+
+`func (o *ClassModel) HasClass() bool`
+
+HasClass returns a boolean if a field has been set.
+
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/go-experimental/go-petstore/docs/Client.md
+++ b/samples/client/petstore/go-experimental/go-petstore/docs/Client.md
@@ -33,22 +33,16 @@ GetClient returns the Client field if non-nil, zero value otherwise.
 
 ### GetClientOk
 
-`func (o *Client) GetClientOk() (string, bool)`
+`func (o *Client) GetClientOk() (*string, bool)`
 
 GetClientOk returns a tuple with the Client field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasClient
-
-`func (o *Client) HasClient() bool`
-
-HasClient returns a boolean if a field has been set.
 
 ### SetClient
 
 `func (o *Client) SetClient(v string)`
 
-SetClient gets a reference to the given string and assigns it to the Client field.
+SetClient sets Client field to given value.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/go-experimental/go-petstore/docs/Client.md
+++ b/samples/client/petstore/go-experimental/go-petstore/docs/Client.md
@@ -44,6 +44,12 @@ and a boolean to check if the value has been set.
 
 SetClient sets Client field to given value.
 
+### HasClient
+
+`func (o *Client) HasClient() bool`
+
+HasClient returns a boolean if a field has been set.
+
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/go-experimental/go-petstore/docs/Dog.md
+++ b/samples/client/petstore/go-experimental/go-petstore/docs/Dog.md
@@ -33,22 +33,16 @@ GetBreed returns the Breed field if non-nil, zero value otherwise.
 
 ### GetBreedOk
 
-`func (o *Dog) GetBreedOk() (string, bool)`
+`func (o *Dog) GetBreedOk() (*string, bool)`
 
 GetBreedOk returns a tuple with the Breed field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasBreed
-
-`func (o *Dog) HasBreed() bool`
-
-HasBreed returns a boolean if a field has been set.
 
 ### SetBreed
 
 `func (o *Dog) SetBreed(v string)`
 
-SetBreed gets a reference to the given string and assigns it to the Breed field.
+SetBreed sets Breed field to given value.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/go-experimental/go-petstore/docs/Dog.md
+++ b/samples/client/petstore/go-experimental/go-petstore/docs/Dog.md
@@ -44,6 +44,12 @@ and a boolean to check if the value has been set.
 
 SetBreed sets Breed field to given value.
 
+### HasBreed
+
+`func (o *Dog) HasBreed() bool`
+
+HasBreed returns a boolean if a field has been set.
+
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/go-experimental/go-petstore/docs/DogAllOf.md
+++ b/samples/client/petstore/go-experimental/go-petstore/docs/DogAllOf.md
@@ -44,6 +44,12 @@ and a boolean to check if the value has been set.
 
 SetBreed sets Breed field to given value.
 
+### HasBreed
+
+`func (o *DogAllOf) HasBreed() bool`
+
+HasBreed returns a boolean if a field has been set.
+
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/go-experimental/go-petstore/docs/DogAllOf.md
+++ b/samples/client/petstore/go-experimental/go-petstore/docs/DogAllOf.md
@@ -33,22 +33,16 @@ GetBreed returns the Breed field if non-nil, zero value otherwise.
 
 ### GetBreedOk
 
-`func (o *DogAllOf) GetBreedOk() (string, bool)`
+`func (o *DogAllOf) GetBreedOk() (*string, bool)`
 
 GetBreedOk returns a tuple with the Breed field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasBreed
-
-`func (o *DogAllOf) HasBreed() bool`
-
-HasBreed returns a boolean if a field has been set.
 
 ### SetBreed
 
 `func (o *DogAllOf) SetBreed(v string)`
 
-SetBreed gets a reference to the given string and assigns it to the Breed field.
+SetBreed sets Breed field to given value.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/go-experimental/go-petstore/docs/EnumArrays.md
+++ b/samples/client/petstore/go-experimental/go-petstore/docs/EnumArrays.md
@@ -45,6 +45,12 @@ and a boolean to check if the value has been set.
 
 SetJustSymbol sets JustSymbol field to given value.
 
+### HasJustSymbol
+
+`func (o *EnumArrays) HasJustSymbol() bool`
+
+HasJustSymbol returns a boolean if a field has been set.
+
 ### GetArrayEnum
 
 `func (o *EnumArrays) GetArrayEnum() []string`
@@ -63,6 +69,12 @@ and a boolean to check if the value has been set.
 `func (o *EnumArrays) SetArrayEnum(v []string)`
 
 SetArrayEnum sets ArrayEnum field to given value.
+
+### HasArrayEnum
+
+`func (o *EnumArrays) HasArrayEnum() bool`
+
+HasArrayEnum returns a boolean if a field has been set.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/go-experimental/go-petstore/docs/EnumArrays.md
+++ b/samples/client/petstore/go-experimental/go-petstore/docs/EnumArrays.md
@@ -34,22 +34,16 @@ GetJustSymbol returns the JustSymbol field if non-nil, zero value otherwise.
 
 ### GetJustSymbolOk
 
-`func (o *EnumArrays) GetJustSymbolOk() (string, bool)`
+`func (o *EnumArrays) GetJustSymbolOk() (*string, bool)`
 
 GetJustSymbolOk returns a tuple with the JustSymbol field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasJustSymbol
-
-`func (o *EnumArrays) HasJustSymbol() bool`
-
-HasJustSymbol returns a boolean if a field has been set.
 
 ### SetJustSymbol
 
 `func (o *EnumArrays) SetJustSymbol(v string)`
 
-SetJustSymbol gets a reference to the given string and assigns it to the JustSymbol field.
+SetJustSymbol sets JustSymbol field to given value.
 
 ### GetArrayEnum
 
@@ -59,22 +53,16 @@ GetArrayEnum returns the ArrayEnum field if non-nil, zero value otherwise.
 
 ### GetArrayEnumOk
 
-`func (o *EnumArrays) GetArrayEnumOk() ([]string, bool)`
+`func (o *EnumArrays) GetArrayEnumOk() (*[]string, bool)`
 
 GetArrayEnumOk returns a tuple with the ArrayEnum field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasArrayEnum
-
-`func (o *EnumArrays) HasArrayEnum() bool`
-
-HasArrayEnum returns a boolean if a field has been set.
 
 ### SetArrayEnum
 
 `func (o *EnumArrays) SetArrayEnum(v []string)`
 
-SetArrayEnum gets a reference to the given []string and assigns it to the ArrayEnum field.
+SetArrayEnum sets ArrayEnum field to given value.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/go-experimental/go-petstore/docs/EnumTest.md
+++ b/samples/client/petstore/go-experimental/go-petstore/docs/EnumTest.md
@@ -37,22 +37,16 @@ GetEnumString returns the EnumString field if non-nil, zero value otherwise.
 
 ### GetEnumStringOk
 
-`func (o *EnumTest) GetEnumStringOk() (string, bool)`
+`func (o *EnumTest) GetEnumStringOk() (*string, bool)`
 
 GetEnumStringOk returns a tuple with the EnumString field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasEnumString
-
-`func (o *EnumTest) HasEnumString() bool`
-
-HasEnumString returns a boolean if a field has been set.
 
 ### SetEnumString
 
 `func (o *EnumTest) SetEnumString(v string)`
 
-SetEnumString gets a reference to the given string and assigns it to the EnumString field.
+SetEnumString sets EnumString field to given value.
 
 ### GetEnumStringRequired
 
@@ -62,22 +56,16 @@ GetEnumStringRequired returns the EnumStringRequired field if non-nil, zero valu
 
 ### GetEnumStringRequiredOk
 
-`func (o *EnumTest) GetEnumStringRequiredOk() (string, bool)`
+`func (o *EnumTest) GetEnumStringRequiredOk() (*string, bool)`
 
 GetEnumStringRequiredOk returns a tuple with the EnumStringRequired field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasEnumStringRequired
-
-`func (o *EnumTest) HasEnumStringRequired() bool`
-
-HasEnumStringRequired returns a boolean if a field has been set.
 
 ### SetEnumStringRequired
 
 `func (o *EnumTest) SetEnumStringRequired(v string)`
 
-SetEnumStringRequired gets a reference to the given string and assigns it to the EnumStringRequired field.
+SetEnumStringRequired sets EnumStringRequired field to given value.
 
 ### GetEnumInteger
 
@@ -87,22 +75,16 @@ GetEnumInteger returns the EnumInteger field if non-nil, zero value otherwise.
 
 ### GetEnumIntegerOk
 
-`func (o *EnumTest) GetEnumIntegerOk() (int32, bool)`
+`func (o *EnumTest) GetEnumIntegerOk() (*int32, bool)`
 
 GetEnumIntegerOk returns a tuple with the EnumInteger field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasEnumInteger
-
-`func (o *EnumTest) HasEnumInteger() bool`
-
-HasEnumInteger returns a boolean if a field has been set.
 
 ### SetEnumInteger
 
 `func (o *EnumTest) SetEnumInteger(v int32)`
 
-SetEnumInteger gets a reference to the given int32 and assigns it to the EnumInteger field.
+SetEnumInteger sets EnumInteger field to given value.
 
 ### GetEnumNumber
 
@@ -112,22 +94,16 @@ GetEnumNumber returns the EnumNumber field if non-nil, zero value otherwise.
 
 ### GetEnumNumberOk
 
-`func (o *EnumTest) GetEnumNumberOk() (float64, bool)`
+`func (o *EnumTest) GetEnumNumberOk() (*float64, bool)`
 
 GetEnumNumberOk returns a tuple with the EnumNumber field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasEnumNumber
-
-`func (o *EnumTest) HasEnumNumber() bool`
-
-HasEnumNumber returns a boolean if a field has been set.
 
 ### SetEnumNumber
 
 `func (o *EnumTest) SetEnumNumber(v float64)`
 
-SetEnumNumber gets a reference to the given float64 and assigns it to the EnumNumber field.
+SetEnumNumber sets EnumNumber field to given value.
 
 ### GetOuterEnum
 
@@ -137,22 +113,16 @@ GetOuterEnum returns the OuterEnum field if non-nil, zero value otherwise.
 
 ### GetOuterEnumOk
 
-`func (o *EnumTest) GetOuterEnumOk() (OuterEnum, bool)`
+`func (o *EnumTest) GetOuterEnumOk() (*OuterEnum, bool)`
 
 GetOuterEnumOk returns a tuple with the OuterEnum field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasOuterEnum
-
-`func (o *EnumTest) HasOuterEnum() bool`
-
-HasOuterEnum returns a boolean if a field has been set.
 
 ### SetOuterEnum
 
 `func (o *EnumTest) SetOuterEnum(v OuterEnum)`
 
-SetOuterEnum gets a reference to the given OuterEnum and assigns it to the OuterEnum field.
+SetOuterEnum sets OuterEnum field to given value.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/go-experimental/go-petstore/docs/EnumTest.md
+++ b/samples/client/petstore/go-experimental/go-petstore/docs/EnumTest.md
@@ -48,6 +48,12 @@ and a boolean to check if the value has been set.
 
 SetEnumString sets EnumString field to given value.
 
+### HasEnumString
+
+`func (o *EnumTest) HasEnumString() bool`
+
+HasEnumString returns a boolean if a field has been set.
+
 ### GetEnumStringRequired
 
 `func (o *EnumTest) GetEnumStringRequired() string`
@@ -66,6 +72,7 @@ and a boolean to check if the value has been set.
 `func (o *EnumTest) SetEnumStringRequired(v string)`
 
 SetEnumStringRequired sets EnumStringRequired field to given value.
+
 
 ### GetEnumInteger
 
@@ -86,6 +93,12 @@ and a boolean to check if the value has been set.
 
 SetEnumInteger sets EnumInteger field to given value.
 
+### HasEnumInteger
+
+`func (o *EnumTest) HasEnumInteger() bool`
+
+HasEnumInteger returns a boolean if a field has been set.
+
 ### GetEnumNumber
 
 `func (o *EnumTest) GetEnumNumber() float64`
@@ -105,6 +118,12 @@ and a boolean to check if the value has been set.
 
 SetEnumNumber sets EnumNumber field to given value.
 
+### HasEnumNumber
+
+`func (o *EnumTest) HasEnumNumber() bool`
+
+HasEnumNumber returns a boolean if a field has been set.
+
 ### GetOuterEnum
 
 `func (o *EnumTest) GetOuterEnum() OuterEnum`
@@ -123,6 +142,12 @@ and a boolean to check if the value has been set.
 `func (o *EnumTest) SetOuterEnum(v OuterEnum)`
 
 SetOuterEnum sets OuterEnum field to given value.
+
+### HasOuterEnum
+
+`func (o *EnumTest) HasOuterEnum() bool`
+
+HasOuterEnum returns a boolean if a field has been set.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/go-experimental/go-petstore/docs/File.md
+++ b/samples/client/petstore/go-experimental/go-petstore/docs/File.md
@@ -44,6 +44,12 @@ and a boolean to check if the value has been set.
 
 SetSourceURI sets SourceURI field to given value.
 
+### HasSourceURI
+
+`func (o *File) HasSourceURI() bool`
+
+HasSourceURI returns a boolean if a field has been set.
+
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/go-experimental/go-petstore/docs/File.md
+++ b/samples/client/petstore/go-experimental/go-petstore/docs/File.md
@@ -33,22 +33,16 @@ GetSourceURI returns the SourceURI field if non-nil, zero value otherwise.
 
 ### GetSourceURIOk
 
-`func (o *File) GetSourceURIOk() (string, bool)`
+`func (o *File) GetSourceURIOk() (*string, bool)`
 
 GetSourceURIOk returns a tuple with the SourceURI field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasSourceURI
-
-`func (o *File) HasSourceURI() bool`
-
-HasSourceURI returns a boolean if a field has been set.
 
 ### SetSourceURI
 
 `func (o *File) SetSourceURI(v string)`
 
-SetSourceURI gets a reference to the given string and assigns it to the SourceURI field.
+SetSourceURI sets SourceURI field to given value.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/go-experimental/go-petstore/docs/FileSchemaTestClass.md
+++ b/samples/client/petstore/go-experimental/go-petstore/docs/FileSchemaTestClass.md
@@ -45,6 +45,12 @@ and a boolean to check if the value has been set.
 
 SetFile sets File field to given value.
 
+### HasFile
+
+`func (o *FileSchemaTestClass) HasFile() bool`
+
+HasFile returns a boolean if a field has been set.
+
 ### GetFiles
 
 `func (o *FileSchemaTestClass) GetFiles() []File`
@@ -63,6 +69,12 @@ and a boolean to check if the value has been set.
 `func (o *FileSchemaTestClass) SetFiles(v []File)`
 
 SetFiles sets Files field to given value.
+
+### HasFiles
+
+`func (o *FileSchemaTestClass) HasFiles() bool`
+
+HasFiles returns a boolean if a field has been set.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/go-experimental/go-petstore/docs/FileSchemaTestClass.md
+++ b/samples/client/petstore/go-experimental/go-petstore/docs/FileSchemaTestClass.md
@@ -34,22 +34,16 @@ GetFile returns the File field if non-nil, zero value otherwise.
 
 ### GetFileOk
 
-`func (o *FileSchemaTestClass) GetFileOk() (File, bool)`
+`func (o *FileSchemaTestClass) GetFileOk() (*File, bool)`
 
 GetFileOk returns a tuple with the File field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasFile
-
-`func (o *FileSchemaTestClass) HasFile() bool`
-
-HasFile returns a boolean if a field has been set.
 
 ### SetFile
 
 `func (o *FileSchemaTestClass) SetFile(v File)`
 
-SetFile gets a reference to the given File and assigns it to the File field.
+SetFile sets File field to given value.
 
 ### GetFiles
 
@@ -59,22 +53,16 @@ GetFiles returns the Files field if non-nil, zero value otherwise.
 
 ### GetFilesOk
 
-`func (o *FileSchemaTestClass) GetFilesOk() ([]File, bool)`
+`func (o *FileSchemaTestClass) GetFilesOk() (*[]File, bool)`
 
 GetFilesOk returns a tuple with the Files field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasFiles
-
-`func (o *FileSchemaTestClass) HasFiles() bool`
-
-HasFiles returns a boolean if a field has been set.
 
 ### SetFiles
 
 `func (o *FileSchemaTestClass) SetFiles(v []File)`
 
-SetFiles gets a reference to the given []File and assigns it to the Files field.
+SetFiles sets Files field to given value.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/go-experimental/go-petstore/docs/FormatTest.md
+++ b/samples/client/petstore/go-experimental/go-petstore/docs/FormatTest.md
@@ -46,22 +46,16 @@ GetInteger returns the Integer field if non-nil, zero value otherwise.
 
 ### GetIntegerOk
 
-`func (o *FormatTest) GetIntegerOk() (int32, bool)`
+`func (o *FormatTest) GetIntegerOk() (*int32, bool)`
 
 GetIntegerOk returns a tuple with the Integer field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasInteger
-
-`func (o *FormatTest) HasInteger() bool`
-
-HasInteger returns a boolean if a field has been set.
 
 ### SetInteger
 
 `func (o *FormatTest) SetInteger(v int32)`
 
-SetInteger gets a reference to the given int32 and assigns it to the Integer field.
+SetInteger sets Integer field to given value.
 
 ### GetInt32
 
@@ -71,22 +65,16 @@ GetInt32 returns the Int32 field if non-nil, zero value otherwise.
 
 ### GetInt32Ok
 
-`func (o *FormatTest) GetInt32Ok() (int32, bool)`
+`func (o *FormatTest) GetInt32Ok() (*int32, bool)`
 
 GetInt32Ok returns a tuple with the Int32 field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasInt32
-
-`func (o *FormatTest) HasInt32() bool`
-
-HasInt32 returns a boolean if a field has been set.
 
 ### SetInt32
 
 `func (o *FormatTest) SetInt32(v int32)`
 
-SetInt32 gets a reference to the given int32 and assigns it to the Int32 field.
+SetInt32 sets Int32 field to given value.
 
 ### GetInt64
 
@@ -96,22 +84,16 @@ GetInt64 returns the Int64 field if non-nil, zero value otherwise.
 
 ### GetInt64Ok
 
-`func (o *FormatTest) GetInt64Ok() (int64, bool)`
+`func (o *FormatTest) GetInt64Ok() (*int64, bool)`
 
 GetInt64Ok returns a tuple with the Int64 field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasInt64
-
-`func (o *FormatTest) HasInt64() bool`
-
-HasInt64 returns a boolean if a field has been set.
 
 ### SetInt64
 
 `func (o *FormatTest) SetInt64(v int64)`
 
-SetInt64 gets a reference to the given int64 and assigns it to the Int64 field.
+SetInt64 sets Int64 field to given value.
 
 ### GetNumber
 
@@ -121,22 +103,16 @@ GetNumber returns the Number field if non-nil, zero value otherwise.
 
 ### GetNumberOk
 
-`func (o *FormatTest) GetNumberOk() (float32, bool)`
+`func (o *FormatTest) GetNumberOk() (*float32, bool)`
 
 GetNumberOk returns a tuple with the Number field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasNumber
-
-`func (o *FormatTest) HasNumber() bool`
-
-HasNumber returns a boolean if a field has been set.
 
 ### SetNumber
 
 `func (o *FormatTest) SetNumber(v float32)`
 
-SetNumber gets a reference to the given float32 and assigns it to the Number field.
+SetNumber sets Number field to given value.
 
 ### GetFloat
 
@@ -146,22 +122,16 @@ GetFloat returns the Float field if non-nil, zero value otherwise.
 
 ### GetFloatOk
 
-`func (o *FormatTest) GetFloatOk() (float32, bool)`
+`func (o *FormatTest) GetFloatOk() (*float32, bool)`
 
 GetFloatOk returns a tuple with the Float field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasFloat
-
-`func (o *FormatTest) HasFloat() bool`
-
-HasFloat returns a boolean if a field has been set.
 
 ### SetFloat
 
 `func (o *FormatTest) SetFloat(v float32)`
 
-SetFloat gets a reference to the given float32 and assigns it to the Float field.
+SetFloat sets Float field to given value.
 
 ### GetDouble
 
@@ -171,22 +141,16 @@ GetDouble returns the Double field if non-nil, zero value otherwise.
 
 ### GetDoubleOk
 
-`func (o *FormatTest) GetDoubleOk() (float64, bool)`
+`func (o *FormatTest) GetDoubleOk() (*float64, bool)`
 
 GetDoubleOk returns a tuple with the Double field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasDouble
-
-`func (o *FormatTest) HasDouble() bool`
-
-HasDouble returns a boolean if a field has been set.
 
 ### SetDouble
 
 `func (o *FormatTest) SetDouble(v float64)`
 
-SetDouble gets a reference to the given float64 and assigns it to the Double field.
+SetDouble sets Double field to given value.
 
 ### GetString
 
@@ -196,22 +160,16 @@ GetString returns the String field if non-nil, zero value otherwise.
 
 ### GetStringOk
 
-`func (o *FormatTest) GetStringOk() (string, bool)`
+`func (o *FormatTest) GetStringOk() (*string, bool)`
 
 GetStringOk returns a tuple with the String field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasString
-
-`func (o *FormatTest) HasString() bool`
-
-HasString returns a boolean if a field has been set.
 
 ### SetString
 
 `func (o *FormatTest) SetString(v string)`
 
-SetString gets a reference to the given string and assigns it to the String field.
+SetString sets String field to given value.
 
 ### GetByte
 
@@ -221,22 +179,16 @@ GetByte returns the Byte field if non-nil, zero value otherwise.
 
 ### GetByteOk
 
-`func (o *FormatTest) GetByteOk() (string, bool)`
+`func (o *FormatTest) GetByteOk() (*string, bool)`
 
 GetByteOk returns a tuple with the Byte field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasByte
-
-`func (o *FormatTest) HasByte() bool`
-
-HasByte returns a boolean if a field has been set.
 
 ### SetByte
 
 `func (o *FormatTest) SetByte(v string)`
 
-SetByte gets a reference to the given string and assigns it to the Byte field.
+SetByte sets Byte field to given value.
 
 ### GetBinary
 
@@ -246,22 +198,16 @@ GetBinary returns the Binary field if non-nil, zero value otherwise.
 
 ### GetBinaryOk
 
-`func (o *FormatTest) GetBinaryOk() (*os.File, bool)`
+`func (o *FormatTest) GetBinaryOk() (**os.File, bool)`
 
 GetBinaryOk returns a tuple with the Binary field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasBinary
-
-`func (o *FormatTest) HasBinary() bool`
-
-HasBinary returns a boolean if a field has been set.
 
 ### SetBinary
 
 `func (o *FormatTest) SetBinary(v *os.File)`
 
-SetBinary gets a reference to the given *os.File and assigns it to the Binary field.
+SetBinary sets Binary field to given value.
 
 ### GetDate
 
@@ -271,22 +217,16 @@ GetDate returns the Date field if non-nil, zero value otherwise.
 
 ### GetDateOk
 
-`func (o *FormatTest) GetDateOk() (string, bool)`
+`func (o *FormatTest) GetDateOk() (*string, bool)`
 
 GetDateOk returns a tuple with the Date field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasDate
-
-`func (o *FormatTest) HasDate() bool`
-
-HasDate returns a boolean if a field has been set.
 
 ### SetDate
 
 `func (o *FormatTest) SetDate(v string)`
 
-SetDate gets a reference to the given string and assigns it to the Date field.
+SetDate sets Date field to given value.
 
 ### GetDateTime
 
@@ -296,22 +236,16 @@ GetDateTime returns the DateTime field if non-nil, zero value otherwise.
 
 ### GetDateTimeOk
 
-`func (o *FormatTest) GetDateTimeOk() (time.Time, bool)`
+`func (o *FormatTest) GetDateTimeOk() (*time.Time, bool)`
 
 GetDateTimeOk returns a tuple with the DateTime field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasDateTime
-
-`func (o *FormatTest) HasDateTime() bool`
-
-HasDateTime returns a boolean if a field has been set.
 
 ### SetDateTime
 
 `func (o *FormatTest) SetDateTime(v time.Time)`
 
-SetDateTime gets a reference to the given time.Time and assigns it to the DateTime field.
+SetDateTime sets DateTime field to given value.
 
 ### GetUuid
 
@@ -321,22 +255,16 @@ GetUuid returns the Uuid field if non-nil, zero value otherwise.
 
 ### GetUuidOk
 
-`func (o *FormatTest) GetUuidOk() (string, bool)`
+`func (o *FormatTest) GetUuidOk() (*string, bool)`
 
 GetUuidOk returns a tuple with the Uuid field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasUuid
-
-`func (o *FormatTest) HasUuid() bool`
-
-HasUuid returns a boolean if a field has been set.
 
 ### SetUuid
 
 `func (o *FormatTest) SetUuid(v string)`
 
-SetUuid gets a reference to the given string and assigns it to the Uuid field.
+SetUuid sets Uuid field to given value.
 
 ### GetPassword
 
@@ -346,22 +274,16 @@ GetPassword returns the Password field if non-nil, zero value otherwise.
 
 ### GetPasswordOk
 
-`func (o *FormatTest) GetPasswordOk() (string, bool)`
+`func (o *FormatTest) GetPasswordOk() (*string, bool)`
 
 GetPasswordOk returns a tuple with the Password field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasPassword
-
-`func (o *FormatTest) HasPassword() bool`
-
-HasPassword returns a boolean if a field has been set.
 
 ### SetPassword
 
 `func (o *FormatTest) SetPassword(v string)`
 
-SetPassword gets a reference to the given string and assigns it to the Password field.
+SetPassword sets Password field to given value.
 
 ### GetBigDecimal
 
@@ -371,22 +293,16 @@ GetBigDecimal returns the BigDecimal field if non-nil, zero value otherwise.
 
 ### GetBigDecimalOk
 
-`func (o *FormatTest) GetBigDecimalOk() (float64, bool)`
+`func (o *FormatTest) GetBigDecimalOk() (*float64, bool)`
 
 GetBigDecimalOk returns a tuple with the BigDecimal field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasBigDecimal
-
-`func (o *FormatTest) HasBigDecimal() bool`
-
-HasBigDecimal returns a boolean if a field has been set.
 
 ### SetBigDecimal
 
 `func (o *FormatTest) SetBigDecimal(v float64)`
 
-SetBigDecimal gets a reference to the given float64 and assigns it to the BigDecimal field.
+SetBigDecimal sets BigDecimal field to given value.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/go-experimental/go-petstore/docs/FormatTest.md
+++ b/samples/client/petstore/go-experimental/go-petstore/docs/FormatTest.md
@@ -57,6 +57,12 @@ and a boolean to check if the value has been set.
 
 SetInteger sets Integer field to given value.
 
+### HasInteger
+
+`func (o *FormatTest) HasInteger() bool`
+
+HasInteger returns a boolean if a field has been set.
+
 ### GetInt32
 
 `func (o *FormatTest) GetInt32() int32`
@@ -75,6 +81,12 @@ and a boolean to check if the value has been set.
 `func (o *FormatTest) SetInt32(v int32)`
 
 SetInt32 sets Int32 field to given value.
+
+### HasInt32
+
+`func (o *FormatTest) HasInt32() bool`
+
+HasInt32 returns a boolean if a field has been set.
 
 ### GetInt64
 
@@ -95,6 +107,12 @@ and a boolean to check if the value has been set.
 
 SetInt64 sets Int64 field to given value.
 
+### HasInt64
+
+`func (o *FormatTest) HasInt64() bool`
+
+HasInt64 returns a boolean if a field has been set.
+
 ### GetNumber
 
 `func (o *FormatTest) GetNumber() float32`
@@ -113,6 +131,7 @@ and a boolean to check if the value has been set.
 `func (o *FormatTest) SetNumber(v float32)`
 
 SetNumber sets Number field to given value.
+
 
 ### GetFloat
 
@@ -133,6 +152,12 @@ and a boolean to check if the value has been set.
 
 SetFloat sets Float field to given value.
 
+### HasFloat
+
+`func (o *FormatTest) HasFloat() bool`
+
+HasFloat returns a boolean if a field has been set.
+
 ### GetDouble
 
 `func (o *FormatTest) GetDouble() float64`
@@ -151,6 +176,12 @@ and a boolean to check if the value has been set.
 `func (o *FormatTest) SetDouble(v float64)`
 
 SetDouble sets Double field to given value.
+
+### HasDouble
+
+`func (o *FormatTest) HasDouble() bool`
+
+HasDouble returns a boolean if a field has been set.
 
 ### GetString
 
@@ -171,6 +202,12 @@ and a boolean to check if the value has been set.
 
 SetString sets String field to given value.
 
+### HasString
+
+`func (o *FormatTest) HasString() bool`
+
+HasString returns a boolean if a field has been set.
+
 ### GetByte
 
 `func (o *FormatTest) GetByte() string`
@@ -189,6 +226,7 @@ and a boolean to check if the value has been set.
 `func (o *FormatTest) SetByte(v string)`
 
 SetByte sets Byte field to given value.
+
 
 ### GetBinary
 
@@ -209,6 +247,12 @@ and a boolean to check if the value has been set.
 
 SetBinary sets Binary field to given value.
 
+### HasBinary
+
+`func (o *FormatTest) HasBinary() bool`
+
+HasBinary returns a boolean if a field has been set.
+
 ### GetDate
 
 `func (o *FormatTest) GetDate() string`
@@ -227,6 +271,7 @@ and a boolean to check if the value has been set.
 `func (o *FormatTest) SetDate(v string)`
 
 SetDate sets Date field to given value.
+
 
 ### GetDateTime
 
@@ -247,6 +292,12 @@ and a boolean to check if the value has been set.
 
 SetDateTime sets DateTime field to given value.
 
+### HasDateTime
+
+`func (o *FormatTest) HasDateTime() bool`
+
+HasDateTime returns a boolean if a field has been set.
+
 ### GetUuid
 
 `func (o *FormatTest) GetUuid() string`
@@ -265,6 +316,12 @@ and a boolean to check if the value has been set.
 `func (o *FormatTest) SetUuid(v string)`
 
 SetUuid sets Uuid field to given value.
+
+### HasUuid
+
+`func (o *FormatTest) HasUuid() bool`
+
+HasUuid returns a boolean if a field has been set.
 
 ### GetPassword
 
@@ -285,6 +342,7 @@ and a boolean to check if the value has been set.
 
 SetPassword sets Password field to given value.
 
+
 ### GetBigDecimal
 
 `func (o *FormatTest) GetBigDecimal() float64`
@@ -303,6 +361,12 @@ and a boolean to check if the value has been set.
 `func (o *FormatTest) SetBigDecimal(v float64)`
 
 SetBigDecimal sets BigDecimal field to given value.
+
+### HasBigDecimal
+
+`func (o *FormatTest) HasBigDecimal() bool`
+
+HasBigDecimal returns a boolean if a field has been set.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/go-experimental/go-petstore/docs/HasOnlyReadOnly.md
+++ b/samples/client/petstore/go-experimental/go-petstore/docs/HasOnlyReadOnly.md
@@ -45,6 +45,12 @@ and a boolean to check if the value has been set.
 
 SetBar sets Bar field to given value.
 
+### HasBar
+
+`func (o *HasOnlyReadOnly) HasBar() bool`
+
+HasBar returns a boolean if a field has been set.
+
 ### GetFoo
 
 `func (o *HasOnlyReadOnly) GetFoo() string`
@@ -63,6 +69,12 @@ and a boolean to check if the value has been set.
 `func (o *HasOnlyReadOnly) SetFoo(v string)`
 
 SetFoo sets Foo field to given value.
+
+### HasFoo
+
+`func (o *HasOnlyReadOnly) HasFoo() bool`
+
+HasFoo returns a boolean if a field has been set.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/go-experimental/go-petstore/docs/HasOnlyReadOnly.md
+++ b/samples/client/petstore/go-experimental/go-petstore/docs/HasOnlyReadOnly.md
@@ -34,22 +34,16 @@ GetBar returns the Bar field if non-nil, zero value otherwise.
 
 ### GetBarOk
 
-`func (o *HasOnlyReadOnly) GetBarOk() (string, bool)`
+`func (o *HasOnlyReadOnly) GetBarOk() (*string, bool)`
 
 GetBarOk returns a tuple with the Bar field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasBar
-
-`func (o *HasOnlyReadOnly) HasBar() bool`
-
-HasBar returns a boolean if a field has been set.
 
 ### SetBar
 
 `func (o *HasOnlyReadOnly) SetBar(v string)`
 
-SetBar gets a reference to the given string and assigns it to the Bar field.
+SetBar sets Bar field to given value.
 
 ### GetFoo
 
@@ -59,22 +53,16 @@ GetFoo returns the Foo field if non-nil, zero value otherwise.
 
 ### GetFooOk
 
-`func (o *HasOnlyReadOnly) GetFooOk() (string, bool)`
+`func (o *HasOnlyReadOnly) GetFooOk() (*string, bool)`
 
 GetFooOk returns a tuple with the Foo field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasFoo
-
-`func (o *HasOnlyReadOnly) HasFoo() bool`
-
-HasFoo returns a boolean if a field has been set.
 
 ### SetFoo
 
 `func (o *HasOnlyReadOnly) SetFoo(v string)`
 
-SetFoo gets a reference to the given string and assigns it to the Foo field.
+SetFoo sets Foo field to given value.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/go-experimental/go-petstore/docs/List.md
+++ b/samples/client/petstore/go-experimental/go-petstore/docs/List.md
@@ -33,22 +33,16 @@ GetVar123List returns the Var123List field if non-nil, zero value otherwise.
 
 ### GetVar123ListOk
 
-`func (o *List) GetVar123ListOk() (string, bool)`
+`func (o *List) GetVar123ListOk() (*string, bool)`
 
 GetVar123ListOk returns a tuple with the Var123List field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasVar123List
-
-`func (o *List) HasVar123List() bool`
-
-HasVar123List returns a boolean if a field has been set.
 
 ### SetVar123List
 
 `func (o *List) SetVar123List(v string)`
 
-SetVar123List gets a reference to the given string and assigns it to the Var123List field.
+SetVar123List sets Var123List field to given value.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/go-experimental/go-petstore/docs/List.md
+++ b/samples/client/petstore/go-experimental/go-petstore/docs/List.md
@@ -44,6 +44,12 @@ and a boolean to check if the value has been set.
 
 SetVar123List sets Var123List field to given value.
 
+### HasVar123List
+
+`func (o *List) HasVar123List() bool`
+
+HasVar123List returns a boolean if a field has been set.
+
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/go-experimental/go-petstore/docs/MapTest.md
+++ b/samples/client/petstore/go-experimental/go-petstore/docs/MapTest.md
@@ -47,6 +47,12 @@ and a boolean to check if the value has been set.
 
 SetMapMapOfString sets MapMapOfString field to given value.
 
+### HasMapMapOfString
+
+`func (o *MapTest) HasMapMapOfString() bool`
+
+HasMapMapOfString returns a boolean if a field has been set.
+
 ### GetMapOfEnumString
 
 `func (o *MapTest) GetMapOfEnumString() map[string]string`
@@ -65,6 +71,12 @@ and a boolean to check if the value has been set.
 `func (o *MapTest) SetMapOfEnumString(v map[string]string)`
 
 SetMapOfEnumString sets MapOfEnumString field to given value.
+
+### HasMapOfEnumString
+
+`func (o *MapTest) HasMapOfEnumString() bool`
+
+HasMapOfEnumString returns a boolean if a field has been set.
 
 ### GetDirectMap
 
@@ -85,6 +97,12 @@ and a boolean to check if the value has been set.
 
 SetDirectMap sets DirectMap field to given value.
 
+### HasDirectMap
+
+`func (o *MapTest) HasDirectMap() bool`
+
+HasDirectMap returns a boolean if a field has been set.
+
 ### GetIndirectMap
 
 `func (o *MapTest) GetIndirectMap() map[string]bool`
@@ -103,6 +121,12 @@ and a boolean to check if the value has been set.
 `func (o *MapTest) SetIndirectMap(v map[string]bool)`
 
 SetIndirectMap sets IndirectMap field to given value.
+
+### HasIndirectMap
+
+`func (o *MapTest) HasIndirectMap() bool`
+
+HasIndirectMap returns a boolean if a field has been set.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/go-experimental/go-petstore/docs/MapTest.md
+++ b/samples/client/petstore/go-experimental/go-petstore/docs/MapTest.md
@@ -36,22 +36,16 @@ GetMapMapOfString returns the MapMapOfString field if non-nil, zero value otherw
 
 ### GetMapMapOfStringOk
 
-`func (o *MapTest) GetMapMapOfStringOk() (map[string]map[string]string, bool)`
+`func (o *MapTest) GetMapMapOfStringOk() (*map[string]map[string]string, bool)`
 
 GetMapMapOfStringOk returns a tuple with the MapMapOfString field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasMapMapOfString
-
-`func (o *MapTest) HasMapMapOfString() bool`
-
-HasMapMapOfString returns a boolean if a field has been set.
 
 ### SetMapMapOfString
 
 `func (o *MapTest) SetMapMapOfString(v map[string]map[string]string)`
 
-SetMapMapOfString gets a reference to the given map[string]map[string]string and assigns it to the MapMapOfString field.
+SetMapMapOfString sets MapMapOfString field to given value.
 
 ### GetMapOfEnumString
 
@@ -61,22 +55,16 @@ GetMapOfEnumString returns the MapOfEnumString field if non-nil, zero value othe
 
 ### GetMapOfEnumStringOk
 
-`func (o *MapTest) GetMapOfEnumStringOk() (map[string]string, bool)`
+`func (o *MapTest) GetMapOfEnumStringOk() (*map[string]string, bool)`
 
 GetMapOfEnumStringOk returns a tuple with the MapOfEnumString field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasMapOfEnumString
-
-`func (o *MapTest) HasMapOfEnumString() bool`
-
-HasMapOfEnumString returns a boolean if a field has been set.
 
 ### SetMapOfEnumString
 
 `func (o *MapTest) SetMapOfEnumString(v map[string]string)`
 
-SetMapOfEnumString gets a reference to the given map[string]string and assigns it to the MapOfEnumString field.
+SetMapOfEnumString sets MapOfEnumString field to given value.
 
 ### GetDirectMap
 
@@ -86,22 +74,16 @@ GetDirectMap returns the DirectMap field if non-nil, zero value otherwise.
 
 ### GetDirectMapOk
 
-`func (o *MapTest) GetDirectMapOk() (map[string]bool, bool)`
+`func (o *MapTest) GetDirectMapOk() (*map[string]bool, bool)`
 
 GetDirectMapOk returns a tuple with the DirectMap field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasDirectMap
-
-`func (o *MapTest) HasDirectMap() bool`
-
-HasDirectMap returns a boolean if a field has been set.
 
 ### SetDirectMap
 
 `func (o *MapTest) SetDirectMap(v map[string]bool)`
 
-SetDirectMap gets a reference to the given map[string]bool and assigns it to the DirectMap field.
+SetDirectMap sets DirectMap field to given value.
 
 ### GetIndirectMap
 
@@ -111,22 +93,16 @@ GetIndirectMap returns the IndirectMap field if non-nil, zero value otherwise.
 
 ### GetIndirectMapOk
 
-`func (o *MapTest) GetIndirectMapOk() (map[string]bool, bool)`
+`func (o *MapTest) GetIndirectMapOk() (*map[string]bool, bool)`
 
 GetIndirectMapOk returns a tuple with the IndirectMap field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasIndirectMap
-
-`func (o *MapTest) HasIndirectMap() bool`
-
-HasIndirectMap returns a boolean if a field has been set.
 
 ### SetIndirectMap
 
 `func (o *MapTest) SetIndirectMap(v map[string]bool)`
 
-SetIndirectMap gets a reference to the given map[string]bool and assigns it to the IndirectMap field.
+SetIndirectMap sets IndirectMap field to given value.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/go-experimental/go-petstore/docs/MixedPropertiesAndAdditionalPropertiesClass.md
+++ b/samples/client/petstore/go-experimental/go-petstore/docs/MixedPropertiesAndAdditionalPropertiesClass.md
@@ -46,6 +46,12 @@ and a boolean to check if the value has been set.
 
 SetUuid sets Uuid field to given value.
 
+### HasUuid
+
+`func (o *MixedPropertiesAndAdditionalPropertiesClass) HasUuid() bool`
+
+HasUuid returns a boolean if a field has been set.
+
 ### GetDateTime
 
 `func (o *MixedPropertiesAndAdditionalPropertiesClass) GetDateTime() time.Time`
@@ -65,6 +71,12 @@ and a boolean to check if the value has been set.
 
 SetDateTime sets DateTime field to given value.
 
+### HasDateTime
+
+`func (o *MixedPropertiesAndAdditionalPropertiesClass) HasDateTime() bool`
+
+HasDateTime returns a boolean if a field has been set.
+
 ### GetMap
 
 `func (o *MixedPropertiesAndAdditionalPropertiesClass) GetMap() map[string]Animal`
@@ -83,6 +95,12 @@ and a boolean to check if the value has been set.
 `func (o *MixedPropertiesAndAdditionalPropertiesClass) SetMap(v map[string]Animal)`
 
 SetMap sets Map field to given value.
+
+### HasMap
+
+`func (o *MixedPropertiesAndAdditionalPropertiesClass) HasMap() bool`
+
+HasMap returns a boolean if a field has been set.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/go-experimental/go-petstore/docs/MixedPropertiesAndAdditionalPropertiesClass.md
+++ b/samples/client/petstore/go-experimental/go-petstore/docs/MixedPropertiesAndAdditionalPropertiesClass.md
@@ -35,22 +35,16 @@ GetUuid returns the Uuid field if non-nil, zero value otherwise.
 
 ### GetUuidOk
 
-`func (o *MixedPropertiesAndAdditionalPropertiesClass) GetUuidOk() (string, bool)`
+`func (o *MixedPropertiesAndAdditionalPropertiesClass) GetUuidOk() (*string, bool)`
 
 GetUuidOk returns a tuple with the Uuid field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasUuid
-
-`func (o *MixedPropertiesAndAdditionalPropertiesClass) HasUuid() bool`
-
-HasUuid returns a boolean if a field has been set.
 
 ### SetUuid
 
 `func (o *MixedPropertiesAndAdditionalPropertiesClass) SetUuid(v string)`
 
-SetUuid gets a reference to the given string and assigns it to the Uuid field.
+SetUuid sets Uuid field to given value.
 
 ### GetDateTime
 
@@ -60,22 +54,16 @@ GetDateTime returns the DateTime field if non-nil, zero value otherwise.
 
 ### GetDateTimeOk
 
-`func (o *MixedPropertiesAndAdditionalPropertiesClass) GetDateTimeOk() (time.Time, bool)`
+`func (o *MixedPropertiesAndAdditionalPropertiesClass) GetDateTimeOk() (*time.Time, bool)`
 
 GetDateTimeOk returns a tuple with the DateTime field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasDateTime
-
-`func (o *MixedPropertiesAndAdditionalPropertiesClass) HasDateTime() bool`
-
-HasDateTime returns a boolean if a field has been set.
 
 ### SetDateTime
 
 `func (o *MixedPropertiesAndAdditionalPropertiesClass) SetDateTime(v time.Time)`
 
-SetDateTime gets a reference to the given time.Time and assigns it to the DateTime field.
+SetDateTime sets DateTime field to given value.
 
 ### GetMap
 
@@ -85,22 +73,16 @@ GetMap returns the Map field if non-nil, zero value otherwise.
 
 ### GetMapOk
 
-`func (o *MixedPropertiesAndAdditionalPropertiesClass) GetMapOk() (map[string]Animal, bool)`
+`func (o *MixedPropertiesAndAdditionalPropertiesClass) GetMapOk() (*map[string]Animal, bool)`
 
 GetMapOk returns a tuple with the Map field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasMap
-
-`func (o *MixedPropertiesAndAdditionalPropertiesClass) HasMap() bool`
-
-HasMap returns a boolean if a field has been set.
 
 ### SetMap
 
 `func (o *MixedPropertiesAndAdditionalPropertiesClass) SetMap(v map[string]Animal)`
 
-SetMap gets a reference to the given map[string]Animal and assigns it to the Map field.
+SetMap sets Map field to given value.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/go-experimental/go-petstore/docs/Model200Response.md
+++ b/samples/client/petstore/go-experimental/go-petstore/docs/Model200Response.md
@@ -34,22 +34,16 @@ GetName returns the Name field if non-nil, zero value otherwise.
 
 ### GetNameOk
 
-`func (o *Model200Response) GetNameOk() (int32, bool)`
+`func (o *Model200Response) GetNameOk() (*int32, bool)`
 
 GetNameOk returns a tuple with the Name field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasName
-
-`func (o *Model200Response) HasName() bool`
-
-HasName returns a boolean if a field has been set.
 
 ### SetName
 
 `func (o *Model200Response) SetName(v int32)`
 
-SetName gets a reference to the given int32 and assigns it to the Name field.
+SetName sets Name field to given value.
 
 ### GetClass
 
@@ -59,22 +53,16 @@ GetClass returns the Class field if non-nil, zero value otherwise.
 
 ### GetClassOk
 
-`func (o *Model200Response) GetClassOk() (string, bool)`
+`func (o *Model200Response) GetClassOk() (*string, bool)`
 
 GetClassOk returns a tuple with the Class field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasClass
-
-`func (o *Model200Response) HasClass() bool`
-
-HasClass returns a boolean if a field has been set.
 
 ### SetClass
 
 `func (o *Model200Response) SetClass(v string)`
 
-SetClass gets a reference to the given string and assigns it to the Class field.
+SetClass sets Class field to given value.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/go-experimental/go-petstore/docs/Model200Response.md
+++ b/samples/client/petstore/go-experimental/go-petstore/docs/Model200Response.md
@@ -45,6 +45,12 @@ and a boolean to check if the value has been set.
 
 SetName sets Name field to given value.
 
+### HasName
+
+`func (o *Model200Response) HasName() bool`
+
+HasName returns a boolean if a field has been set.
+
 ### GetClass
 
 `func (o *Model200Response) GetClass() string`
@@ -63,6 +69,12 @@ and a boolean to check if the value has been set.
 `func (o *Model200Response) SetClass(v string)`
 
 SetClass sets Class field to given value.
+
+### HasClass
+
+`func (o *Model200Response) HasClass() bool`
+
+HasClass returns a boolean if a field has been set.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/go-experimental/go-petstore/docs/Name.md
+++ b/samples/client/petstore/go-experimental/go-petstore/docs/Name.md
@@ -36,22 +36,16 @@ GetName returns the Name field if non-nil, zero value otherwise.
 
 ### GetNameOk
 
-`func (o *Name) GetNameOk() (int32, bool)`
+`func (o *Name) GetNameOk() (*int32, bool)`
 
 GetNameOk returns a tuple with the Name field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasName
-
-`func (o *Name) HasName() bool`
-
-HasName returns a boolean if a field has been set.
 
 ### SetName
 
 `func (o *Name) SetName(v int32)`
 
-SetName gets a reference to the given int32 and assigns it to the Name field.
+SetName sets Name field to given value.
 
 ### GetSnakeCase
 
@@ -61,22 +55,16 @@ GetSnakeCase returns the SnakeCase field if non-nil, zero value otherwise.
 
 ### GetSnakeCaseOk
 
-`func (o *Name) GetSnakeCaseOk() (int32, bool)`
+`func (o *Name) GetSnakeCaseOk() (*int32, bool)`
 
 GetSnakeCaseOk returns a tuple with the SnakeCase field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasSnakeCase
-
-`func (o *Name) HasSnakeCase() bool`
-
-HasSnakeCase returns a boolean if a field has been set.
 
 ### SetSnakeCase
 
 `func (o *Name) SetSnakeCase(v int32)`
 
-SetSnakeCase gets a reference to the given int32 and assigns it to the SnakeCase field.
+SetSnakeCase sets SnakeCase field to given value.
 
 ### GetProperty
 
@@ -86,22 +74,16 @@ GetProperty returns the Property field if non-nil, zero value otherwise.
 
 ### GetPropertyOk
 
-`func (o *Name) GetPropertyOk() (string, bool)`
+`func (o *Name) GetPropertyOk() (*string, bool)`
 
 GetPropertyOk returns a tuple with the Property field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasProperty
-
-`func (o *Name) HasProperty() bool`
-
-HasProperty returns a boolean if a field has been set.
 
 ### SetProperty
 
 `func (o *Name) SetProperty(v string)`
 
-SetProperty gets a reference to the given string and assigns it to the Property field.
+SetProperty sets Property field to given value.
 
 ### GetVar123Number
 
@@ -111,22 +93,16 @@ GetVar123Number returns the Var123Number field if non-nil, zero value otherwise.
 
 ### GetVar123NumberOk
 
-`func (o *Name) GetVar123NumberOk() (int32, bool)`
+`func (o *Name) GetVar123NumberOk() (*int32, bool)`
 
 GetVar123NumberOk returns a tuple with the Var123Number field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasVar123Number
-
-`func (o *Name) HasVar123Number() bool`
-
-HasVar123Number returns a boolean if a field has been set.
 
 ### SetVar123Number
 
 `func (o *Name) SetVar123Number(v int32)`
 
-SetVar123Number gets a reference to the given int32 and assigns it to the Var123Number field.
+SetVar123Number sets Var123Number field to given value.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/go-experimental/go-petstore/docs/Name.md
+++ b/samples/client/petstore/go-experimental/go-petstore/docs/Name.md
@@ -47,6 +47,7 @@ and a boolean to check if the value has been set.
 
 SetName sets Name field to given value.
 
+
 ### GetSnakeCase
 
 `func (o *Name) GetSnakeCase() int32`
@@ -65,6 +66,12 @@ and a boolean to check if the value has been set.
 `func (o *Name) SetSnakeCase(v int32)`
 
 SetSnakeCase sets SnakeCase field to given value.
+
+### HasSnakeCase
+
+`func (o *Name) HasSnakeCase() bool`
+
+HasSnakeCase returns a boolean if a field has been set.
 
 ### GetProperty
 
@@ -85,6 +92,12 @@ and a boolean to check if the value has been set.
 
 SetProperty sets Property field to given value.
 
+### HasProperty
+
+`func (o *Name) HasProperty() bool`
+
+HasProperty returns a boolean if a field has been set.
+
 ### GetVar123Number
 
 `func (o *Name) GetVar123Number() int32`
@@ -103,6 +116,12 @@ and a boolean to check if the value has been set.
 `func (o *Name) SetVar123Number(v int32)`
 
 SetVar123Number sets Var123Number field to given value.
+
+### HasVar123Number
+
+`func (o *Name) HasVar123Number() bool`
+
+HasVar123Number returns a boolean if a field has been set.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/go-experimental/go-petstore/docs/NumberOnly.md
+++ b/samples/client/petstore/go-experimental/go-petstore/docs/NumberOnly.md
@@ -44,6 +44,12 @@ and a boolean to check if the value has been set.
 
 SetJustNumber sets JustNumber field to given value.
 
+### HasJustNumber
+
+`func (o *NumberOnly) HasJustNumber() bool`
+
+HasJustNumber returns a boolean if a field has been set.
+
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/go-experimental/go-petstore/docs/NumberOnly.md
+++ b/samples/client/petstore/go-experimental/go-petstore/docs/NumberOnly.md
@@ -33,22 +33,16 @@ GetJustNumber returns the JustNumber field if non-nil, zero value otherwise.
 
 ### GetJustNumberOk
 
-`func (o *NumberOnly) GetJustNumberOk() (float32, bool)`
+`func (o *NumberOnly) GetJustNumberOk() (*float32, bool)`
 
 GetJustNumberOk returns a tuple with the JustNumber field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasJustNumber
-
-`func (o *NumberOnly) HasJustNumber() bool`
-
-HasJustNumber returns a boolean if a field has been set.
 
 ### SetJustNumber
 
 `func (o *NumberOnly) SetJustNumber(v float32)`
 
-SetJustNumber gets a reference to the given float32 and assigns it to the JustNumber field.
+SetJustNumber sets JustNumber field to given value.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/go-experimental/go-petstore/docs/Order.md
+++ b/samples/client/petstore/go-experimental/go-petstore/docs/Order.md
@@ -38,22 +38,16 @@ GetId returns the Id field if non-nil, zero value otherwise.
 
 ### GetIdOk
 
-`func (o *Order) GetIdOk() (int64, bool)`
+`func (o *Order) GetIdOk() (*int64, bool)`
 
 GetIdOk returns a tuple with the Id field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasId
-
-`func (o *Order) HasId() bool`
-
-HasId returns a boolean if a field has been set.
 
 ### SetId
 
 `func (o *Order) SetId(v int64)`
 
-SetId gets a reference to the given int64 and assigns it to the Id field.
+SetId sets Id field to given value.
 
 ### GetPetId
 
@@ -63,22 +57,16 @@ GetPetId returns the PetId field if non-nil, zero value otherwise.
 
 ### GetPetIdOk
 
-`func (o *Order) GetPetIdOk() (int64, bool)`
+`func (o *Order) GetPetIdOk() (*int64, bool)`
 
 GetPetIdOk returns a tuple with the PetId field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasPetId
-
-`func (o *Order) HasPetId() bool`
-
-HasPetId returns a boolean if a field has been set.
 
 ### SetPetId
 
 `func (o *Order) SetPetId(v int64)`
 
-SetPetId gets a reference to the given int64 and assigns it to the PetId field.
+SetPetId sets PetId field to given value.
 
 ### GetQuantity
 
@@ -88,22 +76,16 @@ GetQuantity returns the Quantity field if non-nil, zero value otherwise.
 
 ### GetQuantityOk
 
-`func (o *Order) GetQuantityOk() (int32, bool)`
+`func (o *Order) GetQuantityOk() (*int32, bool)`
 
 GetQuantityOk returns a tuple with the Quantity field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasQuantity
-
-`func (o *Order) HasQuantity() bool`
-
-HasQuantity returns a boolean if a field has been set.
 
 ### SetQuantity
 
 `func (o *Order) SetQuantity(v int32)`
 
-SetQuantity gets a reference to the given int32 and assigns it to the Quantity field.
+SetQuantity sets Quantity field to given value.
 
 ### GetShipDate
 
@@ -113,22 +95,16 @@ GetShipDate returns the ShipDate field if non-nil, zero value otherwise.
 
 ### GetShipDateOk
 
-`func (o *Order) GetShipDateOk() (time.Time, bool)`
+`func (o *Order) GetShipDateOk() (*time.Time, bool)`
 
 GetShipDateOk returns a tuple with the ShipDate field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasShipDate
-
-`func (o *Order) HasShipDate() bool`
-
-HasShipDate returns a boolean if a field has been set.
 
 ### SetShipDate
 
 `func (o *Order) SetShipDate(v time.Time)`
 
-SetShipDate gets a reference to the given time.Time and assigns it to the ShipDate field.
+SetShipDate sets ShipDate field to given value.
 
 ### GetStatus
 
@@ -138,22 +114,16 @@ GetStatus returns the Status field if non-nil, zero value otherwise.
 
 ### GetStatusOk
 
-`func (o *Order) GetStatusOk() (string, bool)`
+`func (o *Order) GetStatusOk() (*string, bool)`
 
 GetStatusOk returns a tuple with the Status field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasStatus
-
-`func (o *Order) HasStatus() bool`
-
-HasStatus returns a boolean if a field has been set.
 
 ### SetStatus
 
 `func (o *Order) SetStatus(v string)`
 
-SetStatus gets a reference to the given string and assigns it to the Status field.
+SetStatus sets Status field to given value.
 
 ### GetComplete
 
@@ -163,22 +133,16 @@ GetComplete returns the Complete field if non-nil, zero value otherwise.
 
 ### GetCompleteOk
 
-`func (o *Order) GetCompleteOk() (bool, bool)`
+`func (o *Order) GetCompleteOk() (*bool, bool)`
 
 GetCompleteOk returns a tuple with the Complete field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasComplete
-
-`func (o *Order) HasComplete() bool`
-
-HasComplete returns a boolean if a field has been set.
 
 ### SetComplete
 
 `func (o *Order) SetComplete(v bool)`
 
-SetComplete gets a reference to the given bool and assigns it to the Complete field.
+SetComplete sets Complete field to given value.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/go-experimental/go-petstore/docs/Order.md
+++ b/samples/client/petstore/go-experimental/go-petstore/docs/Order.md
@@ -49,6 +49,12 @@ and a boolean to check if the value has been set.
 
 SetId sets Id field to given value.
 
+### HasId
+
+`func (o *Order) HasId() bool`
+
+HasId returns a boolean if a field has been set.
+
 ### GetPetId
 
 `func (o *Order) GetPetId() int64`
@@ -67,6 +73,12 @@ and a boolean to check if the value has been set.
 `func (o *Order) SetPetId(v int64)`
 
 SetPetId sets PetId field to given value.
+
+### HasPetId
+
+`func (o *Order) HasPetId() bool`
+
+HasPetId returns a boolean if a field has been set.
 
 ### GetQuantity
 
@@ -87,6 +99,12 @@ and a boolean to check if the value has been set.
 
 SetQuantity sets Quantity field to given value.
 
+### HasQuantity
+
+`func (o *Order) HasQuantity() bool`
+
+HasQuantity returns a boolean if a field has been set.
+
 ### GetShipDate
 
 `func (o *Order) GetShipDate() time.Time`
@@ -105,6 +123,12 @@ and a boolean to check if the value has been set.
 `func (o *Order) SetShipDate(v time.Time)`
 
 SetShipDate sets ShipDate field to given value.
+
+### HasShipDate
+
+`func (o *Order) HasShipDate() bool`
+
+HasShipDate returns a boolean if a field has been set.
 
 ### GetStatus
 
@@ -125,6 +149,12 @@ and a boolean to check if the value has been set.
 
 SetStatus sets Status field to given value.
 
+### HasStatus
+
+`func (o *Order) HasStatus() bool`
+
+HasStatus returns a boolean if a field has been set.
+
 ### GetComplete
 
 `func (o *Order) GetComplete() bool`
@@ -143,6 +173,12 @@ and a boolean to check if the value has been set.
 `func (o *Order) SetComplete(v bool)`
 
 SetComplete sets Complete field to given value.
+
+### HasComplete
+
+`func (o *Order) HasComplete() bool`
+
+HasComplete returns a boolean if a field has been set.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/go-experimental/go-petstore/docs/OuterComposite.md
+++ b/samples/client/petstore/go-experimental/go-petstore/docs/OuterComposite.md
@@ -35,22 +35,16 @@ GetMyNumber returns the MyNumber field if non-nil, zero value otherwise.
 
 ### GetMyNumberOk
 
-`func (o *OuterComposite) GetMyNumberOk() (float32, bool)`
+`func (o *OuterComposite) GetMyNumberOk() (*float32, bool)`
 
 GetMyNumberOk returns a tuple with the MyNumber field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasMyNumber
-
-`func (o *OuterComposite) HasMyNumber() bool`
-
-HasMyNumber returns a boolean if a field has been set.
 
 ### SetMyNumber
 
 `func (o *OuterComposite) SetMyNumber(v float32)`
 
-SetMyNumber gets a reference to the given float32 and assigns it to the MyNumber field.
+SetMyNumber sets MyNumber field to given value.
 
 ### GetMyString
 
@@ -60,22 +54,16 @@ GetMyString returns the MyString field if non-nil, zero value otherwise.
 
 ### GetMyStringOk
 
-`func (o *OuterComposite) GetMyStringOk() (string, bool)`
+`func (o *OuterComposite) GetMyStringOk() (*string, bool)`
 
 GetMyStringOk returns a tuple with the MyString field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasMyString
-
-`func (o *OuterComposite) HasMyString() bool`
-
-HasMyString returns a boolean if a field has been set.
 
 ### SetMyString
 
 `func (o *OuterComposite) SetMyString(v string)`
 
-SetMyString gets a reference to the given string and assigns it to the MyString field.
+SetMyString sets MyString field to given value.
 
 ### GetMyBoolean
 
@@ -85,22 +73,16 @@ GetMyBoolean returns the MyBoolean field if non-nil, zero value otherwise.
 
 ### GetMyBooleanOk
 
-`func (o *OuterComposite) GetMyBooleanOk() (bool, bool)`
+`func (o *OuterComposite) GetMyBooleanOk() (*bool, bool)`
 
 GetMyBooleanOk returns a tuple with the MyBoolean field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasMyBoolean
-
-`func (o *OuterComposite) HasMyBoolean() bool`
-
-HasMyBoolean returns a boolean if a field has been set.
 
 ### SetMyBoolean
 
 `func (o *OuterComposite) SetMyBoolean(v bool)`
 
-SetMyBoolean gets a reference to the given bool and assigns it to the MyBoolean field.
+SetMyBoolean sets MyBoolean field to given value.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/go-experimental/go-petstore/docs/OuterComposite.md
+++ b/samples/client/petstore/go-experimental/go-petstore/docs/OuterComposite.md
@@ -46,6 +46,12 @@ and a boolean to check if the value has been set.
 
 SetMyNumber sets MyNumber field to given value.
 
+### HasMyNumber
+
+`func (o *OuterComposite) HasMyNumber() bool`
+
+HasMyNumber returns a boolean if a field has been set.
+
 ### GetMyString
 
 `func (o *OuterComposite) GetMyString() string`
@@ -65,6 +71,12 @@ and a boolean to check if the value has been set.
 
 SetMyString sets MyString field to given value.
 
+### HasMyString
+
+`func (o *OuterComposite) HasMyString() bool`
+
+HasMyString returns a boolean if a field has been set.
+
 ### GetMyBoolean
 
 `func (o *OuterComposite) GetMyBoolean() bool`
@@ -83,6 +95,12 @@ and a boolean to check if the value has been set.
 `func (o *OuterComposite) SetMyBoolean(v bool)`
 
 SetMyBoolean sets MyBoolean field to given value.
+
+### HasMyBoolean
+
+`func (o *OuterComposite) HasMyBoolean() bool`
+
+HasMyBoolean returns a boolean if a field has been set.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/go-experimental/go-petstore/docs/Pet.md
+++ b/samples/client/petstore/go-experimental/go-petstore/docs/Pet.md
@@ -49,6 +49,12 @@ and a boolean to check if the value has been set.
 
 SetId sets Id field to given value.
 
+### HasId
+
+`func (o *Pet) HasId() bool`
+
+HasId returns a boolean if a field has been set.
+
 ### GetCategory
 
 `func (o *Pet) GetCategory() Category`
@@ -67,6 +73,12 @@ and a boolean to check if the value has been set.
 `func (o *Pet) SetCategory(v Category)`
 
 SetCategory sets Category field to given value.
+
+### HasCategory
+
+`func (o *Pet) HasCategory() bool`
+
+HasCategory returns a boolean if a field has been set.
 
 ### GetName
 
@@ -87,6 +99,7 @@ and a boolean to check if the value has been set.
 
 SetName sets Name field to given value.
 
+
 ### GetPhotoUrls
 
 `func (o *Pet) GetPhotoUrls() []string`
@@ -105,6 +118,7 @@ and a boolean to check if the value has been set.
 `func (o *Pet) SetPhotoUrls(v []string)`
 
 SetPhotoUrls sets PhotoUrls field to given value.
+
 
 ### GetTags
 
@@ -125,6 +139,12 @@ and a boolean to check if the value has been set.
 
 SetTags sets Tags field to given value.
 
+### HasTags
+
+`func (o *Pet) HasTags() bool`
+
+HasTags returns a boolean if a field has been set.
+
 ### GetStatus
 
 `func (o *Pet) GetStatus() string`
@@ -143,6 +163,12 @@ and a boolean to check if the value has been set.
 `func (o *Pet) SetStatus(v string)`
 
 SetStatus sets Status field to given value.
+
+### HasStatus
+
+`func (o *Pet) HasStatus() bool`
+
+HasStatus returns a boolean if a field has been set.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/go-experimental/go-petstore/docs/Pet.md
+++ b/samples/client/petstore/go-experimental/go-petstore/docs/Pet.md
@@ -38,22 +38,16 @@ GetId returns the Id field if non-nil, zero value otherwise.
 
 ### GetIdOk
 
-`func (o *Pet) GetIdOk() (int64, bool)`
+`func (o *Pet) GetIdOk() (*int64, bool)`
 
 GetIdOk returns a tuple with the Id field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasId
-
-`func (o *Pet) HasId() bool`
-
-HasId returns a boolean if a field has been set.
 
 ### SetId
 
 `func (o *Pet) SetId(v int64)`
 
-SetId gets a reference to the given int64 and assigns it to the Id field.
+SetId sets Id field to given value.
 
 ### GetCategory
 
@@ -63,22 +57,16 @@ GetCategory returns the Category field if non-nil, zero value otherwise.
 
 ### GetCategoryOk
 
-`func (o *Pet) GetCategoryOk() (Category, bool)`
+`func (o *Pet) GetCategoryOk() (*Category, bool)`
 
 GetCategoryOk returns a tuple with the Category field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasCategory
-
-`func (o *Pet) HasCategory() bool`
-
-HasCategory returns a boolean if a field has been set.
 
 ### SetCategory
 
 `func (o *Pet) SetCategory(v Category)`
 
-SetCategory gets a reference to the given Category and assigns it to the Category field.
+SetCategory sets Category field to given value.
 
 ### GetName
 
@@ -88,22 +76,16 @@ GetName returns the Name field if non-nil, zero value otherwise.
 
 ### GetNameOk
 
-`func (o *Pet) GetNameOk() (string, bool)`
+`func (o *Pet) GetNameOk() (*string, bool)`
 
 GetNameOk returns a tuple with the Name field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasName
-
-`func (o *Pet) HasName() bool`
-
-HasName returns a boolean if a field has been set.
 
 ### SetName
 
 `func (o *Pet) SetName(v string)`
 
-SetName gets a reference to the given string and assigns it to the Name field.
+SetName sets Name field to given value.
 
 ### GetPhotoUrls
 
@@ -113,22 +95,16 @@ GetPhotoUrls returns the PhotoUrls field if non-nil, zero value otherwise.
 
 ### GetPhotoUrlsOk
 
-`func (o *Pet) GetPhotoUrlsOk() ([]string, bool)`
+`func (o *Pet) GetPhotoUrlsOk() (*[]string, bool)`
 
 GetPhotoUrlsOk returns a tuple with the PhotoUrls field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasPhotoUrls
-
-`func (o *Pet) HasPhotoUrls() bool`
-
-HasPhotoUrls returns a boolean if a field has been set.
 
 ### SetPhotoUrls
 
 `func (o *Pet) SetPhotoUrls(v []string)`
 
-SetPhotoUrls gets a reference to the given []string and assigns it to the PhotoUrls field.
+SetPhotoUrls sets PhotoUrls field to given value.
 
 ### GetTags
 
@@ -138,22 +114,16 @@ GetTags returns the Tags field if non-nil, zero value otherwise.
 
 ### GetTagsOk
 
-`func (o *Pet) GetTagsOk() ([]Tag, bool)`
+`func (o *Pet) GetTagsOk() (*[]Tag, bool)`
 
 GetTagsOk returns a tuple with the Tags field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasTags
-
-`func (o *Pet) HasTags() bool`
-
-HasTags returns a boolean if a field has been set.
 
 ### SetTags
 
 `func (o *Pet) SetTags(v []Tag)`
 
-SetTags gets a reference to the given []Tag and assigns it to the Tags field.
+SetTags sets Tags field to given value.
 
 ### GetStatus
 
@@ -163,22 +133,16 @@ GetStatus returns the Status field if non-nil, zero value otherwise.
 
 ### GetStatusOk
 
-`func (o *Pet) GetStatusOk() (string, bool)`
+`func (o *Pet) GetStatusOk() (*string, bool)`
 
 GetStatusOk returns a tuple with the Status field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasStatus
-
-`func (o *Pet) HasStatus() bool`
-
-HasStatus returns a boolean if a field has been set.
 
 ### SetStatus
 
 `func (o *Pet) SetStatus(v string)`
 
-SetStatus gets a reference to the given string and assigns it to the Status field.
+SetStatus sets Status field to given value.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/go-experimental/go-petstore/docs/ReadOnlyFirst.md
+++ b/samples/client/petstore/go-experimental/go-petstore/docs/ReadOnlyFirst.md
@@ -34,22 +34,16 @@ GetBar returns the Bar field if non-nil, zero value otherwise.
 
 ### GetBarOk
 
-`func (o *ReadOnlyFirst) GetBarOk() (string, bool)`
+`func (o *ReadOnlyFirst) GetBarOk() (*string, bool)`
 
 GetBarOk returns a tuple with the Bar field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasBar
-
-`func (o *ReadOnlyFirst) HasBar() bool`
-
-HasBar returns a boolean if a field has been set.
 
 ### SetBar
 
 `func (o *ReadOnlyFirst) SetBar(v string)`
 
-SetBar gets a reference to the given string and assigns it to the Bar field.
+SetBar sets Bar field to given value.
 
 ### GetBaz
 
@@ -59,22 +53,16 @@ GetBaz returns the Baz field if non-nil, zero value otherwise.
 
 ### GetBazOk
 
-`func (o *ReadOnlyFirst) GetBazOk() (string, bool)`
+`func (o *ReadOnlyFirst) GetBazOk() (*string, bool)`
 
 GetBazOk returns a tuple with the Baz field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasBaz
-
-`func (o *ReadOnlyFirst) HasBaz() bool`
-
-HasBaz returns a boolean if a field has been set.
 
 ### SetBaz
 
 `func (o *ReadOnlyFirst) SetBaz(v string)`
 
-SetBaz gets a reference to the given string and assigns it to the Baz field.
+SetBaz sets Baz field to given value.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/go-experimental/go-petstore/docs/ReadOnlyFirst.md
+++ b/samples/client/petstore/go-experimental/go-petstore/docs/ReadOnlyFirst.md
@@ -45,6 +45,12 @@ and a boolean to check if the value has been set.
 
 SetBar sets Bar field to given value.
 
+### HasBar
+
+`func (o *ReadOnlyFirst) HasBar() bool`
+
+HasBar returns a boolean if a field has been set.
+
 ### GetBaz
 
 `func (o *ReadOnlyFirst) GetBaz() string`
@@ -63,6 +69,12 @@ and a boolean to check if the value has been set.
 `func (o *ReadOnlyFirst) SetBaz(v string)`
 
 SetBaz sets Baz field to given value.
+
+### HasBaz
+
+`func (o *ReadOnlyFirst) HasBaz() bool`
+
+HasBaz returns a boolean if a field has been set.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/go-experimental/go-petstore/docs/Return.md
+++ b/samples/client/petstore/go-experimental/go-petstore/docs/Return.md
@@ -33,22 +33,16 @@ GetReturn returns the Return field if non-nil, zero value otherwise.
 
 ### GetReturnOk
 
-`func (o *Return) GetReturnOk() (int32, bool)`
+`func (o *Return) GetReturnOk() (*int32, bool)`
 
 GetReturnOk returns a tuple with the Return field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasReturn
-
-`func (o *Return) HasReturn() bool`
-
-HasReturn returns a boolean if a field has been set.
 
 ### SetReturn
 
 `func (o *Return) SetReturn(v int32)`
 
-SetReturn gets a reference to the given int32 and assigns it to the Return field.
+SetReturn sets Return field to given value.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/go-experimental/go-petstore/docs/Return.md
+++ b/samples/client/petstore/go-experimental/go-petstore/docs/Return.md
@@ -44,6 +44,12 @@ and a boolean to check if the value has been set.
 
 SetReturn sets Return field to given value.
 
+### HasReturn
+
+`func (o *Return) HasReturn() bool`
+
+HasReturn returns a boolean if a field has been set.
+
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/go-experimental/go-petstore/docs/SpecialModelName.md
+++ b/samples/client/petstore/go-experimental/go-petstore/docs/SpecialModelName.md
@@ -33,22 +33,16 @@ GetSpecialPropertyName returns the SpecialPropertyName field if non-nil, zero va
 
 ### GetSpecialPropertyNameOk
 
-`func (o *SpecialModelName) GetSpecialPropertyNameOk() (int64, bool)`
+`func (o *SpecialModelName) GetSpecialPropertyNameOk() (*int64, bool)`
 
 GetSpecialPropertyNameOk returns a tuple with the SpecialPropertyName field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasSpecialPropertyName
-
-`func (o *SpecialModelName) HasSpecialPropertyName() bool`
-
-HasSpecialPropertyName returns a boolean if a field has been set.
 
 ### SetSpecialPropertyName
 
 `func (o *SpecialModelName) SetSpecialPropertyName(v int64)`
 
-SetSpecialPropertyName gets a reference to the given int64 and assigns it to the SpecialPropertyName field.
+SetSpecialPropertyName sets SpecialPropertyName field to given value.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/go-experimental/go-petstore/docs/SpecialModelName.md
+++ b/samples/client/petstore/go-experimental/go-petstore/docs/SpecialModelName.md
@@ -44,6 +44,12 @@ and a boolean to check if the value has been set.
 
 SetSpecialPropertyName sets SpecialPropertyName field to given value.
 
+### HasSpecialPropertyName
+
+`func (o *SpecialModelName) HasSpecialPropertyName() bool`
+
+HasSpecialPropertyName returns a boolean if a field has been set.
+
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/go-experimental/go-petstore/docs/Tag.md
+++ b/samples/client/petstore/go-experimental/go-petstore/docs/Tag.md
@@ -34,22 +34,16 @@ GetId returns the Id field if non-nil, zero value otherwise.
 
 ### GetIdOk
 
-`func (o *Tag) GetIdOk() (int64, bool)`
+`func (o *Tag) GetIdOk() (*int64, bool)`
 
 GetIdOk returns a tuple with the Id field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasId
-
-`func (o *Tag) HasId() bool`
-
-HasId returns a boolean if a field has been set.
 
 ### SetId
 
 `func (o *Tag) SetId(v int64)`
 
-SetId gets a reference to the given int64 and assigns it to the Id field.
+SetId sets Id field to given value.
 
 ### GetName
 
@@ -59,22 +53,16 @@ GetName returns the Name field if non-nil, zero value otherwise.
 
 ### GetNameOk
 
-`func (o *Tag) GetNameOk() (string, bool)`
+`func (o *Tag) GetNameOk() (*string, bool)`
 
 GetNameOk returns a tuple with the Name field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasName
-
-`func (o *Tag) HasName() bool`
-
-HasName returns a boolean if a field has been set.
 
 ### SetName
 
 `func (o *Tag) SetName(v string)`
 
-SetName gets a reference to the given string and assigns it to the Name field.
+SetName sets Name field to given value.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/go-experimental/go-petstore/docs/Tag.md
+++ b/samples/client/petstore/go-experimental/go-petstore/docs/Tag.md
@@ -45,6 +45,12 @@ and a boolean to check if the value has been set.
 
 SetId sets Id field to given value.
 
+### HasId
+
+`func (o *Tag) HasId() bool`
+
+HasId returns a boolean if a field has been set.
+
 ### GetName
 
 `func (o *Tag) GetName() string`
@@ -63,6 +69,12 @@ and a boolean to check if the value has been set.
 `func (o *Tag) SetName(v string)`
 
 SetName sets Name field to given value.
+
+### HasName
+
+`func (o *Tag) HasName() bool`
+
+HasName returns a boolean if a field has been set.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/go-experimental/go-petstore/docs/TypeHolderDefault.md
+++ b/samples/client/petstore/go-experimental/go-petstore/docs/TypeHolderDefault.md
@@ -37,22 +37,16 @@ GetStringItem returns the StringItem field if non-nil, zero value otherwise.
 
 ### GetStringItemOk
 
-`func (o *TypeHolderDefault) GetStringItemOk() (string, bool)`
+`func (o *TypeHolderDefault) GetStringItemOk() (*string, bool)`
 
 GetStringItemOk returns a tuple with the StringItem field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasStringItem
-
-`func (o *TypeHolderDefault) HasStringItem() bool`
-
-HasStringItem returns a boolean if a field has been set.
 
 ### SetStringItem
 
 `func (o *TypeHolderDefault) SetStringItem(v string)`
 
-SetStringItem gets a reference to the given string and assigns it to the StringItem field.
+SetStringItem sets StringItem field to given value.
 
 ### GetNumberItem
 
@@ -62,22 +56,16 @@ GetNumberItem returns the NumberItem field if non-nil, zero value otherwise.
 
 ### GetNumberItemOk
 
-`func (o *TypeHolderDefault) GetNumberItemOk() (float32, bool)`
+`func (o *TypeHolderDefault) GetNumberItemOk() (*float32, bool)`
 
 GetNumberItemOk returns a tuple with the NumberItem field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasNumberItem
-
-`func (o *TypeHolderDefault) HasNumberItem() bool`
-
-HasNumberItem returns a boolean if a field has been set.
 
 ### SetNumberItem
 
 `func (o *TypeHolderDefault) SetNumberItem(v float32)`
 
-SetNumberItem gets a reference to the given float32 and assigns it to the NumberItem field.
+SetNumberItem sets NumberItem field to given value.
 
 ### GetIntegerItem
 
@@ -87,22 +75,16 @@ GetIntegerItem returns the IntegerItem field if non-nil, zero value otherwise.
 
 ### GetIntegerItemOk
 
-`func (o *TypeHolderDefault) GetIntegerItemOk() (int32, bool)`
+`func (o *TypeHolderDefault) GetIntegerItemOk() (*int32, bool)`
 
 GetIntegerItemOk returns a tuple with the IntegerItem field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasIntegerItem
-
-`func (o *TypeHolderDefault) HasIntegerItem() bool`
-
-HasIntegerItem returns a boolean if a field has been set.
 
 ### SetIntegerItem
 
 `func (o *TypeHolderDefault) SetIntegerItem(v int32)`
 
-SetIntegerItem gets a reference to the given int32 and assigns it to the IntegerItem field.
+SetIntegerItem sets IntegerItem field to given value.
 
 ### GetBoolItem
 
@@ -112,22 +94,16 @@ GetBoolItem returns the BoolItem field if non-nil, zero value otherwise.
 
 ### GetBoolItemOk
 
-`func (o *TypeHolderDefault) GetBoolItemOk() (bool, bool)`
+`func (o *TypeHolderDefault) GetBoolItemOk() (*bool, bool)`
 
 GetBoolItemOk returns a tuple with the BoolItem field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasBoolItem
-
-`func (o *TypeHolderDefault) HasBoolItem() bool`
-
-HasBoolItem returns a boolean if a field has been set.
 
 ### SetBoolItem
 
 `func (o *TypeHolderDefault) SetBoolItem(v bool)`
 
-SetBoolItem gets a reference to the given bool and assigns it to the BoolItem field.
+SetBoolItem sets BoolItem field to given value.
 
 ### GetArrayItem
 
@@ -137,22 +113,16 @@ GetArrayItem returns the ArrayItem field if non-nil, zero value otherwise.
 
 ### GetArrayItemOk
 
-`func (o *TypeHolderDefault) GetArrayItemOk() ([]int32, bool)`
+`func (o *TypeHolderDefault) GetArrayItemOk() (*[]int32, bool)`
 
 GetArrayItemOk returns a tuple with the ArrayItem field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasArrayItem
-
-`func (o *TypeHolderDefault) HasArrayItem() bool`
-
-HasArrayItem returns a boolean if a field has been set.
 
 ### SetArrayItem
 
 `func (o *TypeHolderDefault) SetArrayItem(v []int32)`
 
-SetArrayItem gets a reference to the given []int32 and assigns it to the ArrayItem field.
+SetArrayItem sets ArrayItem field to given value.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/go-experimental/go-petstore/docs/TypeHolderDefault.md
+++ b/samples/client/petstore/go-experimental/go-petstore/docs/TypeHolderDefault.md
@@ -48,6 +48,7 @@ and a boolean to check if the value has been set.
 
 SetStringItem sets StringItem field to given value.
 
+
 ### GetNumberItem
 
 `func (o *TypeHolderDefault) GetNumberItem() float32`
@@ -66,6 +67,7 @@ and a boolean to check if the value has been set.
 `func (o *TypeHolderDefault) SetNumberItem(v float32)`
 
 SetNumberItem sets NumberItem field to given value.
+
 
 ### GetIntegerItem
 
@@ -86,6 +88,7 @@ and a boolean to check if the value has been set.
 
 SetIntegerItem sets IntegerItem field to given value.
 
+
 ### GetBoolItem
 
 `func (o *TypeHolderDefault) GetBoolItem() bool`
@@ -105,6 +108,7 @@ and a boolean to check if the value has been set.
 
 SetBoolItem sets BoolItem field to given value.
 
+
 ### GetArrayItem
 
 `func (o *TypeHolderDefault) GetArrayItem() []int32`
@@ -123,6 +127,7 @@ and a boolean to check if the value has been set.
 `func (o *TypeHolderDefault) SetArrayItem(v []int32)`
 
 SetArrayItem sets ArrayItem field to given value.
+
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/go-experimental/go-petstore/docs/TypeHolderExample.md
+++ b/samples/client/petstore/go-experimental/go-petstore/docs/TypeHolderExample.md
@@ -49,6 +49,7 @@ and a boolean to check if the value has been set.
 
 SetStringItem sets StringItem field to given value.
 
+
 ### GetNumberItem
 
 `func (o *TypeHolderExample) GetNumberItem() float32`
@@ -67,6 +68,7 @@ and a boolean to check if the value has been set.
 `func (o *TypeHolderExample) SetNumberItem(v float32)`
 
 SetNumberItem sets NumberItem field to given value.
+
 
 ### GetFloatItem
 
@@ -87,6 +89,7 @@ and a boolean to check if the value has been set.
 
 SetFloatItem sets FloatItem field to given value.
 
+
 ### GetIntegerItem
 
 `func (o *TypeHolderExample) GetIntegerItem() int32`
@@ -105,6 +108,7 @@ and a boolean to check if the value has been set.
 `func (o *TypeHolderExample) SetIntegerItem(v int32)`
 
 SetIntegerItem sets IntegerItem field to given value.
+
 
 ### GetBoolItem
 
@@ -125,6 +129,7 @@ and a boolean to check if the value has been set.
 
 SetBoolItem sets BoolItem field to given value.
 
+
 ### GetArrayItem
 
 `func (o *TypeHolderExample) GetArrayItem() []int32`
@@ -143,6 +148,7 @@ and a boolean to check if the value has been set.
 `func (o *TypeHolderExample) SetArrayItem(v []int32)`
 
 SetArrayItem sets ArrayItem field to given value.
+
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/go-experimental/go-petstore/docs/TypeHolderExample.md
+++ b/samples/client/petstore/go-experimental/go-petstore/docs/TypeHolderExample.md
@@ -38,22 +38,16 @@ GetStringItem returns the StringItem field if non-nil, zero value otherwise.
 
 ### GetStringItemOk
 
-`func (o *TypeHolderExample) GetStringItemOk() (string, bool)`
+`func (o *TypeHolderExample) GetStringItemOk() (*string, bool)`
 
 GetStringItemOk returns a tuple with the StringItem field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasStringItem
-
-`func (o *TypeHolderExample) HasStringItem() bool`
-
-HasStringItem returns a boolean if a field has been set.
 
 ### SetStringItem
 
 `func (o *TypeHolderExample) SetStringItem(v string)`
 
-SetStringItem gets a reference to the given string and assigns it to the StringItem field.
+SetStringItem sets StringItem field to given value.
 
 ### GetNumberItem
 
@@ -63,22 +57,16 @@ GetNumberItem returns the NumberItem field if non-nil, zero value otherwise.
 
 ### GetNumberItemOk
 
-`func (o *TypeHolderExample) GetNumberItemOk() (float32, bool)`
+`func (o *TypeHolderExample) GetNumberItemOk() (*float32, bool)`
 
 GetNumberItemOk returns a tuple with the NumberItem field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasNumberItem
-
-`func (o *TypeHolderExample) HasNumberItem() bool`
-
-HasNumberItem returns a boolean if a field has been set.
 
 ### SetNumberItem
 
 `func (o *TypeHolderExample) SetNumberItem(v float32)`
 
-SetNumberItem gets a reference to the given float32 and assigns it to the NumberItem field.
+SetNumberItem sets NumberItem field to given value.
 
 ### GetFloatItem
 
@@ -88,22 +76,16 @@ GetFloatItem returns the FloatItem field if non-nil, zero value otherwise.
 
 ### GetFloatItemOk
 
-`func (o *TypeHolderExample) GetFloatItemOk() (float32, bool)`
+`func (o *TypeHolderExample) GetFloatItemOk() (*float32, bool)`
 
 GetFloatItemOk returns a tuple with the FloatItem field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasFloatItem
-
-`func (o *TypeHolderExample) HasFloatItem() bool`
-
-HasFloatItem returns a boolean if a field has been set.
 
 ### SetFloatItem
 
 `func (o *TypeHolderExample) SetFloatItem(v float32)`
 
-SetFloatItem gets a reference to the given float32 and assigns it to the FloatItem field.
+SetFloatItem sets FloatItem field to given value.
 
 ### GetIntegerItem
 
@@ -113,22 +95,16 @@ GetIntegerItem returns the IntegerItem field if non-nil, zero value otherwise.
 
 ### GetIntegerItemOk
 
-`func (o *TypeHolderExample) GetIntegerItemOk() (int32, bool)`
+`func (o *TypeHolderExample) GetIntegerItemOk() (*int32, bool)`
 
 GetIntegerItemOk returns a tuple with the IntegerItem field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasIntegerItem
-
-`func (o *TypeHolderExample) HasIntegerItem() bool`
-
-HasIntegerItem returns a boolean if a field has been set.
 
 ### SetIntegerItem
 
 `func (o *TypeHolderExample) SetIntegerItem(v int32)`
 
-SetIntegerItem gets a reference to the given int32 and assigns it to the IntegerItem field.
+SetIntegerItem sets IntegerItem field to given value.
 
 ### GetBoolItem
 
@@ -138,22 +114,16 @@ GetBoolItem returns the BoolItem field if non-nil, zero value otherwise.
 
 ### GetBoolItemOk
 
-`func (o *TypeHolderExample) GetBoolItemOk() (bool, bool)`
+`func (o *TypeHolderExample) GetBoolItemOk() (*bool, bool)`
 
 GetBoolItemOk returns a tuple with the BoolItem field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasBoolItem
-
-`func (o *TypeHolderExample) HasBoolItem() bool`
-
-HasBoolItem returns a boolean if a field has been set.
 
 ### SetBoolItem
 
 `func (o *TypeHolderExample) SetBoolItem(v bool)`
 
-SetBoolItem gets a reference to the given bool and assigns it to the BoolItem field.
+SetBoolItem sets BoolItem field to given value.
 
 ### GetArrayItem
 
@@ -163,22 +133,16 @@ GetArrayItem returns the ArrayItem field if non-nil, zero value otherwise.
 
 ### GetArrayItemOk
 
-`func (o *TypeHolderExample) GetArrayItemOk() ([]int32, bool)`
+`func (o *TypeHolderExample) GetArrayItemOk() (*[]int32, bool)`
 
 GetArrayItemOk returns a tuple with the ArrayItem field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasArrayItem
-
-`func (o *TypeHolderExample) HasArrayItem() bool`
-
-HasArrayItem returns a boolean if a field has been set.
 
 ### SetArrayItem
 
 `func (o *TypeHolderExample) SetArrayItem(v []int32)`
 
-SetArrayItem gets a reference to the given []int32 and assigns it to the ArrayItem field.
+SetArrayItem sets ArrayItem field to given value.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/go-experimental/go-petstore/docs/User.md
+++ b/samples/client/petstore/go-experimental/go-petstore/docs/User.md
@@ -51,6 +51,12 @@ and a boolean to check if the value has been set.
 
 SetId sets Id field to given value.
 
+### HasId
+
+`func (o *User) HasId() bool`
+
+HasId returns a boolean if a field has been set.
+
 ### GetUsername
 
 `func (o *User) GetUsername() string`
@@ -69,6 +75,12 @@ and a boolean to check if the value has been set.
 `func (o *User) SetUsername(v string)`
 
 SetUsername sets Username field to given value.
+
+### HasUsername
+
+`func (o *User) HasUsername() bool`
+
+HasUsername returns a boolean if a field has been set.
 
 ### GetFirstName
 
@@ -89,6 +101,12 @@ and a boolean to check if the value has been set.
 
 SetFirstName sets FirstName field to given value.
 
+### HasFirstName
+
+`func (o *User) HasFirstName() bool`
+
+HasFirstName returns a boolean if a field has been set.
+
 ### GetLastName
 
 `func (o *User) GetLastName() string`
@@ -107,6 +125,12 @@ and a boolean to check if the value has been set.
 `func (o *User) SetLastName(v string)`
 
 SetLastName sets LastName field to given value.
+
+### HasLastName
+
+`func (o *User) HasLastName() bool`
+
+HasLastName returns a boolean if a field has been set.
 
 ### GetEmail
 
@@ -127,6 +151,12 @@ and a boolean to check if the value has been set.
 
 SetEmail sets Email field to given value.
 
+### HasEmail
+
+`func (o *User) HasEmail() bool`
+
+HasEmail returns a boolean if a field has been set.
+
 ### GetPassword
 
 `func (o *User) GetPassword() string`
@@ -145,6 +175,12 @@ and a boolean to check if the value has been set.
 `func (o *User) SetPassword(v string)`
 
 SetPassword sets Password field to given value.
+
+### HasPassword
+
+`func (o *User) HasPassword() bool`
+
+HasPassword returns a boolean if a field has been set.
 
 ### GetPhone
 
@@ -165,6 +201,12 @@ and a boolean to check if the value has been set.
 
 SetPhone sets Phone field to given value.
 
+### HasPhone
+
+`func (o *User) HasPhone() bool`
+
+HasPhone returns a boolean if a field has been set.
+
 ### GetUserStatus
 
 `func (o *User) GetUserStatus() int32`
@@ -183,6 +225,12 @@ and a boolean to check if the value has been set.
 `func (o *User) SetUserStatus(v int32)`
 
 SetUserStatus sets UserStatus field to given value.
+
+### HasUserStatus
+
+`func (o *User) HasUserStatus() bool`
+
+HasUserStatus returns a boolean if a field has been set.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/go-experimental/go-petstore/docs/User.md
+++ b/samples/client/petstore/go-experimental/go-petstore/docs/User.md
@@ -40,22 +40,16 @@ GetId returns the Id field if non-nil, zero value otherwise.
 
 ### GetIdOk
 
-`func (o *User) GetIdOk() (int64, bool)`
+`func (o *User) GetIdOk() (*int64, bool)`
 
 GetIdOk returns a tuple with the Id field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasId
-
-`func (o *User) HasId() bool`
-
-HasId returns a boolean if a field has been set.
 
 ### SetId
 
 `func (o *User) SetId(v int64)`
 
-SetId gets a reference to the given int64 and assigns it to the Id field.
+SetId sets Id field to given value.
 
 ### GetUsername
 
@@ -65,22 +59,16 @@ GetUsername returns the Username field if non-nil, zero value otherwise.
 
 ### GetUsernameOk
 
-`func (o *User) GetUsernameOk() (string, bool)`
+`func (o *User) GetUsernameOk() (*string, bool)`
 
 GetUsernameOk returns a tuple with the Username field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasUsername
-
-`func (o *User) HasUsername() bool`
-
-HasUsername returns a boolean if a field has been set.
 
 ### SetUsername
 
 `func (o *User) SetUsername(v string)`
 
-SetUsername gets a reference to the given string and assigns it to the Username field.
+SetUsername sets Username field to given value.
 
 ### GetFirstName
 
@@ -90,22 +78,16 @@ GetFirstName returns the FirstName field if non-nil, zero value otherwise.
 
 ### GetFirstNameOk
 
-`func (o *User) GetFirstNameOk() (string, bool)`
+`func (o *User) GetFirstNameOk() (*string, bool)`
 
 GetFirstNameOk returns a tuple with the FirstName field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasFirstName
-
-`func (o *User) HasFirstName() bool`
-
-HasFirstName returns a boolean if a field has been set.
 
 ### SetFirstName
 
 `func (o *User) SetFirstName(v string)`
 
-SetFirstName gets a reference to the given string and assigns it to the FirstName field.
+SetFirstName sets FirstName field to given value.
 
 ### GetLastName
 
@@ -115,22 +97,16 @@ GetLastName returns the LastName field if non-nil, zero value otherwise.
 
 ### GetLastNameOk
 
-`func (o *User) GetLastNameOk() (string, bool)`
+`func (o *User) GetLastNameOk() (*string, bool)`
 
 GetLastNameOk returns a tuple with the LastName field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasLastName
-
-`func (o *User) HasLastName() bool`
-
-HasLastName returns a boolean if a field has been set.
 
 ### SetLastName
 
 `func (o *User) SetLastName(v string)`
 
-SetLastName gets a reference to the given string and assigns it to the LastName field.
+SetLastName sets LastName field to given value.
 
 ### GetEmail
 
@@ -140,22 +116,16 @@ GetEmail returns the Email field if non-nil, zero value otherwise.
 
 ### GetEmailOk
 
-`func (o *User) GetEmailOk() (string, bool)`
+`func (o *User) GetEmailOk() (*string, bool)`
 
 GetEmailOk returns a tuple with the Email field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasEmail
-
-`func (o *User) HasEmail() bool`
-
-HasEmail returns a boolean if a field has been set.
 
 ### SetEmail
 
 `func (o *User) SetEmail(v string)`
 
-SetEmail gets a reference to the given string and assigns it to the Email field.
+SetEmail sets Email field to given value.
 
 ### GetPassword
 
@@ -165,22 +135,16 @@ GetPassword returns the Password field if non-nil, zero value otherwise.
 
 ### GetPasswordOk
 
-`func (o *User) GetPasswordOk() (string, bool)`
+`func (o *User) GetPasswordOk() (*string, bool)`
 
 GetPasswordOk returns a tuple with the Password field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasPassword
-
-`func (o *User) HasPassword() bool`
-
-HasPassword returns a boolean if a field has been set.
 
 ### SetPassword
 
 `func (o *User) SetPassword(v string)`
 
-SetPassword gets a reference to the given string and assigns it to the Password field.
+SetPassword sets Password field to given value.
 
 ### GetPhone
 
@@ -190,22 +154,16 @@ GetPhone returns the Phone field if non-nil, zero value otherwise.
 
 ### GetPhoneOk
 
-`func (o *User) GetPhoneOk() (string, bool)`
+`func (o *User) GetPhoneOk() (*string, bool)`
 
 GetPhoneOk returns a tuple with the Phone field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasPhone
-
-`func (o *User) HasPhone() bool`
-
-HasPhone returns a boolean if a field has been set.
 
 ### SetPhone
 
 `func (o *User) SetPhone(v string)`
 
-SetPhone gets a reference to the given string and assigns it to the Phone field.
+SetPhone sets Phone field to given value.
 
 ### GetUserStatus
 
@@ -215,22 +173,16 @@ GetUserStatus returns the UserStatus field if non-nil, zero value otherwise.
 
 ### GetUserStatusOk
 
-`func (o *User) GetUserStatusOk() (int32, bool)`
+`func (o *User) GetUserStatusOk() (*int32, bool)`
 
 GetUserStatusOk returns a tuple with the UserStatus field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasUserStatus
-
-`func (o *User) HasUserStatus() bool`
-
-HasUserStatus returns a boolean if a field has been set.
 
 ### SetUserStatus
 
 `func (o *User) SetUserStatus(v int32)`
 
-SetUserStatus gets a reference to the given int32 and assigns it to the UserStatus field.
+SetUserStatus sets UserStatus field to given value.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/go-experimental/go-petstore/docs/XmlItem.md
+++ b/samples/client/petstore/go-experimental/go-petstore/docs/XmlItem.md
@@ -61,22 +61,16 @@ GetAttributeString returns the AttributeString field if non-nil, zero value othe
 
 ### GetAttributeStringOk
 
-`func (o *XmlItem) GetAttributeStringOk() (string, bool)`
+`func (o *XmlItem) GetAttributeStringOk() (*string, bool)`
 
 GetAttributeStringOk returns a tuple with the AttributeString field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasAttributeString
-
-`func (o *XmlItem) HasAttributeString() bool`
-
-HasAttributeString returns a boolean if a field has been set.
 
 ### SetAttributeString
 
 `func (o *XmlItem) SetAttributeString(v string)`
 
-SetAttributeString gets a reference to the given string and assigns it to the AttributeString field.
+SetAttributeString sets AttributeString field to given value.
 
 ### GetAttributeNumber
 
@@ -86,22 +80,16 @@ GetAttributeNumber returns the AttributeNumber field if non-nil, zero value othe
 
 ### GetAttributeNumberOk
 
-`func (o *XmlItem) GetAttributeNumberOk() (float32, bool)`
+`func (o *XmlItem) GetAttributeNumberOk() (*float32, bool)`
 
 GetAttributeNumberOk returns a tuple with the AttributeNumber field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasAttributeNumber
-
-`func (o *XmlItem) HasAttributeNumber() bool`
-
-HasAttributeNumber returns a boolean if a field has been set.
 
 ### SetAttributeNumber
 
 `func (o *XmlItem) SetAttributeNumber(v float32)`
 
-SetAttributeNumber gets a reference to the given float32 and assigns it to the AttributeNumber field.
+SetAttributeNumber sets AttributeNumber field to given value.
 
 ### GetAttributeInteger
 
@@ -111,22 +99,16 @@ GetAttributeInteger returns the AttributeInteger field if non-nil, zero value ot
 
 ### GetAttributeIntegerOk
 
-`func (o *XmlItem) GetAttributeIntegerOk() (int32, bool)`
+`func (o *XmlItem) GetAttributeIntegerOk() (*int32, bool)`
 
 GetAttributeIntegerOk returns a tuple with the AttributeInteger field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasAttributeInteger
-
-`func (o *XmlItem) HasAttributeInteger() bool`
-
-HasAttributeInteger returns a boolean if a field has been set.
 
 ### SetAttributeInteger
 
 `func (o *XmlItem) SetAttributeInteger(v int32)`
 
-SetAttributeInteger gets a reference to the given int32 and assigns it to the AttributeInteger field.
+SetAttributeInteger sets AttributeInteger field to given value.
 
 ### GetAttributeBoolean
 
@@ -136,22 +118,16 @@ GetAttributeBoolean returns the AttributeBoolean field if non-nil, zero value ot
 
 ### GetAttributeBooleanOk
 
-`func (o *XmlItem) GetAttributeBooleanOk() (bool, bool)`
+`func (o *XmlItem) GetAttributeBooleanOk() (*bool, bool)`
 
 GetAttributeBooleanOk returns a tuple with the AttributeBoolean field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasAttributeBoolean
-
-`func (o *XmlItem) HasAttributeBoolean() bool`
-
-HasAttributeBoolean returns a boolean if a field has been set.
 
 ### SetAttributeBoolean
 
 `func (o *XmlItem) SetAttributeBoolean(v bool)`
 
-SetAttributeBoolean gets a reference to the given bool and assigns it to the AttributeBoolean field.
+SetAttributeBoolean sets AttributeBoolean field to given value.
 
 ### GetWrappedArray
 
@@ -161,22 +137,16 @@ GetWrappedArray returns the WrappedArray field if non-nil, zero value otherwise.
 
 ### GetWrappedArrayOk
 
-`func (o *XmlItem) GetWrappedArrayOk() ([]int32, bool)`
+`func (o *XmlItem) GetWrappedArrayOk() (*[]int32, bool)`
 
 GetWrappedArrayOk returns a tuple with the WrappedArray field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasWrappedArray
-
-`func (o *XmlItem) HasWrappedArray() bool`
-
-HasWrappedArray returns a boolean if a field has been set.
 
 ### SetWrappedArray
 
 `func (o *XmlItem) SetWrappedArray(v []int32)`
 
-SetWrappedArray gets a reference to the given []int32 and assigns it to the WrappedArray field.
+SetWrappedArray sets WrappedArray field to given value.
 
 ### GetNameString
 
@@ -186,22 +156,16 @@ GetNameString returns the NameString field if non-nil, zero value otherwise.
 
 ### GetNameStringOk
 
-`func (o *XmlItem) GetNameStringOk() (string, bool)`
+`func (o *XmlItem) GetNameStringOk() (*string, bool)`
 
 GetNameStringOk returns a tuple with the NameString field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasNameString
-
-`func (o *XmlItem) HasNameString() bool`
-
-HasNameString returns a boolean if a field has been set.
 
 ### SetNameString
 
 `func (o *XmlItem) SetNameString(v string)`
 
-SetNameString gets a reference to the given string and assigns it to the NameString field.
+SetNameString sets NameString field to given value.
 
 ### GetNameNumber
 
@@ -211,22 +175,16 @@ GetNameNumber returns the NameNumber field if non-nil, zero value otherwise.
 
 ### GetNameNumberOk
 
-`func (o *XmlItem) GetNameNumberOk() (float32, bool)`
+`func (o *XmlItem) GetNameNumberOk() (*float32, bool)`
 
 GetNameNumberOk returns a tuple with the NameNumber field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasNameNumber
-
-`func (o *XmlItem) HasNameNumber() bool`
-
-HasNameNumber returns a boolean if a field has been set.
 
 ### SetNameNumber
 
 `func (o *XmlItem) SetNameNumber(v float32)`
 
-SetNameNumber gets a reference to the given float32 and assigns it to the NameNumber field.
+SetNameNumber sets NameNumber field to given value.
 
 ### GetNameInteger
 
@@ -236,22 +194,16 @@ GetNameInteger returns the NameInteger field if non-nil, zero value otherwise.
 
 ### GetNameIntegerOk
 
-`func (o *XmlItem) GetNameIntegerOk() (int32, bool)`
+`func (o *XmlItem) GetNameIntegerOk() (*int32, bool)`
 
 GetNameIntegerOk returns a tuple with the NameInteger field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasNameInteger
-
-`func (o *XmlItem) HasNameInteger() bool`
-
-HasNameInteger returns a boolean if a field has been set.
 
 ### SetNameInteger
 
 `func (o *XmlItem) SetNameInteger(v int32)`
 
-SetNameInteger gets a reference to the given int32 and assigns it to the NameInteger field.
+SetNameInteger sets NameInteger field to given value.
 
 ### GetNameBoolean
 
@@ -261,22 +213,16 @@ GetNameBoolean returns the NameBoolean field if non-nil, zero value otherwise.
 
 ### GetNameBooleanOk
 
-`func (o *XmlItem) GetNameBooleanOk() (bool, bool)`
+`func (o *XmlItem) GetNameBooleanOk() (*bool, bool)`
 
 GetNameBooleanOk returns a tuple with the NameBoolean field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasNameBoolean
-
-`func (o *XmlItem) HasNameBoolean() bool`
-
-HasNameBoolean returns a boolean if a field has been set.
 
 ### SetNameBoolean
 
 `func (o *XmlItem) SetNameBoolean(v bool)`
 
-SetNameBoolean gets a reference to the given bool and assigns it to the NameBoolean field.
+SetNameBoolean sets NameBoolean field to given value.
 
 ### GetNameArray
 
@@ -286,22 +232,16 @@ GetNameArray returns the NameArray field if non-nil, zero value otherwise.
 
 ### GetNameArrayOk
 
-`func (o *XmlItem) GetNameArrayOk() ([]int32, bool)`
+`func (o *XmlItem) GetNameArrayOk() (*[]int32, bool)`
 
 GetNameArrayOk returns a tuple with the NameArray field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasNameArray
-
-`func (o *XmlItem) HasNameArray() bool`
-
-HasNameArray returns a boolean if a field has been set.
 
 ### SetNameArray
 
 `func (o *XmlItem) SetNameArray(v []int32)`
 
-SetNameArray gets a reference to the given []int32 and assigns it to the NameArray field.
+SetNameArray sets NameArray field to given value.
 
 ### GetNameWrappedArray
 
@@ -311,22 +251,16 @@ GetNameWrappedArray returns the NameWrappedArray field if non-nil, zero value ot
 
 ### GetNameWrappedArrayOk
 
-`func (o *XmlItem) GetNameWrappedArrayOk() ([]int32, bool)`
+`func (o *XmlItem) GetNameWrappedArrayOk() (*[]int32, bool)`
 
 GetNameWrappedArrayOk returns a tuple with the NameWrappedArray field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasNameWrappedArray
-
-`func (o *XmlItem) HasNameWrappedArray() bool`
-
-HasNameWrappedArray returns a boolean if a field has been set.
 
 ### SetNameWrappedArray
 
 `func (o *XmlItem) SetNameWrappedArray(v []int32)`
 
-SetNameWrappedArray gets a reference to the given []int32 and assigns it to the NameWrappedArray field.
+SetNameWrappedArray sets NameWrappedArray field to given value.
 
 ### GetPrefixString
 
@@ -336,22 +270,16 @@ GetPrefixString returns the PrefixString field if non-nil, zero value otherwise.
 
 ### GetPrefixStringOk
 
-`func (o *XmlItem) GetPrefixStringOk() (string, bool)`
+`func (o *XmlItem) GetPrefixStringOk() (*string, bool)`
 
 GetPrefixStringOk returns a tuple with the PrefixString field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasPrefixString
-
-`func (o *XmlItem) HasPrefixString() bool`
-
-HasPrefixString returns a boolean if a field has been set.
 
 ### SetPrefixString
 
 `func (o *XmlItem) SetPrefixString(v string)`
 
-SetPrefixString gets a reference to the given string and assigns it to the PrefixString field.
+SetPrefixString sets PrefixString field to given value.
 
 ### GetPrefixNumber
 
@@ -361,22 +289,16 @@ GetPrefixNumber returns the PrefixNumber field if non-nil, zero value otherwise.
 
 ### GetPrefixNumberOk
 
-`func (o *XmlItem) GetPrefixNumberOk() (float32, bool)`
+`func (o *XmlItem) GetPrefixNumberOk() (*float32, bool)`
 
 GetPrefixNumberOk returns a tuple with the PrefixNumber field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasPrefixNumber
-
-`func (o *XmlItem) HasPrefixNumber() bool`
-
-HasPrefixNumber returns a boolean if a field has been set.
 
 ### SetPrefixNumber
 
 `func (o *XmlItem) SetPrefixNumber(v float32)`
 
-SetPrefixNumber gets a reference to the given float32 and assigns it to the PrefixNumber field.
+SetPrefixNumber sets PrefixNumber field to given value.
 
 ### GetPrefixInteger
 
@@ -386,22 +308,16 @@ GetPrefixInteger returns the PrefixInteger field if non-nil, zero value otherwis
 
 ### GetPrefixIntegerOk
 
-`func (o *XmlItem) GetPrefixIntegerOk() (int32, bool)`
+`func (o *XmlItem) GetPrefixIntegerOk() (*int32, bool)`
 
 GetPrefixIntegerOk returns a tuple with the PrefixInteger field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasPrefixInteger
-
-`func (o *XmlItem) HasPrefixInteger() bool`
-
-HasPrefixInteger returns a boolean if a field has been set.
 
 ### SetPrefixInteger
 
 `func (o *XmlItem) SetPrefixInteger(v int32)`
 
-SetPrefixInteger gets a reference to the given int32 and assigns it to the PrefixInteger field.
+SetPrefixInteger sets PrefixInteger field to given value.
 
 ### GetPrefixBoolean
 
@@ -411,22 +327,16 @@ GetPrefixBoolean returns the PrefixBoolean field if non-nil, zero value otherwis
 
 ### GetPrefixBooleanOk
 
-`func (o *XmlItem) GetPrefixBooleanOk() (bool, bool)`
+`func (o *XmlItem) GetPrefixBooleanOk() (*bool, bool)`
 
 GetPrefixBooleanOk returns a tuple with the PrefixBoolean field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasPrefixBoolean
-
-`func (o *XmlItem) HasPrefixBoolean() bool`
-
-HasPrefixBoolean returns a boolean if a field has been set.
 
 ### SetPrefixBoolean
 
 `func (o *XmlItem) SetPrefixBoolean(v bool)`
 
-SetPrefixBoolean gets a reference to the given bool and assigns it to the PrefixBoolean field.
+SetPrefixBoolean sets PrefixBoolean field to given value.
 
 ### GetPrefixArray
 
@@ -436,22 +346,16 @@ GetPrefixArray returns the PrefixArray field if non-nil, zero value otherwise.
 
 ### GetPrefixArrayOk
 
-`func (o *XmlItem) GetPrefixArrayOk() ([]int32, bool)`
+`func (o *XmlItem) GetPrefixArrayOk() (*[]int32, bool)`
 
 GetPrefixArrayOk returns a tuple with the PrefixArray field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasPrefixArray
-
-`func (o *XmlItem) HasPrefixArray() bool`
-
-HasPrefixArray returns a boolean if a field has been set.
 
 ### SetPrefixArray
 
 `func (o *XmlItem) SetPrefixArray(v []int32)`
 
-SetPrefixArray gets a reference to the given []int32 and assigns it to the PrefixArray field.
+SetPrefixArray sets PrefixArray field to given value.
 
 ### GetPrefixWrappedArray
 
@@ -461,22 +365,16 @@ GetPrefixWrappedArray returns the PrefixWrappedArray field if non-nil, zero valu
 
 ### GetPrefixWrappedArrayOk
 
-`func (o *XmlItem) GetPrefixWrappedArrayOk() ([]int32, bool)`
+`func (o *XmlItem) GetPrefixWrappedArrayOk() (*[]int32, bool)`
 
 GetPrefixWrappedArrayOk returns a tuple with the PrefixWrappedArray field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasPrefixWrappedArray
-
-`func (o *XmlItem) HasPrefixWrappedArray() bool`
-
-HasPrefixWrappedArray returns a boolean if a field has been set.
 
 ### SetPrefixWrappedArray
 
 `func (o *XmlItem) SetPrefixWrappedArray(v []int32)`
 
-SetPrefixWrappedArray gets a reference to the given []int32 and assigns it to the PrefixWrappedArray field.
+SetPrefixWrappedArray sets PrefixWrappedArray field to given value.
 
 ### GetNamespaceString
 
@@ -486,22 +384,16 @@ GetNamespaceString returns the NamespaceString field if non-nil, zero value othe
 
 ### GetNamespaceStringOk
 
-`func (o *XmlItem) GetNamespaceStringOk() (string, bool)`
+`func (o *XmlItem) GetNamespaceStringOk() (*string, bool)`
 
 GetNamespaceStringOk returns a tuple with the NamespaceString field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasNamespaceString
-
-`func (o *XmlItem) HasNamespaceString() bool`
-
-HasNamespaceString returns a boolean if a field has been set.
 
 ### SetNamespaceString
 
 `func (o *XmlItem) SetNamespaceString(v string)`
 
-SetNamespaceString gets a reference to the given string and assigns it to the NamespaceString field.
+SetNamespaceString sets NamespaceString field to given value.
 
 ### GetNamespaceNumber
 
@@ -511,22 +403,16 @@ GetNamespaceNumber returns the NamespaceNumber field if non-nil, zero value othe
 
 ### GetNamespaceNumberOk
 
-`func (o *XmlItem) GetNamespaceNumberOk() (float32, bool)`
+`func (o *XmlItem) GetNamespaceNumberOk() (*float32, bool)`
 
 GetNamespaceNumberOk returns a tuple with the NamespaceNumber field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasNamespaceNumber
-
-`func (o *XmlItem) HasNamespaceNumber() bool`
-
-HasNamespaceNumber returns a boolean if a field has been set.
 
 ### SetNamespaceNumber
 
 `func (o *XmlItem) SetNamespaceNumber(v float32)`
 
-SetNamespaceNumber gets a reference to the given float32 and assigns it to the NamespaceNumber field.
+SetNamespaceNumber sets NamespaceNumber field to given value.
 
 ### GetNamespaceInteger
 
@@ -536,22 +422,16 @@ GetNamespaceInteger returns the NamespaceInteger field if non-nil, zero value ot
 
 ### GetNamespaceIntegerOk
 
-`func (o *XmlItem) GetNamespaceIntegerOk() (int32, bool)`
+`func (o *XmlItem) GetNamespaceIntegerOk() (*int32, bool)`
 
 GetNamespaceIntegerOk returns a tuple with the NamespaceInteger field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasNamespaceInteger
-
-`func (o *XmlItem) HasNamespaceInteger() bool`
-
-HasNamespaceInteger returns a boolean if a field has been set.
 
 ### SetNamespaceInteger
 
 `func (o *XmlItem) SetNamespaceInteger(v int32)`
 
-SetNamespaceInteger gets a reference to the given int32 and assigns it to the NamespaceInteger field.
+SetNamespaceInteger sets NamespaceInteger field to given value.
 
 ### GetNamespaceBoolean
 
@@ -561,22 +441,16 @@ GetNamespaceBoolean returns the NamespaceBoolean field if non-nil, zero value ot
 
 ### GetNamespaceBooleanOk
 
-`func (o *XmlItem) GetNamespaceBooleanOk() (bool, bool)`
+`func (o *XmlItem) GetNamespaceBooleanOk() (*bool, bool)`
 
 GetNamespaceBooleanOk returns a tuple with the NamespaceBoolean field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasNamespaceBoolean
-
-`func (o *XmlItem) HasNamespaceBoolean() bool`
-
-HasNamespaceBoolean returns a boolean if a field has been set.
 
 ### SetNamespaceBoolean
 
 `func (o *XmlItem) SetNamespaceBoolean(v bool)`
 
-SetNamespaceBoolean gets a reference to the given bool and assigns it to the NamespaceBoolean field.
+SetNamespaceBoolean sets NamespaceBoolean field to given value.
 
 ### GetNamespaceArray
 
@@ -586,22 +460,16 @@ GetNamespaceArray returns the NamespaceArray field if non-nil, zero value otherw
 
 ### GetNamespaceArrayOk
 
-`func (o *XmlItem) GetNamespaceArrayOk() ([]int32, bool)`
+`func (o *XmlItem) GetNamespaceArrayOk() (*[]int32, bool)`
 
 GetNamespaceArrayOk returns a tuple with the NamespaceArray field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasNamespaceArray
-
-`func (o *XmlItem) HasNamespaceArray() bool`
-
-HasNamespaceArray returns a boolean if a field has been set.
 
 ### SetNamespaceArray
 
 `func (o *XmlItem) SetNamespaceArray(v []int32)`
 
-SetNamespaceArray gets a reference to the given []int32 and assigns it to the NamespaceArray field.
+SetNamespaceArray sets NamespaceArray field to given value.
 
 ### GetNamespaceWrappedArray
 
@@ -611,22 +479,16 @@ GetNamespaceWrappedArray returns the NamespaceWrappedArray field if non-nil, zer
 
 ### GetNamespaceWrappedArrayOk
 
-`func (o *XmlItem) GetNamespaceWrappedArrayOk() ([]int32, bool)`
+`func (o *XmlItem) GetNamespaceWrappedArrayOk() (*[]int32, bool)`
 
 GetNamespaceWrappedArrayOk returns a tuple with the NamespaceWrappedArray field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasNamespaceWrappedArray
-
-`func (o *XmlItem) HasNamespaceWrappedArray() bool`
-
-HasNamespaceWrappedArray returns a boolean if a field has been set.
 
 ### SetNamespaceWrappedArray
 
 `func (o *XmlItem) SetNamespaceWrappedArray(v []int32)`
 
-SetNamespaceWrappedArray gets a reference to the given []int32 and assigns it to the NamespaceWrappedArray field.
+SetNamespaceWrappedArray sets NamespaceWrappedArray field to given value.
 
 ### GetPrefixNsString
 
@@ -636,22 +498,16 @@ GetPrefixNsString returns the PrefixNsString field if non-nil, zero value otherw
 
 ### GetPrefixNsStringOk
 
-`func (o *XmlItem) GetPrefixNsStringOk() (string, bool)`
+`func (o *XmlItem) GetPrefixNsStringOk() (*string, bool)`
 
 GetPrefixNsStringOk returns a tuple with the PrefixNsString field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasPrefixNsString
-
-`func (o *XmlItem) HasPrefixNsString() bool`
-
-HasPrefixNsString returns a boolean if a field has been set.
 
 ### SetPrefixNsString
 
 `func (o *XmlItem) SetPrefixNsString(v string)`
 
-SetPrefixNsString gets a reference to the given string and assigns it to the PrefixNsString field.
+SetPrefixNsString sets PrefixNsString field to given value.
 
 ### GetPrefixNsNumber
 
@@ -661,22 +517,16 @@ GetPrefixNsNumber returns the PrefixNsNumber field if non-nil, zero value otherw
 
 ### GetPrefixNsNumberOk
 
-`func (o *XmlItem) GetPrefixNsNumberOk() (float32, bool)`
+`func (o *XmlItem) GetPrefixNsNumberOk() (*float32, bool)`
 
 GetPrefixNsNumberOk returns a tuple with the PrefixNsNumber field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasPrefixNsNumber
-
-`func (o *XmlItem) HasPrefixNsNumber() bool`
-
-HasPrefixNsNumber returns a boolean if a field has been set.
 
 ### SetPrefixNsNumber
 
 `func (o *XmlItem) SetPrefixNsNumber(v float32)`
 
-SetPrefixNsNumber gets a reference to the given float32 and assigns it to the PrefixNsNumber field.
+SetPrefixNsNumber sets PrefixNsNumber field to given value.
 
 ### GetPrefixNsInteger
 
@@ -686,22 +536,16 @@ GetPrefixNsInteger returns the PrefixNsInteger field if non-nil, zero value othe
 
 ### GetPrefixNsIntegerOk
 
-`func (o *XmlItem) GetPrefixNsIntegerOk() (int32, bool)`
+`func (o *XmlItem) GetPrefixNsIntegerOk() (*int32, bool)`
 
 GetPrefixNsIntegerOk returns a tuple with the PrefixNsInteger field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasPrefixNsInteger
-
-`func (o *XmlItem) HasPrefixNsInteger() bool`
-
-HasPrefixNsInteger returns a boolean if a field has been set.
 
 ### SetPrefixNsInteger
 
 `func (o *XmlItem) SetPrefixNsInteger(v int32)`
 
-SetPrefixNsInteger gets a reference to the given int32 and assigns it to the PrefixNsInteger field.
+SetPrefixNsInteger sets PrefixNsInteger field to given value.
 
 ### GetPrefixNsBoolean
 
@@ -711,22 +555,16 @@ GetPrefixNsBoolean returns the PrefixNsBoolean field if non-nil, zero value othe
 
 ### GetPrefixNsBooleanOk
 
-`func (o *XmlItem) GetPrefixNsBooleanOk() (bool, bool)`
+`func (o *XmlItem) GetPrefixNsBooleanOk() (*bool, bool)`
 
 GetPrefixNsBooleanOk returns a tuple with the PrefixNsBoolean field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasPrefixNsBoolean
-
-`func (o *XmlItem) HasPrefixNsBoolean() bool`
-
-HasPrefixNsBoolean returns a boolean if a field has been set.
 
 ### SetPrefixNsBoolean
 
 `func (o *XmlItem) SetPrefixNsBoolean(v bool)`
 
-SetPrefixNsBoolean gets a reference to the given bool and assigns it to the PrefixNsBoolean field.
+SetPrefixNsBoolean sets PrefixNsBoolean field to given value.
 
 ### GetPrefixNsArray
 
@@ -736,22 +574,16 @@ GetPrefixNsArray returns the PrefixNsArray field if non-nil, zero value otherwis
 
 ### GetPrefixNsArrayOk
 
-`func (o *XmlItem) GetPrefixNsArrayOk() ([]int32, bool)`
+`func (o *XmlItem) GetPrefixNsArrayOk() (*[]int32, bool)`
 
 GetPrefixNsArrayOk returns a tuple with the PrefixNsArray field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasPrefixNsArray
-
-`func (o *XmlItem) HasPrefixNsArray() bool`
-
-HasPrefixNsArray returns a boolean if a field has been set.
 
 ### SetPrefixNsArray
 
 `func (o *XmlItem) SetPrefixNsArray(v []int32)`
 
-SetPrefixNsArray gets a reference to the given []int32 and assigns it to the PrefixNsArray field.
+SetPrefixNsArray sets PrefixNsArray field to given value.
 
 ### GetPrefixNsWrappedArray
 
@@ -761,22 +593,16 @@ GetPrefixNsWrappedArray returns the PrefixNsWrappedArray field if non-nil, zero 
 
 ### GetPrefixNsWrappedArrayOk
 
-`func (o *XmlItem) GetPrefixNsWrappedArrayOk() ([]int32, bool)`
+`func (o *XmlItem) GetPrefixNsWrappedArrayOk() (*[]int32, bool)`
 
 GetPrefixNsWrappedArrayOk returns a tuple with the PrefixNsWrappedArray field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasPrefixNsWrappedArray
-
-`func (o *XmlItem) HasPrefixNsWrappedArray() bool`
-
-HasPrefixNsWrappedArray returns a boolean if a field has been set.
 
 ### SetPrefixNsWrappedArray
 
 `func (o *XmlItem) SetPrefixNsWrappedArray(v []int32)`
 
-SetPrefixNsWrappedArray gets a reference to the given []int32 and assigns it to the PrefixNsWrappedArray field.
+SetPrefixNsWrappedArray sets PrefixNsWrappedArray field to given value.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/go-experimental/go-petstore/docs/XmlItem.md
+++ b/samples/client/petstore/go-experimental/go-petstore/docs/XmlItem.md
@@ -72,6 +72,12 @@ and a boolean to check if the value has been set.
 
 SetAttributeString sets AttributeString field to given value.
 
+### HasAttributeString
+
+`func (o *XmlItem) HasAttributeString() bool`
+
+HasAttributeString returns a boolean if a field has been set.
+
 ### GetAttributeNumber
 
 `func (o *XmlItem) GetAttributeNumber() float32`
@@ -90,6 +96,12 @@ and a boolean to check if the value has been set.
 `func (o *XmlItem) SetAttributeNumber(v float32)`
 
 SetAttributeNumber sets AttributeNumber field to given value.
+
+### HasAttributeNumber
+
+`func (o *XmlItem) HasAttributeNumber() bool`
+
+HasAttributeNumber returns a boolean if a field has been set.
 
 ### GetAttributeInteger
 
@@ -110,6 +122,12 @@ and a boolean to check if the value has been set.
 
 SetAttributeInteger sets AttributeInteger field to given value.
 
+### HasAttributeInteger
+
+`func (o *XmlItem) HasAttributeInteger() bool`
+
+HasAttributeInteger returns a boolean if a field has been set.
+
 ### GetAttributeBoolean
 
 `func (o *XmlItem) GetAttributeBoolean() bool`
@@ -128,6 +146,12 @@ and a boolean to check if the value has been set.
 `func (o *XmlItem) SetAttributeBoolean(v bool)`
 
 SetAttributeBoolean sets AttributeBoolean field to given value.
+
+### HasAttributeBoolean
+
+`func (o *XmlItem) HasAttributeBoolean() bool`
+
+HasAttributeBoolean returns a boolean if a field has been set.
 
 ### GetWrappedArray
 
@@ -148,6 +172,12 @@ and a boolean to check if the value has been set.
 
 SetWrappedArray sets WrappedArray field to given value.
 
+### HasWrappedArray
+
+`func (o *XmlItem) HasWrappedArray() bool`
+
+HasWrappedArray returns a boolean if a field has been set.
+
 ### GetNameString
 
 `func (o *XmlItem) GetNameString() string`
@@ -166,6 +196,12 @@ and a boolean to check if the value has been set.
 `func (o *XmlItem) SetNameString(v string)`
 
 SetNameString sets NameString field to given value.
+
+### HasNameString
+
+`func (o *XmlItem) HasNameString() bool`
+
+HasNameString returns a boolean if a field has been set.
 
 ### GetNameNumber
 
@@ -186,6 +222,12 @@ and a boolean to check if the value has been set.
 
 SetNameNumber sets NameNumber field to given value.
 
+### HasNameNumber
+
+`func (o *XmlItem) HasNameNumber() bool`
+
+HasNameNumber returns a boolean if a field has been set.
+
 ### GetNameInteger
 
 `func (o *XmlItem) GetNameInteger() int32`
@@ -204,6 +246,12 @@ and a boolean to check if the value has been set.
 `func (o *XmlItem) SetNameInteger(v int32)`
 
 SetNameInteger sets NameInteger field to given value.
+
+### HasNameInteger
+
+`func (o *XmlItem) HasNameInteger() bool`
+
+HasNameInteger returns a boolean if a field has been set.
 
 ### GetNameBoolean
 
@@ -224,6 +272,12 @@ and a boolean to check if the value has been set.
 
 SetNameBoolean sets NameBoolean field to given value.
 
+### HasNameBoolean
+
+`func (o *XmlItem) HasNameBoolean() bool`
+
+HasNameBoolean returns a boolean if a field has been set.
+
 ### GetNameArray
 
 `func (o *XmlItem) GetNameArray() []int32`
@@ -242,6 +296,12 @@ and a boolean to check if the value has been set.
 `func (o *XmlItem) SetNameArray(v []int32)`
 
 SetNameArray sets NameArray field to given value.
+
+### HasNameArray
+
+`func (o *XmlItem) HasNameArray() bool`
+
+HasNameArray returns a boolean if a field has been set.
 
 ### GetNameWrappedArray
 
@@ -262,6 +322,12 @@ and a boolean to check if the value has been set.
 
 SetNameWrappedArray sets NameWrappedArray field to given value.
 
+### HasNameWrappedArray
+
+`func (o *XmlItem) HasNameWrappedArray() bool`
+
+HasNameWrappedArray returns a boolean if a field has been set.
+
 ### GetPrefixString
 
 `func (o *XmlItem) GetPrefixString() string`
@@ -280,6 +346,12 @@ and a boolean to check if the value has been set.
 `func (o *XmlItem) SetPrefixString(v string)`
 
 SetPrefixString sets PrefixString field to given value.
+
+### HasPrefixString
+
+`func (o *XmlItem) HasPrefixString() bool`
+
+HasPrefixString returns a boolean if a field has been set.
 
 ### GetPrefixNumber
 
@@ -300,6 +372,12 @@ and a boolean to check if the value has been set.
 
 SetPrefixNumber sets PrefixNumber field to given value.
 
+### HasPrefixNumber
+
+`func (o *XmlItem) HasPrefixNumber() bool`
+
+HasPrefixNumber returns a boolean if a field has been set.
+
 ### GetPrefixInteger
 
 `func (o *XmlItem) GetPrefixInteger() int32`
@@ -318,6 +396,12 @@ and a boolean to check if the value has been set.
 `func (o *XmlItem) SetPrefixInteger(v int32)`
 
 SetPrefixInteger sets PrefixInteger field to given value.
+
+### HasPrefixInteger
+
+`func (o *XmlItem) HasPrefixInteger() bool`
+
+HasPrefixInteger returns a boolean if a field has been set.
 
 ### GetPrefixBoolean
 
@@ -338,6 +422,12 @@ and a boolean to check if the value has been set.
 
 SetPrefixBoolean sets PrefixBoolean field to given value.
 
+### HasPrefixBoolean
+
+`func (o *XmlItem) HasPrefixBoolean() bool`
+
+HasPrefixBoolean returns a boolean if a field has been set.
+
 ### GetPrefixArray
 
 `func (o *XmlItem) GetPrefixArray() []int32`
@@ -356,6 +446,12 @@ and a boolean to check if the value has been set.
 `func (o *XmlItem) SetPrefixArray(v []int32)`
 
 SetPrefixArray sets PrefixArray field to given value.
+
+### HasPrefixArray
+
+`func (o *XmlItem) HasPrefixArray() bool`
+
+HasPrefixArray returns a boolean if a field has been set.
 
 ### GetPrefixWrappedArray
 
@@ -376,6 +472,12 @@ and a boolean to check if the value has been set.
 
 SetPrefixWrappedArray sets PrefixWrappedArray field to given value.
 
+### HasPrefixWrappedArray
+
+`func (o *XmlItem) HasPrefixWrappedArray() bool`
+
+HasPrefixWrappedArray returns a boolean if a field has been set.
+
 ### GetNamespaceString
 
 `func (o *XmlItem) GetNamespaceString() string`
@@ -394,6 +496,12 @@ and a boolean to check if the value has been set.
 `func (o *XmlItem) SetNamespaceString(v string)`
 
 SetNamespaceString sets NamespaceString field to given value.
+
+### HasNamespaceString
+
+`func (o *XmlItem) HasNamespaceString() bool`
+
+HasNamespaceString returns a boolean if a field has been set.
 
 ### GetNamespaceNumber
 
@@ -414,6 +522,12 @@ and a boolean to check if the value has been set.
 
 SetNamespaceNumber sets NamespaceNumber field to given value.
 
+### HasNamespaceNumber
+
+`func (o *XmlItem) HasNamespaceNumber() bool`
+
+HasNamespaceNumber returns a boolean if a field has been set.
+
 ### GetNamespaceInteger
 
 `func (o *XmlItem) GetNamespaceInteger() int32`
@@ -432,6 +546,12 @@ and a boolean to check if the value has been set.
 `func (o *XmlItem) SetNamespaceInteger(v int32)`
 
 SetNamespaceInteger sets NamespaceInteger field to given value.
+
+### HasNamespaceInteger
+
+`func (o *XmlItem) HasNamespaceInteger() bool`
+
+HasNamespaceInteger returns a boolean if a field has been set.
 
 ### GetNamespaceBoolean
 
@@ -452,6 +572,12 @@ and a boolean to check if the value has been set.
 
 SetNamespaceBoolean sets NamespaceBoolean field to given value.
 
+### HasNamespaceBoolean
+
+`func (o *XmlItem) HasNamespaceBoolean() bool`
+
+HasNamespaceBoolean returns a boolean if a field has been set.
+
 ### GetNamespaceArray
 
 `func (o *XmlItem) GetNamespaceArray() []int32`
@@ -470,6 +596,12 @@ and a boolean to check if the value has been set.
 `func (o *XmlItem) SetNamespaceArray(v []int32)`
 
 SetNamespaceArray sets NamespaceArray field to given value.
+
+### HasNamespaceArray
+
+`func (o *XmlItem) HasNamespaceArray() bool`
+
+HasNamespaceArray returns a boolean if a field has been set.
 
 ### GetNamespaceWrappedArray
 
@@ -490,6 +622,12 @@ and a boolean to check if the value has been set.
 
 SetNamespaceWrappedArray sets NamespaceWrappedArray field to given value.
 
+### HasNamespaceWrappedArray
+
+`func (o *XmlItem) HasNamespaceWrappedArray() bool`
+
+HasNamespaceWrappedArray returns a boolean if a field has been set.
+
 ### GetPrefixNsString
 
 `func (o *XmlItem) GetPrefixNsString() string`
@@ -508,6 +646,12 @@ and a boolean to check if the value has been set.
 `func (o *XmlItem) SetPrefixNsString(v string)`
 
 SetPrefixNsString sets PrefixNsString field to given value.
+
+### HasPrefixNsString
+
+`func (o *XmlItem) HasPrefixNsString() bool`
+
+HasPrefixNsString returns a boolean if a field has been set.
 
 ### GetPrefixNsNumber
 
@@ -528,6 +672,12 @@ and a boolean to check if the value has been set.
 
 SetPrefixNsNumber sets PrefixNsNumber field to given value.
 
+### HasPrefixNsNumber
+
+`func (o *XmlItem) HasPrefixNsNumber() bool`
+
+HasPrefixNsNumber returns a boolean if a field has been set.
+
 ### GetPrefixNsInteger
 
 `func (o *XmlItem) GetPrefixNsInteger() int32`
@@ -546,6 +696,12 @@ and a boolean to check if the value has been set.
 `func (o *XmlItem) SetPrefixNsInteger(v int32)`
 
 SetPrefixNsInteger sets PrefixNsInteger field to given value.
+
+### HasPrefixNsInteger
+
+`func (o *XmlItem) HasPrefixNsInteger() bool`
+
+HasPrefixNsInteger returns a boolean if a field has been set.
 
 ### GetPrefixNsBoolean
 
@@ -566,6 +722,12 @@ and a boolean to check if the value has been set.
 
 SetPrefixNsBoolean sets PrefixNsBoolean field to given value.
 
+### HasPrefixNsBoolean
+
+`func (o *XmlItem) HasPrefixNsBoolean() bool`
+
+HasPrefixNsBoolean returns a boolean if a field has been set.
+
 ### GetPrefixNsArray
 
 `func (o *XmlItem) GetPrefixNsArray() []int32`
@@ -585,6 +747,12 @@ and a boolean to check if the value has been set.
 
 SetPrefixNsArray sets PrefixNsArray field to given value.
 
+### HasPrefixNsArray
+
+`func (o *XmlItem) HasPrefixNsArray() bool`
+
+HasPrefixNsArray returns a boolean if a field has been set.
+
 ### GetPrefixNsWrappedArray
 
 `func (o *XmlItem) GetPrefixNsWrappedArray() []int32`
@@ -603,6 +771,12 @@ and a boolean to check if the value has been set.
 `func (o *XmlItem) SetPrefixNsWrappedArray(v []int32)`
 
 SetPrefixNsWrappedArray sets PrefixNsWrappedArray field to given value.
+
+### HasPrefixNsWrappedArray
+
+`func (o *XmlItem) HasPrefixNsWrappedArray() bool`
+
+HasPrefixNsWrappedArray returns a boolean if a field has been set.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/go-experimental/go-petstore/model_200_response.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_200_response.go
@@ -24,16 +24,16 @@ type Model200Response struct {
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
 func NewModel200Response() *Model200Response {
-    this := Model200Response{}
-    return &this
+	this := Model200Response{}
+	return &this
 }
 
 // NewModel200ResponseWithDefaults instantiates a new Model200Response object
 // This constructor will only assign default values to properties that have it defined,
 // but it doesn't guarantee that properties required by API are set
 func NewModel200ResponseWithDefaults() *Model200Response {
-    this := Model200Response{}
-    return &this
+	this := Model200Response{}
+	return &this
 }
 
 // GetName returns the Name field value if set, zero value otherwise.
@@ -45,14 +45,14 @@ func (o *Model200Response) GetName() int32 {
 	return *o.Name
 }
 
-// GetNameOk returns a tuple with the Name field value if set, zero value otherwise
+// GetNameOk returns a tuple with the Name field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *Model200Response) GetNameOk() (int32, bool) {
+
+func (o *Model200Response) GetNameOk() (*int32, bool) {
 	if o == nil || o.Name == nil {
-		var ret int32
-		return ret, false
+		return nil, false
 	}
-	return *o.Name, true
+	return o.Name, true
 }
 
 // HasName returns a boolean if a field has been set.
@@ -78,14 +78,14 @@ func (o *Model200Response) GetClass() string {
 	return *o.Class
 }
 
-// GetClassOk returns a tuple with the Class field value if set, zero value otherwise
+// GetClassOk returns a tuple with the Class field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *Model200Response) GetClassOk() (string, bool) {
+
+func (o *Model200Response) GetClassOk() (*string, bool) {
 	if o == nil || o.Class == nil {
-		var ret string
-		return ret, false
+		return nil, false
 	}
-	return *o.Class, true
+	return o.Class, true
 }
 
 // HasClass returns a boolean if a field has been set.

--- a/samples/client/petstore/go-experimental/go-petstore/model_200_response.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_200_response.go
@@ -10,7 +10,6 @@
 package petstore
 
 import (
-	"bytes"
 	"encoding/json"
 )
 
@@ -53,12 +52,12 @@ func (o *Model200Response) GetNameOk() (int32, bool) {
 		var ret int32
 		return ret, false
 	}
-	return *o.Name, true
+    return *o.Name, true
 }
 
 // HasName returns a boolean if a field has been set.
 func (o *Model200Response) HasName() bool {
-	if o != nil && o.Name != nil {
+    if o != nil && o.Name != nil {
 		return true
 	}
 
@@ -86,12 +85,12 @@ func (o *Model200Response) GetClassOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-	return *o.Class, true
+    return *o.Class, true
 }
 
 // HasClass returns a boolean if a field has been set.
 func (o *Model200Response) HasClass() bool {
-	if o != nil && o.Class != nil {
+    if o != nil && o.Class != nil {
 		return true
 	}
 
@@ -103,25 +102,49 @@ func (o *Model200Response) SetClass(v string) {
 	o.Class = &v
 }
 
+func (o Model200Response) MarshalJSON() ([]byte, error) {
+    toSerialize := map[string]interface{}{}
+    if o.Name != nil {
+        toSerialize["name"] = o.Name
+    }
+    if o.Class != nil {
+        toSerialize["class"] = o.Class
+    }
+    return json.Marshal(toSerialize)
+}
+
 type NullableModel200Response struct {
-	Value Model200Response
-	ExplicitNull bool
+	value *Model200Response
+	isSet bool
+}
+
+func (v NullableModel200Response) Get() *Model200Response {
+    return v.value
+}
+
+func (v NullableModel200Response) Set(val *Model200Response) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableModel200Response) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableModel200Response) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableModel200Response(val *Model200Response) *NullableModel200Response {
+    return &NullableModel200Response{value: val, isSet: true}
 }
 
 func (v NullableModel200Response) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-		return json.Marshal(v.Value)
-	}
+    return json.Marshal(v.value)
 }
 
 func (v *NullableModel200Response) UnmarshalJSON(src []byte) error {
-	if bytes.Equal(src, []byte("null")) {
-		v.ExplicitNull = true
-		return nil
-	}
-
-	return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_200_response.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_200_response.go
@@ -52,12 +52,12 @@ func (o *Model200Response) GetNameOk() (int32, bool) {
 		var ret int32
 		return ret, false
 	}
-    return *o.Name, true
+	return *o.Name, true
 }
 
 // HasName returns a boolean if a field has been set.
 func (o *Model200Response) HasName() bool {
-    if o != nil && o.Name != nil {
+	if o != nil && o.Name != nil {
 		return true
 	}
 
@@ -85,12 +85,12 @@ func (o *Model200Response) GetClassOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-    return *o.Class, true
+	return *o.Class, true
 }
 
 // HasClass returns a boolean if a field has been set.
 func (o *Model200Response) HasClass() bool {
-    if o != nil && o.Class != nil {
+	if o != nil && o.Class != nil {
 		return true
 	}
 
@@ -103,14 +103,14 @@ func (o *Model200Response) SetClass(v string) {
 }
 
 func (o Model200Response) MarshalJSON() ([]byte, error) {
-    toSerialize := map[string]interface{}{}
-    if o.Name != nil {
-        toSerialize["name"] = o.Name
-    }
-    if o.Class != nil {
-        toSerialize["class"] = o.Class
-    }
-    return json.Marshal(toSerialize)
+	toSerialize := map[string]interface{}{}
+	if o.Name != nil {
+		toSerialize["name"] = o.Name
+	}
+	if o.Class != nil {
+		toSerialize["class"] = o.Class
+	}
+	return json.Marshal(toSerialize)
 }
 
 type NullableModel200Response struct {
@@ -119,32 +119,32 @@ type NullableModel200Response struct {
 }
 
 func (v NullableModel200Response) Get() *Model200Response {
-    return v.value
+	return v.value
 }
 
 func (v NullableModel200Response) Set(val *Model200Response) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableModel200Response) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableModel200Response) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableModel200Response(val *Model200Response) *NullableModel200Response {
-    return &NullableModel200Response{value: val, isSet: true}
+	return &NullableModel200Response{value: val, isSet: true}
 }
 
 func (v NullableModel200Response) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableModel200Response) UnmarshalJSON(src []byte) error {
-    v.isSet = true
+	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_200_response.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_200_response.go
@@ -47,7 +47,6 @@ func (o *Model200Response) GetName() int32 {
 
 // GetNameOk returns a tuple with the Name field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *Model200Response) GetNameOk() (*int32, bool) {
 	if o == nil || o.Name == nil {
 		return nil, false
@@ -80,7 +79,6 @@ func (o *Model200Response) GetClass() string {
 
 // GetClassOk returns a tuple with the Class field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *Model200Response) GetClassOk() (*string, bool) {
 	if o == nil || o.Class == nil {
 		return nil, false

--- a/samples/client/petstore/go-experimental/go-petstore/model_200_response.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_200_response.go
@@ -122,7 +122,7 @@ func (v NullableModel200Response) Get() *Model200Response {
 	return v.value
 }
 
-func (v NullableModel200Response) Set(val *Model200Response) {
+func (v *NullableModel200Response) Set(val *Model200Response) {
 	v.value = val
 	v.isSet = true
 }
@@ -131,7 +131,7 @@ func (v NullableModel200Response) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableModel200Response) Unset() {
+func (v *NullableModel200Response) Unset() {
 	v.value = nil
 	v.isSet = false
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_additional_properties_any_type.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_additional_properties_any_type.go
@@ -46,7 +46,6 @@ func (o *AdditionalPropertiesAnyType) GetName() string {
 
 // GetNameOk returns a tuple with the Name field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *AdditionalPropertiesAnyType) GetNameOk() (*string, bool) {
 	if o == nil || o.Name == nil {
 		return nil, false

--- a/samples/client/petstore/go-experimental/go-petstore/model_additional_properties_any_type.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_additional_properties_any_type.go
@@ -10,7 +10,6 @@
 package petstore
 
 import (
-	"bytes"
 	"encoding/json"
 )
 
@@ -52,12 +51,12 @@ func (o *AdditionalPropertiesAnyType) GetNameOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-	return *o.Name, true
+    return *o.Name, true
 }
 
 // HasName returns a boolean if a field has been set.
 func (o *AdditionalPropertiesAnyType) HasName() bool {
-	if o != nil && o.Name != nil {
+    if o != nil && o.Name != nil {
 		return true
 	}
 
@@ -69,25 +68,46 @@ func (o *AdditionalPropertiesAnyType) SetName(v string) {
 	o.Name = &v
 }
 
+func (o AdditionalPropertiesAnyType) MarshalJSON() ([]byte, error) {
+    toSerialize := map[string]interface{}{}
+    if o.Name != nil {
+        toSerialize["name"] = o.Name
+    }
+    return json.Marshal(toSerialize)
+}
+
 type NullableAdditionalPropertiesAnyType struct {
-	Value AdditionalPropertiesAnyType
-	ExplicitNull bool
+	value *AdditionalPropertiesAnyType
+	isSet bool
+}
+
+func (v NullableAdditionalPropertiesAnyType) Get() *AdditionalPropertiesAnyType {
+    return v.value
+}
+
+func (v NullableAdditionalPropertiesAnyType) Set(val *AdditionalPropertiesAnyType) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableAdditionalPropertiesAnyType) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableAdditionalPropertiesAnyType) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableAdditionalPropertiesAnyType(val *AdditionalPropertiesAnyType) *NullableAdditionalPropertiesAnyType {
+    return &NullableAdditionalPropertiesAnyType{value: val, isSet: true}
 }
 
 func (v NullableAdditionalPropertiesAnyType) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-		return json.Marshal(v.Value)
-	}
+    return json.Marshal(v.value)
 }
 
 func (v *NullableAdditionalPropertiesAnyType) UnmarshalJSON(src []byte) error {
-	if bytes.Equal(src, []byte("null")) {
-		v.ExplicitNull = true
-		return nil
-	}
-
-	return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_additional_properties_any_type.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_additional_properties_any_type.go
@@ -23,16 +23,16 @@ type AdditionalPropertiesAnyType struct {
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
 func NewAdditionalPropertiesAnyType() *AdditionalPropertiesAnyType {
-    this := AdditionalPropertiesAnyType{}
-    return &this
+	this := AdditionalPropertiesAnyType{}
+	return &this
 }
 
 // NewAdditionalPropertiesAnyTypeWithDefaults instantiates a new AdditionalPropertiesAnyType object
 // This constructor will only assign default values to properties that have it defined,
 // but it doesn't guarantee that properties required by API are set
 func NewAdditionalPropertiesAnyTypeWithDefaults() *AdditionalPropertiesAnyType {
-    this := AdditionalPropertiesAnyType{}
-    return &this
+	this := AdditionalPropertiesAnyType{}
+	return &this
 }
 
 // GetName returns the Name field value if set, zero value otherwise.
@@ -44,14 +44,14 @@ func (o *AdditionalPropertiesAnyType) GetName() string {
 	return *o.Name
 }
 
-// GetNameOk returns a tuple with the Name field value if set, zero value otherwise
+// GetNameOk returns a tuple with the Name field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *AdditionalPropertiesAnyType) GetNameOk() (string, bool) {
+
+func (o *AdditionalPropertiesAnyType) GetNameOk() (*string, bool) {
 	if o == nil || o.Name == nil {
-		var ret string
-		return ret, false
+		return nil, false
 	}
-	return *o.Name, true
+	return o.Name, true
 }
 
 // HasName returns a boolean if a field has been set.

--- a/samples/client/petstore/go-experimental/go-petstore/model_additional_properties_any_type.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_additional_properties_any_type.go
@@ -85,7 +85,7 @@ func (v NullableAdditionalPropertiesAnyType) Get() *AdditionalPropertiesAnyType 
 	return v.value
 }
 
-func (v NullableAdditionalPropertiesAnyType) Set(val *AdditionalPropertiesAnyType) {
+func (v *NullableAdditionalPropertiesAnyType) Set(val *AdditionalPropertiesAnyType) {
 	v.value = val
 	v.isSet = true
 }
@@ -94,7 +94,7 @@ func (v NullableAdditionalPropertiesAnyType) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableAdditionalPropertiesAnyType) Unset() {
+func (v *NullableAdditionalPropertiesAnyType) Unset() {
 	v.value = nil
 	v.isSet = false
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_additional_properties_any_type.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_additional_properties_any_type.go
@@ -51,12 +51,12 @@ func (o *AdditionalPropertiesAnyType) GetNameOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-    return *o.Name, true
+	return *o.Name, true
 }
 
 // HasName returns a boolean if a field has been set.
 func (o *AdditionalPropertiesAnyType) HasName() bool {
-    if o != nil && o.Name != nil {
+	if o != nil && o.Name != nil {
 		return true
 	}
 
@@ -69,11 +69,11 @@ func (o *AdditionalPropertiesAnyType) SetName(v string) {
 }
 
 func (o AdditionalPropertiesAnyType) MarshalJSON() ([]byte, error) {
-    toSerialize := map[string]interface{}{}
-    if o.Name != nil {
-        toSerialize["name"] = o.Name
-    }
-    return json.Marshal(toSerialize)
+	toSerialize := map[string]interface{}{}
+	if o.Name != nil {
+		toSerialize["name"] = o.Name
+	}
+	return json.Marshal(toSerialize)
 }
 
 type NullableAdditionalPropertiesAnyType struct {
@@ -82,32 +82,32 @@ type NullableAdditionalPropertiesAnyType struct {
 }
 
 func (v NullableAdditionalPropertiesAnyType) Get() *AdditionalPropertiesAnyType {
-    return v.value
+	return v.value
 }
 
 func (v NullableAdditionalPropertiesAnyType) Set(val *AdditionalPropertiesAnyType) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableAdditionalPropertiesAnyType) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableAdditionalPropertiesAnyType) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableAdditionalPropertiesAnyType(val *AdditionalPropertiesAnyType) *NullableAdditionalPropertiesAnyType {
-    return &NullableAdditionalPropertiesAnyType{value: val, isSet: true}
+	return &NullableAdditionalPropertiesAnyType{value: val, isSet: true}
 }
 
 func (v NullableAdditionalPropertiesAnyType) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableAdditionalPropertiesAnyType) UnmarshalJSON(src []byte) error {
-    v.isSet = true
+	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_additional_properties_array.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_additional_properties_array.go
@@ -85,7 +85,7 @@ func (v NullableAdditionalPropertiesArray) Get() *AdditionalPropertiesArray {
 	return v.value
 }
 
-func (v NullableAdditionalPropertiesArray) Set(val *AdditionalPropertiesArray) {
+func (v *NullableAdditionalPropertiesArray) Set(val *AdditionalPropertiesArray) {
 	v.value = val
 	v.isSet = true
 }
@@ -94,7 +94,7 @@ func (v NullableAdditionalPropertiesArray) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableAdditionalPropertiesArray) Unset() {
+func (v *NullableAdditionalPropertiesArray) Unset() {
 	v.value = nil
 	v.isSet = false
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_additional_properties_array.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_additional_properties_array.go
@@ -23,16 +23,16 @@ type AdditionalPropertiesArray struct {
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
 func NewAdditionalPropertiesArray() *AdditionalPropertiesArray {
-    this := AdditionalPropertiesArray{}
-    return &this
+	this := AdditionalPropertiesArray{}
+	return &this
 }
 
 // NewAdditionalPropertiesArrayWithDefaults instantiates a new AdditionalPropertiesArray object
 // This constructor will only assign default values to properties that have it defined,
 // but it doesn't guarantee that properties required by API are set
 func NewAdditionalPropertiesArrayWithDefaults() *AdditionalPropertiesArray {
-    this := AdditionalPropertiesArray{}
-    return &this
+	this := AdditionalPropertiesArray{}
+	return &this
 }
 
 // GetName returns the Name field value if set, zero value otherwise.
@@ -44,14 +44,14 @@ func (o *AdditionalPropertiesArray) GetName() string {
 	return *o.Name
 }
 
-// GetNameOk returns a tuple with the Name field value if set, zero value otherwise
+// GetNameOk returns a tuple with the Name field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *AdditionalPropertiesArray) GetNameOk() (string, bool) {
+
+func (o *AdditionalPropertiesArray) GetNameOk() (*string, bool) {
 	if o == nil || o.Name == nil {
-		var ret string
-		return ret, false
+		return nil, false
 	}
-	return *o.Name, true
+	return o.Name, true
 }
 
 // HasName returns a boolean if a field has been set.

--- a/samples/client/petstore/go-experimental/go-petstore/model_additional_properties_array.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_additional_properties_array.go
@@ -46,7 +46,6 @@ func (o *AdditionalPropertiesArray) GetName() string {
 
 // GetNameOk returns a tuple with the Name field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *AdditionalPropertiesArray) GetNameOk() (*string, bool) {
 	if o == nil || o.Name == nil {
 		return nil, false

--- a/samples/client/petstore/go-experimental/go-petstore/model_additional_properties_array.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_additional_properties_array.go
@@ -51,12 +51,12 @@ func (o *AdditionalPropertiesArray) GetNameOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-    return *o.Name, true
+	return *o.Name, true
 }
 
 // HasName returns a boolean if a field has been set.
 func (o *AdditionalPropertiesArray) HasName() bool {
-    if o != nil && o.Name != nil {
+	if o != nil && o.Name != nil {
 		return true
 	}
 
@@ -69,11 +69,11 @@ func (o *AdditionalPropertiesArray) SetName(v string) {
 }
 
 func (o AdditionalPropertiesArray) MarshalJSON() ([]byte, error) {
-    toSerialize := map[string]interface{}{}
-    if o.Name != nil {
-        toSerialize["name"] = o.Name
-    }
-    return json.Marshal(toSerialize)
+	toSerialize := map[string]interface{}{}
+	if o.Name != nil {
+		toSerialize["name"] = o.Name
+	}
+	return json.Marshal(toSerialize)
 }
 
 type NullableAdditionalPropertiesArray struct {
@@ -82,32 +82,32 @@ type NullableAdditionalPropertiesArray struct {
 }
 
 func (v NullableAdditionalPropertiesArray) Get() *AdditionalPropertiesArray {
-    return v.value
+	return v.value
 }
 
 func (v NullableAdditionalPropertiesArray) Set(val *AdditionalPropertiesArray) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableAdditionalPropertiesArray) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableAdditionalPropertiesArray) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableAdditionalPropertiesArray(val *AdditionalPropertiesArray) *NullableAdditionalPropertiesArray {
-    return &NullableAdditionalPropertiesArray{value: val, isSet: true}
+	return &NullableAdditionalPropertiesArray{value: val, isSet: true}
 }
 
 func (v NullableAdditionalPropertiesArray) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableAdditionalPropertiesArray) UnmarshalJSON(src []byte) error {
-    v.isSet = true
+	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_additional_properties_array.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_additional_properties_array.go
@@ -10,7 +10,6 @@
 package petstore
 
 import (
-	"bytes"
 	"encoding/json"
 )
 
@@ -52,12 +51,12 @@ func (o *AdditionalPropertiesArray) GetNameOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-	return *o.Name, true
+    return *o.Name, true
 }
 
 // HasName returns a boolean if a field has been set.
 func (o *AdditionalPropertiesArray) HasName() bool {
-	if o != nil && o.Name != nil {
+    if o != nil && o.Name != nil {
 		return true
 	}
 
@@ -69,25 +68,46 @@ func (o *AdditionalPropertiesArray) SetName(v string) {
 	o.Name = &v
 }
 
+func (o AdditionalPropertiesArray) MarshalJSON() ([]byte, error) {
+    toSerialize := map[string]interface{}{}
+    if o.Name != nil {
+        toSerialize["name"] = o.Name
+    }
+    return json.Marshal(toSerialize)
+}
+
 type NullableAdditionalPropertiesArray struct {
-	Value AdditionalPropertiesArray
-	ExplicitNull bool
+	value *AdditionalPropertiesArray
+	isSet bool
+}
+
+func (v NullableAdditionalPropertiesArray) Get() *AdditionalPropertiesArray {
+    return v.value
+}
+
+func (v NullableAdditionalPropertiesArray) Set(val *AdditionalPropertiesArray) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableAdditionalPropertiesArray) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableAdditionalPropertiesArray) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableAdditionalPropertiesArray(val *AdditionalPropertiesArray) *NullableAdditionalPropertiesArray {
+    return &NullableAdditionalPropertiesArray{value: val, isSet: true}
 }
 
 func (v NullableAdditionalPropertiesArray) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-		return json.Marshal(v.Value)
-	}
+    return json.Marshal(v.value)
 }
 
 func (v *NullableAdditionalPropertiesArray) UnmarshalJSON(src []byte) error {
-	if bytes.Equal(src, []byte("null")) {
-		v.ExplicitNull = true
-		return nil
-	}
-
-	return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_additional_properties_boolean.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_additional_properties_boolean.go
@@ -23,16 +23,16 @@ type AdditionalPropertiesBoolean struct {
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
 func NewAdditionalPropertiesBoolean() *AdditionalPropertiesBoolean {
-    this := AdditionalPropertiesBoolean{}
-    return &this
+	this := AdditionalPropertiesBoolean{}
+	return &this
 }
 
 // NewAdditionalPropertiesBooleanWithDefaults instantiates a new AdditionalPropertiesBoolean object
 // This constructor will only assign default values to properties that have it defined,
 // but it doesn't guarantee that properties required by API are set
 func NewAdditionalPropertiesBooleanWithDefaults() *AdditionalPropertiesBoolean {
-    this := AdditionalPropertiesBoolean{}
-    return &this
+	this := AdditionalPropertiesBoolean{}
+	return &this
 }
 
 // GetName returns the Name field value if set, zero value otherwise.
@@ -44,14 +44,14 @@ func (o *AdditionalPropertiesBoolean) GetName() string {
 	return *o.Name
 }
 
-// GetNameOk returns a tuple with the Name field value if set, zero value otherwise
+// GetNameOk returns a tuple with the Name field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *AdditionalPropertiesBoolean) GetNameOk() (string, bool) {
+
+func (o *AdditionalPropertiesBoolean) GetNameOk() (*string, bool) {
 	if o == nil || o.Name == nil {
-		var ret string
-		return ret, false
+		return nil, false
 	}
-	return *o.Name, true
+	return o.Name, true
 }
 
 // HasName returns a boolean if a field has been set.

--- a/samples/client/petstore/go-experimental/go-petstore/model_additional_properties_boolean.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_additional_properties_boolean.go
@@ -51,12 +51,12 @@ func (o *AdditionalPropertiesBoolean) GetNameOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-    return *o.Name, true
+	return *o.Name, true
 }
 
 // HasName returns a boolean if a field has been set.
 func (o *AdditionalPropertiesBoolean) HasName() bool {
-    if o != nil && o.Name != nil {
+	if o != nil && o.Name != nil {
 		return true
 	}
 
@@ -69,11 +69,11 @@ func (o *AdditionalPropertiesBoolean) SetName(v string) {
 }
 
 func (o AdditionalPropertiesBoolean) MarshalJSON() ([]byte, error) {
-    toSerialize := map[string]interface{}{}
-    if o.Name != nil {
-        toSerialize["name"] = o.Name
-    }
-    return json.Marshal(toSerialize)
+	toSerialize := map[string]interface{}{}
+	if o.Name != nil {
+		toSerialize["name"] = o.Name
+	}
+	return json.Marshal(toSerialize)
 }
 
 type NullableAdditionalPropertiesBoolean struct {
@@ -82,32 +82,32 @@ type NullableAdditionalPropertiesBoolean struct {
 }
 
 func (v NullableAdditionalPropertiesBoolean) Get() *AdditionalPropertiesBoolean {
-    return v.value
+	return v.value
 }
 
 func (v NullableAdditionalPropertiesBoolean) Set(val *AdditionalPropertiesBoolean) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableAdditionalPropertiesBoolean) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableAdditionalPropertiesBoolean) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableAdditionalPropertiesBoolean(val *AdditionalPropertiesBoolean) *NullableAdditionalPropertiesBoolean {
-    return &NullableAdditionalPropertiesBoolean{value: val, isSet: true}
+	return &NullableAdditionalPropertiesBoolean{value: val, isSet: true}
 }
 
 func (v NullableAdditionalPropertiesBoolean) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableAdditionalPropertiesBoolean) UnmarshalJSON(src []byte) error {
-    v.isSet = true
+	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_additional_properties_boolean.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_additional_properties_boolean.go
@@ -85,7 +85,7 @@ func (v NullableAdditionalPropertiesBoolean) Get() *AdditionalPropertiesBoolean 
 	return v.value
 }
 
-func (v NullableAdditionalPropertiesBoolean) Set(val *AdditionalPropertiesBoolean) {
+func (v *NullableAdditionalPropertiesBoolean) Set(val *AdditionalPropertiesBoolean) {
 	v.value = val
 	v.isSet = true
 }
@@ -94,7 +94,7 @@ func (v NullableAdditionalPropertiesBoolean) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableAdditionalPropertiesBoolean) Unset() {
+func (v *NullableAdditionalPropertiesBoolean) Unset() {
 	v.value = nil
 	v.isSet = false
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_additional_properties_boolean.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_additional_properties_boolean.go
@@ -46,7 +46,6 @@ func (o *AdditionalPropertiesBoolean) GetName() string {
 
 // GetNameOk returns a tuple with the Name field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *AdditionalPropertiesBoolean) GetNameOk() (*string, bool) {
 	if o == nil || o.Name == nil {
 		return nil, false

--- a/samples/client/petstore/go-experimental/go-petstore/model_additional_properties_boolean.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_additional_properties_boolean.go
@@ -10,7 +10,6 @@
 package petstore
 
 import (
-	"bytes"
 	"encoding/json"
 )
 
@@ -52,12 +51,12 @@ func (o *AdditionalPropertiesBoolean) GetNameOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-	return *o.Name, true
+    return *o.Name, true
 }
 
 // HasName returns a boolean if a field has been set.
 func (o *AdditionalPropertiesBoolean) HasName() bool {
-	if o != nil && o.Name != nil {
+    if o != nil && o.Name != nil {
 		return true
 	}
 
@@ -69,25 +68,46 @@ func (o *AdditionalPropertiesBoolean) SetName(v string) {
 	o.Name = &v
 }
 
+func (o AdditionalPropertiesBoolean) MarshalJSON() ([]byte, error) {
+    toSerialize := map[string]interface{}{}
+    if o.Name != nil {
+        toSerialize["name"] = o.Name
+    }
+    return json.Marshal(toSerialize)
+}
+
 type NullableAdditionalPropertiesBoolean struct {
-	Value AdditionalPropertiesBoolean
-	ExplicitNull bool
+	value *AdditionalPropertiesBoolean
+	isSet bool
+}
+
+func (v NullableAdditionalPropertiesBoolean) Get() *AdditionalPropertiesBoolean {
+    return v.value
+}
+
+func (v NullableAdditionalPropertiesBoolean) Set(val *AdditionalPropertiesBoolean) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableAdditionalPropertiesBoolean) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableAdditionalPropertiesBoolean) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableAdditionalPropertiesBoolean(val *AdditionalPropertiesBoolean) *NullableAdditionalPropertiesBoolean {
+    return &NullableAdditionalPropertiesBoolean{value: val, isSet: true}
 }
 
 func (v NullableAdditionalPropertiesBoolean) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-		return json.Marshal(v.Value)
-	}
+    return json.Marshal(v.value)
 }
 
 func (v *NullableAdditionalPropertiesBoolean) UnmarshalJSON(src []byte) error {
-	if bytes.Equal(src, []byte("null")) {
-		v.ExplicitNull = true
-		return nil
-	}
-
-	return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_additional_properties_class.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_additional_properties_class.go
@@ -33,16 +33,16 @@ type AdditionalPropertiesClass struct {
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
 func NewAdditionalPropertiesClass() *AdditionalPropertiesClass {
-    this := AdditionalPropertiesClass{}
-    return &this
+	this := AdditionalPropertiesClass{}
+	return &this
 }
 
 // NewAdditionalPropertiesClassWithDefaults instantiates a new AdditionalPropertiesClass object
 // This constructor will only assign default values to properties that have it defined,
 // but it doesn't guarantee that properties required by API are set
 func NewAdditionalPropertiesClassWithDefaults() *AdditionalPropertiesClass {
-    this := AdditionalPropertiesClass{}
-    return &this
+	this := AdditionalPropertiesClass{}
+	return &this
 }
 
 // GetMapString returns the MapString field value if set, zero value otherwise.
@@ -54,14 +54,14 @@ func (o *AdditionalPropertiesClass) GetMapString() map[string]string {
 	return *o.MapString
 }
 
-// GetMapStringOk returns a tuple with the MapString field value if set, zero value otherwise
+// GetMapStringOk returns a tuple with the MapString field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *AdditionalPropertiesClass) GetMapStringOk() (map[string]string, bool) {
+
+func (o *AdditionalPropertiesClass) GetMapStringOk() (*map[string]string, bool) {
 	if o == nil || o.MapString == nil {
-		var ret map[string]string
-		return ret, false
+		return nil, false
 	}
-	return *o.MapString, true
+	return o.MapString, true
 }
 
 // HasMapString returns a boolean if a field has been set.
@@ -87,14 +87,14 @@ func (o *AdditionalPropertiesClass) GetMapNumber() map[string]float32 {
 	return *o.MapNumber
 }
 
-// GetMapNumberOk returns a tuple with the MapNumber field value if set, zero value otherwise
+// GetMapNumberOk returns a tuple with the MapNumber field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *AdditionalPropertiesClass) GetMapNumberOk() (map[string]float32, bool) {
+
+func (o *AdditionalPropertiesClass) GetMapNumberOk() (*map[string]float32, bool) {
 	if o == nil || o.MapNumber == nil {
-		var ret map[string]float32
-		return ret, false
+		return nil, false
 	}
-	return *o.MapNumber, true
+	return o.MapNumber, true
 }
 
 // HasMapNumber returns a boolean if a field has been set.
@@ -120,14 +120,14 @@ func (o *AdditionalPropertiesClass) GetMapInteger() map[string]int32 {
 	return *o.MapInteger
 }
 
-// GetMapIntegerOk returns a tuple with the MapInteger field value if set, zero value otherwise
+// GetMapIntegerOk returns a tuple with the MapInteger field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *AdditionalPropertiesClass) GetMapIntegerOk() (map[string]int32, bool) {
+
+func (o *AdditionalPropertiesClass) GetMapIntegerOk() (*map[string]int32, bool) {
 	if o == nil || o.MapInteger == nil {
-		var ret map[string]int32
-		return ret, false
+		return nil, false
 	}
-	return *o.MapInteger, true
+	return o.MapInteger, true
 }
 
 // HasMapInteger returns a boolean if a field has been set.
@@ -153,14 +153,14 @@ func (o *AdditionalPropertiesClass) GetMapBoolean() map[string]bool {
 	return *o.MapBoolean
 }
 
-// GetMapBooleanOk returns a tuple with the MapBoolean field value if set, zero value otherwise
+// GetMapBooleanOk returns a tuple with the MapBoolean field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *AdditionalPropertiesClass) GetMapBooleanOk() (map[string]bool, bool) {
+
+func (o *AdditionalPropertiesClass) GetMapBooleanOk() (*map[string]bool, bool) {
 	if o == nil || o.MapBoolean == nil {
-		var ret map[string]bool
-		return ret, false
+		return nil, false
 	}
-	return *o.MapBoolean, true
+	return o.MapBoolean, true
 }
 
 // HasMapBoolean returns a boolean if a field has been set.
@@ -186,14 +186,14 @@ func (o *AdditionalPropertiesClass) GetMapArrayInteger() map[string][]int32 {
 	return *o.MapArrayInteger
 }
 
-// GetMapArrayIntegerOk returns a tuple with the MapArrayInteger field value if set, zero value otherwise
+// GetMapArrayIntegerOk returns a tuple with the MapArrayInteger field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *AdditionalPropertiesClass) GetMapArrayIntegerOk() (map[string][]int32, bool) {
+
+func (o *AdditionalPropertiesClass) GetMapArrayIntegerOk() (*map[string][]int32, bool) {
 	if o == nil || o.MapArrayInteger == nil {
-		var ret map[string][]int32
-		return ret, false
+		return nil, false
 	}
-	return *o.MapArrayInteger, true
+	return o.MapArrayInteger, true
 }
 
 // HasMapArrayInteger returns a boolean if a field has been set.
@@ -219,14 +219,14 @@ func (o *AdditionalPropertiesClass) GetMapArrayAnytype() map[string][]map[string
 	return *o.MapArrayAnytype
 }
 
-// GetMapArrayAnytypeOk returns a tuple with the MapArrayAnytype field value if set, zero value otherwise
+// GetMapArrayAnytypeOk returns a tuple with the MapArrayAnytype field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *AdditionalPropertiesClass) GetMapArrayAnytypeOk() (map[string][]map[string]interface{}, bool) {
+
+func (o *AdditionalPropertiesClass) GetMapArrayAnytypeOk() (*map[string][]map[string]interface{}, bool) {
 	if o == nil || o.MapArrayAnytype == nil {
-		var ret map[string][]map[string]interface{}
-		return ret, false
+		return nil, false
 	}
-	return *o.MapArrayAnytype, true
+	return o.MapArrayAnytype, true
 }
 
 // HasMapArrayAnytype returns a boolean if a field has been set.
@@ -252,14 +252,14 @@ func (o *AdditionalPropertiesClass) GetMapMapString() map[string]map[string]stri
 	return *o.MapMapString
 }
 
-// GetMapMapStringOk returns a tuple with the MapMapString field value if set, zero value otherwise
+// GetMapMapStringOk returns a tuple with the MapMapString field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *AdditionalPropertiesClass) GetMapMapStringOk() (map[string]map[string]string, bool) {
+
+func (o *AdditionalPropertiesClass) GetMapMapStringOk() (*map[string]map[string]string, bool) {
 	if o == nil || o.MapMapString == nil {
-		var ret map[string]map[string]string
-		return ret, false
+		return nil, false
 	}
-	return *o.MapMapString, true
+	return o.MapMapString, true
 }
 
 // HasMapMapString returns a boolean if a field has been set.
@@ -285,14 +285,14 @@ func (o *AdditionalPropertiesClass) GetMapMapAnytype() map[string]map[string]map
 	return *o.MapMapAnytype
 }
 
-// GetMapMapAnytypeOk returns a tuple with the MapMapAnytype field value if set, zero value otherwise
+// GetMapMapAnytypeOk returns a tuple with the MapMapAnytype field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *AdditionalPropertiesClass) GetMapMapAnytypeOk() (map[string]map[string]map[string]interface{}, bool) {
+
+func (o *AdditionalPropertiesClass) GetMapMapAnytypeOk() (*map[string]map[string]map[string]interface{}, bool) {
 	if o == nil || o.MapMapAnytype == nil {
-		var ret map[string]map[string]map[string]interface{}
-		return ret, false
+		return nil, false
 	}
-	return *o.MapMapAnytype, true
+	return o.MapMapAnytype, true
 }
 
 // HasMapMapAnytype returns a boolean if a field has been set.
@@ -318,14 +318,14 @@ func (o *AdditionalPropertiesClass) GetAnytype1() map[string]interface{} {
 	return *o.Anytype1
 }
 
-// GetAnytype1Ok returns a tuple with the Anytype1 field value if set, zero value otherwise
+// GetAnytype1Ok returns a tuple with the Anytype1 field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *AdditionalPropertiesClass) GetAnytype1Ok() (map[string]interface{}, bool) {
+
+func (o *AdditionalPropertiesClass) GetAnytype1Ok() (*map[string]interface{}, bool) {
 	if o == nil || o.Anytype1 == nil {
-		var ret map[string]interface{}
-		return ret, false
+		return nil, false
 	}
-	return *o.Anytype1, true
+	return o.Anytype1, true
 }
 
 // HasAnytype1 returns a boolean if a field has been set.
@@ -351,14 +351,14 @@ func (o *AdditionalPropertiesClass) GetAnytype2() map[string]interface{} {
 	return *o.Anytype2
 }
 
-// GetAnytype2Ok returns a tuple with the Anytype2 field value if set, zero value otherwise
+// GetAnytype2Ok returns a tuple with the Anytype2 field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *AdditionalPropertiesClass) GetAnytype2Ok() (map[string]interface{}, bool) {
+
+func (o *AdditionalPropertiesClass) GetAnytype2Ok() (*map[string]interface{}, bool) {
 	if o == nil || o.Anytype2 == nil {
-		var ret map[string]interface{}
-		return ret, false
+		return nil, false
 	}
-	return *o.Anytype2, true
+	return o.Anytype2, true
 }
 
 // HasAnytype2 returns a boolean if a field has been set.
@@ -384,14 +384,14 @@ func (o *AdditionalPropertiesClass) GetAnytype3() map[string]interface{} {
 	return *o.Anytype3
 }
 
-// GetAnytype3Ok returns a tuple with the Anytype3 field value if set, zero value otherwise
+// GetAnytype3Ok returns a tuple with the Anytype3 field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *AdditionalPropertiesClass) GetAnytype3Ok() (map[string]interface{}, bool) {
+
+func (o *AdditionalPropertiesClass) GetAnytype3Ok() (*map[string]interface{}, bool) {
 	if o == nil || o.Anytype3 == nil {
-		var ret map[string]interface{}
-		return ret, false
+		return nil, false
 	}
-	return *o.Anytype3, true
+	return o.Anytype3, true
 }
 
 // HasAnytype3 returns a boolean if a field has been set.

--- a/samples/client/petstore/go-experimental/go-petstore/model_additional_properties_class.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_additional_properties_class.go
@@ -61,12 +61,12 @@ func (o *AdditionalPropertiesClass) GetMapStringOk() (map[string]string, bool) {
 		var ret map[string]string
 		return ret, false
 	}
-    return *o.MapString, true
+	return *o.MapString, true
 }
 
 // HasMapString returns a boolean if a field has been set.
 func (o *AdditionalPropertiesClass) HasMapString() bool {
-    if o != nil && o.MapString != nil {
+	if o != nil && o.MapString != nil {
 		return true
 	}
 
@@ -94,12 +94,12 @@ func (o *AdditionalPropertiesClass) GetMapNumberOk() (map[string]float32, bool) 
 		var ret map[string]float32
 		return ret, false
 	}
-    return *o.MapNumber, true
+	return *o.MapNumber, true
 }
 
 // HasMapNumber returns a boolean if a field has been set.
 func (o *AdditionalPropertiesClass) HasMapNumber() bool {
-    if o != nil && o.MapNumber != nil {
+	if o != nil && o.MapNumber != nil {
 		return true
 	}
 
@@ -127,12 +127,12 @@ func (o *AdditionalPropertiesClass) GetMapIntegerOk() (map[string]int32, bool) {
 		var ret map[string]int32
 		return ret, false
 	}
-    return *o.MapInteger, true
+	return *o.MapInteger, true
 }
 
 // HasMapInteger returns a boolean if a field has been set.
 func (o *AdditionalPropertiesClass) HasMapInteger() bool {
-    if o != nil && o.MapInteger != nil {
+	if o != nil && o.MapInteger != nil {
 		return true
 	}
 
@@ -160,12 +160,12 @@ func (o *AdditionalPropertiesClass) GetMapBooleanOk() (map[string]bool, bool) {
 		var ret map[string]bool
 		return ret, false
 	}
-    return *o.MapBoolean, true
+	return *o.MapBoolean, true
 }
 
 // HasMapBoolean returns a boolean if a field has been set.
 func (o *AdditionalPropertiesClass) HasMapBoolean() bool {
-    if o != nil && o.MapBoolean != nil {
+	if o != nil && o.MapBoolean != nil {
 		return true
 	}
 
@@ -193,12 +193,12 @@ func (o *AdditionalPropertiesClass) GetMapArrayIntegerOk() (map[string][]int32, 
 		var ret map[string][]int32
 		return ret, false
 	}
-    return *o.MapArrayInteger, true
+	return *o.MapArrayInteger, true
 }
 
 // HasMapArrayInteger returns a boolean if a field has been set.
 func (o *AdditionalPropertiesClass) HasMapArrayInteger() bool {
-    if o != nil && o.MapArrayInteger != nil {
+	if o != nil && o.MapArrayInteger != nil {
 		return true
 	}
 
@@ -226,12 +226,12 @@ func (o *AdditionalPropertiesClass) GetMapArrayAnytypeOk() (map[string][]map[str
 		var ret map[string][]map[string]interface{}
 		return ret, false
 	}
-    return *o.MapArrayAnytype, true
+	return *o.MapArrayAnytype, true
 }
 
 // HasMapArrayAnytype returns a boolean if a field has been set.
 func (o *AdditionalPropertiesClass) HasMapArrayAnytype() bool {
-    if o != nil && o.MapArrayAnytype != nil {
+	if o != nil && o.MapArrayAnytype != nil {
 		return true
 	}
 
@@ -259,12 +259,12 @@ func (o *AdditionalPropertiesClass) GetMapMapStringOk() (map[string]map[string]s
 		var ret map[string]map[string]string
 		return ret, false
 	}
-    return *o.MapMapString, true
+	return *o.MapMapString, true
 }
 
 // HasMapMapString returns a boolean if a field has been set.
 func (o *AdditionalPropertiesClass) HasMapMapString() bool {
-    if o != nil && o.MapMapString != nil {
+	if o != nil && o.MapMapString != nil {
 		return true
 	}
 
@@ -292,12 +292,12 @@ func (o *AdditionalPropertiesClass) GetMapMapAnytypeOk() (map[string]map[string]
 		var ret map[string]map[string]map[string]interface{}
 		return ret, false
 	}
-    return *o.MapMapAnytype, true
+	return *o.MapMapAnytype, true
 }
 
 // HasMapMapAnytype returns a boolean if a field has been set.
 func (o *AdditionalPropertiesClass) HasMapMapAnytype() bool {
-    if o != nil && o.MapMapAnytype != nil {
+	if o != nil && o.MapMapAnytype != nil {
 		return true
 	}
 
@@ -325,12 +325,12 @@ func (o *AdditionalPropertiesClass) GetAnytype1Ok() (map[string]interface{}, boo
 		var ret map[string]interface{}
 		return ret, false
 	}
-    return *o.Anytype1, true
+	return *o.Anytype1, true
 }
 
 // HasAnytype1 returns a boolean if a field has been set.
 func (o *AdditionalPropertiesClass) HasAnytype1() bool {
-    if o != nil && o.Anytype1 != nil {
+	if o != nil && o.Anytype1 != nil {
 		return true
 	}
 
@@ -358,12 +358,12 @@ func (o *AdditionalPropertiesClass) GetAnytype2Ok() (map[string]interface{}, boo
 		var ret map[string]interface{}
 		return ret, false
 	}
-    return *o.Anytype2, true
+	return *o.Anytype2, true
 }
 
 // HasAnytype2 returns a boolean if a field has been set.
 func (o *AdditionalPropertiesClass) HasAnytype2() bool {
-    if o != nil && o.Anytype2 != nil {
+	if o != nil && o.Anytype2 != nil {
 		return true
 	}
 
@@ -391,12 +391,12 @@ func (o *AdditionalPropertiesClass) GetAnytype3Ok() (map[string]interface{}, boo
 		var ret map[string]interface{}
 		return ret, false
 	}
-    return *o.Anytype3, true
+	return *o.Anytype3, true
 }
 
 // HasAnytype3 returns a boolean if a field has been set.
 func (o *AdditionalPropertiesClass) HasAnytype3() bool {
-    if o != nil && o.Anytype3 != nil {
+	if o != nil && o.Anytype3 != nil {
 		return true
 	}
 
@@ -409,41 +409,41 @@ func (o *AdditionalPropertiesClass) SetAnytype3(v map[string]interface{}) {
 }
 
 func (o AdditionalPropertiesClass) MarshalJSON() ([]byte, error) {
-    toSerialize := map[string]interface{}{}
-    if o.MapString != nil {
-        toSerialize["map_string"] = o.MapString
-    }
-    if o.MapNumber != nil {
-        toSerialize["map_number"] = o.MapNumber
-    }
-    if o.MapInteger != nil {
-        toSerialize["map_integer"] = o.MapInteger
-    }
-    if o.MapBoolean != nil {
-        toSerialize["map_boolean"] = o.MapBoolean
-    }
-    if o.MapArrayInteger != nil {
-        toSerialize["map_array_integer"] = o.MapArrayInteger
-    }
-    if o.MapArrayAnytype != nil {
-        toSerialize["map_array_anytype"] = o.MapArrayAnytype
-    }
-    if o.MapMapString != nil {
-        toSerialize["map_map_string"] = o.MapMapString
-    }
-    if o.MapMapAnytype != nil {
-        toSerialize["map_map_anytype"] = o.MapMapAnytype
-    }
-    if o.Anytype1 != nil {
-        toSerialize["anytype_1"] = o.Anytype1
-    }
-    if o.Anytype2 != nil {
-        toSerialize["anytype_2"] = o.Anytype2
-    }
-    if o.Anytype3 != nil {
-        toSerialize["anytype_3"] = o.Anytype3
-    }
-    return json.Marshal(toSerialize)
+	toSerialize := map[string]interface{}{}
+	if o.MapString != nil {
+		toSerialize["map_string"] = o.MapString
+	}
+	if o.MapNumber != nil {
+		toSerialize["map_number"] = o.MapNumber
+	}
+	if o.MapInteger != nil {
+		toSerialize["map_integer"] = o.MapInteger
+	}
+	if o.MapBoolean != nil {
+		toSerialize["map_boolean"] = o.MapBoolean
+	}
+	if o.MapArrayInteger != nil {
+		toSerialize["map_array_integer"] = o.MapArrayInteger
+	}
+	if o.MapArrayAnytype != nil {
+		toSerialize["map_array_anytype"] = o.MapArrayAnytype
+	}
+	if o.MapMapString != nil {
+		toSerialize["map_map_string"] = o.MapMapString
+	}
+	if o.MapMapAnytype != nil {
+		toSerialize["map_map_anytype"] = o.MapMapAnytype
+	}
+	if o.Anytype1 != nil {
+		toSerialize["anytype_1"] = o.Anytype1
+	}
+	if o.Anytype2 != nil {
+		toSerialize["anytype_2"] = o.Anytype2
+	}
+	if o.Anytype3 != nil {
+		toSerialize["anytype_3"] = o.Anytype3
+	}
+	return json.Marshal(toSerialize)
 }
 
 type NullableAdditionalPropertiesClass struct {
@@ -452,32 +452,32 @@ type NullableAdditionalPropertiesClass struct {
 }
 
 func (v NullableAdditionalPropertiesClass) Get() *AdditionalPropertiesClass {
-    return v.value
+	return v.value
 }
 
 func (v NullableAdditionalPropertiesClass) Set(val *AdditionalPropertiesClass) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableAdditionalPropertiesClass) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableAdditionalPropertiesClass) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableAdditionalPropertiesClass(val *AdditionalPropertiesClass) *NullableAdditionalPropertiesClass {
-    return &NullableAdditionalPropertiesClass{value: val, isSet: true}
+	return &NullableAdditionalPropertiesClass{value: val, isSet: true}
 }
 
 func (v NullableAdditionalPropertiesClass) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableAdditionalPropertiesClass) UnmarshalJSON(src []byte) error {
-    v.isSet = true
+	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_additional_properties_class.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_additional_properties_class.go
@@ -56,7 +56,6 @@ func (o *AdditionalPropertiesClass) GetMapString() map[string]string {
 
 // GetMapStringOk returns a tuple with the MapString field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *AdditionalPropertiesClass) GetMapStringOk() (*map[string]string, bool) {
 	if o == nil || o.MapString == nil {
 		return nil, false
@@ -89,7 +88,6 @@ func (o *AdditionalPropertiesClass) GetMapNumber() map[string]float32 {
 
 // GetMapNumberOk returns a tuple with the MapNumber field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *AdditionalPropertiesClass) GetMapNumberOk() (*map[string]float32, bool) {
 	if o == nil || o.MapNumber == nil {
 		return nil, false
@@ -122,7 +120,6 @@ func (o *AdditionalPropertiesClass) GetMapInteger() map[string]int32 {
 
 // GetMapIntegerOk returns a tuple with the MapInteger field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *AdditionalPropertiesClass) GetMapIntegerOk() (*map[string]int32, bool) {
 	if o == nil || o.MapInteger == nil {
 		return nil, false
@@ -155,7 +152,6 @@ func (o *AdditionalPropertiesClass) GetMapBoolean() map[string]bool {
 
 // GetMapBooleanOk returns a tuple with the MapBoolean field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *AdditionalPropertiesClass) GetMapBooleanOk() (*map[string]bool, bool) {
 	if o == nil || o.MapBoolean == nil {
 		return nil, false
@@ -188,7 +184,6 @@ func (o *AdditionalPropertiesClass) GetMapArrayInteger() map[string][]int32 {
 
 // GetMapArrayIntegerOk returns a tuple with the MapArrayInteger field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *AdditionalPropertiesClass) GetMapArrayIntegerOk() (*map[string][]int32, bool) {
 	if o == nil || o.MapArrayInteger == nil {
 		return nil, false
@@ -221,7 +216,6 @@ func (o *AdditionalPropertiesClass) GetMapArrayAnytype() map[string][]map[string
 
 // GetMapArrayAnytypeOk returns a tuple with the MapArrayAnytype field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *AdditionalPropertiesClass) GetMapArrayAnytypeOk() (*map[string][]map[string]interface{}, bool) {
 	if o == nil || o.MapArrayAnytype == nil {
 		return nil, false
@@ -254,7 +248,6 @@ func (o *AdditionalPropertiesClass) GetMapMapString() map[string]map[string]stri
 
 // GetMapMapStringOk returns a tuple with the MapMapString field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *AdditionalPropertiesClass) GetMapMapStringOk() (*map[string]map[string]string, bool) {
 	if o == nil || o.MapMapString == nil {
 		return nil, false
@@ -287,7 +280,6 @@ func (o *AdditionalPropertiesClass) GetMapMapAnytype() map[string]map[string]map
 
 // GetMapMapAnytypeOk returns a tuple with the MapMapAnytype field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *AdditionalPropertiesClass) GetMapMapAnytypeOk() (*map[string]map[string]map[string]interface{}, bool) {
 	if o == nil || o.MapMapAnytype == nil {
 		return nil, false
@@ -320,7 +312,6 @@ func (o *AdditionalPropertiesClass) GetAnytype1() map[string]interface{} {
 
 // GetAnytype1Ok returns a tuple with the Anytype1 field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *AdditionalPropertiesClass) GetAnytype1Ok() (*map[string]interface{}, bool) {
 	if o == nil || o.Anytype1 == nil {
 		return nil, false
@@ -353,7 +344,6 @@ func (o *AdditionalPropertiesClass) GetAnytype2() map[string]interface{} {
 
 // GetAnytype2Ok returns a tuple with the Anytype2 field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *AdditionalPropertiesClass) GetAnytype2Ok() (*map[string]interface{}, bool) {
 	if o == nil || o.Anytype2 == nil {
 		return nil, false
@@ -386,7 +376,6 @@ func (o *AdditionalPropertiesClass) GetAnytype3() map[string]interface{} {
 
 // GetAnytype3Ok returns a tuple with the Anytype3 field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *AdditionalPropertiesClass) GetAnytype3Ok() (*map[string]interface{}, bool) {
 	if o == nil || o.Anytype3 == nil {
 		return nil, false

--- a/samples/client/petstore/go-experimental/go-petstore/model_additional_properties_class.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_additional_properties_class.go
@@ -10,7 +10,6 @@
 package petstore
 
 import (
-	"bytes"
 	"encoding/json"
 )
 
@@ -62,12 +61,12 @@ func (o *AdditionalPropertiesClass) GetMapStringOk() (map[string]string, bool) {
 		var ret map[string]string
 		return ret, false
 	}
-	return *o.MapString, true
+    return *o.MapString, true
 }
 
 // HasMapString returns a boolean if a field has been set.
 func (o *AdditionalPropertiesClass) HasMapString() bool {
-	if o != nil && o.MapString != nil {
+    if o != nil && o.MapString != nil {
 		return true
 	}
 
@@ -95,12 +94,12 @@ func (o *AdditionalPropertiesClass) GetMapNumberOk() (map[string]float32, bool) 
 		var ret map[string]float32
 		return ret, false
 	}
-	return *o.MapNumber, true
+    return *o.MapNumber, true
 }
 
 // HasMapNumber returns a boolean if a field has been set.
 func (o *AdditionalPropertiesClass) HasMapNumber() bool {
-	if o != nil && o.MapNumber != nil {
+    if o != nil && o.MapNumber != nil {
 		return true
 	}
 
@@ -128,12 +127,12 @@ func (o *AdditionalPropertiesClass) GetMapIntegerOk() (map[string]int32, bool) {
 		var ret map[string]int32
 		return ret, false
 	}
-	return *o.MapInteger, true
+    return *o.MapInteger, true
 }
 
 // HasMapInteger returns a boolean if a field has been set.
 func (o *AdditionalPropertiesClass) HasMapInteger() bool {
-	if o != nil && o.MapInteger != nil {
+    if o != nil && o.MapInteger != nil {
 		return true
 	}
 
@@ -161,12 +160,12 @@ func (o *AdditionalPropertiesClass) GetMapBooleanOk() (map[string]bool, bool) {
 		var ret map[string]bool
 		return ret, false
 	}
-	return *o.MapBoolean, true
+    return *o.MapBoolean, true
 }
 
 // HasMapBoolean returns a boolean if a field has been set.
 func (o *AdditionalPropertiesClass) HasMapBoolean() bool {
-	if o != nil && o.MapBoolean != nil {
+    if o != nil && o.MapBoolean != nil {
 		return true
 	}
 
@@ -194,12 +193,12 @@ func (o *AdditionalPropertiesClass) GetMapArrayIntegerOk() (map[string][]int32, 
 		var ret map[string][]int32
 		return ret, false
 	}
-	return *o.MapArrayInteger, true
+    return *o.MapArrayInteger, true
 }
 
 // HasMapArrayInteger returns a boolean if a field has been set.
 func (o *AdditionalPropertiesClass) HasMapArrayInteger() bool {
-	if o != nil && o.MapArrayInteger != nil {
+    if o != nil && o.MapArrayInteger != nil {
 		return true
 	}
 
@@ -227,12 +226,12 @@ func (o *AdditionalPropertiesClass) GetMapArrayAnytypeOk() (map[string][]map[str
 		var ret map[string][]map[string]interface{}
 		return ret, false
 	}
-	return *o.MapArrayAnytype, true
+    return *o.MapArrayAnytype, true
 }
 
 // HasMapArrayAnytype returns a boolean if a field has been set.
 func (o *AdditionalPropertiesClass) HasMapArrayAnytype() bool {
-	if o != nil && o.MapArrayAnytype != nil {
+    if o != nil && o.MapArrayAnytype != nil {
 		return true
 	}
 
@@ -260,12 +259,12 @@ func (o *AdditionalPropertiesClass) GetMapMapStringOk() (map[string]map[string]s
 		var ret map[string]map[string]string
 		return ret, false
 	}
-	return *o.MapMapString, true
+    return *o.MapMapString, true
 }
 
 // HasMapMapString returns a boolean if a field has been set.
 func (o *AdditionalPropertiesClass) HasMapMapString() bool {
-	if o != nil && o.MapMapString != nil {
+    if o != nil && o.MapMapString != nil {
 		return true
 	}
 
@@ -293,12 +292,12 @@ func (o *AdditionalPropertiesClass) GetMapMapAnytypeOk() (map[string]map[string]
 		var ret map[string]map[string]map[string]interface{}
 		return ret, false
 	}
-	return *o.MapMapAnytype, true
+    return *o.MapMapAnytype, true
 }
 
 // HasMapMapAnytype returns a boolean if a field has been set.
 func (o *AdditionalPropertiesClass) HasMapMapAnytype() bool {
-	if o != nil && o.MapMapAnytype != nil {
+    if o != nil && o.MapMapAnytype != nil {
 		return true
 	}
 
@@ -326,12 +325,12 @@ func (o *AdditionalPropertiesClass) GetAnytype1Ok() (map[string]interface{}, boo
 		var ret map[string]interface{}
 		return ret, false
 	}
-	return *o.Anytype1, true
+    return *o.Anytype1, true
 }
 
 // HasAnytype1 returns a boolean if a field has been set.
 func (o *AdditionalPropertiesClass) HasAnytype1() bool {
-	if o != nil && o.Anytype1 != nil {
+    if o != nil && o.Anytype1 != nil {
 		return true
 	}
 
@@ -359,12 +358,12 @@ func (o *AdditionalPropertiesClass) GetAnytype2Ok() (map[string]interface{}, boo
 		var ret map[string]interface{}
 		return ret, false
 	}
-	return *o.Anytype2, true
+    return *o.Anytype2, true
 }
 
 // HasAnytype2 returns a boolean if a field has been set.
 func (o *AdditionalPropertiesClass) HasAnytype2() bool {
-	if o != nil && o.Anytype2 != nil {
+    if o != nil && o.Anytype2 != nil {
 		return true
 	}
 
@@ -392,12 +391,12 @@ func (o *AdditionalPropertiesClass) GetAnytype3Ok() (map[string]interface{}, boo
 		var ret map[string]interface{}
 		return ret, false
 	}
-	return *o.Anytype3, true
+    return *o.Anytype3, true
 }
 
 // HasAnytype3 returns a boolean if a field has been set.
 func (o *AdditionalPropertiesClass) HasAnytype3() bool {
-	if o != nil && o.Anytype3 != nil {
+    if o != nil && o.Anytype3 != nil {
 		return true
 	}
 
@@ -409,25 +408,76 @@ func (o *AdditionalPropertiesClass) SetAnytype3(v map[string]interface{}) {
 	o.Anytype3 = &v
 }
 
+func (o AdditionalPropertiesClass) MarshalJSON() ([]byte, error) {
+    toSerialize := map[string]interface{}{}
+    if o.MapString != nil {
+        toSerialize["map_string"] = o.MapString
+    }
+    if o.MapNumber != nil {
+        toSerialize["map_number"] = o.MapNumber
+    }
+    if o.MapInteger != nil {
+        toSerialize["map_integer"] = o.MapInteger
+    }
+    if o.MapBoolean != nil {
+        toSerialize["map_boolean"] = o.MapBoolean
+    }
+    if o.MapArrayInteger != nil {
+        toSerialize["map_array_integer"] = o.MapArrayInteger
+    }
+    if o.MapArrayAnytype != nil {
+        toSerialize["map_array_anytype"] = o.MapArrayAnytype
+    }
+    if o.MapMapString != nil {
+        toSerialize["map_map_string"] = o.MapMapString
+    }
+    if o.MapMapAnytype != nil {
+        toSerialize["map_map_anytype"] = o.MapMapAnytype
+    }
+    if o.Anytype1 != nil {
+        toSerialize["anytype_1"] = o.Anytype1
+    }
+    if o.Anytype2 != nil {
+        toSerialize["anytype_2"] = o.Anytype2
+    }
+    if o.Anytype3 != nil {
+        toSerialize["anytype_3"] = o.Anytype3
+    }
+    return json.Marshal(toSerialize)
+}
+
 type NullableAdditionalPropertiesClass struct {
-	Value AdditionalPropertiesClass
-	ExplicitNull bool
+	value *AdditionalPropertiesClass
+	isSet bool
+}
+
+func (v NullableAdditionalPropertiesClass) Get() *AdditionalPropertiesClass {
+    return v.value
+}
+
+func (v NullableAdditionalPropertiesClass) Set(val *AdditionalPropertiesClass) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableAdditionalPropertiesClass) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableAdditionalPropertiesClass) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableAdditionalPropertiesClass(val *AdditionalPropertiesClass) *NullableAdditionalPropertiesClass {
+    return &NullableAdditionalPropertiesClass{value: val, isSet: true}
 }
 
 func (v NullableAdditionalPropertiesClass) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-		return json.Marshal(v.Value)
-	}
+    return json.Marshal(v.value)
 }
 
 func (v *NullableAdditionalPropertiesClass) UnmarshalJSON(src []byte) error {
-	if bytes.Equal(src, []byte("null")) {
-		v.ExplicitNull = true
-		return nil
-	}
-
-	return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_additional_properties_class.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_additional_properties_class.go
@@ -455,7 +455,7 @@ func (v NullableAdditionalPropertiesClass) Get() *AdditionalPropertiesClass {
 	return v.value
 }
 
-func (v NullableAdditionalPropertiesClass) Set(val *AdditionalPropertiesClass) {
+func (v *NullableAdditionalPropertiesClass) Set(val *AdditionalPropertiesClass) {
 	v.value = val
 	v.isSet = true
 }
@@ -464,7 +464,7 @@ func (v NullableAdditionalPropertiesClass) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableAdditionalPropertiesClass) Unset() {
+func (v *NullableAdditionalPropertiesClass) Unset() {
 	v.value = nil
 	v.isSet = false
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_additional_properties_integer.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_additional_properties_integer.go
@@ -85,7 +85,7 @@ func (v NullableAdditionalPropertiesInteger) Get() *AdditionalPropertiesInteger 
 	return v.value
 }
 
-func (v NullableAdditionalPropertiesInteger) Set(val *AdditionalPropertiesInteger) {
+func (v *NullableAdditionalPropertiesInteger) Set(val *AdditionalPropertiesInteger) {
 	v.value = val
 	v.isSet = true
 }
@@ -94,7 +94,7 @@ func (v NullableAdditionalPropertiesInteger) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableAdditionalPropertiesInteger) Unset() {
+func (v *NullableAdditionalPropertiesInteger) Unset() {
 	v.value = nil
 	v.isSet = false
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_additional_properties_integer.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_additional_properties_integer.go
@@ -10,7 +10,6 @@
 package petstore
 
 import (
-	"bytes"
 	"encoding/json"
 )
 
@@ -52,12 +51,12 @@ func (o *AdditionalPropertiesInteger) GetNameOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-	return *o.Name, true
+    return *o.Name, true
 }
 
 // HasName returns a boolean if a field has been set.
 func (o *AdditionalPropertiesInteger) HasName() bool {
-	if o != nil && o.Name != nil {
+    if o != nil && o.Name != nil {
 		return true
 	}
 
@@ -69,25 +68,46 @@ func (o *AdditionalPropertiesInteger) SetName(v string) {
 	o.Name = &v
 }
 
+func (o AdditionalPropertiesInteger) MarshalJSON() ([]byte, error) {
+    toSerialize := map[string]interface{}{}
+    if o.Name != nil {
+        toSerialize["name"] = o.Name
+    }
+    return json.Marshal(toSerialize)
+}
+
 type NullableAdditionalPropertiesInteger struct {
-	Value AdditionalPropertiesInteger
-	ExplicitNull bool
+	value *AdditionalPropertiesInteger
+	isSet bool
+}
+
+func (v NullableAdditionalPropertiesInteger) Get() *AdditionalPropertiesInteger {
+    return v.value
+}
+
+func (v NullableAdditionalPropertiesInteger) Set(val *AdditionalPropertiesInteger) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableAdditionalPropertiesInteger) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableAdditionalPropertiesInteger) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableAdditionalPropertiesInteger(val *AdditionalPropertiesInteger) *NullableAdditionalPropertiesInteger {
+    return &NullableAdditionalPropertiesInteger{value: val, isSet: true}
 }
 
 func (v NullableAdditionalPropertiesInteger) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-		return json.Marshal(v.Value)
-	}
+    return json.Marshal(v.value)
 }
 
 func (v *NullableAdditionalPropertiesInteger) UnmarshalJSON(src []byte) error {
-	if bytes.Equal(src, []byte("null")) {
-		v.ExplicitNull = true
-		return nil
-	}
-
-	return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_additional_properties_integer.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_additional_properties_integer.go
@@ -23,16 +23,16 @@ type AdditionalPropertiesInteger struct {
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
 func NewAdditionalPropertiesInteger() *AdditionalPropertiesInteger {
-    this := AdditionalPropertiesInteger{}
-    return &this
+	this := AdditionalPropertiesInteger{}
+	return &this
 }
 
 // NewAdditionalPropertiesIntegerWithDefaults instantiates a new AdditionalPropertiesInteger object
 // This constructor will only assign default values to properties that have it defined,
 // but it doesn't guarantee that properties required by API are set
 func NewAdditionalPropertiesIntegerWithDefaults() *AdditionalPropertiesInteger {
-    this := AdditionalPropertiesInteger{}
-    return &this
+	this := AdditionalPropertiesInteger{}
+	return &this
 }
 
 // GetName returns the Name field value if set, zero value otherwise.
@@ -44,14 +44,14 @@ func (o *AdditionalPropertiesInteger) GetName() string {
 	return *o.Name
 }
 
-// GetNameOk returns a tuple with the Name field value if set, zero value otherwise
+// GetNameOk returns a tuple with the Name field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *AdditionalPropertiesInteger) GetNameOk() (string, bool) {
+
+func (o *AdditionalPropertiesInteger) GetNameOk() (*string, bool) {
 	if o == nil || o.Name == nil {
-		var ret string
-		return ret, false
+		return nil, false
 	}
-	return *o.Name, true
+	return o.Name, true
 }
 
 // HasName returns a boolean if a field has been set.

--- a/samples/client/petstore/go-experimental/go-petstore/model_additional_properties_integer.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_additional_properties_integer.go
@@ -51,12 +51,12 @@ func (o *AdditionalPropertiesInteger) GetNameOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-    return *o.Name, true
+	return *o.Name, true
 }
 
 // HasName returns a boolean if a field has been set.
 func (o *AdditionalPropertiesInteger) HasName() bool {
-    if o != nil && o.Name != nil {
+	if o != nil && o.Name != nil {
 		return true
 	}
 
@@ -69,11 +69,11 @@ func (o *AdditionalPropertiesInteger) SetName(v string) {
 }
 
 func (o AdditionalPropertiesInteger) MarshalJSON() ([]byte, error) {
-    toSerialize := map[string]interface{}{}
-    if o.Name != nil {
-        toSerialize["name"] = o.Name
-    }
-    return json.Marshal(toSerialize)
+	toSerialize := map[string]interface{}{}
+	if o.Name != nil {
+		toSerialize["name"] = o.Name
+	}
+	return json.Marshal(toSerialize)
 }
 
 type NullableAdditionalPropertiesInteger struct {
@@ -82,32 +82,32 @@ type NullableAdditionalPropertiesInteger struct {
 }
 
 func (v NullableAdditionalPropertiesInteger) Get() *AdditionalPropertiesInteger {
-    return v.value
+	return v.value
 }
 
 func (v NullableAdditionalPropertiesInteger) Set(val *AdditionalPropertiesInteger) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableAdditionalPropertiesInteger) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableAdditionalPropertiesInteger) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableAdditionalPropertiesInteger(val *AdditionalPropertiesInteger) *NullableAdditionalPropertiesInteger {
-    return &NullableAdditionalPropertiesInteger{value: val, isSet: true}
+	return &NullableAdditionalPropertiesInteger{value: val, isSet: true}
 }
 
 func (v NullableAdditionalPropertiesInteger) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableAdditionalPropertiesInteger) UnmarshalJSON(src []byte) error {
-    v.isSet = true
+	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_additional_properties_integer.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_additional_properties_integer.go
@@ -46,7 +46,6 @@ func (o *AdditionalPropertiesInteger) GetName() string {
 
 // GetNameOk returns a tuple with the Name field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *AdditionalPropertiesInteger) GetNameOk() (*string, bool) {
 	if o == nil || o.Name == nil {
 		return nil, false

--- a/samples/client/petstore/go-experimental/go-petstore/model_additional_properties_number.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_additional_properties_number.go
@@ -85,7 +85,7 @@ func (v NullableAdditionalPropertiesNumber) Get() *AdditionalPropertiesNumber {
 	return v.value
 }
 
-func (v NullableAdditionalPropertiesNumber) Set(val *AdditionalPropertiesNumber) {
+func (v *NullableAdditionalPropertiesNumber) Set(val *AdditionalPropertiesNumber) {
 	v.value = val
 	v.isSet = true
 }
@@ -94,7 +94,7 @@ func (v NullableAdditionalPropertiesNumber) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableAdditionalPropertiesNumber) Unset() {
+func (v *NullableAdditionalPropertiesNumber) Unset() {
 	v.value = nil
 	v.isSet = false
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_additional_properties_number.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_additional_properties_number.go
@@ -51,12 +51,12 @@ func (o *AdditionalPropertiesNumber) GetNameOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-    return *o.Name, true
+	return *o.Name, true
 }
 
 // HasName returns a boolean if a field has been set.
 func (o *AdditionalPropertiesNumber) HasName() bool {
-    if o != nil && o.Name != nil {
+	if o != nil && o.Name != nil {
 		return true
 	}
 
@@ -69,11 +69,11 @@ func (o *AdditionalPropertiesNumber) SetName(v string) {
 }
 
 func (o AdditionalPropertiesNumber) MarshalJSON() ([]byte, error) {
-    toSerialize := map[string]interface{}{}
-    if o.Name != nil {
-        toSerialize["name"] = o.Name
-    }
-    return json.Marshal(toSerialize)
+	toSerialize := map[string]interface{}{}
+	if o.Name != nil {
+		toSerialize["name"] = o.Name
+	}
+	return json.Marshal(toSerialize)
 }
 
 type NullableAdditionalPropertiesNumber struct {
@@ -82,32 +82,32 @@ type NullableAdditionalPropertiesNumber struct {
 }
 
 func (v NullableAdditionalPropertiesNumber) Get() *AdditionalPropertiesNumber {
-    return v.value
+	return v.value
 }
 
 func (v NullableAdditionalPropertiesNumber) Set(val *AdditionalPropertiesNumber) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableAdditionalPropertiesNumber) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableAdditionalPropertiesNumber) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableAdditionalPropertiesNumber(val *AdditionalPropertiesNumber) *NullableAdditionalPropertiesNumber {
-    return &NullableAdditionalPropertiesNumber{value: val, isSet: true}
+	return &NullableAdditionalPropertiesNumber{value: val, isSet: true}
 }
 
 func (v NullableAdditionalPropertiesNumber) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableAdditionalPropertiesNumber) UnmarshalJSON(src []byte) error {
-    v.isSet = true
+	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_additional_properties_number.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_additional_properties_number.go
@@ -10,7 +10,6 @@
 package petstore
 
 import (
-	"bytes"
 	"encoding/json"
 )
 
@@ -52,12 +51,12 @@ func (o *AdditionalPropertiesNumber) GetNameOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-	return *o.Name, true
+    return *o.Name, true
 }
 
 // HasName returns a boolean if a field has been set.
 func (o *AdditionalPropertiesNumber) HasName() bool {
-	if o != nil && o.Name != nil {
+    if o != nil && o.Name != nil {
 		return true
 	}
 
@@ -69,25 +68,46 @@ func (o *AdditionalPropertiesNumber) SetName(v string) {
 	o.Name = &v
 }
 
+func (o AdditionalPropertiesNumber) MarshalJSON() ([]byte, error) {
+    toSerialize := map[string]interface{}{}
+    if o.Name != nil {
+        toSerialize["name"] = o.Name
+    }
+    return json.Marshal(toSerialize)
+}
+
 type NullableAdditionalPropertiesNumber struct {
-	Value AdditionalPropertiesNumber
-	ExplicitNull bool
+	value *AdditionalPropertiesNumber
+	isSet bool
+}
+
+func (v NullableAdditionalPropertiesNumber) Get() *AdditionalPropertiesNumber {
+    return v.value
+}
+
+func (v NullableAdditionalPropertiesNumber) Set(val *AdditionalPropertiesNumber) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableAdditionalPropertiesNumber) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableAdditionalPropertiesNumber) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableAdditionalPropertiesNumber(val *AdditionalPropertiesNumber) *NullableAdditionalPropertiesNumber {
+    return &NullableAdditionalPropertiesNumber{value: val, isSet: true}
 }
 
 func (v NullableAdditionalPropertiesNumber) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-		return json.Marshal(v.Value)
-	}
+    return json.Marshal(v.value)
 }
 
 func (v *NullableAdditionalPropertiesNumber) UnmarshalJSON(src []byte) error {
-	if bytes.Equal(src, []byte("null")) {
-		v.ExplicitNull = true
-		return nil
-	}
-
-	return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_additional_properties_number.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_additional_properties_number.go
@@ -46,7 +46,6 @@ func (o *AdditionalPropertiesNumber) GetName() string {
 
 // GetNameOk returns a tuple with the Name field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *AdditionalPropertiesNumber) GetNameOk() (*string, bool) {
 	if o == nil || o.Name == nil {
 		return nil, false

--- a/samples/client/petstore/go-experimental/go-petstore/model_additional_properties_number.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_additional_properties_number.go
@@ -23,16 +23,16 @@ type AdditionalPropertiesNumber struct {
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
 func NewAdditionalPropertiesNumber() *AdditionalPropertiesNumber {
-    this := AdditionalPropertiesNumber{}
-    return &this
+	this := AdditionalPropertiesNumber{}
+	return &this
 }
 
 // NewAdditionalPropertiesNumberWithDefaults instantiates a new AdditionalPropertiesNumber object
 // This constructor will only assign default values to properties that have it defined,
 // but it doesn't guarantee that properties required by API are set
 func NewAdditionalPropertiesNumberWithDefaults() *AdditionalPropertiesNumber {
-    this := AdditionalPropertiesNumber{}
-    return &this
+	this := AdditionalPropertiesNumber{}
+	return &this
 }
 
 // GetName returns the Name field value if set, zero value otherwise.
@@ -44,14 +44,14 @@ func (o *AdditionalPropertiesNumber) GetName() string {
 	return *o.Name
 }
 
-// GetNameOk returns a tuple with the Name field value if set, zero value otherwise
+// GetNameOk returns a tuple with the Name field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *AdditionalPropertiesNumber) GetNameOk() (string, bool) {
+
+func (o *AdditionalPropertiesNumber) GetNameOk() (*string, bool) {
 	if o == nil || o.Name == nil {
-		var ret string
-		return ret, false
+		return nil, false
 	}
-	return *o.Name, true
+	return o.Name, true
 }
 
 // HasName returns a boolean if a field has been set.

--- a/samples/client/petstore/go-experimental/go-petstore/model_additional_properties_object.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_additional_properties_object.go
@@ -23,16 +23,16 @@ type AdditionalPropertiesObject struct {
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
 func NewAdditionalPropertiesObject() *AdditionalPropertiesObject {
-    this := AdditionalPropertiesObject{}
-    return &this
+	this := AdditionalPropertiesObject{}
+	return &this
 }
 
 // NewAdditionalPropertiesObjectWithDefaults instantiates a new AdditionalPropertiesObject object
 // This constructor will only assign default values to properties that have it defined,
 // but it doesn't guarantee that properties required by API are set
 func NewAdditionalPropertiesObjectWithDefaults() *AdditionalPropertiesObject {
-    this := AdditionalPropertiesObject{}
-    return &this
+	this := AdditionalPropertiesObject{}
+	return &this
 }
 
 // GetName returns the Name field value if set, zero value otherwise.
@@ -44,14 +44,14 @@ func (o *AdditionalPropertiesObject) GetName() string {
 	return *o.Name
 }
 
-// GetNameOk returns a tuple with the Name field value if set, zero value otherwise
+// GetNameOk returns a tuple with the Name field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *AdditionalPropertiesObject) GetNameOk() (string, bool) {
+
+func (o *AdditionalPropertiesObject) GetNameOk() (*string, bool) {
 	if o == nil || o.Name == nil {
-		var ret string
-		return ret, false
+		return nil, false
 	}
-	return *o.Name, true
+	return o.Name, true
 }
 
 // HasName returns a boolean if a field has been set.

--- a/samples/client/petstore/go-experimental/go-petstore/model_additional_properties_object.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_additional_properties_object.go
@@ -46,7 +46,6 @@ func (o *AdditionalPropertiesObject) GetName() string {
 
 // GetNameOk returns a tuple with the Name field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *AdditionalPropertiesObject) GetNameOk() (*string, bool) {
 	if o == nil || o.Name == nil {
 		return nil, false

--- a/samples/client/petstore/go-experimental/go-petstore/model_additional_properties_object.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_additional_properties_object.go
@@ -51,12 +51,12 @@ func (o *AdditionalPropertiesObject) GetNameOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-    return *o.Name, true
+	return *o.Name, true
 }
 
 // HasName returns a boolean if a field has been set.
 func (o *AdditionalPropertiesObject) HasName() bool {
-    if o != nil && o.Name != nil {
+	if o != nil && o.Name != nil {
 		return true
 	}
 
@@ -69,11 +69,11 @@ func (o *AdditionalPropertiesObject) SetName(v string) {
 }
 
 func (o AdditionalPropertiesObject) MarshalJSON() ([]byte, error) {
-    toSerialize := map[string]interface{}{}
-    if o.Name != nil {
-        toSerialize["name"] = o.Name
-    }
-    return json.Marshal(toSerialize)
+	toSerialize := map[string]interface{}{}
+	if o.Name != nil {
+		toSerialize["name"] = o.Name
+	}
+	return json.Marshal(toSerialize)
 }
 
 type NullableAdditionalPropertiesObject struct {
@@ -82,32 +82,32 @@ type NullableAdditionalPropertiesObject struct {
 }
 
 func (v NullableAdditionalPropertiesObject) Get() *AdditionalPropertiesObject {
-    return v.value
+	return v.value
 }
 
 func (v NullableAdditionalPropertiesObject) Set(val *AdditionalPropertiesObject) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableAdditionalPropertiesObject) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableAdditionalPropertiesObject) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableAdditionalPropertiesObject(val *AdditionalPropertiesObject) *NullableAdditionalPropertiesObject {
-    return &NullableAdditionalPropertiesObject{value: val, isSet: true}
+	return &NullableAdditionalPropertiesObject{value: val, isSet: true}
 }
 
 func (v NullableAdditionalPropertiesObject) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableAdditionalPropertiesObject) UnmarshalJSON(src []byte) error {
-    v.isSet = true
+	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_additional_properties_object.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_additional_properties_object.go
@@ -10,7 +10,6 @@
 package petstore
 
 import (
-	"bytes"
 	"encoding/json"
 )
 
@@ -52,12 +51,12 @@ func (o *AdditionalPropertiesObject) GetNameOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-	return *o.Name, true
+    return *o.Name, true
 }
 
 // HasName returns a boolean if a field has been set.
 func (o *AdditionalPropertiesObject) HasName() bool {
-	if o != nil && o.Name != nil {
+    if o != nil && o.Name != nil {
 		return true
 	}
 
@@ -69,25 +68,46 @@ func (o *AdditionalPropertiesObject) SetName(v string) {
 	o.Name = &v
 }
 
+func (o AdditionalPropertiesObject) MarshalJSON() ([]byte, error) {
+    toSerialize := map[string]interface{}{}
+    if o.Name != nil {
+        toSerialize["name"] = o.Name
+    }
+    return json.Marshal(toSerialize)
+}
+
 type NullableAdditionalPropertiesObject struct {
-	Value AdditionalPropertiesObject
-	ExplicitNull bool
+	value *AdditionalPropertiesObject
+	isSet bool
+}
+
+func (v NullableAdditionalPropertiesObject) Get() *AdditionalPropertiesObject {
+    return v.value
+}
+
+func (v NullableAdditionalPropertiesObject) Set(val *AdditionalPropertiesObject) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableAdditionalPropertiesObject) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableAdditionalPropertiesObject) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableAdditionalPropertiesObject(val *AdditionalPropertiesObject) *NullableAdditionalPropertiesObject {
+    return &NullableAdditionalPropertiesObject{value: val, isSet: true}
 }
 
 func (v NullableAdditionalPropertiesObject) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-		return json.Marshal(v.Value)
-	}
+    return json.Marshal(v.value)
 }
 
 func (v *NullableAdditionalPropertiesObject) UnmarshalJSON(src []byte) error {
-	if bytes.Equal(src, []byte("null")) {
-		v.ExplicitNull = true
-		return nil
-	}
-
-	return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_additional_properties_object.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_additional_properties_object.go
@@ -85,7 +85,7 @@ func (v NullableAdditionalPropertiesObject) Get() *AdditionalPropertiesObject {
 	return v.value
 }
 
-func (v NullableAdditionalPropertiesObject) Set(val *AdditionalPropertiesObject) {
+func (v *NullableAdditionalPropertiesObject) Set(val *AdditionalPropertiesObject) {
 	v.value = val
 	v.isSet = true
 }
@@ -94,7 +94,7 @@ func (v NullableAdditionalPropertiesObject) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableAdditionalPropertiesObject) Unset() {
+func (v *NullableAdditionalPropertiesObject) Unset() {
 	v.value = nil
 	v.isSet = false
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_additional_properties_string.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_additional_properties_string.go
@@ -85,7 +85,7 @@ func (v NullableAdditionalPropertiesString) Get() *AdditionalPropertiesString {
 	return v.value
 }
 
-func (v NullableAdditionalPropertiesString) Set(val *AdditionalPropertiesString) {
+func (v *NullableAdditionalPropertiesString) Set(val *AdditionalPropertiesString) {
 	v.value = val
 	v.isSet = true
 }
@@ -94,7 +94,7 @@ func (v NullableAdditionalPropertiesString) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableAdditionalPropertiesString) Unset() {
+func (v *NullableAdditionalPropertiesString) Unset() {
 	v.value = nil
 	v.isSet = false
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_additional_properties_string.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_additional_properties_string.go
@@ -10,7 +10,6 @@
 package petstore
 
 import (
-	"bytes"
 	"encoding/json"
 )
 
@@ -52,12 +51,12 @@ func (o *AdditionalPropertiesString) GetNameOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-	return *o.Name, true
+    return *o.Name, true
 }
 
 // HasName returns a boolean if a field has been set.
 func (o *AdditionalPropertiesString) HasName() bool {
-	if o != nil && o.Name != nil {
+    if o != nil && o.Name != nil {
 		return true
 	}
 
@@ -69,25 +68,46 @@ func (o *AdditionalPropertiesString) SetName(v string) {
 	o.Name = &v
 }
 
+func (o AdditionalPropertiesString) MarshalJSON() ([]byte, error) {
+    toSerialize := map[string]interface{}{}
+    if o.Name != nil {
+        toSerialize["name"] = o.Name
+    }
+    return json.Marshal(toSerialize)
+}
+
 type NullableAdditionalPropertiesString struct {
-	Value AdditionalPropertiesString
-	ExplicitNull bool
+	value *AdditionalPropertiesString
+	isSet bool
+}
+
+func (v NullableAdditionalPropertiesString) Get() *AdditionalPropertiesString {
+    return v.value
+}
+
+func (v NullableAdditionalPropertiesString) Set(val *AdditionalPropertiesString) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableAdditionalPropertiesString) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableAdditionalPropertiesString) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableAdditionalPropertiesString(val *AdditionalPropertiesString) *NullableAdditionalPropertiesString {
+    return &NullableAdditionalPropertiesString{value: val, isSet: true}
 }
 
 func (v NullableAdditionalPropertiesString) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-		return json.Marshal(v.Value)
-	}
+    return json.Marshal(v.value)
 }
 
 func (v *NullableAdditionalPropertiesString) UnmarshalJSON(src []byte) error {
-	if bytes.Equal(src, []byte("null")) {
-		v.ExplicitNull = true
-		return nil
-	}
-
-	return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_additional_properties_string.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_additional_properties_string.go
@@ -23,16 +23,16 @@ type AdditionalPropertiesString struct {
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
 func NewAdditionalPropertiesString() *AdditionalPropertiesString {
-    this := AdditionalPropertiesString{}
-    return &this
+	this := AdditionalPropertiesString{}
+	return &this
 }
 
 // NewAdditionalPropertiesStringWithDefaults instantiates a new AdditionalPropertiesString object
 // This constructor will only assign default values to properties that have it defined,
 // but it doesn't guarantee that properties required by API are set
 func NewAdditionalPropertiesStringWithDefaults() *AdditionalPropertiesString {
-    this := AdditionalPropertiesString{}
-    return &this
+	this := AdditionalPropertiesString{}
+	return &this
 }
 
 // GetName returns the Name field value if set, zero value otherwise.
@@ -44,14 +44,14 @@ func (o *AdditionalPropertiesString) GetName() string {
 	return *o.Name
 }
 
-// GetNameOk returns a tuple with the Name field value if set, zero value otherwise
+// GetNameOk returns a tuple with the Name field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *AdditionalPropertiesString) GetNameOk() (string, bool) {
+
+func (o *AdditionalPropertiesString) GetNameOk() (*string, bool) {
 	if o == nil || o.Name == nil {
-		var ret string
-		return ret, false
+		return nil, false
 	}
-	return *o.Name, true
+	return o.Name, true
 }
 
 // HasName returns a boolean if a field has been set.

--- a/samples/client/petstore/go-experimental/go-petstore/model_additional_properties_string.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_additional_properties_string.go
@@ -51,12 +51,12 @@ func (o *AdditionalPropertiesString) GetNameOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-    return *o.Name, true
+	return *o.Name, true
 }
 
 // HasName returns a boolean if a field has been set.
 func (o *AdditionalPropertiesString) HasName() bool {
-    if o != nil && o.Name != nil {
+	if o != nil && o.Name != nil {
 		return true
 	}
 
@@ -69,11 +69,11 @@ func (o *AdditionalPropertiesString) SetName(v string) {
 }
 
 func (o AdditionalPropertiesString) MarshalJSON() ([]byte, error) {
-    toSerialize := map[string]interface{}{}
-    if o.Name != nil {
-        toSerialize["name"] = o.Name
-    }
-    return json.Marshal(toSerialize)
+	toSerialize := map[string]interface{}{}
+	if o.Name != nil {
+		toSerialize["name"] = o.Name
+	}
+	return json.Marshal(toSerialize)
 }
 
 type NullableAdditionalPropertiesString struct {
@@ -82,32 +82,32 @@ type NullableAdditionalPropertiesString struct {
 }
 
 func (v NullableAdditionalPropertiesString) Get() *AdditionalPropertiesString {
-    return v.value
+	return v.value
 }
 
 func (v NullableAdditionalPropertiesString) Set(val *AdditionalPropertiesString) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableAdditionalPropertiesString) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableAdditionalPropertiesString) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableAdditionalPropertiesString(val *AdditionalPropertiesString) *NullableAdditionalPropertiesString {
-    return &NullableAdditionalPropertiesString{value: val, isSet: true}
+	return &NullableAdditionalPropertiesString{value: val, isSet: true}
 }
 
 func (v NullableAdditionalPropertiesString) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableAdditionalPropertiesString) UnmarshalJSON(src []byte) error {
-    v.isSet = true
+	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_additional_properties_string.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_additional_properties_string.go
@@ -46,7 +46,6 @@ func (o *AdditionalPropertiesString) GetName() string {
 
 // GetNameOk returns a tuple with the Name field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *AdditionalPropertiesString) GetNameOk() (*string, bool) {
 	if o == nil || o.Name == nil {
 		return nil, false

--- a/samples/client/petstore/go-experimental/go-petstore/model_animal.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_animal.go
@@ -24,31 +24,41 @@ type Animal struct {
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
 func NewAnimal(className string, ) *Animal {
-    this := Animal{}
-    this.ClassName = className
+	this := Animal{}
+	this.ClassName = className
 	var color string = "red"
 	this.Color = &color
-    return &this
+	return &this
 }
 
 // NewAnimalWithDefaults instantiates a new Animal object
 // This constructor will only assign default values to properties that have it defined,
 // but it doesn't guarantee that properties required by API are set
 func NewAnimalWithDefaults() *Animal {
-    this := Animal{}
+	this := Animal{}
 	var color string = "red"
 	this.Color = &color
-    return &this
+	return &this
 }
 
 // GetClassName returns the ClassName field value
 func (o *Animal) GetClassName() string {
-	if o == nil {
+	if o == nil  {
 		var ret string
 		return ret
 	}
 
 	return o.ClassName
+}
+
+// GetClassNameOk returns a tuple with the ClassName field value
+// and a boolean to check if the value has been set.
+
+func (o *Animal) GetClassNameOk() (*string, bool) {
+    if o == nil  {
+        return nil, false
+    }
+    return &o.ClassName, true
 }
 
 // SetClassName sets field value
@@ -65,14 +75,14 @@ func (o *Animal) GetColor() string {
 	return *o.Color
 }
 
-// GetColorOk returns a tuple with the Color field value if set, zero value otherwise
+// GetColorOk returns a tuple with the Color field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *Animal) GetColorOk() (string, bool) {
+
+func (o *Animal) GetColorOk() (*string, bool) {
 	if o == nil || o.Color == nil {
-		var ret string
-		return ret, false
+		return nil, false
 	}
-	return *o.Color, true
+	return o.Color, true
 }
 
 // HasColor returns a boolean if a field has been set.

--- a/samples/client/petstore/go-experimental/go-petstore/model_animal.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_animal.go
@@ -10,7 +10,6 @@
 package petstore
 
 import (
-	"bytes"
 	"encoding/json"
 )
 
@@ -73,12 +72,12 @@ func (o *Animal) GetColorOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-	return *o.Color, true
+    return *o.Color, true
 }
 
 // HasColor returns a boolean if a field has been set.
 func (o *Animal) HasColor() bool {
-	if o != nil && o.Color != nil {
+    if o != nil && o.Color != nil {
 		return true
 	}
 
@@ -90,25 +89,49 @@ func (o *Animal) SetColor(v string) {
 	o.Color = &v
 }
 
+func (o Animal) MarshalJSON() ([]byte, error) {
+    toSerialize := map[string]interface{}{}
+    if true {
+        toSerialize["className"] = o.ClassName
+    }
+    if o.Color != nil {
+        toSerialize["color"] = o.Color
+    }
+    return json.Marshal(toSerialize)
+}
+
 type NullableAnimal struct {
-	Value Animal
-	ExplicitNull bool
+	value *Animal
+	isSet bool
+}
+
+func (v NullableAnimal) Get() *Animal {
+    return v.value
+}
+
+func (v NullableAnimal) Set(val *Animal) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableAnimal) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableAnimal) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableAnimal(val *Animal) *NullableAnimal {
+    return &NullableAnimal{value: val, isSet: true}
 }
 
 func (v NullableAnimal) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-		return json.Marshal(v.Value)
-	}
+    return json.Marshal(v.value)
 }
 
 func (v *NullableAnimal) UnmarshalJSON(src []byte) error {
-	if bytes.Equal(src, []byte("null")) {
-		v.ExplicitNull = true
-		return nil
-	}
-
-	return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_animal.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_animal.go
@@ -109,7 +109,7 @@ func (v NullableAnimal) Get() *Animal {
 	return v.value
 }
 
-func (v NullableAnimal) Set(val *Animal) {
+func (v *NullableAnimal) Set(val *Animal) {
 	v.value = val
 	v.isSet = true
 }
@@ -118,7 +118,7 @@ func (v NullableAnimal) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableAnimal) Unset() {
+func (v *NullableAnimal) Unset() {
 	v.value = nil
 	v.isSet = false
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_animal.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_animal.go
@@ -26,8 +26,8 @@ type Animal struct {
 func NewAnimal(className string, ) *Animal {
     this := Animal{}
     this.ClassName = className
-    var color string = "red"
-    this.Color = &color
+	var color string = "red"
+	this.Color = &color
     return &this
 }
 
@@ -36,8 +36,8 @@ func NewAnimal(className string, ) *Animal {
 // but it doesn't guarantee that properties required by API are set
 func NewAnimalWithDefaults() *Animal {
     this := Animal{}
-    var color string = "red"
-    this.Color = &color
+	var color string = "red"
+	this.Color = &color
     return &this
 }
 
@@ -72,12 +72,12 @@ func (o *Animal) GetColorOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-    return *o.Color, true
+	return *o.Color, true
 }
 
 // HasColor returns a boolean if a field has been set.
 func (o *Animal) HasColor() bool {
-    if o != nil && o.Color != nil {
+	if o != nil && o.Color != nil {
 		return true
 	}
 
@@ -90,14 +90,14 @@ func (o *Animal) SetColor(v string) {
 }
 
 func (o Animal) MarshalJSON() ([]byte, error) {
-    toSerialize := map[string]interface{}{}
-    if true {
-        toSerialize["className"] = o.ClassName
-    }
-    if o.Color != nil {
-        toSerialize["color"] = o.Color
-    }
-    return json.Marshal(toSerialize)
+	toSerialize := map[string]interface{}{}
+	if true {
+		toSerialize["className"] = o.ClassName
+	}
+	if o.Color != nil {
+		toSerialize["color"] = o.Color
+	}
+	return json.Marshal(toSerialize)
 }
 
 type NullableAnimal struct {
@@ -106,32 +106,32 @@ type NullableAnimal struct {
 }
 
 func (v NullableAnimal) Get() *Animal {
-    return v.value
+	return v.value
 }
 
 func (v NullableAnimal) Set(val *Animal) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableAnimal) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableAnimal) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableAnimal(val *Animal) *NullableAnimal {
-    return &NullableAnimal{value: val, isSet: true}
+	return &NullableAnimal{value: val, isSet: true}
 }
 
 func (v NullableAnimal) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableAnimal) UnmarshalJSON(src []byte) error {
-    v.isSet = true
+	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_animal.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_animal.go
@@ -53,12 +53,11 @@ func (o *Animal) GetClassName() string {
 
 // GetClassNameOk returns a tuple with the ClassName field value
 // and a boolean to check if the value has been set.
-
 func (o *Animal) GetClassNameOk() (*string, bool) {
-    if o == nil  {
-        return nil, false
-    }
-    return &o.ClassName, true
+	if o == nil  {
+		return nil, false
+	}
+	return &o.ClassName, true
 }
 
 // SetClassName sets field value
@@ -77,7 +76,6 @@ func (o *Animal) GetColor() string {
 
 // GetColorOk returns a tuple with the Color field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *Animal) GetColorOk() (*string, bool) {
 	if o == nil || o.Color == nil {
 		return nil, false

--- a/samples/client/petstore/go-experimental/go-petstore/model_api_response.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_api_response.go
@@ -53,12 +53,12 @@ func (o *ApiResponse) GetCodeOk() (int32, bool) {
 		var ret int32
 		return ret, false
 	}
-    return *o.Code, true
+	return *o.Code, true
 }
 
 // HasCode returns a boolean if a field has been set.
 func (o *ApiResponse) HasCode() bool {
-    if o != nil && o.Code != nil {
+	if o != nil && o.Code != nil {
 		return true
 	}
 
@@ -86,12 +86,12 @@ func (o *ApiResponse) GetTypeOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-    return *o.Type, true
+	return *o.Type, true
 }
 
 // HasType returns a boolean if a field has been set.
 func (o *ApiResponse) HasType() bool {
-    if o != nil && o.Type != nil {
+	if o != nil && o.Type != nil {
 		return true
 	}
 
@@ -119,12 +119,12 @@ func (o *ApiResponse) GetMessageOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-    return *o.Message, true
+	return *o.Message, true
 }
 
 // HasMessage returns a boolean if a field has been set.
 func (o *ApiResponse) HasMessage() bool {
-    if o != nil && o.Message != nil {
+	if o != nil && o.Message != nil {
 		return true
 	}
 
@@ -137,17 +137,17 @@ func (o *ApiResponse) SetMessage(v string) {
 }
 
 func (o ApiResponse) MarshalJSON() ([]byte, error) {
-    toSerialize := map[string]interface{}{}
-    if o.Code != nil {
-        toSerialize["code"] = o.Code
-    }
-    if o.Type != nil {
-        toSerialize["type"] = o.Type
-    }
-    if o.Message != nil {
-        toSerialize["message"] = o.Message
-    }
-    return json.Marshal(toSerialize)
+	toSerialize := map[string]interface{}{}
+	if o.Code != nil {
+		toSerialize["code"] = o.Code
+	}
+	if o.Type != nil {
+		toSerialize["type"] = o.Type
+	}
+	if o.Message != nil {
+		toSerialize["message"] = o.Message
+	}
+	return json.Marshal(toSerialize)
 }
 
 type NullableApiResponse struct {
@@ -156,32 +156,32 @@ type NullableApiResponse struct {
 }
 
 func (v NullableApiResponse) Get() *ApiResponse {
-    return v.value
+	return v.value
 }
 
 func (v NullableApiResponse) Set(val *ApiResponse) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableApiResponse) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableApiResponse) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableApiResponse(val *ApiResponse) *NullableApiResponse {
-    return &NullableApiResponse{value: val, isSet: true}
+	return &NullableApiResponse{value: val, isSet: true}
 }
 
 func (v NullableApiResponse) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableApiResponse) UnmarshalJSON(src []byte) error {
-    v.isSet = true
+	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_api_response.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_api_response.go
@@ -48,7 +48,6 @@ func (o *ApiResponse) GetCode() int32 {
 
 // GetCodeOk returns a tuple with the Code field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *ApiResponse) GetCodeOk() (*int32, bool) {
 	if o == nil || o.Code == nil {
 		return nil, false
@@ -81,7 +80,6 @@ func (o *ApiResponse) GetType() string {
 
 // GetTypeOk returns a tuple with the Type field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *ApiResponse) GetTypeOk() (*string, bool) {
 	if o == nil || o.Type == nil {
 		return nil, false
@@ -114,7 +112,6 @@ func (o *ApiResponse) GetMessage() string {
 
 // GetMessageOk returns a tuple with the Message field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *ApiResponse) GetMessageOk() (*string, bool) {
 	if o == nil || o.Message == nil {
 		return nil, false

--- a/samples/client/petstore/go-experimental/go-petstore/model_api_response.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_api_response.go
@@ -10,7 +10,6 @@
 package petstore
 
 import (
-	"bytes"
 	"encoding/json"
 )
 
@@ -54,12 +53,12 @@ func (o *ApiResponse) GetCodeOk() (int32, bool) {
 		var ret int32
 		return ret, false
 	}
-	return *o.Code, true
+    return *o.Code, true
 }
 
 // HasCode returns a boolean if a field has been set.
 func (o *ApiResponse) HasCode() bool {
-	if o != nil && o.Code != nil {
+    if o != nil && o.Code != nil {
 		return true
 	}
 
@@ -87,12 +86,12 @@ func (o *ApiResponse) GetTypeOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-	return *o.Type, true
+    return *o.Type, true
 }
 
 // HasType returns a boolean if a field has been set.
 func (o *ApiResponse) HasType() bool {
-	if o != nil && o.Type != nil {
+    if o != nil && o.Type != nil {
 		return true
 	}
 
@@ -120,12 +119,12 @@ func (o *ApiResponse) GetMessageOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-	return *o.Message, true
+    return *o.Message, true
 }
 
 // HasMessage returns a boolean if a field has been set.
 func (o *ApiResponse) HasMessage() bool {
-	if o != nil && o.Message != nil {
+    if o != nil && o.Message != nil {
 		return true
 	}
 
@@ -137,25 +136,52 @@ func (o *ApiResponse) SetMessage(v string) {
 	o.Message = &v
 }
 
+func (o ApiResponse) MarshalJSON() ([]byte, error) {
+    toSerialize := map[string]interface{}{}
+    if o.Code != nil {
+        toSerialize["code"] = o.Code
+    }
+    if o.Type != nil {
+        toSerialize["type"] = o.Type
+    }
+    if o.Message != nil {
+        toSerialize["message"] = o.Message
+    }
+    return json.Marshal(toSerialize)
+}
+
 type NullableApiResponse struct {
-	Value ApiResponse
-	ExplicitNull bool
+	value *ApiResponse
+	isSet bool
+}
+
+func (v NullableApiResponse) Get() *ApiResponse {
+    return v.value
+}
+
+func (v NullableApiResponse) Set(val *ApiResponse) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableApiResponse) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableApiResponse) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableApiResponse(val *ApiResponse) *NullableApiResponse {
+    return &NullableApiResponse{value: val, isSet: true}
 }
 
 func (v NullableApiResponse) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-		return json.Marshal(v.Value)
-	}
+    return json.Marshal(v.value)
 }
 
 func (v *NullableApiResponse) UnmarshalJSON(src []byte) error {
-	if bytes.Equal(src, []byte("null")) {
-		v.ExplicitNull = true
-		return nil
-	}
-
-	return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_api_response.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_api_response.go
@@ -159,7 +159,7 @@ func (v NullableApiResponse) Get() *ApiResponse {
 	return v.value
 }
 
-func (v NullableApiResponse) Set(val *ApiResponse) {
+func (v *NullableApiResponse) Set(val *ApiResponse) {
 	v.value = val
 	v.isSet = true
 }
@@ -168,7 +168,7 @@ func (v NullableApiResponse) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableApiResponse) Unset() {
+func (v *NullableApiResponse) Unset() {
 	v.value = nil
 	v.isSet = false
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_api_response.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_api_response.go
@@ -25,16 +25,16 @@ type ApiResponse struct {
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
 func NewApiResponse() *ApiResponse {
-    this := ApiResponse{}
-    return &this
+	this := ApiResponse{}
+	return &this
 }
 
 // NewApiResponseWithDefaults instantiates a new ApiResponse object
 // This constructor will only assign default values to properties that have it defined,
 // but it doesn't guarantee that properties required by API are set
 func NewApiResponseWithDefaults() *ApiResponse {
-    this := ApiResponse{}
-    return &this
+	this := ApiResponse{}
+	return &this
 }
 
 // GetCode returns the Code field value if set, zero value otherwise.
@@ -46,14 +46,14 @@ func (o *ApiResponse) GetCode() int32 {
 	return *o.Code
 }
 
-// GetCodeOk returns a tuple with the Code field value if set, zero value otherwise
+// GetCodeOk returns a tuple with the Code field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *ApiResponse) GetCodeOk() (int32, bool) {
+
+func (o *ApiResponse) GetCodeOk() (*int32, bool) {
 	if o == nil || o.Code == nil {
-		var ret int32
-		return ret, false
+		return nil, false
 	}
-	return *o.Code, true
+	return o.Code, true
 }
 
 // HasCode returns a boolean if a field has been set.
@@ -79,14 +79,14 @@ func (o *ApiResponse) GetType() string {
 	return *o.Type
 }
 
-// GetTypeOk returns a tuple with the Type field value if set, zero value otherwise
+// GetTypeOk returns a tuple with the Type field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *ApiResponse) GetTypeOk() (string, bool) {
+
+func (o *ApiResponse) GetTypeOk() (*string, bool) {
 	if o == nil || o.Type == nil {
-		var ret string
-		return ret, false
+		return nil, false
 	}
-	return *o.Type, true
+	return o.Type, true
 }
 
 // HasType returns a boolean if a field has been set.
@@ -112,14 +112,14 @@ func (o *ApiResponse) GetMessage() string {
 	return *o.Message
 }
 
-// GetMessageOk returns a tuple with the Message field value if set, zero value otherwise
+// GetMessageOk returns a tuple with the Message field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *ApiResponse) GetMessageOk() (string, bool) {
+
+func (o *ApiResponse) GetMessageOk() (*string, bool) {
 	if o == nil || o.Message == nil {
-		var ret string
-		return ret, false
+		return nil, false
 	}
-	return *o.Message, true
+	return o.Message, true
 }
 
 // HasMessage returns a boolean if a field has been set.

--- a/samples/client/petstore/go-experimental/go-petstore/model_array_of_array_of_number_only.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_array_of_array_of_number_only.go
@@ -51,12 +51,12 @@ func (o *ArrayOfArrayOfNumberOnly) GetArrayArrayNumberOk() ([][]float32, bool) {
 		var ret [][]float32
 		return ret, false
 	}
-    return *o.ArrayArrayNumber, true
+	return *o.ArrayArrayNumber, true
 }
 
 // HasArrayArrayNumber returns a boolean if a field has been set.
 func (o *ArrayOfArrayOfNumberOnly) HasArrayArrayNumber() bool {
-    if o != nil && o.ArrayArrayNumber != nil {
+	if o != nil && o.ArrayArrayNumber != nil {
 		return true
 	}
 
@@ -69,11 +69,11 @@ func (o *ArrayOfArrayOfNumberOnly) SetArrayArrayNumber(v [][]float32) {
 }
 
 func (o ArrayOfArrayOfNumberOnly) MarshalJSON() ([]byte, error) {
-    toSerialize := map[string]interface{}{}
-    if o.ArrayArrayNumber != nil {
-        toSerialize["ArrayArrayNumber"] = o.ArrayArrayNumber
-    }
-    return json.Marshal(toSerialize)
+	toSerialize := map[string]interface{}{}
+	if o.ArrayArrayNumber != nil {
+		toSerialize["ArrayArrayNumber"] = o.ArrayArrayNumber
+	}
+	return json.Marshal(toSerialize)
 }
 
 type NullableArrayOfArrayOfNumberOnly struct {
@@ -82,32 +82,32 @@ type NullableArrayOfArrayOfNumberOnly struct {
 }
 
 func (v NullableArrayOfArrayOfNumberOnly) Get() *ArrayOfArrayOfNumberOnly {
-    return v.value
+	return v.value
 }
 
 func (v NullableArrayOfArrayOfNumberOnly) Set(val *ArrayOfArrayOfNumberOnly) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableArrayOfArrayOfNumberOnly) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableArrayOfArrayOfNumberOnly) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableArrayOfArrayOfNumberOnly(val *ArrayOfArrayOfNumberOnly) *NullableArrayOfArrayOfNumberOnly {
-    return &NullableArrayOfArrayOfNumberOnly{value: val, isSet: true}
+	return &NullableArrayOfArrayOfNumberOnly{value: val, isSet: true}
 }
 
 func (v NullableArrayOfArrayOfNumberOnly) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableArrayOfArrayOfNumberOnly) UnmarshalJSON(src []byte) error {
-    v.isSet = true
+	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_array_of_array_of_number_only.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_array_of_array_of_number_only.go
@@ -85,7 +85,7 @@ func (v NullableArrayOfArrayOfNumberOnly) Get() *ArrayOfArrayOfNumberOnly {
 	return v.value
 }
 
-func (v NullableArrayOfArrayOfNumberOnly) Set(val *ArrayOfArrayOfNumberOnly) {
+func (v *NullableArrayOfArrayOfNumberOnly) Set(val *ArrayOfArrayOfNumberOnly) {
 	v.value = val
 	v.isSet = true
 }
@@ -94,7 +94,7 @@ func (v NullableArrayOfArrayOfNumberOnly) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableArrayOfArrayOfNumberOnly) Unset() {
+func (v *NullableArrayOfArrayOfNumberOnly) Unset() {
 	v.value = nil
 	v.isSet = false
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_array_of_array_of_number_only.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_array_of_array_of_number_only.go
@@ -23,16 +23,16 @@ type ArrayOfArrayOfNumberOnly struct {
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
 func NewArrayOfArrayOfNumberOnly() *ArrayOfArrayOfNumberOnly {
-    this := ArrayOfArrayOfNumberOnly{}
-    return &this
+	this := ArrayOfArrayOfNumberOnly{}
+	return &this
 }
 
 // NewArrayOfArrayOfNumberOnlyWithDefaults instantiates a new ArrayOfArrayOfNumberOnly object
 // This constructor will only assign default values to properties that have it defined,
 // but it doesn't guarantee that properties required by API are set
 func NewArrayOfArrayOfNumberOnlyWithDefaults() *ArrayOfArrayOfNumberOnly {
-    this := ArrayOfArrayOfNumberOnly{}
-    return &this
+	this := ArrayOfArrayOfNumberOnly{}
+	return &this
 }
 
 // GetArrayArrayNumber returns the ArrayArrayNumber field value if set, zero value otherwise.
@@ -44,14 +44,14 @@ func (o *ArrayOfArrayOfNumberOnly) GetArrayArrayNumber() [][]float32 {
 	return *o.ArrayArrayNumber
 }
 
-// GetArrayArrayNumberOk returns a tuple with the ArrayArrayNumber field value if set, zero value otherwise
+// GetArrayArrayNumberOk returns a tuple with the ArrayArrayNumber field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *ArrayOfArrayOfNumberOnly) GetArrayArrayNumberOk() ([][]float32, bool) {
+
+func (o *ArrayOfArrayOfNumberOnly) GetArrayArrayNumberOk() (*[][]float32, bool) {
 	if o == nil || o.ArrayArrayNumber == nil {
-		var ret [][]float32
-		return ret, false
+		return nil, false
 	}
-	return *o.ArrayArrayNumber, true
+	return o.ArrayArrayNumber, true
 }
 
 // HasArrayArrayNumber returns a boolean if a field has been set.

--- a/samples/client/petstore/go-experimental/go-petstore/model_array_of_array_of_number_only.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_array_of_array_of_number_only.go
@@ -10,7 +10,6 @@
 package petstore
 
 import (
-	"bytes"
 	"encoding/json"
 )
 
@@ -52,12 +51,12 @@ func (o *ArrayOfArrayOfNumberOnly) GetArrayArrayNumberOk() ([][]float32, bool) {
 		var ret [][]float32
 		return ret, false
 	}
-	return *o.ArrayArrayNumber, true
+    return *o.ArrayArrayNumber, true
 }
 
 // HasArrayArrayNumber returns a boolean if a field has been set.
 func (o *ArrayOfArrayOfNumberOnly) HasArrayArrayNumber() bool {
-	if o != nil && o.ArrayArrayNumber != nil {
+    if o != nil && o.ArrayArrayNumber != nil {
 		return true
 	}
 
@@ -69,25 +68,46 @@ func (o *ArrayOfArrayOfNumberOnly) SetArrayArrayNumber(v [][]float32) {
 	o.ArrayArrayNumber = &v
 }
 
+func (o ArrayOfArrayOfNumberOnly) MarshalJSON() ([]byte, error) {
+    toSerialize := map[string]interface{}{}
+    if o.ArrayArrayNumber != nil {
+        toSerialize["ArrayArrayNumber"] = o.ArrayArrayNumber
+    }
+    return json.Marshal(toSerialize)
+}
+
 type NullableArrayOfArrayOfNumberOnly struct {
-	Value ArrayOfArrayOfNumberOnly
-	ExplicitNull bool
+	value *ArrayOfArrayOfNumberOnly
+	isSet bool
+}
+
+func (v NullableArrayOfArrayOfNumberOnly) Get() *ArrayOfArrayOfNumberOnly {
+    return v.value
+}
+
+func (v NullableArrayOfArrayOfNumberOnly) Set(val *ArrayOfArrayOfNumberOnly) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableArrayOfArrayOfNumberOnly) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableArrayOfArrayOfNumberOnly) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableArrayOfArrayOfNumberOnly(val *ArrayOfArrayOfNumberOnly) *NullableArrayOfArrayOfNumberOnly {
+    return &NullableArrayOfArrayOfNumberOnly{value: val, isSet: true}
 }
 
 func (v NullableArrayOfArrayOfNumberOnly) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-		return json.Marshal(v.Value)
-	}
+    return json.Marshal(v.value)
 }
 
 func (v *NullableArrayOfArrayOfNumberOnly) UnmarshalJSON(src []byte) error {
-	if bytes.Equal(src, []byte("null")) {
-		v.ExplicitNull = true
-		return nil
-	}
-
-	return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_array_of_array_of_number_only.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_array_of_array_of_number_only.go
@@ -46,7 +46,6 @@ func (o *ArrayOfArrayOfNumberOnly) GetArrayArrayNumber() [][]float32 {
 
 // GetArrayArrayNumberOk returns a tuple with the ArrayArrayNumber field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *ArrayOfArrayOfNumberOnly) GetArrayArrayNumberOk() (*[][]float32, bool) {
 	if o == nil || o.ArrayArrayNumber == nil {
 		return nil, false

--- a/samples/client/petstore/go-experimental/go-petstore/model_array_of_number_only.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_array_of_number_only.go
@@ -51,12 +51,12 @@ func (o *ArrayOfNumberOnly) GetArrayNumberOk() ([]float32, bool) {
 		var ret []float32
 		return ret, false
 	}
-    return *o.ArrayNumber, true
+	return *o.ArrayNumber, true
 }
 
 // HasArrayNumber returns a boolean if a field has been set.
 func (o *ArrayOfNumberOnly) HasArrayNumber() bool {
-    if o != nil && o.ArrayNumber != nil {
+	if o != nil && o.ArrayNumber != nil {
 		return true
 	}
 
@@ -69,11 +69,11 @@ func (o *ArrayOfNumberOnly) SetArrayNumber(v []float32) {
 }
 
 func (o ArrayOfNumberOnly) MarshalJSON() ([]byte, error) {
-    toSerialize := map[string]interface{}{}
-    if o.ArrayNumber != nil {
-        toSerialize["ArrayNumber"] = o.ArrayNumber
-    }
-    return json.Marshal(toSerialize)
+	toSerialize := map[string]interface{}{}
+	if o.ArrayNumber != nil {
+		toSerialize["ArrayNumber"] = o.ArrayNumber
+	}
+	return json.Marshal(toSerialize)
 }
 
 type NullableArrayOfNumberOnly struct {
@@ -82,32 +82,32 @@ type NullableArrayOfNumberOnly struct {
 }
 
 func (v NullableArrayOfNumberOnly) Get() *ArrayOfNumberOnly {
-    return v.value
+	return v.value
 }
 
 func (v NullableArrayOfNumberOnly) Set(val *ArrayOfNumberOnly) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableArrayOfNumberOnly) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableArrayOfNumberOnly) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableArrayOfNumberOnly(val *ArrayOfNumberOnly) *NullableArrayOfNumberOnly {
-    return &NullableArrayOfNumberOnly{value: val, isSet: true}
+	return &NullableArrayOfNumberOnly{value: val, isSet: true}
 }
 
 func (v NullableArrayOfNumberOnly) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableArrayOfNumberOnly) UnmarshalJSON(src []byte) error {
-    v.isSet = true
+	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_array_of_number_only.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_array_of_number_only.go
@@ -85,7 +85,7 @@ func (v NullableArrayOfNumberOnly) Get() *ArrayOfNumberOnly {
 	return v.value
 }
 
-func (v NullableArrayOfNumberOnly) Set(val *ArrayOfNumberOnly) {
+func (v *NullableArrayOfNumberOnly) Set(val *ArrayOfNumberOnly) {
 	v.value = val
 	v.isSet = true
 }
@@ -94,7 +94,7 @@ func (v NullableArrayOfNumberOnly) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableArrayOfNumberOnly) Unset() {
+func (v *NullableArrayOfNumberOnly) Unset() {
 	v.value = nil
 	v.isSet = false
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_array_of_number_only.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_array_of_number_only.go
@@ -10,7 +10,6 @@
 package petstore
 
 import (
-	"bytes"
 	"encoding/json"
 )
 
@@ -52,12 +51,12 @@ func (o *ArrayOfNumberOnly) GetArrayNumberOk() ([]float32, bool) {
 		var ret []float32
 		return ret, false
 	}
-	return *o.ArrayNumber, true
+    return *o.ArrayNumber, true
 }
 
 // HasArrayNumber returns a boolean if a field has been set.
 func (o *ArrayOfNumberOnly) HasArrayNumber() bool {
-	if o != nil && o.ArrayNumber != nil {
+    if o != nil && o.ArrayNumber != nil {
 		return true
 	}
 
@@ -69,25 +68,46 @@ func (o *ArrayOfNumberOnly) SetArrayNumber(v []float32) {
 	o.ArrayNumber = &v
 }
 
+func (o ArrayOfNumberOnly) MarshalJSON() ([]byte, error) {
+    toSerialize := map[string]interface{}{}
+    if o.ArrayNumber != nil {
+        toSerialize["ArrayNumber"] = o.ArrayNumber
+    }
+    return json.Marshal(toSerialize)
+}
+
 type NullableArrayOfNumberOnly struct {
-	Value ArrayOfNumberOnly
-	ExplicitNull bool
+	value *ArrayOfNumberOnly
+	isSet bool
+}
+
+func (v NullableArrayOfNumberOnly) Get() *ArrayOfNumberOnly {
+    return v.value
+}
+
+func (v NullableArrayOfNumberOnly) Set(val *ArrayOfNumberOnly) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableArrayOfNumberOnly) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableArrayOfNumberOnly) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableArrayOfNumberOnly(val *ArrayOfNumberOnly) *NullableArrayOfNumberOnly {
+    return &NullableArrayOfNumberOnly{value: val, isSet: true}
 }
 
 func (v NullableArrayOfNumberOnly) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-		return json.Marshal(v.Value)
-	}
+    return json.Marshal(v.value)
 }
 
 func (v *NullableArrayOfNumberOnly) UnmarshalJSON(src []byte) error {
-	if bytes.Equal(src, []byte("null")) {
-		v.ExplicitNull = true
-		return nil
-	}
-
-	return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_array_of_number_only.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_array_of_number_only.go
@@ -23,16 +23,16 @@ type ArrayOfNumberOnly struct {
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
 func NewArrayOfNumberOnly() *ArrayOfNumberOnly {
-    this := ArrayOfNumberOnly{}
-    return &this
+	this := ArrayOfNumberOnly{}
+	return &this
 }
 
 // NewArrayOfNumberOnlyWithDefaults instantiates a new ArrayOfNumberOnly object
 // This constructor will only assign default values to properties that have it defined,
 // but it doesn't guarantee that properties required by API are set
 func NewArrayOfNumberOnlyWithDefaults() *ArrayOfNumberOnly {
-    this := ArrayOfNumberOnly{}
-    return &this
+	this := ArrayOfNumberOnly{}
+	return &this
 }
 
 // GetArrayNumber returns the ArrayNumber field value if set, zero value otherwise.
@@ -44,14 +44,14 @@ func (o *ArrayOfNumberOnly) GetArrayNumber() []float32 {
 	return *o.ArrayNumber
 }
 
-// GetArrayNumberOk returns a tuple with the ArrayNumber field value if set, zero value otherwise
+// GetArrayNumberOk returns a tuple with the ArrayNumber field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *ArrayOfNumberOnly) GetArrayNumberOk() ([]float32, bool) {
+
+func (o *ArrayOfNumberOnly) GetArrayNumberOk() (*[]float32, bool) {
 	if o == nil || o.ArrayNumber == nil {
-		var ret []float32
-		return ret, false
+		return nil, false
 	}
-	return *o.ArrayNumber, true
+	return o.ArrayNumber, true
 }
 
 // HasArrayNumber returns a boolean if a field has been set.

--- a/samples/client/petstore/go-experimental/go-petstore/model_array_of_number_only.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_array_of_number_only.go
@@ -46,7 +46,6 @@ func (o *ArrayOfNumberOnly) GetArrayNumber() []float32 {
 
 // GetArrayNumberOk returns a tuple with the ArrayNumber field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *ArrayOfNumberOnly) GetArrayNumberOk() (*[]float32, bool) {
 	if o == nil || o.ArrayNumber == nil {
 		return nil, false

--- a/samples/client/petstore/go-experimental/go-petstore/model_array_test_.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_array_test_.go
@@ -53,12 +53,12 @@ func (o *ArrayTest) GetArrayOfStringOk() ([]string, bool) {
 		var ret []string
 		return ret, false
 	}
-    return *o.ArrayOfString, true
+	return *o.ArrayOfString, true
 }
 
 // HasArrayOfString returns a boolean if a field has been set.
 func (o *ArrayTest) HasArrayOfString() bool {
-    if o != nil && o.ArrayOfString != nil {
+	if o != nil && o.ArrayOfString != nil {
 		return true
 	}
 
@@ -86,12 +86,12 @@ func (o *ArrayTest) GetArrayArrayOfIntegerOk() ([][]int64, bool) {
 		var ret [][]int64
 		return ret, false
 	}
-    return *o.ArrayArrayOfInteger, true
+	return *o.ArrayArrayOfInteger, true
 }
 
 // HasArrayArrayOfInteger returns a boolean if a field has been set.
 func (o *ArrayTest) HasArrayArrayOfInteger() bool {
-    if o != nil && o.ArrayArrayOfInteger != nil {
+	if o != nil && o.ArrayArrayOfInteger != nil {
 		return true
 	}
 
@@ -119,12 +119,12 @@ func (o *ArrayTest) GetArrayArrayOfModelOk() ([][]ReadOnlyFirst, bool) {
 		var ret [][]ReadOnlyFirst
 		return ret, false
 	}
-    return *o.ArrayArrayOfModel, true
+	return *o.ArrayArrayOfModel, true
 }
 
 // HasArrayArrayOfModel returns a boolean if a field has been set.
 func (o *ArrayTest) HasArrayArrayOfModel() bool {
-    if o != nil && o.ArrayArrayOfModel != nil {
+	if o != nil && o.ArrayArrayOfModel != nil {
 		return true
 	}
 
@@ -137,17 +137,17 @@ func (o *ArrayTest) SetArrayArrayOfModel(v [][]ReadOnlyFirst) {
 }
 
 func (o ArrayTest) MarshalJSON() ([]byte, error) {
-    toSerialize := map[string]interface{}{}
-    if o.ArrayOfString != nil {
-        toSerialize["array_of_string"] = o.ArrayOfString
-    }
-    if o.ArrayArrayOfInteger != nil {
-        toSerialize["array_array_of_integer"] = o.ArrayArrayOfInteger
-    }
-    if o.ArrayArrayOfModel != nil {
-        toSerialize["array_array_of_model"] = o.ArrayArrayOfModel
-    }
-    return json.Marshal(toSerialize)
+	toSerialize := map[string]interface{}{}
+	if o.ArrayOfString != nil {
+		toSerialize["array_of_string"] = o.ArrayOfString
+	}
+	if o.ArrayArrayOfInteger != nil {
+		toSerialize["array_array_of_integer"] = o.ArrayArrayOfInteger
+	}
+	if o.ArrayArrayOfModel != nil {
+		toSerialize["array_array_of_model"] = o.ArrayArrayOfModel
+	}
+	return json.Marshal(toSerialize)
 }
 
 type NullableArrayTest struct {
@@ -156,32 +156,32 @@ type NullableArrayTest struct {
 }
 
 func (v NullableArrayTest) Get() *ArrayTest {
-    return v.value
+	return v.value
 }
 
 func (v NullableArrayTest) Set(val *ArrayTest) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableArrayTest) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableArrayTest) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableArrayTest(val *ArrayTest) *NullableArrayTest {
-    return &NullableArrayTest{value: val, isSet: true}
+	return &NullableArrayTest{value: val, isSet: true}
 }
 
 func (v NullableArrayTest) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableArrayTest) UnmarshalJSON(src []byte) error {
-    v.isSet = true
+	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_array_test_.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_array_test_.go
@@ -10,7 +10,6 @@
 package petstore
 
 import (
-	"bytes"
 	"encoding/json"
 )
 
@@ -54,12 +53,12 @@ func (o *ArrayTest) GetArrayOfStringOk() ([]string, bool) {
 		var ret []string
 		return ret, false
 	}
-	return *o.ArrayOfString, true
+    return *o.ArrayOfString, true
 }
 
 // HasArrayOfString returns a boolean if a field has been set.
 func (o *ArrayTest) HasArrayOfString() bool {
-	if o != nil && o.ArrayOfString != nil {
+    if o != nil && o.ArrayOfString != nil {
 		return true
 	}
 
@@ -87,12 +86,12 @@ func (o *ArrayTest) GetArrayArrayOfIntegerOk() ([][]int64, bool) {
 		var ret [][]int64
 		return ret, false
 	}
-	return *o.ArrayArrayOfInteger, true
+    return *o.ArrayArrayOfInteger, true
 }
 
 // HasArrayArrayOfInteger returns a boolean if a field has been set.
 func (o *ArrayTest) HasArrayArrayOfInteger() bool {
-	if o != nil && o.ArrayArrayOfInteger != nil {
+    if o != nil && o.ArrayArrayOfInteger != nil {
 		return true
 	}
 
@@ -120,12 +119,12 @@ func (o *ArrayTest) GetArrayArrayOfModelOk() ([][]ReadOnlyFirst, bool) {
 		var ret [][]ReadOnlyFirst
 		return ret, false
 	}
-	return *o.ArrayArrayOfModel, true
+    return *o.ArrayArrayOfModel, true
 }
 
 // HasArrayArrayOfModel returns a boolean if a field has been set.
 func (o *ArrayTest) HasArrayArrayOfModel() bool {
-	if o != nil && o.ArrayArrayOfModel != nil {
+    if o != nil && o.ArrayArrayOfModel != nil {
 		return true
 	}
 
@@ -137,25 +136,52 @@ func (o *ArrayTest) SetArrayArrayOfModel(v [][]ReadOnlyFirst) {
 	o.ArrayArrayOfModel = &v
 }
 
+func (o ArrayTest) MarshalJSON() ([]byte, error) {
+    toSerialize := map[string]interface{}{}
+    if o.ArrayOfString != nil {
+        toSerialize["array_of_string"] = o.ArrayOfString
+    }
+    if o.ArrayArrayOfInteger != nil {
+        toSerialize["array_array_of_integer"] = o.ArrayArrayOfInteger
+    }
+    if o.ArrayArrayOfModel != nil {
+        toSerialize["array_array_of_model"] = o.ArrayArrayOfModel
+    }
+    return json.Marshal(toSerialize)
+}
+
 type NullableArrayTest struct {
-	Value ArrayTest
-	ExplicitNull bool
+	value *ArrayTest
+	isSet bool
+}
+
+func (v NullableArrayTest) Get() *ArrayTest {
+    return v.value
+}
+
+func (v NullableArrayTest) Set(val *ArrayTest) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableArrayTest) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableArrayTest) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableArrayTest(val *ArrayTest) *NullableArrayTest {
+    return &NullableArrayTest{value: val, isSet: true}
 }
 
 func (v NullableArrayTest) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-		return json.Marshal(v.Value)
-	}
+    return json.Marshal(v.value)
 }
 
 func (v *NullableArrayTest) UnmarshalJSON(src []byte) error {
-	if bytes.Equal(src, []byte("null")) {
-		v.ExplicitNull = true
-		return nil
-	}
-
-	return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_array_test_.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_array_test_.go
@@ -159,7 +159,7 @@ func (v NullableArrayTest) Get() *ArrayTest {
 	return v.value
 }
 
-func (v NullableArrayTest) Set(val *ArrayTest) {
+func (v *NullableArrayTest) Set(val *ArrayTest) {
 	v.value = val
 	v.isSet = true
 }
@@ -168,7 +168,7 @@ func (v NullableArrayTest) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableArrayTest) Unset() {
+func (v *NullableArrayTest) Unset() {
 	v.value = nil
 	v.isSet = false
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_array_test_.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_array_test_.go
@@ -48,7 +48,6 @@ func (o *ArrayTest) GetArrayOfString() []string {
 
 // GetArrayOfStringOk returns a tuple with the ArrayOfString field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *ArrayTest) GetArrayOfStringOk() (*[]string, bool) {
 	if o == nil || o.ArrayOfString == nil {
 		return nil, false
@@ -81,7 +80,6 @@ func (o *ArrayTest) GetArrayArrayOfInteger() [][]int64 {
 
 // GetArrayArrayOfIntegerOk returns a tuple with the ArrayArrayOfInteger field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *ArrayTest) GetArrayArrayOfIntegerOk() (*[][]int64, bool) {
 	if o == nil || o.ArrayArrayOfInteger == nil {
 		return nil, false
@@ -114,7 +112,6 @@ func (o *ArrayTest) GetArrayArrayOfModel() [][]ReadOnlyFirst {
 
 // GetArrayArrayOfModelOk returns a tuple with the ArrayArrayOfModel field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *ArrayTest) GetArrayArrayOfModelOk() (*[][]ReadOnlyFirst, bool) {
 	if o == nil || o.ArrayArrayOfModel == nil {
 		return nil, false

--- a/samples/client/petstore/go-experimental/go-petstore/model_array_test_.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_array_test_.go
@@ -25,16 +25,16 @@ type ArrayTest struct {
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
 func NewArrayTest() *ArrayTest {
-    this := ArrayTest{}
-    return &this
+	this := ArrayTest{}
+	return &this
 }
 
 // NewArrayTestWithDefaults instantiates a new ArrayTest object
 // This constructor will only assign default values to properties that have it defined,
 // but it doesn't guarantee that properties required by API are set
 func NewArrayTestWithDefaults() *ArrayTest {
-    this := ArrayTest{}
-    return &this
+	this := ArrayTest{}
+	return &this
 }
 
 // GetArrayOfString returns the ArrayOfString field value if set, zero value otherwise.
@@ -46,14 +46,14 @@ func (o *ArrayTest) GetArrayOfString() []string {
 	return *o.ArrayOfString
 }
 
-// GetArrayOfStringOk returns a tuple with the ArrayOfString field value if set, zero value otherwise
+// GetArrayOfStringOk returns a tuple with the ArrayOfString field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *ArrayTest) GetArrayOfStringOk() ([]string, bool) {
+
+func (o *ArrayTest) GetArrayOfStringOk() (*[]string, bool) {
 	if o == nil || o.ArrayOfString == nil {
-		var ret []string
-		return ret, false
+		return nil, false
 	}
-	return *o.ArrayOfString, true
+	return o.ArrayOfString, true
 }
 
 // HasArrayOfString returns a boolean if a field has been set.
@@ -79,14 +79,14 @@ func (o *ArrayTest) GetArrayArrayOfInteger() [][]int64 {
 	return *o.ArrayArrayOfInteger
 }
 
-// GetArrayArrayOfIntegerOk returns a tuple with the ArrayArrayOfInteger field value if set, zero value otherwise
+// GetArrayArrayOfIntegerOk returns a tuple with the ArrayArrayOfInteger field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *ArrayTest) GetArrayArrayOfIntegerOk() ([][]int64, bool) {
+
+func (o *ArrayTest) GetArrayArrayOfIntegerOk() (*[][]int64, bool) {
 	if o == nil || o.ArrayArrayOfInteger == nil {
-		var ret [][]int64
-		return ret, false
+		return nil, false
 	}
-	return *o.ArrayArrayOfInteger, true
+	return o.ArrayArrayOfInteger, true
 }
 
 // HasArrayArrayOfInteger returns a boolean if a field has been set.
@@ -112,14 +112,14 @@ func (o *ArrayTest) GetArrayArrayOfModel() [][]ReadOnlyFirst {
 	return *o.ArrayArrayOfModel
 }
 
-// GetArrayArrayOfModelOk returns a tuple with the ArrayArrayOfModel field value if set, zero value otherwise
+// GetArrayArrayOfModelOk returns a tuple with the ArrayArrayOfModel field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *ArrayTest) GetArrayArrayOfModelOk() ([][]ReadOnlyFirst, bool) {
+
+func (o *ArrayTest) GetArrayArrayOfModelOk() (*[][]ReadOnlyFirst, bool) {
 	if o == nil || o.ArrayArrayOfModel == nil {
-		var ret [][]ReadOnlyFirst
-		return ret, false
+		return nil, false
 	}
-	return *o.ArrayArrayOfModel, true
+	return o.ArrayArrayOfModel, true
 }
 
 // HasArrayArrayOfModel returns a boolean if a field has been set.

--- a/samples/client/petstore/go-experimental/go-petstore/model_big_cat.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_big_cat.go
@@ -10,7 +10,6 @@
 package petstore
 
 import (
-	"bytes"
 	"encoding/json"
 )
 
@@ -53,12 +52,12 @@ func (o *BigCat) GetKindOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-	return *o.Kind, true
+    return *o.Kind, true
 }
 
 // HasKind returns a boolean if a field has been set.
 func (o *BigCat) HasKind() bool {
-	if o != nil && o.Kind != nil {
+    if o != nil && o.Kind != nil {
 		return true
 	}
 
@@ -70,25 +69,54 @@ func (o *BigCat) SetKind(v string) {
 	o.Kind = &v
 }
 
+func (o BigCat) MarshalJSON() ([]byte, error) {
+    toSerialize := map[string]interface{}{}
+    serializedCat, errCat := json.Marshal(o.Cat)
+    if errCat != nil {
+        return []byte{}, errCat
+    }
+    errCat = json.Unmarshal([]byte(serializedCat), &toSerialize)
+    if errCat != nil {
+       return []byte{}, errCat
+    }
+    if o.Kind != nil {
+        toSerialize["kind"] = o.Kind
+    }
+    return json.Marshal(toSerialize)
+}
+
 type NullableBigCat struct {
-	Value BigCat
-	ExplicitNull bool
+	value *BigCat
+	isSet bool
+}
+
+func (v NullableBigCat) Get() *BigCat {
+    return v.value
+}
+
+func (v NullableBigCat) Set(val *BigCat) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableBigCat) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableBigCat) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableBigCat(val *BigCat) *NullableBigCat {
+    return &NullableBigCat{value: val, isSet: true}
 }
 
 func (v NullableBigCat) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-		return json.Marshal(v.Value)
-	}
+    return json.Marshal(v.value)
 }
 
 func (v *NullableBigCat) UnmarshalJSON(src []byte) error {
-	if bytes.Equal(src, []byte("null")) {
-		v.ExplicitNull = true
-		return nil
-	}
-
-	return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_big_cat.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_big_cat.go
@@ -94,7 +94,7 @@ func (v NullableBigCat) Get() *BigCat {
 	return v.value
 }
 
-func (v NullableBigCat) Set(val *BigCat) {
+func (v *NullableBigCat) Set(val *BigCat) {
 	v.value = val
 	v.isSet = true
 }
@@ -103,7 +103,7 @@ func (v NullableBigCat) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableBigCat) Unset() {
+func (v *NullableBigCat) Unset() {
 	v.value = nil
 	v.isSet = false
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_big_cat.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_big_cat.go
@@ -24,16 +24,16 @@ type BigCat struct {
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
 func NewBigCat() *BigCat {
-    this := BigCat{}
-    return &this
+	this := BigCat{}
+	return &this
 }
 
 // NewBigCatWithDefaults instantiates a new BigCat object
 // This constructor will only assign default values to properties that have it defined,
 // but it doesn't guarantee that properties required by API are set
 func NewBigCatWithDefaults() *BigCat {
-    this := BigCat{}
-    return &this
+	this := BigCat{}
+	return &this
 }
 
 // GetKind returns the Kind field value if set, zero value otherwise.
@@ -45,14 +45,14 @@ func (o *BigCat) GetKind() string {
 	return *o.Kind
 }
 
-// GetKindOk returns a tuple with the Kind field value if set, zero value otherwise
+// GetKindOk returns a tuple with the Kind field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *BigCat) GetKindOk() (string, bool) {
+
+func (o *BigCat) GetKindOk() (*string, bool) {
 	if o == nil || o.Kind == nil {
-		var ret string
-		return ret, false
+		return nil, false
 	}
-	return *o.Kind, true
+	return o.Kind, true
 }
 
 // HasKind returns a boolean if a field has been set.

--- a/samples/client/petstore/go-experimental/go-petstore/model_big_cat.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_big_cat.go
@@ -52,12 +52,12 @@ func (o *BigCat) GetKindOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-    return *o.Kind, true
+	return *o.Kind, true
 }
 
 // HasKind returns a boolean if a field has been set.
 func (o *BigCat) HasKind() bool {
-    if o != nil && o.Kind != nil {
+	if o != nil && o.Kind != nil {
 		return true
 	}
 
@@ -70,19 +70,19 @@ func (o *BigCat) SetKind(v string) {
 }
 
 func (o BigCat) MarshalJSON() ([]byte, error) {
-    toSerialize := map[string]interface{}{}
-    serializedCat, errCat := json.Marshal(o.Cat)
-    if errCat != nil {
-        return []byte{}, errCat
-    }
-    errCat = json.Unmarshal([]byte(serializedCat), &toSerialize)
-    if errCat != nil {
-       return []byte{}, errCat
-    }
-    if o.Kind != nil {
-        toSerialize["kind"] = o.Kind
-    }
-    return json.Marshal(toSerialize)
+	toSerialize := map[string]interface{}{}
+	serializedCat, errCat := json.Marshal(o.Cat)
+	if errCat != nil {
+		return []byte{}, errCat
+	}
+	errCat = json.Unmarshal([]byte(serializedCat), &toSerialize)
+	if errCat != nil {
+		return []byte{}, errCat
+	}
+	if o.Kind != nil {
+		toSerialize["kind"] = o.Kind
+	}
+	return json.Marshal(toSerialize)
 }
 
 type NullableBigCat struct {
@@ -91,32 +91,32 @@ type NullableBigCat struct {
 }
 
 func (v NullableBigCat) Get() *BigCat {
-    return v.value
+	return v.value
 }
 
 func (v NullableBigCat) Set(val *BigCat) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableBigCat) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableBigCat) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableBigCat(val *BigCat) *NullableBigCat {
-    return &NullableBigCat{value: val, isSet: true}
+	return &NullableBigCat{value: val, isSet: true}
 }
 
 func (v NullableBigCat) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableBigCat) UnmarshalJSON(src []byte) error {
-    v.isSet = true
+	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_big_cat.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_big_cat.go
@@ -47,7 +47,6 @@ func (o *BigCat) GetKind() string {
 
 // GetKindOk returns a tuple with the Kind field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *BigCat) GetKindOk() (*string, bool) {
 	if o == nil || o.Kind == nil {
 		return nil, false

--- a/samples/client/petstore/go-experimental/go-petstore/model_big_cat_all_of.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_big_cat_all_of.go
@@ -51,12 +51,12 @@ func (o *BigCatAllOf) GetKindOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-    return *o.Kind, true
+	return *o.Kind, true
 }
 
 // HasKind returns a boolean if a field has been set.
 func (o *BigCatAllOf) HasKind() bool {
-    if o != nil && o.Kind != nil {
+	if o != nil && o.Kind != nil {
 		return true
 	}
 
@@ -69,11 +69,11 @@ func (o *BigCatAllOf) SetKind(v string) {
 }
 
 func (o BigCatAllOf) MarshalJSON() ([]byte, error) {
-    toSerialize := map[string]interface{}{}
-    if o.Kind != nil {
-        toSerialize["kind"] = o.Kind
-    }
-    return json.Marshal(toSerialize)
+	toSerialize := map[string]interface{}{}
+	if o.Kind != nil {
+		toSerialize["kind"] = o.Kind
+	}
+	return json.Marshal(toSerialize)
 }
 
 type NullableBigCatAllOf struct {
@@ -82,32 +82,32 @@ type NullableBigCatAllOf struct {
 }
 
 func (v NullableBigCatAllOf) Get() *BigCatAllOf {
-    return v.value
+	return v.value
 }
 
 func (v NullableBigCatAllOf) Set(val *BigCatAllOf) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableBigCatAllOf) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableBigCatAllOf) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableBigCatAllOf(val *BigCatAllOf) *NullableBigCatAllOf {
-    return &NullableBigCatAllOf{value: val, isSet: true}
+	return &NullableBigCatAllOf{value: val, isSet: true}
 }
 
 func (v NullableBigCatAllOf) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableBigCatAllOf) UnmarshalJSON(src []byte) error {
-    v.isSet = true
+	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_big_cat_all_of.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_big_cat_all_of.go
@@ -85,7 +85,7 @@ func (v NullableBigCatAllOf) Get() *BigCatAllOf {
 	return v.value
 }
 
-func (v NullableBigCatAllOf) Set(val *BigCatAllOf) {
+func (v *NullableBigCatAllOf) Set(val *BigCatAllOf) {
 	v.value = val
 	v.isSet = true
 }
@@ -94,7 +94,7 @@ func (v NullableBigCatAllOf) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableBigCatAllOf) Unset() {
+func (v *NullableBigCatAllOf) Unset() {
 	v.value = nil
 	v.isSet = false
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_big_cat_all_of.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_big_cat_all_of.go
@@ -46,7 +46,6 @@ func (o *BigCatAllOf) GetKind() string {
 
 // GetKindOk returns a tuple with the Kind field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *BigCatAllOf) GetKindOk() (*string, bool) {
 	if o == nil || o.Kind == nil {
 		return nil, false

--- a/samples/client/petstore/go-experimental/go-petstore/model_big_cat_all_of.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_big_cat_all_of.go
@@ -10,7 +10,6 @@
 package petstore
 
 import (
-	"bytes"
 	"encoding/json"
 )
 
@@ -52,12 +51,12 @@ func (o *BigCatAllOf) GetKindOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-	return *o.Kind, true
+    return *o.Kind, true
 }
 
 // HasKind returns a boolean if a field has been set.
 func (o *BigCatAllOf) HasKind() bool {
-	if o != nil && o.Kind != nil {
+    if o != nil && o.Kind != nil {
 		return true
 	}
 
@@ -69,25 +68,46 @@ func (o *BigCatAllOf) SetKind(v string) {
 	o.Kind = &v
 }
 
+func (o BigCatAllOf) MarshalJSON() ([]byte, error) {
+    toSerialize := map[string]interface{}{}
+    if o.Kind != nil {
+        toSerialize["kind"] = o.Kind
+    }
+    return json.Marshal(toSerialize)
+}
+
 type NullableBigCatAllOf struct {
-	Value BigCatAllOf
-	ExplicitNull bool
+	value *BigCatAllOf
+	isSet bool
+}
+
+func (v NullableBigCatAllOf) Get() *BigCatAllOf {
+    return v.value
+}
+
+func (v NullableBigCatAllOf) Set(val *BigCatAllOf) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableBigCatAllOf) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableBigCatAllOf) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableBigCatAllOf(val *BigCatAllOf) *NullableBigCatAllOf {
+    return &NullableBigCatAllOf{value: val, isSet: true}
 }
 
 func (v NullableBigCatAllOf) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-		return json.Marshal(v.Value)
-	}
+    return json.Marshal(v.value)
 }
 
 func (v *NullableBigCatAllOf) UnmarshalJSON(src []byte) error {
-	if bytes.Equal(src, []byte("null")) {
-		v.ExplicitNull = true
-		return nil
-	}
-
-	return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_big_cat_all_of.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_big_cat_all_of.go
@@ -23,16 +23,16 @@ type BigCatAllOf struct {
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
 func NewBigCatAllOf() *BigCatAllOf {
-    this := BigCatAllOf{}
-    return &this
+	this := BigCatAllOf{}
+	return &this
 }
 
 // NewBigCatAllOfWithDefaults instantiates a new BigCatAllOf object
 // This constructor will only assign default values to properties that have it defined,
 // but it doesn't guarantee that properties required by API are set
 func NewBigCatAllOfWithDefaults() *BigCatAllOf {
-    this := BigCatAllOf{}
-    return &this
+	this := BigCatAllOf{}
+	return &this
 }
 
 // GetKind returns the Kind field value if set, zero value otherwise.
@@ -44,14 +44,14 @@ func (o *BigCatAllOf) GetKind() string {
 	return *o.Kind
 }
 
-// GetKindOk returns a tuple with the Kind field value if set, zero value otherwise
+// GetKindOk returns a tuple with the Kind field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *BigCatAllOf) GetKindOk() (string, bool) {
+
+func (o *BigCatAllOf) GetKindOk() (*string, bool) {
 	if o == nil || o.Kind == nil {
-		var ret string
-		return ret, false
+		return nil, false
 	}
-	return *o.Kind, true
+	return o.Kind, true
 }
 
 // HasKind returns a boolean if a field has been set.

--- a/samples/client/petstore/go-experimental/go-petstore/model_capitalization.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_capitalization.go
@@ -57,12 +57,12 @@ func (o *Capitalization) GetSmallCamelOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-    return *o.SmallCamel, true
+	return *o.SmallCamel, true
 }
 
 // HasSmallCamel returns a boolean if a field has been set.
 func (o *Capitalization) HasSmallCamel() bool {
-    if o != nil && o.SmallCamel != nil {
+	if o != nil && o.SmallCamel != nil {
 		return true
 	}
 
@@ -90,12 +90,12 @@ func (o *Capitalization) GetCapitalCamelOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-    return *o.CapitalCamel, true
+	return *o.CapitalCamel, true
 }
 
 // HasCapitalCamel returns a boolean if a field has been set.
 func (o *Capitalization) HasCapitalCamel() bool {
-    if o != nil && o.CapitalCamel != nil {
+	if o != nil && o.CapitalCamel != nil {
 		return true
 	}
 
@@ -123,12 +123,12 @@ func (o *Capitalization) GetSmallSnakeOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-    return *o.SmallSnake, true
+	return *o.SmallSnake, true
 }
 
 // HasSmallSnake returns a boolean if a field has been set.
 func (o *Capitalization) HasSmallSnake() bool {
-    if o != nil && o.SmallSnake != nil {
+	if o != nil && o.SmallSnake != nil {
 		return true
 	}
 
@@ -156,12 +156,12 @@ func (o *Capitalization) GetCapitalSnakeOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-    return *o.CapitalSnake, true
+	return *o.CapitalSnake, true
 }
 
 // HasCapitalSnake returns a boolean if a field has been set.
 func (o *Capitalization) HasCapitalSnake() bool {
-    if o != nil && o.CapitalSnake != nil {
+	if o != nil && o.CapitalSnake != nil {
 		return true
 	}
 
@@ -189,12 +189,12 @@ func (o *Capitalization) GetSCAETHFlowPointsOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-    return *o.SCAETHFlowPoints, true
+	return *o.SCAETHFlowPoints, true
 }
 
 // HasSCAETHFlowPoints returns a boolean if a field has been set.
 func (o *Capitalization) HasSCAETHFlowPoints() bool {
-    if o != nil && o.SCAETHFlowPoints != nil {
+	if o != nil && o.SCAETHFlowPoints != nil {
 		return true
 	}
 
@@ -222,12 +222,12 @@ func (o *Capitalization) GetATT_NAMEOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-    return *o.ATT_NAME, true
+	return *o.ATT_NAME, true
 }
 
 // HasATT_NAME returns a boolean if a field has been set.
 func (o *Capitalization) HasATT_NAME() bool {
-    if o != nil && o.ATT_NAME != nil {
+	if o != nil && o.ATT_NAME != nil {
 		return true
 	}
 
@@ -240,26 +240,26 @@ func (o *Capitalization) SetATT_NAME(v string) {
 }
 
 func (o Capitalization) MarshalJSON() ([]byte, error) {
-    toSerialize := map[string]interface{}{}
-    if o.SmallCamel != nil {
-        toSerialize["smallCamel"] = o.SmallCamel
-    }
-    if o.CapitalCamel != nil {
-        toSerialize["CapitalCamel"] = o.CapitalCamel
-    }
-    if o.SmallSnake != nil {
-        toSerialize["small_Snake"] = o.SmallSnake
-    }
-    if o.CapitalSnake != nil {
-        toSerialize["Capital_Snake"] = o.CapitalSnake
-    }
-    if o.SCAETHFlowPoints != nil {
-        toSerialize["SCA_ETH_Flow_Points"] = o.SCAETHFlowPoints
-    }
-    if o.ATT_NAME != nil {
-        toSerialize["ATT_NAME"] = o.ATT_NAME
-    }
-    return json.Marshal(toSerialize)
+	toSerialize := map[string]interface{}{}
+	if o.SmallCamel != nil {
+		toSerialize["smallCamel"] = o.SmallCamel
+	}
+	if o.CapitalCamel != nil {
+		toSerialize["CapitalCamel"] = o.CapitalCamel
+	}
+	if o.SmallSnake != nil {
+		toSerialize["small_Snake"] = o.SmallSnake
+	}
+	if o.CapitalSnake != nil {
+		toSerialize["Capital_Snake"] = o.CapitalSnake
+	}
+	if o.SCAETHFlowPoints != nil {
+		toSerialize["SCA_ETH_Flow_Points"] = o.SCAETHFlowPoints
+	}
+	if o.ATT_NAME != nil {
+		toSerialize["ATT_NAME"] = o.ATT_NAME
+	}
+	return json.Marshal(toSerialize)
 }
 
 type NullableCapitalization struct {
@@ -268,32 +268,32 @@ type NullableCapitalization struct {
 }
 
 func (v NullableCapitalization) Get() *Capitalization {
-    return v.value
+	return v.value
 }
 
 func (v NullableCapitalization) Set(val *Capitalization) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableCapitalization) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableCapitalization) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableCapitalization(val *Capitalization) *NullableCapitalization {
-    return &NullableCapitalization{value: val, isSet: true}
+	return &NullableCapitalization{value: val, isSet: true}
 }
 
 func (v NullableCapitalization) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableCapitalization) UnmarshalJSON(src []byte) error {
-    v.isSet = true
+	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_capitalization.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_capitalization.go
@@ -271,7 +271,7 @@ func (v NullableCapitalization) Get() *Capitalization {
 	return v.value
 }
 
-func (v NullableCapitalization) Set(val *Capitalization) {
+func (v *NullableCapitalization) Set(val *Capitalization) {
 	v.value = val
 	v.isSet = true
 }
@@ -280,7 +280,7 @@ func (v NullableCapitalization) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableCapitalization) Unset() {
+func (v *NullableCapitalization) Unset() {
 	v.value = nil
 	v.isSet = false
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_capitalization.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_capitalization.go
@@ -52,7 +52,6 @@ func (o *Capitalization) GetSmallCamel() string {
 
 // GetSmallCamelOk returns a tuple with the SmallCamel field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *Capitalization) GetSmallCamelOk() (*string, bool) {
 	if o == nil || o.SmallCamel == nil {
 		return nil, false
@@ -85,7 +84,6 @@ func (o *Capitalization) GetCapitalCamel() string {
 
 // GetCapitalCamelOk returns a tuple with the CapitalCamel field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *Capitalization) GetCapitalCamelOk() (*string, bool) {
 	if o == nil || o.CapitalCamel == nil {
 		return nil, false
@@ -118,7 +116,6 @@ func (o *Capitalization) GetSmallSnake() string {
 
 // GetSmallSnakeOk returns a tuple with the SmallSnake field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *Capitalization) GetSmallSnakeOk() (*string, bool) {
 	if o == nil || o.SmallSnake == nil {
 		return nil, false
@@ -151,7 +148,6 @@ func (o *Capitalization) GetCapitalSnake() string {
 
 // GetCapitalSnakeOk returns a tuple with the CapitalSnake field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *Capitalization) GetCapitalSnakeOk() (*string, bool) {
 	if o == nil || o.CapitalSnake == nil {
 		return nil, false
@@ -184,7 +180,6 @@ func (o *Capitalization) GetSCAETHFlowPoints() string {
 
 // GetSCAETHFlowPointsOk returns a tuple with the SCAETHFlowPoints field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *Capitalization) GetSCAETHFlowPointsOk() (*string, bool) {
 	if o == nil || o.SCAETHFlowPoints == nil {
 		return nil, false
@@ -217,7 +212,6 @@ func (o *Capitalization) GetATT_NAME() string {
 
 // GetATT_NAMEOk returns a tuple with the ATT_NAME field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *Capitalization) GetATT_NAMEOk() (*string, bool) {
 	if o == nil || o.ATT_NAME == nil {
 		return nil, false

--- a/samples/client/petstore/go-experimental/go-petstore/model_capitalization.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_capitalization.go
@@ -29,16 +29,16 @@ type Capitalization struct {
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
 func NewCapitalization() *Capitalization {
-    this := Capitalization{}
-    return &this
+	this := Capitalization{}
+	return &this
 }
 
 // NewCapitalizationWithDefaults instantiates a new Capitalization object
 // This constructor will only assign default values to properties that have it defined,
 // but it doesn't guarantee that properties required by API are set
 func NewCapitalizationWithDefaults() *Capitalization {
-    this := Capitalization{}
-    return &this
+	this := Capitalization{}
+	return &this
 }
 
 // GetSmallCamel returns the SmallCamel field value if set, zero value otherwise.
@@ -50,14 +50,14 @@ func (o *Capitalization) GetSmallCamel() string {
 	return *o.SmallCamel
 }
 
-// GetSmallCamelOk returns a tuple with the SmallCamel field value if set, zero value otherwise
+// GetSmallCamelOk returns a tuple with the SmallCamel field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *Capitalization) GetSmallCamelOk() (string, bool) {
+
+func (o *Capitalization) GetSmallCamelOk() (*string, bool) {
 	if o == nil || o.SmallCamel == nil {
-		var ret string
-		return ret, false
+		return nil, false
 	}
-	return *o.SmallCamel, true
+	return o.SmallCamel, true
 }
 
 // HasSmallCamel returns a boolean if a field has been set.
@@ -83,14 +83,14 @@ func (o *Capitalization) GetCapitalCamel() string {
 	return *o.CapitalCamel
 }
 
-// GetCapitalCamelOk returns a tuple with the CapitalCamel field value if set, zero value otherwise
+// GetCapitalCamelOk returns a tuple with the CapitalCamel field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *Capitalization) GetCapitalCamelOk() (string, bool) {
+
+func (o *Capitalization) GetCapitalCamelOk() (*string, bool) {
 	if o == nil || o.CapitalCamel == nil {
-		var ret string
-		return ret, false
+		return nil, false
 	}
-	return *o.CapitalCamel, true
+	return o.CapitalCamel, true
 }
 
 // HasCapitalCamel returns a boolean if a field has been set.
@@ -116,14 +116,14 @@ func (o *Capitalization) GetSmallSnake() string {
 	return *o.SmallSnake
 }
 
-// GetSmallSnakeOk returns a tuple with the SmallSnake field value if set, zero value otherwise
+// GetSmallSnakeOk returns a tuple with the SmallSnake field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *Capitalization) GetSmallSnakeOk() (string, bool) {
+
+func (o *Capitalization) GetSmallSnakeOk() (*string, bool) {
 	if o == nil || o.SmallSnake == nil {
-		var ret string
-		return ret, false
+		return nil, false
 	}
-	return *o.SmallSnake, true
+	return o.SmallSnake, true
 }
 
 // HasSmallSnake returns a boolean if a field has been set.
@@ -149,14 +149,14 @@ func (o *Capitalization) GetCapitalSnake() string {
 	return *o.CapitalSnake
 }
 
-// GetCapitalSnakeOk returns a tuple with the CapitalSnake field value if set, zero value otherwise
+// GetCapitalSnakeOk returns a tuple with the CapitalSnake field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *Capitalization) GetCapitalSnakeOk() (string, bool) {
+
+func (o *Capitalization) GetCapitalSnakeOk() (*string, bool) {
 	if o == nil || o.CapitalSnake == nil {
-		var ret string
-		return ret, false
+		return nil, false
 	}
-	return *o.CapitalSnake, true
+	return o.CapitalSnake, true
 }
 
 // HasCapitalSnake returns a boolean if a field has been set.
@@ -182,14 +182,14 @@ func (o *Capitalization) GetSCAETHFlowPoints() string {
 	return *o.SCAETHFlowPoints
 }
 
-// GetSCAETHFlowPointsOk returns a tuple with the SCAETHFlowPoints field value if set, zero value otherwise
+// GetSCAETHFlowPointsOk returns a tuple with the SCAETHFlowPoints field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *Capitalization) GetSCAETHFlowPointsOk() (string, bool) {
+
+func (o *Capitalization) GetSCAETHFlowPointsOk() (*string, bool) {
 	if o == nil || o.SCAETHFlowPoints == nil {
-		var ret string
-		return ret, false
+		return nil, false
 	}
-	return *o.SCAETHFlowPoints, true
+	return o.SCAETHFlowPoints, true
 }
 
 // HasSCAETHFlowPoints returns a boolean if a field has been set.
@@ -215,14 +215,14 @@ func (o *Capitalization) GetATT_NAME() string {
 	return *o.ATT_NAME
 }
 
-// GetATT_NAMEOk returns a tuple with the ATT_NAME field value if set, zero value otherwise
+// GetATT_NAMEOk returns a tuple with the ATT_NAME field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *Capitalization) GetATT_NAMEOk() (string, bool) {
+
+func (o *Capitalization) GetATT_NAMEOk() (*string, bool) {
 	if o == nil || o.ATT_NAME == nil {
-		var ret string
-		return ret, false
+		return nil, false
 	}
-	return *o.ATT_NAME, true
+	return o.ATT_NAME, true
 }
 
 // HasATT_NAME returns a boolean if a field has been set.

--- a/samples/client/petstore/go-experimental/go-petstore/model_capitalization.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_capitalization.go
@@ -10,7 +10,6 @@
 package petstore
 
 import (
-	"bytes"
 	"encoding/json"
 )
 
@@ -58,12 +57,12 @@ func (o *Capitalization) GetSmallCamelOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-	return *o.SmallCamel, true
+    return *o.SmallCamel, true
 }
 
 // HasSmallCamel returns a boolean if a field has been set.
 func (o *Capitalization) HasSmallCamel() bool {
-	if o != nil && o.SmallCamel != nil {
+    if o != nil && o.SmallCamel != nil {
 		return true
 	}
 
@@ -91,12 +90,12 @@ func (o *Capitalization) GetCapitalCamelOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-	return *o.CapitalCamel, true
+    return *o.CapitalCamel, true
 }
 
 // HasCapitalCamel returns a boolean if a field has been set.
 func (o *Capitalization) HasCapitalCamel() bool {
-	if o != nil && o.CapitalCamel != nil {
+    if o != nil && o.CapitalCamel != nil {
 		return true
 	}
 
@@ -124,12 +123,12 @@ func (o *Capitalization) GetSmallSnakeOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-	return *o.SmallSnake, true
+    return *o.SmallSnake, true
 }
 
 // HasSmallSnake returns a boolean if a field has been set.
 func (o *Capitalization) HasSmallSnake() bool {
-	if o != nil && o.SmallSnake != nil {
+    if o != nil && o.SmallSnake != nil {
 		return true
 	}
 
@@ -157,12 +156,12 @@ func (o *Capitalization) GetCapitalSnakeOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-	return *o.CapitalSnake, true
+    return *o.CapitalSnake, true
 }
 
 // HasCapitalSnake returns a boolean if a field has been set.
 func (o *Capitalization) HasCapitalSnake() bool {
-	if o != nil && o.CapitalSnake != nil {
+    if o != nil && o.CapitalSnake != nil {
 		return true
 	}
 
@@ -190,12 +189,12 @@ func (o *Capitalization) GetSCAETHFlowPointsOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-	return *o.SCAETHFlowPoints, true
+    return *o.SCAETHFlowPoints, true
 }
 
 // HasSCAETHFlowPoints returns a boolean if a field has been set.
 func (o *Capitalization) HasSCAETHFlowPoints() bool {
-	if o != nil && o.SCAETHFlowPoints != nil {
+    if o != nil && o.SCAETHFlowPoints != nil {
 		return true
 	}
 
@@ -223,12 +222,12 @@ func (o *Capitalization) GetATT_NAMEOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-	return *o.ATT_NAME, true
+    return *o.ATT_NAME, true
 }
 
 // HasATT_NAME returns a boolean if a field has been set.
 func (o *Capitalization) HasATT_NAME() bool {
-	if o != nil && o.ATT_NAME != nil {
+    if o != nil && o.ATT_NAME != nil {
 		return true
 	}
 
@@ -240,25 +239,61 @@ func (o *Capitalization) SetATT_NAME(v string) {
 	o.ATT_NAME = &v
 }
 
+func (o Capitalization) MarshalJSON() ([]byte, error) {
+    toSerialize := map[string]interface{}{}
+    if o.SmallCamel != nil {
+        toSerialize["smallCamel"] = o.SmallCamel
+    }
+    if o.CapitalCamel != nil {
+        toSerialize["CapitalCamel"] = o.CapitalCamel
+    }
+    if o.SmallSnake != nil {
+        toSerialize["small_Snake"] = o.SmallSnake
+    }
+    if o.CapitalSnake != nil {
+        toSerialize["Capital_Snake"] = o.CapitalSnake
+    }
+    if o.SCAETHFlowPoints != nil {
+        toSerialize["SCA_ETH_Flow_Points"] = o.SCAETHFlowPoints
+    }
+    if o.ATT_NAME != nil {
+        toSerialize["ATT_NAME"] = o.ATT_NAME
+    }
+    return json.Marshal(toSerialize)
+}
+
 type NullableCapitalization struct {
-	Value Capitalization
-	ExplicitNull bool
+	value *Capitalization
+	isSet bool
+}
+
+func (v NullableCapitalization) Get() *Capitalization {
+    return v.value
+}
+
+func (v NullableCapitalization) Set(val *Capitalization) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableCapitalization) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableCapitalization) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableCapitalization(val *Capitalization) *NullableCapitalization {
+    return &NullableCapitalization{value: val, isSet: true}
 }
 
 func (v NullableCapitalization) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-		return json.Marshal(v.Value)
-	}
+    return json.Marshal(v.value)
 }
 
 func (v *NullableCapitalization) UnmarshalJSON(src []byte) error {
-	if bytes.Equal(src, []byte("null")) {
-		v.ExplicitNull = true
-		return nil
-	}
-
-	return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_cat.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_cat.go
@@ -24,16 +24,16 @@ type Cat struct {
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
 func NewCat() *Cat {
-    this := Cat{}
-    return &this
+	this := Cat{}
+	return &this
 }
 
 // NewCatWithDefaults instantiates a new Cat object
 // This constructor will only assign default values to properties that have it defined,
 // but it doesn't guarantee that properties required by API are set
 func NewCatWithDefaults() *Cat {
-    this := Cat{}
-    return &this
+	this := Cat{}
+	return &this
 }
 
 // GetDeclawed returns the Declawed field value if set, zero value otherwise.
@@ -45,14 +45,14 @@ func (o *Cat) GetDeclawed() bool {
 	return *o.Declawed
 }
 
-// GetDeclawedOk returns a tuple with the Declawed field value if set, zero value otherwise
+// GetDeclawedOk returns a tuple with the Declawed field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *Cat) GetDeclawedOk() (bool, bool) {
+
+func (o *Cat) GetDeclawedOk() (*bool, bool) {
 	if o == nil || o.Declawed == nil {
-		var ret bool
-		return ret, false
+		return nil, false
 	}
-	return *o.Declawed, true
+	return o.Declawed, true
 }
 
 // HasDeclawed returns a boolean if a field has been set.

--- a/samples/client/petstore/go-experimental/go-petstore/model_cat.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_cat.go
@@ -52,12 +52,12 @@ func (o *Cat) GetDeclawedOk() (bool, bool) {
 		var ret bool
 		return ret, false
 	}
-    return *o.Declawed, true
+	return *o.Declawed, true
 }
 
 // HasDeclawed returns a boolean if a field has been set.
 func (o *Cat) HasDeclawed() bool {
-    if o != nil && o.Declawed != nil {
+	if o != nil && o.Declawed != nil {
 		return true
 	}
 
@@ -70,19 +70,19 @@ func (o *Cat) SetDeclawed(v bool) {
 }
 
 func (o Cat) MarshalJSON() ([]byte, error) {
-    toSerialize := map[string]interface{}{}
-    serializedAnimal, errAnimal := json.Marshal(o.Animal)
-    if errAnimal != nil {
-        return []byte{}, errAnimal
-    }
-    errAnimal = json.Unmarshal([]byte(serializedAnimal), &toSerialize)
-    if errAnimal != nil {
-       return []byte{}, errAnimal
-    }
-    if o.Declawed != nil {
-        toSerialize["declawed"] = o.Declawed
-    }
-    return json.Marshal(toSerialize)
+	toSerialize := map[string]interface{}{}
+	serializedAnimal, errAnimal := json.Marshal(o.Animal)
+	if errAnimal != nil {
+		return []byte{}, errAnimal
+	}
+	errAnimal = json.Unmarshal([]byte(serializedAnimal), &toSerialize)
+	if errAnimal != nil {
+		return []byte{}, errAnimal
+	}
+	if o.Declawed != nil {
+		toSerialize["declawed"] = o.Declawed
+	}
+	return json.Marshal(toSerialize)
 }
 
 type NullableCat struct {
@@ -91,32 +91,32 @@ type NullableCat struct {
 }
 
 func (v NullableCat) Get() *Cat {
-    return v.value
+	return v.value
 }
 
 func (v NullableCat) Set(val *Cat) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableCat) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableCat) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableCat(val *Cat) *NullableCat {
-    return &NullableCat{value: val, isSet: true}
+	return &NullableCat{value: val, isSet: true}
 }
 
 func (v NullableCat) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableCat) UnmarshalJSON(src []byte) error {
-    v.isSet = true
+	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_cat.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_cat.go
@@ -47,7 +47,6 @@ func (o *Cat) GetDeclawed() bool {
 
 // GetDeclawedOk returns a tuple with the Declawed field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *Cat) GetDeclawedOk() (*bool, bool) {
 	if o == nil || o.Declawed == nil {
 		return nil, false

--- a/samples/client/petstore/go-experimental/go-petstore/model_cat.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_cat.go
@@ -10,7 +10,6 @@
 package petstore
 
 import (
-	"bytes"
 	"encoding/json"
 )
 
@@ -53,12 +52,12 @@ func (o *Cat) GetDeclawedOk() (bool, bool) {
 		var ret bool
 		return ret, false
 	}
-	return *o.Declawed, true
+    return *o.Declawed, true
 }
 
 // HasDeclawed returns a boolean if a field has been set.
 func (o *Cat) HasDeclawed() bool {
-	if o != nil && o.Declawed != nil {
+    if o != nil && o.Declawed != nil {
 		return true
 	}
 
@@ -70,25 +69,54 @@ func (o *Cat) SetDeclawed(v bool) {
 	o.Declawed = &v
 }
 
+func (o Cat) MarshalJSON() ([]byte, error) {
+    toSerialize := map[string]interface{}{}
+    serializedAnimal, errAnimal := json.Marshal(o.Animal)
+    if errAnimal != nil {
+        return []byte{}, errAnimal
+    }
+    errAnimal = json.Unmarshal([]byte(serializedAnimal), &toSerialize)
+    if errAnimal != nil {
+       return []byte{}, errAnimal
+    }
+    if o.Declawed != nil {
+        toSerialize["declawed"] = o.Declawed
+    }
+    return json.Marshal(toSerialize)
+}
+
 type NullableCat struct {
-	Value Cat
-	ExplicitNull bool
+	value *Cat
+	isSet bool
+}
+
+func (v NullableCat) Get() *Cat {
+    return v.value
+}
+
+func (v NullableCat) Set(val *Cat) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableCat) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableCat) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableCat(val *Cat) *NullableCat {
+    return &NullableCat{value: val, isSet: true}
 }
 
 func (v NullableCat) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-		return json.Marshal(v.Value)
-	}
+    return json.Marshal(v.value)
 }
 
 func (v *NullableCat) UnmarshalJSON(src []byte) error {
-	if bytes.Equal(src, []byte("null")) {
-		v.ExplicitNull = true
-		return nil
-	}
-
-	return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_cat.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_cat.go
@@ -94,7 +94,7 @@ func (v NullableCat) Get() *Cat {
 	return v.value
 }
 
-func (v NullableCat) Set(val *Cat) {
+func (v *NullableCat) Set(val *Cat) {
 	v.value = val
 	v.isSet = true
 }
@@ -103,7 +103,7 @@ func (v NullableCat) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableCat) Unset() {
+func (v *NullableCat) Unset() {
 	v.value = nil
 	v.isSet = false
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_cat_all_of.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_cat_all_of.go
@@ -51,12 +51,12 @@ func (o *CatAllOf) GetDeclawedOk() (bool, bool) {
 		var ret bool
 		return ret, false
 	}
-    return *o.Declawed, true
+	return *o.Declawed, true
 }
 
 // HasDeclawed returns a boolean if a field has been set.
 func (o *CatAllOf) HasDeclawed() bool {
-    if o != nil && o.Declawed != nil {
+	if o != nil && o.Declawed != nil {
 		return true
 	}
 
@@ -69,11 +69,11 @@ func (o *CatAllOf) SetDeclawed(v bool) {
 }
 
 func (o CatAllOf) MarshalJSON() ([]byte, error) {
-    toSerialize := map[string]interface{}{}
-    if o.Declawed != nil {
-        toSerialize["declawed"] = o.Declawed
-    }
-    return json.Marshal(toSerialize)
+	toSerialize := map[string]interface{}{}
+	if o.Declawed != nil {
+		toSerialize["declawed"] = o.Declawed
+	}
+	return json.Marshal(toSerialize)
 }
 
 type NullableCatAllOf struct {
@@ -82,32 +82,32 @@ type NullableCatAllOf struct {
 }
 
 func (v NullableCatAllOf) Get() *CatAllOf {
-    return v.value
+	return v.value
 }
 
 func (v NullableCatAllOf) Set(val *CatAllOf) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableCatAllOf) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableCatAllOf) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableCatAllOf(val *CatAllOf) *NullableCatAllOf {
-    return &NullableCatAllOf{value: val, isSet: true}
+	return &NullableCatAllOf{value: val, isSet: true}
 }
 
 func (v NullableCatAllOf) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableCatAllOf) UnmarshalJSON(src []byte) error {
-    v.isSet = true
+	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_cat_all_of.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_cat_all_of.go
@@ -85,7 +85,7 @@ func (v NullableCatAllOf) Get() *CatAllOf {
 	return v.value
 }
 
-func (v NullableCatAllOf) Set(val *CatAllOf) {
+func (v *NullableCatAllOf) Set(val *CatAllOf) {
 	v.value = val
 	v.isSet = true
 }
@@ -94,7 +94,7 @@ func (v NullableCatAllOf) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableCatAllOf) Unset() {
+func (v *NullableCatAllOf) Unset() {
 	v.value = nil
 	v.isSet = false
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_cat_all_of.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_cat_all_of.go
@@ -46,7 +46,6 @@ func (o *CatAllOf) GetDeclawed() bool {
 
 // GetDeclawedOk returns a tuple with the Declawed field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *CatAllOf) GetDeclawedOk() (*bool, bool) {
 	if o == nil || o.Declawed == nil {
 		return nil, false

--- a/samples/client/petstore/go-experimental/go-petstore/model_cat_all_of.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_cat_all_of.go
@@ -10,7 +10,6 @@
 package petstore
 
 import (
-	"bytes"
 	"encoding/json"
 )
 
@@ -52,12 +51,12 @@ func (o *CatAllOf) GetDeclawedOk() (bool, bool) {
 		var ret bool
 		return ret, false
 	}
-	return *o.Declawed, true
+    return *o.Declawed, true
 }
 
 // HasDeclawed returns a boolean if a field has been set.
 func (o *CatAllOf) HasDeclawed() bool {
-	if o != nil && o.Declawed != nil {
+    if o != nil && o.Declawed != nil {
 		return true
 	}
 
@@ -69,25 +68,46 @@ func (o *CatAllOf) SetDeclawed(v bool) {
 	o.Declawed = &v
 }
 
+func (o CatAllOf) MarshalJSON() ([]byte, error) {
+    toSerialize := map[string]interface{}{}
+    if o.Declawed != nil {
+        toSerialize["declawed"] = o.Declawed
+    }
+    return json.Marshal(toSerialize)
+}
+
 type NullableCatAllOf struct {
-	Value CatAllOf
-	ExplicitNull bool
+	value *CatAllOf
+	isSet bool
+}
+
+func (v NullableCatAllOf) Get() *CatAllOf {
+    return v.value
+}
+
+func (v NullableCatAllOf) Set(val *CatAllOf) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableCatAllOf) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableCatAllOf) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableCatAllOf(val *CatAllOf) *NullableCatAllOf {
+    return &NullableCatAllOf{value: val, isSet: true}
 }
 
 func (v NullableCatAllOf) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-		return json.Marshal(v.Value)
-	}
+    return json.Marshal(v.value)
 }
 
 func (v *NullableCatAllOf) UnmarshalJSON(src []byte) error {
-	if bytes.Equal(src, []byte("null")) {
-		v.ExplicitNull = true
-		return nil
-	}
-
-	return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_cat_all_of.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_cat_all_of.go
@@ -23,16 +23,16 @@ type CatAllOf struct {
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
 func NewCatAllOf() *CatAllOf {
-    this := CatAllOf{}
-    return &this
+	this := CatAllOf{}
+	return &this
 }
 
 // NewCatAllOfWithDefaults instantiates a new CatAllOf object
 // This constructor will only assign default values to properties that have it defined,
 // but it doesn't guarantee that properties required by API are set
 func NewCatAllOfWithDefaults() *CatAllOf {
-    this := CatAllOf{}
-    return &this
+	this := CatAllOf{}
+	return &this
 }
 
 // GetDeclawed returns the Declawed field value if set, zero value otherwise.
@@ -44,14 +44,14 @@ func (o *CatAllOf) GetDeclawed() bool {
 	return *o.Declawed
 }
 
-// GetDeclawedOk returns a tuple with the Declawed field value if set, zero value otherwise
+// GetDeclawedOk returns a tuple with the Declawed field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *CatAllOf) GetDeclawedOk() (bool, bool) {
+
+func (o *CatAllOf) GetDeclawedOk() (*bool, bool) {
 	if o == nil || o.Declawed == nil {
-		var ret bool
-		return ret, false
+		return nil, false
 	}
-	return *o.Declawed, true
+	return o.Declawed, true
 }
 
 // HasDeclawed returns a boolean if a field has been set.

--- a/samples/client/petstore/go-experimental/go-petstore/model_category.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_category.go
@@ -50,7 +50,6 @@ func (o *Category) GetId() int64 {
 
 // GetIdOk returns a tuple with the Id field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *Category) GetIdOk() (*int64, bool) {
 	if o == nil || o.Id == nil {
 		return nil, false
@@ -84,12 +83,11 @@ func (o *Category) GetName() string {
 
 // GetNameOk returns a tuple with the Name field value
 // and a boolean to check if the value has been set.
-
 func (o *Category) GetNameOk() (*string, bool) {
-    if o == nil  {
-        return nil, false
-    }
-    return &o.Name, true
+	if o == nil  {
+		return nil, false
+	}
+	return &o.Name, true
 }
 
 // SetName sets field value

--- a/samples/client/petstore/go-experimental/go-petstore/model_category.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_category.go
@@ -107,7 +107,7 @@ func (v NullableCategory) Get() *Category {
 	return v.value
 }
 
-func (v NullableCategory) Set(val *Category) {
+func (v *NullableCategory) Set(val *Category) {
 	v.value = val
 	v.isSet = true
 }
@@ -116,7 +116,7 @@ func (v NullableCategory) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableCategory) Unset() {
+func (v *NullableCategory) Unset() {
 	v.value = nil
 	v.isSet = false
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_category.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_category.go
@@ -10,7 +10,6 @@
 package petstore
 
 import (
-	"bytes"
 	"encoding/json"
 )
 
@@ -56,12 +55,12 @@ func (o *Category) GetIdOk() (int64, bool) {
 		var ret int64
 		return ret, false
 	}
-	return *o.Id, true
+    return *o.Id, true
 }
 
 // HasId returns a boolean if a field has been set.
 func (o *Category) HasId() bool {
-	if o != nil && o.Id != nil {
+    if o != nil && o.Id != nil {
 		return true
 	}
 
@@ -88,25 +87,49 @@ func (o *Category) SetName(v string) {
 	o.Name = v
 }
 
+func (o Category) MarshalJSON() ([]byte, error) {
+    toSerialize := map[string]interface{}{}
+    if o.Id != nil {
+        toSerialize["id"] = o.Id
+    }
+    if true {
+        toSerialize["name"] = o.Name
+    }
+    return json.Marshal(toSerialize)
+}
+
 type NullableCategory struct {
-	Value Category
-	ExplicitNull bool
+	value *Category
+	isSet bool
+}
+
+func (v NullableCategory) Get() *Category {
+    return v.value
+}
+
+func (v NullableCategory) Set(val *Category) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableCategory) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableCategory) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableCategory(val *Category) *NullableCategory {
+    return &NullableCategory{value: val, isSet: true}
 }
 
 func (v NullableCategory) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-		return json.Marshal(v.Value)
-	}
+    return json.Marshal(v.value)
 }
 
 func (v *NullableCategory) UnmarshalJSON(src []byte) error {
-	if bytes.Equal(src, []byte("null")) {
-		v.ExplicitNull = true
-		return nil
-	}
-
-	return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_category.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_category.go
@@ -34,8 +34,8 @@ func NewCategory(name string, ) *Category {
 // but it doesn't guarantee that properties required by API are set
 func NewCategoryWithDefaults() *Category {
     this := Category{}
-    var name string = "default-name"
-    this.Name = name
+	var name string = "default-name"
+	this.Name = name
     return &this
 }
 
@@ -55,12 +55,12 @@ func (o *Category) GetIdOk() (int64, bool) {
 		var ret int64
 		return ret, false
 	}
-    return *o.Id, true
+	return *o.Id, true
 }
 
 // HasId returns a boolean if a field has been set.
 func (o *Category) HasId() bool {
-    if o != nil && o.Id != nil {
+	if o != nil && o.Id != nil {
 		return true
 	}
 
@@ -88,14 +88,14 @@ func (o *Category) SetName(v string) {
 }
 
 func (o Category) MarshalJSON() ([]byte, error) {
-    toSerialize := map[string]interface{}{}
-    if o.Id != nil {
-        toSerialize["id"] = o.Id
-    }
-    if true {
-        toSerialize["name"] = o.Name
-    }
-    return json.Marshal(toSerialize)
+	toSerialize := map[string]interface{}{}
+	if o.Id != nil {
+		toSerialize["id"] = o.Id
+	}
+	if true {
+		toSerialize["name"] = o.Name
+	}
+	return json.Marshal(toSerialize)
 }
 
 type NullableCategory struct {
@@ -104,32 +104,32 @@ type NullableCategory struct {
 }
 
 func (v NullableCategory) Get() *Category {
-    return v.value
+	return v.value
 }
 
 func (v NullableCategory) Set(val *Category) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableCategory) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableCategory) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableCategory(val *Category) *NullableCategory {
-    return &NullableCategory{value: val, isSet: true}
+	return &NullableCategory{value: val, isSet: true}
 }
 
 func (v NullableCategory) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableCategory) UnmarshalJSON(src []byte) error {
-    v.isSet = true
+	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_category.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_category.go
@@ -24,19 +24,19 @@ type Category struct {
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
 func NewCategory(name string, ) *Category {
-    this := Category{}
-    this.Name = name
-    return &this
+	this := Category{}
+	this.Name = name
+	return &this
 }
 
 // NewCategoryWithDefaults instantiates a new Category object
 // This constructor will only assign default values to properties that have it defined,
 // but it doesn't guarantee that properties required by API are set
 func NewCategoryWithDefaults() *Category {
-    this := Category{}
+	this := Category{}
 	var name string = "default-name"
 	this.Name = name
-    return &this
+	return &this
 }
 
 // GetId returns the Id field value if set, zero value otherwise.
@@ -48,14 +48,14 @@ func (o *Category) GetId() int64 {
 	return *o.Id
 }
 
-// GetIdOk returns a tuple with the Id field value if set, zero value otherwise
+// GetIdOk returns a tuple with the Id field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *Category) GetIdOk() (int64, bool) {
+
+func (o *Category) GetIdOk() (*int64, bool) {
 	if o == nil || o.Id == nil {
-		var ret int64
-		return ret, false
+		return nil, false
 	}
-	return *o.Id, true
+	return o.Id, true
 }
 
 // HasId returns a boolean if a field has been set.
@@ -74,12 +74,22 @@ func (o *Category) SetId(v int64) {
 
 // GetName returns the Name field value
 func (o *Category) GetName() string {
-	if o == nil {
+	if o == nil  {
 		var ret string
 		return ret
 	}
 
 	return o.Name
+}
+
+// GetNameOk returns a tuple with the Name field value
+// and a boolean to check if the value has been set.
+
+func (o *Category) GetNameOk() (*string, bool) {
+    if o == nil  {
+        return nil, false
+    }
+    return &o.Name, true
 }
 
 // SetName sets field value

--- a/samples/client/petstore/go-experimental/go-petstore/model_class_model.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_class_model.go
@@ -85,7 +85,7 @@ func (v NullableClassModel) Get() *ClassModel {
 	return v.value
 }
 
-func (v NullableClassModel) Set(val *ClassModel) {
+func (v *NullableClassModel) Set(val *ClassModel) {
 	v.value = val
 	v.isSet = true
 }
@@ -94,7 +94,7 @@ func (v NullableClassModel) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableClassModel) Unset() {
+func (v *NullableClassModel) Unset() {
 	v.value = nil
 	v.isSet = false
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_class_model.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_class_model.go
@@ -46,7 +46,6 @@ func (o *ClassModel) GetClass() string {
 
 // GetClassOk returns a tuple with the Class field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *ClassModel) GetClassOk() (*string, bool) {
 	if o == nil || o.Class == nil {
 		return nil, false

--- a/samples/client/petstore/go-experimental/go-petstore/model_class_model.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_class_model.go
@@ -10,7 +10,6 @@
 package petstore
 
 import (
-	"bytes"
 	"encoding/json"
 )
 
@@ -52,12 +51,12 @@ func (o *ClassModel) GetClassOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-	return *o.Class, true
+    return *o.Class, true
 }
 
 // HasClass returns a boolean if a field has been set.
 func (o *ClassModel) HasClass() bool {
-	if o != nil && o.Class != nil {
+    if o != nil && o.Class != nil {
 		return true
 	}
 
@@ -69,25 +68,46 @@ func (o *ClassModel) SetClass(v string) {
 	o.Class = &v
 }
 
+func (o ClassModel) MarshalJSON() ([]byte, error) {
+    toSerialize := map[string]interface{}{}
+    if o.Class != nil {
+        toSerialize["_class"] = o.Class
+    }
+    return json.Marshal(toSerialize)
+}
+
 type NullableClassModel struct {
-	Value ClassModel
-	ExplicitNull bool
+	value *ClassModel
+	isSet bool
+}
+
+func (v NullableClassModel) Get() *ClassModel {
+    return v.value
+}
+
+func (v NullableClassModel) Set(val *ClassModel) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableClassModel) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableClassModel) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableClassModel(val *ClassModel) *NullableClassModel {
+    return &NullableClassModel{value: val, isSet: true}
 }
 
 func (v NullableClassModel) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-		return json.Marshal(v.Value)
-	}
+    return json.Marshal(v.value)
 }
 
 func (v *NullableClassModel) UnmarshalJSON(src []byte) error {
-	if bytes.Equal(src, []byte("null")) {
-		v.ExplicitNull = true
-		return nil
-	}
-
-	return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_class_model.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_class_model.go
@@ -51,12 +51,12 @@ func (o *ClassModel) GetClassOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-    return *o.Class, true
+	return *o.Class, true
 }
 
 // HasClass returns a boolean if a field has been set.
 func (o *ClassModel) HasClass() bool {
-    if o != nil && o.Class != nil {
+	if o != nil && o.Class != nil {
 		return true
 	}
 
@@ -69,11 +69,11 @@ func (o *ClassModel) SetClass(v string) {
 }
 
 func (o ClassModel) MarshalJSON() ([]byte, error) {
-    toSerialize := map[string]interface{}{}
-    if o.Class != nil {
-        toSerialize["_class"] = o.Class
-    }
-    return json.Marshal(toSerialize)
+	toSerialize := map[string]interface{}{}
+	if o.Class != nil {
+		toSerialize["_class"] = o.Class
+	}
+	return json.Marshal(toSerialize)
 }
 
 type NullableClassModel struct {
@@ -82,32 +82,32 @@ type NullableClassModel struct {
 }
 
 func (v NullableClassModel) Get() *ClassModel {
-    return v.value
+	return v.value
 }
 
 func (v NullableClassModel) Set(val *ClassModel) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableClassModel) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableClassModel) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableClassModel(val *ClassModel) *NullableClassModel {
-    return &NullableClassModel{value: val, isSet: true}
+	return &NullableClassModel{value: val, isSet: true}
 }
 
 func (v NullableClassModel) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableClassModel) UnmarshalJSON(src []byte) error {
-    v.isSet = true
+	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_class_model.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_class_model.go
@@ -23,16 +23,16 @@ type ClassModel struct {
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
 func NewClassModel() *ClassModel {
-    this := ClassModel{}
-    return &this
+	this := ClassModel{}
+	return &this
 }
 
 // NewClassModelWithDefaults instantiates a new ClassModel object
 // This constructor will only assign default values to properties that have it defined,
 // but it doesn't guarantee that properties required by API are set
 func NewClassModelWithDefaults() *ClassModel {
-    this := ClassModel{}
-    return &this
+	this := ClassModel{}
+	return &this
 }
 
 // GetClass returns the Class field value if set, zero value otherwise.
@@ -44,14 +44,14 @@ func (o *ClassModel) GetClass() string {
 	return *o.Class
 }
 
-// GetClassOk returns a tuple with the Class field value if set, zero value otherwise
+// GetClassOk returns a tuple with the Class field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *ClassModel) GetClassOk() (string, bool) {
+
+func (o *ClassModel) GetClassOk() (*string, bool) {
 	if o == nil || o.Class == nil {
-		var ret string
-		return ret, false
+		return nil, false
 	}
-	return *o.Class, true
+	return o.Class, true
 }
 
 // HasClass returns a boolean if a field has been set.

--- a/samples/client/petstore/go-experimental/go-petstore/model_client.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_client.go
@@ -23,16 +23,16 @@ type Client struct {
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
 func NewClient() *Client {
-    this := Client{}
-    return &this
+	this := Client{}
+	return &this
 }
 
 // NewClientWithDefaults instantiates a new Client object
 // This constructor will only assign default values to properties that have it defined,
 // but it doesn't guarantee that properties required by API are set
 func NewClientWithDefaults() *Client {
-    this := Client{}
-    return &this
+	this := Client{}
+	return &this
 }
 
 // GetClient returns the Client field value if set, zero value otherwise.
@@ -44,14 +44,14 @@ func (o *Client) GetClient() string {
 	return *o.Client
 }
 
-// GetClientOk returns a tuple with the Client field value if set, zero value otherwise
+// GetClientOk returns a tuple with the Client field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *Client) GetClientOk() (string, bool) {
+
+func (o *Client) GetClientOk() (*string, bool) {
 	if o == nil || o.Client == nil {
-		var ret string
-		return ret, false
+		return nil, false
 	}
-	return *o.Client, true
+	return o.Client, true
 }
 
 // HasClient returns a boolean if a field has been set.

--- a/samples/client/petstore/go-experimental/go-petstore/model_client.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_client.go
@@ -46,7 +46,6 @@ func (o *Client) GetClient() string {
 
 // GetClientOk returns a tuple with the Client field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *Client) GetClientOk() (*string, bool) {
 	if o == nil || o.Client == nil {
 		return nil, false

--- a/samples/client/petstore/go-experimental/go-petstore/model_client.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_client.go
@@ -85,7 +85,7 @@ func (v NullableClient) Get() *Client {
 	return v.value
 }
 
-func (v NullableClient) Set(val *Client) {
+func (v *NullableClient) Set(val *Client) {
 	v.value = val
 	v.isSet = true
 }
@@ -94,7 +94,7 @@ func (v NullableClient) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableClient) Unset() {
+func (v *NullableClient) Unset() {
 	v.value = nil
 	v.isSet = false
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_client.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_client.go
@@ -51,12 +51,12 @@ func (o *Client) GetClientOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-    return *o.Client, true
+	return *o.Client, true
 }
 
 // HasClient returns a boolean if a field has been set.
 func (o *Client) HasClient() bool {
-    if o != nil && o.Client != nil {
+	if o != nil && o.Client != nil {
 		return true
 	}
 
@@ -69,11 +69,11 @@ func (o *Client) SetClient(v string) {
 }
 
 func (o Client) MarshalJSON() ([]byte, error) {
-    toSerialize := map[string]interface{}{}
-    if o.Client != nil {
-        toSerialize["client"] = o.Client
-    }
-    return json.Marshal(toSerialize)
+	toSerialize := map[string]interface{}{}
+	if o.Client != nil {
+		toSerialize["client"] = o.Client
+	}
+	return json.Marshal(toSerialize)
 }
 
 type NullableClient struct {
@@ -82,32 +82,32 @@ type NullableClient struct {
 }
 
 func (v NullableClient) Get() *Client {
-    return v.value
+	return v.value
 }
 
 func (v NullableClient) Set(val *Client) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableClient) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableClient) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableClient(val *Client) *NullableClient {
-    return &NullableClient{value: val, isSet: true}
+	return &NullableClient{value: val, isSet: true}
 }
 
 func (v NullableClient) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableClient) UnmarshalJSON(src []byte) error {
-    v.isSet = true
+	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_client.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_client.go
@@ -10,7 +10,6 @@
 package petstore
 
 import (
-	"bytes"
 	"encoding/json"
 )
 
@@ -52,12 +51,12 @@ func (o *Client) GetClientOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-	return *o.Client, true
+    return *o.Client, true
 }
 
 // HasClient returns a boolean if a field has been set.
 func (o *Client) HasClient() bool {
-	if o != nil && o.Client != nil {
+    if o != nil && o.Client != nil {
 		return true
 	}
 
@@ -69,25 +68,46 @@ func (o *Client) SetClient(v string) {
 	o.Client = &v
 }
 
+func (o Client) MarshalJSON() ([]byte, error) {
+    toSerialize := map[string]interface{}{}
+    if o.Client != nil {
+        toSerialize["client"] = o.Client
+    }
+    return json.Marshal(toSerialize)
+}
+
 type NullableClient struct {
-	Value Client
-	ExplicitNull bool
+	value *Client
+	isSet bool
+}
+
+func (v NullableClient) Get() *Client {
+    return v.value
+}
+
+func (v NullableClient) Set(val *Client) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableClient) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableClient) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableClient(val *Client) *NullableClient {
+    return &NullableClient{value: val, isSet: true}
 }
 
 func (v NullableClient) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-		return json.Marshal(v.Value)
-	}
+    return json.Marshal(v.value)
 }
 
 func (v *NullableClient) UnmarshalJSON(src []byte) error {
-	if bytes.Equal(src, []byte("null")) {
-		v.ExplicitNull = true
-		return nil
-	}
-
-	return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_dog.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_dog.go
@@ -10,7 +10,6 @@
 package petstore
 
 import (
-	"bytes"
 	"encoding/json"
 )
 
@@ -53,12 +52,12 @@ func (o *Dog) GetBreedOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-	return *o.Breed, true
+    return *o.Breed, true
 }
 
 // HasBreed returns a boolean if a field has been set.
 func (o *Dog) HasBreed() bool {
-	if o != nil && o.Breed != nil {
+    if o != nil && o.Breed != nil {
 		return true
 	}
 
@@ -70,25 +69,54 @@ func (o *Dog) SetBreed(v string) {
 	o.Breed = &v
 }
 
+func (o Dog) MarshalJSON() ([]byte, error) {
+    toSerialize := map[string]interface{}{}
+    serializedAnimal, errAnimal := json.Marshal(o.Animal)
+    if errAnimal != nil {
+        return []byte{}, errAnimal
+    }
+    errAnimal = json.Unmarshal([]byte(serializedAnimal), &toSerialize)
+    if errAnimal != nil {
+       return []byte{}, errAnimal
+    }
+    if o.Breed != nil {
+        toSerialize["breed"] = o.Breed
+    }
+    return json.Marshal(toSerialize)
+}
+
 type NullableDog struct {
-	Value Dog
-	ExplicitNull bool
+	value *Dog
+	isSet bool
+}
+
+func (v NullableDog) Get() *Dog {
+    return v.value
+}
+
+func (v NullableDog) Set(val *Dog) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableDog) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableDog) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableDog(val *Dog) *NullableDog {
+    return &NullableDog{value: val, isSet: true}
 }
 
 func (v NullableDog) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-		return json.Marshal(v.Value)
-	}
+    return json.Marshal(v.value)
 }
 
 func (v *NullableDog) UnmarshalJSON(src []byte) error {
-	if bytes.Equal(src, []byte("null")) {
-		v.ExplicitNull = true
-		return nil
-	}
-
-	return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_dog.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_dog.go
@@ -24,16 +24,16 @@ type Dog struct {
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
 func NewDog() *Dog {
-    this := Dog{}
-    return &this
+	this := Dog{}
+	return &this
 }
 
 // NewDogWithDefaults instantiates a new Dog object
 // This constructor will only assign default values to properties that have it defined,
 // but it doesn't guarantee that properties required by API are set
 func NewDogWithDefaults() *Dog {
-    this := Dog{}
-    return &this
+	this := Dog{}
+	return &this
 }
 
 // GetBreed returns the Breed field value if set, zero value otherwise.
@@ -45,14 +45,14 @@ func (o *Dog) GetBreed() string {
 	return *o.Breed
 }
 
-// GetBreedOk returns a tuple with the Breed field value if set, zero value otherwise
+// GetBreedOk returns a tuple with the Breed field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *Dog) GetBreedOk() (string, bool) {
+
+func (o *Dog) GetBreedOk() (*string, bool) {
 	if o == nil || o.Breed == nil {
-		var ret string
-		return ret, false
+		return nil, false
 	}
-	return *o.Breed, true
+	return o.Breed, true
 }
 
 // HasBreed returns a boolean if a field has been set.

--- a/samples/client/petstore/go-experimental/go-petstore/model_dog.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_dog.go
@@ -47,7 +47,6 @@ func (o *Dog) GetBreed() string {
 
 // GetBreedOk returns a tuple with the Breed field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *Dog) GetBreedOk() (*string, bool) {
 	if o == nil || o.Breed == nil {
 		return nil, false

--- a/samples/client/petstore/go-experimental/go-petstore/model_dog.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_dog.go
@@ -52,12 +52,12 @@ func (o *Dog) GetBreedOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-    return *o.Breed, true
+	return *o.Breed, true
 }
 
 // HasBreed returns a boolean if a field has been set.
 func (o *Dog) HasBreed() bool {
-    if o != nil && o.Breed != nil {
+	if o != nil && o.Breed != nil {
 		return true
 	}
 
@@ -70,19 +70,19 @@ func (o *Dog) SetBreed(v string) {
 }
 
 func (o Dog) MarshalJSON() ([]byte, error) {
-    toSerialize := map[string]interface{}{}
-    serializedAnimal, errAnimal := json.Marshal(o.Animal)
-    if errAnimal != nil {
-        return []byte{}, errAnimal
-    }
-    errAnimal = json.Unmarshal([]byte(serializedAnimal), &toSerialize)
-    if errAnimal != nil {
-       return []byte{}, errAnimal
-    }
-    if o.Breed != nil {
-        toSerialize["breed"] = o.Breed
-    }
-    return json.Marshal(toSerialize)
+	toSerialize := map[string]interface{}{}
+	serializedAnimal, errAnimal := json.Marshal(o.Animal)
+	if errAnimal != nil {
+		return []byte{}, errAnimal
+	}
+	errAnimal = json.Unmarshal([]byte(serializedAnimal), &toSerialize)
+	if errAnimal != nil {
+		return []byte{}, errAnimal
+	}
+	if o.Breed != nil {
+		toSerialize["breed"] = o.Breed
+	}
+	return json.Marshal(toSerialize)
 }
 
 type NullableDog struct {
@@ -91,32 +91,32 @@ type NullableDog struct {
 }
 
 func (v NullableDog) Get() *Dog {
-    return v.value
+	return v.value
 }
 
 func (v NullableDog) Set(val *Dog) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableDog) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableDog) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableDog(val *Dog) *NullableDog {
-    return &NullableDog{value: val, isSet: true}
+	return &NullableDog{value: val, isSet: true}
 }
 
 func (v NullableDog) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableDog) UnmarshalJSON(src []byte) error {
-    v.isSet = true
+	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_dog.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_dog.go
@@ -94,7 +94,7 @@ func (v NullableDog) Get() *Dog {
 	return v.value
 }
 
-func (v NullableDog) Set(val *Dog) {
+func (v *NullableDog) Set(val *Dog) {
 	v.value = val
 	v.isSet = true
 }
@@ -103,7 +103,7 @@ func (v NullableDog) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableDog) Unset() {
+func (v *NullableDog) Unset() {
 	v.value = nil
 	v.isSet = false
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_dog_all_of.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_dog_all_of.go
@@ -46,7 +46,6 @@ func (o *DogAllOf) GetBreed() string {
 
 // GetBreedOk returns a tuple with the Breed field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *DogAllOf) GetBreedOk() (*string, bool) {
 	if o == nil || o.Breed == nil {
 		return nil, false

--- a/samples/client/petstore/go-experimental/go-petstore/model_dog_all_of.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_dog_all_of.go
@@ -23,16 +23,16 @@ type DogAllOf struct {
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
 func NewDogAllOf() *DogAllOf {
-    this := DogAllOf{}
-    return &this
+	this := DogAllOf{}
+	return &this
 }
 
 // NewDogAllOfWithDefaults instantiates a new DogAllOf object
 // This constructor will only assign default values to properties that have it defined,
 // but it doesn't guarantee that properties required by API are set
 func NewDogAllOfWithDefaults() *DogAllOf {
-    this := DogAllOf{}
-    return &this
+	this := DogAllOf{}
+	return &this
 }
 
 // GetBreed returns the Breed field value if set, zero value otherwise.
@@ -44,14 +44,14 @@ func (o *DogAllOf) GetBreed() string {
 	return *o.Breed
 }
 
-// GetBreedOk returns a tuple with the Breed field value if set, zero value otherwise
+// GetBreedOk returns a tuple with the Breed field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *DogAllOf) GetBreedOk() (string, bool) {
+
+func (o *DogAllOf) GetBreedOk() (*string, bool) {
 	if o == nil || o.Breed == nil {
-		var ret string
-		return ret, false
+		return nil, false
 	}
-	return *o.Breed, true
+	return o.Breed, true
 }
 
 // HasBreed returns a boolean if a field has been set.

--- a/samples/client/petstore/go-experimental/go-petstore/model_dog_all_of.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_dog_all_of.go
@@ -51,12 +51,12 @@ func (o *DogAllOf) GetBreedOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-    return *o.Breed, true
+	return *o.Breed, true
 }
 
 // HasBreed returns a boolean if a field has been set.
 func (o *DogAllOf) HasBreed() bool {
-    if o != nil && o.Breed != nil {
+	if o != nil && o.Breed != nil {
 		return true
 	}
 
@@ -69,11 +69,11 @@ func (o *DogAllOf) SetBreed(v string) {
 }
 
 func (o DogAllOf) MarshalJSON() ([]byte, error) {
-    toSerialize := map[string]interface{}{}
-    if o.Breed != nil {
-        toSerialize["breed"] = o.Breed
-    }
-    return json.Marshal(toSerialize)
+	toSerialize := map[string]interface{}{}
+	if o.Breed != nil {
+		toSerialize["breed"] = o.Breed
+	}
+	return json.Marshal(toSerialize)
 }
 
 type NullableDogAllOf struct {
@@ -82,32 +82,32 @@ type NullableDogAllOf struct {
 }
 
 func (v NullableDogAllOf) Get() *DogAllOf {
-    return v.value
+	return v.value
 }
 
 func (v NullableDogAllOf) Set(val *DogAllOf) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableDogAllOf) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableDogAllOf) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableDogAllOf(val *DogAllOf) *NullableDogAllOf {
-    return &NullableDogAllOf{value: val, isSet: true}
+	return &NullableDogAllOf{value: val, isSet: true}
 }
 
 func (v NullableDogAllOf) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableDogAllOf) UnmarshalJSON(src []byte) error {
-    v.isSet = true
+	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_dog_all_of.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_dog_all_of.go
@@ -85,7 +85,7 @@ func (v NullableDogAllOf) Get() *DogAllOf {
 	return v.value
 }
 
-func (v NullableDogAllOf) Set(val *DogAllOf) {
+func (v *NullableDogAllOf) Set(val *DogAllOf) {
 	v.value = val
 	v.isSet = true
 }
@@ -94,7 +94,7 @@ func (v NullableDogAllOf) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableDogAllOf) Unset() {
+func (v *NullableDogAllOf) Unset() {
 	v.value = nil
 	v.isSet = false
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_dog_all_of.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_dog_all_of.go
@@ -10,7 +10,6 @@
 package petstore
 
 import (
-	"bytes"
 	"encoding/json"
 )
 
@@ -52,12 +51,12 @@ func (o *DogAllOf) GetBreedOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-	return *o.Breed, true
+    return *o.Breed, true
 }
 
 // HasBreed returns a boolean if a field has been set.
 func (o *DogAllOf) HasBreed() bool {
-	if o != nil && o.Breed != nil {
+    if o != nil && o.Breed != nil {
 		return true
 	}
 
@@ -69,25 +68,46 @@ func (o *DogAllOf) SetBreed(v string) {
 	o.Breed = &v
 }
 
+func (o DogAllOf) MarshalJSON() ([]byte, error) {
+    toSerialize := map[string]interface{}{}
+    if o.Breed != nil {
+        toSerialize["breed"] = o.Breed
+    }
+    return json.Marshal(toSerialize)
+}
+
 type NullableDogAllOf struct {
-	Value DogAllOf
-	ExplicitNull bool
+	value *DogAllOf
+	isSet bool
+}
+
+func (v NullableDogAllOf) Get() *DogAllOf {
+    return v.value
+}
+
+func (v NullableDogAllOf) Set(val *DogAllOf) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableDogAllOf) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableDogAllOf) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableDogAllOf(val *DogAllOf) *NullableDogAllOf {
+    return &NullableDogAllOf{value: val, isSet: true}
 }
 
 func (v NullableDogAllOf) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-		return json.Marshal(v.Value)
-	}
+    return json.Marshal(v.value)
 }
 
 func (v *NullableDogAllOf) UnmarshalJSON(src []byte) error {
-	if bytes.Equal(src, []byte("null")) {
-		v.ExplicitNull = true
-		return nil
-	}
-
-	return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_enum_arrays.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_enum_arrays.go
@@ -10,7 +10,6 @@
 package petstore
 
 import (
-	"bytes"
 	"encoding/json"
 )
 
@@ -53,12 +52,12 @@ func (o *EnumArrays) GetJustSymbolOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-	return *o.JustSymbol, true
+    return *o.JustSymbol, true
 }
 
 // HasJustSymbol returns a boolean if a field has been set.
 func (o *EnumArrays) HasJustSymbol() bool {
-	if o != nil && o.JustSymbol != nil {
+    if o != nil && o.JustSymbol != nil {
 		return true
 	}
 
@@ -86,12 +85,12 @@ func (o *EnumArrays) GetArrayEnumOk() ([]string, bool) {
 		var ret []string
 		return ret, false
 	}
-	return *o.ArrayEnum, true
+    return *o.ArrayEnum, true
 }
 
 // HasArrayEnum returns a boolean if a field has been set.
 func (o *EnumArrays) HasArrayEnum() bool {
-	if o != nil && o.ArrayEnum != nil {
+    if o != nil && o.ArrayEnum != nil {
 		return true
 	}
 
@@ -103,25 +102,49 @@ func (o *EnumArrays) SetArrayEnum(v []string) {
 	o.ArrayEnum = &v
 }
 
+func (o EnumArrays) MarshalJSON() ([]byte, error) {
+    toSerialize := map[string]interface{}{}
+    if o.JustSymbol != nil {
+        toSerialize["just_symbol"] = o.JustSymbol
+    }
+    if o.ArrayEnum != nil {
+        toSerialize["array_enum"] = o.ArrayEnum
+    }
+    return json.Marshal(toSerialize)
+}
+
 type NullableEnumArrays struct {
-	Value EnumArrays
-	ExplicitNull bool
+	value *EnumArrays
+	isSet bool
+}
+
+func (v NullableEnumArrays) Get() *EnumArrays {
+    return v.value
+}
+
+func (v NullableEnumArrays) Set(val *EnumArrays) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableEnumArrays) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableEnumArrays) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableEnumArrays(val *EnumArrays) *NullableEnumArrays {
+    return &NullableEnumArrays{value: val, isSet: true}
 }
 
 func (v NullableEnumArrays) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-		return json.Marshal(v.Value)
-	}
+    return json.Marshal(v.value)
 }
 
 func (v *NullableEnumArrays) UnmarshalJSON(src []byte) error {
-	if bytes.Equal(src, []byte("null")) {
-		v.ExplicitNull = true
-		return nil
-	}
-
-	return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_enum_arrays.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_enum_arrays.go
@@ -24,16 +24,16 @@ type EnumArrays struct {
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
 func NewEnumArrays() *EnumArrays {
-    this := EnumArrays{}
-    return &this
+	this := EnumArrays{}
+	return &this
 }
 
 // NewEnumArraysWithDefaults instantiates a new EnumArrays object
 // This constructor will only assign default values to properties that have it defined,
 // but it doesn't guarantee that properties required by API are set
 func NewEnumArraysWithDefaults() *EnumArrays {
-    this := EnumArrays{}
-    return &this
+	this := EnumArrays{}
+	return &this
 }
 
 // GetJustSymbol returns the JustSymbol field value if set, zero value otherwise.
@@ -45,14 +45,14 @@ func (o *EnumArrays) GetJustSymbol() string {
 	return *o.JustSymbol
 }
 
-// GetJustSymbolOk returns a tuple with the JustSymbol field value if set, zero value otherwise
+// GetJustSymbolOk returns a tuple with the JustSymbol field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *EnumArrays) GetJustSymbolOk() (string, bool) {
+
+func (o *EnumArrays) GetJustSymbolOk() (*string, bool) {
 	if o == nil || o.JustSymbol == nil {
-		var ret string
-		return ret, false
+		return nil, false
 	}
-	return *o.JustSymbol, true
+	return o.JustSymbol, true
 }
 
 // HasJustSymbol returns a boolean if a field has been set.
@@ -78,14 +78,14 @@ func (o *EnumArrays) GetArrayEnum() []string {
 	return *o.ArrayEnum
 }
 
-// GetArrayEnumOk returns a tuple with the ArrayEnum field value if set, zero value otherwise
+// GetArrayEnumOk returns a tuple with the ArrayEnum field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *EnumArrays) GetArrayEnumOk() ([]string, bool) {
+
+func (o *EnumArrays) GetArrayEnumOk() (*[]string, bool) {
 	if o == nil || o.ArrayEnum == nil {
-		var ret []string
-		return ret, false
+		return nil, false
 	}
-	return *o.ArrayEnum, true
+	return o.ArrayEnum, true
 }
 
 // HasArrayEnum returns a boolean if a field has been set.

--- a/samples/client/petstore/go-experimental/go-petstore/model_enum_arrays.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_enum_arrays.go
@@ -52,12 +52,12 @@ func (o *EnumArrays) GetJustSymbolOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-    return *o.JustSymbol, true
+	return *o.JustSymbol, true
 }
 
 // HasJustSymbol returns a boolean if a field has been set.
 func (o *EnumArrays) HasJustSymbol() bool {
-    if o != nil && o.JustSymbol != nil {
+	if o != nil && o.JustSymbol != nil {
 		return true
 	}
 
@@ -85,12 +85,12 @@ func (o *EnumArrays) GetArrayEnumOk() ([]string, bool) {
 		var ret []string
 		return ret, false
 	}
-    return *o.ArrayEnum, true
+	return *o.ArrayEnum, true
 }
 
 // HasArrayEnum returns a boolean if a field has been set.
 func (o *EnumArrays) HasArrayEnum() bool {
-    if o != nil && o.ArrayEnum != nil {
+	if o != nil && o.ArrayEnum != nil {
 		return true
 	}
 
@@ -103,14 +103,14 @@ func (o *EnumArrays) SetArrayEnum(v []string) {
 }
 
 func (o EnumArrays) MarshalJSON() ([]byte, error) {
-    toSerialize := map[string]interface{}{}
-    if o.JustSymbol != nil {
-        toSerialize["just_symbol"] = o.JustSymbol
-    }
-    if o.ArrayEnum != nil {
-        toSerialize["array_enum"] = o.ArrayEnum
-    }
-    return json.Marshal(toSerialize)
+	toSerialize := map[string]interface{}{}
+	if o.JustSymbol != nil {
+		toSerialize["just_symbol"] = o.JustSymbol
+	}
+	if o.ArrayEnum != nil {
+		toSerialize["array_enum"] = o.ArrayEnum
+	}
+	return json.Marshal(toSerialize)
 }
 
 type NullableEnumArrays struct {
@@ -119,32 +119,32 @@ type NullableEnumArrays struct {
 }
 
 func (v NullableEnumArrays) Get() *EnumArrays {
-    return v.value
+	return v.value
 }
 
 func (v NullableEnumArrays) Set(val *EnumArrays) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableEnumArrays) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableEnumArrays) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableEnumArrays(val *EnumArrays) *NullableEnumArrays {
-    return &NullableEnumArrays{value: val, isSet: true}
+	return &NullableEnumArrays{value: val, isSet: true}
 }
 
 func (v NullableEnumArrays) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableEnumArrays) UnmarshalJSON(src []byte) error {
-    v.isSet = true
+	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_enum_arrays.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_enum_arrays.go
@@ -47,7 +47,6 @@ func (o *EnumArrays) GetJustSymbol() string {
 
 // GetJustSymbolOk returns a tuple with the JustSymbol field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *EnumArrays) GetJustSymbolOk() (*string, bool) {
 	if o == nil || o.JustSymbol == nil {
 		return nil, false
@@ -80,7 +79,6 @@ func (o *EnumArrays) GetArrayEnum() []string {
 
 // GetArrayEnumOk returns a tuple with the ArrayEnum field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *EnumArrays) GetArrayEnumOk() (*[]string, bool) {
 	if o == nil || o.ArrayEnum == nil {
 		return nil, false

--- a/samples/client/petstore/go-experimental/go-petstore/model_enum_arrays.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_enum_arrays.go
@@ -122,7 +122,7 @@ func (v NullableEnumArrays) Get() *EnumArrays {
 	return v.value
 }
 
-func (v NullableEnumArrays) Set(val *EnumArrays) {
+func (v *NullableEnumArrays) Set(val *EnumArrays) {
 	v.value = val
 	v.isSet = true
 }
@@ -131,7 +131,7 @@ func (v NullableEnumArrays) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableEnumArrays) Unset() {
+func (v *NullableEnumArrays) Unset() {
 	v.value = nil
 	v.isSet = false
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_enum_class.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_enum_class.go
@@ -10,7 +10,6 @@
 package petstore
 
 import (
-	"bytes"
 	"encoding/json"
 )
 
@@ -25,24 +24,37 @@ const (
 )
 
 type NullableEnumClass struct {
-	Value EnumClass
-	ExplicitNull bool
+	value *EnumClass
+	isSet bool
+}
+
+func (v NullableEnumClass) Get() *EnumClass {
+    return v.value
+}
+
+func (v NullableEnumClass) Set(val *EnumClass) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableEnumClass) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableEnumClass) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableEnumClass(val *EnumClass) *NullableEnumClass {
+    return &NullableEnumClass{value: val, isSet: true}
 }
 
 func (v NullableEnumClass) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-		return json.Marshal(v.Value)
-	}
+    return json.Marshal(v.value)
 }
 
 func (v *NullableEnumClass) UnmarshalJSON(src []byte) error {
-	if bytes.Equal(src, []byte("null")) {
-		v.ExplicitNull = true
-		return nil
-	}
-
-	return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_enum_class.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_enum_class.go
@@ -32,7 +32,7 @@ func (v NullableEnumClass) Get() *EnumClass {
 	return v.value
 }
 
-func (v NullableEnumClass) Set(val *EnumClass) {
+func (v *NullableEnumClass) Set(val *EnumClass) {
 	v.value = val
 	v.isSet = true
 }
@@ -41,7 +41,7 @@ func (v NullableEnumClass) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableEnumClass) Unset() {
+func (v *NullableEnumClass) Unset() {
 	v.value = nil
 	v.isSet = false
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_enum_class.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_enum_class.go
@@ -29,32 +29,32 @@ type NullableEnumClass struct {
 }
 
 func (v NullableEnumClass) Get() *EnumClass {
-    return v.value
+	return v.value
 }
 
 func (v NullableEnumClass) Set(val *EnumClass) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableEnumClass) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableEnumClass) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableEnumClass(val *EnumClass) *NullableEnumClass {
-    return &NullableEnumClass{value: val, isSet: true}
+	return &NullableEnumClass{value: val, isSet: true}
 }
 
 func (v NullableEnumClass) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableEnumClass) UnmarshalJSON(src []byte) error {
-    v.isSet = true
+	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_enum_test_.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_enum_test_.go
@@ -51,7 +51,6 @@ func (o *EnumTest) GetEnumString() string {
 
 // GetEnumStringOk returns a tuple with the EnumString field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *EnumTest) GetEnumStringOk() (*string, bool) {
 	if o == nil || o.EnumString == nil {
 		return nil, false
@@ -85,12 +84,11 @@ func (o *EnumTest) GetEnumStringRequired() string {
 
 // GetEnumStringRequiredOk returns a tuple with the EnumStringRequired field value
 // and a boolean to check if the value has been set.
-
 func (o *EnumTest) GetEnumStringRequiredOk() (*string, bool) {
-    if o == nil  {
-        return nil, false
-    }
-    return &o.EnumStringRequired, true
+	if o == nil  {
+		return nil, false
+	}
+	return &o.EnumStringRequired, true
 }
 
 // SetEnumStringRequired sets field value
@@ -109,7 +107,6 @@ func (o *EnumTest) GetEnumInteger() int32 {
 
 // GetEnumIntegerOk returns a tuple with the EnumInteger field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *EnumTest) GetEnumIntegerOk() (*int32, bool) {
 	if o == nil || o.EnumInteger == nil {
 		return nil, false
@@ -142,7 +139,6 @@ func (o *EnumTest) GetEnumNumber() float64 {
 
 // GetEnumNumberOk returns a tuple with the EnumNumber field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *EnumTest) GetEnumNumberOk() (*float64, bool) {
 	if o == nil || o.EnumNumber == nil {
 		return nil, false
@@ -175,7 +171,6 @@ func (o *EnumTest) GetOuterEnum() OuterEnum {
 
 // GetOuterEnumOk returns a tuple with the OuterEnum field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *EnumTest) GetOuterEnumOk() (*OuterEnum, bool) {
 	if o == nil || o.OuterEnum == nil {
 		return nil, false

--- a/samples/client/petstore/go-experimental/go-petstore/model_enum_test_.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_enum_test_.go
@@ -216,7 +216,7 @@ func (v NullableEnumTest) Get() *EnumTest {
 	return v.value
 }
 
-func (v NullableEnumTest) Set(val *EnumTest) {
+func (v *NullableEnumTest) Set(val *EnumTest) {
 	v.value = val
 	v.isSet = true
 }
@@ -225,7 +225,7 @@ func (v NullableEnumTest) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableEnumTest) Unset() {
+func (v *NullableEnumTest) Unset() {
 	v.value = nil
 	v.isSet = false
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_enum_test_.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_enum_test_.go
@@ -27,17 +27,17 @@ type EnumTest struct {
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
 func NewEnumTest(enumStringRequired string, ) *EnumTest {
-    this := EnumTest{}
-    this.EnumStringRequired = enumStringRequired
-    return &this
+	this := EnumTest{}
+	this.EnumStringRequired = enumStringRequired
+	return &this
 }
 
 // NewEnumTestWithDefaults instantiates a new EnumTest object
 // This constructor will only assign default values to properties that have it defined,
 // but it doesn't guarantee that properties required by API are set
 func NewEnumTestWithDefaults() *EnumTest {
-    this := EnumTest{}
-    return &this
+	this := EnumTest{}
+	return &this
 }
 
 // GetEnumString returns the EnumString field value if set, zero value otherwise.
@@ -49,14 +49,14 @@ func (o *EnumTest) GetEnumString() string {
 	return *o.EnumString
 }
 
-// GetEnumStringOk returns a tuple with the EnumString field value if set, zero value otherwise
+// GetEnumStringOk returns a tuple with the EnumString field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *EnumTest) GetEnumStringOk() (string, bool) {
+
+func (o *EnumTest) GetEnumStringOk() (*string, bool) {
 	if o == nil || o.EnumString == nil {
-		var ret string
-		return ret, false
+		return nil, false
 	}
-	return *o.EnumString, true
+	return o.EnumString, true
 }
 
 // HasEnumString returns a boolean if a field has been set.
@@ -75,12 +75,22 @@ func (o *EnumTest) SetEnumString(v string) {
 
 // GetEnumStringRequired returns the EnumStringRequired field value
 func (o *EnumTest) GetEnumStringRequired() string {
-	if o == nil {
+	if o == nil  {
 		var ret string
 		return ret
 	}
 
 	return o.EnumStringRequired
+}
+
+// GetEnumStringRequiredOk returns a tuple with the EnumStringRequired field value
+// and a boolean to check if the value has been set.
+
+func (o *EnumTest) GetEnumStringRequiredOk() (*string, bool) {
+    if o == nil  {
+        return nil, false
+    }
+    return &o.EnumStringRequired, true
 }
 
 // SetEnumStringRequired sets field value
@@ -97,14 +107,14 @@ func (o *EnumTest) GetEnumInteger() int32 {
 	return *o.EnumInteger
 }
 
-// GetEnumIntegerOk returns a tuple with the EnumInteger field value if set, zero value otherwise
+// GetEnumIntegerOk returns a tuple with the EnumInteger field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *EnumTest) GetEnumIntegerOk() (int32, bool) {
+
+func (o *EnumTest) GetEnumIntegerOk() (*int32, bool) {
 	if o == nil || o.EnumInteger == nil {
-		var ret int32
-		return ret, false
+		return nil, false
 	}
-	return *o.EnumInteger, true
+	return o.EnumInteger, true
 }
 
 // HasEnumInteger returns a boolean if a field has been set.
@@ -130,14 +140,14 @@ func (o *EnumTest) GetEnumNumber() float64 {
 	return *o.EnumNumber
 }
 
-// GetEnumNumberOk returns a tuple with the EnumNumber field value if set, zero value otherwise
+// GetEnumNumberOk returns a tuple with the EnumNumber field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *EnumTest) GetEnumNumberOk() (float64, bool) {
+
+func (o *EnumTest) GetEnumNumberOk() (*float64, bool) {
 	if o == nil || o.EnumNumber == nil {
-		var ret float64
-		return ret, false
+		return nil, false
 	}
-	return *o.EnumNumber, true
+	return o.EnumNumber, true
 }
 
 // HasEnumNumber returns a boolean if a field has been set.
@@ -163,14 +173,14 @@ func (o *EnumTest) GetOuterEnum() OuterEnum {
 	return *o.OuterEnum
 }
 
-// GetOuterEnumOk returns a tuple with the OuterEnum field value if set, zero value otherwise
+// GetOuterEnumOk returns a tuple with the OuterEnum field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *EnumTest) GetOuterEnumOk() (OuterEnum, bool) {
+
+func (o *EnumTest) GetOuterEnumOk() (*OuterEnum, bool) {
 	if o == nil || o.OuterEnum == nil {
-		var ret OuterEnum
-		return ret, false
+		return nil, false
 	}
-	return *o.OuterEnum, true
+	return o.OuterEnum, true
 }
 
 // HasOuterEnum returns a boolean if a field has been set.

--- a/samples/client/petstore/go-experimental/go-petstore/model_enum_test_.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_enum_test_.go
@@ -10,7 +10,6 @@
 package petstore
 
 import (
-	"bytes"
 	"encoding/json"
 )
 
@@ -57,12 +56,12 @@ func (o *EnumTest) GetEnumStringOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-	return *o.EnumString, true
+    return *o.EnumString, true
 }
 
 // HasEnumString returns a boolean if a field has been set.
 func (o *EnumTest) HasEnumString() bool {
-	if o != nil && o.EnumString != nil {
+    if o != nil && o.EnumString != nil {
 		return true
 	}
 
@@ -105,12 +104,12 @@ func (o *EnumTest) GetEnumIntegerOk() (int32, bool) {
 		var ret int32
 		return ret, false
 	}
-	return *o.EnumInteger, true
+    return *o.EnumInteger, true
 }
 
 // HasEnumInteger returns a boolean if a field has been set.
 func (o *EnumTest) HasEnumInteger() bool {
-	if o != nil && o.EnumInteger != nil {
+    if o != nil && o.EnumInteger != nil {
 		return true
 	}
 
@@ -138,12 +137,12 @@ func (o *EnumTest) GetEnumNumberOk() (float64, bool) {
 		var ret float64
 		return ret, false
 	}
-	return *o.EnumNumber, true
+    return *o.EnumNumber, true
 }
 
 // HasEnumNumber returns a boolean if a field has been set.
 func (o *EnumTest) HasEnumNumber() bool {
-	if o != nil && o.EnumNumber != nil {
+    if o != nil && o.EnumNumber != nil {
 		return true
 	}
 
@@ -171,12 +170,12 @@ func (o *EnumTest) GetOuterEnumOk() (OuterEnum, bool) {
 		var ret OuterEnum
 		return ret, false
 	}
-	return *o.OuterEnum, true
+    return *o.OuterEnum, true
 }
 
 // HasOuterEnum returns a boolean if a field has been set.
 func (o *EnumTest) HasOuterEnum() bool {
-	if o != nil && o.OuterEnum != nil {
+    if o != nil && o.OuterEnum != nil {
 		return true
 	}
 
@@ -188,25 +187,58 @@ func (o *EnumTest) SetOuterEnum(v OuterEnum) {
 	o.OuterEnum = &v
 }
 
+func (o EnumTest) MarshalJSON() ([]byte, error) {
+    toSerialize := map[string]interface{}{}
+    if o.EnumString != nil {
+        toSerialize["enum_string"] = o.EnumString
+    }
+    if true {
+        toSerialize["enum_string_required"] = o.EnumStringRequired
+    }
+    if o.EnumInteger != nil {
+        toSerialize["enum_integer"] = o.EnumInteger
+    }
+    if o.EnumNumber != nil {
+        toSerialize["enum_number"] = o.EnumNumber
+    }
+    if o.OuterEnum != nil {
+        toSerialize["outerEnum"] = o.OuterEnum
+    }
+    return json.Marshal(toSerialize)
+}
+
 type NullableEnumTest struct {
-	Value EnumTest
-	ExplicitNull bool
+	value *EnumTest
+	isSet bool
+}
+
+func (v NullableEnumTest) Get() *EnumTest {
+    return v.value
+}
+
+func (v NullableEnumTest) Set(val *EnumTest) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableEnumTest) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableEnumTest) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableEnumTest(val *EnumTest) *NullableEnumTest {
+    return &NullableEnumTest{value: val, isSet: true}
 }
 
 func (v NullableEnumTest) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-		return json.Marshal(v.Value)
-	}
+    return json.Marshal(v.value)
 }
 
 func (v *NullableEnumTest) UnmarshalJSON(src []byte) error {
-	if bytes.Equal(src, []byte("null")) {
-		v.ExplicitNull = true
-		return nil
-	}
-
-	return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_enum_test_.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_enum_test_.go
@@ -56,12 +56,12 @@ func (o *EnumTest) GetEnumStringOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-    return *o.EnumString, true
+	return *o.EnumString, true
 }
 
 // HasEnumString returns a boolean if a field has been set.
 func (o *EnumTest) HasEnumString() bool {
-    if o != nil && o.EnumString != nil {
+	if o != nil && o.EnumString != nil {
 		return true
 	}
 
@@ -104,12 +104,12 @@ func (o *EnumTest) GetEnumIntegerOk() (int32, bool) {
 		var ret int32
 		return ret, false
 	}
-    return *o.EnumInteger, true
+	return *o.EnumInteger, true
 }
 
 // HasEnumInteger returns a boolean if a field has been set.
 func (o *EnumTest) HasEnumInteger() bool {
-    if o != nil && o.EnumInteger != nil {
+	if o != nil && o.EnumInteger != nil {
 		return true
 	}
 
@@ -137,12 +137,12 @@ func (o *EnumTest) GetEnumNumberOk() (float64, bool) {
 		var ret float64
 		return ret, false
 	}
-    return *o.EnumNumber, true
+	return *o.EnumNumber, true
 }
 
 // HasEnumNumber returns a boolean if a field has been set.
 func (o *EnumTest) HasEnumNumber() bool {
-    if o != nil && o.EnumNumber != nil {
+	if o != nil && o.EnumNumber != nil {
 		return true
 	}
 
@@ -170,12 +170,12 @@ func (o *EnumTest) GetOuterEnumOk() (OuterEnum, bool) {
 		var ret OuterEnum
 		return ret, false
 	}
-    return *o.OuterEnum, true
+	return *o.OuterEnum, true
 }
 
 // HasOuterEnum returns a boolean if a field has been set.
 func (o *EnumTest) HasOuterEnum() bool {
-    if o != nil && o.OuterEnum != nil {
+	if o != nil && o.OuterEnum != nil {
 		return true
 	}
 
@@ -188,23 +188,23 @@ func (o *EnumTest) SetOuterEnum(v OuterEnum) {
 }
 
 func (o EnumTest) MarshalJSON() ([]byte, error) {
-    toSerialize := map[string]interface{}{}
-    if o.EnumString != nil {
-        toSerialize["enum_string"] = o.EnumString
-    }
-    if true {
-        toSerialize["enum_string_required"] = o.EnumStringRequired
-    }
-    if o.EnumInteger != nil {
-        toSerialize["enum_integer"] = o.EnumInteger
-    }
-    if o.EnumNumber != nil {
-        toSerialize["enum_number"] = o.EnumNumber
-    }
-    if o.OuterEnum != nil {
-        toSerialize["outerEnum"] = o.OuterEnum
-    }
-    return json.Marshal(toSerialize)
+	toSerialize := map[string]interface{}{}
+	if o.EnumString != nil {
+		toSerialize["enum_string"] = o.EnumString
+	}
+	if true {
+		toSerialize["enum_string_required"] = o.EnumStringRequired
+	}
+	if o.EnumInteger != nil {
+		toSerialize["enum_integer"] = o.EnumInteger
+	}
+	if o.EnumNumber != nil {
+		toSerialize["enum_number"] = o.EnumNumber
+	}
+	if o.OuterEnum != nil {
+		toSerialize["outerEnum"] = o.OuterEnum
+	}
+	return json.Marshal(toSerialize)
 }
 
 type NullableEnumTest struct {
@@ -213,32 +213,32 @@ type NullableEnumTest struct {
 }
 
 func (v NullableEnumTest) Get() *EnumTest {
-    return v.value
+	return v.value
 }
 
 func (v NullableEnumTest) Set(val *EnumTest) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableEnumTest) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableEnumTest) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableEnumTest(val *EnumTest) *NullableEnumTest {
-    return &NullableEnumTest{value: val, isSet: true}
+	return &NullableEnumTest{value: val, isSet: true}
 }
 
 func (v NullableEnumTest) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableEnumTest) UnmarshalJSON(src []byte) error {
-    v.isSet = true
+	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_file.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_file.go
@@ -86,7 +86,7 @@ func (v NullableFile) Get() *File {
 	return v.value
 }
 
-func (v NullableFile) Set(val *File) {
+func (v *NullableFile) Set(val *File) {
 	v.value = val
 	v.isSet = true
 }
@@ -95,7 +95,7 @@ func (v NullableFile) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableFile) Unset() {
+func (v *NullableFile) Unset() {
 	v.value = nil
 	v.isSet = false
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_file.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_file.go
@@ -47,7 +47,6 @@ func (o *File) GetSourceURI() string {
 
 // GetSourceURIOk returns a tuple with the SourceURI field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *File) GetSourceURIOk() (*string, bool) {
 	if o == nil || o.SourceURI == nil {
 		return nil, false

--- a/samples/client/petstore/go-experimental/go-petstore/model_file.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_file.go
@@ -52,12 +52,12 @@ func (o *File) GetSourceURIOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-    return *o.SourceURI, true
+	return *o.SourceURI, true
 }
 
 // HasSourceURI returns a boolean if a field has been set.
 func (o *File) HasSourceURI() bool {
-    if o != nil && o.SourceURI != nil {
+	if o != nil && o.SourceURI != nil {
 		return true
 	}
 
@@ -70,11 +70,11 @@ func (o *File) SetSourceURI(v string) {
 }
 
 func (o File) MarshalJSON() ([]byte, error) {
-    toSerialize := map[string]interface{}{}
-    if o.SourceURI != nil {
-        toSerialize["sourceURI"] = o.SourceURI
-    }
-    return json.Marshal(toSerialize)
+	toSerialize := map[string]interface{}{}
+	if o.SourceURI != nil {
+		toSerialize["sourceURI"] = o.SourceURI
+	}
+	return json.Marshal(toSerialize)
 }
 
 type NullableFile struct {
@@ -83,32 +83,32 @@ type NullableFile struct {
 }
 
 func (v NullableFile) Get() *File {
-    return v.value
+	return v.value
 }
 
 func (v NullableFile) Set(val *File) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableFile) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableFile) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableFile(val *File) *NullableFile {
-    return &NullableFile{value: val, isSet: true}
+	return &NullableFile{value: val, isSet: true}
 }
 
 func (v NullableFile) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableFile) UnmarshalJSON(src []byte) error {
-    v.isSet = true
+	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_file.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_file.go
@@ -24,16 +24,16 @@ type File struct {
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
 func NewFile() *File {
-    this := File{}
-    return &this
+	this := File{}
+	return &this
 }
 
 // NewFileWithDefaults instantiates a new File object
 // This constructor will only assign default values to properties that have it defined,
 // but it doesn't guarantee that properties required by API are set
 func NewFileWithDefaults() *File {
-    this := File{}
-    return &this
+	this := File{}
+	return &this
 }
 
 // GetSourceURI returns the SourceURI field value if set, zero value otherwise.
@@ -45,14 +45,14 @@ func (o *File) GetSourceURI() string {
 	return *o.SourceURI
 }
 
-// GetSourceURIOk returns a tuple with the SourceURI field value if set, zero value otherwise
+// GetSourceURIOk returns a tuple with the SourceURI field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *File) GetSourceURIOk() (string, bool) {
+
+func (o *File) GetSourceURIOk() (*string, bool) {
 	if o == nil || o.SourceURI == nil {
-		var ret string
-		return ret, false
+		return nil, false
 	}
-	return *o.SourceURI, true
+	return o.SourceURI, true
 }
 
 // HasSourceURI returns a boolean if a field has been set.

--- a/samples/client/petstore/go-experimental/go-petstore/model_file.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_file.go
@@ -10,7 +10,6 @@
 package petstore
 
 import (
-	"bytes"
 	"encoding/json"
 )
 
@@ -53,12 +52,12 @@ func (o *File) GetSourceURIOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-	return *o.SourceURI, true
+    return *o.SourceURI, true
 }
 
 // HasSourceURI returns a boolean if a field has been set.
 func (o *File) HasSourceURI() bool {
-	if o != nil && o.SourceURI != nil {
+    if o != nil && o.SourceURI != nil {
 		return true
 	}
 
@@ -70,25 +69,46 @@ func (o *File) SetSourceURI(v string) {
 	o.SourceURI = &v
 }
 
+func (o File) MarshalJSON() ([]byte, error) {
+    toSerialize := map[string]interface{}{}
+    if o.SourceURI != nil {
+        toSerialize["sourceURI"] = o.SourceURI
+    }
+    return json.Marshal(toSerialize)
+}
+
 type NullableFile struct {
-	Value File
-	ExplicitNull bool
+	value *File
+	isSet bool
+}
+
+func (v NullableFile) Get() *File {
+    return v.value
+}
+
+func (v NullableFile) Set(val *File) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableFile) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableFile) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableFile(val *File) *NullableFile {
+    return &NullableFile{value: val, isSet: true}
 }
 
 func (v NullableFile) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-		return json.Marshal(v.Value)
-	}
+    return json.Marshal(v.value)
 }
 
 func (v *NullableFile) UnmarshalJSON(src []byte) error {
-	if bytes.Equal(src, []byte("null")) {
-		v.ExplicitNull = true
-		return nil
-	}
-
-	return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_file_schema_test_class.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_file_schema_test_class.go
@@ -47,7 +47,6 @@ func (o *FileSchemaTestClass) GetFile() File {
 
 // GetFileOk returns a tuple with the File field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *FileSchemaTestClass) GetFileOk() (*File, bool) {
 	if o == nil || o.File == nil {
 		return nil, false
@@ -80,7 +79,6 @@ func (o *FileSchemaTestClass) GetFiles() []File {
 
 // GetFilesOk returns a tuple with the Files field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *FileSchemaTestClass) GetFilesOk() (*[]File, bool) {
 	if o == nil || o.Files == nil {
 		return nil, false

--- a/samples/client/petstore/go-experimental/go-petstore/model_file_schema_test_class.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_file_schema_test_class.go
@@ -52,12 +52,12 @@ func (o *FileSchemaTestClass) GetFileOk() (File, bool) {
 		var ret File
 		return ret, false
 	}
-    return *o.File, true
+	return *o.File, true
 }
 
 // HasFile returns a boolean if a field has been set.
 func (o *FileSchemaTestClass) HasFile() bool {
-    if o != nil && o.File != nil {
+	if o != nil && o.File != nil {
 		return true
 	}
 
@@ -85,12 +85,12 @@ func (o *FileSchemaTestClass) GetFilesOk() ([]File, bool) {
 		var ret []File
 		return ret, false
 	}
-    return *o.Files, true
+	return *o.Files, true
 }
 
 // HasFiles returns a boolean if a field has been set.
 func (o *FileSchemaTestClass) HasFiles() bool {
-    if o != nil && o.Files != nil {
+	if o != nil && o.Files != nil {
 		return true
 	}
 
@@ -103,14 +103,14 @@ func (o *FileSchemaTestClass) SetFiles(v []File) {
 }
 
 func (o FileSchemaTestClass) MarshalJSON() ([]byte, error) {
-    toSerialize := map[string]interface{}{}
-    if o.File != nil {
-        toSerialize["file"] = o.File
-    }
-    if o.Files != nil {
-        toSerialize["files"] = o.Files
-    }
-    return json.Marshal(toSerialize)
+	toSerialize := map[string]interface{}{}
+	if o.File != nil {
+		toSerialize["file"] = o.File
+	}
+	if o.Files != nil {
+		toSerialize["files"] = o.Files
+	}
+	return json.Marshal(toSerialize)
 }
 
 type NullableFileSchemaTestClass struct {
@@ -119,32 +119,32 @@ type NullableFileSchemaTestClass struct {
 }
 
 func (v NullableFileSchemaTestClass) Get() *FileSchemaTestClass {
-    return v.value
+	return v.value
 }
 
 func (v NullableFileSchemaTestClass) Set(val *FileSchemaTestClass) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableFileSchemaTestClass) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableFileSchemaTestClass) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableFileSchemaTestClass(val *FileSchemaTestClass) *NullableFileSchemaTestClass {
-    return &NullableFileSchemaTestClass{value: val, isSet: true}
+	return &NullableFileSchemaTestClass{value: val, isSet: true}
 }
 
 func (v NullableFileSchemaTestClass) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableFileSchemaTestClass) UnmarshalJSON(src []byte) error {
-    v.isSet = true
+	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_file_schema_test_class.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_file_schema_test_class.go
@@ -122,7 +122,7 @@ func (v NullableFileSchemaTestClass) Get() *FileSchemaTestClass {
 	return v.value
 }
 
-func (v NullableFileSchemaTestClass) Set(val *FileSchemaTestClass) {
+func (v *NullableFileSchemaTestClass) Set(val *FileSchemaTestClass) {
 	v.value = val
 	v.isSet = true
 }
@@ -131,7 +131,7 @@ func (v NullableFileSchemaTestClass) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableFileSchemaTestClass) Unset() {
+func (v *NullableFileSchemaTestClass) Unset() {
 	v.value = nil
 	v.isSet = false
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_file_schema_test_class.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_file_schema_test_class.go
@@ -10,7 +10,6 @@
 package petstore
 
 import (
-	"bytes"
 	"encoding/json"
 )
 
@@ -53,12 +52,12 @@ func (o *FileSchemaTestClass) GetFileOk() (File, bool) {
 		var ret File
 		return ret, false
 	}
-	return *o.File, true
+    return *o.File, true
 }
 
 // HasFile returns a boolean if a field has been set.
 func (o *FileSchemaTestClass) HasFile() bool {
-	if o != nil && o.File != nil {
+    if o != nil && o.File != nil {
 		return true
 	}
 
@@ -86,12 +85,12 @@ func (o *FileSchemaTestClass) GetFilesOk() ([]File, bool) {
 		var ret []File
 		return ret, false
 	}
-	return *o.Files, true
+    return *o.Files, true
 }
 
 // HasFiles returns a boolean if a field has been set.
 func (o *FileSchemaTestClass) HasFiles() bool {
-	if o != nil && o.Files != nil {
+    if o != nil && o.Files != nil {
 		return true
 	}
 
@@ -103,25 +102,49 @@ func (o *FileSchemaTestClass) SetFiles(v []File) {
 	o.Files = &v
 }
 
+func (o FileSchemaTestClass) MarshalJSON() ([]byte, error) {
+    toSerialize := map[string]interface{}{}
+    if o.File != nil {
+        toSerialize["file"] = o.File
+    }
+    if o.Files != nil {
+        toSerialize["files"] = o.Files
+    }
+    return json.Marshal(toSerialize)
+}
+
 type NullableFileSchemaTestClass struct {
-	Value FileSchemaTestClass
-	ExplicitNull bool
+	value *FileSchemaTestClass
+	isSet bool
+}
+
+func (v NullableFileSchemaTestClass) Get() *FileSchemaTestClass {
+    return v.value
+}
+
+func (v NullableFileSchemaTestClass) Set(val *FileSchemaTestClass) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableFileSchemaTestClass) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableFileSchemaTestClass) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableFileSchemaTestClass(val *FileSchemaTestClass) *NullableFileSchemaTestClass {
+    return &NullableFileSchemaTestClass{value: val, isSet: true}
 }
 
 func (v NullableFileSchemaTestClass) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-		return json.Marshal(v.Value)
-	}
+    return json.Marshal(v.value)
 }
 
 func (v *NullableFileSchemaTestClass) UnmarshalJSON(src []byte) error {
-	if bytes.Equal(src, []byte("null")) {
-		v.ExplicitNull = true
-		return nil
-	}
-
-	return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_file_schema_test_class.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_file_schema_test_class.go
@@ -24,16 +24,16 @@ type FileSchemaTestClass struct {
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
 func NewFileSchemaTestClass() *FileSchemaTestClass {
-    this := FileSchemaTestClass{}
-    return &this
+	this := FileSchemaTestClass{}
+	return &this
 }
 
 // NewFileSchemaTestClassWithDefaults instantiates a new FileSchemaTestClass object
 // This constructor will only assign default values to properties that have it defined,
 // but it doesn't guarantee that properties required by API are set
 func NewFileSchemaTestClassWithDefaults() *FileSchemaTestClass {
-    this := FileSchemaTestClass{}
-    return &this
+	this := FileSchemaTestClass{}
+	return &this
 }
 
 // GetFile returns the File field value if set, zero value otherwise.
@@ -45,14 +45,14 @@ func (o *FileSchemaTestClass) GetFile() File {
 	return *o.File
 }
 
-// GetFileOk returns a tuple with the File field value if set, zero value otherwise
+// GetFileOk returns a tuple with the File field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *FileSchemaTestClass) GetFileOk() (File, bool) {
+
+func (o *FileSchemaTestClass) GetFileOk() (*File, bool) {
 	if o == nil || o.File == nil {
-		var ret File
-		return ret, false
+		return nil, false
 	}
-	return *o.File, true
+	return o.File, true
 }
 
 // HasFile returns a boolean if a field has been set.
@@ -78,14 +78,14 @@ func (o *FileSchemaTestClass) GetFiles() []File {
 	return *o.Files
 }
 
-// GetFilesOk returns a tuple with the Files field value if set, zero value otherwise
+// GetFilesOk returns a tuple with the Files field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *FileSchemaTestClass) GetFilesOk() ([]File, bool) {
+
+func (o *FileSchemaTestClass) GetFilesOk() (*[]File, bool) {
 	if o == nil || o.Files == nil {
-		var ret []File
-		return ret, false
+		return nil, false
 	}
-	return *o.Files, true
+	return o.Files, true
 }
 
 // HasFiles returns a boolean if a field has been set.

--- a/samples/client/petstore/go-experimental/go-petstore/model_format_test_.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_format_test_.go
@@ -38,20 +38,20 @@ type FormatTest struct {
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
 func NewFormatTest(number float32, byte_ string, date string, password string, ) *FormatTest {
-    this := FormatTest{}
-    this.Number = number
-    this.Byte = byte_
-    this.Date = date
-    this.Password = password
-    return &this
+	this := FormatTest{}
+	this.Number = number
+	this.Byte = byte_
+	this.Date = date
+	this.Password = password
+	return &this
 }
 
 // NewFormatTestWithDefaults instantiates a new FormatTest object
 // This constructor will only assign default values to properties that have it defined,
 // but it doesn't guarantee that properties required by API are set
 func NewFormatTestWithDefaults() *FormatTest {
-    this := FormatTest{}
-    return &this
+	this := FormatTest{}
+	return &this
 }
 
 // GetInteger returns the Integer field value if set, zero value otherwise.
@@ -63,14 +63,14 @@ func (o *FormatTest) GetInteger() int32 {
 	return *o.Integer
 }
 
-// GetIntegerOk returns a tuple with the Integer field value if set, zero value otherwise
+// GetIntegerOk returns a tuple with the Integer field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *FormatTest) GetIntegerOk() (int32, bool) {
+
+func (o *FormatTest) GetIntegerOk() (*int32, bool) {
 	if o == nil || o.Integer == nil {
-		var ret int32
-		return ret, false
+		return nil, false
 	}
-	return *o.Integer, true
+	return o.Integer, true
 }
 
 // HasInteger returns a boolean if a field has been set.
@@ -96,14 +96,14 @@ func (o *FormatTest) GetInt32() int32 {
 	return *o.Int32
 }
 
-// GetInt32Ok returns a tuple with the Int32 field value if set, zero value otherwise
+// GetInt32Ok returns a tuple with the Int32 field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *FormatTest) GetInt32Ok() (int32, bool) {
+
+func (o *FormatTest) GetInt32Ok() (*int32, bool) {
 	if o == nil || o.Int32 == nil {
-		var ret int32
-		return ret, false
+		return nil, false
 	}
-	return *o.Int32, true
+	return o.Int32, true
 }
 
 // HasInt32 returns a boolean if a field has been set.
@@ -129,14 +129,14 @@ func (o *FormatTest) GetInt64() int64 {
 	return *o.Int64
 }
 
-// GetInt64Ok returns a tuple with the Int64 field value if set, zero value otherwise
+// GetInt64Ok returns a tuple with the Int64 field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *FormatTest) GetInt64Ok() (int64, bool) {
+
+func (o *FormatTest) GetInt64Ok() (*int64, bool) {
 	if o == nil || o.Int64 == nil {
-		var ret int64
-		return ret, false
+		return nil, false
 	}
-	return *o.Int64, true
+	return o.Int64, true
 }
 
 // HasInt64 returns a boolean if a field has been set.
@@ -155,12 +155,22 @@ func (o *FormatTest) SetInt64(v int64) {
 
 // GetNumber returns the Number field value
 func (o *FormatTest) GetNumber() float32 {
-	if o == nil {
+	if o == nil  {
 		var ret float32
 		return ret
 	}
 
 	return o.Number
+}
+
+// GetNumberOk returns a tuple with the Number field value
+// and a boolean to check if the value has been set.
+
+func (o *FormatTest) GetNumberOk() (*float32, bool) {
+    if o == nil  {
+        return nil, false
+    }
+    return &o.Number, true
 }
 
 // SetNumber sets field value
@@ -177,14 +187,14 @@ func (o *FormatTest) GetFloat() float32 {
 	return *o.Float
 }
 
-// GetFloatOk returns a tuple with the Float field value if set, zero value otherwise
+// GetFloatOk returns a tuple with the Float field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *FormatTest) GetFloatOk() (float32, bool) {
+
+func (o *FormatTest) GetFloatOk() (*float32, bool) {
 	if o == nil || o.Float == nil {
-		var ret float32
-		return ret, false
+		return nil, false
 	}
-	return *o.Float, true
+	return o.Float, true
 }
 
 // HasFloat returns a boolean if a field has been set.
@@ -210,14 +220,14 @@ func (o *FormatTest) GetDouble() float64 {
 	return *o.Double
 }
 
-// GetDoubleOk returns a tuple with the Double field value if set, zero value otherwise
+// GetDoubleOk returns a tuple with the Double field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *FormatTest) GetDoubleOk() (float64, bool) {
+
+func (o *FormatTest) GetDoubleOk() (*float64, bool) {
 	if o == nil || o.Double == nil {
-		var ret float64
-		return ret, false
+		return nil, false
 	}
-	return *o.Double, true
+	return o.Double, true
 }
 
 // HasDouble returns a boolean if a field has been set.
@@ -243,14 +253,14 @@ func (o *FormatTest) GetString() string {
 	return *o.String
 }
 
-// GetStringOk returns a tuple with the String field value if set, zero value otherwise
+// GetStringOk returns a tuple with the String field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *FormatTest) GetStringOk() (string, bool) {
+
+func (o *FormatTest) GetStringOk() (*string, bool) {
 	if o == nil || o.String == nil {
-		var ret string
-		return ret, false
+		return nil, false
 	}
-	return *o.String, true
+	return o.String, true
 }
 
 // HasString returns a boolean if a field has been set.
@@ -269,12 +279,22 @@ func (o *FormatTest) SetString(v string) {
 
 // GetByte returns the Byte field value
 func (o *FormatTest) GetByte() string {
-	if o == nil {
+	if o == nil  {
 		var ret string
 		return ret
 	}
 
 	return o.Byte
+}
+
+// GetByteOk returns a tuple with the Byte field value
+// and a boolean to check if the value has been set.
+
+func (o *FormatTest) GetByteOk() (*string, bool) {
+    if o == nil  {
+        return nil, false
+    }
+    return &o.Byte, true
 }
 
 // SetByte sets field value
@@ -291,14 +311,14 @@ func (o *FormatTest) GetBinary() *os.File {
 	return *o.Binary
 }
 
-// GetBinaryOk returns a tuple with the Binary field value if set, zero value otherwise
+// GetBinaryOk returns a tuple with the Binary field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *FormatTest) GetBinaryOk() (*os.File, bool) {
+
+func (o *FormatTest) GetBinaryOk() (**os.File, bool) {
 	if o == nil || o.Binary == nil {
-		var ret *os.File
-		return ret, false
+		return nil, false
 	}
-	return *o.Binary, true
+	return o.Binary, true
 }
 
 // HasBinary returns a boolean if a field has been set.
@@ -317,12 +337,22 @@ func (o *FormatTest) SetBinary(v *os.File) {
 
 // GetDate returns the Date field value
 func (o *FormatTest) GetDate() string {
-	if o == nil {
+	if o == nil  {
 		var ret string
 		return ret
 	}
 
 	return o.Date
+}
+
+// GetDateOk returns a tuple with the Date field value
+// and a boolean to check if the value has been set.
+
+func (o *FormatTest) GetDateOk() (*string, bool) {
+    if o == nil  {
+        return nil, false
+    }
+    return &o.Date, true
 }
 
 // SetDate sets field value
@@ -339,14 +369,14 @@ func (o *FormatTest) GetDateTime() time.Time {
 	return *o.DateTime
 }
 
-// GetDateTimeOk returns a tuple with the DateTime field value if set, zero value otherwise
+// GetDateTimeOk returns a tuple with the DateTime field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *FormatTest) GetDateTimeOk() (time.Time, bool) {
+
+func (o *FormatTest) GetDateTimeOk() (*time.Time, bool) {
 	if o == nil || o.DateTime == nil {
-		var ret time.Time
-		return ret, false
+		return nil, false
 	}
-	return *o.DateTime, true
+	return o.DateTime, true
 }
 
 // HasDateTime returns a boolean if a field has been set.
@@ -372,14 +402,14 @@ func (o *FormatTest) GetUuid() string {
 	return *o.Uuid
 }
 
-// GetUuidOk returns a tuple with the Uuid field value if set, zero value otherwise
+// GetUuidOk returns a tuple with the Uuid field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *FormatTest) GetUuidOk() (string, bool) {
+
+func (o *FormatTest) GetUuidOk() (*string, bool) {
 	if o == nil || o.Uuid == nil {
-		var ret string
-		return ret, false
+		return nil, false
 	}
-	return *o.Uuid, true
+	return o.Uuid, true
 }
 
 // HasUuid returns a boolean if a field has been set.
@@ -398,12 +428,22 @@ func (o *FormatTest) SetUuid(v string) {
 
 // GetPassword returns the Password field value
 func (o *FormatTest) GetPassword() string {
-	if o == nil {
+	if o == nil  {
 		var ret string
 		return ret
 	}
 
 	return o.Password
+}
+
+// GetPasswordOk returns a tuple with the Password field value
+// and a boolean to check if the value has been set.
+
+func (o *FormatTest) GetPasswordOk() (*string, bool) {
+    if o == nil  {
+        return nil, false
+    }
+    return &o.Password, true
 }
 
 // SetPassword sets field value
@@ -420,14 +460,14 @@ func (o *FormatTest) GetBigDecimal() float64 {
 	return *o.BigDecimal
 }
 
-// GetBigDecimalOk returns a tuple with the BigDecimal field value if set, zero value otherwise
+// GetBigDecimalOk returns a tuple with the BigDecimal field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *FormatTest) GetBigDecimalOk() (float64, bool) {
+
+func (o *FormatTest) GetBigDecimalOk() (*float64, bool) {
 	if o == nil || o.BigDecimal == nil {
-		var ret float64
-		return ret, false
+		return nil, false
 	}
-	return *o.BigDecimal, true
+	return o.BigDecimal, true
 }
 
 // HasBigDecimal returns a boolean if a field has been set.

--- a/samples/client/petstore/go-experimental/go-petstore/model_format_test_.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_format_test_.go
@@ -70,12 +70,12 @@ func (o *FormatTest) GetIntegerOk() (int32, bool) {
 		var ret int32
 		return ret, false
 	}
-    return *o.Integer, true
+	return *o.Integer, true
 }
 
 // HasInteger returns a boolean if a field has been set.
 func (o *FormatTest) HasInteger() bool {
-    if o != nil && o.Integer != nil {
+	if o != nil && o.Integer != nil {
 		return true
 	}
 
@@ -103,12 +103,12 @@ func (o *FormatTest) GetInt32Ok() (int32, bool) {
 		var ret int32
 		return ret, false
 	}
-    return *o.Int32, true
+	return *o.Int32, true
 }
 
 // HasInt32 returns a boolean if a field has been set.
 func (o *FormatTest) HasInt32() bool {
-    if o != nil && o.Int32 != nil {
+	if o != nil && o.Int32 != nil {
 		return true
 	}
 
@@ -136,12 +136,12 @@ func (o *FormatTest) GetInt64Ok() (int64, bool) {
 		var ret int64
 		return ret, false
 	}
-    return *o.Int64, true
+	return *o.Int64, true
 }
 
 // HasInt64 returns a boolean if a field has been set.
 func (o *FormatTest) HasInt64() bool {
-    if o != nil && o.Int64 != nil {
+	if o != nil && o.Int64 != nil {
 		return true
 	}
 
@@ -184,12 +184,12 @@ func (o *FormatTest) GetFloatOk() (float32, bool) {
 		var ret float32
 		return ret, false
 	}
-    return *o.Float, true
+	return *o.Float, true
 }
 
 // HasFloat returns a boolean if a field has been set.
 func (o *FormatTest) HasFloat() bool {
-    if o != nil && o.Float != nil {
+	if o != nil && o.Float != nil {
 		return true
 	}
 
@@ -217,12 +217,12 @@ func (o *FormatTest) GetDoubleOk() (float64, bool) {
 		var ret float64
 		return ret, false
 	}
-    return *o.Double, true
+	return *o.Double, true
 }
 
 // HasDouble returns a boolean if a field has been set.
 func (o *FormatTest) HasDouble() bool {
-    if o != nil && o.Double != nil {
+	if o != nil && o.Double != nil {
 		return true
 	}
 
@@ -250,12 +250,12 @@ func (o *FormatTest) GetStringOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-    return *o.String, true
+	return *o.String, true
 }
 
 // HasString returns a boolean if a field has been set.
 func (o *FormatTest) HasString() bool {
-    if o != nil && o.String != nil {
+	if o != nil && o.String != nil {
 		return true
 	}
 
@@ -298,12 +298,12 @@ func (o *FormatTest) GetBinaryOk() (*os.File, bool) {
 		var ret *os.File
 		return ret, false
 	}
-    return *o.Binary, true
+	return *o.Binary, true
 }
 
 // HasBinary returns a boolean if a field has been set.
 func (o *FormatTest) HasBinary() bool {
-    if o != nil && o.Binary != nil {
+	if o != nil && o.Binary != nil {
 		return true
 	}
 
@@ -346,12 +346,12 @@ func (o *FormatTest) GetDateTimeOk() (time.Time, bool) {
 		var ret time.Time
 		return ret, false
 	}
-    return *o.DateTime, true
+	return *o.DateTime, true
 }
 
 // HasDateTime returns a boolean if a field has been set.
 func (o *FormatTest) HasDateTime() bool {
-    if o != nil && o.DateTime != nil {
+	if o != nil && o.DateTime != nil {
 		return true
 	}
 
@@ -379,12 +379,12 @@ func (o *FormatTest) GetUuidOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-    return *o.Uuid, true
+	return *o.Uuid, true
 }
 
 // HasUuid returns a boolean if a field has been set.
 func (o *FormatTest) HasUuid() bool {
-    if o != nil && o.Uuid != nil {
+	if o != nil && o.Uuid != nil {
 		return true
 	}
 
@@ -427,12 +427,12 @@ func (o *FormatTest) GetBigDecimalOk() (float64, bool) {
 		var ret float64
 		return ret, false
 	}
-    return *o.BigDecimal, true
+	return *o.BigDecimal, true
 }
 
 // HasBigDecimal returns a boolean if a field has been set.
 func (o *FormatTest) HasBigDecimal() bool {
-    if o != nil && o.BigDecimal != nil {
+	if o != nil && o.BigDecimal != nil {
 		return true
 	}
 
@@ -445,50 +445,50 @@ func (o *FormatTest) SetBigDecimal(v float64) {
 }
 
 func (o FormatTest) MarshalJSON() ([]byte, error) {
-    toSerialize := map[string]interface{}{}
-    if o.Integer != nil {
-        toSerialize["integer"] = o.Integer
-    }
-    if o.Int32 != nil {
-        toSerialize["int32"] = o.Int32
-    }
-    if o.Int64 != nil {
-        toSerialize["int64"] = o.Int64
-    }
-    if true {
-        toSerialize["number"] = o.Number
-    }
-    if o.Float != nil {
-        toSerialize["float"] = o.Float
-    }
-    if o.Double != nil {
-        toSerialize["double"] = o.Double
-    }
-    if o.String != nil {
-        toSerialize["string"] = o.String
-    }
-    if true {
-        toSerialize["byte"] = o.Byte
-    }
-    if o.Binary != nil {
-        toSerialize["binary"] = o.Binary
-    }
-    if true {
-        toSerialize["date"] = o.Date
-    }
-    if o.DateTime != nil {
-        toSerialize["dateTime"] = o.DateTime
-    }
-    if o.Uuid != nil {
-        toSerialize["uuid"] = o.Uuid
-    }
-    if true {
-        toSerialize["password"] = o.Password
-    }
-    if o.BigDecimal != nil {
-        toSerialize["BigDecimal"] = o.BigDecimal
-    }
-    return json.Marshal(toSerialize)
+	toSerialize := map[string]interface{}{}
+	if o.Integer != nil {
+		toSerialize["integer"] = o.Integer
+	}
+	if o.Int32 != nil {
+		toSerialize["int32"] = o.Int32
+	}
+	if o.Int64 != nil {
+		toSerialize["int64"] = o.Int64
+	}
+	if true {
+		toSerialize["number"] = o.Number
+	}
+	if o.Float != nil {
+		toSerialize["float"] = o.Float
+	}
+	if o.Double != nil {
+		toSerialize["double"] = o.Double
+	}
+	if o.String != nil {
+		toSerialize["string"] = o.String
+	}
+	if true {
+		toSerialize["byte"] = o.Byte
+	}
+	if o.Binary != nil {
+		toSerialize["binary"] = o.Binary
+	}
+	if true {
+		toSerialize["date"] = o.Date
+	}
+	if o.DateTime != nil {
+		toSerialize["dateTime"] = o.DateTime
+	}
+	if o.Uuid != nil {
+		toSerialize["uuid"] = o.Uuid
+	}
+	if true {
+		toSerialize["password"] = o.Password
+	}
+	if o.BigDecimal != nil {
+		toSerialize["BigDecimal"] = o.BigDecimal
+	}
+	return json.Marshal(toSerialize)
 }
 
 type NullableFormatTest struct {
@@ -497,32 +497,32 @@ type NullableFormatTest struct {
 }
 
 func (v NullableFormatTest) Get() *FormatTest {
-    return v.value
+	return v.value
 }
 
 func (v NullableFormatTest) Set(val *FormatTest) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableFormatTest) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableFormatTest) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableFormatTest(val *FormatTest) *NullableFormatTest {
-    return &NullableFormatTest{value: val, isSet: true}
+	return &NullableFormatTest{value: val, isSet: true}
 }
 
 func (v NullableFormatTest) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableFormatTest) UnmarshalJSON(src []byte) error {
-    v.isSet = true
+	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_format_test_.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_format_test_.go
@@ -500,7 +500,7 @@ func (v NullableFormatTest) Get() *FormatTest {
 	return v.value
 }
 
-func (v NullableFormatTest) Set(val *FormatTest) {
+func (v *NullableFormatTest) Set(val *FormatTest) {
 	v.value = val
 	v.isSet = true
 }
@@ -509,7 +509,7 @@ func (v NullableFormatTest) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableFormatTest) Unset() {
+func (v *NullableFormatTest) Unset() {
 	v.value = nil
 	v.isSet = false
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_format_test_.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_format_test_.go
@@ -65,7 +65,6 @@ func (o *FormatTest) GetInteger() int32 {
 
 // GetIntegerOk returns a tuple with the Integer field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *FormatTest) GetIntegerOk() (*int32, bool) {
 	if o == nil || o.Integer == nil {
 		return nil, false
@@ -98,7 +97,6 @@ func (o *FormatTest) GetInt32() int32 {
 
 // GetInt32Ok returns a tuple with the Int32 field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *FormatTest) GetInt32Ok() (*int32, bool) {
 	if o == nil || o.Int32 == nil {
 		return nil, false
@@ -131,7 +129,6 @@ func (o *FormatTest) GetInt64() int64 {
 
 // GetInt64Ok returns a tuple with the Int64 field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *FormatTest) GetInt64Ok() (*int64, bool) {
 	if o == nil || o.Int64 == nil {
 		return nil, false
@@ -165,12 +162,11 @@ func (o *FormatTest) GetNumber() float32 {
 
 // GetNumberOk returns a tuple with the Number field value
 // and a boolean to check if the value has been set.
-
 func (o *FormatTest) GetNumberOk() (*float32, bool) {
-    if o == nil  {
-        return nil, false
-    }
-    return &o.Number, true
+	if o == nil  {
+		return nil, false
+	}
+	return &o.Number, true
 }
 
 // SetNumber sets field value
@@ -189,7 +185,6 @@ func (o *FormatTest) GetFloat() float32 {
 
 // GetFloatOk returns a tuple with the Float field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *FormatTest) GetFloatOk() (*float32, bool) {
 	if o == nil || o.Float == nil {
 		return nil, false
@@ -222,7 +217,6 @@ func (o *FormatTest) GetDouble() float64 {
 
 // GetDoubleOk returns a tuple with the Double field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *FormatTest) GetDoubleOk() (*float64, bool) {
 	if o == nil || o.Double == nil {
 		return nil, false
@@ -255,7 +249,6 @@ func (o *FormatTest) GetString() string {
 
 // GetStringOk returns a tuple with the String field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *FormatTest) GetStringOk() (*string, bool) {
 	if o == nil || o.String == nil {
 		return nil, false
@@ -289,12 +282,11 @@ func (o *FormatTest) GetByte() string {
 
 // GetByteOk returns a tuple with the Byte field value
 // and a boolean to check if the value has been set.
-
 func (o *FormatTest) GetByteOk() (*string, bool) {
-    if o == nil  {
-        return nil, false
-    }
-    return &o.Byte, true
+	if o == nil  {
+		return nil, false
+	}
+	return &o.Byte, true
 }
 
 // SetByte sets field value
@@ -313,7 +305,6 @@ func (o *FormatTest) GetBinary() *os.File {
 
 // GetBinaryOk returns a tuple with the Binary field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *FormatTest) GetBinaryOk() (**os.File, bool) {
 	if o == nil || o.Binary == nil {
 		return nil, false
@@ -347,12 +338,11 @@ func (o *FormatTest) GetDate() string {
 
 // GetDateOk returns a tuple with the Date field value
 // and a boolean to check if the value has been set.
-
 func (o *FormatTest) GetDateOk() (*string, bool) {
-    if o == nil  {
-        return nil, false
-    }
-    return &o.Date, true
+	if o == nil  {
+		return nil, false
+	}
+	return &o.Date, true
 }
 
 // SetDate sets field value
@@ -371,7 +361,6 @@ func (o *FormatTest) GetDateTime() time.Time {
 
 // GetDateTimeOk returns a tuple with the DateTime field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *FormatTest) GetDateTimeOk() (*time.Time, bool) {
 	if o == nil || o.DateTime == nil {
 		return nil, false
@@ -404,7 +393,6 @@ func (o *FormatTest) GetUuid() string {
 
 // GetUuidOk returns a tuple with the Uuid field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *FormatTest) GetUuidOk() (*string, bool) {
 	if o == nil || o.Uuid == nil {
 		return nil, false
@@ -438,12 +426,11 @@ func (o *FormatTest) GetPassword() string {
 
 // GetPasswordOk returns a tuple with the Password field value
 // and a boolean to check if the value has been set.
-
 func (o *FormatTest) GetPasswordOk() (*string, bool) {
-    if o == nil  {
-        return nil, false
-    }
-    return &o.Password, true
+	if o == nil  {
+		return nil, false
+	}
+	return &o.Password, true
 }
 
 // SetPassword sets field value
@@ -462,7 +449,6 @@ func (o *FormatTest) GetBigDecimal() float64 {
 
 // GetBigDecimalOk returns a tuple with the BigDecimal field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *FormatTest) GetBigDecimalOk() (*float64, bool) {
 	if o == nil || o.BigDecimal == nil {
 		return nil, false

--- a/samples/client/petstore/go-experimental/go-petstore/model_format_test_.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_format_test_.go
@@ -10,7 +10,6 @@
 package petstore
 
 import (
-	"bytes"
 	"encoding/json"
 	"os"
 	"time"
@@ -71,12 +70,12 @@ func (o *FormatTest) GetIntegerOk() (int32, bool) {
 		var ret int32
 		return ret, false
 	}
-	return *o.Integer, true
+    return *o.Integer, true
 }
 
 // HasInteger returns a boolean if a field has been set.
 func (o *FormatTest) HasInteger() bool {
-	if o != nil && o.Integer != nil {
+    if o != nil && o.Integer != nil {
 		return true
 	}
 
@@ -104,12 +103,12 @@ func (o *FormatTest) GetInt32Ok() (int32, bool) {
 		var ret int32
 		return ret, false
 	}
-	return *o.Int32, true
+    return *o.Int32, true
 }
 
 // HasInt32 returns a boolean if a field has been set.
 func (o *FormatTest) HasInt32() bool {
-	if o != nil && o.Int32 != nil {
+    if o != nil && o.Int32 != nil {
 		return true
 	}
 
@@ -137,12 +136,12 @@ func (o *FormatTest) GetInt64Ok() (int64, bool) {
 		var ret int64
 		return ret, false
 	}
-	return *o.Int64, true
+    return *o.Int64, true
 }
 
 // HasInt64 returns a boolean if a field has been set.
 func (o *FormatTest) HasInt64() bool {
-	if o != nil && o.Int64 != nil {
+    if o != nil && o.Int64 != nil {
 		return true
 	}
 
@@ -185,12 +184,12 @@ func (o *FormatTest) GetFloatOk() (float32, bool) {
 		var ret float32
 		return ret, false
 	}
-	return *o.Float, true
+    return *o.Float, true
 }
 
 // HasFloat returns a boolean if a field has been set.
 func (o *FormatTest) HasFloat() bool {
-	if o != nil && o.Float != nil {
+    if o != nil && o.Float != nil {
 		return true
 	}
 
@@ -218,12 +217,12 @@ func (o *FormatTest) GetDoubleOk() (float64, bool) {
 		var ret float64
 		return ret, false
 	}
-	return *o.Double, true
+    return *o.Double, true
 }
 
 // HasDouble returns a boolean if a field has been set.
 func (o *FormatTest) HasDouble() bool {
-	if o != nil && o.Double != nil {
+    if o != nil && o.Double != nil {
 		return true
 	}
 
@@ -251,12 +250,12 @@ func (o *FormatTest) GetStringOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-	return *o.String, true
+    return *o.String, true
 }
 
 // HasString returns a boolean if a field has been set.
 func (o *FormatTest) HasString() bool {
-	if o != nil && o.String != nil {
+    if o != nil && o.String != nil {
 		return true
 	}
 
@@ -299,12 +298,12 @@ func (o *FormatTest) GetBinaryOk() (*os.File, bool) {
 		var ret *os.File
 		return ret, false
 	}
-	return *o.Binary, true
+    return *o.Binary, true
 }
 
 // HasBinary returns a boolean if a field has been set.
 func (o *FormatTest) HasBinary() bool {
-	if o != nil && o.Binary != nil {
+    if o != nil && o.Binary != nil {
 		return true
 	}
 
@@ -347,12 +346,12 @@ func (o *FormatTest) GetDateTimeOk() (time.Time, bool) {
 		var ret time.Time
 		return ret, false
 	}
-	return *o.DateTime, true
+    return *o.DateTime, true
 }
 
 // HasDateTime returns a boolean if a field has been set.
 func (o *FormatTest) HasDateTime() bool {
-	if o != nil && o.DateTime != nil {
+    if o != nil && o.DateTime != nil {
 		return true
 	}
 
@@ -380,12 +379,12 @@ func (o *FormatTest) GetUuidOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-	return *o.Uuid, true
+    return *o.Uuid, true
 }
 
 // HasUuid returns a boolean if a field has been set.
 func (o *FormatTest) HasUuid() bool {
-	if o != nil && o.Uuid != nil {
+    if o != nil && o.Uuid != nil {
 		return true
 	}
 
@@ -428,12 +427,12 @@ func (o *FormatTest) GetBigDecimalOk() (float64, bool) {
 		var ret float64
 		return ret, false
 	}
-	return *o.BigDecimal, true
+    return *o.BigDecimal, true
 }
 
 // HasBigDecimal returns a boolean if a field has been set.
 func (o *FormatTest) HasBigDecimal() bool {
-	if o != nil && o.BigDecimal != nil {
+    if o != nil && o.BigDecimal != nil {
 		return true
 	}
 
@@ -445,25 +444,85 @@ func (o *FormatTest) SetBigDecimal(v float64) {
 	o.BigDecimal = &v
 }
 
+func (o FormatTest) MarshalJSON() ([]byte, error) {
+    toSerialize := map[string]interface{}{}
+    if o.Integer != nil {
+        toSerialize["integer"] = o.Integer
+    }
+    if o.Int32 != nil {
+        toSerialize["int32"] = o.Int32
+    }
+    if o.Int64 != nil {
+        toSerialize["int64"] = o.Int64
+    }
+    if true {
+        toSerialize["number"] = o.Number
+    }
+    if o.Float != nil {
+        toSerialize["float"] = o.Float
+    }
+    if o.Double != nil {
+        toSerialize["double"] = o.Double
+    }
+    if o.String != nil {
+        toSerialize["string"] = o.String
+    }
+    if true {
+        toSerialize["byte"] = o.Byte
+    }
+    if o.Binary != nil {
+        toSerialize["binary"] = o.Binary
+    }
+    if true {
+        toSerialize["date"] = o.Date
+    }
+    if o.DateTime != nil {
+        toSerialize["dateTime"] = o.DateTime
+    }
+    if o.Uuid != nil {
+        toSerialize["uuid"] = o.Uuid
+    }
+    if true {
+        toSerialize["password"] = o.Password
+    }
+    if o.BigDecimal != nil {
+        toSerialize["BigDecimal"] = o.BigDecimal
+    }
+    return json.Marshal(toSerialize)
+}
+
 type NullableFormatTest struct {
-	Value FormatTest
-	ExplicitNull bool
+	value *FormatTest
+	isSet bool
+}
+
+func (v NullableFormatTest) Get() *FormatTest {
+    return v.value
+}
+
+func (v NullableFormatTest) Set(val *FormatTest) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableFormatTest) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableFormatTest) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableFormatTest(val *FormatTest) *NullableFormatTest {
+    return &NullableFormatTest{value: val, isSet: true}
 }
 
 func (v NullableFormatTest) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-		return json.Marshal(v.Value)
-	}
+    return json.Marshal(v.value)
 }
 
 func (v *NullableFormatTest) UnmarshalJSON(src []byte) error {
-	if bytes.Equal(src, []byte("null")) {
-		v.ExplicitNull = true
-		return nil
-	}
-
-	return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_has_only_read_only.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_has_only_read_only.go
@@ -52,12 +52,12 @@ func (o *HasOnlyReadOnly) GetBarOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-    return *o.Bar, true
+	return *o.Bar, true
 }
 
 // HasBar returns a boolean if a field has been set.
 func (o *HasOnlyReadOnly) HasBar() bool {
-    if o != nil && o.Bar != nil {
+	if o != nil && o.Bar != nil {
 		return true
 	}
 
@@ -85,12 +85,12 @@ func (o *HasOnlyReadOnly) GetFooOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-    return *o.Foo, true
+	return *o.Foo, true
 }
 
 // HasFoo returns a boolean if a field has been set.
 func (o *HasOnlyReadOnly) HasFoo() bool {
-    if o != nil && o.Foo != nil {
+	if o != nil && o.Foo != nil {
 		return true
 	}
 
@@ -103,14 +103,14 @@ func (o *HasOnlyReadOnly) SetFoo(v string) {
 }
 
 func (o HasOnlyReadOnly) MarshalJSON() ([]byte, error) {
-    toSerialize := map[string]interface{}{}
-    if o.Bar != nil {
-        toSerialize["bar"] = o.Bar
-    }
-    if o.Foo != nil {
-        toSerialize["foo"] = o.Foo
-    }
-    return json.Marshal(toSerialize)
+	toSerialize := map[string]interface{}{}
+	if o.Bar != nil {
+		toSerialize["bar"] = o.Bar
+	}
+	if o.Foo != nil {
+		toSerialize["foo"] = o.Foo
+	}
+	return json.Marshal(toSerialize)
 }
 
 type NullableHasOnlyReadOnly struct {
@@ -119,32 +119,32 @@ type NullableHasOnlyReadOnly struct {
 }
 
 func (v NullableHasOnlyReadOnly) Get() *HasOnlyReadOnly {
-    return v.value
+	return v.value
 }
 
 func (v NullableHasOnlyReadOnly) Set(val *HasOnlyReadOnly) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableHasOnlyReadOnly) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableHasOnlyReadOnly) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableHasOnlyReadOnly(val *HasOnlyReadOnly) *NullableHasOnlyReadOnly {
-    return &NullableHasOnlyReadOnly{value: val, isSet: true}
+	return &NullableHasOnlyReadOnly{value: val, isSet: true}
 }
 
 func (v NullableHasOnlyReadOnly) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableHasOnlyReadOnly) UnmarshalJSON(src []byte) error {
-    v.isSet = true
+	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_has_only_read_only.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_has_only_read_only.go
@@ -47,7 +47,6 @@ func (o *HasOnlyReadOnly) GetBar() string {
 
 // GetBarOk returns a tuple with the Bar field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *HasOnlyReadOnly) GetBarOk() (*string, bool) {
 	if o == nil || o.Bar == nil {
 		return nil, false
@@ -80,7 +79,6 @@ func (o *HasOnlyReadOnly) GetFoo() string {
 
 // GetFooOk returns a tuple with the Foo field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *HasOnlyReadOnly) GetFooOk() (*string, bool) {
 	if o == nil || o.Foo == nil {
 		return nil, false

--- a/samples/client/petstore/go-experimental/go-petstore/model_has_only_read_only.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_has_only_read_only.go
@@ -24,16 +24,16 @@ type HasOnlyReadOnly struct {
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
 func NewHasOnlyReadOnly() *HasOnlyReadOnly {
-    this := HasOnlyReadOnly{}
-    return &this
+	this := HasOnlyReadOnly{}
+	return &this
 }
 
 // NewHasOnlyReadOnlyWithDefaults instantiates a new HasOnlyReadOnly object
 // This constructor will only assign default values to properties that have it defined,
 // but it doesn't guarantee that properties required by API are set
 func NewHasOnlyReadOnlyWithDefaults() *HasOnlyReadOnly {
-    this := HasOnlyReadOnly{}
-    return &this
+	this := HasOnlyReadOnly{}
+	return &this
 }
 
 // GetBar returns the Bar field value if set, zero value otherwise.
@@ -45,14 +45,14 @@ func (o *HasOnlyReadOnly) GetBar() string {
 	return *o.Bar
 }
 
-// GetBarOk returns a tuple with the Bar field value if set, zero value otherwise
+// GetBarOk returns a tuple with the Bar field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *HasOnlyReadOnly) GetBarOk() (string, bool) {
+
+func (o *HasOnlyReadOnly) GetBarOk() (*string, bool) {
 	if o == nil || o.Bar == nil {
-		var ret string
-		return ret, false
+		return nil, false
 	}
-	return *o.Bar, true
+	return o.Bar, true
 }
 
 // HasBar returns a boolean if a field has been set.
@@ -78,14 +78,14 @@ func (o *HasOnlyReadOnly) GetFoo() string {
 	return *o.Foo
 }
 
-// GetFooOk returns a tuple with the Foo field value if set, zero value otherwise
+// GetFooOk returns a tuple with the Foo field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *HasOnlyReadOnly) GetFooOk() (string, bool) {
+
+func (o *HasOnlyReadOnly) GetFooOk() (*string, bool) {
 	if o == nil || o.Foo == nil {
-		var ret string
-		return ret, false
+		return nil, false
 	}
-	return *o.Foo, true
+	return o.Foo, true
 }
 
 // HasFoo returns a boolean if a field has been set.

--- a/samples/client/petstore/go-experimental/go-petstore/model_has_only_read_only.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_has_only_read_only.go
@@ -122,7 +122,7 @@ func (v NullableHasOnlyReadOnly) Get() *HasOnlyReadOnly {
 	return v.value
 }
 
-func (v NullableHasOnlyReadOnly) Set(val *HasOnlyReadOnly) {
+func (v *NullableHasOnlyReadOnly) Set(val *HasOnlyReadOnly) {
 	v.value = val
 	v.isSet = true
 }
@@ -131,7 +131,7 @@ func (v NullableHasOnlyReadOnly) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableHasOnlyReadOnly) Unset() {
+func (v *NullableHasOnlyReadOnly) Unset() {
 	v.value = nil
 	v.isSet = false
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_has_only_read_only.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_has_only_read_only.go
@@ -10,7 +10,6 @@
 package petstore
 
 import (
-	"bytes"
 	"encoding/json"
 )
 
@@ -53,12 +52,12 @@ func (o *HasOnlyReadOnly) GetBarOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-	return *o.Bar, true
+    return *o.Bar, true
 }
 
 // HasBar returns a boolean if a field has been set.
 func (o *HasOnlyReadOnly) HasBar() bool {
-	if o != nil && o.Bar != nil {
+    if o != nil && o.Bar != nil {
 		return true
 	}
 
@@ -86,12 +85,12 @@ func (o *HasOnlyReadOnly) GetFooOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-	return *o.Foo, true
+    return *o.Foo, true
 }
 
 // HasFoo returns a boolean if a field has been set.
 func (o *HasOnlyReadOnly) HasFoo() bool {
-	if o != nil && o.Foo != nil {
+    if o != nil && o.Foo != nil {
 		return true
 	}
 
@@ -103,25 +102,49 @@ func (o *HasOnlyReadOnly) SetFoo(v string) {
 	o.Foo = &v
 }
 
+func (o HasOnlyReadOnly) MarshalJSON() ([]byte, error) {
+    toSerialize := map[string]interface{}{}
+    if o.Bar != nil {
+        toSerialize["bar"] = o.Bar
+    }
+    if o.Foo != nil {
+        toSerialize["foo"] = o.Foo
+    }
+    return json.Marshal(toSerialize)
+}
+
 type NullableHasOnlyReadOnly struct {
-	Value HasOnlyReadOnly
-	ExplicitNull bool
+	value *HasOnlyReadOnly
+	isSet bool
+}
+
+func (v NullableHasOnlyReadOnly) Get() *HasOnlyReadOnly {
+    return v.value
+}
+
+func (v NullableHasOnlyReadOnly) Set(val *HasOnlyReadOnly) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableHasOnlyReadOnly) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableHasOnlyReadOnly) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableHasOnlyReadOnly(val *HasOnlyReadOnly) *NullableHasOnlyReadOnly {
+    return &NullableHasOnlyReadOnly{value: val, isSet: true}
 }
 
 func (v NullableHasOnlyReadOnly) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-		return json.Marshal(v.Value)
-	}
+    return json.Marshal(v.value)
 }
 
 func (v *NullableHasOnlyReadOnly) UnmarshalJSON(src []byte) error {
-	if bytes.Equal(src, []byte("null")) {
-		v.ExplicitNull = true
-		return nil
-	}
-
-	return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_list.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_list.go
@@ -85,7 +85,7 @@ func (v NullableList) Get() *List {
 	return v.value
 }
 
-func (v NullableList) Set(val *List) {
+func (v *NullableList) Set(val *List) {
 	v.value = val
 	v.isSet = true
 }
@@ -94,7 +94,7 @@ func (v NullableList) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableList) Unset() {
+func (v *NullableList) Unset() {
 	v.value = nil
 	v.isSet = false
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_list.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_list.go
@@ -10,7 +10,6 @@
 package petstore
 
 import (
-	"bytes"
 	"encoding/json"
 )
 
@@ -52,12 +51,12 @@ func (o *List) GetVar123ListOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-	return *o.Var123List, true
+    return *o.Var123List, true
 }
 
 // HasVar123List returns a boolean if a field has been set.
 func (o *List) HasVar123List() bool {
-	if o != nil && o.Var123List != nil {
+    if o != nil && o.Var123List != nil {
 		return true
 	}
 
@@ -69,25 +68,46 @@ func (o *List) SetVar123List(v string) {
 	o.Var123List = &v
 }
 
+func (o List) MarshalJSON() ([]byte, error) {
+    toSerialize := map[string]interface{}{}
+    if o.Var123List != nil {
+        toSerialize["123-list"] = o.Var123List
+    }
+    return json.Marshal(toSerialize)
+}
+
 type NullableList struct {
-	Value List
-	ExplicitNull bool
+	value *List
+	isSet bool
+}
+
+func (v NullableList) Get() *List {
+    return v.value
+}
+
+func (v NullableList) Set(val *List) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableList) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableList) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableList(val *List) *NullableList {
+    return &NullableList{value: val, isSet: true}
 }
 
 func (v NullableList) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-		return json.Marshal(v.Value)
-	}
+    return json.Marshal(v.value)
 }
 
 func (v *NullableList) UnmarshalJSON(src []byte) error {
-	if bytes.Equal(src, []byte("null")) {
-		v.ExplicitNull = true
-		return nil
-	}
-
-	return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_list.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_list.go
@@ -51,12 +51,12 @@ func (o *List) GetVar123ListOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-    return *o.Var123List, true
+	return *o.Var123List, true
 }
 
 // HasVar123List returns a boolean if a field has been set.
 func (o *List) HasVar123List() bool {
-    if o != nil && o.Var123List != nil {
+	if o != nil && o.Var123List != nil {
 		return true
 	}
 
@@ -69,11 +69,11 @@ func (o *List) SetVar123List(v string) {
 }
 
 func (o List) MarshalJSON() ([]byte, error) {
-    toSerialize := map[string]interface{}{}
-    if o.Var123List != nil {
-        toSerialize["123-list"] = o.Var123List
-    }
-    return json.Marshal(toSerialize)
+	toSerialize := map[string]interface{}{}
+	if o.Var123List != nil {
+		toSerialize["123-list"] = o.Var123List
+	}
+	return json.Marshal(toSerialize)
 }
 
 type NullableList struct {
@@ -82,32 +82,32 @@ type NullableList struct {
 }
 
 func (v NullableList) Get() *List {
-    return v.value
+	return v.value
 }
 
 func (v NullableList) Set(val *List) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableList) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableList) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableList(val *List) *NullableList {
-    return &NullableList{value: val, isSet: true}
+	return &NullableList{value: val, isSet: true}
 }
 
 func (v NullableList) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableList) UnmarshalJSON(src []byte) error {
-    v.isSet = true
+	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_list.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_list.go
@@ -46,7 +46,6 @@ func (o *List) GetVar123List() string {
 
 // GetVar123ListOk returns a tuple with the Var123List field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *List) GetVar123ListOk() (*string, bool) {
 	if o == nil || o.Var123List == nil {
 		return nil, false

--- a/samples/client/petstore/go-experimental/go-petstore/model_list.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_list.go
@@ -23,16 +23,16 @@ type List struct {
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
 func NewList() *List {
-    this := List{}
-    return &this
+	this := List{}
+	return &this
 }
 
 // NewListWithDefaults instantiates a new List object
 // This constructor will only assign default values to properties that have it defined,
 // but it doesn't guarantee that properties required by API are set
 func NewListWithDefaults() *List {
-    this := List{}
-    return &this
+	this := List{}
+	return &this
 }
 
 // GetVar123List returns the Var123List field value if set, zero value otherwise.
@@ -44,14 +44,14 @@ func (o *List) GetVar123List() string {
 	return *o.Var123List
 }
 
-// GetVar123ListOk returns a tuple with the Var123List field value if set, zero value otherwise
+// GetVar123ListOk returns a tuple with the Var123List field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *List) GetVar123ListOk() (string, bool) {
+
+func (o *List) GetVar123ListOk() (*string, bool) {
 	if o == nil || o.Var123List == nil {
-		var ret string
-		return ret, false
+		return nil, false
 	}
-	return *o.Var123List, true
+	return o.Var123List, true
 }
 
 // HasVar123List returns a boolean if a field has been set.

--- a/samples/client/petstore/go-experimental/go-petstore/model_map_test_.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_map_test_.go
@@ -196,7 +196,7 @@ func (v NullableMapTest) Get() *MapTest {
 	return v.value
 }
 
-func (v NullableMapTest) Set(val *MapTest) {
+func (v *NullableMapTest) Set(val *MapTest) {
 	v.value = val
 	v.isSet = true
 }
@@ -205,7 +205,7 @@ func (v NullableMapTest) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableMapTest) Unset() {
+func (v *NullableMapTest) Unset() {
 	v.value = nil
 	v.isSet = false
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_map_test_.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_map_test_.go
@@ -49,7 +49,6 @@ func (o *MapTest) GetMapMapOfString() map[string]map[string]string {
 
 // GetMapMapOfStringOk returns a tuple with the MapMapOfString field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *MapTest) GetMapMapOfStringOk() (*map[string]map[string]string, bool) {
 	if o == nil || o.MapMapOfString == nil {
 		return nil, false
@@ -82,7 +81,6 @@ func (o *MapTest) GetMapOfEnumString() map[string]string {
 
 // GetMapOfEnumStringOk returns a tuple with the MapOfEnumString field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *MapTest) GetMapOfEnumStringOk() (*map[string]string, bool) {
 	if o == nil || o.MapOfEnumString == nil {
 		return nil, false
@@ -115,7 +113,6 @@ func (o *MapTest) GetDirectMap() map[string]bool {
 
 // GetDirectMapOk returns a tuple with the DirectMap field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *MapTest) GetDirectMapOk() (*map[string]bool, bool) {
 	if o == nil || o.DirectMap == nil {
 		return nil, false
@@ -148,7 +145,6 @@ func (o *MapTest) GetIndirectMap() map[string]bool {
 
 // GetIndirectMapOk returns a tuple with the IndirectMap field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *MapTest) GetIndirectMapOk() (*map[string]bool, bool) {
 	if o == nil || o.IndirectMap == nil {
 		return nil, false

--- a/samples/client/petstore/go-experimental/go-petstore/model_map_test_.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_map_test_.go
@@ -54,12 +54,12 @@ func (o *MapTest) GetMapMapOfStringOk() (map[string]map[string]string, bool) {
 		var ret map[string]map[string]string
 		return ret, false
 	}
-    return *o.MapMapOfString, true
+	return *o.MapMapOfString, true
 }
 
 // HasMapMapOfString returns a boolean if a field has been set.
 func (o *MapTest) HasMapMapOfString() bool {
-    if o != nil && o.MapMapOfString != nil {
+	if o != nil && o.MapMapOfString != nil {
 		return true
 	}
 
@@ -87,12 +87,12 @@ func (o *MapTest) GetMapOfEnumStringOk() (map[string]string, bool) {
 		var ret map[string]string
 		return ret, false
 	}
-    return *o.MapOfEnumString, true
+	return *o.MapOfEnumString, true
 }
 
 // HasMapOfEnumString returns a boolean if a field has been set.
 func (o *MapTest) HasMapOfEnumString() bool {
-    if o != nil && o.MapOfEnumString != nil {
+	if o != nil && o.MapOfEnumString != nil {
 		return true
 	}
 
@@ -120,12 +120,12 @@ func (o *MapTest) GetDirectMapOk() (map[string]bool, bool) {
 		var ret map[string]bool
 		return ret, false
 	}
-    return *o.DirectMap, true
+	return *o.DirectMap, true
 }
 
 // HasDirectMap returns a boolean if a field has been set.
 func (o *MapTest) HasDirectMap() bool {
-    if o != nil && o.DirectMap != nil {
+	if o != nil && o.DirectMap != nil {
 		return true
 	}
 
@@ -153,12 +153,12 @@ func (o *MapTest) GetIndirectMapOk() (map[string]bool, bool) {
 		var ret map[string]bool
 		return ret, false
 	}
-    return *o.IndirectMap, true
+	return *o.IndirectMap, true
 }
 
 // HasIndirectMap returns a boolean if a field has been set.
 func (o *MapTest) HasIndirectMap() bool {
-    if o != nil && o.IndirectMap != nil {
+	if o != nil && o.IndirectMap != nil {
 		return true
 	}
 
@@ -171,20 +171,20 @@ func (o *MapTest) SetIndirectMap(v map[string]bool) {
 }
 
 func (o MapTest) MarshalJSON() ([]byte, error) {
-    toSerialize := map[string]interface{}{}
-    if o.MapMapOfString != nil {
-        toSerialize["map_map_of_string"] = o.MapMapOfString
-    }
-    if o.MapOfEnumString != nil {
-        toSerialize["map_of_enum_string"] = o.MapOfEnumString
-    }
-    if o.DirectMap != nil {
-        toSerialize["direct_map"] = o.DirectMap
-    }
-    if o.IndirectMap != nil {
-        toSerialize["indirect_map"] = o.IndirectMap
-    }
-    return json.Marshal(toSerialize)
+	toSerialize := map[string]interface{}{}
+	if o.MapMapOfString != nil {
+		toSerialize["map_map_of_string"] = o.MapMapOfString
+	}
+	if o.MapOfEnumString != nil {
+		toSerialize["map_of_enum_string"] = o.MapOfEnumString
+	}
+	if o.DirectMap != nil {
+		toSerialize["direct_map"] = o.DirectMap
+	}
+	if o.IndirectMap != nil {
+		toSerialize["indirect_map"] = o.IndirectMap
+	}
+	return json.Marshal(toSerialize)
 }
 
 type NullableMapTest struct {
@@ -193,32 +193,32 @@ type NullableMapTest struct {
 }
 
 func (v NullableMapTest) Get() *MapTest {
-    return v.value
+	return v.value
 }
 
 func (v NullableMapTest) Set(val *MapTest) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableMapTest) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableMapTest) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableMapTest(val *MapTest) *NullableMapTest {
-    return &NullableMapTest{value: val, isSet: true}
+	return &NullableMapTest{value: val, isSet: true}
 }
 
 func (v NullableMapTest) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableMapTest) UnmarshalJSON(src []byte) error {
-    v.isSet = true
+	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_map_test_.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_map_test_.go
@@ -26,16 +26,16 @@ type MapTest struct {
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
 func NewMapTest() *MapTest {
-    this := MapTest{}
-    return &this
+	this := MapTest{}
+	return &this
 }
 
 // NewMapTestWithDefaults instantiates a new MapTest object
 // This constructor will only assign default values to properties that have it defined,
 // but it doesn't guarantee that properties required by API are set
 func NewMapTestWithDefaults() *MapTest {
-    this := MapTest{}
-    return &this
+	this := MapTest{}
+	return &this
 }
 
 // GetMapMapOfString returns the MapMapOfString field value if set, zero value otherwise.
@@ -47,14 +47,14 @@ func (o *MapTest) GetMapMapOfString() map[string]map[string]string {
 	return *o.MapMapOfString
 }
 
-// GetMapMapOfStringOk returns a tuple with the MapMapOfString field value if set, zero value otherwise
+// GetMapMapOfStringOk returns a tuple with the MapMapOfString field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *MapTest) GetMapMapOfStringOk() (map[string]map[string]string, bool) {
+
+func (o *MapTest) GetMapMapOfStringOk() (*map[string]map[string]string, bool) {
 	if o == nil || o.MapMapOfString == nil {
-		var ret map[string]map[string]string
-		return ret, false
+		return nil, false
 	}
-	return *o.MapMapOfString, true
+	return o.MapMapOfString, true
 }
 
 // HasMapMapOfString returns a boolean if a field has been set.
@@ -80,14 +80,14 @@ func (o *MapTest) GetMapOfEnumString() map[string]string {
 	return *o.MapOfEnumString
 }
 
-// GetMapOfEnumStringOk returns a tuple with the MapOfEnumString field value if set, zero value otherwise
+// GetMapOfEnumStringOk returns a tuple with the MapOfEnumString field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *MapTest) GetMapOfEnumStringOk() (map[string]string, bool) {
+
+func (o *MapTest) GetMapOfEnumStringOk() (*map[string]string, bool) {
 	if o == nil || o.MapOfEnumString == nil {
-		var ret map[string]string
-		return ret, false
+		return nil, false
 	}
-	return *o.MapOfEnumString, true
+	return o.MapOfEnumString, true
 }
 
 // HasMapOfEnumString returns a boolean if a field has been set.
@@ -113,14 +113,14 @@ func (o *MapTest) GetDirectMap() map[string]bool {
 	return *o.DirectMap
 }
 
-// GetDirectMapOk returns a tuple with the DirectMap field value if set, zero value otherwise
+// GetDirectMapOk returns a tuple with the DirectMap field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *MapTest) GetDirectMapOk() (map[string]bool, bool) {
+
+func (o *MapTest) GetDirectMapOk() (*map[string]bool, bool) {
 	if o == nil || o.DirectMap == nil {
-		var ret map[string]bool
-		return ret, false
+		return nil, false
 	}
-	return *o.DirectMap, true
+	return o.DirectMap, true
 }
 
 // HasDirectMap returns a boolean if a field has been set.
@@ -146,14 +146,14 @@ func (o *MapTest) GetIndirectMap() map[string]bool {
 	return *o.IndirectMap
 }
 
-// GetIndirectMapOk returns a tuple with the IndirectMap field value if set, zero value otherwise
+// GetIndirectMapOk returns a tuple with the IndirectMap field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *MapTest) GetIndirectMapOk() (map[string]bool, bool) {
+
+func (o *MapTest) GetIndirectMapOk() (*map[string]bool, bool) {
 	if o == nil || o.IndirectMap == nil {
-		var ret map[string]bool
-		return ret, false
+		return nil, false
 	}
-	return *o.IndirectMap, true
+	return o.IndirectMap, true
 }
 
 // HasIndirectMap returns a boolean if a field has been set.

--- a/samples/client/petstore/go-experimental/go-petstore/model_map_test_.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_map_test_.go
@@ -10,7 +10,6 @@
 package petstore
 
 import (
-	"bytes"
 	"encoding/json"
 )
 
@@ -55,12 +54,12 @@ func (o *MapTest) GetMapMapOfStringOk() (map[string]map[string]string, bool) {
 		var ret map[string]map[string]string
 		return ret, false
 	}
-	return *o.MapMapOfString, true
+    return *o.MapMapOfString, true
 }
 
 // HasMapMapOfString returns a boolean if a field has been set.
 func (o *MapTest) HasMapMapOfString() bool {
-	if o != nil && o.MapMapOfString != nil {
+    if o != nil && o.MapMapOfString != nil {
 		return true
 	}
 
@@ -88,12 +87,12 @@ func (o *MapTest) GetMapOfEnumStringOk() (map[string]string, bool) {
 		var ret map[string]string
 		return ret, false
 	}
-	return *o.MapOfEnumString, true
+    return *o.MapOfEnumString, true
 }
 
 // HasMapOfEnumString returns a boolean if a field has been set.
 func (o *MapTest) HasMapOfEnumString() bool {
-	if o != nil && o.MapOfEnumString != nil {
+    if o != nil && o.MapOfEnumString != nil {
 		return true
 	}
 
@@ -121,12 +120,12 @@ func (o *MapTest) GetDirectMapOk() (map[string]bool, bool) {
 		var ret map[string]bool
 		return ret, false
 	}
-	return *o.DirectMap, true
+    return *o.DirectMap, true
 }
 
 // HasDirectMap returns a boolean if a field has been set.
 func (o *MapTest) HasDirectMap() bool {
-	if o != nil && o.DirectMap != nil {
+    if o != nil && o.DirectMap != nil {
 		return true
 	}
 
@@ -154,12 +153,12 @@ func (o *MapTest) GetIndirectMapOk() (map[string]bool, bool) {
 		var ret map[string]bool
 		return ret, false
 	}
-	return *o.IndirectMap, true
+    return *o.IndirectMap, true
 }
 
 // HasIndirectMap returns a boolean if a field has been set.
 func (o *MapTest) HasIndirectMap() bool {
-	if o != nil && o.IndirectMap != nil {
+    if o != nil && o.IndirectMap != nil {
 		return true
 	}
 
@@ -171,25 +170,55 @@ func (o *MapTest) SetIndirectMap(v map[string]bool) {
 	o.IndirectMap = &v
 }
 
+func (o MapTest) MarshalJSON() ([]byte, error) {
+    toSerialize := map[string]interface{}{}
+    if o.MapMapOfString != nil {
+        toSerialize["map_map_of_string"] = o.MapMapOfString
+    }
+    if o.MapOfEnumString != nil {
+        toSerialize["map_of_enum_string"] = o.MapOfEnumString
+    }
+    if o.DirectMap != nil {
+        toSerialize["direct_map"] = o.DirectMap
+    }
+    if o.IndirectMap != nil {
+        toSerialize["indirect_map"] = o.IndirectMap
+    }
+    return json.Marshal(toSerialize)
+}
+
 type NullableMapTest struct {
-	Value MapTest
-	ExplicitNull bool
+	value *MapTest
+	isSet bool
+}
+
+func (v NullableMapTest) Get() *MapTest {
+    return v.value
+}
+
+func (v NullableMapTest) Set(val *MapTest) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableMapTest) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableMapTest) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableMapTest(val *MapTest) *NullableMapTest {
+    return &NullableMapTest{value: val, isSet: true}
 }
 
 func (v NullableMapTest) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-		return json.Marshal(v.Value)
-	}
+    return json.Marshal(v.value)
 }
 
 func (v *NullableMapTest) UnmarshalJSON(src []byte) error {
-	if bytes.Equal(src, []byte("null")) {
-		v.ExplicitNull = true
-		return nil
-	}
-
-	return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_mixed_properties_and_additional_properties_class.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_mixed_properties_and_additional_properties_class.go
@@ -26,16 +26,16 @@ type MixedPropertiesAndAdditionalPropertiesClass struct {
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
 func NewMixedPropertiesAndAdditionalPropertiesClass() *MixedPropertiesAndAdditionalPropertiesClass {
-    this := MixedPropertiesAndAdditionalPropertiesClass{}
-    return &this
+	this := MixedPropertiesAndAdditionalPropertiesClass{}
+	return &this
 }
 
 // NewMixedPropertiesAndAdditionalPropertiesClassWithDefaults instantiates a new MixedPropertiesAndAdditionalPropertiesClass object
 // This constructor will only assign default values to properties that have it defined,
 // but it doesn't guarantee that properties required by API are set
 func NewMixedPropertiesAndAdditionalPropertiesClassWithDefaults() *MixedPropertiesAndAdditionalPropertiesClass {
-    this := MixedPropertiesAndAdditionalPropertiesClass{}
-    return &this
+	this := MixedPropertiesAndAdditionalPropertiesClass{}
+	return &this
 }
 
 // GetUuid returns the Uuid field value if set, zero value otherwise.
@@ -47,14 +47,14 @@ func (o *MixedPropertiesAndAdditionalPropertiesClass) GetUuid() string {
 	return *o.Uuid
 }
 
-// GetUuidOk returns a tuple with the Uuid field value if set, zero value otherwise
+// GetUuidOk returns a tuple with the Uuid field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *MixedPropertiesAndAdditionalPropertiesClass) GetUuidOk() (string, bool) {
+
+func (o *MixedPropertiesAndAdditionalPropertiesClass) GetUuidOk() (*string, bool) {
 	if o == nil || o.Uuid == nil {
-		var ret string
-		return ret, false
+		return nil, false
 	}
-	return *o.Uuid, true
+	return o.Uuid, true
 }
 
 // HasUuid returns a boolean if a field has been set.
@@ -80,14 +80,14 @@ func (o *MixedPropertiesAndAdditionalPropertiesClass) GetDateTime() time.Time {
 	return *o.DateTime
 }
 
-// GetDateTimeOk returns a tuple with the DateTime field value if set, zero value otherwise
+// GetDateTimeOk returns a tuple with the DateTime field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *MixedPropertiesAndAdditionalPropertiesClass) GetDateTimeOk() (time.Time, bool) {
+
+func (o *MixedPropertiesAndAdditionalPropertiesClass) GetDateTimeOk() (*time.Time, bool) {
 	if o == nil || o.DateTime == nil {
-		var ret time.Time
-		return ret, false
+		return nil, false
 	}
-	return *o.DateTime, true
+	return o.DateTime, true
 }
 
 // HasDateTime returns a boolean if a field has been set.
@@ -113,14 +113,14 @@ func (o *MixedPropertiesAndAdditionalPropertiesClass) GetMap() map[string]Animal
 	return *o.Map
 }
 
-// GetMapOk returns a tuple with the Map field value if set, zero value otherwise
+// GetMapOk returns a tuple with the Map field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *MixedPropertiesAndAdditionalPropertiesClass) GetMapOk() (map[string]Animal, bool) {
+
+func (o *MixedPropertiesAndAdditionalPropertiesClass) GetMapOk() (*map[string]Animal, bool) {
 	if o == nil || o.Map == nil {
-		var ret map[string]Animal
-		return ret, false
+		return nil, false
 	}
-	return *o.Map, true
+	return o.Map, true
 }
 
 // HasMap returns a boolean if a field has been set.

--- a/samples/client/petstore/go-experimental/go-petstore/model_mixed_properties_and_additional_properties_class.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_mixed_properties_and_additional_properties_class.go
@@ -10,7 +10,6 @@
 package petstore
 
 import (
-	"bytes"
 	"encoding/json"
 	"time"
 )
@@ -55,12 +54,12 @@ func (o *MixedPropertiesAndAdditionalPropertiesClass) GetUuidOk() (string, bool)
 		var ret string
 		return ret, false
 	}
-	return *o.Uuid, true
+    return *o.Uuid, true
 }
 
 // HasUuid returns a boolean if a field has been set.
 func (o *MixedPropertiesAndAdditionalPropertiesClass) HasUuid() bool {
-	if o != nil && o.Uuid != nil {
+    if o != nil && o.Uuid != nil {
 		return true
 	}
 
@@ -88,12 +87,12 @@ func (o *MixedPropertiesAndAdditionalPropertiesClass) GetDateTimeOk() (time.Time
 		var ret time.Time
 		return ret, false
 	}
-	return *o.DateTime, true
+    return *o.DateTime, true
 }
 
 // HasDateTime returns a boolean if a field has been set.
 func (o *MixedPropertiesAndAdditionalPropertiesClass) HasDateTime() bool {
-	if o != nil && o.DateTime != nil {
+    if o != nil && o.DateTime != nil {
 		return true
 	}
 
@@ -121,12 +120,12 @@ func (o *MixedPropertiesAndAdditionalPropertiesClass) GetMapOk() (map[string]Ani
 		var ret map[string]Animal
 		return ret, false
 	}
-	return *o.Map, true
+    return *o.Map, true
 }
 
 // HasMap returns a boolean if a field has been set.
 func (o *MixedPropertiesAndAdditionalPropertiesClass) HasMap() bool {
-	if o != nil && o.Map != nil {
+    if o != nil && o.Map != nil {
 		return true
 	}
 
@@ -138,25 +137,52 @@ func (o *MixedPropertiesAndAdditionalPropertiesClass) SetMap(v map[string]Animal
 	o.Map = &v
 }
 
+func (o MixedPropertiesAndAdditionalPropertiesClass) MarshalJSON() ([]byte, error) {
+    toSerialize := map[string]interface{}{}
+    if o.Uuid != nil {
+        toSerialize["uuid"] = o.Uuid
+    }
+    if o.DateTime != nil {
+        toSerialize["dateTime"] = o.DateTime
+    }
+    if o.Map != nil {
+        toSerialize["map"] = o.Map
+    }
+    return json.Marshal(toSerialize)
+}
+
 type NullableMixedPropertiesAndAdditionalPropertiesClass struct {
-	Value MixedPropertiesAndAdditionalPropertiesClass
-	ExplicitNull bool
+	value *MixedPropertiesAndAdditionalPropertiesClass
+	isSet bool
+}
+
+func (v NullableMixedPropertiesAndAdditionalPropertiesClass) Get() *MixedPropertiesAndAdditionalPropertiesClass {
+    return v.value
+}
+
+func (v NullableMixedPropertiesAndAdditionalPropertiesClass) Set(val *MixedPropertiesAndAdditionalPropertiesClass) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableMixedPropertiesAndAdditionalPropertiesClass) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableMixedPropertiesAndAdditionalPropertiesClass) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableMixedPropertiesAndAdditionalPropertiesClass(val *MixedPropertiesAndAdditionalPropertiesClass) *NullableMixedPropertiesAndAdditionalPropertiesClass {
+    return &NullableMixedPropertiesAndAdditionalPropertiesClass{value: val, isSet: true}
 }
 
 func (v NullableMixedPropertiesAndAdditionalPropertiesClass) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-		return json.Marshal(v.Value)
-	}
+    return json.Marshal(v.value)
 }
 
 func (v *NullableMixedPropertiesAndAdditionalPropertiesClass) UnmarshalJSON(src []byte) error {
-	if bytes.Equal(src, []byte("null")) {
-		v.ExplicitNull = true
-		return nil
-	}
-
-	return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_mixed_properties_and_additional_properties_class.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_mixed_properties_and_additional_properties_class.go
@@ -49,7 +49,6 @@ func (o *MixedPropertiesAndAdditionalPropertiesClass) GetUuid() string {
 
 // GetUuidOk returns a tuple with the Uuid field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *MixedPropertiesAndAdditionalPropertiesClass) GetUuidOk() (*string, bool) {
 	if o == nil || o.Uuid == nil {
 		return nil, false
@@ -82,7 +81,6 @@ func (o *MixedPropertiesAndAdditionalPropertiesClass) GetDateTime() time.Time {
 
 // GetDateTimeOk returns a tuple with the DateTime field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *MixedPropertiesAndAdditionalPropertiesClass) GetDateTimeOk() (*time.Time, bool) {
 	if o == nil || o.DateTime == nil {
 		return nil, false
@@ -115,7 +113,6 @@ func (o *MixedPropertiesAndAdditionalPropertiesClass) GetMap() map[string]Animal
 
 // GetMapOk returns a tuple with the Map field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *MixedPropertiesAndAdditionalPropertiesClass) GetMapOk() (*map[string]Animal, bool) {
 	if o == nil || o.Map == nil {
 		return nil, false

--- a/samples/client/petstore/go-experimental/go-petstore/model_mixed_properties_and_additional_properties_class.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_mixed_properties_and_additional_properties_class.go
@@ -160,7 +160,7 @@ func (v NullableMixedPropertiesAndAdditionalPropertiesClass) Get() *MixedPropert
 	return v.value
 }
 
-func (v NullableMixedPropertiesAndAdditionalPropertiesClass) Set(val *MixedPropertiesAndAdditionalPropertiesClass) {
+func (v *NullableMixedPropertiesAndAdditionalPropertiesClass) Set(val *MixedPropertiesAndAdditionalPropertiesClass) {
 	v.value = val
 	v.isSet = true
 }
@@ -169,7 +169,7 @@ func (v NullableMixedPropertiesAndAdditionalPropertiesClass) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableMixedPropertiesAndAdditionalPropertiesClass) Unset() {
+func (v *NullableMixedPropertiesAndAdditionalPropertiesClass) Unset() {
 	v.value = nil
 	v.isSet = false
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_mixed_properties_and_additional_properties_class.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_mixed_properties_and_additional_properties_class.go
@@ -54,12 +54,12 @@ func (o *MixedPropertiesAndAdditionalPropertiesClass) GetUuidOk() (string, bool)
 		var ret string
 		return ret, false
 	}
-    return *o.Uuid, true
+	return *o.Uuid, true
 }
 
 // HasUuid returns a boolean if a field has been set.
 func (o *MixedPropertiesAndAdditionalPropertiesClass) HasUuid() bool {
-    if o != nil && o.Uuid != nil {
+	if o != nil && o.Uuid != nil {
 		return true
 	}
 
@@ -87,12 +87,12 @@ func (o *MixedPropertiesAndAdditionalPropertiesClass) GetDateTimeOk() (time.Time
 		var ret time.Time
 		return ret, false
 	}
-    return *o.DateTime, true
+	return *o.DateTime, true
 }
 
 // HasDateTime returns a boolean if a field has been set.
 func (o *MixedPropertiesAndAdditionalPropertiesClass) HasDateTime() bool {
-    if o != nil && o.DateTime != nil {
+	if o != nil && o.DateTime != nil {
 		return true
 	}
 
@@ -120,12 +120,12 @@ func (o *MixedPropertiesAndAdditionalPropertiesClass) GetMapOk() (map[string]Ani
 		var ret map[string]Animal
 		return ret, false
 	}
-    return *o.Map, true
+	return *o.Map, true
 }
 
 // HasMap returns a boolean if a field has been set.
 func (o *MixedPropertiesAndAdditionalPropertiesClass) HasMap() bool {
-    if o != nil && o.Map != nil {
+	if o != nil && o.Map != nil {
 		return true
 	}
 
@@ -138,17 +138,17 @@ func (o *MixedPropertiesAndAdditionalPropertiesClass) SetMap(v map[string]Animal
 }
 
 func (o MixedPropertiesAndAdditionalPropertiesClass) MarshalJSON() ([]byte, error) {
-    toSerialize := map[string]interface{}{}
-    if o.Uuid != nil {
-        toSerialize["uuid"] = o.Uuid
-    }
-    if o.DateTime != nil {
-        toSerialize["dateTime"] = o.DateTime
-    }
-    if o.Map != nil {
-        toSerialize["map"] = o.Map
-    }
-    return json.Marshal(toSerialize)
+	toSerialize := map[string]interface{}{}
+	if o.Uuid != nil {
+		toSerialize["uuid"] = o.Uuid
+	}
+	if o.DateTime != nil {
+		toSerialize["dateTime"] = o.DateTime
+	}
+	if o.Map != nil {
+		toSerialize["map"] = o.Map
+	}
+	return json.Marshal(toSerialize)
 }
 
 type NullableMixedPropertiesAndAdditionalPropertiesClass struct {
@@ -157,32 +157,32 @@ type NullableMixedPropertiesAndAdditionalPropertiesClass struct {
 }
 
 func (v NullableMixedPropertiesAndAdditionalPropertiesClass) Get() *MixedPropertiesAndAdditionalPropertiesClass {
-    return v.value
+	return v.value
 }
 
 func (v NullableMixedPropertiesAndAdditionalPropertiesClass) Set(val *MixedPropertiesAndAdditionalPropertiesClass) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableMixedPropertiesAndAdditionalPropertiesClass) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableMixedPropertiesAndAdditionalPropertiesClass) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableMixedPropertiesAndAdditionalPropertiesClass(val *MixedPropertiesAndAdditionalPropertiesClass) *NullableMixedPropertiesAndAdditionalPropertiesClass {
-    return &NullableMixedPropertiesAndAdditionalPropertiesClass{value: val, isSet: true}
+	return &NullableMixedPropertiesAndAdditionalPropertiesClass{value: val, isSet: true}
 }
 
 func (v NullableMixedPropertiesAndAdditionalPropertiesClass) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableMixedPropertiesAndAdditionalPropertiesClass) UnmarshalJSON(src []byte) error {
-    v.isSet = true
+	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_name.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_name.go
@@ -179,7 +179,7 @@ func (v NullableName) Get() *Name {
 	return v.value
 }
 
-func (v NullableName) Set(val *Name) {
+func (v *NullableName) Set(val *Name) {
 	v.value = val
 	v.isSet = true
 }
@@ -188,7 +188,7 @@ func (v NullableName) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableName) Unset() {
+func (v *NullableName) Unset() {
 	v.value = nil
 	v.isSet = false
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_name.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_name.go
@@ -51,12 +51,11 @@ func (o *Name) GetName() int32 {
 
 // GetNameOk returns a tuple with the Name field value
 // and a boolean to check if the value has been set.
-
 func (o *Name) GetNameOk() (*int32, bool) {
-    if o == nil  {
-        return nil, false
-    }
-    return &o.Name, true
+	if o == nil  {
+		return nil, false
+	}
+	return &o.Name, true
 }
 
 // SetName sets field value
@@ -75,7 +74,6 @@ func (o *Name) GetSnakeCase() int32 {
 
 // GetSnakeCaseOk returns a tuple with the SnakeCase field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *Name) GetSnakeCaseOk() (*int32, bool) {
 	if o == nil || o.SnakeCase == nil {
 		return nil, false
@@ -108,7 +106,6 @@ func (o *Name) GetProperty() string {
 
 // GetPropertyOk returns a tuple with the Property field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *Name) GetPropertyOk() (*string, bool) {
 	if o == nil || o.Property == nil {
 		return nil, false
@@ -141,7 +138,6 @@ func (o *Name) GetVar123Number() int32 {
 
 // GetVar123NumberOk returns a tuple with the Var123Number field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *Name) GetVar123NumberOk() (*int32, bool) {
 	if o == nil || o.Var123Number == nil {
 		return nil, false

--- a/samples/client/petstore/go-experimental/go-petstore/model_name.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_name.go
@@ -10,7 +10,6 @@
 package petstore
 
 import (
-	"bytes"
 	"encoding/json"
 )
 
@@ -71,12 +70,12 @@ func (o *Name) GetSnakeCaseOk() (int32, bool) {
 		var ret int32
 		return ret, false
 	}
-	return *o.SnakeCase, true
+    return *o.SnakeCase, true
 }
 
 // HasSnakeCase returns a boolean if a field has been set.
 func (o *Name) HasSnakeCase() bool {
-	if o != nil && o.SnakeCase != nil {
+    if o != nil && o.SnakeCase != nil {
 		return true
 	}
 
@@ -104,12 +103,12 @@ func (o *Name) GetPropertyOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-	return *o.Property, true
+    return *o.Property, true
 }
 
 // HasProperty returns a boolean if a field has been set.
 func (o *Name) HasProperty() bool {
-	if o != nil && o.Property != nil {
+    if o != nil && o.Property != nil {
 		return true
 	}
 
@@ -137,12 +136,12 @@ func (o *Name) GetVar123NumberOk() (int32, bool) {
 		var ret int32
 		return ret, false
 	}
-	return *o.Var123Number, true
+    return *o.Var123Number, true
 }
 
 // HasVar123Number returns a boolean if a field has been set.
 func (o *Name) HasVar123Number() bool {
-	if o != nil && o.Var123Number != nil {
+    if o != nil && o.Var123Number != nil {
 		return true
 	}
 
@@ -154,25 +153,55 @@ func (o *Name) SetVar123Number(v int32) {
 	o.Var123Number = &v
 }
 
+func (o Name) MarshalJSON() ([]byte, error) {
+    toSerialize := map[string]interface{}{}
+    if true {
+        toSerialize["name"] = o.Name
+    }
+    if o.SnakeCase != nil {
+        toSerialize["snake_case"] = o.SnakeCase
+    }
+    if o.Property != nil {
+        toSerialize["property"] = o.Property
+    }
+    if o.Var123Number != nil {
+        toSerialize["123Number"] = o.Var123Number
+    }
+    return json.Marshal(toSerialize)
+}
+
 type NullableName struct {
-	Value Name
-	ExplicitNull bool
+	value *Name
+	isSet bool
+}
+
+func (v NullableName) Get() *Name {
+    return v.value
+}
+
+func (v NullableName) Set(val *Name) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableName) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableName) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableName(val *Name) *NullableName {
+    return &NullableName{value: val, isSet: true}
 }
 
 func (v NullableName) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-		return json.Marshal(v.Value)
-	}
+    return json.Marshal(v.value)
 }
 
 func (v *NullableName) UnmarshalJSON(src []byte) error {
-	if bytes.Equal(src, []byte("null")) {
-		v.ExplicitNull = true
-		return nil
-	}
-
-	return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_name.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_name.go
@@ -70,12 +70,12 @@ func (o *Name) GetSnakeCaseOk() (int32, bool) {
 		var ret int32
 		return ret, false
 	}
-    return *o.SnakeCase, true
+	return *o.SnakeCase, true
 }
 
 // HasSnakeCase returns a boolean if a field has been set.
 func (o *Name) HasSnakeCase() bool {
-    if o != nil && o.SnakeCase != nil {
+	if o != nil && o.SnakeCase != nil {
 		return true
 	}
 
@@ -103,12 +103,12 @@ func (o *Name) GetPropertyOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-    return *o.Property, true
+	return *o.Property, true
 }
 
 // HasProperty returns a boolean if a field has been set.
 func (o *Name) HasProperty() bool {
-    if o != nil && o.Property != nil {
+	if o != nil && o.Property != nil {
 		return true
 	}
 
@@ -136,12 +136,12 @@ func (o *Name) GetVar123NumberOk() (int32, bool) {
 		var ret int32
 		return ret, false
 	}
-    return *o.Var123Number, true
+	return *o.Var123Number, true
 }
 
 // HasVar123Number returns a boolean if a field has been set.
 func (o *Name) HasVar123Number() bool {
-    if o != nil && o.Var123Number != nil {
+	if o != nil && o.Var123Number != nil {
 		return true
 	}
 
@@ -154,20 +154,20 @@ func (o *Name) SetVar123Number(v int32) {
 }
 
 func (o Name) MarshalJSON() ([]byte, error) {
-    toSerialize := map[string]interface{}{}
-    if true {
-        toSerialize["name"] = o.Name
-    }
-    if o.SnakeCase != nil {
-        toSerialize["snake_case"] = o.SnakeCase
-    }
-    if o.Property != nil {
-        toSerialize["property"] = o.Property
-    }
-    if o.Var123Number != nil {
-        toSerialize["123Number"] = o.Var123Number
-    }
-    return json.Marshal(toSerialize)
+	toSerialize := map[string]interface{}{}
+	if true {
+		toSerialize["name"] = o.Name
+	}
+	if o.SnakeCase != nil {
+		toSerialize["snake_case"] = o.SnakeCase
+	}
+	if o.Property != nil {
+		toSerialize["property"] = o.Property
+	}
+	if o.Var123Number != nil {
+		toSerialize["123Number"] = o.Var123Number
+	}
+	return json.Marshal(toSerialize)
 }
 
 type NullableName struct {
@@ -176,32 +176,32 @@ type NullableName struct {
 }
 
 func (v NullableName) Get() *Name {
-    return v.value
+	return v.value
 }
 
 func (v NullableName) Set(val *Name) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableName) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableName) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableName(val *Name) *NullableName {
-    return &NullableName{value: val, isSet: true}
+	return &NullableName{value: val, isSet: true}
 }
 
 func (v NullableName) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableName) UnmarshalJSON(src []byte) error {
-    v.isSet = true
+	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_name.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_name.go
@@ -26,27 +26,37 @@ type Name struct {
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
 func NewName(name int32, ) *Name {
-    this := Name{}
-    this.Name = name
-    return &this
+	this := Name{}
+	this.Name = name
+	return &this
 }
 
 // NewNameWithDefaults instantiates a new Name object
 // This constructor will only assign default values to properties that have it defined,
 // but it doesn't guarantee that properties required by API are set
 func NewNameWithDefaults() *Name {
-    this := Name{}
-    return &this
+	this := Name{}
+	return &this
 }
 
 // GetName returns the Name field value
 func (o *Name) GetName() int32 {
-	if o == nil {
+	if o == nil  {
 		var ret int32
 		return ret
 	}
 
 	return o.Name
+}
+
+// GetNameOk returns a tuple with the Name field value
+// and a boolean to check if the value has been set.
+
+func (o *Name) GetNameOk() (*int32, bool) {
+    if o == nil  {
+        return nil, false
+    }
+    return &o.Name, true
 }
 
 // SetName sets field value
@@ -63,14 +73,14 @@ func (o *Name) GetSnakeCase() int32 {
 	return *o.SnakeCase
 }
 
-// GetSnakeCaseOk returns a tuple with the SnakeCase field value if set, zero value otherwise
+// GetSnakeCaseOk returns a tuple with the SnakeCase field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *Name) GetSnakeCaseOk() (int32, bool) {
+
+func (o *Name) GetSnakeCaseOk() (*int32, bool) {
 	if o == nil || o.SnakeCase == nil {
-		var ret int32
-		return ret, false
+		return nil, false
 	}
-	return *o.SnakeCase, true
+	return o.SnakeCase, true
 }
 
 // HasSnakeCase returns a boolean if a field has been set.
@@ -96,14 +106,14 @@ func (o *Name) GetProperty() string {
 	return *o.Property
 }
 
-// GetPropertyOk returns a tuple with the Property field value if set, zero value otherwise
+// GetPropertyOk returns a tuple with the Property field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *Name) GetPropertyOk() (string, bool) {
+
+func (o *Name) GetPropertyOk() (*string, bool) {
 	if o == nil || o.Property == nil {
-		var ret string
-		return ret, false
+		return nil, false
 	}
-	return *o.Property, true
+	return o.Property, true
 }
 
 // HasProperty returns a boolean if a field has been set.
@@ -129,14 +139,14 @@ func (o *Name) GetVar123Number() int32 {
 	return *o.Var123Number
 }
 
-// GetVar123NumberOk returns a tuple with the Var123Number field value if set, zero value otherwise
+// GetVar123NumberOk returns a tuple with the Var123Number field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *Name) GetVar123NumberOk() (int32, bool) {
+
+func (o *Name) GetVar123NumberOk() (*int32, bool) {
 	if o == nil || o.Var123Number == nil {
-		var ret int32
-		return ret, false
+		return nil, false
 	}
-	return *o.Var123Number, true
+	return o.Var123Number, true
 }
 
 // HasVar123Number returns a boolean if a field has been set.

--- a/samples/client/petstore/go-experimental/go-petstore/model_number_only.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_number_only.go
@@ -85,7 +85,7 @@ func (v NullableNumberOnly) Get() *NumberOnly {
 	return v.value
 }
 
-func (v NullableNumberOnly) Set(val *NumberOnly) {
+func (v *NullableNumberOnly) Set(val *NumberOnly) {
 	v.value = val
 	v.isSet = true
 }
@@ -94,7 +94,7 @@ func (v NullableNumberOnly) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableNumberOnly) Unset() {
+func (v *NullableNumberOnly) Unset() {
 	v.value = nil
 	v.isSet = false
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_number_only.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_number_only.go
@@ -51,12 +51,12 @@ func (o *NumberOnly) GetJustNumberOk() (float32, bool) {
 		var ret float32
 		return ret, false
 	}
-    return *o.JustNumber, true
+	return *o.JustNumber, true
 }
 
 // HasJustNumber returns a boolean if a field has been set.
 func (o *NumberOnly) HasJustNumber() bool {
-    if o != nil && o.JustNumber != nil {
+	if o != nil && o.JustNumber != nil {
 		return true
 	}
 
@@ -69,11 +69,11 @@ func (o *NumberOnly) SetJustNumber(v float32) {
 }
 
 func (o NumberOnly) MarshalJSON() ([]byte, error) {
-    toSerialize := map[string]interface{}{}
-    if o.JustNumber != nil {
-        toSerialize["JustNumber"] = o.JustNumber
-    }
-    return json.Marshal(toSerialize)
+	toSerialize := map[string]interface{}{}
+	if o.JustNumber != nil {
+		toSerialize["JustNumber"] = o.JustNumber
+	}
+	return json.Marshal(toSerialize)
 }
 
 type NullableNumberOnly struct {
@@ -82,32 +82,32 @@ type NullableNumberOnly struct {
 }
 
 func (v NullableNumberOnly) Get() *NumberOnly {
-    return v.value
+	return v.value
 }
 
 func (v NullableNumberOnly) Set(val *NumberOnly) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableNumberOnly) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableNumberOnly) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableNumberOnly(val *NumberOnly) *NullableNumberOnly {
-    return &NullableNumberOnly{value: val, isSet: true}
+	return &NullableNumberOnly{value: val, isSet: true}
 }
 
 func (v NullableNumberOnly) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableNumberOnly) UnmarshalJSON(src []byte) error {
-    v.isSet = true
+	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_number_only.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_number_only.go
@@ -10,7 +10,6 @@
 package petstore
 
 import (
-	"bytes"
 	"encoding/json"
 )
 
@@ -52,12 +51,12 @@ func (o *NumberOnly) GetJustNumberOk() (float32, bool) {
 		var ret float32
 		return ret, false
 	}
-	return *o.JustNumber, true
+    return *o.JustNumber, true
 }
 
 // HasJustNumber returns a boolean if a field has been set.
 func (o *NumberOnly) HasJustNumber() bool {
-	if o != nil && o.JustNumber != nil {
+    if o != nil && o.JustNumber != nil {
 		return true
 	}
 
@@ -69,25 +68,46 @@ func (o *NumberOnly) SetJustNumber(v float32) {
 	o.JustNumber = &v
 }
 
+func (o NumberOnly) MarshalJSON() ([]byte, error) {
+    toSerialize := map[string]interface{}{}
+    if o.JustNumber != nil {
+        toSerialize["JustNumber"] = o.JustNumber
+    }
+    return json.Marshal(toSerialize)
+}
+
 type NullableNumberOnly struct {
-	Value NumberOnly
-	ExplicitNull bool
+	value *NumberOnly
+	isSet bool
+}
+
+func (v NullableNumberOnly) Get() *NumberOnly {
+    return v.value
+}
+
+func (v NullableNumberOnly) Set(val *NumberOnly) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableNumberOnly) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableNumberOnly) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableNumberOnly(val *NumberOnly) *NullableNumberOnly {
+    return &NullableNumberOnly{value: val, isSet: true}
 }
 
 func (v NullableNumberOnly) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-		return json.Marshal(v.Value)
-	}
+    return json.Marshal(v.value)
 }
 
 func (v *NullableNumberOnly) UnmarshalJSON(src []byte) error {
-	if bytes.Equal(src, []byte("null")) {
-		v.ExplicitNull = true
-		return nil
-	}
-
-	return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_number_only.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_number_only.go
@@ -23,16 +23,16 @@ type NumberOnly struct {
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
 func NewNumberOnly() *NumberOnly {
-    this := NumberOnly{}
-    return &this
+	this := NumberOnly{}
+	return &this
 }
 
 // NewNumberOnlyWithDefaults instantiates a new NumberOnly object
 // This constructor will only assign default values to properties that have it defined,
 // but it doesn't guarantee that properties required by API are set
 func NewNumberOnlyWithDefaults() *NumberOnly {
-    this := NumberOnly{}
-    return &this
+	this := NumberOnly{}
+	return &this
 }
 
 // GetJustNumber returns the JustNumber field value if set, zero value otherwise.
@@ -44,14 +44,14 @@ func (o *NumberOnly) GetJustNumber() float32 {
 	return *o.JustNumber
 }
 
-// GetJustNumberOk returns a tuple with the JustNumber field value if set, zero value otherwise
+// GetJustNumberOk returns a tuple with the JustNumber field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *NumberOnly) GetJustNumberOk() (float32, bool) {
+
+func (o *NumberOnly) GetJustNumberOk() (*float32, bool) {
 	if o == nil || o.JustNumber == nil {
-		var ret float32
-		return ret, false
+		return nil, false
 	}
-	return *o.JustNumber, true
+	return o.JustNumber, true
 }
 
 // HasJustNumber returns a boolean if a field has been set.

--- a/samples/client/petstore/go-experimental/go-petstore/model_number_only.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_number_only.go
@@ -46,7 +46,6 @@ func (o *NumberOnly) GetJustNumber() float32 {
 
 // GetJustNumberOk returns a tuple with the JustNumber field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *NumberOnly) GetJustNumberOk() (*float32, bool) {
 	if o == nil || o.JustNumber == nil {
 		return nil, false

--- a/samples/client/petstore/go-experimental/go-petstore/model_order.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_order.go
@@ -276,7 +276,7 @@ func (v NullableOrder) Get() *Order {
 	return v.value
 }
 
-func (v NullableOrder) Set(val *Order) {
+func (v *NullableOrder) Set(val *Order) {
 	v.value = val
 	v.isSet = true
 }
@@ -285,7 +285,7 @@ func (v NullableOrder) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableOrder) Unset() {
+func (v *NullableOrder) Unset() {
 	v.value = nil
 	v.isSet = false
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_order.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_order.go
@@ -31,8 +31,8 @@ type Order struct {
 // will change when the set of required properties is changed
 func NewOrder() *Order {
     this := Order{}
-    var complete bool = false
-    this.Complete = &complete
+	var complete bool = false
+	this.Complete = &complete
     return &this
 }
 
@@ -41,8 +41,8 @@ func NewOrder() *Order {
 // but it doesn't guarantee that properties required by API are set
 func NewOrderWithDefaults() *Order {
     this := Order{}
-    var complete bool = false
-    this.Complete = &complete
+	var complete bool = false
+	this.Complete = &complete
     return &this
 }
 
@@ -62,12 +62,12 @@ func (o *Order) GetIdOk() (int64, bool) {
 		var ret int64
 		return ret, false
 	}
-    return *o.Id, true
+	return *o.Id, true
 }
 
 // HasId returns a boolean if a field has been set.
 func (o *Order) HasId() bool {
-    if o != nil && o.Id != nil {
+	if o != nil && o.Id != nil {
 		return true
 	}
 
@@ -95,12 +95,12 @@ func (o *Order) GetPetIdOk() (int64, bool) {
 		var ret int64
 		return ret, false
 	}
-    return *o.PetId, true
+	return *o.PetId, true
 }
 
 // HasPetId returns a boolean if a field has been set.
 func (o *Order) HasPetId() bool {
-    if o != nil && o.PetId != nil {
+	if o != nil && o.PetId != nil {
 		return true
 	}
 
@@ -128,12 +128,12 @@ func (o *Order) GetQuantityOk() (int32, bool) {
 		var ret int32
 		return ret, false
 	}
-    return *o.Quantity, true
+	return *o.Quantity, true
 }
 
 // HasQuantity returns a boolean if a field has been set.
 func (o *Order) HasQuantity() bool {
-    if o != nil && o.Quantity != nil {
+	if o != nil && o.Quantity != nil {
 		return true
 	}
 
@@ -161,12 +161,12 @@ func (o *Order) GetShipDateOk() (time.Time, bool) {
 		var ret time.Time
 		return ret, false
 	}
-    return *o.ShipDate, true
+	return *o.ShipDate, true
 }
 
 // HasShipDate returns a boolean if a field has been set.
 func (o *Order) HasShipDate() bool {
-    if o != nil && o.ShipDate != nil {
+	if o != nil && o.ShipDate != nil {
 		return true
 	}
 
@@ -194,12 +194,12 @@ func (o *Order) GetStatusOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-    return *o.Status, true
+	return *o.Status, true
 }
 
 // HasStatus returns a boolean if a field has been set.
 func (o *Order) HasStatus() bool {
-    if o != nil && o.Status != nil {
+	if o != nil && o.Status != nil {
 		return true
 	}
 
@@ -227,12 +227,12 @@ func (o *Order) GetCompleteOk() (bool, bool) {
 		var ret bool
 		return ret, false
 	}
-    return *o.Complete, true
+	return *o.Complete, true
 }
 
 // HasComplete returns a boolean if a field has been set.
 func (o *Order) HasComplete() bool {
-    if o != nil && o.Complete != nil {
+	if o != nil && o.Complete != nil {
 		return true
 	}
 
@@ -245,26 +245,26 @@ func (o *Order) SetComplete(v bool) {
 }
 
 func (o Order) MarshalJSON() ([]byte, error) {
-    toSerialize := map[string]interface{}{}
-    if o.Id != nil {
-        toSerialize["id"] = o.Id
-    }
-    if o.PetId != nil {
-        toSerialize["petId"] = o.PetId
-    }
-    if o.Quantity != nil {
-        toSerialize["quantity"] = o.Quantity
-    }
-    if o.ShipDate != nil {
-        toSerialize["shipDate"] = o.ShipDate
-    }
-    if o.Status != nil {
-        toSerialize["status"] = o.Status
-    }
-    if o.Complete != nil {
-        toSerialize["complete"] = o.Complete
-    }
-    return json.Marshal(toSerialize)
+	toSerialize := map[string]interface{}{}
+	if o.Id != nil {
+		toSerialize["id"] = o.Id
+	}
+	if o.PetId != nil {
+		toSerialize["petId"] = o.PetId
+	}
+	if o.Quantity != nil {
+		toSerialize["quantity"] = o.Quantity
+	}
+	if o.ShipDate != nil {
+		toSerialize["shipDate"] = o.ShipDate
+	}
+	if o.Status != nil {
+		toSerialize["status"] = o.Status
+	}
+	if o.Complete != nil {
+		toSerialize["complete"] = o.Complete
+	}
+	return json.Marshal(toSerialize)
 }
 
 type NullableOrder struct {
@@ -273,32 +273,32 @@ type NullableOrder struct {
 }
 
 func (v NullableOrder) Get() *Order {
-    return v.value
+	return v.value
 }
 
 func (v NullableOrder) Set(val *Order) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableOrder) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableOrder) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableOrder(val *Order) *NullableOrder {
-    return &NullableOrder{value: val, isSet: true}
+	return &NullableOrder{value: val, isSet: true}
 }
 
 func (v NullableOrder) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableOrder) UnmarshalJSON(src []byte) error {
-    v.isSet = true
+	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_order.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_order.go
@@ -30,20 +30,20 @@ type Order struct {
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
 func NewOrder() *Order {
-    this := Order{}
+	this := Order{}
 	var complete bool = false
 	this.Complete = &complete
-    return &this
+	return &this
 }
 
 // NewOrderWithDefaults instantiates a new Order object
 // This constructor will only assign default values to properties that have it defined,
 // but it doesn't guarantee that properties required by API are set
 func NewOrderWithDefaults() *Order {
-    this := Order{}
+	this := Order{}
 	var complete bool = false
 	this.Complete = &complete
-    return &this
+	return &this
 }
 
 // GetId returns the Id field value if set, zero value otherwise.
@@ -55,14 +55,14 @@ func (o *Order) GetId() int64 {
 	return *o.Id
 }
 
-// GetIdOk returns a tuple with the Id field value if set, zero value otherwise
+// GetIdOk returns a tuple with the Id field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *Order) GetIdOk() (int64, bool) {
+
+func (o *Order) GetIdOk() (*int64, bool) {
 	if o == nil || o.Id == nil {
-		var ret int64
-		return ret, false
+		return nil, false
 	}
-	return *o.Id, true
+	return o.Id, true
 }
 
 // HasId returns a boolean if a field has been set.
@@ -88,14 +88,14 @@ func (o *Order) GetPetId() int64 {
 	return *o.PetId
 }
 
-// GetPetIdOk returns a tuple with the PetId field value if set, zero value otherwise
+// GetPetIdOk returns a tuple with the PetId field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *Order) GetPetIdOk() (int64, bool) {
+
+func (o *Order) GetPetIdOk() (*int64, bool) {
 	if o == nil || o.PetId == nil {
-		var ret int64
-		return ret, false
+		return nil, false
 	}
-	return *o.PetId, true
+	return o.PetId, true
 }
 
 // HasPetId returns a boolean if a field has been set.
@@ -121,14 +121,14 @@ func (o *Order) GetQuantity() int32 {
 	return *o.Quantity
 }
 
-// GetQuantityOk returns a tuple with the Quantity field value if set, zero value otherwise
+// GetQuantityOk returns a tuple with the Quantity field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *Order) GetQuantityOk() (int32, bool) {
+
+func (o *Order) GetQuantityOk() (*int32, bool) {
 	if o == nil || o.Quantity == nil {
-		var ret int32
-		return ret, false
+		return nil, false
 	}
-	return *o.Quantity, true
+	return o.Quantity, true
 }
 
 // HasQuantity returns a boolean if a field has been set.
@@ -154,14 +154,14 @@ func (o *Order) GetShipDate() time.Time {
 	return *o.ShipDate
 }
 
-// GetShipDateOk returns a tuple with the ShipDate field value if set, zero value otherwise
+// GetShipDateOk returns a tuple with the ShipDate field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *Order) GetShipDateOk() (time.Time, bool) {
+
+func (o *Order) GetShipDateOk() (*time.Time, bool) {
 	if o == nil || o.ShipDate == nil {
-		var ret time.Time
-		return ret, false
+		return nil, false
 	}
-	return *o.ShipDate, true
+	return o.ShipDate, true
 }
 
 // HasShipDate returns a boolean if a field has been set.
@@ -187,14 +187,14 @@ func (o *Order) GetStatus() string {
 	return *o.Status
 }
 
-// GetStatusOk returns a tuple with the Status field value if set, zero value otherwise
+// GetStatusOk returns a tuple with the Status field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *Order) GetStatusOk() (string, bool) {
+
+func (o *Order) GetStatusOk() (*string, bool) {
 	if o == nil || o.Status == nil {
-		var ret string
-		return ret, false
+		return nil, false
 	}
-	return *o.Status, true
+	return o.Status, true
 }
 
 // HasStatus returns a boolean if a field has been set.
@@ -220,14 +220,14 @@ func (o *Order) GetComplete() bool {
 	return *o.Complete
 }
 
-// GetCompleteOk returns a tuple with the Complete field value if set, zero value otherwise
+// GetCompleteOk returns a tuple with the Complete field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *Order) GetCompleteOk() (bool, bool) {
+
+func (o *Order) GetCompleteOk() (*bool, bool) {
 	if o == nil || o.Complete == nil {
-		var ret bool
-		return ret, false
+		return nil, false
 	}
-	return *o.Complete, true
+	return o.Complete, true
 }
 
 // HasComplete returns a boolean if a field has been set.

--- a/samples/client/petstore/go-experimental/go-petstore/model_order.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_order.go
@@ -10,7 +10,6 @@
 package petstore
 
 import (
-	"bytes"
 	"encoding/json"
 	"time"
 )
@@ -63,12 +62,12 @@ func (o *Order) GetIdOk() (int64, bool) {
 		var ret int64
 		return ret, false
 	}
-	return *o.Id, true
+    return *o.Id, true
 }
 
 // HasId returns a boolean if a field has been set.
 func (o *Order) HasId() bool {
-	if o != nil && o.Id != nil {
+    if o != nil && o.Id != nil {
 		return true
 	}
 
@@ -96,12 +95,12 @@ func (o *Order) GetPetIdOk() (int64, bool) {
 		var ret int64
 		return ret, false
 	}
-	return *o.PetId, true
+    return *o.PetId, true
 }
 
 // HasPetId returns a boolean if a field has been set.
 func (o *Order) HasPetId() bool {
-	if o != nil && o.PetId != nil {
+    if o != nil && o.PetId != nil {
 		return true
 	}
 
@@ -129,12 +128,12 @@ func (o *Order) GetQuantityOk() (int32, bool) {
 		var ret int32
 		return ret, false
 	}
-	return *o.Quantity, true
+    return *o.Quantity, true
 }
 
 // HasQuantity returns a boolean if a field has been set.
 func (o *Order) HasQuantity() bool {
-	if o != nil && o.Quantity != nil {
+    if o != nil && o.Quantity != nil {
 		return true
 	}
 
@@ -162,12 +161,12 @@ func (o *Order) GetShipDateOk() (time.Time, bool) {
 		var ret time.Time
 		return ret, false
 	}
-	return *o.ShipDate, true
+    return *o.ShipDate, true
 }
 
 // HasShipDate returns a boolean if a field has been set.
 func (o *Order) HasShipDate() bool {
-	if o != nil && o.ShipDate != nil {
+    if o != nil && o.ShipDate != nil {
 		return true
 	}
 
@@ -195,12 +194,12 @@ func (o *Order) GetStatusOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-	return *o.Status, true
+    return *o.Status, true
 }
 
 // HasStatus returns a boolean if a field has been set.
 func (o *Order) HasStatus() bool {
-	if o != nil && o.Status != nil {
+    if o != nil && o.Status != nil {
 		return true
 	}
 
@@ -228,12 +227,12 @@ func (o *Order) GetCompleteOk() (bool, bool) {
 		var ret bool
 		return ret, false
 	}
-	return *o.Complete, true
+    return *o.Complete, true
 }
 
 // HasComplete returns a boolean if a field has been set.
 func (o *Order) HasComplete() bool {
-	if o != nil && o.Complete != nil {
+    if o != nil && o.Complete != nil {
 		return true
 	}
 
@@ -245,25 +244,61 @@ func (o *Order) SetComplete(v bool) {
 	o.Complete = &v
 }
 
+func (o Order) MarshalJSON() ([]byte, error) {
+    toSerialize := map[string]interface{}{}
+    if o.Id != nil {
+        toSerialize["id"] = o.Id
+    }
+    if o.PetId != nil {
+        toSerialize["petId"] = o.PetId
+    }
+    if o.Quantity != nil {
+        toSerialize["quantity"] = o.Quantity
+    }
+    if o.ShipDate != nil {
+        toSerialize["shipDate"] = o.ShipDate
+    }
+    if o.Status != nil {
+        toSerialize["status"] = o.Status
+    }
+    if o.Complete != nil {
+        toSerialize["complete"] = o.Complete
+    }
+    return json.Marshal(toSerialize)
+}
+
 type NullableOrder struct {
-	Value Order
-	ExplicitNull bool
+	value *Order
+	isSet bool
+}
+
+func (v NullableOrder) Get() *Order {
+    return v.value
+}
+
+func (v NullableOrder) Set(val *Order) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableOrder) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableOrder) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableOrder(val *Order) *NullableOrder {
+    return &NullableOrder{value: val, isSet: true}
 }
 
 func (v NullableOrder) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-		return json.Marshal(v.Value)
-	}
+    return json.Marshal(v.value)
 }
 
 func (v *NullableOrder) UnmarshalJSON(src []byte) error {
-	if bytes.Equal(src, []byte("null")) {
-		v.ExplicitNull = true
-		return nil
-	}
-
-	return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_order.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_order.go
@@ -57,7 +57,6 @@ func (o *Order) GetId() int64 {
 
 // GetIdOk returns a tuple with the Id field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *Order) GetIdOk() (*int64, bool) {
 	if o == nil || o.Id == nil {
 		return nil, false
@@ -90,7 +89,6 @@ func (o *Order) GetPetId() int64 {
 
 // GetPetIdOk returns a tuple with the PetId field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *Order) GetPetIdOk() (*int64, bool) {
 	if o == nil || o.PetId == nil {
 		return nil, false
@@ -123,7 +121,6 @@ func (o *Order) GetQuantity() int32 {
 
 // GetQuantityOk returns a tuple with the Quantity field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *Order) GetQuantityOk() (*int32, bool) {
 	if o == nil || o.Quantity == nil {
 		return nil, false
@@ -156,7 +153,6 @@ func (o *Order) GetShipDate() time.Time {
 
 // GetShipDateOk returns a tuple with the ShipDate field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *Order) GetShipDateOk() (*time.Time, bool) {
 	if o == nil || o.ShipDate == nil {
 		return nil, false
@@ -189,7 +185,6 @@ func (o *Order) GetStatus() string {
 
 // GetStatusOk returns a tuple with the Status field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *Order) GetStatusOk() (*string, bool) {
 	if o == nil || o.Status == nil {
 		return nil, false
@@ -222,7 +217,6 @@ func (o *Order) GetComplete() bool {
 
 // GetCompleteOk returns a tuple with the Complete field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *Order) GetCompleteOk() (*bool, bool) {
 	if o == nil || o.Complete == nil {
 		return nil, false

--- a/samples/client/petstore/go-experimental/go-petstore/model_outer_composite.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_outer_composite.go
@@ -25,16 +25,16 @@ type OuterComposite struct {
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
 func NewOuterComposite() *OuterComposite {
-    this := OuterComposite{}
-    return &this
+	this := OuterComposite{}
+	return &this
 }
 
 // NewOuterCompositeWithDefaults instantiates a new OuterComposite object
 // This constructor will only assign default values to properties that have it defined,
 // but it doesn't guarantee that properties required by API are set
 func NewOuterCompositeWithDefaults() *OuterComposite {
-    this := OuterComposite{}
-    return &this
+	this := OuterComposite{}
+	return &this
 }
 
 // GetMyNumber returns the MyNumber field value if set, zero value otherwise.
@@ -46,14 +46,14 @@ func (o *OuterComposite) GetMyNumber() float32 {
 	return *o.MyNumber
 }
 
-// GetMyNumberOk returns a tuple with the MyNumber field value if set, zero value otherwise
+// GetMyNumberOk returns a tuple with the MyNumber field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *OuterComposite) GetMyNumberOk() (float32, bool) {
+
+func (o *OuterComposite) GetMyNumberOk() (*float32, bool) {
 	if o == nil || o.MyNumber == nil {
-		var ret float32
-		return ret, false
+		return nil, false
 	}
-	return *o.MyNumber, true
+	return o.MyNumber, true
 }
 
 // HasMyNumber returns a boolean if a field has been set.
@@ -79,14 +79,14 @@ func (o *OuterComposite) GetMyString() string {
 	return *o.MyString
 }
 
-// GetMyStringOk returns a tuple with the MyString field value if set, zero value otherwise
+// GetMyStringOk returns a tuple with the MyString field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *OuterComposite) GetMyStringOk() (string, bool) {
+
+func (o *OuterComposite) GetMyStringOk() (*string, bool) {
 	if o == nil || o.MyString == nil {
-		var ret string
-		return ret, false
+		return nil, false
 	}
-	return *o.MyString, true
+	return o.MyString, true
 }
 
 // HasMyString returns a boolean if a field has been set.
@@ -112,14 +112,14 @@ func (o *OuterComposite) GetMyBoolean() bool {
 	return *o.MyBoolean
 }
 
-// GetMyBooleanOk returns a tuple with the MyBoolean field value if set, zero value otherwise
+// GetMyBooleanOk returns a tuple with the MyBoolean field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *OuterComposite) GetMyBooleanOk() (bool, bool) {
+
+func (o *OuterComposite) GetMyBooleanOk() (*bool, bool) {
 	if o == nil || o.MyBoolean == nil {
-		var ret bool
-		return ret, false
+		return nil, false
 	}
-	return *o.MyBoolean, true
+	return o.MyBoolean, true
 }
 
 // HasMyBoolean returns a boolean if a field has been set.

--- a/samples/client/petstore/go-experimental/go-petstore/model_outer_composite.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_outer_composite.go
@@ -10,7 +10,6 @@
 package petstore
 
 import (
-	"bytes"
 	"encoding/json"
 )
 
@@ -54,12 +53,12 @@ func (o *OuterComposite) GetMyNumberOk() (float32, bool) {
 		var ret float32
 		return ret, false
 	}
-	return *o.MyNumber, true
+    return *o.MyNumber, true
 }
 
 // HasMyNumber returns a boolean if a field has been set.
 func (o *OuterComposite) HasMyNumber() bool {
-	if o != nil && o.MyNumber != nil {
+    if o != nil && o.MyNumber != nil {
 		return true
 	}
 
@@ -87,12 +86,12 @@ func (o *OuterComposite) GetMyStringOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-	return *o.MyString, true
+    return *o.MyString, true
 }
 
 // HasMyString returns a boolean if a field has been set.
 func (o *OuterComposite) HasMyString() bool {
-	if o != nil && o.MyString != nil {
+    if o != nil && o.MyString != nil {
 		return true
 	}
 
@@ -120,12 +119,12 @@ func (o *OuterComposite) GetMyBooleanOk() (bool, bool) {
 		var ret bool
 		return ret, false
 	}
-	return *o.MyBoolean, true
+    return *o.MyBoolean, true
 }
 
 // HasMyBoolean returns a boolean if a field has been set.
 func (o *OuterComposite) HasMyBoolean() bool {
-	if o != nil && o.MyBoolean != nil {
+    if o != nil && o.MyBoolean != nil {
 		return true
 	}
 
@@ -137,25 +136,52 @@ func (o *OuterComposite) SetMyBoolean(v bool) {
 	o.MyBoolean = &v
 }
 
+func (o OuterComposite) MarshalJSON() ([]byte, error) {
+    toSerialize := map[string]interface{}{}
+    if o.MyNumber != nil {
+        toSerialize["my_number"] = o.MyNumber
+    }
+    if o.MyString != nil {
+        toSerialize["my_string"] = o.MyString
+    }
+    if o.MyBoolean != nil {
+        toSerialize["my_boolean"] = o.MyBoolean
+    }
+    return json.Marshal(toSerialize)
+}
+
 type NullableOuterComposite struct {
-	Value OuterComposite
-	ExplicitNull bool
+	value *OuterComposite
+	isSet bool
+}
+
+func (v NullableOuterComposite) Get() *OuterComposite {
+    return v.value
+}
+
+func (v NullableOuterComposite) Set(val *OuterComposite) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableOuterComposite) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableOuterComposite) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableOuterComposite(val *OuterComposite) *NullableOuterComposite {
+    return &NullableOuterComposite{value: val, isSet: true}
 }
 
 func (v NullableOuterComposite) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-		return json.Marshal(v.Value)
-	}
+    return json.Marshal(v.value)
 }
 
 func (v *NullableOuterComposite) UnmarshalJSON(src []byte) error {
-	if bytes.Equal(src, []byte("null")) {
-		v.ExplicitNull = true
-		return nil
-	}
-
-	return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_outer_composite.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_outer_composite.go
@@ -48,7 +48,6 @@ func (o *OuterComposite) GetMyNumber() float32 {
 
 // GetMyNumberOk returns a tuple with the MyNumber field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *OuterComposite) GetMyNumberOk() (*float32, bool) {
 	if o == nil || o.MyNumber == nil {
 		return nil, false
@@ -81,7 +80,6 @@ func (o *OuterComposite) GetMyString() string {
 
 // GetMyStringOk returns a tuple with the MyString field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *OuterComposite) GetMyStringOk() (*string, bool) {
 	if o == nil || o.MyString == nil {
 		return nil, false
@@ -114,7 +112,6 @@ func (o *OuterComposite) GetMyBoolean() bool {
 
 // GetMyBooleanOk returns a tuple with the MyBoolean field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *OuterComposite) GetMyBooleanOk() (*bool, bool) {
 	if o == nil || o.MyBoolean == nil {
 		return nil, false

--- a/samples/client/petstore/go-experimental/go-petstore/model_outer_composite.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_outer_composite.go
@@ -53,12 +53,12 @@ func (o *OuterComposite) GetMyNumberOk() (float32, bool) {
 		var ret float32
 		return ret, false
 	}
-    return *o.MyNumber, true
+	return *o.MyNumber, true
 }
 
 // HasMyNumber returns a boolean if a field has been set.
 func (o *OuterComposite) HasMyNumber() bool {
-    if o != nil && o.MyNumber != nil {
+	if o != nil && o.MyNumber != nil {
 		return true
 	}
 
@@ -86,12 +86,12 @@ func (o *OuterComposite) GetMyStringOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-    return *o.MyString, true
+	return *o.MyString, true
 }
 
 // HasMyString returns a boolean if a field has been set.
 func (o *OuterComposite) HasMyString() bool {
-    if o != nil && o.MyString != nil {
+	if o != nil && o.MyString != nil {
 		return true
 	}
 
@@ -119,12 +119,12 @@ func (o *OuterComposite) GetMyBooleanOk() (bool, bool) {
 		var ret bool
 		return ret, false
 	}
-    return *o.MyBoolean, true
+	return *o.MyBoolean, true
 }
 
 // HasMyBoolean returns a boolean if a field has been set.
 func (o *OuterComposite) HasMyBoolean() bool {
-    if o != nil && o.MyBoolean != nil {
+	if o != nil && o.MyBoolean != nil {
 		return true
 	}
 
@@ -137,17 +137,17 @@ func (o *OuterComposite) SetMyBoolean(v bool) {
 }
 
 func (o OuterComposite) MarshalJSON() ([]byte, error) {
-    toSerialize := map[string]interface{}{}
-    if o.MyNumber != nil {
-        toSerialize["my_number"] = o.MyNumber
-    }
-    if o.MyString != nil {
-        toSerialize["my_string"] = o.MyString
-    }
-    if o.MyBoolean != nil {
-        toSerialize["my_boolean"] = o.MyBoolean
-    }
-    return json.Marshal(toSerialize)
+	toSerialize := map[string]interface{}{}
+	if o.MyNumber != nil {
+		toSerialize["my_number"] = o.MyNumber
+	}
+	if o.MyString != nil {
+		toSerialize["my_string"] = o.MyString
+	}
+	if o.MyBoolean != nil {
+		toSerialize["my_boolean"] = o.MyBoolean
+	}
+	return json.Marshal(toSerialize)
 }
 
 type NullableOuterComposite struct {
@@ -156,32 +156,32 @@ type NullableOuterComposite struct {
 }
 
 func (v NullableOuterComposite) Get() *OuterComposite {
-    return v.value
+	return v.value
 }
 
 func (v NullableOuterComposite) Set(val *OuterComposite) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableOuterComposite) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableOuterComposite) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableOuterComposite(val *OuterComposite) *NullableOuterComposite {
-    return &NullableOuterComposite{value: val, isSet: true}
+	return &NullableOuterComposite{value: val, isSet: true}
 }
 
 func (v NullableOuterComposite) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableOuterComposite) UnmarshalJSON(src []byte) error {
-    v.isSet = true
+	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_outer_composite.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_outer_composite.go
@@ -159,7 +159,7 @@ func (v NullableOuterComposite) Get() *OuterComposite {
 	return v.value
 }
 
-func (v NullableOuterComposite) Set(val *OuterComposite) {
+func (v *NullableOuterComposite) Set(val *OuterComposite) {
 	v.value = val
 	v.isSet = true
 }
@@ -168,7 +168,7 @@ func (v NullableOuterComposite) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableOuterComposite) Unset() {
+func (v *NullableOuterComposite) Unset() {
 	v.value = nil
 	v.isSet = false
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_outer_enum.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_outer_enum.go
@@ -32,7 +32,7 @@ func (v NullableOuterEnum) Get() *OuterEnum {
 	return v.value
 }
 
-func (v NullableOuterEnum) Set(val *OuterEnum) {
+func (v *NullableOuterEnum) Set(val *OuterEnum) {
 	v.value = val
 	v.isSet = true
 }
@@ -41,7 +41,7 @@ func (v NullableOuterEnum) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableOuterEnum) Unset() {
+func (v *NullableOuterEnum) Unset() {
 	v.value = nil
 	v.isSet = false
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_outer_enum.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_outer_enum.go
@@ -29,32 +29,32 @@ type NullableOuterEnum struct {
 }
 
 func (v NullableOuterEnum) Get() *OuterEnum {
-    return v.value
+	return v.value
 }
 
 func (v NullableOuterEnum) Set(val *OuterEnum) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableOuterEnum) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableOuterEnum) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableOuterEnum(val *OuterEnum) *NullableOuterEnum {
-    return &NullableOuterEnum{value: val, isSet: true}
+	return &NullableOuterEnum{value: val, isSet: true}
 }
 
 func (v NullableOuterEnum) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableOuterEnum) UnmarshalJSON(src []byte) error {
-    v.isSet = true
+	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_outer_enum.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_outer_enum.go
@@ -10,7 +10,6 @@
 package petstore
 
 import (
-	"bytes"
 	"encoding/json"
 )
 
@@ -25,24 +24,37 @@ const (
 )
 
 type NullableOuterEnum struct {
-	Value OuterEnum
-	ExplicitNull bool
+	value *OuterEnum
+	isSet bool
+}
+
+func (v NullableOuterEnum) Get() *OuterEnum {
+    return v.value
+}
+
+func (v NullableOuterEnum) Set(val *OuterEnum) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableOuterEnum) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableOuterEnum) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableOuterEnum(val *OuterEnum) *NullableOuterEnum {
+    return &NullableOuterEnum{value: val, isSet: true}
 }
 
 func (v NullableOuterEnum) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-		return json.Marshal(v.Value)
-	}
+    return json.Marshal(v.value)
 }
 
 func (v *NullableOuterEnum) UnmarshalJSON(src []byte) error {
-	if bytes.Equal(src, []byte("null")) {
-		v.ExplicitNull = true
-		return nil
-	}
-
-	return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_pet.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_pet.go
@@ -54,7 +54,6 @@ func (o *Pet) GetId() int64 {
 
 // GetIdOk returns a tuple with the Id field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *Pet) GetIdOk() (*int64, bool) {
 	if o == nil || o.Id == nil {
 		return nil, false
@@ -87,7 +86,6 @@ func (o *Pet) GetCategory() Category {
 
 // GetCategoryOk returns a tuple with the Category field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *Pet) GetCategoryOk() (*Category, bool) {
 	if o == nil || o.Category == nil {
 		return nil, false
@@ -121,12 +119,11 @@ func (o *Pet) GetName() string {
 
 // GetNameOk returns a tuple with the Name field value
 // and a boolean to check if the value has been set.
-
 func (o *Pet) GetNameOk() (*string, bool) {
-    if o == nil  {
-        return nil, false
-    }
-    return &o.Name, true
+	if o == nil  {
+		return nil, false
+	}
+	return &o.Name, true
 }
 
 // SetName sets field value
@@ -146,12 +143,11 @@ func (o *Pet) GetPhotoUrls() []string {
 
 // GetPhotoUrlsOk returns a tuple with the PhotoUrls field value
 // and a boolean to check if the value has been set.
-
 func (o *Pet) GetPhotoUrlsOk() (*[]string, bool) {
-    if o == nil  {
-        return nil, false
-    }
-    return &o.PhotoUrls, true
+	if o == nil  {
+		return nil, false
+	}
+	return &o.PhotoUrls, true
 }
 
 // SetPhotoUrls sets field value
@@ -170,7 +166,6 @@ func (o *Pet) GetTags() []Tag {
 
 // GetTagsOk returns a tuple with the Tags field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *Pet) GetTagsOk() (*[]Tag, bool) {
 	if o == nil || o.Tags == nil {
 		return nil, false
@@ -203,7 +198,6 @@ func (o *Pet) GetStatus() string {
 
 // GetStatusOk returns a tuple with the Status field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *Pet) GetStatusOk() (*string, bool) {
 	if o == nil || o.Status == nil {
 		return nil, false

--- a/samples/client/petstore/go-experimental/go-petstore/model_pet.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_pet.go
@@ -10,7 +10,6 @@
 package petstore
 
 import (
-	"bytes"
 	"encoding/json"
 )
 
@@ -60,12 +59,12 @@ func (o *Pet) GetIdOk() (int64, bool) {
 		var ret int64
 		return ret, false
 	}
-	return *o.Id, true
+    return *o.Id, true
 }
 
 // HasId returns a boolean if a field has been set.
 func (o *Pet) HasId() bool {
-	if o != nil && o.Id != nil {
+    if o != nil && o.Id != nil {
 		return true
 	}
 
@@ -93,12 +92,12 @@ func (o *Pet) GetCategoryOk() (Category, bool) {
 		var ret Category
 		return ret, false
 	}
-	return *o.Category, true
+    return *o.Category, true
 }
 
 // HasCategory returns a boolean if a field has been set.
 func (o *Pet) HasCategory() bool {
-	if o != nil && o.Category != nil {
+    if o != nil && o.Category != nil {
 		return true
 	}
 
@@ -156,12 +155,12 @@ func (o *Pet) GetTagsOk() ([]Tag, bool) {
 		var ret []Tag
 		return ret, false
 	}
-	return *o.Tags, true
+    return *o.Tags, true
 }
 
 // HasTags returns a boolean if a field has been set.
 func (o *Pet) HasTags() bool {
-	if o != nil && o.Tags != nil {
+    if o != nil && o.Tags != nil {
 		return true
 	}
 
@@ -189,12 +188,12 @@ func (o *Pet) GetStatusOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-	return *o.Status, true
+    return *o.Status, true
 }
 
 // HasStatus returns a boolean if a field has been set.
 func (o *Pet) HasStatus() bool {
-	if o != nil && o.Status != nil {
+    if o != nil && o.Status != nil {
 		return true
 	}
 
@@ -206,25 +205,61 @@ func (o *Pet) SetStatus(v string) {
 	o.Status = &v
 }
 
+func (o Pet) MarshalJSON() ([]byte, error) {
+    toSerialize := map[string]interface{}{}
+    if o.Id != nil {
+        toSerialize["id"] = o.Id
+    }
+    if o.Category != nil {
+        toSerialize["category"] = o.Category
+    }
+    if true {
+        toSerialize["name"] = o.Name
+    }
+    if true {
+        toSerialize["photoUrls"] = o.PhotoUrls
+    }
+    if o.Tags != nil {
+        toSerialize["tags"] = o.Tags
+    }
+    if o.Status != nil {
+        toSerialize["status"] = o.Status
+    }
+    return json.Marshal(toSerialize)
+}
+
 type NullablePet struct {
-	Value Pet
-	ExplicitNull bool
+	value *Pet
+	isSet bool
+}
+
+func (v NullablePet) Get() *Pet {
+    return v.value
+}
+
+func (v NullablePet) Set(val *Pet) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullablePet) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullablePet) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullablePet(val *Pet) *NullablePet {
+    return &NullablePet{value: val, isSet: true}
 }
 
 func (v NullablePet) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-		return json.Marshal(v.Value)
-	}
+    return json.Marshal(v.value)
 }
 
 func (v *NullablePet) UnmarshalJSON(src []byte) error {
-	if bytes.Equal(src, []byte("null")) {
-		v.ExplicitNull = true
-		return nil
-	}
-
-	return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_pet.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_pet.go
@@ -29,18 +29,18 @@ type Pet struct {
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
 func NewPet(name string, photoUrls []string, ) *Pet {
-    this := Pet{}
-    this.Name = name
-    this.PhotoUrls = photoUrls
-    return &this
+	this := Pet{}
+	this.Name = name
+	this.PhotoUrls = photoUrls
+	return &this
 }
 
 // NewPetWithDefaults instantiates a new Pet object
 // This constructor will only assign default values to properties that have it defined,
 // but it doesn't guarantee that properties required by API are set
 func NewPetWithDefaults() *Pet {
-    this := Pet{}
-    return &this
+	this := Pet{}
+	return &this
 }
 
 // GetId returns the Id field value if set, zero value otherwise.
@@ -52,14 +52,14 @@ func (o *Pet) GetId() int64 {
 	return *o.Id
 }
 
-// GetIdOk returns a tuple with the Id field value if set, zero value otherwise
+// GetIdOk returns a tuple with the Id field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *Pet) GetIdOk() (int64, bool) {
+
+func (o *Pet) GetIdOk() (*int64, bool) {
 	if o == nil || o.Id == nil {
-		var ret int64
-		return ret, false
+		return nil, false
 	}
-	return *o.Id, true
+	return o.Id, true
 }
 
 // HasId returns a boolean if a field has been set.
@@ -85,14 +85,14 @@ func (o *Pet) GetCategory() Category {
 	return *o.Category
 }
 
-// GetCategoryOk returns a tuple with the Category field value if set, zero value otherwise
+// GetCategoryOk returns a tuple with the Category field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *Pet) GetCategoryOk() (Category, bool) {
+
+func (o *Pet) GetCategoryOk() (*Category, bool) {
 	if o == nil || o.Category == nil {
-		var ret Category
-		return ret, false
+		return nil, false
 	}
-	return *o.Category, true
+	return o.Category, true
 }
 
 // HasCategory returns a boolean if a field has been set.
@@ -111,12 +111,22 @@ func (o *Pet) SetCategory(v Category) {
 
 // GetName returns the Name field value
 func (o *Pet) GetName() string {
-	if o == nil {
+	if o == nil  {
 		var ret string
 		return ret
 	}
 
 	return o.Name
+}
+
+// GetNameOk returns a tuple with the Name field value
+// and a boolean to check if the value has been set.
+
+func (o *Pet) GetNameOk() (*string, bool) {
+    if o == nil  {
+        return nil, false
+    }
+    return &o.Name, true
 }
 
 // SetName sets field value
@@ -126,12 +136,22 @@ func (o *Pet) SetName(v string) {
 
 // GetPhotoUrls returns the PhotoUrls field value
 func (o *Pet) GetPhotoUrls() []string {
-	if o == nil {
+	if o == nil  {
 		var ret []string
 		return ret
 	}
 
 	return o.PhotoUrls
+}
+
+// GetPhotoUrlsOk returns a tuple with the PhotoUrls field value
+// and a boolean to check if the value has been set.
+
+func (o *Pet) GetPhotoUrlsOk() (*[]string, bool) {
+    if o == nil  {
+        return nil, false
+    }
+    return &o.PhotoUrls, true
 }
 
 // SetPhotoUrls sets field value
@@ -148,14 +168,14 @@ func (o *Pet) GetTags() []Tag {
 	return *o.Tags
 }
 
-// GetTagsOk returns a tuple with the Tags field value if set, zero value otherwise
+// GetTagsOk returns a tuple with the Tags field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *Pet) GetTagsOk() ([]Tag, bool) {
+
+func (o *Pet) GetTagsOk() (*[]Tag, bool) {
 	if o == nil || o.Tags == nil {
-		var ret []Tag
-		return ret, false
+		return nil, false
 	}
-	return *o.Tags, true
+	return o.Tags, true
 }
 
 // HasTags returns a boolean if a field has been set.
@@ -181,14 +201,14 @@ func (o *Pet) GetStatus() string {
 	return *o.Status
 }
 
-// GetStatusOk returns a tuple with the Status field value if set, zero value otherwise
+// GetStatusOk returns a tuple with the Status field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *Pet) GetStatusOk() (string, bool) {
+
+func (o *Pet) GetStatusOk() (*string, bool) {
 	if o == nil || o.Status == nil {
-		var ret string
-		return ret, false
+		return nil, false
 	}
-	return *o.Status, true
+	return o.Status, true
 }
 
 // HasStatus returns a boolean if a field has been set.

--- a/samples/client/petstore/go-experimental/go-petstore/model_pet.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_pet.go
@@ -237,7 +237,7 @@ func (v NullablePet) Get() *Pet {
 	return v.value
 }
 
-func (v NullablePet) Set(val *Pet) {
+func (v *NullablePet) Set(val *Pet) {
 	v.value = val
 	v.isSet = true
 }
@@ -246,7 +246,7 @@ func (v NullablePet) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullablePet) Unset() {
+func (v *NullablePet) Unset() {
 	v.value = nil
 	v.isSet = false
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_pet.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_pet.go
@@ -59,12 +59,12 @@ func (o *Pet) GetIdOk() (int64, bool) {
 		var ret int64
 		return ret, false
 	}
-    return *o.Id, true
+	return *o.Id, true
 }
 
 // HasId returns a boolean if a field has been set.
 func (o *Pet) HasId() bool {
-    if o != nil && o.Id != nil {
+	if o != nil && o.Id != nil {
 		return true
 	}
 
@@ -92,12 +92,12 @@ func (o *Pet) GetCategoryOk() (Category, bool) {
 		var ret Category
 		return ret, false
 	}
-    return *o.Category, true
+	return *o.Category, true
 }
 
 // HasCategory returns a boolean if a field has been set.
 func (o *Pet) HasCategory() bool {
-    if o != nil && o.Category != nil {
+	if o != nil && o.Category != nil {
 		return true
 	}
 
@@ -155,12 +155,12 @@ func (o *Pet) GetTagsOk() ([]Tag, bool) {
 		var ret []Tag
 		return ret, false
 	}
-    return *o.Tags, true
+	return *o.Tags, true
 }
 
 // HasTags returns a boolean if a field has been set.
 func (o *Pet) HasTags() bool {
-    if o != nil && o.Tags != nil {
+	if o != nil && o.Tags != nil {
 		return true
 	}
 
@@ -188,12 +188,12 @@ func (o *Pet) GetStatusOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-    return *o.Status, true
+	return *o.Status, true
 }
 
 // HasStatus returns a boolean if a field has been set.
 func (o *Pet) HasStatus() bool {
-    if o != nil && o.Status != nil {
+	if o != nil && o.Status != nil {
 		return true
 	}
 
@@ -206,26 +206,26 @@ func (o *Pet) SetStatus(v string) {
 }
 
 func (o Pet) MarshalJSON() ([]byte, error) {
-    toSerialize := map[string]interface{}{}
-    if o.Id != nil {
-        toSerialize["id"] = o.Id
-    }
-    if o.Category != nil {
-        toSerialize["category"] = o.Category
-    }
-    if true {
-        toSerialize["name"] = o.Name
-    }
-    if true {
-        toSerialize["photoUrls"] = o.PhotoUrls
-    }
-    if o.Tags != nil {
-        toSerialize["tags"] = o.Tags
-    }
-    if o.Status != nil {
-        toSerialize["status"] = o.Status
-    }
-    return json.Marshal(toSerialize)
+	toSerialize := map[string]interface{}{}
+	if o.Id != nil {
+		toSerialize["id"] = o.Id
+	}
+	if o.Category != nil {
+		toSerialize["category"] = o.Category
+	}
+	if true {
+		toSerialize["name"] = o.Name
+	}
+	if true {
+		toSerialize["photoUrls"] = o.PhotoUrls
+	}
+	if o.Tags != nil {
+		toSerialize["tags"] = o.Tags
+	}
+	if o.Status != nil {
+		toSerialize["status"] = o.Status
+	}
+	return json.Marshal(toSerialize)
 }
 
 type NullablePet struct {
@@ -234,32 +234,32 @@ type NullablePet struct {
 }
 
 func (v NullablePet) Get() *Pet {
-    return v.value
+	return v.value
 }
 
 func (v NullablePet) Set(val *Pet) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullablePet) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullablePet) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullablePet(val *Pet) *NullablePet {
-    return &NullablePet{value: val, isSet: true}
+	return &NullablePet{value: val, isSet: true}
 }
 
 func (v NullablePet) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullablePet) UnmarshalJSON(src []byte) error {
-    v.isSet = true
+	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_read_only_first.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_read_only_first.go
@@ -24,16 +24,16 @@ type ReadOnlyFirst struct {
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
 func NewReadOnlyFirst() *ReadOnlyFirst {
-    this := ReadOnlyFirst{}
-    return &this
+	this := ReadOnlyFirst{}
+	return &this
 }
 
 // NewReadOnlyFirstWithDefaults instantiates a new ReadOnlyFirst object
 // This constructor will only assign default values to properties that have it defined,
 // but it doesn't guarantee that properties required by API are set
 func NewReadOnlyFirstWithDefaults() *ReadOnlyFirst {
-    this := ReadOnlyFirst{}
-    return &this
+	this := ReadOnlyFirst{}
+	return &this
 }
 
 // GetBar returns the Bar field value if set, zero value otherwise.
@@ -45,14 +45,14 @@ func (o *ReadOnlyFirst) GetBar() string {
 	return *o.Bar
 }
 
-// GetBarOk returns a tuple with the Bar field value if set, zero value otherwise
+// GetBarOk returns a tuple with the Bar field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *ReadOnlyFirst) GetBarOk() (string, bool) {
+
+func (o *ReadOnlyFirst) GetBarOk() (*string, bool) {
 	if o == nil || o.Bar == nil {
-		var ret string
-		return ret, false
+		return nil, false
 	}
-	return *o.Bar, true
+	return o.Bar, true
 }
 
 // HasBar returns a boolean if a field has been set.
@@ -78,14 +78,14 @@ func (o *ReadOnlyFirst) GetBaz() string {
 	return *o.Baz
 }
 
-// GetBazOk returns a tuple with the Baz field value if set, zero value otherwise
+// GetBazOk returns a tuple with the Baz field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *ReadOnlyFirst) GetBazOk() (string, bool) {
+
+func (o *ReadOnlyFirst) GetBazOk() (*string, bool) {
 	if o == nil || o.Baz == nil {
-		var ret string
-		return ret, false
+		return nil, false
 	}
-	return *o.Baz, true
+	return o.Baz, true
 }
 
 // HasBaz returns a boolean if a field has been set.

--- a/samples/client/petstore/go-experimental/go-petstore/model_read_only_first.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_read_only_first.go
@@ -10,7 +10,6 @@
 package petstore
 
 import (
-	"bytes"
 	"encoding/json"
 )
 
@@ -53,12 +52,12 @@ func (o *ReadOnlyFirst) GetBarOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-	return *o.Bar, true
+    return *o.Bar, true
 }
 
 // HasBar returns a boolean if a field has been set.
 func (o *ReadOnlyFirst) HasBar() bool {
-	if o != nil && o.Bar != nil {
+    if o != nil && o.Bar != nil {
 		return true
 	}
 
@@ -86,12 +85,12 @@ func (o *ReadOnlyFirst) GetBazOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-	return *o.Baz, true
+    return *o.Baz, true
 }
 
 // HasBaz returns a boolean if a field has been set.
 func (o *ReadOnlyFirst) HasBaz() bool {
-	if o != nil && o.Baz != nil {
+    if o != nil && o.Baz != nil {
 		return true
 	}
 
@@ -103,25 +102,49 @@ func (o *ReadOnlyFirst) SetBaz(v string) {
 	o.Baz = &v
 }
 
+func (o ReadOnlyFirst) MarshalJSON() ([]byte, error) {
+    toSerialize := map[string]interface{}{}
+    if o.Bar != nil {
+        toSerialize["bar"] = o.Bar
+    }
+    if o.Baz != nil {
+        toSerialize["baz"] = o.Baz
+    }
+    return json.Marshal(toSerialize)
+}
+
 type NullableReadOnlyFirst struct {
-	Value ReadOnlyFirst
-	ExplicitNull bool
+	value *ReadOnlyFirst
+	isSet bool
+}
+
+func (v NullableReadOnlyFirst) Get() *ReadOnlyFirst {
+    return v.value
+}
+
+func (v NullableReadOnlyFirst) Set(val *ReadOnlyFirst) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableReadOnlyFirst) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableReadOnlyFirst) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableReadOnlyFirst(val *ReadOnlyFirst) *NullableReadOnlyFirst {
+    return &NullableReadOnlyFirst{value: val, isSet: true}
 }
 
 func (v NullableReadOnlyFirst) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-		return json.Marshal(v.Value)
-	}
+    return json.Marshal(v.value)
 }
 
 func (v *NullableReadOnlyFirst) UnmarshalJSON(src []byte) error {
-	if bytes.Equal(src, []byte("null")) {
-		v.ExplicitNull = true
-		return nil
-	}
-
-	return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_read_only_first.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_read_only_first.go
@@ -52,12 +52,12 @@ func (o *ReadOnlyFirst) GetBarOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-    return *o.Bar, true
+	return *o.Bar, true
 }
 
 // HasBar returns a boolean if a field has been set.
 func (o *ReadOnlyFirst) HasBar() bool {
-    if o != nil && o.Bar != nil {
+	if o != nil && o.Bar != nil {
 		return true
 	}
 
@@ -85,12 +85,12 @@ func (o *ReadOnlyFirst) GetBazOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-    return *o.Baz, true
+	return *o.Baz, true
 }
 
 // HasBaz returns a boolean if a field has been set.
 func (o *ReadOnlyFirst) HasBaz() bool {
-    if o != nil && o.Baz != nil {
+	if o != nil && o.Baz != nil {
 		return true
 	}
 
@@ -103,14 +103,14 @@ func (o *ReadOnlyFirst) SetBaz(v string) {
 }
 
 func (o ReadOnlyFirst) MarshalJSON() ([]byte, error) {
-    toSerialize := map[string]interface{}{}
-    if o.Bar != nil {
-        toSerialize["bar"] = o.Bar
-    }
-    if o.Baz != nil {
-        toSerialize["baz"] = o.Baz
-    }
-    return json.Marshal(toSerialize)
+	toSerialize := map[string]interface{}{}
+	if o.Bar != nil {
+		toSerialize["bar"] = o.Bar
+	}
+	if o.Baz != nil {
+		toSerialize["baz"] = o.Baz
+	}
+	return json.Marshal(toSerialize)
 }
 
 type NullableReadOnlyFirst struct {
@@ -119,32 +119,32 @@ type NullableReadOnlyFirst struct {
 }
 
 func (v NullableReadOnlyFirst) Get() *ReadOnlyFirst {
-    return v.value
+	return v.value
 }
 
 func (v NullableReadOnlyFirst) Set(val *ReadOnlyFirst) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableReadOnlyFirst) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableReadOnlyFirst) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableReadOnlyFirst(val *ReadOnlyFirst) *NullableReadOnlyFirst {
-    return &NullableReadOnlyFirst{value: val, isSet: true}
+	return &NullableReadOnlyFirst{value: val, isSet: true}
 }
 
 func (v NullableReadOnlyFirst) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableReadOnlyFirst) UnmarshalJSON(src []byte) error {
-    v.isSet = true
+	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_read_only_first.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_read_only_first.go
@@ -47,7 +47,6 @@ func (o *ReadOnlyFirst) GetBar() string {
 
 // GetBarOk returns a tuple with the Bar field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *ReadOnlyFirst) GetBarOk() (*string, bool) {
 	if o == nil || o.Bar == nil {
 		return nil, false
@@ -80,7 +79,6 @@ func (o *ReadOnlyFirst) GetBaz() string {
 
 // GetBazOk returns a tuple with the Baz field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *ReadOnlyFirst) GetBazOk() (*string, bool) {
 	if o == nil || o.Baz == nil {
 		return nil, false

--- a/samples/client/petstore/go-experimental/go-petstore/model_read_only_first.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_read_only_first.go
@@ -122,7 +122,7 @@ func (v NullableReadOnlyFirst) Get() *ReadOnlyFirst {
 	return v.value
 }
 
-func (v NullableReadOnlyFirst) Set(val *ReadOnlyFirst) {
+func (v *NullableReadOnlyFirst) Set(val *ReadOnlyFirst) {
 	v.value = val
 	v.isSet = true
 }
@@ -131,7 +131,7 @@ func (v NullableReadOnlyFirst) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableReadOnlyFirst) Unset() {
+func (v *NullableReadOnlyFirst) Unset() {
 	v.value = nil
 	v.isSet = false
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_return.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_return.go
@@ -23,16 +23,16 @@ type Return struct {
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
 func NewReturn() *Return {
-    this := Return{}
-    return &this
+	this := Return{}
+	return &this
 }
 
 // NewReturnWithDefaults instantiates a new Return object
 // This constructor will only assign default values to properties that have it defined,
 // but it doesn't guarantee that properties required by API are set
 func NewReturnWithDefaults() *Return {
-    this := Return{}
-    return &this
+	this := Return{}
+	return &this
 }
 
 // GetReturn returns the Return field value if set, zero value otherwise.
@@ -44,14 +44,14 @@ func (o *Return) GetReturn() int32 {
 	return *o.Return
 }
 
-// GetReturnOk returns a tuple with the Return field value if set, zero value otherwise
+// GetReturnOk returns a tuple with the Return field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *Return) GetReturnOk() (int32, bool) {
+
+func (o *Return) GetReturnOk() (*int32, bool) {
 	if o == nil || o.Return == nil {
-		var ret int32
-		return ret, false
+		return nil, false
 	}
-	return *o.Return, true
+	return o.Return, true
 }
 
 // HasReturn returns a boolean if a field has been set.

--- a/samples/client/petstore/go-experimental/go-petstore/model_return.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_return.go
@@ -10,7 +10,6 @@
 package petstore
 
 import (
-	"bytes"
 	"encoding/json"
 )
 
@@ -52,12 +51,12 @@ func (o *Return) GetReturnOk() (int32, bool) {
 		var ret int32
 		return ret, false
 	}
-	return *o.Return, true
+    return *o.Return, true
 }
 
 // HasReturn returns a boolean if a field has been set.
 func (o *Return) HasReturn() bool {
-	if o != nil && o.Return != nil {
+    if o != nil && o.Return != nil {
 		return true
 	}
 
@@ -69,25 +68,46 @@ func (o *Return) SetReturn(v int32) {
 	o.Return = &v
 }
 
+func (o Return) MarshalJSON() ([]byte, error) {
+    toSerialize := map[string]interface{}{}
+    if o.Return != nil {
+        toSerialize["return"] = o.Return
+    }
+    return json.Marshal(toSerialize)
+}
+
 type NullableReturn struct {
-	Value Return
-	ExplicitNull bool
+	value *Return
+	isSet bool
+}
+
+func (v NullableReturn) Get() *Return {
+    return v.value
+}
+
+func (v NullableReturn) Set(val *Return) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableReturn) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableReturn) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableReturn(val *Return) *NullableReturn {
+    return &NullableReturn{value: val, isSet: true}
 }
 
 func (v NullableReturn) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-		return json.Marshal(v.Value)
-	}
+    return json.Marshal(v.value)
 }
 
 func (v *NullableReturn) UnmarshalJSON(src []byte) error {
-	if bytes.Equal(src, []byte("null")) {
-		v.ExplicitNull = true
-		return nil
-	}
-
-	return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_return.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_return.go
@@ -85,7 +85,7 @@ func (v NullableReturn) Get() *Return {
 	return v.value
 }
 
-func (v NullableReturn) Set(val *Return) {
+func (v *NullableReturn) Set(val *Return) {
 	v.value = val
 	v.isSet = true
 }
@@ -94,7 +94,7 @@ func (v NullableReturn) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableReturn) Unset() {
+func (v *NullableReturn) Unset() {
 	v.value = nil
 	v.isSet = false
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_return.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_return.go
@@ -51,12 +51,12 @@ func (o *Return) GetReturnOk() (int32, bool) {
 		var ret int32
 		return ret, false
 	}
-    return *o.Return, true
+	return *o.Return, true
 }
 
 // HasReturn returns a boolean if a field has been set.
 func (o *Return) HasReturn() bool {
-    if o != nil && o.Return != nil {
+	if o != nil && o.Return != nil {
 		return true
 	}
 
@@ -69,11 +69,11 @@ func (o *Return) SetReturn(v int32) {
 }
 
 func (o Return) MarshalJSON() ([]byte, error) {
-    toSerialize := map[string]interface{}{}
-    if o.Return != nil {
-        toSerialize["return"] = o.Return
-    }
-    return json.Marshal(toSerialize)
+	toSerialize := map[string]interface{}{}
+	if o.Return != nil {
+		toSerialize["return"] = o.Return
+	}
+	return json.Marshal(toSerialize)
 }
 
 type NullableReturn struct {
@@ -82,32 +82,32 @@ type NullableReturn struct {
 }
 
 func (v NullableReturn) Get() *Return {
-    return v.value
+	return v.value
 }
 
 func (v NullableReturn) Set(val *Return) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableReturn) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableReturn) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableReturn(val *Return) *NullableReturn {
-    return &NullableReturn{value: val, isSet: true}
+	return &NullableReturn{value: val, isSet: true}
 }
 
 func (v NullableReturn) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableReturn) UnmarshalJSON(src []byte) error {
-    v.isSet = true
+	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_return.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_return.go
@@ -46,7 +46,6 @@ func (o *Return) GetReturn() int32 {
 
 // GetReturnOk returns a tuple with the Return field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *Return) GetReturnOk() (*int32, bool) {
 	if o == nil || o.Return == nil {
 		return nil, false

--- a/samples/client/petstore/go-experimental/go-petstore/model_special_model_name.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_special_model_name.go
@@ -10,7 +10,6 @@
 package petstore
 
 import (
-	"bytes"
 	"encoding/json"
 )
 
@@ -52,12 +51,12 @@ func (o *SpecialModelName) GetSpecialPropertyNameOk() (int64, bool) {
 		var ret int64
 		return ret, false
 	}
-	return *o.SpecialPropertyName, true
+    return *o.SpecialPropertyName, true
 }
 
 // HasSpecialPropertyName returns a boolean if a field has been set.
 func (o *SpecialModelName) HasSpecialPropertyName() bool {
-	if o != nil && o.SpecialPropertyName != nil {
+    if o != nil && o.SpecialPropertyName != nil {
 		return true
 	}
 
@@ -69,25 +68,46 @@ func (o *SpecialModelName) SetSpecialPropertyName(v int64) {
 	o.SpecialPropertyName = &v
 }
 
+func (o SpecialModelName) MarshalJSON() ([]byte, error) {
+    toSerialize := map[string]interface{}{}
+    if o.SpecialPropertyName != nil {
+        toSerialize["$special[property.name]"] = o.SpecialPropertyName
+    }
+    return json.Marshal(toSerialize)
+}
+
 type NullableSpecialModelName struct {
-	Value SpecialModelName
-	ExplicitNull bool
+	value *SpecialModelName
+	isSet bool
+}
+
+func (v NullableSpecialModelName) Get() *SpecialModelName {
+    return v.value
+}
+
+func (v NullableSpecialModelName) Set(val *SpecialModelName) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableSpecialModelName) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableSpecialModelName) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableSpecialModelName(val *SpecialModelName) *NullableSpecialModelName {
+    return &NullableSpecialModelName{value: val, isSet: true}
 }
 
 func (v NullableSpecialModelName) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-		return json.Marshal(v.Value)
-	}
+    return json.Marshal(v.value)
 }
 
 func (v *NullableSpecialModelName) UnmarshalJSON(src []byte) error {
-	if bytes.Equal(src, []byte("null")) {
-		v.ExplicitNull = true
-		return nil
-	}
-
-	return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_special_model_name.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_special_model_name.go
@@ -51,12 +51,12 @@ func (o *SpecialModelName) GetSpecialPropertyNameOk() (int64, bool) {
 		var ret int64
 		return ret, false
 	}
-    return *o.SpecialPropertyName, true
+	return *o.SpecialPropertyName, true
 }
 
 // HasSpecialPropertyName returns a boolean if a field has been set.
 func (o *SpecialModelName) HasSpecialPropertyName() bool {
-    if o != nil && o.SpecialPropertyName != nil {
+	if o != nil && o.SpecialPropertyName != nil {
 		return true
 	}
 
@@ -69,11 +69,11 @@ func (o *SpecialModelName) SetSpecialPropertyName(v int64) {
 }
 
 func (o SpecialModelName) MarshalJSON() ([]byte, error) {
-    toSerialize := map[string]interface{}{}
-    if o.SpecialPropertyName != nil {
-        toSerialize["$special[property.name]"] = o.SpecialPropertyName
-    }
-    return json.Marshal(toSerialize)
+	toSerialize := map[string]interface{}{}
+	if o.SpecialPropertyName != nil {
+		toSerialize["$special[property.name]"] = o.SpecialPropertyName
+	}
+	return json.Marshal(toSerialize)
 }
 
 type NullableSpecialModelName struct {
@@ -82,32 +82,32 @@ type NullableSpecialModelName struct {
 }
 
 func (v NullableSpecialModelName) Get() *SpecialModelName {
-    return v.value
+	return v.value
 }
 
 func (v NullableSpecialModelName) Set(val *SpecialModelName) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableSpecialModelName) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableSpecialModelName) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableSpecialModelName(val *SpecialModelName) *NullableSpecialModelName {
-    return &NullableSpecialModelName{value: val, isSet: true}
+	return &NullableSpecialModelName{value: val, isSet: true}
 }
 
 func (v NullableSpecialModelName) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableSpecialModelName) UnmarshalJSON(src []byte) error {
-    v.isSet = true
+	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_special_model_name.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_special_model_name.go
@@ -85,7 +85,7 @@ func (v NullableSpecialModelName) Get() *SpecialModelName {
 	return v.value
 }
 
-func (v NullableSpecialModelName) Set(val *SpecialModelName) {
+func (v *NullableSpecialModelName) Set(val *SpecialModelName) {
 	v.value = val
 	v.isSet = true
 }
@@ -94,7 +94,7 @@ func (v NullableSpecialModelName) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableSpecialModelName) Unset() {
+func (v *NullableSpecialModelName) Unset() {
 	v.value = nil
 	v.isSet = false
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_special_model_name.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_special_model_name.go
@@ -23,16 +23,16 @@ type SpecialModelName struct {
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
 func NewSpecialModelName() *SpecialModelName {
-    this := SpecialModelName{}
-    return &this
+	this := SpecialModelName{}
+	return &this
 }
 
 // NewSpecialModelNameWithDefaults instantiates a new SpecialModelName object
 // This constructor will only assign default values to properties that have it defined,
 // but it doesn't guarantee that properties required by API are set
 func NewSpecialModelNameWithDefaults() *SpecialModelName {
-    this := SpecialModelName{}
-    return &this
+	this := SpecialModelName{}
+	return &this
 }
 
 // GetSpecialPropertyName returns the SpecialPropertyName field value if set, zero value otherwise.
@@ -44,14 +44,14 @@ func (o *SpecialModelName) GetSpecialPropertyName() int64 {
 	return *o.SpecialPropertyName
 }
 
-// GetSpecialPropertyNameOk returns a tuple with the SpecialPropertyName field value if set, zero value otherwise
+// GetSpecialPropertyNameOk returns a tuple with the SpecialPropertyName field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *SpecialModelName) GetSpecialPropertyNameOk() (int64, bool) {
+
+func (o *SpecialModelName) GetSpecialPropertyNameOk() (*int64, bool) {
 	if o == nil || o.SpecialPropertyName == nil {
-		var ret int64
-		return ret, false
+		return nil, false
 	}
-	return *o.SpecialPropertyName, true
+	return o.SpecialPropertyName, true
 }
 
 // HasSpecialPropertyName returns a boolean if a field has been set.

--- a/samples/client/petstore/go-experimental/go-petstore/model_special_model_name.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_special_model_name.go
@@ -46,7 +46,6 @@ func (o *SpecialModelName) GetSpecialPropertyName() int64 {
 
 // GetSpecialPropertyNameOk returns a tuple with the SpecialPropertyName field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *SpecialModelName) GetSpecialPropertyNameOk() (*int64, bool) {
 	if o == nil || o.SpecialPropertyName == nil {
 		return nil, false

--- a/samples/client/petstore/go-experimental/go-petstore/model_tag.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_tag.go
@@ -47,7 +47,6 @@ func (o *Tag) GetId() int64 {
 
 // GetIdOk returns a tuple with the Id field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *Tag) GetIdOk() (*int64, bool) {
 	if o == nil || o.Id == nil {
 		return nil, false
@@ -80,7 +79,6 @@ func (o *Tag) GetName() string {
 
 // GetNameOk returns a tuple with the Name field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *Tag) GetNameOk() (*string, bool) {
 	if o == nil || o.Name == nil {
 		return nil, false

--- a/samples/client/petstore/go-experimental/go-petstore/model_tag.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_tag.go
@@ -24,16 +24,16 @@ type Tag struct {
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
 func NewTag() *Tag {
-    this := Tag{}
-    return &this
+	this := Tag{}
+	return &this
 }
 
 // NewTagWithDefaults instantiates a new Tag object
 // This constructor will only assign default values to properties that have it defined,
 // but it doesn't guarantee that properties required by API are set
 func NewTagWithDefaults() *Tag {
-    this := Tag{}
-    return &this
+	this := Tag{}
+	return &this
 }
 
 // GetId returns the Id field value if set, zero value otherwise.
@@ -45,14 +45,14 @@ func (o *Tag) GetId() int64 {
 	return *o.Id
 }
 
-// GetIdOk returns a tuple with the Id field value if set, zero value otherwise
+// GetIdOk returns a tuple with the Id field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *Tag) GetIdOk() (int64, bool) {
+
+func (o *Tag) GetIdOk() (*int64, bool) {
 	if o == nil || o.Id == nil {
-		var ret int64
-		return ret, false
+		return nil, false
 	}
-	return *o.Id, true
+	return o.Id, true
 }
 
 // HasId returns a boolean if a field has been set.
@@ -78,14 +78,14 @@ func (o *Tag) GetName() string {
 	return *o.Name
 }
 
-// GetNameOk returns a tuple with the Name field value if set, zero value otherwise
+// GetNameOk returns a tuple with the Name field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *Tag) GetNameOk() (string, bool) {
+
+func (o *Tag) GetNameOk() (*string, bool) {
 	if o == nil || o.Name == nil {
-		var ret string
-		return ret, false
+		return nil, false
 	}
-	return *o.Name, true
+	return o.Name, true
 }
 
 // HasName returns a boolean if a field has been set.

--- a/samples/client/petstore/go-experimental/go-petstore/model_tag.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_tag.go
@@ -52,12 +52,12 @@ func (o *Tag) GetIdOk() (int64, bool) {
 		var ret int64
 		return ret, false
 	}
-    return *o.Id, true
+	return *o.Id, true
 }
 
 // HasId returns a boolean if a field has been set.
 func (o *Tag) HasId() bool {
-    if o != nil && o.Id != nil {
+	if o != nil && o.Id != nil {
 		return true
 	}
 
@@ -85,12 +85,12 @@ func (o *Tag) GetNameOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-    return *o.Name, true
+	return *o.Name, true
 }
 
 // HasName returns a boolean if a field has been set.
 func (o *Tag) HasName() bool {
-    if o != nil && o.Name != nil {
+	if o != nil && o.Name != nil {
 		return true
 	}
 
@@ -103,14 +103,14 @@ func (o *Tag) SetName(v string) {
 }
 
 func (o Tag) MarshalJSON() ([]byte, error) {
-    toSerialize := map[string]interface{}{}
-    if o.Id != nil {
-        toSerialize["id"] = o.Id
-    }
-    if o.Name != nil {
-        toSerialize["name"] = o.Name
-    }
-    return json.Marshal(toSerialize)
+	toSerialize := map[string]interface{}{}
+	if o.Id != nil {
+		toSerialize["id"] = o.Id
+	}
+	if o.Name != nil {
+		toSerialize["name"] = o.Name
+	}
+	return json.Marshal(toSerialize)
 }
 
 type NullableTag struct {
@@ -119,32 +119,32 @@ type NullableTag struct {
 }
 
 func (v NullableTag) Get() *Tag {
-    return v.value
+	return v.value
 }
 
 func (v NullableTag) Set(val *Tag) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableTag) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableTag) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableTag(val *Tag) *NullableTag {
-    return &NullableTag{value: val, isSet: true}
+	return &NullableTag{value: val, isSet: true}
 }
 
 func (v NullableTag) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableTag) UnmarshalJSON(src []byte) error {
-    v.isSet = true
+	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_tag.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_tag.go
@@ -122,7 +122,7 @@ func (v NullableTag) Get() *Tag {
 	return v.value
 }
 
-func (v NullableTag) Set(val *Tag) {
+func (v *NullableTag) Set(val *Tag) {
 	v.value = val
 	v.isSet = true
 }
@@ -131,7 +131,7 @@ func (v NullableTag) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableTag) Unset() {
+func (v *NullableTag) Unset() {
 	v.value = nil
 	v.isSet = false
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_tag.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_tag.go
@@ -10,7 +10,6 @@
 package petstore
 
 import (
-	"bytes"
 	"encoding/json"
 )
 
@@ -53,12 +52,12 @@ func (o *Tag) GetIdOk() (int64, bool) {
 		var ret int64
 		return ret, false
 	}
-	return *o.Id, true
+    return *o.Id, true
 }
 
 // HasId returns a boolean if a field has been set.
 func (o *Tag) HasId() bool {
-	if o != nil && o.Id != nil {
+    if o != nil && o.Id != nil {
 		return true
 	}
 
@@ -86,12 +85,12 @@ func (o *Tag) GetNameOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-	return *o.Name, true
+    return *o.Name, true
 }
 
 // HasName returns a boolean if a field has been set.
 func (o *Tag) HasName() bool {
-	if o != nil && o.Name != nil {
+    if o != nil && o.Name != nil {
 		return true
 	}
 
@@ -103,25 +102,49 @@ func (o *Tag) SetName(v string) {
 	o.Name = &v
 }
 
+func (o Tag) MarshalJSON() ([]byte, error) {
+    toSerialize := map[string]interface{}{}
+    if o.Id != nil {
+        toSerialize["id"] = o.Id
+    }
+    if o.Name != nil {
+        toSerialize["name"] = o.Name
+    }
+    return json.Marshal(toSerialize)
+}
+
 type NullableTag struct {
-	Value Tag
-	ExplicitNull bool
+	value *Tag
+	isSet bool
+}
+
+func (v NullableTag) Get() *Tag {
+    return v.value
+}
+
+func (v NullableTag) Set(val *Tag) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableTag) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableTag) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableTag(val *Tag) *NullableTag {
+    return &NullableTag{value: val, isSet: true}
 }
 
 func (v NullableTag) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-		return json.Marshal(v.Value)
-	}
+    return json.Marshal(v.value)
 }
 
 func (v *NullableTag) UnmarshalJSON(src []byte) error {
-	if bytes.Equal(src, []byte("null")) {
-		v.ExplicitNull = true
-		return nil
-	}
-
-	return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_type_holder_default.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_type_holder_default.go
@@ -27,35 +27,45 @@ type TypeHolderDefault struct {
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
 func NewTypeHolderDefault(stringItem string, numberItem float32, integerItem int32, boolItem bool, arrayItem []int32, ) *TypeHolderDefault {
-    this := TypeHolderDefault{}
-    this.StringItem = stringItem
-    this.NumberItem = numberItem
-    this.IntegerItem = integerItem
-    this.BoolItem = boolItem
-    this.ArrayItem = arrayItem
-    return &this
+	this := TypeHolderDefault{}
+	this.StringItem = stringItem
+	this.NumberItem = numberItem
+	this.IntegerItem = integerItem
+	this.BoolItem = boolItem
+	this.ArrayItem = arrayItem
+	return &this
 }
 
 // NewTypeHolderDefaultWithDefaults instantiates a new TypeHolderDefault object
 // This constructor will only assign default values to properties that have it defined,
 // but it doesn't guarantee that properties required by API are set
 func NewTypeHolderDefaultWithDefaults() *TypeHolderDefault {
-    this := TypeHolderDefault{}
+	this := TypeHolderDefault{}
 	var stringItem string = "what"
 	this.StringItem = stringItem
 	var boolItem bool = true
 	this.BoolItem = boolItem
-    return &this
+	return &this
 }
 
 // GetStringItem returns the StringItem field value
 func (o *TypeHolderDefault) GetStringItem() string {
-	if o == nil {
+	if o == nil  {
 		var ret string
 		return ret
 	}
 
 	return o.StringItem
+}
+
+// GetStringItemOk returns a tuple with the StringItem field value
+// and a boolean to check if the value has been set.
+
+func (o *TypeHolderDefault) GetStringItemOk() (*string, bool) {
+    if o == nil  {
+        return nil, false
+    }
+    return &o.StringItem, true
 }
 
 // SetStringItem sets field value
@@ -65,12 +75,22 @@ func (o *TypeHolderDefault) SetStringItem(v string) {
 
 // GetNumberItem returns the NumberItem field value
 func (o *TypeHolderDefault) GetNumberItem() float32 {
-	if o == nil {
+	if o == nil  {
 		var ret float32
 		return ret
 	}
 
 	return o.NumberItem
+}
+
+// GetNumberItemOk returns a tuple with the NumberItem field value
+// and a boolean to check if the value has been set.
+
+func (o *TypeHolderDefault) GetNumberItemOk() (*float32, bool) {
+    if o == nil  {
+        return nil, false
+    }
+    return &o.NumberItem, true
 }
 
 // SetNumberItem sets field value
@@ -80,12 +100,22 @@ func (o *TypeHolderDefault) SetNumberItem(v float32) {
 
 // GetIntegerItem returns the IntegerItem field value
 func (o *TypeHolderDefault) GetIntegerItem() int32 {
-	if o == nil {
+	if o == nil  {
 		var ret int32
 		return ret
 	}
 
 	return o.IntegerItem
+}
+
+// GetIntegerItemOk returns a tuple with the IntegerItem field value
+// and a boolean to check if the value has been set.
+
+func (o *TypeHolderDefault) GetIntegerItemOk() (*int32, bool) {
+    if o == nil  {
+        return nil, false
+    }
+    return &o.IntegerItem, true
 }
 
 // SetIntegerItem sets field value
@@ -95,12 +125,22 @@ func (o *TypeHolderDefault) SetIntegerItem(v int32) {
 
 // GetBoolItem returns the BoolItem field value
 func (o *TypeHolderDefault) GetBoolItem() bool {
-	if o == nil {
+	if o == nil  {
 		var ret bool
 		return ret
 	}
 
 	return o.BoolItem
+}
+
+// GetBoolItemOk returns a tuple with the BoolItem field value
+// and a boolean to check if the value has been set.
+
+func (o *TypeHolderDefault) GetBoolItemOk() (*bool, bool) {
+    if o == nil  {
+        return nil, false
+    }
+    return &o.BoolItem, true
 }
 
 // SetBoolItem sets field value
@@ -110,12 +150,22 @@ func (o *TypeHolderDefault) SetBoolItem(v bool) {
 
 // GetArrayItem returns the ArrayItem field value
 func (o *TypeHolderDefault) GetArrayItem() []int32 {
-	if o == nil {
+	if o == nil  {
 		var ret []int32
 		return ret
 	}
 
 	return o.ArrayItem
+}
+
+// GetArrayItemOk returns a tuple with the ArrayItem field value
+// and a boolean to check if the value has been set.
+
+func (o *TypeHolderDefault) GetArrayItemOk() (*[]int32, bool) {
+    if o == nil  {
+        return nil, false
+    }
+    return &o.ArrayItem, true
 }
 
 // SetArrayItem sets field value

--- a/samples/client/petstore/go-experimental/go-petstore/model_type_holder_default.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_type_holder_default.go
@@ -152,7 +152,7 @@ func (v NullableTypeHolderDefault) Get() *TypeHolderDefault {
 	return v.value
 }
 
-func (v NullableTypeHolderDefault) Set(val *TypeHolderDefault) {
+func (v *NullableTypeHolderDefault) Set(val *TypeHolderDefault) {
 	v.value = val
 	v.isSet = true
 }
@@ -161,7 +161,7 @@ func (v NullableTypeHolderDefault) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableTypeHolderDefault) Unset() {
+func (v *NullableTypeHolderDefault) Unset() {
 	v.value = nil
 	v.isSet = false
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_type_holder_default.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_type_holder_default.go
@@ -60,12 +60,11 @@ func (o *TypeHolderDefault) GetStringItem() string {
 
 // GetStringItemOk returns a tuple with the StringItem field value
 // and a boolean to check if the value has been set.
-
 func (o *TypeHolderDefault) GetStringItemOk() (*string, bool) {
-    if o == nil  {
-        return nil, false
-    }
-    return &o.StringItem, true
+	if o == nil  {
+		return nil, false
+	}
+	return &o.StringItem, true
 }
 
 // SetStringItem sets field value
@@ -85,12 +84,11 @@ func (o *TypeHolderDefault) GetNumberItem() float32 {
 
 // GetNumberItemOk returns a tuple with the NumberItem field value
 // and a boolean to check if the value has been set.
-
 func (o *TypeHolderDefault) GetNumberItemOk() (*float32, bool) {
-    if o == nil  {
-        return nil, false
-    }
-    return &o.NumberItem, true
+	if o == nil  {
+		return nil, false
+	}
+	return &o.NumberItem, true
 }
 
 // SetNumberItem sets field value
@@ -110,12 +108,11 @@ func (o *TypeHolderDefault) GetIntegerItem() int32 {
 
 // GetIntegerItemOk returns a tuple with the IntegerItem field value
 // and a boolean to check if the value has been set.
-
 func (o *TypeHolderDefault) GetIntegerItemOk() (*int32, bool) {
-    if o == nil  {
-        return nil, false
-    }
-    return &o.IntegerItem, true
+	if o == nil  {
+		return nil, false
+	}
+	return &o.IntegerItem, true
 }
 
 // SetIntegerItem sets field value
@@ -135,12 +132,11 @@ func (o *TypeHolderDefault) GetBoolItem() bool {
 
 // GetBoolItemOk returns a tuple with the BoolItem field value
 // and a boolean to check if the value has been set.
-
 func (o *TypeHolderDefault) GetBoolItemOk() (*bool, bool) {
-    if o == nil  {
-        return nil, false
-    }
-    return &o.BoolItem, true
+	if o == nil  {
+		return nil, false
+	}
+	return &o.BoolItem, true
 }
 
 // SetBoolItem sets field value
@@ -160,12 +156,11 @@ func (o *TypeHolderDefault) GetArrayItem() []int32 {
 
 // GetArrayItemOk returns a tuple with the ArrayItem field value
 // and a boolean to check if the value has been set.
-
 func (o *TypeHolderDefault) GetArrayItemOk() (*[]int32, bool) {
-    if o == nil  {
-        return nil, false
-    }
-    return &o.ArrayItem, true
+	if o == nil  {
+		return nil, false
+	}
+	return &o.ArrayItem, true
 }
 
 // SetArrayItem sets field value

--- a/samples/client/petstore/go-experimental/go-petstore/model_type_holder_default.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_type_holder_default.go
@@ -10,7 +10,6 @@
 package petstore
 
 import (
-	"bytes"
 	"encoding/json"
 )
 
@@ -124,25 +123,58 @@ func (o *TypeHolderDefault) SetArrayItem(v []int32) {
 	o.ArrayItem = v
 }
 
+func (o TypeHolderDefault) MarshalJSON() ([]byte, error) {
+    toSerialize := map[string]interface{}{}
+    if true {
+        toSerialize["string_item"] = o.StringItem
+    }
+    if true {
+        toSerialize["number_item"] = o.NumberItem
+    }
+    if true {
+        toSerialize["integer_item"] = o.IntegerItem
+    }
+    if true {
+        toSerialize["bool_item"] = o.BoolItem
+    }
+    if true {
+        toSerialize["array_item"] = o.ArrayItem
+    }
+    return json.Marshal(toSerialize)
+}
+
 type NullableTypeHolderDefault struct {
-	Value TypeHolderDefault
-	ExplicitNull bool
+	value *TypeHolderDefault
+	isSet bool
+}
+
+func (v NullableTypeHolderDefault) Get() *TypeHolderDefault {
+    return v.value
+}
+
+func (v NullableTypeHolderDefault) Set(val *TypeHolderDefault) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableTypeHolderDefault) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableTypeHolderDefault) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableTypeHolderDefault(val *TypeHolderDefault) *NullableTypeHolderDefault {
+    return &NullableTypeHolderDefault{value: val, isSet: true}
 }
 
 func (v NullableTypeHolderDefault) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-		return json.Marshal(v.Value)
-	}
+    return json.Marshal(v.value)
 }
 
 func (v *NullableTypeHolderDefault) UnmarshalJSON(src []byte) error {
-	if bytes.Equal(src, []byte("null")) {
-		v.ExplicitNull = true
-		return nil
-	}
-
-	return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_type_holder_default.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_type_holder_default.go
@@ -41,10 +41,10 @@ func NewTypeHolderDefault(stringItem string, numberItem float32, integerItem int
 // but it doesn't guarantee that properties required by API are set
 func NewTypeHolderDefaultWithDefaults() *TypeHolderDefault {
     this := TypeHolderDefault{}
-    var stringItem string = "what"
-    this.StringItem = stringItem
-    var boolItem bool = true
-    this.BoolItem = boolItem
+	var stringItem string = "what"
+	this.StringItem = stringItem
+	var boolItem bool = true
+	this.BoolItem = boolItem
     return &this
 }
 
@@ -124,23 +124,23 @@ func (o *TypeHolderDefault) SetArrayItem(v []int32) {
 }
 
 func (o TypeHolderDefault) MarshalJSON() ([]byte, error) {
-    toSerialize := map[string]interface{}{}
-    if true {
-        toSerialize["string_item"] = o.StringItem
-    }
-    if true {
-        toSerialize["number_item"] = o.NumberItem
-    }
-    if true {
-        toSerialize["integer_item"] = o.IntegerItem
-    }
-    if true {
-        toSerialize["bool_item"] = o.BoolItem
-    }
-    if true {
-        toSerialize["array_item"] = o.ArrayItem
-    }
-    return json.Marshal(toSerialize)
+	toSerialize := map[string]interface{}{}
+	if true {
+		toSerialize["string_item"] = o.StringItem
+	}
+	if true {
+		toSerialize["number_item"] = o.NumberItem
+	}
+	if true {
+		toSerialize["integer_item"] = o.IntegerItem
+	}
+	if true {
+		toSerialize["bool_item"] = o.BoolItem
+	}
+	if true {
+		toSerialize["array_item"] = o.ArrayItem
+	}
+	return json.Marshal(toSerialize)
 }
 
 type NullableTypeHolderDefault struct {
@@ -149,32 +149,32 @@ type NullableTypeHolderDefault struct {
 }
 
 func (v NullableTypeHolderDefault) Get() *TypeHolderDefault {
-    return v.value
+	return v.value
 }
 
 func (v NullableTypeHolderDefault) Set(val *TypeHolderDefault) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableTypeHolderDefault) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableTypeHolderDefault) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableTypeHolderDefault(val *TypeHolderDefault) *NullableTypeHolderDefault {
-    return &NullableTypeHolderDefault{value: val, isSet: true}
+	return &NullableTypeHolderDefault{value: val, isSet: true}
 }
 
 func (v NullableTypeHolderDefault) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableTypeHolderDefault) UnmarshalJSON(src []byte) error {
-    v.isSet = true
+	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_type_holder_example.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_type_holder_example.go
@@ -168,7 +168,7 @@ func (v NullableTypeHolderExample) Get() *TypeHolderExample {
 	return v.value
 }
 
-func (v NullableTypeHolderExample) Set(val *TypeHolderExample) {
+func (v *NullableTypeHolderExample) Set(val *TypeHolderExample) {
 	v.value = val
 	v.isSet = true
 }
@@ -177,7 +177,7 @@ func (v NullableTypeHolderExample) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableTypeHolderExample) Unset() {
+func (v *NullableTypeHolderExample) Unset() {
 	v.value = nil
 	v.isSet = false
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_type_holder_example.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_type_holder_example.go
@@ -28,32 +28,42 @@ type TypeHolderExample struct {
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
 func NewTypeHolderExample(stringItem string, numberItem float32, floatItem float32, integerItem int32, boolItem bool, arrayItem []int32, ) *TypeHolderExample {
-    this := TypeHolderExample{}
-    this.StringItem = stringItem
-    this.NumberItem = numberItem
-    this.FloatItem = floatItem
-    this.IntegerItem = integerItem
-    this.BoolItem = boolItem
-    this.ArrayItem = arrayItem
-    return &this
+	this := TypeHolderExample{}
+	this.StringItem = stringItem
+	this.NumberItem = numberItem
+	this.FloatItem = floatItem
+	this.IntegerItem = integerItem
+	this.BoolItem = boolItem
+	this.ArrayItem = arrayItem
+	return &this
 }
 
 // NewTypeHolderExampleWithDefaults instantiates a new TypeHolderExample object
 // This constructor will only assign default values to properties that have it defined,
 // but it doesn't guarantee that properties required by API are set
 func NewTypeHolderExampleWithDefaults() *TypeHolderExample {
-    this := TypeHolderExample{}
-    return &this
+	this := TypeHolderExample{}
+	return &this
 }
 
 // GetStringItem returns the StringItem field value
 func (o *TypeHolderExample) GetStringItem() string {
-	if o == nil {
+	if o == nil  {
 		var ret string
 		return ret
 	}
 
 	return o.StringItem
+}
+
+// GetStringItemOk returns a tuple with the StringItem field value
+// and a boolean to check if the value has been set.
+
+func (o *TypeHolderExample) GetStringItemOk() (*string, bool) {
+    if o == nil  {
+        return nil, false
+    }
+    return &o.StringItem, true
 }
 
 // SetStringItem sets field value
@@ -63,12 +73,22 @@ func (o *TypeHolderExample) SetStringItem(v string) {
 
 // GetNumberItem returns the NumberItem field value
 func (o *TypeHolderExample) GetNumberItem() float32 {
-	if o == nil {
+	if o == nil  {
 		var ret float32
 		return ret
 	}
 
 	return o.NumberItem
+}
+
+// GetNumberItemOk returns a tuple with the NumberItem field value
+// and a boolean to check if the value has been set.
+
+func (o *TypeHolderExample) GetNumberItemOk() (*float32, bool) {
+    if o == nil  {
+        return nil, false
+    }
+    return &o.NumberItem, true
 }
 
 // SetNumberItem sets field value
@@ -78,12 +98,22 @@ func (o *TypeHolderExample) SetNumberItem(v float32) {
 
 // GetFloatItem returns the FloatItem field value
 func (o *TypeHolderExample) GetFloatItem() float32 {
-	if o == nil {
+	if o == nil  {
 		var ret float32
 		return ret
 	}
 
 	return o.FloatItem
+}
+
+// GetFloatItemOk returns a tuple with the FloatItem field value
+// and a boolean to check if the value has been set.
+
+func (o *TypeHolderExample) GetFloatItemOk() (*float32, bool) {
+    if o == nil  {
+        return nil, false
+    }
+    return &o.FloatItem, true
 }
 
 // SetFloatItem sets field value
@@ -93,12 +123,22 @@ func (o *TypeHolderExample) SetFloatItem(v float32) {
 
 // GetIntegerItem returns the IntegerItem field value
 func (o *TypeHolderExample) GetIntegerItem() int32 {
-	if o == nil {
+	if o == nil  {
 		var ret int32
 		return ret
 	}
 
 	return o.IntegerItem
+}
+
+// GetIntegerItemOk returns a tuple with the IntegerItem field value
+// and a boolean to check if the value has been set.
+
+func (o *TypeHolderExample) GetIntegerItemOk() (*int32, bool) {
+    if o == nil  {
+        return nil, false
+    }
+    return &o.IntegerItem, true
 }
 
 // SetIntegerItem sets field value
@@ -108,12 +148,22 @@ func (o *TypeHolderExample) SetIntegerItem(v int32) {
 
 // GetBoolItem returns the BoolItem field value
 func (o *TypeHolderExample) GetBoolItem() bool {
-	if o == nil {
+	if o == nil  {
 		var ret bool
 		return ret
 	}
 
 	return o.BoolItem
+}
+
+// GetBoolItemOk returns a tuple with the BoolItem field value
+// and a boolean to check if the value has been set.
+
+func (o *TypeHolderExample) GetBoolItemOk() (*bool, bool) {
+    if o == nil  {
+        return nil, false
+    }
+    return &o.BoolItem, true
 }
 
 // SetBoolItem sets field value
@@ -123,12 +173,22 @@ func (o *TypeHolderExample) SetBoolItem(v bool) {
 
 // GetArrayItem returns the ArrayItem field value
 func (o *TypeHolderExample) GetArrayItem() []int32 {
-	if o == nil {
+	if o == nil  {
 		var ret []int32
 		return ret
 	}
 
 	return o.ArrayItem
+}
+
+// GetArrayItemOk returns a tuple with the ArrayItem field value
+// and a boolean to check if the value has been set.
+
+func (o *TypeHolderExample) GetArrayItemOk() (*[]int32, bool) {
+    if o == nil  {
+        return nil, false
+    }
+    return &o.ArrayItem, true
 }
 
 // SetArrayItem sets field value

--- a/samples/client/petstore/go-experimental/go-petstore/model_type_holder_example.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_type_holder_example.go
@@ -137,26 +137,26 @@ func (o *TypeHolderExample) SetArrayItem(v []int32) {
 }
 
 func (o TypeHolderExample) MarshalJSON() ([]byte, error) {
-    toSerialize := map[string]interface{}{}
-    if true {
-        toSerialize["string_item"] = o.StringItem
-    }
-    if true {
-        toSerialize["number_item"] = o.NumberItem
-    }
-    if true {
-        toSerialize["float_item"] = o.FloatItem
-    }
-    if true {
-        toSerialize["integer_item"] = o.IntegerItem
-    }
-    if true {
-        toSerialize["bool_item"] = o.BoolItem
-    }
-    if true {
-        toSerialize["array_item"] = o.ArrayItem
-    }
-    return json.Marshal(toSerialize)
+	toSerialize := map[string]interface{}{}
+	if true {
+		toSerialize["string_item"] = o.StringItem
+	}
+	if true {
+		toSerialize["number_item"] = o.NumberItem
+	}
+	if true {
+		toSerialize["float_item"] = o.FloatItem
+	}
+	if true {
+		toSerialize["integer_item"] = o.IntegerItem
+	}
+	if true {
+		toSerialize["bool_item"] = o.BoolItem
+	}
+	if true {
+		toSerialize["array_item"] = o.ArrayItem
+	}
+	return json.Marshal(toSerialize)
 }
 
 type NullableTypeHolderExample struct {
@@ -165,32 +165,32 @@ type NullableTypeHolderExample struct {
 }
 
 func (v NullableTypeHolderExample) Get() *TypeHolderExample {
-    return v.value
+	return v.value
 }
 
 func (v NullableTypeHolderExample) Set(val *TypeHolderExample) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableTypeHolderExample) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableTypeHolderExample) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableTypeHolderExample(val *TypeHolderExample) *NullableTypeHolderExample {
-    return &NullableTypeHolderExample{value: val, isSet: true}
+	return &NullableTypeHolderExample{value: val, isSet: true}
 }
 
 func (v NullableTypeHolderExample) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableTypeHolderExample) UnmarshalJSON(src []byte) error {
-    v.isSet = true
+	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_type_holder_example.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_type_holder_example.go
@@ -10,7 +10,6 @@
 package petstore
 
 import (
-	"bytes"
 	"encoding/json"
 )
 
@@ -137,25 +136,61 @@ func (o *TypeHolderExample) SetArrayItem(v []int32) {
 	o.ArrayItem = v
 }
 
+func (o TypeHolderExample) MarshalJSON() ([]byte, error) {
+    toSerialize := map[string]interface{}{}
+    if true {
+        toSerialize["string_item"] = o.StringItem
+    }
+    if true {
+        toSerialize["number_item"] = o.NumberItem
+    }
+    if true {
+        toSerialize["float_item"] = o.FloatItem
+    }
+    if true {
+        toSerialize["integer_item"] = o.IntegerItem
+    }
+    if true {
+        toSerialize["bool_item"] = o.BoolItem
+    }
+    if true {
+        toSerialize["array_item"] = o.ArrayItem
+    }
+    return json.Marshal(toSerialize)
+}
+
 type NullableTypeHolderExample struct {
-	Value TypeHolderExample
-	ExplicitNull bool
+	value *TypeHolderExample
+	isSet bool
+}
+
+func (v NullableTypeHolderExample) Get() *TypeHolderExample {
+    return v.value
+}
+
+func (v NullableTypeHolderExample) Set(val *TypeHolderExample) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableTypeHolderExample) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableTypeHolderExample) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableTypeHolderExample(val *TypeHolderExample) *NullableTypeHolderExample {
+    return &NullableTypeHolderExample{value: val, isSet: true}
 }
 
 func (v NullableTypeHolderExample) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-		return json.Marshal(v.Value)
-	}
+    return json.Marshal(v.value)
 }
 
 func (v *NullableTypeHolderExample) UnmarshalJSON(src []byte) error {
-	if bytes.Equal(src, []byte("null")) {
-		v.ExplicitNull = true
-		return nil
-	}
-
-	return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_type_holder_example.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_type_holder_example.go
@@ -58,12 +58,11 @@ func (o *TypeHolderExample) GetStringItem() string {
 
 // GetStringItemOk returns a tuple with the StringItem field value
 // and a boolean to check if the value has been set.
-
 func (o *TypeHolderExample) GetStringItemOk() (*string, bool) {
-    if o == nil  {
-        return nil, false
-    }
-    return &o.StringItem, true
+	if o == nil  {
+		return nil, false
+	}
+	return &o.StringItem, true
 }
 
 // SetStringItem sets field value
@@ -83,12 +82,11 @@ func (o *TypeHolderExample) GetNumberItem() float32 {
 
 // GetNumberItemOk returns a tuple with the NumberItem field value
 // and a boolean to check if the value has been set.
-
 func (o *TypeHolderExample) GetNumberItemOk() (*float32, bool) {
-    if o == nil  {
-        return nil, false
-    }
-    return &o.NumberItem, true
+	if o == nil  {
+		return nil, false
+	}
+	return &o.NumberItem, true
 }
 
 // SetNumberItem sets field value
@@ -108,12 +106,11 @@ func (o *TypeHolderExample) GetFloatItem() float32 {
 
 // GetFloatItemOk returns a tuple with the FloatItem field value
 // and a boolean to check if the value has been set.
-
 func (o *TypeHolderExample) GetFloatItemOk() (*float32, bool) {
-    if o == nil  {
-        return nil, false
-    }
-    return &o.FloatItem, true
+	if o == nil  {
+		return nil, false
+	}
+	return &o.FloatItem, true
 }
 
 // SetFloatItem sets field value
@@ -133,12 +130,11 @@ func (o *TypeHolderExample) GetIntegerItem() int32 {
 
 // GetIntegerItemOk returns a tuple with the IntegerItem field value
 // and a boolean to check if the value has been set.
-
 func (o *TypeHolderExample) GetIntegerItemOk() (*int32, bool) {
-    if o == nil  {
-        return nil, false
-    }
-    return &o.IntegerItem, true
+	if o == nil  {
+		return nil, false
+	}
+	return &o.IntegerItem, true
 }
 
 // SetIntegerItem sets field value
@@ -158,12 +154,11 @@ func (o *TypeHolderExample) GetBoolItem() bool {
 
 // GetBoolItemOk returns a tuple with the BoolItem field value
 // and a boolean to check if the value has been set.
-
 func (o *TypeHolderExample) GetBoolItemOk() (*bool, bool) {
-    if o == nil  {
-        return nil, false
-    }
-    return &o.BoolItem, true
+	if o == nil  {
+		return nil, false
+	}
+	return &o.BoolItem, true
 }
 
 // SetBoolItem sets field value
@@ -183,12 +178,11 @@ func (o *TypeHolderExample) GetArrayItem() []int32 {
 
 // GetArrayItemOk returns a tuple with the ArrayItem field value
 // and a boolean to check if the value has been set.
-
 func (o *TypeHolderExample) GetArrayItemOk() (*[]int32, bool) {
-    if o == nil  {
-        return nil, false
-    }
-    return &o.ArrayItem, true
+	if o == nil  {
+		return nil, false
+	}
+	return &o.ArrayItem, true
 }
 
 // SetArrayItem sets field value

--- a/samples/client/petstore/go-experimental/go-petstore/model_user.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_user.go
@@ -345,7 +345,7 @@ func (v NullableUser) Get() *User {
 	return v.value
 }
 
-func (v NullableUser) Set(val *User) {
+func (v *NullableUser) Set(val *User) {
 	v.value = val
 	v.isSet = true
 }
@@ -354,7 +354,7 @@ func (v NullableUser) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableUser) Unset() {
+func (v *NullableUser) Unset() {
 	v.value = nil
 	v.isSet = false
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_user.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_user.go
@@ -59,12 +59,12 @@ func (o *User) GetIdOk() (int64, bool) {
 		var ret int64
 		return ret, false
 	}
-    return *o.Id, true
+	return *o.Id, true
 }
 
 // HasId returns a boolean if a field has been set.
 func (o *User) HasId() bool {
-    if o != nil && o.Id != nil {
+	if o != nil && o.Id != nil {
 		return true
 	}
 
@@ -92,12 +92,12 @@ func (o *User) GetUsernameOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-    return *o.Username, true
+	return *o.Username, true
 }
 
 // HasUsername returns a boolean if a field has been set.
 func (o *User) HasUsername() bool {
-    if o != nil && o.Username != nil {
+	if o != nil && o.Username != nil {
 		return true
 	}
 
@@ -125,12 +125,12 @@ func (o *User) GetFirstNameOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-    return *o.FirstName, true
+	return *o.FirstName, true
 }
 
 // HasFirstName returns a boolean if a field has been set.
 func (o *User) HasFirstName() bool {
-    if o != nil && o.FirstName != nil {
+	if o != nil && o.FirstName != nil {
 		return true
 	}
 
@@ -158,12 +158,12 @@ func (o *User) GetLastNameOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-    return *o.LastName, true
+	return *o.LastName, true
 }
 
 // HasLastName returns a boolean if a field has been set.
 func (o *User) HasLastName() bool {
-    if o != nil && o.LastName != nil {
+	if o != nil && o.LastName != nil {
 		return true
 	}
 
@@ -191,12 +191,12 @@ func (o *User) GetEmailOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-    return *o.Email, true
+	return *o.Email, true
 }
 
 // HasEmail returns a boolean if a field has been set.
 func (o *User) HasEmail() bool {
-    if o != nil && o.Email != nil {
+	if o != nil && o.Email != nil {
 		return true
 	}
 
@@ -224,12 +224,12 @@ func (o *User) GetPasswordOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-    return *o.Password, true
+	return *o.Password, true
 }
 
 // HasPassword returns a boolean if a field has been set.
 func (o *User) HasPassword() bool {
-    if o != nil && o.Password != nil {
+	if o != nil && o.Password != nil {
 		return true
 	}
 
@@ -257,12 +257,12 @@ func (o *User) GetPhoneOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-    return *o.Phone, true
+	return *o.Phone, true
 }
 
 // HasPhone returns a boolean if a field has been set.
 func (o *User) HasPhone() bool {
-    if o != nil && o.Phone != nil {
+	if o != nil && o.Phone != nil {
 		return true
 	}
 
@@ -290,12 +290,12 @@ func (o *User) GetUserStatusOk() (int32, bool) {
 		var ret int32
 		return ret, false
 	}
-    return *o.UserStatus, true
+	return *o.UserStatus, true
 }
 
 // HasUserStatus returns a boolean if a field has been set.
 func (o *User) HasUserStatus() bool {
-    if o != nil && o.UserStatus != nil {
+	if o != nil && o.UserStatus != nil {
 		return true
 	}
 
@@ -308,32 +308,32 @@ func (o *User) SetUserStatus(v int32) {
 }
 
 func (o User) MarshalJSON() ([]byte, error) {
-    toSerialize := map[string]interface{}{}
-    if o.Id != nil {
-        toSerialize["id"] = o.Id
-    }
-    if o.Username != nil {
-        toSerialize["username"] = o.Username
-    }
-    if o.FirstName != nil {
-        toSerialize["firstName"] = o.FirstName
-    }
-    if o.LastName != nil {
-        toSerialize["lastName"] = o.LastName
-    }
-    if o.Email != nil {
-        toSerialize["email"] = o.Email
-    }
-    if o.Password != nil {
-        toSerialize["password"] = o.Password
-    }
-    if o.Phone != nil {
-        toSerialize["phone"] = o.Phone
-    }
-    if o.UserStatus != nil {
-        toSerialize["userStatus"] = o.UserStatus
-    }
-    return json.Marshal(toSerialize)
+	toSerialize := map[string]interface{}{}
+	if o.Id != nil {
+		toSerialize["id"] = o.Id
+	}
+	if o.Username != nil {
+		toSerialize["username"] = o.Username
+	}
+	if o.FirstName != nil {
+		toSerialize["firstName"] = o.FirstName
+	}
+	if o.LastName != nil {
+		toSerialize["lastName"] = o.LastName
+	}
+	if o.Email != nil {
+		toSerialize["email"] = o.Email
+	}
+	if o.Password != nil {
+		toSerialize["password"] = o.Password
+	}
+	if o.Phone != nil {
+		toSerialize["phone"] = o.Phone
+	}
+	if o.UserStatus != nil {
+		toSerialize["userStatus"] = o.UserStatus
+	}
+	return json.Marshal(toSerialize)
 }
 
 type NullableUser struct {
@@ -342,32 +342,32 @@ type NullableUser struct {
 }
 
 func (v NullableUser) Get() *User {
-    return v.value
+	return v.value
 }
 
 func (v NullableUser) Set(val *User) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableUser) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableUser) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableUser(val *User) *NullableUser {
-    return &NullableUser{value: val, isSet: true}
+	return &NullableUser{value: val, isSet: true}
 }
 
 func (v NullableUser) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableUser) UnmarshalJSON(src []byte) error {
-    v.isSet = true
+	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_user.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_user.go
@@ -54,7 +54,6 @@ func (o *User) GetId() int64 {
 
 // GetIdOk returns a tuple with the Id field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *User) GetIdOk() (*int64, bool) {
 	if o == nil || o.Id == nil {
 		return nil, false
@@ -87,7 +86,6 @@ func (o *User) GetUsername() string {
 
 // GetUsernameOk returns a tuple with the Username field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *User) GetUsernameOk() (*string, bool) {
 	if o == nil || o.Username == nil {
 		return nil, false
@@ -120,7 +118,6 @@ func (o *User) GetFirstName() string {
 
 // GetFirstNameOk returns a tuple with the FirstName field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *User) GetFirstNameOk() (*string, bool) {
 	if o == nil || o.FirstName == nil {
 		return nil, false
@@ -153,7 +150,6 @@ func (o *User) GetLastName() string {
 
 // GetLastNameOk returns a tuple with the LastName field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *User) GetLastNameOk() (*string, bool) {
 	if o == nil || o.LastName == nil {
 		return nil, false
@@ -186,7 +182,6 @@ func (o *User) GetEmail() string {
 
 // GetEmailOk returns a tuple with the Email field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *User) GetEmailOk() (*string, bool) {
 	if o == nil || o.Email == nil {
 		return nil, false
@@ -219,7 +214,6 @@ func (o *User) GetPassword() string {
 
 // GetPasswordOk returns a tuple with the Password field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *User) GetPasswordOk() (*string, bool) {
 	if o == nil || o.Password == nil {
 		return nil, false
@@ -252,7 +246,6 @@ func (o *User) GetPhone() string {
 
 // GetPhoneOk returns a tuple with the Phone field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *User) GetPhoneOk() (*string, bool) {
 	if o == nil || o.Phone == nil {
 		return nil, false
@@ -285,7 +278,6 @@ func (o *User) GetUserStatus() int32 {
 
 // GetUserStatusOk returns a tuple with the UserStatus field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *User) GetUserStatusOk() (*int32, bool) {
 	if o == nil || o.UserStatus == nil {
 		return nil, false

--- a/samples/client/petstore/go-experimental/go-petstore/model_user.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_user.go
@@ -10,7 +10,6 @@
 package petstore
 
 import (
-	"bytes"
 	"encoding/json"
 )
 
@@ -60,12 +59,12 @@ func (o *User) GetIdOk() (int64, bool) {
 		var ret int64
 		return ret, false
 	}
-	return *o.Id, true
+    return *o.Id, true
 }
 
 // HasId returns a boolean if a field has been set.
 func (o *User) HasId() bool {
-	if o != nil && o.Id != nil {
+    if o != nil && o.Id != nil {
 		return true
 	}
 
@@ -93,12 +92,12 @@ func (o *User) GetUsernameOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-	return *o.Username, true
+    return *o.Username, true
 }
 
 // HasUsername returns a boolean if a field has been set.
 func (o *User) HasUsername() bool {
-	if o != nil && o.Username != nil {
+    if o != nil && o.Username != nil {
 		return true
 	}
 
@@ -126,12 +125,12 @@ func (o *User) GetFirstNameOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-	return *o.FirstName, true
+    return *o.FirstName, true
 }
 
 // HasFirstName returns a boolean if a field has been set.
 func (o *User) HasFirstName() bool {
-	if o != nil && o.FirstName != nil {
+    if o != nil && o.FirstName != nil {
 		return true
 	}
 
@@ -159,12 +158,12 @@ func (o *User) GetLastNameOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-	return *o.LastName, true
+    return *o.LastName, true
 }
 
 // HasLastName returns a boolean if a field has been set.
 func (o *User) HasLastName() bool {
-	if o != nil && o.LastName != nil {
+    if o != nil && o.LastName != nil {
 		return true
 	}
 
@@ -192,12 +191,12 @@ func (o *User) GetEmailOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-	return *o.Email, true
+    return *o.Email, true
 }
 
 // HasEmail returns a boolean if a field has been set.
 func (o *User) HasEmail() bool {
-	if o != nil && o.Email != nil {
+    if o != nil && o.Email != nil {
 		return true
 	}
 
@@ -225,12 +224,12 @@ func (o *User) GetPasswordOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-	return *o.Password, true
+    return *o.Password, true
 }
 
 // HasPassword returns a boolean if a field has been set.
 func (o *User) HasPassword() bool {
-	if o != nil && o.Password != nil {
+    if o != nil && o.Password != nil {
 		return true
 	}
 
@@ -258,12 +257,12 @@ func (o *User) GetPhoneOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-	return *o.Phone, true
+    return *o.Phone, true
 }
 
 // HasPhone returns a boolean if a field has been set.
 func (o *User) HasPhone() bool {
-	if o != nil && o.Phone != nil {
+    if o != nil && o.Phone != nil {
 		return true
 	}
 
@@ -291,12 +290,12 @@ func (o *User) GetUserStatusOk() (int32, bool) {
 		var ret int32
 		return ret, false
 	}
-	return *o.UserStatus, true
+    return *o.UserStatus, true
 }
 
 // HasUserStatus returns a boolean if a field has been set.
 func (o *User) HasUserStatus() bool {
-	if o != nil && o.UserStatus != nil {
+    if o != nil && o.UserStatus != nil {
 		return true
 	}
 
@@ -308,25 +307,67 @@ func (o *User) SetUserStatus(v int32) {
 	o.UserStatus = &v
 }
 
+func (o User) MarshalJSON() ([]byte, error) {
+    toSerialize := map[string]interface{}{}
+    if o.Id != nil {
+        toSerialize["id"] = o.Id
+    }
+    if o.Username != nil {
+        toSerialize["username"] = o.Username
+    }
+    if o.FirstName != nil {
+        toSerialize["firstName"] = o.FirstName
+    }
+    if o.LastName != nil {
+        toSerialize["lastName"] = o.LastName
+    }
+    if o.Email != nil {
+        toSerialize["email"] = o.Email
+    }
+    if o.Password != nil {
+        toSerialize["password"] = o.Password
+    }
+    if o.Phone != nil {
+        toSerialize["phone"] = o.Phone
+    }
+    if o.UserStatus != nil {
+        toSerialize["userStatus"] = o.UserStatus
+    }
+    return json.Marshal(toSerialize)
+}
+
 type NullableUser struct {
-	Value User
-	ExplicitNull bool
+	value *User
+	isSet bool
+}
+
+func (v NullableUser) Get() *User {
+    return v.value
+}
+
+func (v NullableUser) Set(val *User) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableUser) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableUser) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableUser(val *User) *NullableUser {
+    return &NullableUser{value: val, isSet: true}
 }
 
 func (v NullableUser) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-		return json.Marshal(v.Value)
-	}
+    return json.Marshal(v.value)
 }
 
 func (v *NullableUser) UnmarshalJSON(src []byte) error {
-	if bytes.Equal(src, []byte("null")) {
-		v.ExplicitNull = true
-		return nil
-	}
-
-	return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_user.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_user.go
@@ -31,16 +31,16 @@ type User struct {
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
 func NewUser() *User {
-    this := User{}
-    return &this
+	this := User{}
+	return &this
 }
 
 // NewUserWithDefaults instantiates a new User object
 // This constructor will only assign default values to properties that have it defined,
 // but it doesn't guarantee that properties required by API are set
 func NewUserWithDefaults() *User {
-    this := User{}
-    return &this
+	this := User{}
+	return &this
 }
 
 // GetId returns the Id field value if set, zero value otherwise.
@@ -52,14 +52,14 @@ func (o *User) GetId() int64 {
 	return *o.Id
 }
 
-// GetIdOk returns a tuple with the Id field value if set, zero value otherwise
+// GetIdOk returns a tuple with the Id field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *User) GetIdOk() (int64, bool) {
+
+func (o *User) GetIdOk() (*int64, bool) {
 	if o == nil || o.Id == nil {
-		var ret int64
-		return ret, false
+		return nil, false
 	}
-	return *o.Id, true
+	return o.Id, true
 }
 
 // HasId returns a boolean if a field has been set.
@@ -85,14 +85,14 @@ func (o *User) GetUsername() string {
 	return *o.Username
 }
 
-// GetUsernameOk returns a tuple with the Username field value if set, zero value otherwise
+// GetUsernameOk returns a tuple with the Username field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *User) GetUsernameOk() (string, bool) {
+
+func (o *User) GetUsernameOk() (*string, bool) {
 	if o == nil || o.Username == nil {
-		var ret string
-		return ret, false
+		return nil, false
 	}
-	return *o.Username, true
+	return o.Username, true
 }
 
 // HasUsername returns a boolean if a field has been set.
@@ -118,14 +118,14 @@ func (o *User) GetFirstName() string {
 	return *o.FirstName
 }
 
-// GetFirstNameOk returns a tuple with the FirstName field value if set, zero value otherwise
+// GetFirstNameOk returns a tuple with the FirstName field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *User) GetFirstNameOk() (string, bool) {
+
+func (o *User) GetFirstNameOk() (*string, bool) {
 	if o == nil || o.FirstName == nil {
-		var ret string
-		return ret, false
+		return nil, false
 	}
-	return *o.FirstName, true
+	return o.FirstName, true
 }
 
 // HasFirstName returns a boolean if a field has been set.
@@ -151,14 +151,14 @@ func (o *User) GetLastName() string {
 	return *o.LastName
 }
 
-// GetLastNameOk returns a tuple with the LastName field value if set, zero value otherwise
+// GetLastNameOk returns a tuple with the LastName field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *User) GetLastNameOk() (string, bool) {
+
+func (o *User) GetLastNameOk() (*string, bool) {
 	if o == nil || o.LastName == nil {
-		var ret string
-		return ret, false
+		return nil, false
 	}
-	return *o.LastName, true
+	return o.LastName, true
 }
 
 // HasLastName returns a boolean if a field has been set.
@@ -184,14 +184,14 @@ func (o *User) GetEmail() string {
 	return *o.Email
 }
 
-// GetEmailOk returns a tuple with the Email field value if set, zero value otherwise
+// GetEmailOk returns a tuple with the Email field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *User) GetEmailOk() (string, bool) {
+
+func (o *User) GetEmailOk() (*string, bool) {
 	if o == nil || o.Email == nil {
-		var ret string
-		return ret, false
+		return nil, false
 	}
-	return *o.Email, true
+	return o.Email, true
 }
 
 // HasEmail returns a boolean if a field has been set.
@@ -217,14 +217,14 @@ func (o *User) GetPassword() string {
 	return *o.Password
 }
 
-// GetPasswordOk returns a tuple with the Password field value if set, zero value otherwise
+// GetPasswordOk returns a tuple with the Password field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *User) GetPasswordOk() (string, bool) {
+
+func (o *User) GetPasswordOk() (*string, bool) {
 	if o == nil || o.Password == nil {
-		var ret string
-		return ret, false
+		return nil, false
 	}
-	return *o.Password, true
+	return o.Password, true
 }
 
 // HasPassword returns a boolean if a field has been set.
@@ -250,14 +250,14 @@ func (o *User) GetPhone() string {
 	return *o.Phone
 }
 
-// GetPhoneOk returns a tuple with the Phone field value if set, zero value otherwise
+// GetPhoneOk returns a tuple with the Phone field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *User) GetPhoneOk() (string, bool) {
+
+func (o *User) GetPhoneOk() (*string, bool) {
 	if o == nil || o.Phone == nil {
-		var ret string
-		return ret, false
+		return nil, false
 	}
-	return *o.Phone, true
+	return o.Phone, true
 }
 
 // HasPhone returns a boolean if a field has been set.
@@ -283,14 +283,14 @@ func (o *User) GetUserStatus() int32 {
 	return *o.UserStatus
 }
 
-// GetUserStatusOk returns a tuple with the UserStatus field value if set, zero value otherwise
+// GetUserStatusOk returns a tuple with the UserStatus field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *User) GetUserStatusOk() (int32, bool) {
+
+func (o *User) GetUserStatusOk() (*int32, bool) {
 	if o == nil || o.UserStatus == nil {
-		var ret int32
-		return ret, false
+		return nil, false
 	}
-	return *o.UserStatus, true
+	return o.UserStatus, true
 }
 
 // HasUserStatus returns a boolean if a field has been set.

--- a/samples/client/petstore/go-experimental/go-petstore/model_xml_item.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_xml_item.go
@@ -79,12 +79,12 @@ func (o *XmlItem) GetAttributeStringOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-    return *o.AttributeString, true
+	return *o.AttributeString, true
 }
 
 // HasAttributeString returns a boolean if a field has been set.
 func (o *XmlItem) HasAttributeString() bool {
-    if o != nil && o.AttributeString != nil {
+	if o != nil && o.AttributeString != nil {
 		return true
 	}
 
@@ -112,12 +112,12 @@ func (o *XmlItem) GetAttributeNumberOk() (float32, bool) {
 		var ret float32
 		return ret, false
 	}
-    return *o.AttributeNumber, true
+	return *o.AttributeNumber, true
 }
 
 // HasAttributeNumber returns a boolean if a field has been set.
 func (o *XmlItem) HasAttributeNumber() bool {
-    if o != nil && o.AttributeNumber != nil {
+	if o != nil && o.AttributeNumber != nil {
 		return true
 	}
 
@@ -145,12 +145,12 @@ func (o *XmlItem) GetAttributeIntegerOk() (int32, bool) {
 		var ret int32
 		return ret, false
 	}
-    return *o.AttributeInteger, true
+	return *o.AttributeInteger, true
 }
 
 // HasAttributeInteger returns a boolean if a field has been set.
 func (o *XmlItem) HasAttributeInteger() bool {
-    if o != nil && o.AttributeInteger != nil {
+	if o != nil && o.AttributeInteger != nil {
 		return true
 	}
 
@@ -178,12 +178,12 @@ func (o *XmlItem) GetAttributeBooleanOk() (bool, bool) {
 		var ret bool
 		return ret, false
 	}
-    return *o.AttributeBoolean, true
+	return *o.AttributeBoolean, true
 }
 
 // HasAttributeBoolean returns a boolean if a field has been set.
 func (o *XmlItem) HasAttributeBoolean() bool {
-    if o != nil && o.AttributeBoolean != nil {
+	if o != nil && o.AttributeBoolean != nil {
 		return true
 	}
 
@@ -211,12 +211,12 @@ func (o *XmlItem) GetWrappedArrayOk() ([]int32, bool) {
 		var ret []int32
 		return ret, false
 	}
-    return *o.WrappedArray, true
+	return *o.WrappedArray, true
 }
 
 // HasWrappedArray returns a boolean if a field has been set.
 func (o *XmlItem) HasWrappedArray() bool {
-    if o != nil && o.WrappedArray != nil {
+	if o != nil && o.WrappedArray != nil {
 		return true
 	}
 
@@ -244,12 +244,12 @@ func (o *XmlItem) GetNameStringOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-    return *o.NameString, true
+	return *o.NameString, true
 }
 
 // HasNameString returns a boolean if a field has been set.
 func (o *XmlItem) HasNameString() bool {
-    if o != nil && o.NameString != nil {
+	if o != nil && o.NameString != nil {
 		return true
 	}
 
@@ -277,12 +277,12 @@ func (o *XmlItem) GetNameNumberOk() (float32, bool) {
 		var ret float32
 		return ret, false
 	}
-    return *o.NameNumber, true
+	return *o.NameNumber, true
 }
 
 // HasNameNumber returns a boolean if a field has been set.
 func (o *XmlItem) HasNameNumber() bool {
-    if o != nil && o.NameNumber != nil {
+	if o != nil && o.NameNumber != nil {
 		return true
 	}
 
@@ -310,12 +310,12 @@ func (o *XmlItem) GetNameIntegerOk() (int32, bool) {
 		var ret int32
 		return ret, false
 	}
-    return *o.NameInteger, true
+	return *o.NameInteger, true
 }
 
 // HasNameInteger returns a boolean if a field has been set.
 func (o *XmlItem) HasNameInteger() bool {
-    if o != nil && o.NameInteger != nil {
+	if o != nil && o.NameInteger != nil {
 		return true
 	}
 
@@ -343,12 +343,12 @@ func (o *XmlItem) GetNameBooleanOk() (bool, bool) {
 		var ret bool
 		return ret, false
 	}
-    return *o.NameBoolean, true
+	return *o.NameBoolean, true
 }
 
 // HasNameBoolean returns a boolean if a field has been set.
 func (o *XmlItem) HasNameBoolean() bool {
-    if o != nil && o.NameBoolean != nil {
+	if o != nil && o.NameBoolean != nil {
 		return true
 	}
 
@@ -376,12 +376,12 @@ func (o *XmlItem) GetNameArrayOk() ([]int32, bool) {
 		var ret []int32
 		return ret, false
 	}
-    return *o.NameArray, true
+	return *o.NameArray, true
 }
 
 // HasNameArray returns a boolean if a field has been set.
 func (o *XmlItem) HasNameArray() bool {
-    if o != nil && o.NameArray != nil {
+	if o != nil && o.NameArray != nil {
 		return true
 	}
 
@@ -409,12 +409,12 @@ func (o *XmlItem) GetNameWrappedArrayOk() ([]int32, bool) {
 		var ret []int32
 		return ret, false
 	}
-    return *o.NameWrappedArray, true
+	return *o.NameWrappedArray, true
 }
 
 // HasNameWrappedArray returns a boolean if a field has been set.
 func (o *XmlItem) HasNameWrappedArray() bool {
-    if o != nil && o.NameWrappedArray != nil {
+	if o != nil && o.NameWrappedArray != nil {
 		return true
 	}
 
@@ -442,12 +442,12 @@ func (o *XmlItem) GetPrefixStringOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-    return *o.PrefixString, true
+	return *o.PrefixString, true
 }
 
 // HasPrefixString returns a boolean if a field has been set.
 func (o *XmlItem) HasPrefixString() bool {
-    if o != nil && o.PrefixString != nil {
+	if o != nil && o.PrefixString != nil {
 		return true
 	}
 
@@ -475,12 +475,12 @@ func (o *XmlItem) GetPrefixNumberOk() (float32, bool) {
 		var ret float32
 		return ret, false
 	}
-    return *o.PrefixNumber, true
+	return *o.PrefixNumber, true
 }
 
 // HasPrefixNumber returns a boolean if a field has been set.
 func (o *XmlItem) HasPrefixNumber() bool {
-    if o != nil && o.PrefixNumber != nil {
+	if o != nil && o.PrefixNumber != nil {
 		return true
 	}
 
@@ -508,12 +508,12 @@ func (o *XmlItem) GetPrefixIntegerOk() (int32, bool) {
 		var ret int32
 		return ret, false
 	}
-    return *o.PrefixInteger, true
+	return *o.PrefixInteger, true
 }
 
 // HasPrefixInteger returns a boolean if a field has been set.
 func (o *XmlItem) HasPrefixInteger() bool {
-    if o != nil && o.PrefixInteger != nil {
+	if o != nil && o.PrefixInteger != nil {
 		return true
 	}
 
@@ -541,12 +541,12 @@ func (o *XmlItem) GetPrefixBooleanOk() (bool, bool) {
 		var ret bool
 		return ret, false
 	}
-    return *o.PrefixBoolean, true
+	return *o.PrefixBoolean, true
 }
 
 // HasPrefixBoolean returns a boolean if a field has been set.
 func (o *XmlItem) HasPrefixBoolean() bool {
-    if o != nil && o.PrefixBoolean != nil {
+	if o != nil && o.PrefixBoolean != nil {
 		return true
 	}
 
@@ -574,12 +574,12 @@ func (o *XmlItem) GetPrefixArrayOk() ([]int32, bool) {
 		var ret []int32
 		return ret, false
 	}
-    return *o.PrefixArray, true
+	return *o.PrefixArray, true
 }
 
 // HasPrefixArray returns a boolean if a field has been set.
 func (o *XmlItem) HasPrefixArray() bool {
-    if o != nil && o.PrefixArray != nil {
+	if o != nil && o.PrefixArray != nil {
 		return true
 	}
 
@@ -607,12 +607,12 @@ func (o *XmlItem) GetPrefixWrappedArrayOk() ([]int32, bool) {
 		var ret []int32
 		return ret, false
 	}
-    return *o.PrefixWrappedArray, true
+	return *o.PrefixWrappedArray, true
 }
 
 // HasPrefixWrappedArray returns a boolean if a field has been set.
 func (o *XmlItem) HasPrefixWrappedArray() bool {
-    if o != nil && o.PrefixWrappedArray != nil {
+	if o != nil && o.PrefixWrappedArray != nil {
 		return true
 	}
 
@@ -640,12 +640,12 @@ func (o *XmlItem) GetNamespaceStringOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-    return *o.NamespaceString, true
+	return *o.NamespaceString, true
 }
 
 // HasNamespaceString returns a boolean if a field has been set.
 func (o *XmlItem) HasNamespaceString() bool {
-    if o != nil && o.NamespaceString != nil {
+	if o != nil && o.NamespaceString != nil {
 		return true
 	}
 
@@ -673,12 +673,12 @@ func (o *XmlItem) GetNamespaceNumberOk() (float32, bool) {
 		var ret float32
 		return ret, false
 	}
-    return *o.NamespaceNumber, true
+	return *o.NamespaceNumber, true
 }
 
 // HasNamespaceNumber returns a boolean if a field has been set.
 func (o *XmlItem) HasNamespaceNumber() bool {
-    if o != nil && o.NamespaceNumber != nil {
+	if o != nil && o.NamespaceNumber != nil {
 		return true
 	}
 
@@ -706,12 +706,12 @@ func (o *XmlItem) GetNamespaceIntegerOk() (int32, bool) {
 		var ret int32
 		return ret, false
 	}
-    return *o.NamespaceInteger, true
+	return *o.NamespaceInteger, true
 }
 
 // HasNamespaceInteger returns a boolean if a field has been set.
 func (o *XmlItem) HasNamespaceInteger() bool {
-    if o != nil && o.NamespaceInteger != nil {
+	if o != nil && o.NamespaceInteger != nil {
 		return true
 	}
 
@@ -739,12 +739,12 @@ func (o *XmlItem) GetNamespaceBooleanOk() (bool, bool) {
 		var ret bool
 		return ret, false
 	}
-    return *o.NamespaceBoolean, true
+	return *o.NamespaceBoolean, true
 }
 
 // HasNamespaceBoolean returns a boolean if a field has been set.
 func (o *XmlItem) HasNamespaceBoolean() bool {
-    if o != nil && o.NamespaceBoolean != nil {
+	if o != nil && o.NamespaceBoolean != nil {
 		return true
 	}
 
@@ -772,12 +772,12 @@ func (o *XmlItem) GetNamespaceArrayOk() ([]int32, bool) {
 		var ret []int32
 		return ret, false
 	}
-    return *o.NamespaceArray, true
+	return *o.NamespaceArray, true
 }
 
 // HasNamespaceArray returns a boolean if a field has been set.
 func (o *XmlItem) HasNamespaceArray() bool {
-    if o != nil && o.NamespaceArray != nil {
+	if o != nil && o.NamespaceArray != nil {
 		return true
 	}
 
@@ -805,12 +805,12 @@ func (o *XmlItem) GetNamespaceWrappedArrayOk() ([]int32, bool) {
 		var ret []int32
 		return ret, false
 	}
-    return *o.NamespaceWrappedArray, true
+	return *o.NamespaceWrappedArray, true
 }
 
 // HasNamespaceWrappedArray returns a boolean if a field has been set.
 func (o *XmlItem) HasNamespaceWrappedArray() bool {
-    if o != nil && o.NamespaceWrappedArray != nil {
+	if o != nil && o.NamespaceWrappedArray != nil {
 		return true
 	}
 
@@ -838,12 +838,12 @@ func (o *XmlItem) GetPrefixNsStringOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-    return *o.PrefixNsString, true
+	return *o.PrefixNsString, true
 }
 
 // HasPrefixNsString returns a boolean if a field has been set.
 func (o *XmlItem) HasPrefixNsString() bool {
-    if o != nil && o.PrefixNsString != nil {
+	if o != nil && o.PrefixNsString != nil {
 		return true
 	}
 
@@ -871,12 +871,12 @@ func (o *XmlItem) GetPrefixNsNumberOk() (float32, bool) {
 		var ret float32
 		return ret, false
 	}
-    return *o.PrefixNsNumber, true
+	return *o.PrefixNsNumber, true
 }
 
 // HasPrefixNsNumber returns a boolean if a field has been set.
 func (o *XmlItem) HasPrefixNsNumber() bool {
-    if o != nil && o.PrefixNsNumber != nil {
+	if o != nil && o.PrefixNsNumber != nil {
 		return true
 	}
 
@@ -904,12 +904,12 @@ func (o *XmlItem) GetPrefixNsIntegerOk() (int32, bool) {
 		var ret int32
 		return ret, false
 	}
-    return *o.PrefixNsInteger, true
+	return *o.PrefixNsInteger, true
 }
 
 // HasPrefixNsInteger returns a boolean if a field has been set.
 func (o *XmlItem) HasPrefixNsInteger() bool {
-    if o != nil && o.PrefixNsInteger != nil {
+	if o != nil && o.PrefixNsInteger != nil {
 		return true
 	}
 
@@ -937,12 +937,12 @@ func (o *XmlItem) GetPrefixNsBooleanOk() (bool, bool) {
 		var ret bool
 		return ret, false
 	}
-    return *o.PrefixNsBoolean, true
+	return *o.PrefixNsBoolean, true
 }
 
 // HasPrefixNsBoolean returns a boolean if a field has been set.
 func (o *XmlItem) HasPrefixNsBoolean() bool {
-    if o != nil && o.PrefixNsBoolean != nil {
+	if o != nil && o.PrefixNsBoolean != nil {
 		return true
 	}
 
@@ -970,12 +970,12 @@ func (o *XmlItem) GetPrefixNsArrayOk() ([]int32, bool) {
 		var ret []int32
 		return ret, false
 	}
-    return *o.PrefixNsArray, true
+	return *o.PrefixNsArray, true
 }
 
 // HasPrefixNsArray returns a boolean if a field has been set.
 func (o *XmlItem) HasPrefixNsArray() bool {
-    if o != nil && o.PrefixNsArray != nil {
+	if o != nil && o.PrefixNsArray != nil {
 		return true
 	}
 
@@ -1003,12 +1003,12 @@ func (o *XmlItem) GetPrefixNsWrappedArrayOk() ([]int32, bool) {
 		var ret []int32
 		return ret, false
 	}
-    return *o.PrefixNsWrappedArray, true
+	return *o.PrefixNsWrappedArray, true
 }
 
 // HasPrefixNsWrappedArray returns a boolean if a field has been set.
 func (o *XmlItem) HasPrefixNsWrappedArray() bool {
-    if o != nil && o.PrefixNsWrappedArray != nil {
+	if o != nil && o.PrefixNsWrappedArray != nil {
 		return true
 	}
 
@@ -1021,95 +1021,95 @@ func (o *XmlItem) SetPrefixNsWrappedArray(v []int32) {
 }
 
 func (o XmlItem) MarshalJSON() ([]byte, error) {
-    toSerialize := map[string]interface{}{}
-    if o.AttributeString != nil {
-        toSerialize["attribute_string"] = o.AttributeString
-    }
-    if o.AttributeNumber != nil {
-        toSerialize["attribute_number"] = o.AttributeNumber
-    }
-    if o.AttributeInteger != nil {
-        toSerialize["attribute_integer"] = o.AttributeInteger
-    }
-    if o.AttributeBoolean != nil {
-        toSerialize["attribute_boolean"] = o.AttributeBoolean
-    }
-    if o.WrappedArray != nil {
-        toSerialize["wrapped_array"] = o.WrappedArray
-    }
-    if o.NameString != nil {
-        toSerialize["name_string"] = o.NameString
-    }
-    if o.NameNumber != nil {
-        toSerialize["name_number"] = o.NameNumber
-    }
-    if o.NameInteger != nil {
-        toSerialize["name_integer"] = o.NameInteger
-    }
-    if o.NameBoolean != nil {
-        toSerialize["name_boolean"] = o.NameBoolean
-    }
-    if o.NameArray != nil {
-        toSerialize["name_array"] = o.NameArray
-    }
-    if o.NameWrappedArray != nil {
-        toSerialize["name_wrapped_array"] = o.NameWrappedArray
-    }
-    if o.PrefixString != nil {
-        toSerialize["prefix_string"] = o.PrefixString
-    }
-    if o.PrefixNumber != nil {
-        toSerialize["prefix_number"] = o.PrefixNumber
-    }
-    if o.PrefixInteger != nil {
-        toSerialize["prefix_integer"] = o.PrefixInteger
-    }
-    if o.PrefixBoolean != nil {
-        toSerialize["prefix_boolean"] = o.PrefixBoolean
-    }
-    if o.PrefixArray != nil {
-        toSerialize["prefix_array"] = o.PrefixArray
-    }
-    if o.PrefixWrappedArray != nil {
-        toSerialize["prefix_wrapped_array"] = o.PrefixWrappedArray
-    }
-    if o.NamespaceString != nil {
-        toSerialize["namespace_string"] = o.NamespaceString
-    }
-    if o.NamespaceNumber != nil {
-        toSerialize["namespace_number"] = o.NamespaceNumber
-    }
-    if o.NamespaceInteger != nil {
-        toSerialize["namespace_integer"] = o.NamespaceInteger
-    }
-    if o.NamespaceBoolean != nil {
-        toSerialize["namespace_boolean"] = o.NamespaceBoolean
-    }
-    if o.NamespaceArray != nil {
-        toSerialize["namespace_array"] = o.NamespaceArray
-    }
-    if o.NamespaceWrappedArray != nil {
-        toSerialize["namespace_wrapped_array"] = o.NamespaceWrappedArray
-    }
-    if o.PrefixNsString != nil {
-        toSerialize["prefix_ns_string"] = o.PrefixNsString
-    }
-    if o.PrefixNsNumber != nil {
-        toSerialize["prefix_ns_number"] = o.PrefixNsNumber
-    }
-    if o.PrefixNsInteger != nil {
-        toSerialize["prefix_ns_integer"] = o.PrefixNsInteger
-    }
-    if o.PrefixNsBoolean != nil {
-        toSerialize["prefix_ns_boolean"] = o.PrefixNsBoolean
-    }
-    if o.PrefixNsArray != nil {
-        toSerialize["prefix_ns_array"] = o.PrefixNsArray
-    }
-    if o.PrefixNsWrappedArray != nil {
-        toSerialize["prefix_ns_wrapped_array"] = o.PrefixNsWrappedArray
-    }
-    return json.Marshal(toSerialize)
+	toSerialize := map[string]interface{}{}
+	if o.AttributeString != nil {
+		toSerialize["attribute_string"] = o.AttributeString
+	}
+	if o.AttributeNumber != nil {
+		toSerialize["attribute_number"] = o.AttributeNumber
+	}
+	if o.AttributeInteger != nil {
+		toSerialize["attribute_integer"] = o.AttributeInteger
+	}
+	if o.AttributeBoolean != nil {
+		toSerialize["attribute_boolean"] = o.AttributeBoolean
+	}
+	if o.WrappedArray != nil {
+		toSerialize["wrapped_array"] = o.WrappedArray
+	}
+	if o.NameString != nil {
+		toSerialize["name_string"] = o.NameString
+	}
+	if o.NameNumber != nil {
+		toSerialize["name_number"] = o.NameNumber
+	}
+	if o.NameInteger != nil {
+		toSerialize["name_integer"] = o.NameInteger
+	}
+	if o.NameBoolean != nil {
+		toSerialize["name_boolean"] = o.NameBoolean
+	}
+	if o.NameArray != nil {
+		toSerialize["name_array"] = o.NameArray
+	}
+	if o.NameWrappedArray != nil {
+		toSerialize["name_wrapped_array"] = o.NameWrappedArray
+	}
+	if o.PrefixString != nil {
+		toSerialize["prefix_string"] = o.PrefixString
+	}
+	if o.PrefixNumber != nil {
+		toSerialize["prefix_number"] = o.PrefixNumber
+	}
+	if o.PrefixInteger != nil {
+		toSerialize["prefix_integer"] = o.PrefixInteger
+	}
+	if o.PrefixBoolean != nil {
+		toSerialize["prefix_boolean"] = o.PrefixBoolean
+	}
+	if o.PrefixArray != nil {
+		toSerialize["prefix_array"] = o.PrefixArray
+	}
+	if o.PrefixWrappedArray != nil {
+		toSerialize["prefix_wrapped_array"] = o.PrefixWrappedArray
+	}
+	if o.NamespaceString != nil {
+		toSerialize["namespace_string"] = o.NamespaceString
+	}
+	if o.NamespaceNumber != nil {
+		toSerialize["namespace_number"] = o.NamespaceNumber
+	}
+	if o.NamespaceInteger != nil {
+		toSerialize["namespace_integer"] = o.NamespaceInteger
+	}
+	if o.NamespaceBoolean != nil {
+		toSerialize["namespace_boolean"] = o.NamespaceBoolean
+	}
+	if o.NamespaceArray != nil {
+		toSerialize["namespace_array"] = o.NamespaceArray
+	}
+	if o.NamespaceWrappedArray != nil {
+		toSerialize["namespace_wrapped_array"] = o.NamespaceWrappedArray
+	}
+	if o.PrefixNsString != nil {
+		toSerialize["prefix_ns_string"] = o.PrefixNsString
+	}
+	if o.PrefixNsNumber != nil {
+		toSerialize["prefix_ns_number"] = o.PrefixNsNumber
+	}
+	if o.PrefixNsInteger != nil {
+		toSerialize["prefix_ns_integer"] = o.PrefixNsInteger
+	}
+	if o.PrefixNsBoolean != nil {
+		toSerialize["prefix_ns_boolean"] = o.PrefixNsBoolean
+	}
+	if o.PrefixNsArray != nil {
+		toSerialize["prefix_ns_array"] = o.PrefixNsArray
+	}
+	if o.PrefixNsWrappedArray != nil {
+		toSerialize["prefix_ns_wrapped_array"] = o.PrefixNsWrappedArray
+	}
+	return json.Marshal(toSerialize)
 }
 
 type NullableXmlItem struct {
@@ -1118,32 +1118,32 @@ type NullableXmlItem struct {
 }
 
 func (v NullableXmlItem) Get() *XmlItem {
-    return v.value
+	return v.value
 }
 
 func (v NullableXmlItem) Set(val *XmlItem) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableXmlItem) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableXmlItem) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableXmlItem(val *XmlItem) *NullableXmlItem {
-    return &NullableXmlItem{value: val, isSet: true}
+	return &NullableXmlItem{value: val, isSet: true}
 }
 
 func (v NullableXmlItem) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableXmlItem) UnmarshalJSON(src []byte) error {
-    v.isSet = true
+	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_xml_item.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_xml_item.go
@@ -51,16 +51,16 @@ type XmlItem struct {
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
 func NewXmlItem() *XmlItem {
-    this := XmlItem{}
-    return &this
+	this := XmlItem{}
+	return &this
 }
 
 // NewXmlItemWithDefaults instantiates a new XmlItem object
 // This constructor will only assign default values to properties that have it defined,
 // but it doesn't guarantee that properties required by API are set
 func NewXmlItemWithDefaults() *XmlItem {
-    this := XmlItem{}
-    return &this
+	this := XmlItem{}
+	return &this
 }
 
 // GetAttributeString returns the AttributeString field value if set, zero value otherwise.
@@ -72,14 +72,14 @@ func (o *XmlItem) GetAttributeString() string {
 	return *o.AttributeString
 }
 
-// GetAttributeStringOk returns a tuple with the AttributeString field value if set, zero value otherwise
+// GetAttributeStringOk returns a tuple with the AttributeString field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *XmlItem) GetAttributeStringOk() (string, bool) {
+
+func (o *XmlItem) GetAttributeStringOk() (*string, bool) {
 	if o == nil || o.AttributeString == nil {
-		var ret string
-		return ret, false
+		return nil, false
 	}
-	return *o.AttributeString, true
+	return o.AttributeString, true
 }
 
 // HasAttributeString returns a boolean if a field has been set.
@@ -105,14 +105,14 @@ func (o *XmlItem) GetAttributeNumber() float32 {
 	return *o.AttributeNumber
 }
 
-// GetAttributeNumberOk returns a tuple with the AttributeNumber field value if set, zero value otherwise
+// GetAttributeNumberOk returns a tuple with the AttributeNumber field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *XmlItem) GetAttributeNumberOk() (float32, bool) {
+
+func (o *XmlItem) GetAttributeNumberOk() (*float32, bool) {
 	if o == nil || o.AttributeNumber == nil {
-		var ret float32
-		return ret, false
+		return nil, false
 	}
-	return *o.AttributeNumber, true
+	return o.AttributeNumber, true
 }
 
 // HasAttributeNumber returns a boolean if a field has been set.
@@ -138,14 +138,14 @@ func (o *XmlItem) GetAttributeInteger() int32 {
 	return *o.AttributeInteger
 }
 
-// GetAttributeIntegerOk returns a tuple with the AttributeInteger field value if set, zero value otherwise
+// GetAttributeIntegerOk returns a tuple with the AttributeInteger field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *XmlItem) GetAttributeIntegerOk() (int32, bool) {
+
+func (o *XmlItem) GetAttributeIntegerOk() (*int32, bool) {
 	if o == nil || o.AttributeInteger == nil {
-		var ret int32
-		return ret, false
+		return nil, false
 	}
-	return *o.AttributeInteger, true
+	return o.AttributeInteger, true
 }
 
 // HasAttributeInteger returns a boolean if a field has been set.
@@ -171,14 +171,14 @@ func (o *XmlItem) GetAttributeBoolean() bool {
 	return *o.AttributeBoolean
 }
 
-// GetAttributeBooleanOk returns a tuple with the AttributeBoolean field value if set, zero value otherwise
+// GetAttributeBooleanOk returns a tuple with the AttributeBoolean field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *XmlItem) GetAttributeBooleanOk() (bool, bool) {
+
+func (o *XmlItem) GetAttributeBooleanOk() (*bool, bool) {
 	if o == nil || o.AttributeBoolean == nil {
-		var ret bool
-		return ret, false
+		return nil, false
 	}
-	return *o.AttributeBoolean, true
+	return o.AttributeBoolean, true
 }
 
 // HasAttributeBoolean returns a boolean if a field has been set.
@@ -204,14 +204,14 @@ func (o *XmlItem) GetWrappedArray() []int32 {
 	return *o.WrappedArray
 }
 
-// GetWrappedArrayOk returns a tuple with the WrappedArray field value if set, zero value otherwise
+// GetWrappedArrayOk returns a tuple with the WrappedArray field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *XmlItem) GetWrappedArrayOk() ([]int32, bool) {
+
+func (o *XmlItem) GetWrappedArrayOk() (*[]int32, bool) {
 	if o == nil || o.WrappedArray == nil {
-		var ret []int32
-		return ret, false
+		return nil, false
 	}
-	return *o.WrappedArray, true
+	return o.WrappedArray, true
 }
 
 // HasWrappedArray returns a boolean if a field has been set.
@@ -237,14 +237,14 @@ func (o *XmlItem) GetNameString() string {
 	return *o.NameString
 }
 
-// GetNameStringOk returns a tuple with the NameString field value if set, zero value otherwise
+// GetNameStringOk returns a tuple with the NameString field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *XmlItem) GetNameStringOk() (string, bool) {
+
+func (o *XmlItem) GetNameStringOk() (*string, bool) {
 	if o == nil || o.NameString == nil {
-		var ret string
-		return ret, false
+		return nil, false
 	}
-	return *o.NameString, true
+	return o.NameString, true
 }
 
 // HasNameString returns a boolean if a field has been set.
@@ -270,14 +270,14 @@ func (o *XmlItem) GetNameNumber() float32 {
 	return *o.NameNumber
 }
 
-// GetNameNumberOk returns a tuple with the NameNumber field value if set, zero value otherwise
+// GetNameNumberOk returns a tuple with the NameNumber field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *XmlItem) GetNameNumberOk() (float32, bool) {
+
+func (o *XmlItem) GetNameNumberOk() (*float32, bool) {
 	if o == nil || o.NameNumber == nil {
-		var ret float32
-		return ret, false
+		return nil, false
 	}
-	return *o.NameNumber, true
+	return o.NameNumber, true
 }
 
 // HasNameNumber returns a boolean if a field has been set.
@@ -303,14 +303,14 @@ func (o *XmlItem) GetNameInteger() int32 {
 	return *o.NameInteger
 }
 
-// GetNameIntegerOk returns a tuple with the NameInteger field value if set, zero value otherwise
+// GetNameIntegerOk returns a tuple with the NameInteger field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *XmlItem) GetNameIntegerOk() (int32, bool) {
+
+func (o *XmlItem) GetNameIntegerOk() (*int32, bool) {
 	if o == nil || o.NameInteger == nil {
-		var ret int32
-		return ret, false
+		return nil, false
 	}
-	return *o.NameInteger, true
+	return o.NameInteger, true
 }
 
 // HasNameInteger returns a boolean if a field has been set.
@@ -336,14 +336,14 @@ func (o *XmlItem) GetNameBoolean() bool {
 	return *o.NameBoolean
 }
 
-// GetNameBooleanOk returns a tuple with the NameBoolean field value if set, zero value otherwise
+// GetNameBooleanOk returns a tuple with the NameBoolean field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *XmlItem) GetNameBooleanOk() (bool, bool) {
+
+func (o *XmlItem) GetNameBooleanOk() (*bool, bool) {
 	if o == nil || o.NameBoolean == nil {
-		var ret bool
-		return ret, false
+		return nil, false
 	}
-	return *o.NameBoolean, true
+	return o.NameBoolean, true
 }
 
 // HasNameBoolean returns a boolean if a field has been set.
@@ -369,14 +369,14 @@ func (o *XmlItem) GetNameArray() []int32 {
 	return *o.NameArray
 }
 
-// GetNameArrayOk returns a tuple with the NameArray field value if set, zero value otherwise
+// GetNameArrayOk returns a tuple with the NameArray field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *XmlItem) GetNameArrayOk() ([]int32, bool) {
+
+func (o *XmlItem) GetNameArrayOk() (*[]int32, bool) {
 	if o == nil || o.NameArray == nil {
-		var ret []int32
-		return ret, false
+		return nil, false
 	}
-	return *o.NameArray, true
+	return o.NameArray, true
 }
 
 // HasNameArray returns a boolean if a field has been set.
@@ -402,14 +402,14 @@ func (o *XmlItem) GetNameWrappedArray() []int32 {
 	return *o.NameWrappedArray
 }
 
-// GetNameWrappedArrayOk returns a tuple with the NameWrappedArray field value if set, zero value otherwise
+// GetNameWrappedArrayOk returns a tuple with the NameWrappedArray field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *XmlItem) GetNameWrappedArrayOk() ([]int32, bool) {
+
+func (o *XmlItem) GetNameWrappedArrayOk() (*[]int32, bool) {
 	if o == nil || o.NameWrappedArray == nil {
-		var ret []int32
-		return ret, false
+		return nil, false
 	}
-	return *o.NameWrappedArray, true
+	return o.NameWrappedArray, true
 }
 
 // HasNameWrappedArray returns a boolean if a field has been set.
@@ -435,14 +435,14 @@ func (o *XmlItem) GetPrefixString() string {
 	return *o.PrefixString
 }
 
-// GetPrefixStringOk returns a tuple with the PrefixString field value if set, zero value otherwise
+// GetPrefixStringOk returns a tuple with the PrefixString field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *XmlItem) GetPrefixStringOk() (string, bool) {
+
+func (o *XmlItem) GetPrefixStringOk() (*string, bool) {
 	if o == nil || o.PrefixString == nil {
-		var ret string
-		return ret, false
+		return nil, false
 	}
-	return *o.PrefixString, true
+	return o.PrefixString, true
 }
 
 // HasPrefixString returns a boolean if a field has been set.
@@ -468,14 +468,14 @@ func (o *XmlItem) GetPrefixNumber() float32 {
 	return *o.PrefixNumber
 }
 
-// GetPrefixNumberOk returns a tuple with the PrefixNumber field value if set, zero value otherwise
+// GetPrefixNumberOk returns a tuple with the PrefixNumber field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *XmlItem) GetPrefixNumberOk() (float32, bool) {
+
+func (o *XmlItem) GetPrefixNumberOk() (*float32, bool) {
 	if o == nil || o.PrefixNumber == nil {
-		var ret float32
-		return ret, false
+		return nil, false
 	}
-	return *o.PrefixNumber, true
+	return o.PrefixNumber, true
 }
 
 // HasPrefixNumber returns a boolean if a field has been set.
@@ -501,14 +501,14 @@ func (o *XmlItem) GetPrefixInteger() int32 {
 	return *o.PrefixInteger
 }
 
-// GetPrefixIntegerOk returns a tuple with the PrefixInteger field value if set, zero value otherwise
+// GetPrefixIntegerOk returns a tuple with the PrefixInteger field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *XmlItem) GetPrefixIntegerOk() (int32, bool) {
+
+func (o *XmlItem) GetPrefixIntegerOk() (*int32, bool) {
 	if o == nil || o.PrefixInteger == nil {
-		var ret int32
-		return ret, false
+		return nil, false
 	}
-	return *o.PrefixInteger, true
+	return o.PrefixInteger, true
 }
 
 // HasPrefixInteger returns a boolean if a field has been set.
@@ -534,14 +534,14 @@ func (o *XmlItem) GetPrefixBoolean() bool {
 	return *o.PrefixBoolean
 }
 
-// GetPrefixBooleanOk returns a tuple with the PrefixBoolean field value if set, zero value otherwise
+// GetPrefixBooleanOk returns a tuple with the PrefixBoolean field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *XmlItem) GetPrefixBooleanOk() (bool, bool) {
+
+func (o *XmlItem) GetPrefixBooleanOk() (*bool, bool) {
 	if o == nil || o.PrefixBoolean == nil {
-		var ret bool
-		return ret, false
+		return nil, false
 	}
-	return *o.PrefixBoolean, true
+	return o.PrefixBoolean, true
 }
 
 // HasPrefixBoolean returns a boolean if a field has been set.
@@ -567,14 +567,14 @@ func (o *XmlItem) GetPrefixArray() []int32 {
 	return *o.PrefixArray
 }
 
-// GetPrefixArrayOk returns a tuple with the PrefixArray field value if set, zero value otherwise
+// GetPrefixArrayOk returns a tuple with the PrefixArray field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *XmlItem) GetPrefixArrayOk() ([]int32, bool) {
+
+func (o *XmlItem) GetPrefixArrayOk() (*[]int32, bool) {
 	if o == nil || o.PrefixArray == nil {
-		var ret []int32
-		return ret, false
+		return nil, false
 	}
-	return *o.PrefixArray, true
+	return o.PrefixArray, true
 }
 
 // HasPrefixArray returns a boolean if a field has been set.
@@ -600,14 +600,14 @@ func (o *XmlItem) GetPrefixWrappedArray() []int32 {
 	return *o.PrefixWrappedArray
 }
 
-// GetPrefixWrappedArrayOk returns a tuple with the PrefixWrappedArray field value if set, zero value otherwise
+// GetPrefixWrappedArrayOk returns a tuple with the PrefixWrappedArray field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *XmlItem) GetPrefixWrappedArrayOk() ([]int32, bool) {
+
+func (o *XmlItem) GetPrefixWrappedArrayOk() (*[]int32, bool) {
 	if o == nil || o.PrefixWrappedArray == nil {
-		var ret []int32
-		return ret, false
+		return nil, false
 	}
-	return *o.PrefixWrappedArray, true
+	return o.PrefixWrappedArray, true
 }
 
 // HasPrefixWrappedArray returns a boolean if a field has been set.
@@ -633,14 +633,14 @@ func (o *XmlItem) GetNamespaceString() string {
 	return *o.NamespaceString
 }
 
-// GetNamespaceStringOk returns a tuple with the NamespaceString field value if set, zero value otherwise
+// GetNamespaceStringOk returns a tuple with the NamespaceString field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *XmlItem) GetNamespaceStringOk() (string, bool) {
+
+func (o *XmlItem) GetNamespaceStringOk() (*string, bool) {
 	if o == nil || o.NamespaceString == nil {
-		var ret string
-		return ret, false
+		return nil, false
 	}
-	return *o.NamespaceString, true
+	return o.NamespaceString, true
 }
 
 // HasNamespaceString returns a boolean if a field has been set.
@@ -666,14 +666,14 @@ func (o *XmlItem) GetNamespaceNumber() float32 {
 	return *o.NamespaceNumber
 }
 
-// GetNamespaceNumberOk returns a tuple with the NamespaceNumber field value if set, zero value otherwise
+// GetNamespaceNumberOk returns a tuple with the NamespaceNumber field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *XmlItem) GetNamespaceNumberOk() (float32, bool) {
+
+func (o *XmlItem) GetNamespaceNumberOk() (*float32, bool) {
 	if o == nil || o.NamespaceNumber == nil {
-		var ret float32
-		return ret, false
+		return nil, false
 	}
-	return *o.NamespaceNumber, true
+	return o.NamespaceNumber, true
 }
 
 // HasNamespaceNumber returns a boolean if a field has been set.
@@ -699,14 +699,14 @@ func (o *XmlItem) GetNamespaceInteger() int32 {
 	return *o.NamespaceInteger
 }
 
-// GetNamespaceIntegerOk returns a tuple with the NamespaceInteger field value if set, zero value otherwise
+// GetNamespaceIntegerOk returns a tuple with the NamespaceInteger field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *XmlItem) GetNamespaceIntegerOk() (int32, bool) {
+
+func (o *XmlItem) GetNamespaceIntegerOk() (*int32, bool) {
 	if o == nil || o.NamespaceInteger == nil {
-		var ret int32
-		return ret, false
+		return nil, false
 	}
-	return *o.NamespaceInteger, true
+	return o.NamespaceInteger, true
 }
 
 // HasNamespaceInteger returns a boolean if a field has been set.
@@ -732,14 +732,14 @@ func (o *XmlItem) GetNamespaceBoolean() bool {
 	return *o.NamespaceBoolean
 }
 
-// GetNamespaceBooleanOk returns a tuple with the NamespaceBoolean field value if set, zero value otherwise
+// GetNamespaceBooleanOk returns a tuple with the NamespaceBoolean field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *XmlItem) GetNamespaceBooleanOk() (bool, bool) {
+
+func (o *XmlItem) GetNamespaceBooleanOk() (*bool, bool) {
 	if o == nil || o.NamespaceBoolean == nil {
-		var ret bool
-		return ret, false
+		return nil, false
 	}
-	return *o.NamespaceBoolean, true
+	return o.NamespaceBoolean, true
 }
 
 // HasNamespaceBoolean returns a boolean if a field has been set.
@@ -765,14 +765,14 @@ func (o *XmlItem) GetNamespaceArray() []int32 {
 	return *o.NamespaceArray
 }
 
-// GetNamespaceArrayOk returns a tuple with the NamespaceArray field value if set, zero value otherwise
+// GetNamespaceArrayOk returns a tuple with the NamespaceArray field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *XmlItem) GetNamespaceArrayOk() ([]int32, bool) {
+
+func (o *XmlItem) GetNamespaceArrayOk() (*[]int32, bool) {
 	if o == nil || o.NamespaceArray == nil {
-		var ret []int32
-		return ret, false
+		return nil, false
 	}
-	return *o.NamespaceArray, true
+	return o.NamespaceArray, true
 }
 
 // HasNamespaceArray returns a boolean if a field has been set.
@@ -798,14 +798,14 @@ func (o *XmlItem) GetNamespaceWrappedArray() []int32 {
 	return *o.NamespaceWrappedArray
 }
 
-// GetNamespaceWrappedArrayOk returns a tuple with the NamespaceWrappedArray field value if set, zero value otherwise
+// GetNamespaceWrappedArrayOk returns a tuple with the NamespaceWrappedArray field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *XmlItem) GetNamespaceWrappedArrayOk() ([]int32, bool) {
+
+func (o *XmlItem) GetNamespaceWrappedArrayOk() (*[]int32, bool) {
 	if o == nil || o.NamespaceWrappedArray == nil {
-		var ret []int32
-		return ret, false
+		return nil, false
 	}
-	return *o.NamespaceWrappedArray, true
+	return o.NamespaceWrappedArray, true
 }
 
 // HasNamespaceWrappedArray returns a boolean if a field has been set.
@@ -831,14 +831,14 @@ func (o *XmlItem) GetPrefixNsString() string {
 	return *o.PrefixNsString
 }
 
-// GetPrefixNsStringOk returns a tuple with the PrefixNsString field value if set, zero value otherwise
+// GetPrefixNsStringOk returns a tuple with the PrefixNsString field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *XmlItem) GetPrefixNsStringOk() (string, bool) {
+
+func (o *XmlItem) GetPrefixNsStringOk() (*string, bool) {
 	if o == nil || o.PrefixNsString == nil {
-		var ret string
-		return ret, false
+		return nil, false
 	}
-	return *o.PrefixNsString, true
+	return o.PrefixNsString, true
 }
 
 // HasPrefixNsString returns a boolean if a field has been set.
@@ -864,14 +864,14 @@ func (o *XmlItem) GetPrefixNsNumber() float32 {
 	return *o.PrefixNsNumber
 }
 
-// GetPrefixNsNumberOk returns a tuple with the PrefixNsNumber field value if set, zero value otherwise
+// GetPrefixNsNumberOk returns a tuple with the PrefixNsNumber field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *XmlItem) GetPrefixNsNumberOk() (float32, bool) {
+
+func (o *XmlItem) GetPrefixNsNumberOk() (*float32, bool) {
 	if o == nil || o.PrefixNsNumber == nil {
-		var ret float32
-		return ret, false
+		return nil, false
 	}
-	return *o.PrefixNsNumber, true
+	return o.PrefixNsNumber, true
 }
 
 // HasPrefixNsNumber returns a boolean if a field has been set.
@@ -897,14 +897,14 @@ func (o *XmlItem) GetPrefixNsInteger() int32 {
 	return *o.PrefixNsInteger
 }
 
-// GetPrefixNsIntegerOk returns a tuple with the PrefixNsInteger field value if set, zero value otherwise
+// GetPrefixNsIntegerOk returns a tuple with the PrefixNsInteger field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *XmlItem) GetPrefixNsIntegerOk() (int32, bool) {
+
+func (o *XmlItem) GetPrefixNsIntegerOk() (*int32, bool) {
 	if o == nil || o.PrefixNsInteger == nil {
-		var ret int32
-		return ret, false
+		return nil, false
 	}
-	return *o.PrefixNsInteger, true
+	return o.PrefixNsInteger, true
 }
 
 // HasPrefixNsInteger returns a boolean if a field has been set.
@@ -930,14 +930,14 @@ func (o *XmlItem) GetPrefixNsBoolean() bool {
 	return *o.PrefixNsBoolean
 }
 
-// GetPrefixNsBooleanOk returns a tuple with the PrefixNsBoolean field value if set, zero value otherwise
+// GetPrefixNsBooleanOk returns a tuple with the PrefixNsBoolean field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *XmlItem) GetPrefixNsBooleanOk() (bool, bool) {
+
+func (o *XmlItem) GetPrefixNsBooleanOk() (*bool, bool) {
 	if o == nil || o.PrefixNsBoolean == nil {
-		var ret bool
-		return ret, false
+		return nil, false
 	}
-	return *o.PrefixNsBoolean, true
+	return o.PrefixNsBoolean, true
 }
 
 // HasPrefixNsBoolean returns a boolean if a field has been set.
@@ -963,14 +963,14 @@ func (o *XmlItem) GetPrefixNsArray() []int32 {
 	return *o.PrefixNsArray
 }
 
-// GetPrefixNsArrayOk returns a tuple with the PrefixNsArray field value if set, zero value otherwise
+// GetPrefixNsArrayOk returns a tuple with the PrefixNsArray field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *XmlItem) GetPrefixNsArrayOk() ([]int32, bool) {
+
+func (o *XmlItem) GetPrefixNsArrayOk() (*[]int32, bool) {
 	if o == nil || o.PrefixNsArray == nil {
-		var ret []int32
-		return ret, false
+		return nil, false
 	}
-	return *o.PrefixNsArray, true
+	return o.PrefixNsArray, true
 }
 
 // HasPrefixNsArray returns a boolean if a field has been set.
@@ -996,14 +996,14 @@ func (o *XmlItem) GetPrefixNsWrappedArray() []int32 {
 	return *o.PrefixNsWrappedArray
 }
 
-// GetPrefixNsWrappedArrayOk returns a tuple with the PrefixNsWrappedArray field value if set, zero value otherwise
+// GetPrefixNsWrappedArrayOk returns a tuple with the PrefixNsWrappedArray field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *XmlItem) GetPrefixNsWrappedArrayOk() ([]int32, bool) {
+
+func (o *XmlItem) GetPrefixNsWrappedArrayOk() (*[]int32, bool) {
 	if o == nil || o.PrefixNsWrappedArray == nil {
-		var ret []int32
-		return ret, false
+		return nil, false
 	}
-	return *o.PrefixNsWrappedArray, true
+	return o.PrefixNsWrappedArray, true
 }
 
 // HasPrefixNsWrappedArray returns a boolean if a field has been set.

--- a/samples/client/petstore/go-experimental/go-petstore/model_xml_item.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_xml_item.go
@@ -1121,7 +1121,7 @@ func (v NullableXmlItem) Get() *XmlItem {
 	return v.value
 }
 
-func (v NullableXmlItem) Set(val *XmlItem) {
+func (v *NullableXmlItem) Set(val *XmlItem) {
 	v.value = val
 	v.isSet = true
 }
@@ -1130,7 +1130,7 @@ func (v NullableXmlItem) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableXmlItem) Unset() {
+func (v *NullableXmlItem) Unset() {
 	v.value = nil
 	v.isSet = false
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_xml_item.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_xml_item.go
@@ -10,7 +10,6 @@
 package petstore
 
 import (
-	"bytes"
 	"encoding/json"
 )
 
@@ -80,12 +79,12 @@ func (o *XmlItem) GetAttributeStringOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-	return *o.AttributeString, true
+    return *o.AttributeString, true
 }
 
 // HasAttributeString returns a boolean if a field has been set.
 func (o *XmlItem) HasAttributeString() bool {
-	if o != nil && o.AttributeString != nil {
+    if o != nil && o.AttributeString != nil {
 		return true
 	}
 
@@ -113,12 +112,12 @@ func (o *XmlItem) GetAttributeNumberOk() (float32, bool) {
 		var ret float32
 		return ret, false
 	}
-	return *o.AttributeNumber, true
+    return *o.AttributeNumber, true
 }
 
 // HasAttributeNumber returns a boolean if a field has been set.
 func (o *XmlItem) HasAttributeNumber() bool {
-	if o != nil && o.AttributeNumber != nil {
+    if o != nil && o.AttributeNumber != nil {
 		return true
 	}
 
@@ -146,12 +145,12 @@ func (o *XmlItem) GetAttributeIntegerOk() (int32, bool) {
 		var ret int32
 		return ret, false
 	}
-	return *o.AttributeInteger, true
+    return *o.AttributeInteger, true
 }
 
 // HasAttributeInteger returns a boolean if a field has been set.
 func (o *XmlItem) HasAttributeInteger() bool {
-	if o != nil && o.AttributeInteger != nil {
+    if o != nil && o.AttributeInteger != nil {
 		return true
 	}
 
@@ -179,12 +178,12 @@ func (o *XmlItem) GetAttributeBooleanOk() (bool, bool) {
 		var ret bool
 		return ret, false
 	}
-	return *o.AttributeBoolean, true
+    return *o.AttributeBoolean, true
 }
 
 // HasAttributeBoolean returns a boolean if a field has been set.
 func (o *XmlItem) HasAttributeBoolean() bool {
-	if o != nil && o.AttributeBoolean != nil {
+    if o != nil && o.AttributeBoolean != nil {
 		return true
 	}
 
@@ -212,12 +211,12 @@ func (o *XmlItem) GetWrappedArrayOk() ([]int32, bool) {
 		var ret []int32
 		return ret, false
 	}
-	return *o.WrappedArray, true
+    return *o.WrappedArray, true
 }
 
 // HasWrappedArray returns a boolean if a field has been set.
 func (o *XmlItem) HasWrappedArray() bool {
-	if o != nil && o.WrappedArray != nil {
+    if o != nil && o.WrappedArray != nil {
 		return true
 	}
 
@@ -245,12 +244,12 @@ func (o *XmlItem) GetNameStringOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-	return *o.NameString, true
+    return *o.NameString, true
 }
 
 // HasNameString returns a boolean if a field has been set.
 func (o *XmlItem) HasNameString() bool {
-	if o != nil && o.NameString != nil {
+    if o != nil && o.NameString != nil {
 		return true
 	}
 
@@ -278,12 +277,12 @@ func (o *XmlItem) GetNameNumberOk() (float32, bool) {
 		var ret float32
 		return ret, false
 	}
-	return *o.NameNumber, true
+    return *o.NameNumber, true
 }
 
 // HasNameNumber returns a boolean if a field has been set.
 func (o *XmlItem) HasNameNumber() bool {
-	if o != nil && o.NameNumber != nil {
+    if o != nil && o.NameNumber != nil {
 		return true
 	}
 
@@ -311,12 +310,12 @@ func (o *XmlItem) GetNameIntegerOk() (int32, bool) {
 		var ret int32
 		return ret, false
 	}
-	return *o.NameInteger, true
+    return *o.NameInteger, true
 }
 
 // HasNameInteger returns a boolean if a field has been set.
 func (o *XmlItem) HasNameInteger() bool {
-	if o != nil && o.NameInteger != nil {
+    if o != nil && o.NameInteger != nil {
 		return true
 	}
 
@@ -344,12 +343,12 @@ func (o *XmlItem) GetNameBooleanOk() (bool, bool) {
 		var ret bool
 		return ret, false
 	}
-	return *o.NameBoolean, true
+    return *o.NameBoolean, true
 }
 
 // HasNameBoolean returns a boolean if a field has been set.
 func (o *XmlItem) HasNameBoolean() bool {
-	if o != nil && o.NameBoolean != nil {
+    if o != nil && o.NameBoolean != nil {
 		return true
 	}
 
@@ -377,12 +376,12 @@ func (o *XmlItem) GetNameArrayOk() ([]int32, bool) {
 		var ret []int32
 		return ret, false
 	}
-	return *o.NameArray, true
+    return *o.NameArray, true
 }
 
 // HasNameArray returns a boolean if a field has been set.
 func (o *XmlItem) HasNameArray() bool {
-	if o != nil && o.NameArray != nil {
+    if o != nil && o.NameArray != nil {
 		return true
 	}
 
@@ -410,12 +409,12 @@ func (o *XmlItem) GetNameWrappedArrayOk() ([]int32, bool) {
 		var ret []int32
 		return ret, false
 	}
-	return *o.NameWrappedArray, true
+    return *o.NameWrappedArray, true
 }
 
 // HasNameWrappedArray returns a boolean if a field has been set.
 func (o *XmlItem) HasNameWrappedArray() bool {
-	if o != nil && o.NameWrappedArray != nil {
+    if o != nil && o.NameWrappedArray != nil {
 		return true
 	}
 
@@ -443,12 +442,12 @@ func (o *XmlItem) GetPrefixStringOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-	return *o.PrefixString, true
+    return *o.PrefixString, true
 }
 
 // HasPrefixString returns a boolean if a field has been set.
 func (o *XmlItem) HasPrefixString() bool {
-	if o != nil && o.PrefixString != nil {
+    if o != nil && o.PrefixString != nil {
 		return true
 	}
 
@@ -476,12 +475,12 @@ func (o *XmlItem) GetPrefixNumberOk() (float32, bool) {
 		var ret float32
 		return ret, false
 	}
-	return *o.PrefixNumber, true
+    return *o.PrefixNumber, true
 }
 
 // HasPrefixNumber returns a boolean if a field has been set.
 func (o *XmlItem) HasPrefixNumber() bool {
-	if o != nil && o.PrefixNumber != nil {
+    if o != nil && o.PrefixNumber != nil {
 		return true
 	}
 
@@ -509,12 +508,12 @@ func (o *XmlItem) GetPrefixIntegerOk() (int32, bool) {
 		var ret int32
 		return ret, false
 	}
-	return *o.PrefixInteger, true
+    return *o.PrefixInteger, true
 }
 
 // HasPrefixInteger returns a boolean if a field has been set.
 func (o *XmlItem) HasPrefixInteger() bool {
-	if o != nil && o.PrefixInteger != nil {
+    if o != nil && o.PrefixInteger != nil {
 		return true
 	}
 
@@ -542,12 +541,12 @@ func (o *XmlItem) GetPrefixBooleanOk() (bool, bool) {
 		var ret bool
 		return ret, false
 	}
-	return *o.PrefixBoolean, true
+    return *o.PrefixBoolean, true
 }
 
 // HasPrefixBoolean returns a boolean if a field has been set.
 func (o *XmlItem) HasPrefixBoolean() bool {
-	if o != nil && o.PrefixBoolean != nil {
+    if o != nil && o.PrefixBoolean != nil {
 		return true
 	}
 
@@ -575,12 +574,12 @@ func (o *XmlItem) GetPrefixArrayOk() ([]int32, bool) {
 		var ret []int32
 		return ret, false
 	}
-	return *o.PrefixArray, true
+    return *o.PrefixArray, true
 }
 
 // HasPrefixArray returns a boolean if a field has been set.
 func (o *XmlItem) HasPrefixArray() bool {
-	if o != nil && o.PrefixArray != nil {
+    if o != nil && o.PrefixArray != nil {
 		return true
 	}
 
@@ -608,12 +607,12 @@ func (o *XmlItem) GetPrefixWrappedArrayOk() ([]int32, bool) {
 		var ret []int32
 		return ret, false
 	}
-	return *o.PrefixWrappedArray, true
+    return *o.PrefixWrappedArray, true
 }
 
 // HasPrefixWrappedArray returns a boolean if a field has been set.
 func (o *XmlItem) HasPrefixWrappedArray() bool {
-	if o != nil && o.PrefixWrappedArray != nil {
+    if o != nil && o.PrefixWrappedArray != nil {
 		return true
 	}
 
@@ -641,12 +640,12 @@ func (o *XmlItem) GetNamespaceStringOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-	return *o.NamespaceString, true
+    return *o.NamespaceString, true
 }
 
 // HasNamespaceString returns a boolean if a field has been set.
 func (o *XmlItem) HasNamespaceString() bool {
-	if o != nil && o.NamespaceString != nil {
+    if o != nil && o.NamespaceString != nil {
 		return true
 	}
 
@@ -674,12 +673,12 @@ func (o *XmlItem) GetNamespaceNumberOk() (float32, bool) {
 		var ret float32
 		return ret, false
 	}
-	return *o.NamespaceNumber, true
+    return *o.NamespaceNumber, true
 }
 
 // HasNamespaceNumber returns a boolean if a field has been set.
 func (o *XmlItem) HasNamespaceNumber() bool {
-	if o != nil && o.NamespaceNumber != nil {
+    if o != nil && o.NamespaceNumber != nil {
 		return true
 	}
 
@@ -707,12 +706,12 @@ func (o *XmlItem) GetNamespaceIntegerOk() (int32, bool) {
 		var ret int32
 		return ret, false
 	}
-	return *o.NamespaceInteger, true
+    return *o.NamespaceInteger, true
 }
 
 // HasNamespaceInteger returns a boolean if a field has been set.
 func (o *XmlItem) HasNamespaceInteger() bool {
-	if o != nil && o.NamespaceInteger != nil {
+    if o != nil && o.NamespaceInteger != nil {
 		return true
 	}
 
@@ -740,12 +739,12 @@ func (o *XmlItem) GetNamespaceBooleanOk() (bool, bool) {
 		var ret bool
 		return ret, false
 	}
-	return *o.NamespaceBoolean, true
+    return *o.NamespaceBoolean, true
 }
 
 // HasNamespaceBoolean returns a boolean if a field has been set.
 func (o *XmlItem) HasNamespaceBoolean() bool {
-	if o != nil && o.NamespaceBoolean != nil {
+    if o != nil && o.NamespaceBoolean != nil {
 		return true
 	}
 
@@ -773,12 +772,12 @@ func (o *XmlItem) GetNamespaceArrayOk() ([]int32, bool) {
 		var ret []int32
 		return ret, false
 	}
-	return *o.NamespaceArray, true
+    return *o.NamespaceArray, true
 }
 
 // HasNamespaceArray returns a boolean if a field has been set.
 func (o *XmlItem) HasNamespaceArray() bool {
-	if o != nil && o.NamespaceArray != nil {
+    if o != nil && o.NamespaceArray != nil {
 		return true
 	}
 
@@ -806,12 +805,12 @@ func (o *XmlItem) GetNamespaceWrappedArrayOk() ([]int32, bool) {
 		var ret []int32
 		return ret, false
 	}
-	return *o.NamespaceWrappedArray, true
+    return *o.NamespaceWrappedArray, true
 }
 
 // HasNamespaceWrappedArray returns a boolean if a field has been set.
 func (o *XmlItem) HasNamespaceWrappedArray() bool {
-	if o != nil && o.NamespaceWrappedArray != nil {
+    if o != nil && o.NamespaceWrappedArray != nil {
 		return true
 	}
 
@@ -839,12 +838,12 @@ func (o *XmlItem) GetPrefixNsStringOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-	return *o.PrefixNsString, true
+    return *o.PrefixNsString, true
 }
 
 // HasPrefixNsString returns a boolean if a field has been set.
 func (o *XmlItem) HasPrefixNsString() bool {
-	if o != nil && o.PrefixNsString != nil {
+    if o != nil && o.PrefixNsString != nil {
 		return true
 	}
 
@@ -872,12 +871,12 @@ func (o *XmlItem) GetPrefixNsNumberOk() (float32, bool) {
 		var ret float32
 		return ret, false
 	}
-	return *o.PrefixNsNumber, true
+    return *o.PrefixNsNumber, true
 }
 
 // HasPrefixNsNumber returns a boolean if a field has been set.
 func (o *XmlItem) HasPrefixNsNumber() bool {
-	if o != nil && o.PrefixNsNumber != nil {
+    if o != nil && o.PrefixNsNumber != nil {
 		return true
 	}
 
@@ -905,12 +904,12 @@ func (o *XmlItem) GetPrefixNsIntegerOk() (int32, bool) {
 		var ret int32
 		return ret, false
 	}
-	return *o.PrefixNsInteger, true
+    return *o.PrefixNsInteger, true
 }
 
 // HasPrefixNsInteger returns a boolean if a field has been set.
 func (o *XmlItem) HasPrefixNsInteger() bool {
-	if o != nil && o.PrefixNsInteger != nil {
+    if o != nil && o.PrefixNsInteger != nil {
 		return true
 	}
 
@@ -938,12 +937,12 @@ func (o *XmlItem) GetPrefixNsBooleanOk() (bool, bool) {
 		var ret bool
 		return ret, false
 	}
-	return *o.PrefixNsBoolean, true
+    return *o.PrefixNsBoolean, true
 }
 
 // HasPrefixNsBoolean returns a boolean if a field has been set.
 func (o *XmlItem) HasPrefixNsBoolean() bool {
-	if o != nil && o.PrefixNsBoolean != nil {
+    if o != nil && o.PrefixNsBoolean != nil {
 		return true
 	}
 
@@ -971,12 +970,12 @@ func (o *XmlItem) GetPrefixNsArrayOk() ([]int32, bool) {
 		var ret []int32
 		return ret, false
 	}
-	return *o.PrefixNsArray, true
+    return *o.PrefixNsArray, true
 }
 
 // HasPrefixNsArray returns a boolean if a field has been set.
 func (o *XmlItem) HasPrefixNsArray() bool {
-	if o != nil && o.PrefixNsArray != nil {
+    if o != nil && o.PrefixNsArray != nil {
 		return true
 	}
 
@@ -1004,12 +1003,12 @@ func (o *XmlItem) GetPrefixNsWrappedArrayOk() ([]int32, bool) {
 		var ret []int32
 		return ret, false
 	}
-	return *o.PrefixNsWrappedArray, true
+    return *o.PrefixNsWrappedArray, true
 }
 
 // HasPrefixNsWrappedArray returns a boolean if a field has been set.
 func (o *XmlItem) HasPrefixNsWrappedArray() bool {
-	if o != nil && o.PrefixNsWrappedArray != nil {
+    if o != nil && o.PrefixNsWrappedArray != nil {
 		return true
 	}
 
@@ -1021,25 +1020,130 @@ func (o *XmlItem) SetPrefixNsWrappedArray(v []int32) {
 	o.PrefixNsWrappedArray = &v
 }
 
+func (o XmlItem) MarshalJSON() ([]byte, error) {
+    toSerialize := map[string]interface{}{}
+    if o.AttributeString != nil {
+        toSerialize["attribute_string"] = o.AttributeString
+    }
+    if o.AttributeNumber != nil {
+        toSerialize["attribute_number"] = o.AttributeNumber
+    }
+    if o.AttributeInteger != nil {
+        toSerialize["attribute_integer"] = o.AttributeInteger
+    }
+    if o.AttributeBoolean != nil {
+        toSerialize["attribute_boolean"] = o.AttributeBoolean
+    }
+    if o.WrappedArray != nil {
+        toSerialize["wrapped_array"] = o.WrappedArray
+    }
+    if o.NameString != nil {
+        toSerialize["name_string"] = o.NameString
+    }
+    if o.NameNumber != nil {
+        toSerialize["name_number"] = o.NameNumber
+    }
+    if o.NameInteger != nil {
+        toSerialize["name_integer"] = o.NameInteger
+    }
+    if o.NameBoolean != nil {
+        toSerialize["name_boolean"] = o.NameBoolean
+    }
+    if o.NameArray != nil {
+        toSerialize["name_array"] = o.NameArray
+    }
+    if o.NameWrappedArray != nil {
+        toSerialize["name_wrapped_array"] = o.NameWrappedArray
+    }
+    if o.PrefixString != nil {
+        toSerialize["prefix_string"] = o.PrefixString
+    }
+    if o.PrefixNumber != nil {
+        toSerialize["prefix_number"] = o.PrefixNumber
+    }
+    if o.PrefixInteger != nil {
+        toSerialize["prefix_integer"] = o.PrefixInteger
+    }
+    if o.PrefixBoolean != nil {
+        toSerialize["prefix_boolean"] = o.PrefixBoolean
+    }
+    if o.PrefixArray != nil {
+        toSerialize["prefix_array"] = o.PrefixArray
+    }
+    if o.PrefixWrappedArray != nil {
+        toSerialize["prefix_wrapped_array"] = o.PrefixWrappedArray
+    }
+    if o.NamespaceString != nil {
+        toSerialize["namespace_string"] = o.NamespaceString
+    }
+    if o.NamespaceNumber != nil {
+        toSerialize["namespace_number"] = o.NamespaceNumber
+    }
+    if o.NamespaceInteger != nil {
+        toSerialize["namespace_integer"] = o.NamespaceInteger
+    }
+    if o.NamespaceBoolean != nil {
+        toSerialize["namespace_boolean"] = o.NamespaceBoolean
+    }
+    if o.NamespaceArray != nil {
+        toSerialize["namespace_array"] = o.NamespaceArray
+    }
+    if o.NamespaceWrappedArray != nil {
+        toSerialize["namespace_wrapped_array"] = o.NamespaceWrappedArray
+    }
+    if o.PrefixNsString != nil {
+        toSerialize["prefix_ns_string"] = o.PrefixNsString
+    }
+    if o.PrefixNsNumber != nil {
+        toSerialize["prefix_ns_number"] = o.PrefixNsNumber
+    }
+    if o.PrefixNsInteger != nil {
+        toSerialize["prefix_ns_integer"] = o.PrefixNsInteger
+    }
+    if o.PrefixNsBoolean != nil {
+        toSerialize["prefix_ns_boolean"] = o.PrefixNsBoolean
+    }
+    if o.PrefixNsArray != nil {
+        toSerialize["prefix_ns_array"] = o.PrefixNsArray
+    }
+    if o.PrefixNsWrappedArray != nil {
+        toSerialize["prefix_ns_wrapped_array"] = o.PrefixNsWrappedArray
+    }
+    return json.Marshal(toSerialize)
+}
+
 type NullableXmlItem struct {
-	Value XmlItem
-	ExplicitNull bool
+	value *XmlItem
+	isSet bool
+}
+
+func (v NullableXmlItem) Get() *XmlItem {
+    return v.value
+}
+
+func (v NullableXmlItem) Set(val *XmlItem) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableXmlItem) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableXmlItem) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableXmlItem(val *XmlItem) *NullableXmlItem {
+    return &NullableXmlItem{value: val, isSet: true}
 }
 
 func (v NullableXmlItem) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-		return json.Marshal(v.Value)
-	}
+    return json.Marshal(v.value)
 }
 
 func (v *NullableXmlItem) UnmarshalJSON(src []byte) error {
-	if bytes.Equal(src, []byte("null")) {
-		v.ExplicitNull = true
-		return nil
-	}
-
-	return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }

--- a/samples/client/petstore/go-experimental/go-petstore/model_xml_item.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_xml_item.go
@@ -74,7 +74,6 @@ func (o *XmlItem) GetAttributeString() string {
 
 // GetAttributeStringOk returns a tuple with the AttributeString field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *XmlItem) GetAttributeStringOk() (*string, bool) {
 	if o == nil || o.AttributeString == nil {
 		return nil, false
@@ -107,7 +106,6 @@ func (o *XmlItem) GetAttributeNumber() float32 {
 
 // GetAttributeNumberOk returns a tuple with the AttributeNumber field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *XmlItem) GetAttributeNumberOk() (*float32, bool) {
 	if o == nil || o.AttributeNumber == nil {
 		return nil, false
@@ -140,7 +138,6 @@ func (o *XmlItem) GetAttributeInteger() int32 {
 
 // GetAttributeIntegerOk returns a tuple with the AttributeInteger field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *XmlItem) GetAttributeIntegerOk() (*int32, bool) {
 	if o == nil || o.AttributeInteger == nil {
 		return nil, false
@@ -173,7 +170,6 @@ func (o *XmlItem) GetAttributeBoolean() bool {
 
 // GetAttributeBooleanOk returns a tuple with the AttributeBoolean field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *XmlItem) GetAttributeBooleanOk() (*bool, bool) {
 	if o == nil || o.AttributeBoolean == nil {
 		return nil, false
@@ -206,7 +202,6 @@ func (o *XmlItem) GetWrappedArray() []int32 {
 
 // GetWrappedArrayOk returns a tuple with the WrappedArray field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *XmlItem) GetWrappedArrayOk() (*[]int32, bool) {
 	if o == nil || o.WrappedArray == nil {
 		return nil, false
@@ -239,7 +234,6 @@ func (o *XmlItem) GetNameString() string {
 
 // GetNameStringOk returns a tuple with the NameString field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *XmlItem) GetNameStringOk() (*string, bool) {
 	if o == nil || o.NameString == nil {
 		return nil, false
@@ -272,7 +266,6 @@ func (o *XmlItem) GetNameNumber() float32 {
 
 // GetNameNumberOk returns a tuple with the NameNumber field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *XmlItem) GetNameNumberOk() (*float32, bool) {
 	if o == nil || o.NameNumber == nil {
 		return nil, false
@@ -305,7 +298,6 @@ func (o *XmlItem) GetNameInteger() int32 {
 
 // GetNameIntegerOk returns a tuple with the NameInteger field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *XmlItem) GetNameIntegerOk() (*int32, bool) {
 	if o == nil || o.NameInteger == nil {
 		return nil, false
@@ -338,7 +330,6 @@ func (o *XmlItem) GetNameBoolean() bool {
 
 // GetNameBooleanOk returns a tuple with the NameBoolean field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *XmlItem) GetNameBooleanOk() (*bool, bool) {
 	if o == nil || o.NameBoolean == nil {
 		return nil, false
@@ -371,7 +362,6 @@ func (o *XmlItem) GetNameArray() []int32 {
 
 // GetNameArrayOk returns a tuple with the NameArray field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *XmlItem) GetNameArrayOk() (*[]int32, bool) {
 	if o == nil || o.NameArray == nil {
 		return nil, false
@@ -404,7 +394,6 @@ func (o *XmlItem) GetNameWrappedArray() []int32 {
 
 // GetNameWrappedArrayOk returns a tuple with the NameWrappedArray field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *XmlItem) GetNameWrappedArrayOk() (*[]int32, bool) {
 	if o == nil || o.NameWrappedArray == nil {
 		return nil, false
@@ -437,7 +426,6 @@ func (o *XmlItem) GetPrefixString() string {
 
 // GetPrefixStringOk returns a tuple with the PrefixString field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *XmlItem) GetPrefixStringOk() (*string, bool) {
 	if o == nil || o.PrefixString == nil {
 		return nil, false
@@ -470,7 +458,6 @@ func (o *XmlItem) GetPrefixNumber() float32 {
 
 // GetPrefixNumberOk returns a tuple with the PrefixNumber field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *XmlItem) GetPrefixNumberOk() (*float32, bool) {
 	if o == nil || o.PrefixNumber == nil {
 		return nil, false
@@ -503,7 +490,6 @@ func (o *XmlItem) GetPrefixInteger() int32 {
 
 // GetPrefixIntegerOk returns a tuple with the PrefixInteger field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *XmlItem) GetPrefixIntegerOk() (*int32, bool) {
 	if o == nil || o.PrefixInteger == nil {
 		return nil, false
@@ -536,7 +522,6 @@ func (o *XmlItem) GetPrefixBoolean() bool {
 
 // GetPrefixBooleanOk returns a tuple with the PrefixBoolean field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *XmlItem) GetPrefixBooleanOk() (*bool, bool) {
 	if o == nil || o.PrefixBoolean == nil {
 		return nil, false
@@ -569,7 +554,6 @@ func (o *XmlItem) GetPrefixArray() []int32 {
 
 // GetPrefixArrayOk returns a tuple with the PrefixArray field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *XmlItem) GetPrefixArrayOk() (*[]int32, bool) {
 	if o == nil || o.PrefixArray == nil {
 		return nil, false
@@ -602,7 +586,6 @@ func (o *XmlItem) GetPrefixWrappedArray() []int32 {
 
 // GetPrefixWrappedArrayOk returns a tuple with the PrefixWrappedArray field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *XmlItem) GetPrefixWrappedArrayOk() (*[]int32, bool) {
 	if o == nil || o.PrefixWrappedArray == nil {
 		return nil, false
@@ -635,7 +618,6 @@ func (o *XmlItem) GetNamespaceString() string {
 
 // GetNamespaceStringOk returns a tuple with the NamespaceString field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *XmlItem) GetNamespaceStringOk() (*string, bool) {
 	if o == nil || o.NamespaceString == nil {
 		return nil, false
@@ -668,7 +650,6 @@ func (o *XmlItem) GetNamespaceNumber() float32 {
 
 // GetNamespaceNumberOk returns a tuple with the NamespaceNumber field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *XmlItem) GetNamespaceNumberOk() (*float32, bool) {
 	if o == nil || o.NamespaceNumber == nil {
 		return nil, false
@@ -701,7 +682,6 @@ func (o *XmlItem) GetNamespaceInteger() int32 {
 
 // GetNamespaceIntegerOk returns a tuple with the NamespaceInteger field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *XmlItem) GetNamespaceIntegerOk() (*int32, bool) {
 	if o == nil || o.NamespaceInteger == nil {
 		return nil, false
@@ -734,7 +714,6 @@ func (o *XmlItem) GetNamespaceBoolean() bool {
 
 // GetNamespaceBooleanOk returns a tuple with the NamespaceBoolean field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *XmlItem) GetNamespaceBooleanOk() (*bool, bool) {
 	if o == nil || o.NamespaceBoolean == nil {
 		return nil, false
@@ -767,7 +746,6 @@ func (o *XmlItem) GetNamespaceArray() []int32 {
 
 // GetNamespaceArrayOk returns a tuple with the NamespaceArray field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *XmlItem) GetNamespaceArrayOk() (*[]int32, bool) {
 	if o == nil || o.NamespaceArray == nil {
 		return nil, false
@@ -800,7 +778,6 @@ func (o *XmlItem) GetNamespaceWrappedArray() []int32 {
 
 // GetNamespaceWrappedArrayOk returns a tuple with the NamespaceWrappedArray field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *XmlItem) GetNamespaceWrappedArrayOk() (*[]int32, bool) {
 	if o == nil || o.NamespaceWrappedArray == nil {
 		return nil, false
@@ -833,7 +810,6 @@ func (o *XmlItem) GetPrefixNsString() string {
 
 // GetPrefixNsStringOk returns a tuple with the PrefixNsString field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *XmlItem) GetPrefixNsStringOk() (*string, bool) {
 	if o == nil || o.PrefixNsString == nil {
 		return nil, false
@@ -866,7 +842,6 @@ func (o *XmlItem) GetPrefixNsNumber() float32 {
 
 // GetPrefixNsNumberOk returns a tuple with the PrefixNsNumber field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *XmlItem) GetPrefixNsNumberOk() (*float32, bool) {
 	if o == nil || o.PrefixNsNumber == nil {
 		return nil, false
@@ -899,7 +874,6 @@ func (o *XmlItem) GetPrefixNsInteger() int32 {
 
 // GetPrefixNsIntegerOk returns a tuple with the PrefixNsInteger field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *XmlItem) GetPrefixNsIntegerOk() (*int32, bool) {
 	if o == nil || o.PrefixNsInteger == nil {
 		return nil, false
@@ -932,7 +906,6 @@ func (o *XmlItem) GetPrefixNsBoolean() bool {
 
 // GetPrefixNsBooleanOk returns a tuple with the PrefixNsBoolean field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *XmlItem) GetPrefixNsBooleanOk() (*bool, bool) {
 	if o == nil || o.PrefixNsBoolean == nil {
 		return nil, false
@@ -965,7 +938,6 @@ func (o *XmlItem) GetPrefixNsArray() []int32 {
 
 // GetPrefixNsArrayOk returns a tuple with the PrefixNsArray field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *XmlItem) GetPrefixNsArrayOk() (*[]int32, bool) {
 	if o == nil || o.PrefixNsArray == nil {
 		return nil, false
@@ -998,7 +970,6 @@ func (o *XmlItem) GetPrefixNsWrappedArray() []int32 {
 
 // GetPrefixNsWrappedArrayOk returns a tuple with the PrefixNsWrappedArray field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *XmlItem) GetPrefixNsWrappedArrayOk() (*[]int32, bool) {
 	if o == nil || o.PrefixNsWrappedArray == nil {
 		return nil, false

--- a/samples/client/petstore/go-experimental/go-petstore/utils.go
+++ b/samples/client/petstore/go-experimental/go-petstore/utils.go
@@ -10,13 +10,9 @@
 package petstore
 
 import (
-    "bytes"
     "encoding/json"
-    "errors"
     "time"
 )
-
-var ErrInvalidNullable = errors.New("nullable cannot have non-zero Value and ExplicitNull simultaneously")
 
 // PtrBool is a helper routine that returns a pointer to given integer value.
 func PtrBool(v bool) *bool { return &v }
@@ -43,202 +39,296 @@ func PtrString(v string) *string { return &v }
 func PtrTime(v time.Time) *time.Time { return &v }
 
 type NullableBool struct {
-    Value bool
-    ExplicitNull bool
+    value *bool
+    isSet bool
+}
+
+func (v NullableBool) Get() *bool {
+    return v.value
+}
+
+func (v NullableBool) Set(val *bool) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableBool) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableBool) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableBool(val *bool) *NullableBool {
+    return &NullableBool{value: val, isSet: true}
 }
 
 func (v NullableBool) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull && v.Value:
-        return nil, ErrInvalidNullable
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-        return json.Marshal(v.Value)
-    }
+    return json.Marshal(v.value)
 }
 
 func (v *NullableBool) UnmarshalJSON(src []byte) error {
-    if bytes.Equal(src, []byte("null")) {
-        v.ExplicitNull = true
-        return nil
-    }
-
-    return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+    return json.Unmarshal(src, &v.value)
 }
 
+
 type NullableInt struct {
-    Value int
-    ExplicitNull bool
+    value *int
+    isSet bool
+}
+
+func (v NullableInt) Get() *int {
+    return v.value
+}
+
+func (v NullableInt) Set(val *int) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableInt) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableInt) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableInt(val *int) *NullableInt {
+    return &NullableInt{value: val, isSet: true}
 }
 
 func (v NullableInt) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull && v.Value != 0:
-        return nil, ErrInvalidNullable
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-        return json.Marshal(v.Value)
-    }
+    return json.Marshal(v.value)
 }
-
 
 func (v *NullableInt) UnmarshalJSON(src []byte) error {
-    if bytes.Equal(src, []byte("null")) {
-        v.ExplicitNull = true
-        return nil
-    }
-
-    return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+    return json.Unmarshal(src, &v.value)
 }
 
+
 type NullableInt32 struct {
-    Value int32
-    ExplicitNull bool
+    value *int32
+    isSet bool
+}
+
+func (v NullableInt32) Get() *int32 {
+    return v.value
+}
+
+func (v NullableInt32) Set(val *int32) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableInt32) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableInt32) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableInt32(val *int32) *NullableInt32 {
+    return &NullableInt32{value: val, isSet: true}
 }
 
 func (v NullableInt32) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull && v.Value != 0:
-        return nil, ErrInvalidNullable
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-        return json.Marshal(v.Value)
-    }
+    return json.Marshal(v.value)
 }
 
 func (v *NullableInt32) UnmarshalJSON(src []byte) error {
-    if bytes.Equal(src, []byte("null")) {
-        v.ExplicitNull = true
-        return nil
-    }
-
-    return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+    return json.Unmarshal(src, &v.value)
 }
 
+
 type NullableInt64 struct {
-    Value int64
-    ExplicitNull bool
+    value *int64
+    isSet bool
+}
+
+func (v NullableInt64) Get() *int64 {
+    return v.value
+}
+
+func (v NullableInt64) Set(val *int64) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableInt64) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableInt64) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableInt64(val *int64) *NullableInt64 {
+    return &NullableInt64{value: val, isSet: true}
 }
 
 func (v NullableInt64) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull && v.Value != 0:
-        return nil, ErrInvalidNullable
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-        return json.Marshal(v.Value)
-    }
+    return json.Marshal(v.value)
 }
 
 func (v *NullableInt64) UnmarshalJSON(src []byte) error {
-    if bytes.Equal(src, []byte("null")) {
-        v.ExplicitNull = true
-        return nil
-    }
-
-    return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+    return json.Unmarshal(src, &v.value)
 }
 
+
 type NullableFloat32 struct {
-    Value float32
-    ExplicitNull bool
+    value *float32
+    isSet bool
+}
+
+func (v NullableFloat32) Get() *float32 {
+    return v.value
+}
+
+func (v NullableFloat32) Set(val *float32) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableFloat32) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableFloat32) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableFloat32(val *float32) *NullableFloat32 {
+    return &NullableFloat32{value: val, isSet: true}
 }
 
 func (v NullableFloat32) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull && v.Value != 0.0:
-        return nil, ErrInvalidNullable
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-        return json.Marshal(v.Value)
-    }
+    return json.Marshal(v.value)
 }
 
 func (v *NullableFloat32) UnmarshalJSON(src []byte) error {
-    if bytes.Equal(src, []byte("null")) {
-        v.ExplicitNull = true
-        return nil
-    }
-
-    return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+    return json.Unmarshal(src, &v.value)
 }
 
+
 type NullableFloat64 struct {
-    Value float64
-    ExplicitNull bool
+    value *float64
+    isSet bool
+}
+
+func (v NullableFloat64) Get() *float64 {
+    return v.value
+}
+
+func (v NullableFloat64) Set(val *float64) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableFloat64) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableFloat64) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableFloat64(val *float64) *NullableFloat64 {
+    return &NullableFloat64{value: val, isSet: true}
 }
 
 func (v NullableFloat64) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull && v.Value != 0.0:
-        return nil, ErrInvalidNullable
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-        return json.Marshal(v.Value)
-    }
+    return json.Marshal(v.value)
 }
 
 func (v *NullableFloat64) UnmarshalJSON(src []byte) error {
-    if bytes.Equal(src, []byte("null")) {
-        v.ExplicitNull = true
-        return nil
-    }
-
-    return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+    return json.Unmarshal(src, &v.value)
 }
 
+
 type NullableString struct {
-    Value string
-    ExplicitNull bool
+    value *string
+    isSet bool
+}
+
+func (v NullableString) Get() *string {
+    return v.value
+}
+
+func (v NullableString) Set(val *string) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableString) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableString) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableString(val *string) *NullableString {
+    return &NullableString{value: val, isSet: true}
 }
 
 func (v NullableString) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull && v.Value != "":
-        return nil, ErrInvalidNullable
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-        return json.Marshal(v.Value)
-    }
+    return json.Marshal(v.value)
 }
 
 func (v *NullableString) UnmarshalJSON(src []byte) error {
-    if bytes.Equal(src, []byte("null")) {
-        v.ExplicitNull = true
-        return nil
-    }
-
-    return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+    return json.Unmarshal(src, &v.value)
 }
 
+
 type NullableTime struct {
-    Value time.Time
-    ExplicitNull bool
+    value *time.Time
+    isSet bool
+}
+
+func (v NullableTime) Get() *time.Time {
+    return v.value
+}
+
+func (v NullableTime) Set(val *time.Time) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableTime) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableTime) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableTime(val *time.Time) *NullableTime {
+    return &NullableTime{value: val, isSet: true}
 }
 
 func (v NullableTime) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull && !v.Value.IsZero():
-        return nil, ErrInvalidNullable
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-        return v.Value.MarshalJSON()
-    }
+    return v.value.MarshalJSON()
 }
 
 func (v *NullableTime) UnmarshalJSON(src []byte) error {
-    if bytes.Equal(src, []byte("null")) {
-        v.ExplicitNull = true
-        return nil
-    }
-
-    return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+    return json.Unmarshal(src, &v.value)
 }

--- a/samples/client/petstore/go-experimental/go-petstore/utils.go
+++ b/samples/client/petstore/go-experimental/go-petstore/utils.go
@@ -47,7 +47,7 @@ func (v NullableBool) Get() *bool {
 	return v.value
 }
 
-func (v NullableBool) Set(val *bool) {
+func (v *NullableBool) Set(val *bool) {
 	v.value = val
 	v.isSet = true
 }
@@ -56,7 +56,7 @@ func (v NullableBool) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableBool) Unset() {
+func (v *NullableBool) Unset() {
 	v.value = nil
 	v.isSet = false
 }
@@ -84,7 +84,7 @@ func (v NullableInt) Get() *int {
 	return v.value
 }
 
-func (v NullableInt) Set(val *int) {
+func (v *NullableInt) Set(val *int) {
 	v.value = val
 	v.isSet = true
 }
@@ -93,7 +93,7 @@ func (v NullableInt) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableInt) Unset() {
+func (v *NullableInt) Unset() {
 	v.value = nil
 	v.isSet = false
 }
@@ -121,7 +121,7 @@ func (v NullableInt32) Get() *int32 {
 	return v.value
 }
 
-func (v NullableInt32) Set(val *int32) {
+func (v *NullableInt32) Set(val *int32) {
 	v.value = val
 	v.isSet = true
 }
@@ -130,7 +130,7 @@ func (v NullableInt32) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableInt32) Unset() {
+func (v *NullableInt32) Unset() {
 	v.value = nil
 	v.isSet = false
 }
@@ -158,7 +158,7 @@ func (v NullableInt64) Get() *int64 {
 	return v.value
 }
 
-func (v NullableInt64) Set(val *int64) {
+func (v *NullableInt64) Set(val *int64) {
 	v.value = val
 	v.isSet = true
 }
@@ -167,7 +167,7 @@ func (v NullableInt64) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableInt64) Unset() {
+func (v *NullableInt64) Unset() {
 	v.value = nil
 	v.isSet = false
 }
@@ -195,7 +195,7 @@ func (v NullableFloat32) Get() *float32 {
 	return v.value
 }
 
-func (v NullableFloat32) Set(val *float32) {
+func (v *NullableFloat32) Set(val *float32) {
 	v.value = val
 	v.isSet = true
 }
@@ -204,7 +204,7 @@ func (v NullableFloat32) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableFloat32) Unset() {
+func (v *NullableFloat32) Unset() {
 	v.value = nil
 	v.isSet = false
 }
@@ -232,7 +232,7 @@ func (v NullableFloat64) Get() *float64 {
 	return v.value
 }
 
-func (v NullableFloat64) Set(val *float64) {
+func (v *NullableFloat64) Set(val *float64) {
 	v.value = val
 	v.isSet = true
 }
@@ -241,7 +241,7 @@ func (v NullableFloat64) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableFloat64) Unset() {
+func (v *NullableFloat64) Unset() {
 	v.value = nil
 	v.isSet = false
 }
@@ -269,7 +269,7 @@ func (v NullableString) Get() *string {
 	return v.value
 }
 
-func (v NullableString) Set(val *string) {
+func (v *NullableString) Set(val *string) {
 	v.value = val
 	v.isSet = true
 }
@@ -278,7 +278,7 @@ func (v NullableString) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableString) Unset() {
+func (v *NullableString) Unset() {
 	v.value = nil
 	v.isSet = false
 }
@@ -306,7 +306,7 @@ func (v NullableTime) Get() *time.Time {
 	return v.value
 }
 
-func (v NullableTime) Set(val *time.Time) {
+func (v *NullableTime) Set(val *time.Time) {
 	v.value = val
 	v.isSet = true
 }
@@ -315,7 +315,7 @@ func (v NullableTime) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableTime) Unset() {
+func (v *NullableTime) Unset() {
 	v.value = nil
 	v.isSet = false
 }

--- a/samples/client/petstore/go-experimental/go-petstore/utils.go
+++ b/samples/client/petstore/go-experimental/go-petstore/utils.go
@@ -10,8 +10,8 @@
 package petstore
 
 import (
-    "encoding/json"
-    "time"
+	"encoding/json"
+	"time"
 )
 
 // PtrBool is a helper routine that returns a pointer to given integer value.
@@ -39,296 +39,296 @@ func PtrString(v string) *string { return &v }
 func PtrTime(v time.Time) *time.Time { return &v }
 
 type NullableBool struct {
-    value *bool
-    isSet bool
+	value *bool
+	isSet bool
 }
 
 func (v NullableBool) Get() *bool {
-    return v.value
+	return v.value
 }
 
 func (v NullableBool) Set(val *bool) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableBool) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableBool) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableBool(val *bool) *NullableBool {
-    return &NullableBool{value: val, isSet: true}
+	return &NullableBool{value: val, isSet: true}
 }
 
 func (v NullableBool) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableBool) UnmarshalJSON(src []byte) error {
-    v.isSet = true
-    return json.Unmarshal(src, &v.value)
+	v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }
 
 
 type NullableInt struct {
-    value *int
-    isSet bool
+	value *int
+	isSet bool
 }
 
 func (v NullableInt) Get() *int {
-    return v.value
+	return v.value
 }
 
 func (v NullableInt) Set(val *int) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableInt) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableInt) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableInt(val *int) *NullableInt {
-    return &NullableInt{value: val, isSet: true}
+	return &NullableInt{value: val, isSet: true}
 }
 
 func (v NullableInt) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableInt) UnmarshalJSON(src []byte) error {
-    v.isSet = true
-    return json.Unmarshal(src, &v.value)
+	v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }
 
 
 type NullableInt32 struct {
-    value *int32
-    isSet bool
+	value *int32
+	isSet bool
 }
 
 func (v NullableInt32) Get() *int32 {
-    return v.value
+	return v.value
 }
 
 func (v NullableInt32) Set(val *int32) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableInt32) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableInt32) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableInt32(val *int32) *NullableInt32 {
-    return &NullableInt32{value: val, isSet: true}
+	return &NullableInt32{value: val, isSet: true}
 }
 
 func (v NullableInt32) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableInt32) UnmarshalJSON(src []byte) error {
-    v.isSet = true
-    return json.Unmarshal(src, &v.value)
+	v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }
 
 
 type NullableInt64 struct {
-    value *int64
-    isSet bool
+	value *int64
+	isSet bool
 }
 
 func (v NullableInt64) Get() *int64 {
-    return v.value
+	return v.value
 }
 
 func (v NullableInt64) Set(val *int64) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableInt64) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableInt64) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableInt64(val *int64) *NullableInt64 {
-    return &NullableInt64{value: val, isSet: true}
+	return &NullableInt64{value: val, isSet: true}
 }
 
 func (v NullableInt64) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableInt64) UnmarshalJSON(src []byte) error {
-    v.isSet = true
-    return json.Unmarshal(src, &v.value)
+	v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }
 
 
 type NullableFloat32 struct {
-    value *float32
-    isSet bool
+	value *float32
+	isSet bool
 }
 
 func (v NullableFloat32) Get() *float32 {
-    return v.value
+	return v.value
 }
 
 func (v NullableFloat32) Set(val *float32) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableFloat32) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableFloat32) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableFloat32(val *float32) *NullableFloat32 {
-    return &NullableFloat32{value: val, isSet: true}
+	return &NullableFloat32{value: val, isSet: true}
 }
 
 func (v NullableFloat32) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableFloat32) UnmarshalJSON(src []byte) error {
-    v.isSet = true
-    return json.Unmarshal(src, &v.value)
+	v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }
 
 
 type NullableFloat64 struct {
-    value *float64
-    isSet bool
+	value *float64
+	isSet bool
 }
 
 func (v NullableFloat64) Get() *float64 {
-    return v.value
+	return v.value
 }
 
 func (v NullableFloat64) Set(val *float64) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableFloat64) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableFloat64) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableFloat64(val *float64) *NullableFloat64 {
-    return &NullableFloat64{value: val, isSet: true}
+	return &NullableFloat64{value: val, isSet: true}
 }
 
 func (v NullableFloat64) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableFloat64) UnmarshalJSON(src []byte) error {
-    v.isSet = true
-    return json.Unmarshal(src, &v.value)
+	v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }
 
 
 type NullableString struct {
-    value *string
-    isSet bool
+	value *string
+	isSet bool
 }
 
 func (v NullableString) Get() *string {
-    return v.value
+	return v.value
 }
 
 func (v NullableString) Set(val *string) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableString) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableString) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableString(val *string) *NullableString {
-    return &NullableString{value: val, isSet: true}
+	return &NullableString{value: val, isSet: true}
 }
 
 func (v NullableString) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableString) UnmarshalJSON(src []byte) error {
-    v.isSet = true
-    return json.Unmarshal(src, &v.value)
+	v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }
 
 
 type NullableTime struct {
-    value *time.Time
-    isSet bool
+	value *time.Time
+	isSet bool
 }
 
 func (v NullableTime) Get() *time.Time {
-    return v.value
+	return v.value
 }
 
 func (v NullableTime) Set(val *time.Time) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableTime) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableTime) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableTime(val *time.Time) *NullableTime {
-    return &NullableTime{value: val, isSet: true}
+	return &NullableTime{value: val, isSet: true}
 }
 
 func (v NullableTime) MarshalJSON() ([]byte, error) {
-    return v.value.MarshalJSON()
+	return v.value.MarshalJSON()
 }
 
 func (v *NullableTime) UnmarshalJSON(src []byte) error {
-    v.isSet = true
-    return json.Unmarshal(src, &v.value)
+	v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/AdditionalPropertiesClass.md
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/AdditionalPropertiesClass.md
@@ -34,22 +34,16 @@ GetMapProperty returns the MapProperty field if non-nil, zero value otherwise.
 
 ### GetMapPropertyOk
 
-`func (o *AdditionalPropertiesClass) GetMapPropertyOk() (map[string]string, bool)`
+`func (o *AdditionalPropertiesClass) GetMapPropertyOk() (*map[string]string, bool)`
 
 GetMapPropertyOk returns a tuple with the MapProperty field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasMapProperty
-
-`func (o *AdditionalPropertiesClass) HasMapProperty() bool`
-
-HasMapProperty returns a boolean if a field has been set.
 
 ### SetMapProperty
 
 `func (o *AdditionalPropertiesClass) SetMapProperty(v map[string]string)`
 
-SetMapProperty gets a reference to the given map[string]string and assigns it to the MapProperty field.
+SetMapProperty sets MapProperty field to given value.
 
 ### GetMapOfMapProperty
 
@@ -59,22 +53,16 @@ GetMapOfMapProperty returns the MapOfMapProperty field if non-nil, zero value ot
 
 ### GetMapOfMapPropertyOk
 
-`func (o *AdditionalPropertiesClass) GetMapOfMapPropertyOk() (map[string]map[string]string, bool)`
+`func (o *AdditionalPropertiesClass) GetMapOfMapPropertyOk() (*map[string]map[string]string, bool)`
 
 GetMapOfMapPropertyOk returns a tuple with the MapOfMapProperty field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasMapOfMapProperty
-
-`func (o *AdditionalPropertiesClass) HasMapOfMapProperty() bool`
-
-HasMapOfMapProperty returns a boolean if a field has been set.
 
 ### SetMapOfMapProperty
 
 `func (o *AdditionalPropertiesClass) SetMapOfMapProperty(v map[string]map[string]string)`
 
-SetMapOfMapProperty gets a reference to the given map[string]map[string]string and assigns it to the MapOfMapProperty field.
+SetMapOfMapProperty sets MapOfMapProperty field to given value.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/AdditionalPropertiesClass.md
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/AdditionalPropertiesClass.md
@@ -45,6 +45,12 @@ and a boolean to check if the value has been set.
 
 SetMapProperty sets MapProperty field to given value.
 
+### HasMapProperty
+
+`func (o *AdditionalPropertiesClass) HasMapProperty() bool`
+
+HasMapProperty returns a boolean if a field has been set.
+
 ### GetMapOfMapProperty
 
 `func (o *AdditionalPropertiesClass) GetMapOfMapProperty() map[string]map[string]string`
@@ -63,6 +69,12 @@ and a boolean to check if the value has been set.
 `func (o *AdditionalPropertiesClass) SetMapOfMapProperty(v map[string]map[string]string)`
 
 SetMapOfMapProperty sets MapOfMapProperty field to given value.
+
+### HasMapOfMapProperty
+
+`func (o *AdditionalPropertiesClass) HasMapOfMapProperty() bool`
+
+HasMapOfMapProperty returns a boolean if a field has been set.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/Animal.md
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/Animal.md
@@ -34,22 +34,16 @@ GetClassName returns the ClassName field if non-nil, zero value otherwise.
 
 ### GetClassNameOk
 
-`func (o *Animal) GetClassNameOk() (string, bool)`
+`func (o *Animal) GetClassNameOk() (*string, bool)`
 
 GetClassNameOk returns a tuple with the ClassName field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasClassName
-
-`func (o *Animal) HasClassName() bool`
-
-HasClassName returns a boolean if a field has been set.
 
 ### SetClassName
 
 `func (o *Animal) SetClassName(v string)`
 
-SetClassName gets a reference to the given string and assigns it to the ClassName field.
+SetClassName sets ClassName field to given value.
 
 ### GetColor
 
@@ -59,22 +53,16 @@ GetColor returns the Color field if non-nil, zero value otherwise.
 
 ### GetColorOk
 
-`func (o *Animal) GetColorOk() (string, bool)`
+`func (o *Animal) GetColorOk() (*string, bool)`
 
 GetColorOk returns a tuple with the Color field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasColor
-
-`func (o *Animal) HasColor() bool`
-
-HasColor returns a boolean if a field has been set.
 
 ### SetColor
 
 `func (o *Animal) SetColor(v string)`
 
-SetColor gets a reference to the given string and assigns it to the Color field.
+SetColor sets Color field to given value.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/Animal.md
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/Animal.md
@@ -45,6 +45,7 @@ and a boolean to check if the value has been set.
 
 SetClassName sets ClassName field to given value.
 
+
 ### GetColor
 
 `func (o *Animal) GetColor() string`
@@ -63,6 +64,12 @@ and a boolean to check if the value has been set.
 `func (o *Animal) SetColor(v string)`
 
 SetColor sets Color field to given value.
+
+### HasColor
+
+`func (o *Animal) HasColor() bool`
+
+HasColor returns a boolean if a field has been set.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/ApiResponse.md
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/ApiResponse.md
@@ -35,22 +35,16 @@ GetCode returns the Code field if non-nil, zero value otherwise.
 
 ### GetCodeOk
 
-`func (o *ApiResponse) GetCodeOk() (int32, bool)`
+`func (o *ApiResponse) GetCodeOk() (*int32, bool)`
 
 GetCodeOk returns a tuple with the Code field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasCode
-
-`func (o *ApiResponse) HasCode() bool`
-
-HasCode returns a boolean if a field has been set.
 
 ### SetCode
 
 `func (o *ApiResponse) SetCode(v int32)`
 
-SetCode gets a reference to the given int32 and assigns it to the Code field.
+SetCode sets Code field to given value.
 
 ### GetType
 
@@ -60,22 +54,16 @@ GetType returns the Type field if non-nil, zero value otherwise.
 
 ### GetTypeOk
 
-`func (o *ApiResponse) GetTypeOk() (string, bool)`
+`func (o *ApiResponse) GetTypeOk() (*string, bool)`
 
 GetTypeOk returns a tuple with the Type field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasType
-
-`func (o *ApiResponse) HasType() bool`
-
-HasType returns a boolean if a field has been set.
 
 ### SetType
 
 `func (o *ApiResponse) SetType(v string)`
 
-SetType gets a reference to the given string and assigns it to the Type field.
+SetType sets Type field to given value.
 
 ### GetMessage
 
@@ -85,22 +73,16 @@ GetMessage returns the Message field if non-nil, zero value otherwise.
 
 ### GetMessageOk
 
-`func (o *ApiResponse) GetMessageOk() (string, bool)`
+`func (o *ApiResponse) GetMessageOk() (*string, bool)`
 
 GetMessageOk returns a tuple with the Message field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasMessage
-
-`func (o *ApiResponse) HasMessage() bool`
-
-HasMessage returns a boolean if a field has been set.
 
 ### SetMessage
 
 `func (o *ApiResponse) SetMessage(v string)`
 
-SetMessage gets a reference to the given string and assigns it to the Message field.
+SetMessage sets Message field to given value.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/ApiResponse.md
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/ApiResponse.md
@@ -46,6 +46,12 @@ and a boolean to check if the value has been set.
 
 SetCode sets Code field to given value.
 
+### HasCode
+
+`func (o *ApiResponse) HasCode() bool`
+
+HasCode returns a boolean if a field has been set.
+
 ### GetType
 
 `func (o *ApiResponse) GetType() string`
@@ -65,6 +71,12 @@ and a boolean to check if the value has been set.
 
 SetType sets Type field to given value.
 
+### HasType
+
+`func (o *ApiResponse) HasType() bool`
+
+HasType returns a boolean if a field has been set.
+
 ### GetMessage
 
 `func (o *ApiResponse) GetMessage() string`
@@ -83,6 +95,12 @@ and a boolean to check if the value has been set.
 `func (o *ApiResponse) SetMessage(v string)`
 
 SetMessage sets Message field to given value.
+
+### HasMessage
+
+`func (o *ApiResponse) HasMessage() bool`
+
+HasMessage returns a boolean if a field has been set.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/ArrayOfArrayOfNumberOnly.md
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/ArrayOfArrayOfNumberOnly.md
@@ -44,6 +44,12 @@ and a boolean to check if the value has been set.
 
 SetArrayArrayNumber sets ArrayArrayNumber field to given value.
 
+### HasArrayArrayNumber
+
+`func (o *ArrayOfArrayOfNumberOnly) HasArrayArrayNumber() bool`
+
+HasArrayArrayNumber returns a boolean if a field has been set.
+
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/ArrayOfArrayOfNumberOnly.md
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/ArrayOfArrayOfNumberOnly.md
@@ -33,22 +33,16 @@ GetArrayArrayNumber returns the ArrayArrayNumber field if non-nil, zero value ot
 
 ### GetArrayArrayNumberOk
 
-`func (o *ArrayOfArrayOfNumberOnly) GetArrayArrayNumberOk() ([][]float32, bool)`
+`func (o *ArrayOfArrayOfNumberOnly) GetArrayArrayNumberOk() (*[][]float32, bool)`
 
 GetArrayArrayNumberOk returns a tuple with the ArrayArrayNumber field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasArrayArrayNumber
-
-`func (o *ArrayOfArrayOfNumberOnly) HasArrayArrayNumber() bool`
-
-HasArrayArrayNumber returns a boolean if a field has been set.
 
 ### SetArrayArrayNumber
 
 `func (o *ArrayOfArrayOfNumberOnly) SetArrayArrayNumber(v [][]float32)`
 
-SetArrayArrayNumber gets a reference to the given [][]float32 and assigns it to the ArrayArrayNumber field.
+SetArrayArrayNumber sets ArrayArrayNumber field to given value.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/ArrayOfNumberOnly.md
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/ArrayOfNumberOnly.md
@@ -33,22 +33,16 @@ GetArrayNumber returns the ArrayNumber field if non-nil, zero value otherwise.
 
 ### GetArrayNumberOk
 
-`func (o *ArrayOfNumberOnly) GetArrayNumberOk() ([]float32, bool)`
+`func (o *ArrayOfNumberOnly) GetArrayNumberOk() (*[]float32, bool)`
 
 GetArrayNumberOk returns a tuple with the ArrayNumber field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasArrayNumber
-
-`func (o *ArrayOfNumberOnly) HasArrayNumber() bool`
-
-HasArrayNumber returns a boolean if a field has been set.
 
 ### SetArrayNumber
 
 `func (o *ArrayOfNumberOnly) SetArrayNumber(v []float32)`
 
-SetArrayNumber gets a reference to the given []float32 and assigns it to the ArrayNumber field.
+SetArrayNumber sets ArrayNumber field to given value.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/ArrayOfNumberOnly.md
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/ArrayOfNumberOnly.md
@@ -44,6 +44,12 @@ and a boolean to check if the value has been set.
 
 SetArrayNumber sets ArrayNumber field to given value.
 
+### HasArrayNumber
+
+`func (o *ArrayOfNumberOnly) HasArrayNumber() bool`
+
+HasArrayNumber returns a boolean if a field has been set.
+
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/ArrayTest.md
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/ArrayTest.md
@@ -35,22 +35,16 @@ GetArrayOfString returns the ArrayOfString field if non-nil, zero value otherwis
 
 ### GetArrayOfStringOk
 
-`func (o *ArrayTest) GetArrayOfStringOk() ([]string, bool)`
+`func (o *ArrayTest) GetArrayOfStringOk() (*[]string, bool)`
 
 GetArrayOfStringOk returns a tuple with the ArrayOfString field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasArrayOfString
-
-`func (o *ArrayTest) HasArrayOfString() bool`
-
-HasArrayOfString returns a boolean if a field has been set.
 
 ### SetArrayOfString
 
 `func (o *ArrayTest) SetArrayOfString(v []string)`
 
-SetArrayOfString gets a reference to the given []string and assigns it to the ArrayOfString field.
+SetArrayOfString sets ArrayOfString field to given value.
 
 ### GetArrayArrayOfInteger
 
@@ -60,22 +54,16 @@ GetArrayArrayOfInteger returns the ArrayArrayOfInteger field if non-nil, zero va
 
 ### GetArrayArrayOfIntegerOk
 
-`func (o *ArrayTest) GetArrayArrayOfIntegerOk() ([][]int64, bool)`
+`func (o *ArrayTest) GetArrayArrayOfIntegerOk() (*[][]int64, bool)`
 
 GetArrayArrayOfIntegerOk returns a tuple with the ArrayArrayOfInteger field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasArrayArrayOfInteger
-
-`func (o *ArrayTest) HasArrayArrayOfInteger() bool`
-
-HasArrayArrayOfInteger returns a boolean if a field has been set.
 
 ### SetArrayArrayOfInteger
 
 `func (o *ArrayTest) SetArrayArrayOfInteger(v [][]int64)`
 
-SetArrayArrayOfInteger gets a reference to the given [][]int64 and assigns it to the ArrayArrayOfInteger field.
+SetArrayArrayOfInteger sets ArrayArrayOfInteger field to given value.
 
 ### GetArrayArrayOfModel
 
@@ -85,22 +73,16 @@ GetArrayArrayOfModel returns the ArrayArrayOfModel field if non-nil, zero value 
 
 ### GetArrayArrayOfModelOk
 
-`func (o *ArrayTest) GetArrayArrayOfModelOk() ([][]ReadOnlyFirst, bool)`
+`func (o *ArrayTest) GetArrayArrayOfModelOk() (*[][]ReadOnlyFirst, bool)`
 
 GetArrayArrayOfModelOk returns a tuple with the ArrayArrayOfModel field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasArrayArrayOfModel
-
-`func (o *ArrayTest) HasArrayArrayOfModel() bool`
-
-HasArrayArrayOfModel returns a boolean if a field has been set.
 
 ### SetArrayArrayOfModel
 
 `func (o *ArrayTest) SetArrayArrayOfModel(v [][]ReadOnlyFirst)`
 
-SetArrayArrayOfModel gets a reference to the given [][]ReadOnlyFirst and assigns it to the ArrayArrayOfModel field.
+SetArrayArrayOfModel sets ArrayArrayOfModel field to given value.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/ArrayTest.md
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/ArrayTest.md
@@ -46,6 +46,12 @@ and a boolean to check if the value has been set.
 
 SetArrayOfString sets ArrayOfString field to given value.
 
+### HasArrayOfString
+
+`func (o *ArrayTest) HasArrayOfString() bool`
+
+HasArrayOfString returns a boolean if a field has been set.
+
 ### GetArrayArrayOfInteger
 
 `func (o *ArrayTest) GetArrayArrayOfInteger() [][]int64`
@@ -65,6 +71,12 @@ and a boolean to check if the value has been set.
 
 SetArrayArrayOfInteger sets ArrayArrayOfInteger field to given value.
 
+### HasArrayArrayOfInteger
+
+`func (o *ArrayTest) HasArrayArrayOfInteger() bool`
+
+HasArrayArrayOfInteger returns a boolean if a field has been set.
+
 ### GetArrayArrayOfModel
 
 `func (o *ArrayTest) GetArrayArrayOfModel() [][]ReadOnlyFirst`
@@ -83,6 +95,12 @@ and a boolean to check if the value has been set.
 `func (o *ArrayTest) SetArrayArrayOfModel(v [][]ReadOnlyFirst)`
 
 SetArrayArrayOfModel sets ArrayArrayOfModel field to given value.
+
+### HasArrayArrayOfModel
+
+`func (o *ArrayTest) HasArrayArrayOfModel() bool`
+
+HasArrayArrayOfModel returns a boolean if a field has been set.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/Capitalization.md
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/Capitalization.md
@@ -49,6 +49,12 @@ and a boolean to check if the value has been set.
 
 SetSmallCamel sets SmallCamel field to given value.
 
+### HasSmallCamel
+
+`func (o *Capitalization) HasSmallCamel() bool`
+
+HasSmallCamel returns a boolean if a field has been set.
+
 ### GetCapitalCamel
 
 `func (o *Capitalization) GetCapitalCamel() string`
@@ -67,6 +73,12 @@ and a boolean to check if the value has been set.
 `func (o *Capitalization) SetCapitalCamel(v string)`
 
 SetCapitalCamel sets CapitalCamel field to given value.
+
+### HasCapitalCamel
+
+`func (o *Capitalization) HasCapitalCamel() bool`
+
+HasCapitalCamel returns a boolean if a field has been set.
 
 ### GetSmallSnake
 
@@ -87,6 +99,12 @@ and a boolean to check if the value has been set.
 
 SetSmallSnake sets SmallSnake field to given value.
 
+### HasSmallSnake
+
+`func (o *Capitalization) HasSmallSnake() bool`
+
+HasSmallSnake returns a boolean if a field has been set.
+
 ### GetCapitalSnake
 
 `func (o *Capitalization) GetCapitalSnake() string`
@@ -105,6 +123,12 @@ and a boolean to check if the value has been set.
 `func (o *Capitalization) SetCapitalSnake(v string)`
 
 SetCapitalSnake sets CapitalSnake field to given value.
+
+### HasCapitalSnake
+
+`func (o *Capitalization) HasCapitalSnake() bool`
+
+HasCapitalSnake returns a boolean if a field has been set.
 
 ### GetSCAETHFlowPoints
 
@@ -125,6 +149,12 @@ and a boolean to check if the value has been set.
 
 SetSCAETHFlowPoints sets SCAETHFlowPoints field to given value.
 
+### HasSCAETHFlowPoints
+
+`func (o *Capitalization) HasSCAETHFlowPoints() bool`
+
+HasSCAETHFlowPoints returns a boolean if a field has been set.
+
 ### GetATT_NAME
 
 `func (o *Capitalization) GetATT_NAME() string`
@@ -143,6 +173,12 @@ and a boolean to check if the value has been set.
 `func (o *Capitalization) SetATT_NAME(v string)`
 
 SetATT_NAME sets ATT_NAME field to given value.
+
+### HasATT_NAME
+
+`func (o *Capitalization) HasATT_NAME() bool`
+
+HasATT_NAME returns a boolean if a field has been set.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/Capitalization.md
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/Capitalization.md
@@ -38,22 +38,16 @@ GetSmallCamel returns the SmallCamel field if non-nil, zero value otherwise.
 
 ### GetSmallCamelOk
 
-`func (o *Capitalization) GetSmallCamelOk() (string, bool)`
+`func (o *Capitalization) GetSmallCamelOk() (*string, bool)`
 
 GetSmallCamelOk returns a tuple with the SmallCamel field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasSmallCamel
-
-`func (o *Capitalization) HasSmallCamel() bool`
-
-HasSmallCamel returns a boolean if a field has been set.
 
 ### SetSmallCamel
 
 `func (o *Capitalization) SetSmallCamel(v string)`
 
-SetSmallCamel gets a reference to the given string and assigns it to the SmallCamel field.
+SetSmallCamel sets SmallCamel field to given value.
 
 ### GetCapitalCamel
 
@@ -63,22 +57,16 @@ GetCapitalCamel returns the CapitalCamel field if non-nil, zero value otherwise.
 
 ### GetCapitalCamelOk
 
-`func (o *Capitalization) GetCapitalCamelOk() (string, bool)`
+`func (o *Capitalization) GetCapitalCamelOk() (*string, bool)`
 
 GetCapitalCamelOk returns a tuple with the CapitalCamel field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasCapitalCamel
-
-`func (o *Capitalization) HasCapitalCamel() bool`
-
-HasCapitalCamel returns a boolean if a field has been set.
 
 ### SetCapitalCamel
 
 `func (o *Capitalization) SetCapitalCamel(v string)`
 
-SetCapitalCamel gets a reference to the given string and assigns it to the CapitalCamel field.
+SetCapitalCamel sets CapitalCamel field to given value.
 
 ### GetSmallSnake
 
@@ -88,22 +76,16 @@ GetSmallSnake returns the SmallSnake field if non-nil, zero value otherwise.
 
 ### GetSmallSnakeOk
 
-`func (o *Capitalization) GetSmallSnakeOk() (string, bool)`
+`func (o *Capitalization) GetSmallSnakeOk() (*string, bool)`
 
 GetSmallSnakeOk returns a tuple with the SmallSnake field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasSmallSnake
-
-`func (o *Capitalization) HasSmallSnake() bool`
-
-HasSmallSnake returns a boolean if a field has been set.
 
 ### SetSmallSnake
 
 `func (o *Capitalization) SetSmallSnake(v string)`
 
-SetSmallSnake gets a reference to the given string and assigns it to the SmallSnake field.
+SetSmallSnake sets SmallSnake field to given value.
 
 ### GetCapitalSnake
 
@@ -113,22 +95,16 @@ GetCapitalSnake returns the CapitalSnake field if non-nil, zero value otherwise.
 
 ### GetCapitalSnakeOk
 
-`func (o *Capitalization) GetCapitalSnakeOk() (string, bool)`
+`func (o *Capitalization) GetCapitalSnakeOk() (*string, bool)`
 
 GetCapitalSnakeOk returns a tuple with the CapitalSnake field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasCapitalSnake
-
-`func (o *Capitalization) HasCapitalSnake() bool`
-
-HasCapitalSnake returns a boolean if a field has been set.
 
 ### SetCapitalSnake
 
 `func (o *Capitalization) SetCapitalSnake(v string)`
 
-SetCapitalSnake gets a reference to the given string and assigns it to the CapitalSnake field.
+SetCapitalSnake sets CapitalSnake field to given value.
 
 ### GetSCAETHFlowPoints
 
@@ -138,22 +114,16 @@ GetSCAETHFlowPoints returns the SCAETHFlowPoints field if non-nil, zero value ot
 
 ### GetSCAETHFlowPointsOk
 
-`func (o *Capitalization) GetSCAETHFlowPointsOk() (string, bool)`
+`func (o *Capitalization) GetSCAETHFlowPointsOk() (*string, bool)`
 
 GetSCAETHFlowPointsOk returns a tuple with the SCAETHFlowPoints field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasSCAETHFlowPoints
-
-`func (o *Capitalization) HasSCAETHFlowPoints() bool`
-
-HasSCAETHFlowPoints returns a boolean if a field has been set.
 
 ### SetSCAETHFlowPoints
 
 `func (o *Capitalization) SetSCAETHFlowPoints(v string)`
 
-SetSCAETHFlowPoints gets a reference to the given string and assigns it to the SCAETHFlowPoints field.
+SetSCAETHFlowPoints sets SCAETHFlowPoints field to given value.
 
 ### GetATT_NAME
 
@@ -163,22 +133,16 @@ GetATT_NAME returns the ATT_NAME field if non-nil, zero value otherwise.
 
 ### GetATT_NAMEOk
 
-`func (o *Capitalization) GetATT_NAMEOk() (string, bool)`
+`func (o *Capitalization) GetATT_NAMEOk() (*string, bool)`
 
 GetATT_NAMEOk returns a tuple with the ATT_NAME field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasATT_NAME
-
-`func (o *Capitalization) HasATT_NAME() bool`
-
-HasATT_NAME returns a boolean if a field has been set.
 
 ### SetATT_NAME
 
 `func (o *Capitalization) SetATT_NAME(v string)`
 
-SetATT_NAME gets a reference to the given string and assigns it to the ATT_NAME field.
+SetATT_NAME sets ATT_NAME field to given value.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/Cat.md
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/Cat.md
@@ -33,22 +33,16 @@ GetDeclawed returns the Declawed field if non-nil, zero value otherwise.
 
 ### GetDeclawedOk
 
-`func (o *Cat) GetDeclawedOk() (bool, bool)`
+`func (o *Cat) GetDeclawedOk() (*bool, bool)`
 
 GetDeclawedOk returns a tuple with the Declawed field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasDeclawed
-
-`func (o *Cat) HasDeclawed() bool`
-
-HasDeclawed returns a boolean if a field has been set.
 
 ### SetDeclawed
 
 `func (o *Cat) SetDeclawed(v bool)`
 
-SetDeclawed gets a reference to the given bool and assigns it to the Declawed field.
+SetDeclawed sets Declawed field to given value.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/Cat.md
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/Cat.md
@@ -44,6 +44,12 @@ and a boolean to check if the value has been set.
 
 SetDeclawed sets Declawed field to given value.
 
+### HasDeclawed
+
+`func (o *Cat) HasDeclawed() bool`
+
+HasDeclawed returns a boolean if a field has been set.
+
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/CatAllOf.md
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/CatAllOf.md
@@ -44,6 +44,12 @@ and a boolean to check if the value has been set.
 
 SetDeclawed sets Declawed field to given value.
 
+### HasDeclawed
+
+`func (o *CatAllOf) HasDeclawed() bool`
+
+HasDeclawed returns a boolean if a field has been set.
+
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/CatAllOf.md
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/CatAllOf.md
@@ -33,22 +33,16 @@ GetDeclawed returns the Declawed field if non-nil, zero value otherwise.
 
 ### GetDeclawedOk
 
-`func (o *CatAllOf) GetDeclawedOk() (bool, bool)`
+`func (o *CatAllOf) GetDeclawedOk() (*bool, bool)`
 
 GetDeclawedOk returns a tuple with the Declawed field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasDeclawed
-
-`func (o *CatAllOf) HasDeclawed() bool`
-
-HasDeclawed returns a boolean if a field has been set.
 
 ### SetDeclawed
 
 `func (o *CatAllOf) SetDeclawed(v bool)`
 
-SetDeclawed gets a reference to the given bool and assigns it to the Declawed field.
+SetDeclawed sets Declawed field to given value.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/Category.md
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/Category.md
@@ -34,22 +34,16 @@ GetId returns the Id field if non-nil, zero value otherwise.
 
 ### GetIdOk
 
-`func (o *Category) GetIdOk() (int64, bool)`
+`func (o *Category) GetIdOk() (*int64, bool)`
 
 GetIdOk returns a tuple with the Id field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasId
-
-`func (o *Category) HasId() bool`
-
-HasId returns a boolean if a field has been set.
 
 ### SetId
 
 `func (o *Category) SetId(v int64)`
 
-SetId gets a reference to the given int64 and assigns it to the Id field.
+SetId sets Id field to given value.
 
 ### GetName
 
@@ -59,22 +53,16 @@ GetName returns the Name field if non-nil, zero value otherwise.
 
 ### GetNameOk
 
-`func (o *Category) GetNameOk() (string, bool)`
+`func (o *Category) GetNameOk() (*string, bool)`
 
 GetNameOk returns a tuple with the Name field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasName
-
-`func (o *Category) HasName() bool`
-
-HasName returns a boolean if a field has been set.
 
 ### SetName
 
 `func (o *Category) SetName(v string)`
 
-SetName gets a reference to the given string and assigns it to the Name field.
+SetName sets Name field to given value.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/Category.md
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/Category.md
@@ -45,6 +45,12 @@ and a boolean to check if the value has been set.
 
 SetId sets Id field to given value.
 
+### HasId
+
+`func (o *Category) HasId() bool`
+
+HasId returns a boolean if a field has been set.
+
 ### GetName
 
 `func (o *Category) GetName() string`
@@ -63,6 +69,7 @@ and a boolean to check if the value has been set.
 `func (o *Category) SetName(v string)`
 
 SetName sets Name field to given value.
+
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/ClassModel.md
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/ClassModel.md
@@ -33,22 +33,16 @@ GetClass returns the Class field if non-nil, zero value otherwise.
 
 ### GetClassOk
 
-`func (o *ClassModel) GetClassOk() (string, bool)`
+`func (o *ClassModel) GetClassOk() (*string, bool)`
 
 GetClassOk returns a tuple with the Class field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasClass
-
-`func (o *ClassModel) HasClass() bool`
-
-HasClass returns a boolean if a field has been set.
 
 ### SetClass
 
 `func (o *ClassModel) SetClass(v string)`
 
-SetClass gets a reference to the given string and assigns it to the Class field.
+SetClass sets Class field to given value.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/ClassModel.md
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/ClassModel.md
@@ -44,6 +44,12 @@ and a boolean to check if the value has been set.
 
 SetClass sets Class field to given value.
 
+### HasClass
+
+`func (o *ClassModel) HasClass() bool`
+
+HasClass returns a boolean if a field has been set.
+
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/Client.md
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/Client.md
@@ -33,22 +33,16 @@ GetClient returns the Client field if non-nil, zero value otherwise.
 
 ### GetClientOk
 
-`func (o *Client) GetClientOk() (string, bool)`
+`func (o *Client) GetClientOk() (*string, bool)`
 
 GetClientOk returns a tuple with the Client field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasClient
-
-`func (o *Client) HasClient() bool`
-
-HasClient returns a boolean if a field has been set.
 
 ### SetClient
 
 `func (o *Client) SetClient(v string)`
 
-SetClient gets a reference to the given string and assigns it to the Client field.
+SetClient sets Client field to given value.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/Client.md
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/Client.md
@@ -44,6 +44,12 @@ and a boolean to check if the value has been set.
 
 SetClient sets Client field to given value.
 
+### HasClient
+
+`func (o *Client) HasClient() bool`
+
+HasClient returns a boolean if a field has been set.
+
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/Dog.md
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/Dog.md
@@ -33,22 +33,16 @@ GetBreed returns the Breed field if non-nil, zero value otherwise.
 
 ### GetBreedOk
 
-`func (o *Dog) GetBreedOk() (string, bool)`
+`func (o *Dog) GetBreedOk() (*string, bool)`
 
 GetBreedOk returns a tuple with the Breed field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasBreed
-
-`func (o *Dog) HasBreed() bool`
-
-HasBreed returns a boolean if a field has been set.
 
 ### SetBreed
 
 `func (o *Dog) SetBreed(v string)`
 
-SetBreed gets a reference to the given string and assigns it to the Breed field.
+SetBreed sets Breed field to given value.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/Dog.md
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/Dog.md
@@ -44,6 +44,12 @@ and a boolean to check if the value has been set.
 
 SetBreed sets Breed field to given value.
 
+### HasBreed
+
+`func (o *Dog) HasBreed() bool`
+
+HasBreed returns a boolean if a field has been set.
+
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/DogAllOf.md
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/DogAllOf.md
@@ -44,6 +44,12 @@ and a boolean to check if the value has been set.
 
 SetBreed sets Breed field to given value.
 
+### HasBreed
+
+`func (o *DogAllOf) HasBreed() bool`
+
+HasBreed returns a boolean if a field has been set.
+
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/DogAllOf.md
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/DogAllOf.md
@@ -33,22 +33,16 @@ GetBreed returns the Breed field if non-nil, zero value otherwise.
 
 ### GetBreedOk
 
-`func (o *DogAllOf) GetBreedOk() (string, bool)`
+`func (o *DogAllOf) GetBreedOk() (*string, bool)`
 
 GetBreedOk returns a tuple with the Breed field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasBreed
-
-`func (o *DogAllOf) HasBreed() bool`
-
-HasBreed returns a boolean if a field has been set.
 
 ### SetBreed
 
 `func (o *DogAllOf) SetBreed(v string)`
 
-SetBreed gets a reference to the given string and assigns it to the Breed field.
+SetBreed sets Breed field to given value.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/EnumArrays.md
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/EnumArrays.md
@@ -45,6 +45,12 @@ and a boolean to check if the value has been set.
 
 SetJustSymbol sets JustSymbol field to given value.
 
+### HasJustSymbol
+
+`func (o *EnumArrays) HasJustSymbol() bool`
+
+HasJustSymbol returns a boolean if a field has been set.
+
 ### GetArrayEnum
 
 `func (o *EnumArrays) GetArrayEnum() []string`
@@ -63,6 +69,12 @@ and a boolean to check if the value has been set.
 `func (o *EnumArrays) SetArrayEnum(v []string)`
 
 SetArrayEnum sets ArrayEnum field to given value.
+
+### HasArrayEnum
+
+`func (o *EnumArrays) HasArrayEnum() bool`
+
+HasArrayEnum returns a boolean if a field has been set.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/EnumArrays.md
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/EnumArrays.md
@@ -34,22 +34,16 @@ GetJustSymbol returns the JustSymbol field if non-nil, zero value otherwise.
 
 ### GetJustSymbolOk
 
-`func (o *EnumArrays) GetJustSymbolOk() (string, bool)`
+`func (o *EnumArrays) GetJustSymbolOk() (*string, bool)`
 
 GetJustSymbolOk returns a tuple with the JustSymbol field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasJustSymbol
-
-`func (o *EnumArrays) HasJustSymbol() bool`
-
-HasJustSymbol returns a boolean if a field has been set.
 
 ### SetJustSymbol
 
 `func (o *EnumArrays) SetJustSymbol(v string)`
 
-SetJustSymbol gets a reference to the given string and assigns it to the JustSymbol field.
+SetJustSymbol sets JustSymbol field to given value.
 
 ### GetArrayEnum
 
@@ -59,22 +53,16 @@ GetArrayEnum returns the ArrayEnum field if non-nil, zero value otherwise.
 
 ### GetArrayEnumOk
 
-`func (o *EnumArrays) GetArrayEnumOk() ([]string, bool)`
+`func (o *EnumArrays) GetArrayEnumOk() (*[]string, bool)`
 
 GetArrayEnumOk returns a tuple with the ArrayEnum field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasArrayEnum
-
-`func (o *EnumArrays) HasArrayEnum() bool`
-
-HasArrayEnum returns a boolean if a field has been set.
 
 ### SetArrayEnum
 
 `func (o *EnumArrays) SetArrayEnum(v []string)`
 
-SetArrayEnum gets a reference to the given []string and assigns it to the ArrayEnum field.
+SetArrayEnum sets ArrayEnum field to given value.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/EnumTest.md
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/EnumTest.md
@@ -51,6 +51,12 @@ and a boolean to check if the value has been set.
 
 SetEnumString sets EnumString field to given value.
 
+### HasEnumString
+
+`func (o *EnumTest) HasEnumString() bool`
+
+HasEnumString returns a boolean if a field has been set.
+
 ### GetEnumStringRequired
 
 `func (o *EnumTest) GetEnumStringRequired() string`
@@ -69,6 +75,7 @@ and a boolean to check if the value has been set.
 `func (o *EnumTest) SetEnumStringRequired(v string)`
 
 SetEnumStringRequired sets EnumStringRequired field to given value.
+
 
 ### GetEnumInteger
 
@@ -89,6 +96,12 @@ and a boolean to check if the value has been set.
 
 SetEnumInteger sets EnumInteger field to given value.
 
+### HasEnumInteger
+
+`func (o *EnumTest) HasEnumInteger() bool`
+
+HasEnumInteger returns a boolean if a field has been set.
+
 ### GetEnumNumber
 
 `func (o *EnumTest) GetEnumNumber() float64`
@@ -107,6 +120,12 @@ and a boolean to check if the value has been set.
 `func (o *EnumTest) SetEnumNumber(v float64)`
 
 SetEnumNumber sets EnumNumber field to given value.
+
+### HasEnumNumber
+
+`func (o *EnumTest) HasEnumNumber() bool`
+
+HasEnumNumber returns a boolean if a field has been set.
 
 ### GetOuterEnum
 
@@ -162,6 +181,12 @@ and a boolean to check if the value has been set.
 
 SetOuterEnumInteger sets OuterEnumInteger field to given value.
 
+### HasOuterEnumInteger
+
+`func (o *EnumTest) HasOuterEnumInteger() bool`
+
+HasOuterEnumInteger returns a boolean if a field has been set.
+
 ### GetOuterEnumDefaultValue
 
 `func (o *EnumTest) GetOuterEnumDefaultValue() OuterEnumDefaultValue`
@@ -181,6 +206,12 @@ and a boolean to check if the value has been set.
 
 SetOuterEnumDefaultValue sets OuterEnumDefaultValue field to given value.
 
+### HasOuterEnumDefaultValue
+
+`func (o *EnumTest) HasOuterEnumDefaultValue() bool`
+
+HasOuterEnumDefaultValue returns a boolean if a field has been set.
+
 ### GetOuterEnumIntegerDefaultValue
 
 `func (o *EnumTest) GetOuterEnumIntegerDefaultValue() OuterEnumIntegerDefaultValue`
@@ -199,6 +230,12 @@ and a boolean to check if the value has been set.
 `func (o *EnumTest) SetOuterEnumIntegerDefaultValue(v OuterEnumIntegerDefaultValue)`
 
 SetOuterEnumIntegerDefaultValue sets OuterEnumIntegerDefaultValue field to given value.
+
+### HasOuterEnumIntegerDefaultValue
+
+`func (o *EnumTest) HasOuterEnumIntegerDefaultValue() bool`
+
+HasOuterEnumIntegerDefaultValue returns a boolean if a field has been set.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/EnumTest.md
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/EnumTest.md
@@ -40,22 +40,16 @@ GetEnumString returns the EnumString field if non-nil, zero value otherwise.
 
 ### GetEnumStringOk
 
-`func (o *EnumTest) GetEnumStringOk() (string, bool)`
+`func (o *EnumTest) GetEnumStringOk() (*string, bool)`
 
 GetEnumStringOk returns a tuple with the EnumString field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasEnumString
-
-`func (o *EnumTest) HasEnumString() bool`
-
-HasEnumString returns a boolean if a field has been set.
 
 ### SetEnumString
 
 `func (o *EnumTest) SetEnumString(v string)`
 
-SetEnumString gets a reference to the given string and assigns it to the EnumString field.
+SetEnumString sets EnumString field to given value.
 
 ### GetEnumStringRequired
 
@@ -65,22 +59,16 @@ GetEnumStringRequired returns the EnumStringRequired field if non-nil, zero valu
 
 ### GetEnumStringRequiredOk
 
-`func (o *EnumTest) GetEnumStringRequiredOk() (string, bool)`
+`func (o *EnumTest) GetEnumStringRequiredOk() (*string, bool)`
 
 GetEnumStringRequiredOk returns a tuple with the EnumStringRequired field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasEnumStringRequired
-
-`func (o *EnumTest) HasEnumStringRequired() bool`
-
-HasEnumStringRequired returns a boolean if a field has been set.
 
 ### SetEnumStringRequired
 
 `func (o *EnumTest) SetEnumStringRequired(v string)`
 
-SetEnumStringRequired gets a reference to the given string and assigns it to the EnumStringRequired field.
+SetEnumStringRequired sets EnumStringRequired field to given value.
 
 ### GetEnumInteger
 
@@ -90,22 +78,16 @@ GetEnumInteger returns the EnumInteger field if non-nil, zero value otherwise.
 
 ### GetEnumIntegerOk
 
-`func (o *EnumTest) GetEnumIntegerOk() (int32, bool)`
+`func (o *EnumTest) GetEnumIntegerOk() (*int32, bool)`
 
 GetEnumIntegerOk returns a tuple with the EnumInteger field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasEnumInteger
-
-`func (o *EnumTest) HasEnumInteger() bool`
-
-HasEnumInteger returns a boolean if a field has been set.
 
 ### SetEnumInteger
 
 `func (o *EnumTest) SetEnumInteger(v int32)`
 
-SetEnumInteger gets a reference to the given int32 and assigns it to the EnumInteger field.
+SetEnumInteger sets EnumInteger field to given value.
 
 ### GetEnumNumber
 
@@ -115,35 +97,35 @@ GetEnumNumber returns the EnumNumber field if non-nil, zero value otherwise.
 
 ### GetEnumNumberOk
 
-`func (o *EnumTest) GetEnumNumberOk() (float64, bool)`
+`func (o *EnumTest) GetEnumNumberOk() (*float64, bool)`
 
 GetEnumNumberOk returns a tuple with the EnumNumber field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasEnumNumber
-
-`func (o *EnumTest) HasEnumNumber() bool`
-
-HasEnumNumber returns a boolean if a field has been set.
 
 ### SetEnumNumber
 
 `func (o *EnumTest) SetEnumNumber(v float64)`
 
-SetEnumNumber gets a reference to the given float64 and assigns it to the EnumNumber field.
+SetEnumNumber sets EnumNumber field to given value.
 
 ### GetOuterEnum
 
-`func (o *EnumTest) GetOuterEnum() NullableOuterEnum`
+`func (o *EnumTest) GetOuterEnum() OuterEnum`
 
 GetOuterEnum returns the OuterEnum field if non-nil, zero value otherwise.
 
 ### GetOuterEnumOk
 
-`func (o *EnumTest) GetOuterEnumOk() (NullableOuterEnum, bool)`
+`func (o *EnumTest) GetOuterEnumOk() (*OuterEnum, bool)`
 
 GetOuterEnumOk returns a tuple with the OuterEnum field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
+
+### SetOuterEnum
+
+`func (o *EnumTest) SetOuterEnum(v OuterEnum)`
+
+SetOuterEnum sets OuterEnum field to given value.
 
 ### HasOuterEnum
 
@@ -151,19 +133,16 @@ and a boolean to check if the value has been set.
 
 HasOuterEnum returns a boolean if a field has been set.
 
-### SetOuterEnum
+### SetOuterEnumNil
 
-`func (o *EnumTest) SetOuterEnum(v NullableOuterEnum)`
+`func (o *EnumTest) SetOuterEnumNil(b bool)`
 
-SetOuterEnum gets a reference to the given NullableOuterEnum and assigns it to the OuterEnum field.
+ SetOuterEnumNil sets the value for OuterEnum to be an explicit nil
 
-### SetOuterEnumExplicitNull
+### UnsetOuterEnum
+`func (o *EnumTest) UnsetOuterEnum()`
 
-`func (o *EnumTest) SetOuterEnumExplicitNull(b bool)`
-
-SetOuterEnumExplicitNull (un)sets OuterEnum to be considered as explicit "null" value
-when serializing to JSON (pass true as argument to set this, false to unset)
-The OuterEnum value is set to nil even if false is passed
+UnsetOuterEnum ensures that no value is present for OuterEnum, not even an explicit nil
 ### GetOuterEnumInteger
 
 `func (o *EnumTest) GetOuterEnumInteger() OuterEnumInteger`
@@ -172,22 +151,16 @@ GetOuterEnumInteger returns the OuterEnumInteger field if non-nil, zero value ot
 
 ### GetOuterEnumIntegerOk
 
-`func (o *EnumTest) GetOuterEnumIntegerOk() (OuterEnumInteger, bool)`
+`func (o *EnumTest) GetOuterEnumIntegerOk() (*OuterEnumInteger, bool)`
 
 GetOuterEnumIntegerOk returns a tuple with the OuterEnumInteger field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasOuterEnumInteger
-
-`func (o *EnumTest) HasOuterEnumInteger() bool`
-
-HasOuterEnumInteger returns a boolean if a field has been set.
 
 ### SetOuterEnumInteger
 
 `func (o *EnumTest) SetOuterEnumInteger(v OuterEnumInteger)`
 
-SetOuterEnumInteger gets a reference to the given OuterEnumInteger and assigns it to the OuterEnumInteger field.
+SetOuterEnumInteger sets OuterEnumInteger field to given value.
 
 ### GetOuterEnumDefaultValue
 
@@ -197,22 +170,16 @@ GetOuterEnumDefaultValue returns the OuterEnumDefaultValue field if non-nil, zer
 
 ### GetOuterEnumDefaultValueOk
 
-`func (o *EnumTest) GetOuterEnumDefaultValueOk() (OuterEnumDefaultValue, bool)`
+`func (o *EnumTest) GetOuterEnumDefaultValueOk() (*OuterEnumDefaultValue, bool)`
 
 GetOuterEnumDefaultValueOk returns a tuple with the OuterEnumDefaultValue field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasOuterEnumDefaultValue
-
-`func (o *EnumTest) HasOuterEnumDefaultValue() bool`
-
-HasOuterEnumDefaultValue returns a boolean if a field has been set.
 
 ### SetOuterEnumDefaultValue
 
 `func (o *EnumTest) SetOuterEnumDefaultValue(v OuterEnumDefaultValue)`
 
-SetOuterEnumDefaultValue gets a reference to the given OuterEnumDefaultValue and assigns it to the OuterEnumDefaultValue field.
+SetOuterEnumDefaultValue sets OuterEnumDefaultValue field to given value.
 
 ### GetOuterEnumIntegerDefaultValue
 
@@ -222,22 +189,16 @@ GetOuterEnumIntegerDefaultValue returns the OuterEnumIntegerDefaultValue field i
 
 ### GetOuterEnumIntegerDefaultValueOk
 
-`func (o *EnumTest) GetOuterEnumIntegerDefaultValueOk() (OuterEnumIntegerDefaultValue, bool)`
+`func (o *EnumTest) GetOuterEnumIntegerDefaultValueOk() (*OuterEnumIntegerDefaultValue, bool)`
 
 GetOuterEnumIntegerDefaultValueOk returns a tuple with the OuterEnumIntegerDefaultValue field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasOuterEnumIntegerDefaultValue
-
-`func (o *EnumTest) HasOuterEnumIntegerDefaultValue() bool`
-
-HasOuterEnumIntegerDefaultValue returns a boolean if a field has been set.
 
 ### SetOuterEnumIntegerDefaultValue
 
 `func (o *EnumTest) SetOuterEnumIntegerDefaultValue(v OuterEnumIntegerDefaultValue)`
 
-SetOuterEnumIntegerDefaultValue gets a reference to the given OuterEnumIntegerDefaultValue and assigns it to the OuterEnumIntegerDefaultValue field.
+SetOuterEnumIntegerDefaultValue sets OuterEnumIntegerDefaultValue field to given value.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/File.md
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/File.md
@@ -44,6 +44,12 @@ and a boolean to check if the value has been set.
 
 SetSourceURI sets SourceURI field to given value.
 
+### HasSourceURI
+
+`func (o *File) HasSourceURI() bool`
+
+HasSourceURI returns a boolean if a field has been set.
+
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/File.md
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/File.md
@@ -33,22 +33,16 @@ GetSourceURI returns the SourceURI field if non-nil, zero value otherwise.
 
 ### GetSourceURIOk
 
-`func (o *File) GetSourceURIOk() (string, bool)`
+`func (o *File) GetSourceURIOk() (*string, bool)`
 
 GetSourceURIOk returns a tuple with the SourceURI field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasSourceURI
-
-`func (o *File) HasSourceURI() bool`
-
-HasSourceURI returns a boolean if a field has been set.
 
 ### SetSourceURI
 
 `func (o *File) SetSourceURI(v string)`
 
-SetSourceURI gets a reference to the given string and assigns it to the SourceURI field.
+SetSourceURI sets SourceURI field to given value.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/FileSchemaTestClass.md
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/FileSchemaTestClass.md
@@ -45,6 +45,12 @@ and a boolean to check if the value has been set.
 
 SetFile sets File field to given value.
 
+### HasFile
+
+`func (o *FileSchemaTestClass) HasFile() bool`
+
+HasFile returns a boolean if a field has been set.
+
 ### GetFiles
 
 `func (o *FileSchemaTestClass) GetFiles() []File`
@@ -63,6 +69,12 @@ and a boolean to check if the value has been set.
 `func (o *FileSchemaTestClass) SetFiles(v []File)`
 
 SetFiles sets Files field to given value.
+
+### HasFiles
+
+`func (o *FileSchemaTestClass) HasFiles() bool`
+
+HasFiles returns a boolean if a field has been set.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/FileSchemaTestClass.md
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/FileSchemaTestClass.md
@@ -34,22 +34,16 @@ GetFile returns the File field if non-nil, zero value otherwise.
 
 ### GetFileOk
 
-`func (o *FileSchemaTestClass) GetFileOk() (File, bool)`
+`func (o *FileSchemaTestClass) GetFileOk() (*File, bool)`
 
 GetFileOk returns a tuple with the File field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasFile
-
-`func (o *FileSchemaTestClass) HasFile() bool`
-
-HasFile returns a boolean if a field has been set.
 
 ### SetFile
 
 `func (o *FileSchemaTestClass) SetFile(v File)`
 
-SetFile gets a reference to the given File and assigns it to the File field.
+SetFile sets File field to given value.
 
 ### GetFiles
 
@@ -59,22 +53,16 @@ GetFiles returns the Files field if non-nil, zero value otherwise.
 
 ### GetFilesOk
 
-`func (o *FileSchemaTestClass) GetFilesOk() ([]File, bool)`
+`func (o *FileSchemaTestClass) GetFilesOk() (*[]File, bool)`
 
 GetFilesOk returns a tuple with the Files field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasFiles
-
-`func (o *FileSchemaTestClass) HasFiles() bool`
-
-HasFiles returns a boolean if a field has been set.
 
 ### SetFiles
 
 `func (o *FileSchemaTestClass) SetFiles(v []File)`
 
-SetFiles gets a reference to the given []File and assigns it to the Files field.
+SetFiles sets Files field to given value.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/Foo.md
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/Foo.md
@@ -44,6 +44,12 @@ and a boolean to check if the value has been set.
 
 SetBar sets Bar field to given value.
 
+### HasBar
+
+`func (o *Foo) HasBar() bool`
+
+HasBar returns a boolean if a field has been set.
+
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/Foo.md
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/Foo.md
@@ -33,22 +33,16 @@ GetBar returns the Bar field if non-nil, zero value otherwise.
 
 ### GetBarOk
 
-`func (o *Foo) GetBarOk() (string, bool)`
+`func (o *Foo) GetBarOk() (*string, bool)`
 
 GetBarOk returns a tuple with the Bar field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasBar
-
-`func (o *Foo) HasBar() bool`
-
-HasBar returns a boolean if a field has been set.
 
 ### SetBar
 
 `func (o *Foo) SetBar(v string)`
 
-SetBar gets a reference to the given string and assigns it to the Bar field.
+SetBar sets Bar field to given value.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/FormatTest.md
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/FormatTest.md
@@ -58,6 +58,12 @@ and a boolean to check if the value has been set.
 
 SetInteger sets Integer field to given value.
 
+### HasInteger
+
+`func (o *FormatTest) HasInteger() bool`
+
+HasInteger returns a boolean if a field has been set.
+
 ### GetInt32
 
 `func (o *FormatTest) GetInt32() int32`
@@ -76,6 +82,12 @@ and a boolean to check if the value has been set.
 `func (o *FormatTest) SetInt32(v int32)`
 
 SetInt32 sets Int32 field to given value.
+
+### HasInt32
+
+`func (o *FormatTest) HasInt32() bool`
+
+HasInt32 returns a boolean if a field has been set.
 
 ### GetInt64
 
@@ -96,6 +108,12 @@ and a boolean to check if the value has been set.
 
 SetInt64 sets Int64 field to given value.
 
+### HasInt64
+
+`func (o *FormatTest) HasInt64() bool`
+
+HasInt64 returns a boolean if a field has been set.
+
 ### GetNumber
 
 `func (o *FormatTest) GetNumber() float32`
@@ -114,6 +132,7 @@ and a boolean to check if the value has been set.
 `func (o *FormatTest) SetNumber(v float32)`
 
 SetNumber sets Number field to given value.
+
 
 ### GetFloat
 
@@ -134,6 +153,12 @@ and a boolean to check if the value has been set.
 
 SetFloat sets Float field to given value.
 
+### HasFloat
+
+`func (o *FormatTest) HasFloat() bool`
+
+HasFloat returns a boolean if a field has been set.
+
 ### GetDouble
 
 `func (o *FormatTest) GetDouble() float64`
@@ -152,6 +177,12 @@ and a boolean to check if the value has been set.
 `func (o *FormatTest) SetDouble(v float64)`
 
 SetDouble sets Double field to given value.
+
+### HasDouble
+
+`func (o *FormatTest) HasDouble() bool`
+
+HasDouble returns a boolean if a field has been set.
 
 ### GetString
 
@@ -172,6 +203,12 @@ and a boolean to check if the value has been set.
 
 SetString sets String field to given value.
 
+### HasString
+
+`func (o *FormatTest) HasString() bool`
+
+HasString returns a boolean if a field has been set.
+
 ### GetByte
 
 `func (o *FormatTest) GetByte() string`
@@ -190,6 +227,7 @@ and a boolean to check if the value has been set.
 `func (o *FormatTest) SetByte(v string)`
 
 SetByte sets Byte field to given value.
+
 
 ### GetBinary
 
@@ -210,6 +248,12 @@ and a boolean to check if the value has been set.
 
 SetBinary sets Binary field to given value.
 
+### HasBinary
+
+`func (o *FormatTest) HasBinary() bool`
+
+HasBinary returns a boolean if a field has been set.
+
 ### GetDate
 
 `func (o *FormatTest) GetDate() string`
@@ -228,6 +272,7 @@ and a boolean to check if the value has been set.
 `func (o *FormatTest) SetDate(v string)`
 
 SetDate sets Date field to given value.
+
 
 ### GetDateTime
 
@@ -248,6 +293,12 @@ and a boolean to check if the value has been set.
 
 SetDateTime sets DateTime field to given value.
 
+### HasDateTime
+
+`func (o *FormatTest) HasDateTime() bool`
+
+HasDateTime returns a boolean if a field has been set.
+
 ### GetUuid
 
 `func (o *FormatTest) GetUuid() string`
@@ -266,6 +317,12 @@ and a boolean to check if the value has been set.
 `func (o *FormatTest) SetUuid(v string)`
 
 SetUuid sets Uuid field to given value.
+
+### HasUuid
+
+`func (o *FormatTest) HasUuid() bool`
+
+HasUuid returns a boolean if a field has been set.
 
 ### GetPassword
 
@@ -286,6 +343,7 @@ and a boolean to check if the value has been set.
 
 SetPassword sets Password field to given value.
 
+
 ### GetPatternWithDigits
 
 `func (o *FormatTest) GetPatternWithDigits() string`
@@ -305,6 +363,12 @@ and a boolean to check if the value has been set.
 
 SetPatternWithDigits sets PatternWithDigits field to given value.
 
+### HasPatternWithDigits
+
+`func (o *FormatTest) HasPatternWithDigits() bool`
+
+HasPatternWithDigits returns a boolean if a field has been set.
+
 ### GetPatternWithDigitsAndDelimiter
 
 `func (o *FormatTest) GetPatternWithDigitsAndDelimiter() string`
@@ -323,6 +387,12 @@ and a boolean to check if the value has been set.
 `func (o *FormatTest) SetPatternWithDigitsAndDelimiter(v string)`
 
 SetPatternWithDigitsAndDelimiter sets PatternWithDigitsAndDelimiter field to given value.
+
+### HasPatternWithDigitsAndDelimiter
+
+`func (o *FormatTest) HasPatternWithDigitsAndDelimiter() bool`
+
+HasPatternWithDigitsAndDelimiter returns a boolean if a field has been set.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/FormatTest.md
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/FormatTest.md
@@ -47,22 +47,16 @@ GetInteger returns the Integer field if non-nil, zero value otherwise.
 
 ### GetIntegerOk
 
-`func (o *FormatTest) GetIntegerOk() (int32, bool)`
+`func (o *FormatTest) GetIntegerOk() (*int32, bool)`
 
 GetIntegerOk returns a tuple with the Integer field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasInteger
-
-`func (o *FormatTest) HasInteger() bool`
-
-HasInteger returns a boolean if a field has been set.
 
 ### SetInteger
 
 `func (o *FormatTest) SetInteger(v int32)`
 
-SetInteger gets a reference to the given int32 and assigns it to the Integer field.
+SetInteger sets Integer field to given value.
 
 ### GetInt32
 
@@ -72,22 +66,16 @@ GetInt32 returns the Int32 field if non-nil, zero value otherwise.
 
 ### GetInt32Ok
 
-`func (o *FormatTest) GetInt32Ok() (int32, bool)`
+`func (o *FormatTest) GetInt32Ok() (*int32, bool)`
 
 GetInt32Ok returns a tuple with the Int32 field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasInt32
-
-`func (o *FormatTest) HasInt32() bool`
-
-HasInt32 returns a boolean if a field has been set.
 
 ### SetInt32
 
 `func (o *FormatTest) SetInt32(v int32)`
 
-SetInt32 gets a reference to the given int32 and assigns it to the Int32 field.
+SetInt32 sets Int32 field to given value.
 
 ### GetInt64
 
@@ -97,22 +85,16 @@ GetInt64 returns the Int64 field if non-nil, zero value otherwise.
 
 ### GetInt64Ok
 
-`func (o *FormatTest) GetInt64Ok() (int64, bool)`
+`func (o *FormatTest) GetInt64Ok() (*int64, bool)`
 
 GetInt64Ok returns a tuple with the Int64 field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasInt64
-
-`func (o *FormatTest) HasInt64() bool`
-
-HasInt64 returns a boolean if a field has been set.
 
 ### SetInt64
 
 `func (o *FormatTest) SetInt64(v int64)`
 
-SetInt64 gets a reference to the given int64 and assigns it to the Int64 field.
+SetInt64 sets Int64 field to given value.
 
 ### GetNumber
 
@@ -122,22 +104,16 @@ GetNumber returns the Number field if non-nil, zero value otherwise.
 
 ### GetNumberOk
 
-`func (o *FormatTest) GetNumberOk() (float32, bool)`
+`func (o *FormatTest) GetNumberOk() (*float32, bool)`
 
 GetNumberOk returns a tuple with the Number field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasNumber
-
-`func (o *FormatTest) HasNumber() bool`
-
-HasNumber returns a boolean if a field has been set.
 
 ### SetNumber
 
 `func (o *FormatTest) SetNumber(v float32)`
 
-SetNumber gets a reference to the given float32 and assigns it to the Number field.
+SetNumber sets Number field to given value.
 
 ### GetFloat
 
@@ -147,22 +123,16 @@ GetFloat returns the Float field if non-nil, zero value otherwise.
 
 ### GetFloatOk
 
-`func (o *FormatTest) GetFloatOk() (float32, bool)`
+`func (o *FormatTest) GetFloatOk() (*float32, bool)`
 
 GetFloatOk returns a tuple with the Float field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasFloat
-
-`func (o *FormatTest) HasFloat() bool`
-
-HasFloat returns a boolean if a field has been set.
 
 ### SetFloat
 
 `func (o *FormatTest) SetFloat(v float32)`
 
-SetFloat gets a reference to the given float32 and assigns it to the Float field.
+SetFloat sets Float field to given value.
 
 ### GetDouble
 
@@ -172,22 +142,16 @@ GetDouble returns the Double field if non-nil, zero value otherwise.
 
 ### GetDoubleOk
 
-`func (o *FormatTest) GetDoubleOk() (float64, bool)`
+`func (o *FormatTest) GetDoubleOk() (*float64, bool)`
 
 GetDoubleOk returns a tuple with the Double field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasDouble
-
-`func (o *FormatTest) HasDouble() bool`
-
-HasDouble returns a boolean if a field has been set.
 
 ### SetDouble
 
 `func (o *FormatTest) SetDouble(v float64)`
 
-SetDouble gets a reference to the given float64 and assigns it to the Double field.
+SetDouble sets Double field to given value.
 
 ### GetString
 
@@ -197,22 +161,16 @@ GetString returns the String field if non-nil, zero value otherwise.
 
 ### GetStringOk
 
-`func (o *FormatTest) GetStringOk() (string, bool)`
+`func (o *FormatTest) GetStringOk() (*string, bool)`
 
 GetStringOk returns a tuple with the String field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasString
-
-`func (o *FormatTest) HasString() bool`
-
-HasString returns a boolean if a field has been set.
 
 ### SetString
 
 `func (o *FormatTest) SetString(v string)`
 
-SetString gets a reference to the given string and assigns it to the String field.
+SetString sets String field to given value.
 
 ### GetByte
 
@@ -222,22 +180,16 @@ GetByte returns the Byte field if non-nil, zero value otherwise.
 
 ### GetByteOk
 
-`func (o *FormatTest) GetByteOk() (string, bool)`
+`func (o *FormatTest) GetByteOk() (*string, bool)`
 
 GetByteOk returns a tuple with the Byte field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasByte
-
-`func (o *FormatTest) HasByte() bool`
-
-HasByte returns a boolean if a field has been set.
 
 ### SetByte
 
 `func (o *FormatTest) SetByte(v string)`
 
-SetByte gets a reference to the given string and assigns it to the Byte field.
+SetByte sets Byte field to given value.
 
 ### GetBinary
 
@@ -247,22 +199,16 @@ GetBinary returns the Binary field if non-nil, zero value otherwise.
 
 ### GetBinaryOk
 
-`func (o *FormatTest) GetBinaryOk() (*os.File, bool)`
+`func (o *FormatTest) GetBinaryOk() (**os.File, bool)`
 
 GetBinaryOk returns a tuple with the Binary field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasBinary
-
-`func (o *FormatTest) HasBinary() bool`
-
-HasBinary returns a boolean if a field has been set.
 
 ### SetBinary
 
 `func (o *FormatTest) SetBinary(v *os.File)`
 
-SetBinary gets a reference to the given *os.File and assigns it to the Binary field.
+SetBinary sets Binary field to given value.
 
 ### GetDate
 
@@ -272,22 +218,16 @@ GetDate returns the Date field if non-nil, zero value otherwise.
 
 ### GetDateOk
 
-`func (o *FormatTest) GetDateOk() (string, bool)`
+`func (o *FormatTest) GetDateOk() (*string, bool)`
 
 GetDateOk returns a tuple with the Date field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasDate
-
-`func (o *FormatTest) HasDate() bool`
-
-HasDate returns a boolean if a field has been set.
 
 ### SetDate
 
 `func (o *FormatTest) SetDate(v string)`
 
-SetDate gets a reference to the given string and assigns it to the Date field.
+SetDate sets Date field to given value.
 
 ### GetDateTime
 
@@ -297,22 +237,16 @@ GetDateTime returns the DateTime field if non-nil, zero value otherwise.
 
 ### GetDateTimeOk
 
-`func (o *FormatTest) GetDateTimeOk() (time.Time, bool)`
+`func (o *FormatTest) GetDateTimeOk() (*time.Time, bool)`
 
 GetDateTimeOk returns a tuple with the DateTime field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasDateTime
-
-`func (o *FormatTest) HasDateTime() bool`
-
-HasDateTime returns a boolean if a field has been set.
 
 ### SetDateTime
 
 `func (o *FormatTest) SetDateTime(v time.Time)`
 
-SetDateTime gets a reference to the given time.Time and assigns it to the DateTime field.
+SetDateTime sets DateTime field to given value.
 
 ### GetUuid
 
@@ -322,22 +256,16 @@ GetUuid returns the Uuid field if non-nil, zero value otherwise.
 
 ### GetUuidOk
 
-`func (o *FormatTest) GetUuidOk() (string, bool)`
+`func (o *FormatTest) GetUuidOk() (*string, bool)`
 
 GetUuidOk returns a tuple with the Uuid field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasUuid
-
-`func (o *FormatTest) HasUuid() bool`
-
-HasUuid returns a boolean if a field has been set.
 
 ### SetUuid
 
 `func (o *FormatTest) SetUuid(v string)`
 
-SetUuid gets a reference to the given string and assigns it to the Uuid field.
+SetUuid sets Uuid field to given value.
 
 ### GetPassword
 
@@ -347,22 +275,16 @@ GetPassword returns the Password field if non-nil, zero value otherwise.
 
 ### GetPasswordOk
 
-`func (o *FormatTest) GetPasswordOk() (string, bool)`
+`func (o *FormatTest) GetPasswordOk() (*string, bool)`
 
 GetPasswordOk returns a tuple with the Password field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasPassword
-
-`func (o *FormatTest) HasPassword() bool`
-
-HasPassword returns a boolean if a field has been set.
 
 ### SetPassword
 
 `func (o *FormatTest) SetPassword(v string)`
 
-SetPassword gets a reference to the given string and assigns it to the Password field.
+SetPassword sets Password field to given value.
 
 ### GetPatternWithDigits
 
@@ -372,22 +294,16 @@ GetPatternWithDigits returns the PatternWithDigits field if non-nil, zero value 
 
 ### GetPatternWithDigitsOk
 
-`func (o *FormatTest) GetPatternWithDigitsOk() (string, bool)`
+`func (o *FormatTest) GetPatternWithDigitsOk() (*string, bool)`
 
 GetPatternWithDigitsOk returns a tuple with the PatternWithDigits field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasPatternWithDigits
-
-`func (o *FormatTest) HasPatternWithDigits() bool`
-
-HasPatternWithDigits returns a boolean if a field has been set.
 
 ### SetPatternWithDigits
 
 `func (o *FormatTest) SetPatternWithDigits(v string)`
 
-SetPatternWithDigits gets a reference to the given string and assigns it to the PatternWithDigits field.
+SetPatternWithDigits sets PatternWithDigits field to given value.
 
 ### GetPatternWithDigitsAndDelimiter
 
@@ -397,22 +313,16 @@ GetPatternWithDigitsAndDelimiter returns the PatternWithDigitsAndDelimiter field
 
 ### GetPatternWithDigitsAndDelimiterOk
 
-`func (o *FormatTest) GetPatternWithDigitsAndDelimiterOk() (string, bool)`
+`func (o *FormatTest) GetPatternWithDigitsAndDelimiterOk() (*string, bool)`
 
 GetPatternWithDigitsAndDelimiterOk returns a tuple with the PatternWithDigitsAndDelimiter field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasPatternWithDigitsAndDelimiter
-
-`func (o *FormatTest) HasPatternWithDigitsAndDelimiter() bool`
-
-HasPatternWithDigitsAndDelimiter returns a boolean if a field has been set.
 
 ### SetPatternWithDigitsAndDelimiter
 
 `func (o *FormatTest) SetPatternWithDigitsAndDelimiter(v string)`
 
-SetPatternWithDigitsAndDelimiter gets a reference to the given string and assigns it to the PatternWithDigitsAndDelimiter field.
+SetPatternWithDigitsAndDelimiter sets PatternWithDigitsAndDelimiter field to given value.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/HasOnlyReadOnly.md
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/HasOnlyReadOnly.md
@@ -45,6 +45,12 @@ and a boolean to check if the value has been set.
 
 SetBar sets Bar field to given value.
 
+### HasBar
+
+`func (o *HasOnlyReadOnly) HasBar() bool`
+
+HasBar returns a boolean if a field has been set.
+
 ### GetFoo
 
 `func (o *HasOnlyReadOnly) GetFoo() string`
@@ -63,6 +69,12 @@ and a boolean to check if the value has been set.
 `func (o *HasOnlyReadOnly) SetFoo(v string)`
 
 SetFoo sets Foo field to given value.
+
+### HasFoo
+
+`func (o *HasOnlyReadOnly) HasFoo() bool`
+
+HasFoo returns a boolean if a field has been set.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/HasOnlyReadOnly.md
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/HasOnlyReadOnly.md
@@ -34,22 +34,16 @@ GetBar returns the Bar field if non-nil, zero value otherwise.
 
 ### GetBarOk
 
-`func (o *HasOnlyReadOnly) GetBarOk() (string, bool)`
+`func (o *HasOnlyReadOnly) GetBarOk() (*string, bool)`
 
 GetBarOk returns a tuple with the Bar field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasBar
-
-`func (o *HasOnlyReadOnly) HasBar() bool`
-
-HasBar returns a boolean if a field has been set.
 
 ### SetBar
 
 `func (o *HasOnlyReadOnly) SetBar(v string)`
 
-SetBar gets a reference to the given string and assigns it to the Bar field.
+SetBar sets Bar field to given value.
 
 ### GetFoo
 
@@ -59,22 +53,16 @@ GetFoo returns the Foo field if non-nil, zero value otherwise.
 
 ### GetFooOk
 
-`func (o *HasOnlyReadOnly) GetFooOk() (string, bool)`
+`func (o *HasOnlyReadOnly) GetFooOk() (*string, bool)`
 
 GetFooOk returns a tuple with the Foo field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasFoo
-
-`func (o *HasOnlyReadOnly) HasFoo() bool`
-
-HasFoo returns a boolean if a field has been set.
 
 ### SetFoo
 
 `func (o *HasOnlyReadOnly) SetFoo(v string)`
 
-SetFoo gets a reference to the given string and assigns it to the Foo field.
+SetFoo sets Foo field to given value.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/HealthCheckResult.md
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/HealthCheckResult.md
@@ -27,16 +27,22 @@ but it doesn't guarantee that properties required by API are set
 
 ### GetNullableMessage
 
-`func (o *HealthCheckResult) GetNullableMessage() NullableString`
+`func (o *HealthCheckResult) GetNullableMessage() string`
 
 GetNullableMessage returns the NullableMessage field if non-nil, zero value otherwise.
 
 ### GetNullableMessageOk
 
-`func (o *HealthCheckResult) GetNullableMessageOk() (NullableString, bool)`
+`func (o *HealthCheckResult) GetNullableMessageOk() (*string, bool)`
 
 GetNullableMessageOk returns a tuple with the NullableMessage field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
+
+### SetNullableMessage
+
+`func (o *HealthCheckResult) SetNullableMessage(v string)`
+
+SetNullableMessage sets NullableMessage field to given value.
 
 ### HasNullableMessage
 
@@ -44,19 +50,16 @@ and a boolean to check if the value has been set.
 
 HasNullableMessage returns a boolean if a field has been set.
 
-### SetNullableMessage
+### SetNullableMessageNil
 
-`func (o *HealthCheckResult) SetNullableMessage(v NullableString)`
+`func (o *HealthCheckResult) SetNullableMessageNil(b bool)`
 
-SetNullableMessage gets a reference to the given NullableString and assigns it to the NullableMessage field.
+ SetNullableMessageNil sets the value for NullableMessage to be an explicit nil
 
-### SetNullableMessageExplicitNull
+### UnsetNullableMessage
+`func (o *HealthCheckResult) UnsetNullableMessage()`
 
-`func (o *HealthCheckResult) SetNullableMessageExplicitNull(b bool)`
-
-SetNullableMessageExplicitNull (un)sets NullableMessage to be considered as explicit "null" value
-when serializing to JSON (pass true as argument to set this, false to unset)
-The NullableMessage value is set to nil even if false is passed
+UnsetNullableMessage ensures that no value is present for NullableMessage, not even an explicit nil
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/InlineObject.md
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/InlineObject.md
@@ -45,6 +45,12 @@ and a boolean to check if the value has been set.
 
 SetName sets Name field to given value.
 
+### HasName
+
+`func (o *InlineObject) HasName() bool`
+
+HasName returns a boolean if a field has been set.
+
 ### GetStatus
 
 `func (o *InlineObject) GetStatus() string`
@@ -63,6 +69,12 @@ and a boolean to check if the value has been set.
 `func (o *InlineObject) SetStatus(v string)`
 
 SetStatus sets Status field to given value.
+
+### HasStatus
+
+`func (o *InlineObject) HasStatus() bool`
+
+HasStatus returns a boolean if a field has been set.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/InlineObject.md
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/InlineObject.md
@@ -34,22 +34,16 @@ GetName returns the Name field if non-nil, zero value otherwise.
 
 ### GetNameOk
 
-`func (o *InlineObject) GetNameOk() (string, bool)`
+`func (o *InlineObject) GetNameOk() (*string, bool)`
 
 GetNameOk returns a tuple with the Name field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasName
-
-`func (o *InlineObject) HasName() bool`
-
-HasName returns a boolean if a field has been set.
 
 ### SetName
 
 `func (o *InlineObject) SetName(v string)`
 
-SetName gets a reference to the given string and assigns it to the Name field.
+SetName sets Name field to given value.
 
 ### GetStatus
 
@@ -59,22 +53,16 @@ GetStatus returns the Status field if non-nil, zero value otherwise.
 
 ### GetStatusOk
 
-`func (o *InlineObject) GetStatusOk() (string, bool)`
+`func (o *InlineObject) GetStatusOk() (*string, bool)`
 
 GetStatusOk returns a tuple with the Status field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasStatus
-
-`func (o *InlineObject) HasStatus() bool`
-
-HasStatus returns a boolean if a field has been set.
 
 ### SetStatus
 
 `func (o *InlineObject) SetStatus(v string)`
 
-SetStatus gets a reference to the given string and assigns it to the Status field.
+SetStatus sets Status field to given value.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/InlineObject1.md
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/InlineObject1.md
@@ -45,6 +45,12 @@ and a boolean to check if the value has been set.
 
 SetAdditionalMetadata sets AdditionalMetadata field to given value.
 
+### HasAdditionalMetadata
+
+`func (o *InlineObject1) HasAdditionalMetadata() bool`
+
+HasAdditionalMetadata returns a boolean if a field has been set.
+
 ### GetFile
 
 `func (o *InlineObject1) GetFile() *os.File`
@@ -63,6 +69,12 @@ and a boolean to check if the value has been set.
 `func (o *InlineObject1) SetFile(v *os.File)`
 
 SetFile sets File field to given value.
+
+### HasFile
+
+`func (o *InlineObject1) HasFile() bool`
+
+HasFile returns a boolean if a field has been set.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/InlineObject1.md
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/InlineObject1.md
@@ -34,22 +34,16 @@ GetAdditionalMetadata returns the AdditionalMetadata field if non-nil, zero valu
 
 ### GetAdditionalMetadataOk
 
-`func (o *InlineObject1) GetAdditionalMetadataOk() (string, bool)`
+`func (o *InlineObject1) GetAdditionalMetadataOk() (*string, bool)`
 
 GetAdditionalMetadataOk returns a tuple with the AdditionalMetadata field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasAdditionalMetadata
-
-`func (o *InlineObject1) HasAdditionalMetadata() bool`
-
-HasAdditionalMetadata returns a boolean if a field has been set.
 
 ### SetAdditionalMetadata
 
 `func (o *InlineObject1) SetAdditionalMetadata(v string)`
 
-SetAdditionalMetadata gets a reference to the given string and assigns it to the AdditionalMetadata field.
+SetAdditionalMetadata sets AdditionalMetadata field to given value.
 
 ### GetFile
 
@@ -59,22 +53,16 @@ GetFile returns the File field if non-nil, zero value otherwise.
 
 ### GetFileOk
 
-`func (o *InlineObject1) GetFileOk() (*os.File, bool)`
+`func (o *InlineObject1) GetFileOk() (**os.File, bool)`
 
 GetFileOk returns a tuple with the File field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasFile
-
-`func (o *InlineObject1) HasFile() bool`
-
-HasFile returns a boolean if a field has been set.
 
 ### SetFile
 
 `func (o *InlineObject1) SetFile(v *os.File)`
 
-SetFile gets a reference to the given *os.File and assigns it to the File field.
+SetFile sets File field to given value.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/InlineObject2.md
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/InlineObject2.md
@@ -45,6 +45,12 @@ and a boolean to check if the value has been set.
 
 SetEnumFormStringArray sets EnumFormStringArray field to given value.
 
+### HasEnumFormStringArray
+
+`func (o *InlineObject2) HasEnumFormStringArray() bool`
+
+HasEnumFormStringArray returns a boolean if a field has been set.
+
 ### GetEnumFormString
 
 `func (o *InlineObject2) GetEnumFormString() string`
@@ -63,6 +69,12 @@ and a boolean to check if the value has been set.
 `func (o *InlineObject2) SetEnumFormString(v string)`
 
 SetEnumFormString sets EnumFormString field to given value.
+
+### HasEnumFormString
+
+`func (o *InlineObject2) HasEnumFormString() bool`
+
+HasEnumFormString returns a boolean if a field has been set.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/InlineObject2.md
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/InlineObject2.md
@@ -34,22 +34,16 @@ GetEnumFormStringArray returns the EnumFormStringArray field if non-nil, zero va
 
 ### GetEnumFormStringArrayOk
 
-`func (o *InlineObject2) GetEnumFormStringArrayOk() ([]string, bool)`
+`func (o *InlineObject2) GetEnumFormStringArrayOk() (*[]string, bool)`
 
 GetEnumFormStringArrayOk returns a tuple with the EnumFormStringArray field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasEnumFormStringArray
-
-`func (o *InlineObject2) HasEnumFormStringArray() bool`
-
-HasEnumFormStringArray returns a boolean if a field has been set.
 
 ### SetEnumFormStringArray
 
 `func (o *InlineObject2) SetEnumFormStringArray(v []string)`
 
-SetEnumFormStringArray gets a reference to the given []string and assigns it to the EnumFormStringArray field.
+SetEnumFormStringArray sets EnumFormStringArray field to given value.
 
 ### GetEnumFormString
 
@@ -59,22 +53,16 @@ GetEnumFormString returns the EnumFormString field if non-nil, zero value otherw
 
 ### GetEnumFormStringOk
 
-`func (o *InlineObject2) GetEnumFormStringOk() (string, bool)`
+`func (o *InlineObject2) GetEnumFormStringOk() (*string, bool)`
 
 GetEnumFormStringOk returns a tuple with the EnumFormString field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasEnumFormString
-
-`func (o *InlineObject2) HasEnumFormString() bool`
-
-HasEnumFormString returns a boolean if a field has been set.
 
 ### SetEnumFormString
 
 `func (o *InlineObject2) SetEnumFormString(v string)`
 
-SetEnumFormString gets a reference to the given string and assigns it to the EnumFormString field.
+SetEnumFormString sets EnumFormString field to given value.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/InlineObject3.md
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/InlineObject3.md
@@ -57,6 +57,12 @@ and a boolean to check if the value has been set.
 
 SetInteger sets Integer field to given value.
 
+### HasInteger
+
+`func (o *InlineObject3) HasInteger() bool`
+
+HasInteger returns a boolean if a field has been set.
+
 ### GetInt32
 
 `func (o *InlineObject3) GetInt32() int32`
@@ -75,6 +81,12 @@ and a boolean to check if the value has been set.
 `func (o *InlineObject3) SetInt32(v int32)`
 
 SetInt32 sets Int32 field to given value.
+
+### HasInt32
+
+`func (o *InlineObject3) HasInt32() bool`
+
+HasInt32 returns a boolean if a field has been set.
 
 ### GetInt64
 
@@ -95,6 +107,12 @@ and a boolean to check if the value has been set.
 
 SetInt64 sets Int64 field to given value.
 
+### HasInt64
+
+`func (o *InlineObject3) HasInt64() bool`
+
+HasInt64 returns a boolean if a field has been set.
+
 ### GetNumber
 
 `func (o *InlineObject3) GetNumber() float32`
@@ -113,6 +131,7 @@ and a boolean to check if the value has been set.
 `func (o *InlineObject3) SetNumber(v float32)`
 
 SetNumber sets Number field to given value.
+
 
 ### GetFloat
 
@@ -133,6 +152,12 @@ and a boolean to check if the value has been set.
 
 SetFloat sets Float field to given value.
 
+### HasFloat
+
+`func (o *InlineObject3) HasFloat() bool`
+
+HasFloat returns a boolean if a field has been set.
+
 ### GetDouble
 
 `func (o *InlineObject3) GetDouble() float64`
@@ -151,6 +176,7 @@ and a boolean to check if the value has been set.
 `func (o *InlineObject3) SetDouble(v float64)`
 
 SetDouble sets Double field to given value.
+
 
 ### GetString
 
@@ -171,6 +197,12 @@ and a boolean to check if the value has been set.
 
 SetString sets String field to given value.
 
+### HasString
+
+`func (o *InlineObject3) HasString() bool`
+
+HasString returns a boolean if a field has been set.
+
 ### GetPatternWithoutDelimiter
 
 `func (o *InlineObject3) GetPatternWithoutDelimiter() string`
@@ -189,6 +221,7 @@ and a boolean to check if the value has been set.
 `func (o *InlineObject3) SetPatternWithoutDelimiter(v string)`
 
 SetPatternWithoutDelimiter sets PatternWithoutDelimiter field to given value.
+
 
 ### GetByte
 
@@ -209,6 +242,7 @@ and a boolean to check if the value has been set.
 
 SetByte sets Byte field to given value.
 
+
 ### GetBinary
 
 `func (o *InlineObject3) GetBinary() *os.File`
@@ -227,6 +261,12 @@ and a boolean to check if the value has been set.
 `func (o *InlineObject3) SetBinary(v *os.File)`
 
 SetBinary sets Binary field to given value.
+
+### HasBinary
+
+`func (o *InlineObject3) HasBinary() bool`
+
+HasBinary returns a boolean if a field has been set.
 
 ### GetDate
 
@@ -247,6 +287,12 @@ and a boolean to check if the value has been set.
 
 SetDate sets Date field to given value.
 
+### HasDate
+
+`func (o *InlineObject3) HasDate() bool`
+
+HasDate returns a boolean if a field has been set.
+
 ### GetDateTime
 
 `func (o *InlineObject3) GetDateTime() time.Time`
@@ -265,6 +311,12 @@ and a boolean to check if the value has been set.
 `func (o *InlineObject3) SetDateTime(v time.Time)`
 
 SetDateTime sets DateTime field to given value.
+
+### HasDateTime
+
+`func (o *InlineObject3) HasDateTime() bool`
+
+HasDateTime returns a boolean if a field has been set.
 
 ### GetPassword
 
@@ -285,6 +337,12 @@ and a boolean to check if the value has been set.
 
 SetPassword sets Password field to given value.
 
+### HasPassword
+
+`func (o *InlineObject3) HasPassword() bool`
+
+HasPassword returns a boolean if a field has been set.
+
 ### GetCallback
 
 `func (o *InlineObject3) GetCallback() string`
@@ -303,6 +361,12 @@ and a boolean to check if the value has been set.
 `func (o *InlineObject3) SetCallback(v string)`
 
 SetCallback sets Callback field to given value.
+
+### HasCallback
+
+`func (o *InlineObject3) HasCallback() bool`
+
+HasCallback returns a boolean if a field has been set.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/InlineObject3.md
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/InlineObject3.md
@@ -46,22 +46,16 @@ GetInteger returns the Integer field if non-nil, zero value otherwise.
 
 ### GetIntegerOk
 
-`func (o *InlineObject3) GetIntegerOk() (int32, bool)`
+`func (o *InlineObject3) GetIntegerOk() (*int32, bool)`
 
 GetIntegerOk returns a tuple with the Integer field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasInteger
-
-`func (o *InlineObject3) HasInteger() bool`
-
-HasInteger returns a boolean if a field has been set.
 
 ### SetInteger
 
 `func (o *InlineObject3) SetInteger(v int32)`
 
-SetInteger gets a reference to the given int32 and assigns it to the Integer field.
+SetInteger sets Integer field to given value.
 
 ### GetInt32
 
@@ -71,22 +65,16 @@ GetInt32 returns the Int32 field if non-nil, zero value otherwise.
 
 ### GetInt32Ok
 
-`func (o *InlineObject3) GetInt32Ok() (int32, bool)`
+`func (o *InlineObject3) GetInt32Ok() (*int32, bool)`
 
 GetInt32Ok returns a tuple with the Int32 field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasInt32
-
-`func (o *InlineObject3) HasInt32() bool`
-
-HasInt32 returns a boolean if a field has been set.
 
 ### SetInt32
 
 `func (o *InlineObject3) SetInt32(v int32)`
 
-SetInt32 gets a reference to the given int32 and assigns it to the Int32 field.
+SetInt32 sets Int32 field to given value.
 
 ### GetInt64
 
@@ -96,22 +84,16 @@ GetInt64 returns the Int64 field if non-nil, zero value otherwise.
 
 ### GetInt64Ok
 
-`func (o *InlineObject3) GetInt64Ok() (int64, bool)`
+`func (o *InlineObject3) GetInt64Ok() (*int64, bool)`
 
 GetInt64Ok returns a tuple with the Int64 field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasInt64
-
-`func (o *InlineObject3) HasInt64() bool`
-
-HasInt64 returns a boolean if a field has been set.
 
 ### SetInt64
 
 `func (o *InlineObject3) SetInt64(v int64)`
 
-SetInt64 gets a reference to the given int64 and assigns it to the Int64 field.
+SetInt64 sets Int64 field to given value.
 
 ### GetNumber
 
@@ -121,22 +103,16 @@ GetNumber returns the Number field if non-nil, zero value otherwise.
 
 ### GetNumberOk
 
-`func (o *InlineObject3) GetNumberOk() (float32, bool)`
+`func (o *InlineObject3) GetNumberOk() (*float32, bool)`
 
 GetNumberOk returns a tuple with the Number field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasNumber
-
-`func (o *InlineObject3) HasNumber() bool`
-
-HasNumber returns a boolean if a field has been set.
 
 ### SetNumber
 
 `func (o *InlineObject3) SetNumber(v float32)`
 
-SetNumber gets a reference to the given float32 and assigns it to the Number field.
+SetNumber sets Number field to given value.
 
 ### GetFloat
 
@@ -146,22 +122,16 @@ GetFloat returns the Float field if non-nil, zero value otherwise.
 
 ### GetFloatOk
 
-`func (o *InlineObject3) GetFloatOk() (float32, bool)`
+`func (o *InlineObject3) GetFloatOk() (*float32, bool)`
 
 GetFloatOk returns a tuple with the Float field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasFloat
-
-`func (o *InlineObject3) HasFloat() bool`
-
-HasFloat returns a boolean if a field has been set.
 
 ### SetFloat
 
 `func (o *InlineObject3) SetFloat(v float32)`
 
-SetFloat gets a reference to the given float32 and assigns it to the Float field.
+SetFloat sets Float field to given value.
 
 ### GetDouble
 
@@ -171,22 +141,16 @@ GetDouble returns the Double field if non-nil, zero value otherwise.
 
 ### GetDoubleOk
 
-`func (o *InlineObject3) GetDoubleOk() (float64, bool)`
+`func (o *InlineObject3) GetDoubleOk() (*float64, bool)`
 
 GetDoubleOk returns a tuple with the Double field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasDouble
-
-`func (o *InlineObject3) HasDouble() bool`
-
-HasDouble returns a boolean if a field has been set.
 
 ### SetDouble
 
 `func (o *InlineObject3) SetDouble(v float64)`
 
-SetDouble gets a reference to the given float64 and assigns it to the Double field.
+SetDouble sets Double field to given value.
 
 ### GetString
 
@@ -196,22 +160,16 @@ GetString returns the String field if non-nil, zero value otherwise.
 
 ### GetStringOk
 
-`func (o *InlineObject3) GetStringOk() (string, bool)`
+`func (o *InlineObject3) GetStringOk() (*string, bool)`
 
 GetStringOk returns a tuple with the String field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasString
-
-`func (o *InlineObject3) HasString() bool`
-
-HasString returns a boolean if a field has been set.
 
 ### SetString
 
 `func (o *InlineObject3) SetString(v string)`
 
-SetString gets a reference to the given string and assigns it to the String field.
+SetString sets String field to given value.
 
 ### GetPatternWithoutDelimiter
 
@@ -221,22 +179,16 @@ GetPatternWithoutDelimiter returns the PatternWithoutDelimiter field if non-nil,
 
 ### GetPatternWithoutDelimiterOk
 
-`func (o *InlineObject3) GetPatternWithoutDelimiterOk() (string, bool)`
+`func (o *InlineObject3) GetPatternWithoutDelimiterOk() (*string, bool)`
 
 GetPatternWithoutDelimiterOk returns a tuple with the PatternWithoutDelimiter field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasPatternWithoutDelimiter
-
-`func (o *InlineObject3) HasPatternWithoutDelimiter() bool`
-
-HasPatternWithoutDelimiter returns a boolean if a field has been set.
 
 ### SetPatternWithoutDelimiter
 
 `func (o *InlineObject3) SetPatternWithoutDelimiter(v string)`
 
-SetPatternWithoutDelimiter gets a reference to the given string and assigns it to the PatternWithoutDelimiter field.
+SetPatternWithoutDelimiter sets PatternWithoutDelimiter field to given value.
 
 ### GetByte
 
@@ -246,22 +198,16 @@ GetByte returns the Byte field if non-nil, zero value otherwise.
 
 ### GetByteOk
 
-`func (o *InlineObject3) GetByteOk() (string, bool)`
+`func (o *InlineObject3) GetByteOk() (*string, bool)`
 
 GetByteOk returns a tuple with the Byte field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasByte
-
-`func (o *InlineObject3) HasByte() bool`
-
-HasByte returns a boolean if a field has been set.
 
 ### SetByte
 
 `func (o *InlineObject3) SetByte(v string)`
 
-SetByte gets a reference to the given string and assigns it to the Byte field.
+SetByte sets Byte field to given value.
 
 ### GetBinary
 
@@ -271,22 +217,16 @@ GetBinary returns the Binary field if non-nil, zero value otherwise.
 
 ### GetBinaryOk
 
-`func (o *InlineObject3) GetBinaryOk() (*os.File, bool)`
+`func (o *InlineObject3) GetBinaryOk() (**os.File, bool)`
 
 GetBinaryOk returns a tuple with the Binary field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasBinary
-
-`func (o *InlineObject3) HasBinary() bool`
-
-HasBinary returns a boolean if a field has been set.
 
 ### SetBinary
 
 `func (o *InlineObject3) SetBinary(v *os.File)`
 
-SetBinary gets a reference to the given *os.File and assigns it to the Binary field.
+SetBinary sets Binary field to given value.
 
 ### GetDate
 
@@ -296,22 +236,16 @@ GetDate returns the Date field if non-nil, zero value otherwise.
 
 ### GetDateOk
 
-`func (o *InlineObject3) GetDateOk() (string, bool)`
+`func (o *InlineObject3) GetDateOk() (*string, bool)`
 
 GetDateOk returns a tuple with the Date field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasDate
-
-`func (o *InlineObject3) HasDate() bool`
-
-HasDate returns a boolean if a field has been set.
 
 ### SetDate
 
 `func (o *InlineObject3) SetDate(v string)`
 
-SetDate gets a reference to the given string and assigns it to the Date field.
+SetDate sets Date field to given value.
 
 ### GetDateTime
 
@@ -321,22 +255,16 @@ GetDateTime returns the DateTime field if non-nil, zero value otherwise.
 
 ### GetDateTimeOk
 
-`func (o *InlineObject3) GetDateTimeOk() (time.Time, bool)`
+`func (o *InlineObject3) GetDateTimeOk() (*time.Time, bool)`
 
 GetDateTimeOk returns a tuple with the DateTime field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasDateTime
-
-`func (o *InlineObject3) HasDateTime() bool`
-
-HasDateTime returns a boolean if a field has been set.
 
 ### SetDateTime
 
 `func (o *InlineObject3) SetDateTime(v time.Time)`
 
-SetDateTime gets a reference to the given time.Time and assigns it to the DateTime field.
+SetDateTime sets DateTime field to given value.
 
 ### GetPassword
 
@@ -346,22 +274,16 @@ GetPassword returns the Password field if non-nil, zero value otherwise.
 
 ### GetPasswordOk
 
-`func (o *InlineObject3) GetPasswordOk() (string, bool)`
+`func (o *InlineObject3) GetPasswordOk() (*string, bool)`
 
 GetPasswordOk returns a tuple with the Password field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasPassword
-
-`func (o *InlineObject3) HasPassword() bool`
-
-HasPassword returns a boolean if a field has been set.
 
 ### SetPassword
 
 `func (o *InlineObject3) SetPassword(v string)`
 
-SetPassword gets a reference to the given string and assigns it to the Password field.
+SetPassword sets Password field to given value.
 
 ### GetCallback
 
@@ -371,22 +293,16 @@ GetCallback returns the Callback field if non-nil, zero value otherwise.
 
 ### GetCallbackOk
 
-`func (o *InlineObject3) GetCallbackOk() (string, bool)`
+`func (o *InlineObject3) GetCallbackOk() (*string, bool)`
 
 GetCallbackOk returns a tuple with the Callback field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasCallback
-
-`func (o *InlineObject3) HasCallback() bool`
-
-HasCallback returns a boolean if a field has been set.
 
 ### SetCallback
 
 `func (o *InlineObject3) SetCallback(v string)`
 
-SetCallback gets a reference to the given string and assigns it to the Callback field.
+SetCallback sets Callback field to given value.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/InlineObject4.md
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/InlineObject4.md
@@ -34,22 +34,16 @@ GetParam returns the Param field if non-nil, zero value otherwise.
 
 ### GetParamOk
 
-`func (o *InlineObject4) GetParamOk() (string, bool)`
+`func (o *InlineObject4) GetParamOk() (*string, bool)`
 
 GetParamOk returns a tuple with the Param field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasParam
-
-`func (o *InlineObject4) HasParam() bool`
-
-HasParam returns a boolean if a field has been set.
 
 ### SetParam
 
 `func (o *InlineObject4) SetParam(v string)`
 
-SetParam gets a reference to the given string and assigns it to the Param field.
+SetParam sets Param field to given value.
 
 ### GetParam2
 
@@ -59,22 +53,16 @@ GetParam2 returns the Param2 field if non-nil, zero value otherwise.
 
 ### GetParam2Ok
 
-`func (o *InlineObject4) GetParam2Ok() (string, bool)`
+`func (o *InlineObject4) GetParam2Ok() (*string, bool)`
 
 GetParam2Ok returns a tuple with the Param2 field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasParam2
-
-`func (o *InlineObject4) HasParam2() bool`
-
-HasParam2 returns a boolean if a field has been set.
 
 ### SetParam2
 
 `func (o *InlineObject4) SetParam2(v string)`
 
-SetParam2 gets a reference to the given string and assigns it to the Param2 field.
+SetParam2 sets Param2 field to given value.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/InlineObject4.md
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/InlineObject4.md
@@ -45,6 +45,7 @@ and a boolean to check if the value has been set.
 
 SetParam sets Param field to given value.
 
+
 ### GetParam2
 
 `func (o *InlineObject4) GetParam2() string`
@@ -63,6 +64,7 @@ and a boolean to check if the value has been set.
 `func (o *InlineObject4) SetParam2(v string)`
 
 SetParam2 sets Param2 field to given value.
+
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/InlineObject5.md
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/InlineObject5.md
@@ -45,6 +45,12 @@ and a boolean to check if the value has been set.
 
 SetAdditionalMetadata sets AdditionalMetadata field to given value.
 
+### HasAdditionalMetadata
+
+`func (o *InlineObject5) HasAdditionalMetadata() bool`
+
+HasAdditionalMetadata returns a boolean if a field has been set.
+
 ### GetRequiredFile
 
 `func (o *InlineObject5) GetRequiredFile() *os.File`
@@ -63,6 +69,7 @@ and a boolean to check if the value has been set.
 `func (o *InlineObject5) SetRequiredFile(v *os.File)`
 
 SetRequiredFile sets RequiredFile field to given value.
+
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/InlineObject5.md
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/InlineObject5.md
@@ -34,22 +34,16 @@ GetAdditionalMetadata returns the AdditionalMetadata field if non-nil, zero valu
 
 ### GetAdditionalMetadataOk
 
-`func (o *InlineObject5) GetAdditionalMetadataOk() (string, bool)`
+`func (o *InlineObject5) GetAdditionalMetadataOk() (*string, bool)`
 
 GetAdditionalMetadataOk returns a tuple with the AdditionalMetadata field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasAdditionalMetadata
-
-`func (o *InlineObject5) HasAdditionalMetadata() bool`
-
-HasAdditionalMetadata returns a boolean if a field has been set.
 
 ### SetAdditionalMetadata
 
 `func (o *InlineObject5) SetAdditionalMetadata(v string)`
 
-SetAdditionalMetadata gets a reference to the given string and assigns it to the AdditionalMetadata field.
+SetAdditionalMetadata sets AdditionalMetadata field to given value.
 
 ### GetRequiredFile
 
@@ -59,22 +53,16 @@ GetRequiredFile returns the RequiredFile field if non-nil, zero value otherwise.
 
 ### GetRequiredFileOk
 
-`func (o *InlineObject5) GetRequiredFileOk() (*os.File, bool)`
+`func (o *InlineObject5) GetRequiredFileOk() (**os.File, bool)`
 
 GetRequiredFileOk returns a tuple with the RequiredFile field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasRequiredFile
-
-`func (o *InlineObject5) HasRequiredFile() bool`
-
-HasRequiredFile returns a boolean if a field has been set.
 
 ### SetRequiredFile
 
 `func (o *InlineObject5) SetRequiredFile(v *os.File)`
 
-SetRequiredFile gets a reference to the given *os.File and assigns it to the RequiredFile field.
+SetRequiredFile sets RequiredFile field to given value.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/InlineResponseDefault.md
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/InlineResponseDefault.md
@@ -33,22 +33,16 @@ GetString returns the String field if non-nil, zero value otherwise.
 
 ### GetStringOk
 
-`func (o *InlineResponseDefault) GetStringOk() (Foo, bool)`
+`func (o *InlineResponseDefault) GetStringOk() (*Foo, bool)`
 
 GetStringOk returns a tuple with the String field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasString
-
-`func (o *InlineResponseDefault) HasString() bool`
-
-HasString returns a boolean if a field has been set.
 
 ### SetString
 
 `func (o *InlineResponseDefault) SetString(v Foo)`
 
-SetString gets a reference to the given Foo and assigns it to the String field.
+SetString sets String field to given value.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/InlineResponseDefault.md
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/InlineResponseDefault.md
@@ -44,6 +44,12 @@ and a boolean to check if the value has been set.
 
 SetString sets String field to given value.
 
+### HasString
+
+`func (o *InlineResponseDefault) HasString() bool`
+
+HasString returns a boolean if a field has been set.
+
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/List.md
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/List.md
@@ -33,22 +33,16 @@ GetVar123List returns the Var123List field if non-nil, zero value otherwise.
 
 ### GetVar123ListOk
 
-`func (o *List) GetVar123ListOk() (string, bool)`
+`func (o *List) GetVar123ListOk() (*string, bool)`
 
 GetVar123ListOk returns a tuple with the Var123List field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasVar123List
-
-`func (o *List) HasVar123List() bool`
-
-HasVar123List returns a boolean if a field has been set.
 
 ### SetVar123List
 
 `func (o *List) SetVar123List(v string)`
 
-SetVar123List gets a reference to the given string and assigns it to the Var123List field.
+SetVar123List sets Var123List field to given value.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/List.md
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/List.md
@@ -44,6 +44,12 @@ and a boolean to check if the value has been set.
 
 SetVar123List sets Var123List field to given value.
 
+### HasVar123List
+
+`func (o *List) HasVar123List() bool`
+
+HasVar123List returns a boolean if a field has been set.
+
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/MapTest.md
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/MapTest.md
@@ -47,6 +47,12 @@ and a boolean to check if the value has been set.
 
 SetMapMapOfString sets MapMapOfString field to given value.
 
+### HasMapMapOfString
+
+`func (o *MapTest) HasMapMapOfString() bool`
+
+HasMapMapOfString returns a boolean if a field has been set.
+
 ### GetMapOfEnumString
 
 `func (o *MapTest) GetMapOfEnumString() map[string]string`
@@ -65,6 +71,12 @@ and a boolean to check if the value has been set.
 `func (o *MapTest) SetMapOfEnumString(v map[string]string)`
 
 SetMapOfEnumString sets MapOfEnumString field to given value.
+
+### HasMapOfEnumString
+
+`func (o *MapTest) HasMapOfEnumString() bool`
+
+HasMapOfEnumString returns a boolean if a field has been set.
 
 ### GetDirectMap
 
@@ -85,6 +97,12 @@ and a boolean to check if the value has been set.
 
 SetDirectMap sets DirectMap field to given value.
 
+### HasDirectMap
+
+`func (o *MapTest) HasDirectMap() bool`
+
+HasDirectMap returns a boolean if a field has been set.
+
 ### GetIndirectMap
 
 `func (o *MapTest) GetIndirectMap() map[string]bool`
@@ -103,6 +121,12 @@ and a boolean to check if the value has been set.
 `func (o *MapTest) SetIndirectMap(v map[string]bool)`
 
 SetIndirectMap sets IndirectMap field to given value.
+
+### HasIndirectMap
+
+`func (o *MapTest) HasIndirectMap() bool`
+
+HasIndirectMap returns a boolean if a field has been set.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/MapTest.md
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/MapTest.md
@@ -36,22 +36,16 @@ GetMapMapOfString returns the MapMapOfString field if non-nil, zero value otherw
 
 ### GetMapMapOfStringOk
 
-`func (o *MapTest) GetMapMapOfStringOk() (map[string]map[string]string, bool)`
+`func (o *MapTest) GetMapMapOfStringOk() (*map[string]map[string]string, bool)`
 
 GetMapMapOfStringOk returns a tuple with the MapMapOfString field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasMapMapOfString
-
-`func (o *MapTest) HasMapMapOfString() bool`
-
-HasMapMapOfString returns a boolean if a field has been set.
 
 ### SetMapMapOfString
 
 `func (o *MapTest) SetMapMapOfString(v map[string]map[string]string)`
 
-SetMapMapOfString gets a reference to the given map[string]map[string]string and assigns it to the MapMapOfString field.
+SetMapMapOfString sets MapMapOfString field to given value.
 
 ### GetMapOfEnumString
 
@@ -61,22 +55,16 @@ GetMapOfEnumString returns the MapOfEnumString field if non-nil, zero value othe
 
 ### GetMapOfEnumStringOk
 
-`func (o *MapTest) GetMapOfEnumStringOk() (map[string]string, bool)`
+`func (o *MapTest) GetMapOfEnumStringOk() (*map[string]string, bool)`
 
 GetMapOfEnumStringOk returns a tuple with the MapOfEnumString field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasMapOfEnumString
-
-`func (o *MapTest) HasMapOfEnumString() bool`
-
-HasMapOfEnumString returns a boolean if a field has been set.
 
 ### SetMapOfEnumString
 
 `func (o *MapTest) SetMapOfEnumString(v map[string]string)`
 
-SetMapOfEnumString gets a reference to the given map[string]string and assigns it to the MapOfEnumString field.
+SetMapOfEnumString sets MapOfEnumString field to given value.
 
 ### GetDirectMap
 
@@ -86,22 +74,16 @@ GetDirectMap returns the DirectMap field if non-nil, zero value otherwise.
 
 ### GetDirectMapOk
 
-`func (o *MapTest) GetDirectMapOk() (map[string]bool, bool)`
+`func (o *MapTest) GetDirectMapOk() (*map[string]bool, bool)`
 
 GetDirectMapOk returns a tuple with the DirectMap field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasDirectMap
-
-`func (o *MapTest) HasDirectMap() bool`
-
-HasDirectMap returns a boolean if a field has been set.
 
 ### SetDirectMap
 
 `func (o *MapTest) SetDirectMap(v map[string]bool)`
 
-SetDirectMap gets a reference to the given map[string]bool and assigns it to the DirectMap field.
+SetDirectMap sets DirectMap field to given value.
 
 ### GetIndirectMap
 
@@ -111,22 +93,16 @@ GetIndirectMap returns the IndirectMap field if non-nil, zero value otherwise.
 
 ### GetIndirectMapOk
 
-`func (o *MapTest) GetIndirectMapOk() (map[string]bool, bool)`
+`func (o *MapTest) GetIndirectMapOk() (*map[string]bool, bool)`
 
 GetIndirectMapOk returns a tuple with the IndirectMap field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasIndirectMap
-
-`func (o *MapTest) HasIndirectMap() bool`
-
-HasIndirectMap returns a boolean if a field has been set.
 
 ### SetIndirectMap
 
 `func (o *MapTest) SetIndirectMap(v map[string]bool)`
 
-SetIndirectMap gets a reference to the given map[string]bool and assigns it to the IndirectMap field.
+SetIndirectMap sets IndirectMap field to given value.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/MixedPropertiesAndAdditionalPropertiesClass.md
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/MixedPropertiesAndAdditionalPropertiesClass.md
@@ -46,6 +46,12 @@ and a boolean to check if the value has been set.
 
 SetUuid sets Uuid field to given value.
 
+### HasUuid
+
+`func (o *MixedPropertiesAndAdditionalPropertiesClass) HasUuid() bool`
+
+HasUuid returns a boolean if a field has been set.
+
 ### GetDateTime
 
 `func (o *MixedPropertiesAndAdditionalPropertiesClass) GetDateTime() time.Time`
@@ -65,6 +71,12 @@ and a boolean to check if the value has been set.
 
 SetDateTime sets DateTime field to given value.
 
+### HasDateTime
+
+`func (o *MixedPropertiesAndAdditionalPropertiesClass) HasDateTime() bool`
+
+HasDateTime returns a boolean if a field has been set.
+
 ### GetMap
 
 `func (o *MixedPropertiesAndAdditionalPropertiesClass) GetMap() map[string]Animal`
@@ -83,6 +95,12 @@ and a boolean to check if the value has been set.
 `func (o *MixedPropertiesAndAdditionalPropertiesClass) SetMap(v map[string]Animal)`
 
 SetMap sets Map field to given value.
+
+### HasMap
+
+`func (o *MixedPropertiesAndAdditionalPropertiesClass) HasMap() bool`
+
+HasMap returns a boolean if a field has been set.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/MixedPropertiesAndAdditionalPropertiesClass.md
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/MixedPropertiesAndAdditionalPropertiesClass.md
@@ -35,22 +35,16 @@ GetUuid returns the Uuid field if non-nil, zero value otherwise.
 
 ### GetUuidOk
 
-`func (o *MixedPropertiesAndAdditionalPropertiesClass) GetUuidOk() (string, bool)`
+`func (o *MixedPropertiesAndAdditionalPropertiesClass) GetUuidOk() (*string, bool)`
 
 GetUuidOk returns a tuple with the Uuid field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasUuid
-
-`func (o *MixedPropertiesAndAdditionalPropertiesClass) HasUuid() bool`
-
-HasUuid returns a boolean if a field has been set.
 
 ### SetUuid
 
 `func (o *MixedPropertiesAndAdditionalPropertiesClass) SetUuid(v string)`
 
-SetUuid gets a reference to the given string and assigns it to the Uuid field.
+SetUuid sets Uuid field to given value.
 
 ### GetDateTime
 
@@ -60,22 +54,16 @@ GetDateTime returns the DateTime field if non-nil, zero value otherwise.
 
 ### GetDateTimeOk
 
-`func (o *MixedPropertiesAndAdditionalPropertiesClass) GetDateTimeOk() (time.Time, bool)`
+`func (o *MixedPropertiesAndAdditionalPropertiesClass) GetDateTimeOk() (*time.Time, bool)`
 
 GetDateTimeOk returns a tuple with the DateTime field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasDateTime
-
-`func (o *MixedPropertiesAndAdditionalPropertiesClass) HasDateTime() bool`
-
-HasDateTime returns a boolean if a field has been set.
 
 ### SetDateTime
 
 `func (o *MixedPropertiesAndAdditionalPropertiesClass) SetDateTime(v time.Time)`
 
-SetDateTime gets a reference to the given time.Time and assigns it to the DateTime field.
+SetDateTime sets DateTime field to given value.
 
 ### GetMap
 
@@ -85,22 +73,16 @@ GetMap returns the Map field if non-nil, zero value otherwise.
 
 ### GetMapOk
 
-`func (o *MixedPropertiesAndAdditionalPropertiesClass) GetMapOk() (map[string]Animal, bool)`
+`func (o *MixedPropertiesAndAdditionalPropertiesClass) GetMapOk() (*map[string]Animal, bool)`
 
 GetMapOk returns a tuple with the Map field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasMap
-
-`func (o *MixedPropertiesAndAdditionalPropertiesClass) HasMap() bool`
-
-HasMap returns a boolean if a field has been set.
 
 ### SetMap
 
 `func (o *MixedPropertiesAndAdditionalPropertiesClass) SetMap(v map[string]Animal)`
 
-SetMap gets a reference to the given map[string]Animal and assigns it to the Map field.
+SetMap sets Map field to given value.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/Model200Response.md
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/Model200Response.md
@@ -34,22 +34,16 @@ GetName returns the Name field if non-nil, zero value otherwise.
 
 ### GetNameOk
 
-`func (o *Model200Response) GetNameOk() (int32, bool)`
+`func (o *Model200Response) GetNameOk() (*int32, bool)`
 
 GetNameOk returns a tuple with the Name field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasName
-
-`func (o *Model200Response) HasName() bool`
-
-HasName returns a boolean if a field has been set.
 
 ### SetName
 
 `func (o *Model200Response) SetName(v int32)`
 
-SetName gets a reference to the given int32 and assigns it to the Name field.
+SetName sets Name field to given value.
 
 ### GetClass
 
@@ -59,22 +53,16 @@ GetClass returns the Class field if non-nil, zero value otherwise.
 
 ### GetClassOk
 
-`func (o *Model200Response) GetClassOk() (string, bool)`
+`func (o *Model200Response) GetClassOk() (*string, bool)`
 
 GetClassOk returns a tuple with the Class field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasClass
-
-`func (o *Model200Response) HasClass() bool`
-
-HasClass returns a boolean if a field has been set.
 
 ### SetClass
 
 `func (o *Model200Response) SetClass(v string)`
 
-SetClass gets a reference to the given string and assigns it to the Class field.
+SetClass sets Class field to given value.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/Model200Response.md
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/Model200Response.md
@@ -45,6 +45,12 @@ and a boolean to check if the value has been set.
 
 SetName sets Name field to given value.
 
+### HasName
+
+`func (o *Model200Response) HasName() bool`
+
+HasName returns a boolean if a field has been set.
+
 ### GetClass
 
 `func (o *Model200Response) GetClass() string`
@@ -63,6 +69,12 @@ and a boolean to check if the value has been set.
 `func (o *Model200Response) SetClass(v string)`
 
 SetClass sets Class field to given value.
+
+### HasClass
+
+`func (o *Model200Response) HasClass() bool`
+
+HasClass returns a boolean if a field has been set.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/Name.md
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/Name.md
@@ -36,22 +36,16 @@ GetName returns the Name field if non-nil, zero value otherwise.
 
 ### GetNameOk
 
-`func (o *Name) GetNameOk() (int32, bool)`
+`func (o *Name) GetNameOk() (*int32, bool)`
 
 GetNameOk returns a tuple with the Name field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasName
-
-`func (o *Name) HasName() bool`
-
-HasName returns a boolean if a field has been set.
 
 ### SetName
 
 `func (o *Name) SetName(v int32)`
 
-SetName gets a reference to the given int32 and assigns it to the Name field.
+SetName sets Name field to given value.
 
 ### GetSnakeCase
 
@@ -61,22 +55,16 @@ GetSnakeCase returns the SnakeCase field if non-nil, zero value otherwise.
 
 ### GetSnakeCaseOk
 
-`func (o *Name) GetSnakeCaseOk() (int32, bool)`
+`func (o *Name) GetSnakeCaseOk() (*int32, bool)`
 
 GetSnakeCaseOk returns a tuple with the SnakeCase field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasSnakeCase
-
-`func (o *Name) HasSnakeCase() bool`
-
-HasSnakeCase returns a boolean if a field has been set.
 
 ### SetSnakeCase
 
 `func (o *Name) SetSnakeCase(v int32)`
 
-SetSnakeCase gets a reference to the given int32 and assigns it to the SnakeCase field.
+SetSnakeCase sets SnakeCase field to given value.
 
 ### GetProperty
 
@@ -86,22 +74,16 @@ GetProperty returns the Property field if non-nil, zero value otherwise.
 
 ### GetPropertyOk
 
-`func (o *Name) GetPropertyOk() (string, bool)`
+`func (o *Name) GetPropertyOk() (*string, bool)`
 
 GetPropertyOk returns a tuple with the Property field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasProperty
-
-`func (o *Name) HasProperty() bool`
-
-HasProperty returns a boolean if a field has been set.
 
 ### SetProperty
 
 `func (o *Name) SetProperty(v string)`
 
-SetProperty gets a reference to the given string and assigns it to the Property field.
+SetProperty sets Property field to given value.
 
 ### GetVar123Number
 
@@ -111,22 +93,16 @@ GetVar123Number returns the Var123Number field if non-nil, zero value otherwise.
 
 ### GetVar123NumberOk
 
-`func (o *Name) GetVar123NumberOk() (int32, bool)`
+`func (o *Name) GetVar123NumberOk() (*int32, bool)`
 
 GetVar123NumberOk returns a tuple with the Var123Number field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasVar123Number
-
-`func (o *Name) HasVar123Number() bool`
-
-HasVar123Number returns a boolean if a field has been set.
 
 ### SetVar123Number
 
 `func (o *Name) SetVar123Number(v int32)`
 
-SetVar123Number gets a reference to the given int32 and assigns it to the Var123Number field.
+SetVar123Number sets Var123Number field to given value.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/Name.md
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/Name.md
@@ -47,6 +47,7 @@ and a boolean to check if the value has been set.
 
 SetName sets Name field to given value.
 
+
 ### GetSnakeCase
 
 `func (o *Name) GetSnakeCase() int32`
@@ -65,6 +66,12 @@ and a boolean to check if the value has been set.
 `func (o *Name) SetSnakeCase(v int32)`
 
 SetSnakeCase sets SnakeCase field to given value.
+
+### HasSnakeCase
+
+`func (o *Name) HasSnakeCase() bool`
+
+HasSnakeCase returns a boolean if a field has been set.
 
 ### GetProperty
 
@@ -85,6 +92,12 @@ and a boolean to check if the value has been set.
 
 SetProperty sets Property field to given value.
 
+### HasProperty
+
+`func (o *Name) HasProperty() bool`
+
+HasProperty returns a boolean if a field has been set.
+
 ### GetVar123Number
 
 `func (o *Name) GetVar123Number() int32`
@@ -103,6 +116,12 @@ and a boolean to check if the value has been set.
 `func (o *Name) SetVar123Number(v int32)`
 
 SetVar123Number sets Var123Number field to given value.
+
+### HasVar123Number
+
+`func (o *Name) HasVar123Number() bool`
+
+HasVar123Number returns a boolean if a field has been set.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/NullableClass.md
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/NullableClass.md
@@ -38,16 +38,22 @@ but it doesn't guarantee that properties required by API are set
 
 ### GetIntegerProp
 
-`func (o *NullableClass) GetIntegerProp() NullableInt32`
+`func (o *NullableClass) GetIntegerProp() int32`
 
 GetIntegerProp returns the IntegerProp field if non-nil, zero value otherwise.
 
 ### GetIntegerPropOk
 
-`func (o *NullableClass) GetIntegerPropOk() (NullableInt32, bool)`
+`func (o *NullableClass) GetIntegerPropOk() (*int32, bool)`
 
 GetIntegerPropOk returns a tuple with the IntegerProp field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
+
+### SetIntegerProp
+
+`func (o *NullableClass) SetIntegerProp(v int32)`
+
+SetIntegerProp sets IntegerProp field to given value.
 
 ### HasIntegerProp
 
@@ -55,31 +61,34 @@ and a boolean to check if the value has been set.
 
 HasIntegerProp returns a boolean if a field has been set.
 
-### SetIntegerProp
+### SetIntegerPropNil
 
-`func (o *NullableClass) SetIntegerProp(v NullableInt32)`
+`func (o *NullableClass) SetIntegerPropNil(b bool)`
 
-SetIntegerProp gets a reference to the given NullableInt32 and assigns it to the IntegerProp field.
+ SetIntegerPropNil sets the value for IntegerProp to be an explicit nil
 
-### SetIntegerPropExplicitNull
+### UnsetIntegerProp
+`func (o *NullableClass) UnsetIntegerProp()`
 
-`func (o *NullableClass) SetIntegerPropExplicitNull(b bool)`
-
-SetIntegerPropExplicitNull (un)sets IntegerProp to be considered as explicit "null" value
-when serializing to JSON (pass true as argument to set this, false to unset)
-The IntegerProp value is set to nil even if false is passed
+UnsetIntegerProp ensures that no value is present for IntegerProp, not even an explicit nil
 ### GetNumberProp
 
-`func (o *NullableClass) GetNumberProp() NullableFloat32`
+`func (o *NullableClass) GetNumberProp() float32`
 
 GetNumberProp returns the NumberProp field if non-nil, zero value otherwise.
 
 ### GetNumberPropOk
 
-`func (o *NullableClass) GetNumberPropOk() (NullableFloat32, bool)`
+`func (o *NullableClass) GetNumberPropOk() (*float32, bool)`
 
 GetNumberPropOk returns a tuple with the NumberProp field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
+
+### SetNumberProp
+
+`func (o *NullableClass) SetNumberProp(v float32)`
+
+SetNumberProp sets NumberProp field to given value.
 
 ### HasNumberProp
 
@@ -87,31 +96,34 @@ and a boolean to check if the value has been set.
 
 HasNumberProp returns a boolean if a field has been set.
 
-### SetNumberProp
+### SetNumberPropNil
 
-`func (o *NullableClass) SetNumberProp(v NullableFloat32)`
+`func (o *NullableClass) SetNumberPropNil(b bool)`
 
-SetNumberProp gets a reference to the given NullableFloat32 and assigns it to the NumberProp field.
+ SetNumberPropNil sets the value for NumberProp to be an explicit nil
 
-### SetNumberPropExplicitNull
+### UnsetNumberProp
+`func (o *NullableClass) UnsetNumberProp()`
 
-`func (o *NullableClass) SetNumberPropExplicitNull(b bool)`
-
-SetNumberPropExplicitNull (un)sets NumberProp to be considered as explicit "null" value
-when serializing to JSON (pass true as argument to set this, false to unset)
-The NumberProp value is set to nil even if false is passed
+UnsetNumberProp ensures that no value is present for NumberProp, not even an explicit nil
 ### GetBooleanProp
 
-`func (o *NullableClass) GetBooleanProp() NullableBool`
+`func (o *NullableClass) GetBooleanProp() bool`
 
 GetBooleanProp returns the BooleanProp field if non-nil, zero value otherwise.
 
 ### GetBooleanPropOk
 
-`func (o *NullableClass) GetBooleanPropOk() (NullableBool, bool)`
+`func (o *NullableClass) GetBooleanPropOk() (*bool, bool)`
 
 GetBooleanPropOk returns a tuple with the BooleanProp field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
+
+### SetBooleanProp
+
+`func (o *NullableClass) SetBooleanProp(v bool)`
+
+SetBooleanProp sets BooleanProp field to given value.
 
 ### HasBooleanProp
 
@@ -119,31 +131,34 @@ and a boolean to check if the value has been set.
 
 HasBooleanProp returns a boolean if a field has been set.
 
-### SetBooleanProp
+### SetBooleanPropNil
 
-`func (o *NullableClass) SetBooleanProp(v NullableBool)`
+`func (o *NullableClass) SetBooleanPropNil(b bool)`
 
-SetBooleanProp gets a reference to the given NullableBool and assigns it to the BooleanProp field.
+ SetBooleanPropNil sets the value for BooleanProp to be an explicit nil
 
-### SetBooleanPropExplicitNull
+### UnsetBooleanProp
+`func (o *NullableClass) UnsetBooleanProp()`
 
-`func (o *NullableClass) SetBooleanPropExplicitNull(b bool)`
-
-SetBooleanPropExplicitNull (un)sets BooleanProp to be considered as explicit "null" value
-when serializing to JSON (pass true as argument to set this, false to unset)
-The BooleanProp value is set to nil even if false is passed
+UnsetBooleanProp ensures that no value is present for BooleanProp, not even an explicit nil
 ### GetStringProp
 
-`func (o *NullableClass) GetStringProp() NullableString`
+`func (o *NullableClass) GetStringProp() string`
 
 GetStringProp returns the StringProp field if non-nil, zero value otherwise.
 
 ### GetStringPropOk
 
-`func (o *NullableClass) GetStringPropOk() (NullableString, bool)`
+`func (o *NullableClass) GetStringPropOk() (*string, bool)`
 
 GetStringPropOk returns a tuple with the StringProp field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
+
+### SetStringProp
+
+`func (o *NullableClass) SetStringProp(v string)`
+
+SetStringProp sets StringProp field to given value.
 
 ### HasStringProp
 
@@ -151,31 +166,34 @@ and a boolean to check if the value has been set.
 
 HasStringProp returns a boolean if a field has been set.
 
-### SetStringProp
+### SetStringPropNil
 
-`func (o *NullableClass) SetStringProp(v NullableString)`
+`func (o *NullableClass) SetStringPropNil(b bool)`
 
-SetStringProp gets a reference to the given NullableString and assigns it to the StringProp field.
+ SetStringPropNil sets the value for StringProp to be an explicit nil
 
-### SetStringPropExplicitNull
+### UnsetStringProp
+`func (o *NullableClass) UnsetStringProp()`
 
-`func (o *NullableClass) SetStringPropExplicitNull(b bool)`
-
-SetStringPropExplicitNull (un)sets StringProp to be considered as explicit "null" value
-when serializing to JSON (pass true as argument to set this, false to unset)
-The StringProp value is set to nil even if false is passed
+UnsetStringProp ensures that no value is present for StringProp, not even an explicit nil
 ### GetDateProp
 
-`func (o *NullableClass) GetDateProp() NullableString`
+`func (o *NullableClass) GetDateProp() string`
 
 GetDateProp returns the DateProp field if non-nil, zero value otherwise.
 
 ### GetDatePropOk
 
-`func (o *NullableClass) GetDatePropOk() (NullableString, bool)`
+`func (o *NullableClass) GetDatePropOk() (*string, bool)`
 
 GetDatePropOk returns a tuple with the DateProp field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
+
+### SetDateProp
+
+`func (o *NullableClass) SetDateProp(v string)`
+
+SetDateProp sets DateProp field to given value.
 
 ### HasDateProp
 
@@ -183,31 +201,34 @@ and a boolean to check if the value has been set.
 
 HasDateProp returns a boolean if a field has been set.
 
-### SetDateProp
+### SetDatePropNil
 
-`func (o *NullableClass) SetDateProp(v NullableString)`
+`func (o *NullableClass) SetDatePropNil(b bool)`
 
-SetDateProp gets a reference to the given NullableString and assigns it to the DateProp field.
+ SetDatePropNil sets the value for DateProp to be an explicit nil
 
-### SetDatePropExplicitNull
+### UnsetDateProp
+`func (o *NullableClass) UnsetDateProp()`
 
-`func (o *NullableClass) SetDatePropExplicitNull(b bool)`
-
-SetDatePropExplicitNull (un)sets DateProp to be considered as explicit "null" value
-when serializing to JSON (pass true as argument to set this, false to unset)
-The DateProp value is set to nil even if false is passed
+UnsetDateProp ensures that no value is present for DateProp, not even an explicit nil
 ### GetDatetimeProp
 
-`func (o *NullableClass) GetDatetimeProp() NullableTime`
+`func (o *NullableClass) GetDatetimeProp() time.Time`
 
 GetDatetimeProp returns the DatetimeProp field if non-nil, zero value otherwise.
 
 ### GetDatetimePropOk
 
-`func (o *NullableClass) GetDatetimePropOk() (NullableTime, bool)`
+`func (o *NullableClass) GetDatetimePropOk() (*time.Time, bool)`
 
 GetDatetimePropOk returns a tuple with the DatetimeProp field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
+
+### SetDatetimeProp
+
+`func (o *NullableClass) SetDatetimeProp(v time.Time)`
+
+SetDatetimeProp sets DatetimeProp field to given value.
 
 ### HasDatetimeProp
 
@@ -215,19 +236,16 @@ and a boolean to check if the value has been set.
 
 HasDatetimeProp returns a boolean if a field has been set.
 
-### SetDatetimeProp
+### SetDatetimePropNil
 
-`func (o *NullableClass) SetDatetimeProp(v NullableTime)`
+`func (o *NullableClass) SetDatetimePropNil(b bool)`
 
-SetDatetimeProp gets a reference to the given NullableTime and assigns it to the DatetimeProp field.
+ SetDatetimePropNil sets the value for DatetimeProp to be an explicit nil
 
-### SetDatetimePropExplicitNull
+### UnsetDatetimeProp
+`func (o *NullableClass) UnsetDatetimeProp()`
 
-`func (o *NullableClass) SetDatetimePropExplicitNull(b bool)`
-
-SetDatetimePropExplicitNull (un)sets DatetimeProp to be considered as explicit "null" value
-when serializing to JSON (pass true as argument to set this, false to unset)
-The DatetimeProp value is set to nil even if false is passed
+UnsetDatetimeProp ensures that no value is present for DatetimeProp, not even an explicit nil
 ### GetArrayNullableProp
 
 `func (o *NullableClass) GetArrayNullableProp() []map[string]interface{}`
@@ -236,10 +254,16 @@ GetArrayNullableProp returns the ArrayNullableProp field if non-nil, zero value 
 
 ### GetArrayNullablePropOk
 
-`func (o *NullableClass) GetArrayNullablePropOk() ([]map[string]interface{}, bool)`
+`func (o *NullableClass) GetArrayNullablePropOk() (*[]map[string]interface{}, bool)`
 
 GetArrayNullablePropOk returns a tuple with the ArrayNullableProp field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
+
+### SetArrayNullableProp
+
+`func (o *NullableClass) SetArrayNullableProp(v []map[string]interface{})`
+
+SetArrayNullableProp sets ArrayNullableProp field to given value.
 
 ### HasArrayNullableProp
 
@@ -247,19 +271,16 @@ and a boolean to check if the value has been set.
 
 HasArrayNullableProp returns a boolean if a field has been set.
 
-### SetArrayNullableProp
+### SetArrayNullablePropNil
 
-`func (o *NullableClass) SetArrayNullableProp(v []map[string]interface{})`
+`func (o *NullableClass) SetArrayNullablePropNil(b bool)`
 
-SetArrayNullableProp gets a reference to the given []map[string]interface{} and assigns it to the ArrayNullableProp field.
+ SetArrayNullablePropNil sets the value for ArrayNullableProp to be an explicit nil
 
-### SetArrayNullablePropExplicitNull
+### UnsetArrayNullableProp
+`func (o *NullableClass) UnsetArrayNullableProp()`
 
-`func (o *NullableClass) SetArrayNullablePropExplicitNull(b bool)`
-
-SetArrayNullablePropExplicitNull (un)sets ArrayNullableProp to be considered as explicit "null" value
-when serializing to JSON (pass true as argument to set this, false to unset)
-The ArrayNullableProp value is set to nil even if false is passed
+UnsetArrayNullableProp ensures that no value is present for ArrayNullableProp, not even an explicit nil
 ### GetArrayAndItemsNullableProp
 
 `func (o *NullableClass) GetArrayAndItemsNullableProp() []map[string]interface{}`
@@ -268,10 +289,16 @@ GetArrayAndItemsNullableProp returns the ArrayAndItemsNullableProp field if non-
 
 ### GetArrayAndItemsNullablePropOk
 
-`func (o *NullableClass) GetArrayAndItemsNullablePropOk() ([]map[string]interface{}, bool)`
+`func (o *NullableClass) GetArrayAndItemsNullablePropOk() (*[]map[string]interface{}, bool)`
 
 GetArrayAndItemsNullablePropOk returns a tuple with the ArrayAndItemsNullableProp field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
+
+### SetArrayAndItemsNullableProp
+
+`func (o *NullableClass) SetArrayAndItemsNullableProp(v []map[string]interface{})`
+
+SetArrayAndItemsNullableProp sets ArrayAndItemsNullableProp field to given value.
 
 ### HasArrayAndItemsNullableProp
 
@@ -279,19 +306,16 @@ and a boolean to check if the value has been set.
 
 HasArrayAndItemsNullableProp returns a boolean if a field has been set.
 
-### SetArrayAndItemsNullableProp
+### SetArrayAndItemsNullablePropNil
 
-`func (o *NullableClass) SetArrayAndItemsNullableProp(v []map[string]interface{})`
+`func (o *NullableClass) SetArrayAndItemsNullablePropNil(b bool)`
 
-SetArrayAndItemsNullableProp gets a reference to the given []map[string]interface{} and assigns it to the ArrayAndItemsNullableProp field.
+ SetArrayAndItemsNullablePropNil sets the value for ArrayAndItemsNullableProp to be an explicit nil
 
-### SetArrayAndItemsNullablePropExplicitNull
+### UnsetArrayAndItemsNullableProp
+`func (o *NullableClass) UnsetArrayAndItemsNullableProp()`
 
-`func (o *NullableClass) SetArrayAndItemsNullablePropExplicitNull(b bool)`
-
-SetArrayAndItemsNullablePropExplicitNull (un)sets ArrayAndItemsNullableProp to be considered as explicit "null" value
-when serializing to JSON (pass true as argument to set this, false to unset)
-The ArrayAndItemsNullableProp value is set to nil even if false is passed
+UnsetArrayAndItemsNullableProp ensures that no value is present for ArrayAndItemsNullableProp, not even an explicit nil
 ### GetArrayItemsNullable
 
 `func (o *NullableClass) GetArrayItemsNullable() []map[string]interface{}`
@@ -300,22 +324,16 @@ GetArrayItemsNullable returns the ArrayItemsNullable field if non-nil, zero valu
 
 ### GetArrayItemsNullableOk
 
-`func (o *NullableClass) GetArrayItemsNullableOk() ([]map[string]interface{}, bool)`
+`func (o *NullableClass) GetArrayItemsNullableOk() (*[]map[string]interface{}, bool)`
 
 GetArrayItemsNullableOk returns a tuple with the ArrayItemsNullable field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasArrayItemsNullable
-
-`func (o *NullableClass) HasArrayItemsNullable() bool`
-
-HasArrayItemsNullable returns a boolean if a field has been set.
 
 ### SetArrayItemsNullable
 
 `func (o *NullableClass) SetArrayItemsNullable(v []map[string]interface{})`
 
-SetArrayItemsNullable gets a reference to the given []map[string]interface{} and assigns it to the ArrayItemsNullable field.
+SetArrayItemsNullable sets ArrayItemsNullable field to given value.
 
 ### GetObjectNullableProp
 
@@ -325,10 +343,16 @@ GetObjectNullableProp returns the ObjectNullableProp field if non-nil, zero valu
 
 ### GetObjectNullablePropOk
 
-`func (o *NullableClass) GetObjectNullablePropOk() (map[string]map[string]interface{}, bool)`
+`func (o *NullableClass) GetObjectNullablePropOk() (*map[string]map[string]interface{}, bool)`
 
 GetObjectNullablePropOk returns a tuple with the ObjectNullableProp field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
+
+### SetObjectNullableProp
+
+`func (o *NullableClass) SetObjectNullableProp(v map[string]map[string]interface{})`
+
+SetObjectNullableProp sets ObjectNullableProp field to given value.
 
 ### HasObjectNullableProp
 
@@ -336,19 +360,16 @@ and a boolean to check if the value has been set.
 
 HasObjectNullableProp returns a boolean if a field has been set.
 
-### SetObjectNullableProp
+### SetObjectNullablePropNil
 
-`func (o *NullableClass) SetObjectNullableProp(v map[string]map[string]interface{})`
+`func (o *NullableClass) SetObjectNullablePropNil(b bool)`
 
-SetObjectNullableProp gets a reference to the given map[string]map[string]interface{} and assigns it to the ObjectNullableProp field.
+ SetObjectNullablePropNil sets the value for ObjectNullableProp to be an explicit nil
 
-### SetObjectNullablePropExplicitNull
+### UnsetObjectNullableProp
+`func (o *NullableClass) UnsetObjectNullableProp()`
 
-`func (o *NullableClass) SetObjectNullablePropExplicitNull(b bool)`
-
-SetObjectNullablePropExplicitNull (un)sets ObjectNullableProp to be considered as explicit "null" value
-when serializing to JSON (pass true as argument to set this, false to unset)
-The ObjectNullableProp value is set to nil even if false is passed
+UnsetObjectNullableProp ensures that no value is present for ObjectNullableProp, not even an explicit nil
 ### GetObjectAndItemsNullableProp
 
 `func (o *NullableClass) GetObjectAndItemsNullableProp() map[string]map[string]interface{}`
@@ -357,10 +378,16 @@ GetObjectAndItemsNullableProp returns the ObjectAndItemsNullableProp field if no
 
 ### GetObjectAndItemsNullablePropOk
 
-`func (o *NullableClass) GetObjectAndItemsNullablePropOk() (map[string]map[string]interface{}, bool)`
+`func (o *NullableClass) GetObjectAndItemsNullablePropOk() (*map[string]map[string]interface{}, bool)`
 
 GetObjectAndItemsNullablePropOk returns a tuple with the ObjectAndItemsNullableProp field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
+
+### SetObjectAndItemsNullableProp
+
+`func (o *NullableClass) SetObjectAndItemsNullableProp(v map[string]map[string]interface{})`
+
+SetObjectAndItemsNullableProp sets ObjectAndItemsNullableProp field to given value.
 
 ### HasObjectAndItemsNullableProp
 
@@ -368,19 +395,16 @@ and a boolean to check if the value has been set.
 
 HasObjectAndItemsNullableProp returns a boolean if a field has been set.
 
-### SetObjectAndItemsNullableProp
+### SetObjectAndItemsNullablePropNil
 
-`func (o *NullableClass) SetObjectAndItemsNullableProp(v map[string]map[string]interface{})`
+`func (o *NullableClass) SetObjectAndItemsNullablePropNil(b bool)`
 
-SetObjectAndItemsNullableProp gets a reference to the given map[string]map[string]interface{} and assigns it to the ObjectAndItemsNullableProp field.
+ SetObjectAndItemsNullablePropNil sets the value for ObjectAndItemsNullableProp to be an explicit nil
 
-### SetObjectAndItemsNullablePropExplicitNull
+### UnsetObjectAndItemsNullableProp
+`func (o *NullableClass) UnsetObjectAndItemsNullableProp()`
 
-`func (o *NullableClass) SetObjectAndItemsNullablePropExplicitNull(b bool)`
-
-SetObjectAndItemsNullablePropExplicitNull (un)sets ObjectAndItemsNullableProp to be considered as explicit "null" value
-when serializing to JSON (pass true as argument to set this, false to unset)
-The ObjectAndItemsNullableProp value is set to nil even if false is passed
+UnsetObjectAndItemsNullableProp ensures that no value is present for ObjectAndItemsNullableProp, not even an explicit nil
 ### GetObjectItemsNullable
 
 `func (o *NullableClass) GetObjectItemsNullable() map[string]map[string]interface{}`
@@ -389,22 +413,16 @@ GetObjectItemsNullable returns the ObjectItemsNullable field if non-nil, zero va
 
 ### GetObjectItemsNullableOk
 
-`func (o *NullableClass) GetObjectItemsNullableOk() (map[string]map[string]interface{}, bool)`
+`func (o *NullableClass) GetObjectItemsNullableOk() (*map[string]map[string]interface{}, bool)`
 
 GetObjectItemsNullableOk returns a tuple with the ObjectItemsNullable field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasObjectItemsNullable
-
-`func (o *NullableClass) HasObjectItemsNullable() bool`
-
-HasObjectItemsNullable returns a boolean if a field has been set.
 
 ### SetObjectItemsNullable
 
 `func (o *NullableClass) SetObjectItemsNullable(v map[string]map[string]interface{})`
 
-SetObjectItemsNullable gets a reference to the given map[string]map[string]interface{} and assigns it to the ObjectItemsNullable field.
+SetObjectItemsNullable sets ObjectItemsNullable field to given value.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/NullableClass.md
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/NullableClass.md
@@ -335,6 +335,12 @@ and a boolean to check if the value has been set.
 
 SetArrayItemsNullable sets ArrayItemsNullable field to given value.
 
+### HasArrayItemsNullable
+
+`func (o *NullableClass) HasArrayItemsNullable() bool`
+
+HasArrayItemsNullable returns a boolean if a field has been set.
+
 ### GetObjectNullableProp
 
 `func (o *NullableClass) GetObjectNullableProp() map[string]map[string]interface{}`
@@ -423,6 +429,12 @@ and a boolean to check if the value has been set.
 `func (o *NullableClass) SetObjectItemsNullable(v map[string]map[string]interface{})`
 
 SetObjectItemsNullable sets ObjectItemsNullable field to given value.
+
+### HasObjectItemsNullable
+
+`func (o *NullableClass) HasObjectItemsNullable() bool`
+
+HasObjectItemsNullable returns a boolean if a field has been set.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/NumberOnly.md
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/NumberOnly.md
@@ -44,6 +44,12 @@ and a boolean to check if the value has been set.
 
 SetJustNumber sets JustNumber field to given value.
 
+### HasJustNumber
+
+`func (o *NumberOnly) HasJustNumber() bool`
+
+HasJustNumber returns a boolean if a field has been set.
+
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/NumberOnly.md
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/NumberOnly.md
@@ -33,22 +33,16 @@ GetJustNumber returns the JustNumber field if non-nil, zero value otherwise.
 
 ### GetJustNumberOk
 
-`func (o *NumberOnly) GetJustNumberOk() (float32, bool)`
+`func (o *NumberOnly) GetJustNumberOk() (*float32, bool)`
 
 GetJustNumberOk returns a tuple with the JustNumber field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasJustNumber
-
-`func (o *NumberOnly) HasJustNumber() bool`
-
-HasJustNumber returns a boolean if a field has been set.
 
 ### SetJustNumber
 
 `func (o *NumberOnly) SetJustNumber(v float32)`
 
-SetJustNumber gets a reference to the given float32 and assigns it to the JustNumber field.
+SetJustNumber sets JustNumber field to given value.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/Order.md
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/Order.md
@@ -38,22 +38,16 @@ GetId returns the Id field if non-nil, zero value otherwise.
 
 ### GetIdOk
 
-`func (o *Order) GetIdOk() (int64, bool)`
+`func (o *Order) GetIdOk() (*int64, bool)`
 
 GetIdOk returns a tuple with the Id field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasId
-
-`func (o *Order) HasId() bool`
-
-HasId returns a boolean if a field has been set.
 
 ### SetId
 
 `func (o *Order) SetId(v int64)`
 
-SetId gets a reference to the given int64 and assigns it to the Id field.
+SetId sets Id field to given value.
 
 ### GetPetId
 
@@ -63,22 +57,16 @@ GetPetId returns the PetId field if non-nil, zero value otherwise.
 
 ### GetPetIdOk
 
-`func (o *Order) GetPetIdOk() (int64, bool)`
+`func (o *Order) GetPetIdOk() (*int64, bool)`
 
 GetPetIdOk returns a tuple with the PetId field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasPetId
-
-`func (o *Order) HasPetId() bool`
-
-HasPetId returns a boolean if a field has been set.
 
 ### SetPetId
 
 `func (o *Order) SetPetId(v int64)`
 
-SetPetId gets a reference to the given int64 and assigns it to the PetId field.
+SetPetId sets PetId field to given value.
 
 ### GetQuantity
 
@@ -88,22 +76,16 @@ GetQuantity returns the Quantity field if non-nil, zero value otherwise.
 
 ### GetQuantityOk
 
-`func (o *Order) GetQuantityOk() (int32, bool)`
+`func (o *Order) GetQuantityOk() (*int32, bool)`
 
 GetQuantityOk returns a tuple with the Quantity field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasQuantity
-
-`func (o *Order) HasQuantity() bool`
-
-HasQuantity returns a boolean if a field has been set.
 
 ### SetQuantity
 
 `func (o *Order) SetQuantity(v int32)`
 
-SetQuantity gets a reference to the given int32 and assigns it to the Quantity field.
+SetQuantity sets Quantity field to given value.
 
 ### GetShipDate
 
@@ -113,22 +95,16 @@ GetShipDate returns the ShipDate field if non-nil, zero value otherwise.
 
 ### GetShipDateOk
 
-`func (o *Order) GetShipDateOk() (time.Time, bool)`
+`func (o *Order) GetShipDateOk() (*time.Time, bool)`
 
 GetShipDateOk returns a tuple with the ShipDate field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasShipDate
-
-`func (o *Order) HasShipDate() bool`
-
-HasShipDate returns a boolean if a field has been set.
 
 ### SetShipDate
 
 `func (o *Order) SetShipDate(v time.Time)`
 
-SetShipDate gets a reference to the given time.Time and assigns it to the ShipDate field.
+SetShipDate sets ShipDate field to given value.
 
 ### GetStatus
 
@@ -138,22 +114,16 @@ GetStatus returns the Status field if non-nil, zero value otherwise.
 
 ### GetStatusOk
 
-`func (o *Order) GetStatusOk() (string, bool)`
+`func (o *Order) GetStatusOk() (*string, bool)`
 
 GetStatusOk returns a tuple with the Status field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasStatus
-
-`func (o *Order) HasStatus() bool`
-
-HasStatus returns a boolean if a field has been set.
 
 ### SetStatus
 
 `func (o *Order) SetStatus(v string)`
 
-SetStatus gets a reference to the given string and assigns it to the Status field.
+SetStatus sets Status field to given value.
 
 ### GetComplete
 
@@ -163,22 +133,16 @@ GetComplete returns the Complete field if non-nil, zero value otherwise.
 
 ### GetCompleteOk
 
-`func (o *Order) GetCompleteOk() (bool, bool)`
+`func (o *Order) GetCompleteOk() (*bool, bool)`
 
 GetCompleteOk returns a tuple with the Complete field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasComplete
-
-`func (o *Order) HasComplete() bool`
-
-HasComplete returns a boolean if a field has been set.
 
 ### SetComplete
 
 `func (o *Order) SetComplete(v bool)`
 
-SetComplete gets a reference to the given bool and assigns it to the Complete field.
+SetComplete sets Complete field to given value.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/Order.md
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/Order.md
@@ -49,6 +49,12 @@ and a boolean to check if the value has been set.
 
 SetId sets Id field to given value.
 
+### HasId
+
+`func (o *Order) HasId() bool`
+
+HasId returns a boolean if a field has been set.
+
 ### GetPetId
 
 `func (o *Order) GetPetId() int64`
@@ -67,6 +73,12 @@ and a boolean to check if the value has been set.
 `func (o *Order) SetPetId(v int64)`
 
 SetPetId sets PetId field to given value.
+
+### HasPetId
+
+`func (o *Order) HasPetId() bool`
+
+HasPetId returns a boolean if a field has been set.
 
 ### GetQuantity
 
@@ -87,6 +99,12 @@ and a boolean to check if the value has been set.
 
 SetQuantity sets Quantity field to given value.
 
+### HasQuantity
+
+`func (o *Order) HasQuantity() bool`
+
+HasQuantity returns a boolean if a field has been set.
+
 ### GetShipDate
 
 `func (o *Order) GetShipDate() time.Time`
@@ -105,6 +123,12 @@ and a boolean to check if the value has been set.
 `func (o *Order) SetShipDate(v time.Time)`
 
 SetShipDate sets ShipDate field to given value.
+
+### HasShipDate
+
+`func (o *Order) HasShipDate() bool`
+
+HasShipDate returns a boolean if a field has been set.
 
 ### GetStatus
 
@@ -125,6 +149,12 @@ and a boolean to check if the value has been set.
 
 SetStatus sets Status field to given value.
 
+### HasStatus
+
+`func (o *Order) HasStatus() bool`
+
+HasStatus returns a boolean if a field has been set.
+
 ### GetComplete
 
 `func (o *Order) GetComplete() bool`
@@ -143,6 +173,12 @@ and a boolean to check if the value has been set.
 `func (o *Order) SetComplete(v bool)`
 
 SetComplete sets Complete field to given value.
+
+### HasComplete
+
+`func (o *Order) HasComplete() bool`
+
+HasComplete returns a boolean if a field has been set.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/OuterComposite.md
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/OuterComposite.md
@@ -35,22 +35,16 @@ GetMyNumber returns the MyNumber field if non-nil, zero value otherwise.
 
 ### GetMyNumberOk
 
-`func (o *OuterComposite) GetMyNumberOk() (float32, bool)`
+`func (o *OuterComposite) GetMyNumberOk() (*float32, bool)`
 
 GetMyNumberOk returns a tuple with the MyNumber field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasMyNumber
-
-`func (o *OuterComposite) HasMyNumber() bool`
-
-HasMyNumber returns a boolean if a field has been set.
 
 ### SetMyNumber
 
 `func (o *OuterComposite) SetMyNumber(v float32)`
 
-SetMyNumber gets a reference to the given float32 and assigns it to the MyNumber field.
+SetMyNumber sets MyNumber field to given value.
 
 ### GetMyString
 
@@ -60,22 +54,16 @@ GetMyString returns the MyString field if non-nil, zero value otherwise.
 
 ### GetMyStringOk
 
-`func (o *OuterComposite) GetMyStringOk() (string, bool)`
+`func (o *OuterComposite) GetMyStringOk() (*string, bool)`
 
 GetMyStringOk returns a tuple with the MyString field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasMyString
-
-`func (o *OuterComposite) HasMyString() bool`
-
-HasMyString returns a boolean if a field has been set.
 
 ### SetMyString
 
 `func (o *OuterComposite) SetMyString(v string)`
 
-SetMyString gets a reference to the given string and assigns it to the MyString field.
+SetMyString sets MyString field to given value.
 
 ### GetMyBoolean
 
@@ -85,22 +73,16 @@ GetMyBoolean returns the MyBoolean field if non-nil, zero value otherwise.
 
 ### GetMyBooleanOk
 
-`func (o *OuterComposite) GetMyBooleanOk() (bool, bool)`
+`func (o *OuterComposite) GetMyBooleanOk() (*bool, bool)`
 
 GetMyBooleanOk returns a tuple with the MyBoolean field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasMyBoolean
-
-`func (o *OuterComposite) HasMyBoolean() bool`
-
-HasMyBoolean returns a boolean if a field has been set.
 
 ### SetMyBoolean
 
 `func (o *OuterComposite) SetMyBoolean(v bool)`
 
-SetMyBoolean gets a reference to the given bool and assigns it to the MyBoolean field.
+SetMyBoolean sets MyBoolean field to given value.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/OuterComposite.md
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/OuterComposite.md
@@ -46,6 +46,12 @@ and a boolean to check if the value has been set.
 
 SetMyNumber sets MyNumber field to given value.
 
+### HasMyNumber
+
+`func (o *OuterComposite) HasMyNumber() bool`
+
+HasMyNumber returns a boolean if a field has been set.
+
 ### GetMyString
 
 `func (o *OuterComposite) GetMyString() string`
@@ -65,6 +71,12 @@ and a boolean to check if the value has been set.
 
 SetMyString sets MyString field to given value.
 
+### HasMyString
+
+`func (o *OuterComposite) HasMyString() bool`
+
+HasMyString returns a boolean if a field has been set.
+
 ### GetMyBoolean
 
 `func (o *OuterComposite) GetMyBoolean() bool`
@@ -83,6 +95,12 @@ and a boolean to check if the value has been set.
 `func (o *OuterComposite) SetMyBoolean(v bool)`
 
 SetMyBoolean sets MyBoolean field to given value.
+
+### HasMyBoolean
+
+`func (o *OuterComposite) HasMyBoolean() bool`
+
+HasMyBoolean returns a boolean if a field has been set.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/Pet.md
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/Pet.md
@@ -49,6 +49,12 @@ and a boolean to check if the value has been set.
 
 SetId sets Id field to given value.
 
+### HasId
+
+`func (o *Pet) HasId() bool`
+
+HasId returns a boolean if a field has been set.
+
 ### GetCategory
 
 `func (o *Pet) GetCategory() Category`
@@ -67,6 +73,12 @@ and a boolean to check if the value has been set.
 `func (o *Pet) SetCategory(v Category)`
 
 SetCategory sets Category field to given value.
+
+### HasCategory
+
+`func (o *Pet) HasCategory() bool`
+
+HasCategory returns a boolean if a field has been set.
 
 ### GetName
 
@@ -87,6 +99,7 @@ and a boolean to check if the value has been set.
 
 SetName sets Name field to given value.
 
+
 ### GetPhotoUrls
 
 `func (o *Pet) GetPhotoUrls() []string`
@@ -105,6 +118,7 @@ and a boolean to check if the value has been set.
 `func (o *Pet) SetPhotoUrls(v []string)`
 
 SetPhotoUrls sets PhotoUrls field to given value.
+
 
 ### GetTags
 
@@ -125,6 +139,12 @@ and a boolean to check if the value has been set.
 
 SetTags sets Tags field to given value.
 
+### HasTags
+
+`func (o *Pet) HasTags() bool`
+
+HasTags returns a boolean if a field has been set.
+
 ### GetStatus
 
 `func (o *Pet) GetStatus() string`
@@ -143,6 +163,12 @@ and a boolean to check if the value has been set.
 `func (o *Pet) SetStatus(v string)`
 
 SetStatus sets Status field to given value.
+
+### HasStatus
+
+`func (o *Pet) HasStatus() bool`
+
+HasStatus returns a boolean if a field has been set.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/Pet.md
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/Pet.md
@@ -38,22 +38,16 @@ GetId returns the Id field if non-nil, zero value otherwise.
 
 ### GetIdOk
 
-`func (o *Pet) GetIdOk() (int64, bool)`
+`func (o *Pet) GetIdOk() (*int64, bool)`
 
 GetIdOk returns a tuple with the Id field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasId
-
-`func (o *Pet) HasId() bool`
-
-HasId returns a boolean if a field has been set.
 
 ### SetId
 
 `func (o *Pet) SetId(v int64)`
 
-SetId gets a reference to the given int64 and assigns it to the Id field.
+SetId sets Id field to given value.
 
 ### GetCategory
 
@@ -63,22 +57,16 @@ GetCategory returns the Category field if non-nil, zero value otherwise.
 
 ### GetCategoryOk
 
-`func (o *Pet) GetCategoryOk() (Category, bool)`
+`func (o *Pet) GetCategoryOk() (*Category, bool)`
 
 GetCategoryOk returns a tuple with the Category field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasCategory
-
-`func (o *Pet) HasCategory() bool`
-
-HasCategory returns a boolean if a field has been set.
 
 ### SetCategory
 
 `func (o *Pet) SetCategory(v Category)`
 
-SetCategory gets a reference to the given Category and assigns it to the Category field.
+SetCategory sets Category field to given value.
 
 ### GetName
 
@@ -88,22 +76,16 @@ GetName returns the Name field if non-nil, zero value otherwise.
 
 ### GetNameOk
 
-`func (o *Pet) GetNameOk() (string, bool)`
+`func (o *Pet) GetNameOk() (*string, bool)`
 
 GetNameOk returns a tuple with the Name field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasName
-
-`func (o *Pet) HasName() bool`
-
-HasName returns a boolean if a field has been set.
 
 ### SetName
 
 `func (o *Pet) SetName(v string)`
 
-SetName gets a reference to the given string and assigns it to the Name field.
+SetName sets Name field to given value.
 
 ### GetPhotoUrls
 
@@ -113,22 +95,16 @@ GetPhotoUrls returns the PhotoUrls field if non-nil, zero value otherwise.
 
 ### GetPhotoUrlsOk
 
-`func (o *Pet) GetPhotoUrlsOk() ([]string, bool)`
+`func (o *Pet) GetPhotoUrlsOk() (*[]string, bool)`
 
 GetPhotoUrlsOk returns a tuple with the PhotoUrls field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasPhotoUrls
-
-`func (o *Pet) HasPhotoUrls() bool`
-
-HasPhotoUrls returns a boolean if a field has been set.
 
 ### SetPhotoUrls
 
 `func (o *Pet) SetPhotoUrls(v []string)`
 
-SetPhotoUrls gets a reference to the given []string and assigns it to the PhotoUrls field.
+SetPhotoUrls sets PhotoUrls field to given value.
 
 ### GetTags
 
@@ -138,22 +114,16 @@ GetTags returns the Tags field if non-nil, zero value otherwise.
 
 ### GetTagsOk
 
-`func (o *Pet) GetTagsOk() ([]Tag, bool)`
+`func (o *Pet) GetTagsOk() (*[]Tag, bool)`
 
 GetTagsOk returns a tuple with the Tags field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasTags
-
-`func (o *Pet) HasTags() bool`
-
-HasTags returns a boolean if a field has been set.
 
 ### SetTags
 
 `func (o *Pet) SetTags(v []Tag)`
 
-SetTags gets a reference to the given []Tag and assigns it to the Tags field.
+SetTags sets Tags field to given value.
 
 ### GetStatus
 
@@ -163,22 +133,16 @@ GetStatus returns the Status field if non-nil, zero value otherwise.
 
 ### GetStatusOk
 
-`func (o *Pet) GetStatusOk() (string, bool)`
+`func (o *Pet) GetStatusOk() (*string, bool)`
 
 GetStatusOk returns a tuple with the Status field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasStatus
-
-`func (o *Pet) HasStatus() bool`
-
-HasStatus returns a boolean if a field has been set.
 
 ### SetStatus
 
 `func (o *Pet) SetStatus(v string)`
 
-SetStatus gets a reference to the given string and assigns it to the Status field.
+SetStatus sets Status field to given value.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/ReadOnlyFirst.md
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/ReadOnlyFirst.md
@@ -34,22 +34,16 @@ GetBar returns the Bar field if non-nil, zero value otherwise.
 
 ### GetBarOk
 
-`func (o *ReadOnlyFirst) GetBarOk() (string, bool)`
+`func (o *ReadOnlyFirst) GetBarOk() (*string, bool)`
 
 GetBarOk returns a tuple with the Bar field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasBar
-
-`func (o *ReadOnlyFirst) HasBar() bool`
-
-HasBar returns a boolean if a field has been set.
 
 ### SetBar
 
 `func (o *ReadOnlyFirst) SetBar(v string)`
 
-SetBar gets a reference to the given string and assigns it to the Bar field.
+SetBar sets Bar field to given value.
 
 ### GetBaz
 
@@ -59,22 +53,16 @@ GetBaz returns the Baz field if non-nil, zero value otherwise.
 
 ### GetBazOk
 
-`func (o *ReadOnlyFirst) GetBazOk() (string, bool)`
+`func (o *ReadOnlyFirst) GetBazOk() (*string, bool)`
 
 GetBazOk returns a tuple with the Baz field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasBaz
-
-`func (o *ReadOnlyFirst) HasBaz() bool`
-
-HasBaz returns a boolean if a field has been set.
 
 ### SetBaz
 
 `func (o *ReadOnlyFirst) SetBaz(v string)`
 
-SetBaz gets a reference to the given string and assigns it to the Baz field.
+SetBaz sets Baz field to given value.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/ReadOnlyFirst.md
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/ReadOnlyFirst.md
@@ -45,6 +45,12 @@ and a boolean to check if the value has been set.
 
 SetBar sets Bar field to given value.
 
+### HasBar
+
+`func (o *ReadOnlyFirst) HasBar() bool`
+
+HasBar returns a boolean if a field has been set.
+
 ### GetBaz
 
 `func (o *ReadOnlyFirst) GetBaz() string`
@@ -63,6 +69,12 @@ and a boolean to check if the value has been set.
 `func (o *ReadOnlyFirst) SetBaz(v string)`
 
 SetBaz sets Baz field to given value.
+
+### HasBaz
+
+`func (o *ReadOnlyFirst) HasBaz() bool`
+
+HasBaz returns a boolean if a field has been set.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/Return.md
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/Return.md
@@ -33,22 +33,16 @@ GetReturn returns the Return field if non-nil, zero value otherwise.
 
 ### GetReturnOk
 
-`func (o *Return) GetReturnOk() (int32, bool)`
+`func (o *Return) GetReturnOk() (*int32, bool)`
 
 GetReturnOk returns a tuple with the Return field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasReturn
-
-`func (o *Return) HasReturn() bool`
-
-HasReturn returns a boolean if a field has been set.
 
 ### SetReturn
 
 `func (o *Return) SetReturn(v int32)`
 
-SetReturn gets a reference to the given int32 and assigns it to the Return field.
+SetReturn sets Return field to given value.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/Return.md
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/Return.md
@@ -44,6 +44,12 @@ and a boolean to check if the value has been set.
 
 SetReturn sets Return field to given value.
 
+### HasReturn
+
+`func (o *Return) HasReturn() bool`
+
+HasReturn returns a boolean if a field has been set.
+
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/SpecialModelName.md
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/SpecialModelName.md
@@ -33,22 +33,16 @@ GetSpecialPropertyName returns the SpecialPropertyName field if non-nil, zero va
 
 ### GetSpecialPropertyNameOk
 
-`func (o *SpecialModelName) GetSpecialPropertyNameOk() (int64, bool)`
+`func (o *SpecialModelName) GetSpecialPropertyNameOk() (*int64, bool)`
 
 GetSpecialPropertyNameOk returns a tuple with the SpecialPropertyName field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasSpecialPropertyName
-
-`func (o *SpecialModelName) HasSpecialPropertyName() bool`
-
-HasSpecialPropertyName returns a boolean if a field has been set.
 
 ### SetSpecialPropertyName
 
 `func (o *SpecialModelName) SetSpecialPropertyName(v int64)`
 
-SetSpecialPropertyName gets a reference to the given int64 and assigns it to the SpecialPropertyName field.
+SetSpecialPropertyName sets SpecialPropertyName field to given value.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/SpecialModelName.md
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/SpecialModelName.md
@@ -44,6 +44,12 @@ and a boolean to check if the value has been set.
 
 SetSpecialPropertyName sets SpecialPropertyName field to given value.
 
+### HasSpecialPropertyName
+
+`func (o *SpecialModelName) HasSpecialPropertyName() bool`
+
+HasSpecialPropertyName returns a boolean if a field has been set.
+
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/Tag.md
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/Tag.md
@@ -34,22 +34,16 @@ GetId returns the Id field if non-nil, zero value otherwise.
 
 ### GetIdOk
 
-`func (o *Tag) GetIdOk() (int64, bool)`
+`func (o *Tag) GetIdOk() (*int64, bool)`
 
 GetIdOk returns a tuple with the Id field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasId
-
-`func (o *Tag) HasId() bool`
-
-HasId returns a boolean if a field has been set.
 
 ### SetId
 
 `func (o *Tag) SetId(v int64)`
 
-SetId gets a reference to the given int64 and assigns it to the Id field.
+SetId sets Id field to given value.
 
 ### GetName
 
@@ -59,22 +53,16 @@ GetName returns the Name field if non-nil, zero value otherwise.
 
 ### GetNameOk
 
-`func (o *Tag) GetNameOk() (string, bool)`
+`func (o *Tag) GetNameOk() (*string, bool)`
 
 GetNameOk returns a tuple with the Name field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasName
-
-`func (o *Tag) HasName() bool`
-
-HasName returns a boolean if a field has been set.
 
 ### SetName
 
 `func (o *Tag) SetName(v string)`
 
-SetName gets a reference to the given string and assigns it to the Name field.
+SetName sets Name field to given value.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/Tag.md
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/Tag.md
@@ -45,6 +45,12 @@ and a boolean to check if the value has been set.
 
 SetId sets Id field to given value.
 
+### HasId
+
+`func (o *Tag) HasId() bool`
+
+HasId returns a boolean if a field has been set.
+
 ### GetName
 
 `func (o *Tag) GetName() string`
@@ -63,6 +69,12 @@ and a boolean to check if the value has been set.
 `func (o *Tag) SetName(v string)`
 
 SetName sets Name field to given value.
+
+### HasName
+
+`func (o *Tag) HasName() bool`
+
+HasName returns a boolean if a field has been set.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/User.md
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/User.md
@@ -51,6 +51,12 @@ and a boolean to check if the value has been set.
 
 SetId sets Id field to given value.
 
+### HasId
+
+`func (o *User) HasId() bool`
+
+HasId returns a boolean if a field has been set.
+
 ### GetUsername
 
 `func (o *User) GetUsername() string`
@@ -69,6 +75,12 @@ and a boolean to check if the value has been set.
 `func (o *User) SetUsername(v string)`
 
 SetUsername sets Username field to given value.
+
+### HasUsername
+
+`func (o *User) HasUsername() bool`
+
+HasUsername returns a boolean if a field has been set.
 
 ### GetFirstName
 
@@ -89,6 +101,12 @@ and a boolean to check if the value has been set.
 
 SetFirstName sets FirstName field to given value.
 
+### HasFirstName
+
+`func (o *User) HasFirstName() bool`
+
+HasFirstName returns a boolean if a field has been set.
+
 ### GetLastName
 
 `func (o *User) GetLastName() string`
@@ -107,6 +125,12 @@ and a boolean to check if the value has been set.
 `func (o *User) SetLastName(v string)`
 
 SetLastName sets LastName field to given value.
+
+### HasLastName
+
+`func (o *User) HasLastName() bool`
+
+HasLastName returns a boolean if a field has been set.
 
 ### GetEmail
 
@@ -127,6 +151,12 @@ and a boolean to check if the value has been set.
 
 SetEmail sets Email field to given value.
 
+### HasEmail
+
+`func (o *User) HasEmail() bool`
+
+HasEmail returns a boolean if a field has been set.
+
 ### GetPassword
 
 `func (o *User) GetPassword() string`
@@ -145,6 +175,12 @@ and a boolean to check if the value has been set.
 `func (o *User) SetPassword(v string)`
 
 SetPassword sets Password field to given value.
+
+### HasPassword
+
+`func (o *User) HasPassword() bool`
+
+HasPassword returns a boolean if a field has been set.
 
 ### GetPhone
 
@@ -165,6 +201,12 @@ and a boolean to check if the value has been set.
 
 SetPhone sets Phone field to given value.
 
+### HasPhone
+
+`func (o *User) HasPhone() bool`
+
+HasPhone returns a boolean if a field has been set.
+
 ### GetUserStatus
 
 `func (o *User) GetUserStatus() int32`
@@ -183,6 +225,12 @@ and a boolean to check if the value has been set.
 `func (o *User) SetUserStatus(v int32)`
 
 SetUserStatus sets UserStatus field to given value.
+
+### HasUserStatus
+
+`func (o *User) HasUserStatus() bool`
+
+HasUserStatus returns a boolean if a field has been set.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/User.md
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/User.md
@@ -40,22 +40,16 @@ GetId returns the Id field if non-nil, zero value otherwise.
 
 ### GetIdOk
 
-`func (o *User) GetIdOk() (int64, bool)`
+`func (o *User) GetIdOk() (*int64, bool)`
 
 GetIdOk returns a tuple with the Id field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasId
-
-`func (o *User) HasId() bool`
-
-HasId returns a boolean if a field has been set.
 
 ### SetId
 
 `func (o *User) SetId(v int64)`
 
-SetId gets a reference to the given int64 and assigns it to the Id field.
+SetId sets Id field to given value.
 
 ### GetUsername
 
@@ -65,22 +59,16 @@ GetUsername returns the Username field if non-nil, zero value otherwise.
 
 ### GetUsernameOk
 
-`func (o *User) GetUsernameOk() (string, bool)`
+`func (o *User) GetUsernameOk() (*string, bool)`
 
 GetUsernameOk returns a tuple with the Username field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasUsername
-
-`func (o *User) HasUsername() bool`
-
-HasUsername returns a boolean if a field has been set.
 
 ### SetUsername
 
 `func (o *User) SetUsername(v string)`
 
-SetUsername gets a reference to the given string and assigns it to the Username field.
+SetUsername sets Username field to given value.
 
 ### GetFirstName
 
@@ -90,22 +78,16 @@ GetFirstName returns the FirstName field if non-nil, zero value otherwise.
 
 ### GetFirstNameOk
 
-`func (o *User) GetFirstNameOk() (string, bool)`
+`func (o *User) GetFirstNameOk() (*string, bool)`
 
 GetFirstNameOk returns a tuple with the FirstName field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasFirstName
-
-`func (o *User) HasFirstName() bool`
-
-HasFirstName returns a boolean if a field has been set.
 
 ### SetFirstName
 
 `func (o *User) SetFirstName(v string)`
 
-SetFirstName gets a reference to the given string and assigns it to the FirstName field.
+SetFirstName sets FirstName field to given value.
 
 ### GetLastName
 
@@ -115,22 +97,16 @@ GetLastName returns the LastName field if non-nil, zero value otherwise.
 
 ### GetLastNameOk
 
-`func (o *User) GetLastNameOk() (string, bool)`
+`func (o *User) GetLastNameOk() (*string, bool)`
 
 GetLastNameOk returns a tuple with the LastName field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasLastName
-
-`func (o *User) HasLastName() bool`
-
-HasLastName returns a boolean if a field has been set.
 
 ### SetLastName
 
 `func (o *User) SetLastName(v string)`
 
-SetLastName gets a reference to the given string and assigns it to the LastName field.
+SetLastName sets LastName field to given value.
 
 ### GetEmail
 
@@ -140,22 +116,16 @@ GetEmail returns the Email field if non-nil, zero value otherwise.
 
 ### GetEmailOk
 
-`func (o *User) GetEmailOk() (string, bool)`
+`func (o *User) GetEmailOk() (*string, bool)`
 
 GetEmailOk returns a tuple with the Email field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasEmail
-
-`func (o *User) HasEmail() bool`
-
-HasEmail returns a boolean if a field has been set.
 
 ### SetEmail
 
 `func (o *User) SetEmail(v string)`
 
-SetEmail gets a reference to the given string and assigns it to the Email field.
+SetEmail sets Email field to given value.
 
 ### GetPassword
 
@@ -165,22 +135,16 @@ GetPassword returns the Password field if non-nil, zero value otherwise.
 
 ### GetPasswordOk
 
-`func (o *User) GetPasswordOk() (string, bool)`
+`func (o *User) GetPasswordOk() (*string, bool)`
 
 GetPasswordOk returns a tuple with the Password field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasPassword
-
-`func (o *User) HasPassword() bool`
-
-HasPassword returns a boolean if a field has been set.
 
 ### SetPassword
 
 `func (o *User) SetPassword(v string)`
 
-SetPassword gets a reference to the given string and assigns it to the Password field.
+SetPassword sets Password field to given value.
 
 ### GetPhone
 
@@ -190,22 +154,16 @@ GetPhone returns the Phone field if non-nil, zero value otherwise.
 
 ### GetPhoneOk
 
-`func (o *User) GetPhoneOk() (string, bool)`
+`func (o *User) GetPhoneOk() (*string, bool)`
 
 GetPhoneOk returns a tuple with the Phone field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasPhone
-
-`func (o *User) HasPhone() bool`
-
-HasPhone returns a boolean if a field has been set.
 
 ### SetPhone
 
 `func (o *User) SetPhone(v string)`
 
-SetPhone gets a reference to the given string and assigns it to the Phone field.
+SetPhone sets Phone field to given value.
 
 ### GetUserStatus
 
@@ -215,22 +173,16 @@ GetUserStatus returns the UserStatus field if non-nil, zero value otherwise.
 
 ### GetUserStatusOk
 
-`func (o *User) GetUserStatusOk() (int32, bool)`
+`func (o *User) GetUserStatusOk() (*int32, bool)`
 
 GetUserStatusOk returns a tuple with the UserStatus field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasUserStatus
-
-`func (o *User) HasUserStatus() bool`
-
-HasUserStatus returns a boolean if a field has been set.
 
 ### SetUserStatus
 
 `func (o *User) SetUserStatus(v int32)`
 
-SetUserStatus gets a reference to the given int32 and assigns it to the UserStatus field.
+SetUserStatus sets UserStatus field to given value.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_200_response.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_200_response.go
@@ -24,16 +24,16 @@ type Model200Response struct {
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
 func NewModel200Response() *Model200Response {
-    this := Model200Response{}
-    return &this
+	this := Model200Response{}
+	return &this
 }
 
 // NewModel200ResponseWithDefaults instantiates a new Model200Response object
 // This constructor will only assign default values to properties that have it defined,
 // but it doesn't guarantee that properties required by API are set
 func NewModel200ResponseWithDefaults() *Model200Response {
-    this := Model200Response{}
-    return &this
+	this := Model200Response{}
+	return &this
 }
 
 // GetName returns the Name field value if set, zero value otherwise.
@@ -45,14 +45,14 @@ func (o *Model200Response) GetName() int32 {
 	return *o.Name
 }
 
-// GetNameOk returns a tuple with the Name field value if set, zero value otherwise
+// GetNameOk returns a tuple with the Name field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *Model200Response) GetNameOk() (int32, bool) {
+
+func (o *Model200Response) GetNameOk() (*int32, bool) {
 	if o == nil || o.Name == nil {
-		var ret int32
-		return ret, false
+		return nil, false
 	}
-	return *o.Name, true
+	return o.Name, true
 }
 
 // HasName returns a boolean if a field has been set.
@@ -78,14 +78,14 @@ func (o *Model200Response) GetClass() string {
 	return *o.Class
 }
 
-// GetClassOk returns a tuple with the Class field value if set, zero value otherwise
+// GetClassOk returns a tuple with the Class field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *Model200Response) GetClassOk() (string, bool) {
+
+func (o *Model200Response) GetClassOk() (*string, bool) {
 	if o == nil || o.Class == nil {
-		var ret string
-		return ret, false
+		return nil, false
 	}
-	return *o.Class, true
+	return o.Class, true
 }
 
 // HasClass returns a boolean if a field has been set.

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_200_response.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_200_response.go
@@ -10,7 +10,6 @@
 package petstore
 
 import (
-	"bytes"
 	"encoding/json"
 )
 
@@ -53,12 +52,12 @@ func (o *Model200Response) GetNameOk() (int32, bool) {
 		var ret int32
 		return ret, false
 	}
-	return *o.Name, true
+    return *o.Name, true
 }
 
 // HasName returns a boolean if a field has been set.
 func (o *Model200Response) HasName() bool {
-	if o != nil && o.Name != nil {
+    if o != nil && o.Name != nil {
 		return true
 	}
 
@@ -86,12 +85,12 @@ func (o *Model200Response) GetClassOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-	return *o.Class, true
+    return *o.Class, true
 }
 
 // HasClass returns a boolean if a field has been set.
 func (o *Model200Response) HasClass() bool {
-	if o != nil && o.Class != nil {
+    if o != nil && o.Class != nil {
 		return true
 	}
 
@@ -103,25 +102,49 @@ func (o *Model200Response) SetClass(v string) {
 	o.Class = &v
 }
 
+func (o Model200Response) MarshalJSON() ([]byte, error) {
+    toSerialize := map[string]interface{}{}
+    if o.Name != nil {
+        toSerialize["name"] = o.Name
+    }
+    if o.Class != nil {
+        toSerialize["class"] = o.Class
+    }
+    return json.Marshal(toSerialize)
+}
+
 type NullableModel200Response struct {
-	Value Model200Response
-	ExplicitNull bool
+	value *Model200Response
+	isSet bool
+}
+
+func (v NullableModel200Response) Get() *Model200Response {
+    return v.value
+}
+
+func (v NullableModel200Response) Set(val *Model200Response) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableModel200Response) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableModel200Response) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableModel200Response(val *Model200Response) *NullableModel200Response {
+    return &NullableModel200Response{value: val, isSet: true}
 }
 
 func (v NullableModel200Response) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-		return json.Marshal(v.Value)
-	}
+    return json.Marshal(v.value)
 }
 
 func (v *NullableModel200Response) UnmarshalJSON(src []byte) error {
-	if bytes.Equal(src, []byte("null")) {
-		v.ExplicitNull = true
-		return nil
-	}
-
-	return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_200_response.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_200_response.go
@@ -52,12 +52,12 @@ func (o *Model200Response) GetNameOk() (int32, bool) {
 		var ret int32
 		return ret, false
 	}
-    return *o.Name, true
+	return *o.Name, true
 }
 
 // HasName returns a boolean if a field has been set.
 func (o *Model200Response) HasName() bool {
-    if o != nil && o.Name != nil {
+	if o != nil && o.Name != nil {
 		return true
 	}
 
@@ -85,12 +85,12 @@ func (o *Model200Response) GetClassOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-    return *o.Class, true
+	return *o.Class, true
 }
 
 // HasClass returns a boolean if a field has been set.
 func (o *Model200Response) HasClass() bool {
-    if o != nil && o.Class != nil {
+	if o != nil && o.Class != nil {
 		return true
 	}
 
@@ -103,14 +103,14 @@ func (o *Model200Response) SetClass(v string) {
 }
 
 func (o Model200Response) MarshalJSON() ([]byte, error) {
-    toSerialize := map[string]interface{}{}
-    if o.Name != nil {
-        toSerialize["name"] = o.Name
-    }
-    if o.Class != nil {
-        toSerialize["class"] = o.Class
-    }
-    return json.Marshal(toSerialize)
+	toSerialize := map[string]interface{}{}
+	if o.Name != nil {
+		toSerialize["name"] = o.Name
+	}
+	if o.Class != nil {
+		toSerialize["class"] = o.Class
+	}
+	return json.Marshal(toSerialize)
 }
 
 type NullableModel200Response struct {
@@ -119,32 +119,32 @@ type NullableModel200Response struct {
 }
 
 func (v NullableModel200Response) Get() *Model200Response {
-    return v.value
+	return v.value
 }
 
 func (v NullableModel200Response) Set(val *Model200Response) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableModel200Response) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableModel200Response) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableModel200Response(val *Model200Response) *NullableModel200Response {
-    return &NullableModel200Response{value: val, isSet: true}
+	return &NullableModel200Response{value: val, isSet: true}
 }
 
 func (v NullableModel200Response) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableModel200Response) UnmarshalJSON(src []byte) error {
-    v.isSet = true
+	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_200_response.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_200_response.go
@@ -47,7 +47,6 @@ func (o *Model200Response) GetName() int32 {
 
 // GetNameOk returns a tuple with the Name field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *Model200Response) GetNameOk() (*int32, bool) {
 	if o == nil || o.Name == nil {
 		return nil, false
@@ -80,7 +79,6 @@ func (o *Model200Response) GetClass() string {
 
 // GetClassOk returns a tuple with the Class field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *Model200Response) GetClassOk() (*string, bool) {
 	if o == nil || o.Class == nil {
 		return nil, false

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_200_response.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_200_response.go
@@ -122,7 +122,7 @@ func (v NullableModel200Response) Get() *Model200Response {
 	return v.value
 }
 
-func (v NullableModel200Response) Set(val *Model200Response) {
+func (v *NullableModel200Response) Set(val *Model200Response) {
 	v.value = val
 	v.isSet = true
 }
@@ -131,7 +131,7 @@ func (v NullableModel200Response) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableModel200Response) Unset() {
+func (v *NullableModel200Response) Unset() {
 	v.value = nil
 	v.isSet = false
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model__special_model_name_.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model__special_model_name_.go
@@ -10,7 +10,6 @@
 package petstore
 
 import (
-	"bytes"
 	"encoding/json"
 )
 
@@ -52,12 +51,12 @@ func (o *SpecialModelName) GetSpecialPropertyNameOk() (int64, bool) {
 		var ret int64
 		return ret, false
 	}
-	return *o.SpecialPropertyName, true
+    return *o.SpecialPropertyName, true
 }
 
 // HasSpecialPropertyName returns a boolean if a field has been set.
 func (o *SpecialModelName) HasSpecialPropertyName() bool {
-	if o != nil && o.SpecialPropertyName != nil {
+    if o != nil && o.SpecialPropertyName != nil {
 		return true
 	}
 
@@ -69,25 +68,46 @@ func (o *SpecialModelName) SetSpecialPropertyName(v int64) {
 	o.SpecialPropertyName = &v
 }
 
+func (o SpecialModelName) MarshalJSON() ([]byte, error) {
+    toSerialize := map[string]interface{}{}
+    if o.SpecialPropertyName != nil {
+        toSerialize["$special[property.name]"] = o.SpecialPropertyName
+    }
+    return json.Marshal(toSerialize)
+}
+
 type NullableSpecialModelName struct {
-	Value SpecialModelName
-	ExplicitNull bool
+	value *SpecialModelName
+	isSet bool
+}
+
+func (v NullableSpecialModelName) Get() *SpecialModelName {
+    return v.value
+}
+
+func (v NullableSpecialModelName) Set(val *SpecialModelName) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableSpecialModelName) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableSpecialModelName) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableSpecialModelName(val *SpecialModelName) *NullableSpecialModelName {
+    return &NullableSpecialModelName{value: val, isSet: true}
 }
 
 func (v NullableSpecialModelName) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-		return json.Marshal(v.Value)
-	}
+    return json.Marshal(v.value)
 }
 
 func (v *NullableSpecialModelName) UnmarshalJSON(src []byte) error {
-	if bytes.Equal(src, []byte("null")) {
-		v.ExplicitNull = true
-		return nil
-	}
-
-	return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model__special_model_name_.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model__special_model_name_.go
@@ -51,12 +51,12 @@ func (o *SpecialModelName) GetSpecialPropertyNameOk() (int64, bool) {
 		var ret int64
 		return ret, false
 	}
-    return *o.SpecialPropertyName, true
+	return *o.SpecialPropertyName, true
 }
 
 // HasSpecialPropertyName returns a boolean if a field has been set.
 func (o *SpecialModelName) HasSpecialPropertyName() bool {
-    if o != nil && o.SpecialPropertyName != nil {
+	if o != nil && o.SpecialPropertyName != nil {
 		return true
 	}
 
@@ -69,11 +69,11 @@ func (o *SpecialModelName) SetSpecialPropertyName(v int64) {
 }
 
 func (o SpecialModelName) MarshalJSON() ([]byte, error) {
-    toSerialize := map[string]interface{}{}
-    if o.SpecialPropertyName != nil {
-        toSerialize["$special[property.name]"] = o.SpecialPropertyName
-    }
-    return json.Marshal(toSerialize)
+	toSerialize := map[string]interface{}{}
+	if o.SpecialPropertyName != nil {
+		toSerialize["$special[property.name]"] = o.SpecialPropertyName
+	}
+	return json.Marshal(toSerialize)
 }
 
 type NullableSpecialModelName struct {
@@ -82,32 +82,32 @@ type NullableSpecialModelName struct {
 }
 
 func (v NullableSpecialModelName) Get() *SpecialModelName {
-    return v.value
+	return v.value
 }
 
 func (v NullableSpecialModelName) Set(val *SpecialModelName) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableSpecialModelName) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableSpecialModelName) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableSpecialModelName(val *SpecialModelName) *NullableSpecialModelName {
-    return &NullableSpecialModelName{value: val, isSet: true}
+	return &NullableSpecialModelName{value: val, isSet: true}
 }
 
 func (v NullableSpecialModelName) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableSpecialModelName) UnmarshalJSON(src []byte) error {
-    v.isSet = true
+	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model__special_model_name_.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model__special_model_name_.go
@@ -85,7 +85,7 @@ func (v NullableSpecialModelName) Get() *SpecialModelName {
 	return v.value
 }
 
-func (v NullableSpecialModelName) Set(val *SpecialModelName) {
+func (v *NullableSpecialModelName) Set(val *SpecialModelName) {
 	v.value = val
 	v.isSet = true
 }
@@ -94,7 +94,7 @@ func (v NullableSpecialModelName) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableSpecialModelName) Unset() {
+func (v *NullableSpecialModelName) Unset() {
 	v.value = nil
 	v.isSet = false
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model__special_model_name_.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model__special_model_name_.go
@@ -23,16 +23,16 @@ type SpecialModelName struct {
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
 func NewSpecialModelName() *SpecialModelName {
-    this := SpecialModelName{}
-    return &this
+	this := SpecialModelName{}
+	return &this
 }
 
 // NewSpecialModelNameWithDefaults instantiates a new SpecialModelName object
 // This constructor will only assign default values to properties that have it defined,
 // but it doesn't guarantee that properties required by API are set
 func NewSpecialModelNameWithDefaults() *SpecialModelName {
-    this := SpecialModelName{}
-    return &this
+	this := SpecialModelName{}
+	return &this
 }
 
 // GetSpecialPropertyName returns the SpecialPropertyName field value if set, zero value otherwise.
@@ -44,14 +44,14 @@ func (o *SpecialModelName) GetSpecialPropertyName() int64 {
 	return *o.SpecialPropertyName
 }
 
-// GetSpecialPropertyNameOk returns a tuple with the SpecialPropertyName field value if set, zero value otherwise
+// GetSpecialPropertyNameOk returns a tuple with the SpecialPropertyName field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *SpecialModelName) GetSpecialPropertyNameOk() (int64, bool) {
+
+func (o *SpecialModelName) GetSpecialPropertyNameOk() (*int64, bool) {
 	if o == nil || o.SpecialPropertyName == nil {
-		var ret int64
-		return ret, false
+		return nil, false
 	}
-	return *o.SpecialPropertyName, true
+	return o.SpecialPropertyName, true
 }
 
 // HasSpecialPropertyName returns a boolean if a field has been set.

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model__special_model_name_.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model__special_model_name_.go
@@ -46,7 +46,6 @@ func (o *SpecialModelName) GetSpecialPropertyName() int64 {
 
 // GetSpecialPropertyNameOk returns a tuple with the SpecialPropertyName field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *SpecialModelName) GetSpecialPropertyNameOk() (*int64, bool) {
 	if o == nil || o.SpecialPropertyName == nil {
 		return nil, false

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_additional_properties_class.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_additional_properties_class.go
@@ -10,7 +10,6 @@
 package petstore
 
 import (
-	"bytes"
 	"encoding/json"
 )
 
@@ -53,12 +52,12 @@ func (o *AdditionalPropertiesClass) GetMapPropertyOk() (map[string]string, bool)
 		var ret map[string]string
 		return ret, false
 	}
-	return *o.MapProperty, true
+    return *o.MapProperty, true
 }
 
 // HasMapProperty returns a boolean if a field has been set.
 func (o *AdditionalPropertiesClass) HasMapProperty() bool {
-	if o != nil && o.MapProperty != nil {
+    if o != nil && o.MapProperty != nil {
 		return true
 	}
 
@@ -86,12 +85,12 @@ func (o *AdditionalPropertiesClass) GetMapOfMapPropertyOk() (map[string]map[stri
 		var ret map[string]map[string]string
 		return ret, false
 	}
-	return *o.MapOfMapProperty, true
+    return *o.MapOfMapProperty, true
 }
 
 // HasMapOfMapProperty returns a boolean if a field has been set.
 func (o *AdditionalPropertiesClass) HasMapOfMapProperty() bool {
-	if o != nil && o.MapOfMapProperty != nil {
+    if o != nil && o.MapOfMapProperty != nil {
 		return true
 	}
 
@@ -103,25 +102,49 @@ func (o *AdditionalPropertiesClass) SetMapOfMapProperty(v map[string]map[string]
 	o.MapOfMapProperty = &v
 }
 
+func (o AdditionalPropertiesClass) MarshalJSON() ([]byte, error) {
+    toSerialize := map[string]interface{}{}
+    if o.MapProperty != nil {
+        toSerialize["map_property"] = o.MapProperty
+    }
+    if o.MapOfMapProperty != nil {
+        toSerialize["map_of_map_property"] = o.MapOfMapProperty
+    }
+    return json.Marshal(toSerialize)
+}
+
 type NullableAdditionalPropertiesClass struct {
-	Value AdditionalPropertiesClass
-	ExplicitNull bool
+	value *AdditionalPropertiesClass
+	isSet bool
+}
+
+func (v NullableAdditionalPropertiesClass) Get() *AdditionalPropertiesClass {
+    return v.value
+}
+
+func (v NullableAdditionalPropertiesClass) Set(val *AdditionalPropertiesClass) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableAdditionalPropertiesClass) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableAdditionalPropertiesClass) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableAdditionalPropertiesClass(val *AdditionalPropertiesClass) *NullableAdditionalPropertiesClass {
+    return &NullableAdditionalPropertiesClass{value: val, isSet: true}
 }
 
 func (v NullableAdditionalPropertiesClass) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-		return json.Marshal(v.Value)
-	}
+    return json.Marshal(v.value)
 }
 
 func (v *NullableAdditionalPropertiesClass) UnmarshalJSON(src []byte) error {
-	if bytes.Equal(src, []byte("null")) {
-		v.ExplicitNull = true
-		return nil
-	}
-
-	return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_additional_properties_class.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_additional_properties_class.go
@@ -122,7 +122,7 @@ func (v NullableAdditionalPropertiesClass) Get() *AdditionalPropertiesClass {
 	return v.value
 }
 
-func (v NullableAdditionalPropertiesClass) Set(val *AdditionalPropertiesClass) {
+func (v *NullableAdditionalPropertiesClass) Set(val *AdditionalPropertiesClass) {
 	v.value = val
 	v.isSet = true
 }
@@ -131,7 +131,7 @@ func (v NullableAdditionalPropertiesClass) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableAdditionalPropertiesClass) Unset() {
+func (v *NullableAdditionalPropertiesClass) Unset() {
 	v.value = nil
 	v.isSet = false
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_additional_properties_class.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_additional_properties_class.go
@@ -24,16 +24,16 @@ type AdditionalPropertiesClass struct {
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
 func NewAdditionalPropertiesClass() *AdditionalPropertiesClass {
-    this := AdditionalPropertiesClass{}
-    return &this
+	this := AdditionalPropertiesClass{}
+	return &this
 }
 
 // NewAdditionalPropertiesClassWithDefaults instantiates a new AdditionalPropertiesClass object
 // This constructor will only assign default values to properties that have it defined,
 // but it doesn't guarantee that properties required by API are set
 func NewAdditionalPropertiesClassWithDefaults() *AdditionalPropertiesClass {
-    this := AdditionalPropertiesClass{}
-    return &this
+	this := AdditionalPropertiesClass{}
+	return &this
 }
 
 // GetMapProperty returns the MapProperty field value if set, zero value otherwise.
@@ -45,14 +45,14 @@ func (o *AdditionalPropertiesClass) GetMapProperty() map[string]string {
 	return *o.MapProperty
 }
 
-// GetMapPropertyOk returns a tuple with the MapProperty field value if set, zero value otherwise
+// GetMapPropertyOk returns a tuple with the MapProperty field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *AdditionalPropertiesClass) GetMapPropertyOk() (map[string]string, bool) {
+
+func (o *AdditionalPropertiesClass) GetMapPropertyOk() (*map[string]string, bool) {
 	if o == nil || o.MapProperty == nil {
-		var ret map[string]string
-		return ret, false
+		return nil, false
 	}
-	return *o.MapProperty, true
+	return o.MapProperty, true
 }
 
 // HasMapProperty returns a boolean if a field has been set.
@@ -78,14 +78,14 @@ func (o *AdditionalPropertiesClass) GetMapOfMapProperty() map[string]map[string]
 	return *o.MapOfMapProperty
 }
 
-// GetMapOfMapPropertyOk returns a tuple with the MapOfMapProperty field value if set, zero value otherwise
+// GetMapOfMapPropertyOk returns a tuple with the MapOfMapProperty field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *AdditionalPropertiesClass) GetMapOfMapPropertyOk() (map[string]map[string]string, bool) {
+
+func (o *AdditionalPropertiesClass) GetMapOfMapPropertyOk() (*map[string]map[string]string, bool) {
 	if o == nil || o.MapOfMapProperty == nil {
-		var ret map[string]map[string]string
-		return ret, false
+		return nil, false
 	}
-	return *o.MapOfMapProperty, true
+	return o.MapOfMapProperty, true
 }
 
 // HasMapOfMapProperty returns a boolean if a field has been set.

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_additional_properties_class.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_additional_properties_class.go
@@ -52,12 +52,12 @@ func (o *AdditionalPropertiesClass) GetMapPropertyOk() (map[string]string, bool)
 		var ret map[string]string
 		return ret, false
 	}
-    return *o.MapProperty, true
+	return *o.MapProperty, true
 }
 
 // HasMapProperty returns a boolean if a field has been set.
 func (o *AdditionalPropertiesClass) HasMapProperty() bool {
-    if o != nil && o.MapProperty != nil {
+	if o != nil && o.MapProperty != nil {
 		return true
 	}
 
@@ -85,12 +85,12 @@ func (o *AdditionalPropertiesClass) GetMapOfMapPropertyOk() (map[string]map[stri
 		var ret map[string]map[string]string
 		return ret, false
 	}
-    return *o.MapOfMapProperty, true
+	return *o.MapOfMapProperty, true
 }
 
 // HasMapOfMapProperty returns a boolean if a field has been set.
 func (o *AdditionalPropertiesClass) HasMapOfMapProperty() bool {
-    if o != nil && o.MapOfMapProperty != nil {
+	if o != nil && o.MapOfMapProperty != nil {
 		return true
 	}
 
@@ -103,14 +103,14 @@ func (o *AdditionalPropertiesClass) SetMapOfMapProperty(v map[string]map[string]
 }
 
 func (o AdditionalPropertiesClass) MarshalJSON() ([]byte, error) {
-    toSerialize := map[string]interface{}{}
-    if o.MapProperty != nil {
-        toSerialize["map_property"] = o.MapProperty
-    }
-    if o.MapOfMapProperty != nil {
-        toSerialize["map_of_map_property"] = o.MapOfMapProperty
-    }
-    return json.Marshal(toSerialize)
+	toSerialize := map[string]interface{}{}
+	if o.MapProperty != nil {
+		toSerialize["map_property"] = o.MapProperty
+	}
+	if o.MapOfMapProperty != nil {
+		toSerialize["map_of_map_property"] = o.MapOfMapProperty
+	}
+	return json.Marshal(toSerialize)
 }
 
 type NullableAdditionalPropertiesClass struct {
@@ -119,32 +119,32 @@ type NullableAdditionalPropertiesClass struct {
 }
 
 func (v NullableAdditionalPropertiesClass) Get() *AdditionalPropertiesClass {
-    return v.value
+	return v.value
 }
 
 func (v NullableAdditionalPropertiesClass) Set(val *AdditionalPropertiesClass) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableAdditionalPropertiesClass) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableAdditionalPropertiesClass) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableAdditionalPropertiesClass(val *AdditionalPropertiesClass) *NullableAdditionalPropertiesClass {
-    return &NullableAdditionalPropertiesClass{value: val, isSet: true}
+	return &NullableAdditionalPropertiesClass{value: val, isSet: true}
 }
 
 func (v NullableAdditionalPropertiesClass) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableAdditionalPropertiesClass) UnmarshalJSON(src []byte) error {
-    v.isSet = true
+	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_additional_properties_class.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_additional_properties_class.go
@@ -47,7 +47,6 @@ func (o *AdditionalPropertiesClass) GetMapProperty() map[string]string {
 
 // GetMapPropertyOk returns a tuple with the MapProperty field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *AdditionalPropertiesClass) GetMapPropertyOk() (*map[string]string, bool) {
 	if o == nil || o.MapProperty == nil {
 		return nil, false
@@ -80,7 +79,6 @@ func (o *AdditionalPropertiesClass) GetMapOfMapProperty() map[string]map[string]
 
 // GetMapOfMapPropertyOk returns a tuple with the MapOfMapProperty field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *AdditionalPropertiesClass) GetMapOfMapPropertyOk() (*map[string]map[string]string, bool) {
 	if o == nil || o.MapOfMapProperty == nil {
 		return nil, false

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_animal.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_animal.go
@@ -24,31 +24,41 @@ type Animal struct {
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
 func NewAnimal(className string, ) *Animal {
-    this := Animal{}
-    this.ClassName = className
+	this := Animal{}
+	this.ClassName = className
 	var color string = "red"
 	this.Color = &color
-    return &this
+	return &this
 }
 
 // NewAnimalWithDefaults instantiates a new Animal object
 // This constructor will only assign default values to properties that have it defined,
 // but it doesn't guarantee that properties required by API are set
 func NewAnimalWithDefaults() *Animal {
-    this := Animal{}
+	this := Animal{}
 	var color string = "red"
 	this.Color = &color
-    return &this
+	return &this
 }
 
 // GetClassName returns the ClassName field value
 func (o *Animal) GetClassName() string {
-	if o == nil {
+	if o == nil  {
 		var ret string
 		return ret
 	}
 
 	return o.ClassName
+}
+
+// GetClassNameOk returns a tuple with the ClassName field value
+// and a boolean to check if the value has been set.
+
+func (o *Animal) GetClassNameOk() (*string, bool) {
+    if o == nil  {
+        return nil, false
+    }
+    return &o.ClassName, true
 }
 
 // SetClassName sets field value
@@ -65,14 +75,14 @@ func (o *Animal) GetColor() string {
 	return *o.Color
 }
 
-// GetColorOk returns a tuple with the Color field value if set, zero value otherwise
+// GetColorOk returns a tuple with the Color field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *Animal) GetColorOk() (string, bool) {
+
+func (o *Animal) GetColorOk() (*string, bool) {
 	if o == nil || o.Color == nil {
-		var ret string
-		return ret, false
+		return nil, false
 	}
-	return *o.Color, true
+	return o.Color, true
 }
 
 // HasColor returns a boolean if a field has been set.

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_animal.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_animal.go
@@ -10,7 +10,6 @@
 package petstore
 
 import (
-	"bytes"
 	"encoding/json"
 )
 
@@ -73,12 +72,12 @@ func (o *Animal) GetColorOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-	return *o.Color, true
+    return *o.Color, true
 }
 
 // HasColor returns a boolean if a field has been set.
 func (o *Animal) HasColor() bool {
-	if o != nil && o.Color != nil {
+    if o != nil && o.Color != nil {
 		return true
 	}
 
@@ -90,25 +89,49 @@ func (o *Animal) SetColor(v string) {
 	o.Color = &v
 }
 
+func (o Animal) MarshalJSON() ([]byte, error) {
+    toSerialize := map[string]interface{}{}
+    if true {
+        toSerialize["className"] = o.ClassName
+    }
+    if o.Color != nil {
+        toSerialize["color"] = o.Color
+    }
+    return json.Marshal(toSerialize)
+}
+
 type NullableAnimal struct {
-	Value Animal
-	ExplicitNull bool
+	value *Animal
+	isSet bool
+}
+
+func (v NullableAnimal) Get() *Animal {
+    return v.value
+}
+
+func (v NullableAnimal) Set(val *Animal) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableAnimal) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableAnimal) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableAnimal(val *Animal) *NullableAnimal {
+    return &NullableAnimal{value: val, isSet: true}
 }
 
 func (v NullableAnimal) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-		return json.Marshal(v.Value)
-	}
+    return json.Marshal(v.value)
 }
 
 func (v *NullableAnimal) UnmarshalJSON(src []byte) error {
-	if bytes.Equal(src, []byte("null")) {
-		v.ExplicitNull = true
-		return nil
-	}
-
-	return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_animal.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_animal.go
@@ -109,7 +109,7 @@ func (v NullableAnimal) Get() *Animal {
 	return v.value
 }
 
-func (v NullableAnimal) Set(val *Animal) {
+func (v *NullableAnimal) Set(val *Animal) {
 	v.value = val
 	v.isSet = true
 }
@@ -118,7 +118,7 @@ func (v NullableAnimal) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableAnimal) Unset() {
+func (v *NullableAnimal) Unset() {
 	v.value = nil
 	v.isSet = false
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_animal.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_animal.go
@@ -26,8 +26,8 @@ type Animal struct {
 func NewAnimal(className string, ) *Animal {
     this := Animal{}
     this.ClassName = className
-    var color string = "red"
-    this.Color = &color
+	var color string = "red"
+	this.Color = &color
     return &this
 }
 
@@ -36,8 +36,8 @@ func NewAnimal(className string, ) *Animal {
 // but it doesn't guarantee that properties required by API are set
 func NewAnimalWithDefaults() *Animal {
     this := Animal{}
-    var color string = "red"
-    this.Color = &color
+	var color string = "red"
+	this.Color = &color
     return &this
 }
 
@@ -72,12 +72,12 @@ func (o *Animal) GetColorOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-    return *o.Color, true
+	return *o.Color, true
 }
 
 // HasColor returns a boolean if a field has been set.
 func (o *Animal) HasColor() bool {
-    if o != nil && o.Color != nil {
+	if o != nil && o.Color != nil {
 		return true
 	}
 
@@ -90,14 +90,14 @@ func (o *Animal) SetColor(v string) {
 }
 
 func (o Animal) MarshalJSON() ([]byte, error) {
-    toSerialize := map[string]interface{}{}
-    if true {
-        toSerialize["className"] = o.ClassName
-    }
-    if o.Color != nil {
-        toSerialize["color"] = o.Color
-    }
-    return json.Marshal(toSerialize)
+	toSerialize := map[string]interface{}{}
+	if true {
+		toSerialize["className"] = o.ClassName
+	}
+	if o.Color != nil {
+		toSerialize["color"] = o.Color
+	}
+	return json.Marshal(toSerialize)
 }
 
 type NullableAnimal struct {
@@ -106,32 +106,32 @@ type NullableAnimal struct {
 }
 
 func (v NullableAnimal) Get() *Animal {
-    return v.value
+	return v.value
 }
 
 func (v NullableAnimal) Set(val *Animal) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableAnimal) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableAnimal) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableAnimal(val *Animal) *NullableAnimal {
-    return &NullableAnimal{value: val, isSet: true}
+	return &NullableAnimal{value: val, isSet: true}
 }
 
 func (v NullableAnimal) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableAnimal) UnmarshalJSON(src []byte) error {
-    v.isSet = true
+	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_animal.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_animal.go
@@ -53,12 +53,11 @@ func (o *Animal) GetClassName() string {
 
 // GetClassNameOk returns a tuple with the ClassName field value
 // and a boolean to check if the value has been set.
-
 func (o *Animal) GetClassNameOk() (*string, bool) {
-    if o == nil  {
-        return nil, false
-    }
-    return &o.ClassName, true
+	if o == nil  {
+		return nil, false
+	}
+	return &o.ClassName, true
 }
 
 // SetClassName sets field value
@@ -77,7 +76,6 @@ func (o *Animal) GetColor() string {
 
 // GetColorOk returns a tuple with the Color field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *Animal) GetColorOk() (*string, bool) {
 	if o == nil || o.Color == nil {
 		return nil, false

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_api_response.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_api_response.go
@@ -53,12 +53,12 @@ func (o *ApiResponse) GetCodeOk() (int32, bool) {
 		var ret int32
 		return ret, false
 	}
-    return *o.Code, true
+	return *o.Code, true
 }
 
 // HasCode returns a boolean if a field has been set.
 func (o *ApiResponse) HasCode() bool {
-    if o != nil && o.Code != nil {
+	if o != nil && o.Code != nil {
 		return true
 	}
 
@@ -86,12 +86,12 @@ func (o *ApiResponse) GetTypeOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-    return *o.Type, true
+	return *o.Type, true
 }
 
 // HasType returns a boolean if a field has been set.
 func (o *ApiResponse) HasType() bool {
-    if o != nil && o.Type != nil {
+	if o != nil && o.Type != nil {
 		return true
 	}
 
@@ -119,12 +119,12 @@ func (o *ApiResponse) GetMessageOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-    return *o.Message, true
+	return *o.Message, true
 }
 
 // HasMessage returns a boolean if a field has been set.
 func (o *ApiResponse) HasMessage() bool {
-    if o != nil && o.Message != nil {
+	if o != nil && o.Message != nil {
 		return true
 	}
 
@@ -137,17 +137,17 @@ func (o *ApiResponse) SetMessage(v string) {
 }
 
 func (o ApiResponse) MarshalJSON() ([]byte, error) {
-    toSerialize := map[string]interface{}{}
-    if o.Code != nil {
-        toSerialize["code"] = o.Code
-    }
-    if o.Type != nil {
-        toSerialize["type"] = o.Type
-    }
-    if o.Message != nil {
-        toSerialize["message"] = o.Message
-    }
-    return json.Marshal(toSerialize)
+	toSerialize := map[string]interface{}{}
+	if o.Code != nil {
+		toSerialize["code"] = o.Code
+	}
+	if o.Type != nil {
+		toSerialize["type"] = o.Type
+	}
+	if o.Message != nil {
+		toSerialize["message"] = o.Message
+	}
+	return json.Marshal(toSerialize)
 }
 
 type NullableApiResponse struct {
@@ -156,32 +156,32 @@ type NullableApiResponse struct {
 }
 
 func (v NullableApiResponse) Get() *ApiResponse {
-    return v.value
+	return v.value
 }
 
 func (v NullableApiResponse) Set(val *ApiResponse) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableApiResponse) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableApiResponse) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableApiResponse(val *ApiResponse) *NullableApiResponse {
-    return &NullableApiResponse{value: val, isSet: true}
+	return &NullableApiResponse{value: val, isSet: true}
 }
 
 func (v NullableApiResponse) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableApiResponse) UnmarshalJSON(src []byte) error {
-    v.isSet = true
+	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_api_response.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_api_response.go
@@ -48,7 +48,6 @@ func (o *ApiResponse) GetCode() int32 {
 
 // GetCodeOk returns a tuple with the Code field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *ApiResponse) GetCodeOk() (*int32, bool) {
 	if o == nil || o.Code == nil {
 		return nil, false
@@ -81,7 +80,6 @@ func (o *ApiResponse) GetType() string {
 
 // GetTypeOk returns a tuple with the Type field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *ApiResponse) GetTypeOk() (*string, bool) {
 	if o == nil || o.Type == nil {
 		return nil, false
@@ -114,7 +112,6 @@ func (o *ApiResponse) GetMessage() string {
 
 // GetMessageOk returns a tuple with the Message field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *ApiResponse) GetMessageOk() (*string, bool) {
 	if o == nil || o.Message == nil {
 		return nil, false

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_api_response.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_api_response.go
@@ -10,7 +10,6 @@
 package petstore
 
 import (
-	"bytes"
 	"encoding/json"
 )
 
@@ -54,12 +53,12 @@ func (o *ApiResponse) GetCodeOk() (int32, bool) {
 		var ret int32
 		return ret, false
 	}
-	return *o.Code, true
+    return *o.Code, true
 }
 
 // HasCode returns a boolean if a field has been set.
 func (o *ApiResponse) HasCode() bool {
-	if o != nil && o.Code != nil {
+    if o != nil && o.Code != nil {
 		return true
 	}
 
@@ -87,12 +86,12 @@ func (o *ApiResponse) GetTypeOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-	return *o.Type, true
+    return *o.Type, true
 }
 
 // HasType returns a boolean if a field has been set.
 func (o *ApiResponse) HasType() bool {
-	if o != nil && o.Type != nil {
+    if o != nil && o.Type != nil {
 		return true
 	}
 
@@ -120,12 +119,12 @@ func (o *ApiResponse) GetMessageOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-	return *o.Message, true
+    return *o.Message, true
 }
 
 // HasMessage returns a boolean if a field has been set.
 func (o *ApiResponse) HasMessage() bool {
-	if o != nil && o.Message != nil {
+    if o != nil && o.Message != nil {
 		return true
 	}
 
@@ -137,25 +136,52 @@ func (o *ApiResponse) SetMessage(v string) {
 	o.Message = &v
 }
 
+func (o ApiResponse) MarshalJSON() ([]byte, error) {
+    toSerialize := map[string]interface{}{}
+    if o.Code != nil {
+        toSerialize["code"] = o.Code
+    }
+    if o.Type != nil {
+        toSerialize["type"] = o.Type
+    }
+    if o.Message != nil {
+        toSerialize["message"] = o.Message
+    }
+    return json.Marshal(toSerialize)
+}
+
 type NullableApiResponse struct {
-	Value ApiResponse
-	ExplicitNull bool
+	value *ApiResponse
+	isSet bool
+}
+
+func (v NullableApiResponse) Get() *ApiResponse {
+    return v.value
+}
+
+func (v NullableApiResponse) Set(val *ApiResponse) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableApiResponse) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableApiResponse) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableApiResponse(val *ApiResponse) *NullableApiResponse {
+    return &NullableApiResponse{value: val, isSet: true}
 }
 
 func (v NullableApiResponse) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-		return json.Marshal(v.Value)
-	}
+    return json.Marshal(v.value)
 }
 
 func (v *NullableApiResponse) UnmarshalJSON(src []byte) error {
-	if bytes.Equal(src, []byte("null")) {
-		v.ExplicitNull = true
-		return nil
-	}
-
-	return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_api_response.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_api_response.go
@@ -159,7 +159,7 @@ func (v NullableApiResponse) Get() *ApiResponse {
 	return v.value
 }
 
-func (v NullableApiResponse) Set(val *ApiResponse) {
+func (v *NullableApiResponse) Set(val *ApiResponse) {
 	v.value = val
 	v.isSet = true
 }
@@ -168,7 +168,7 @@ func (v NullableApiResponse) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableApiResponse) Unset() {
+func (v *NullableApiResponse) Unset() {
 	v.value = nil
 	v.isSet = false
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_api_response.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_api_response.go
@@ -25,16 +25,16 @@ type ApiResponse struct {
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
 func NewApiResponse() *ApiResponse {
-    this := ApiResponse{}
-    return &this
+	this := ApiResponse{}
+	return &this
 }
 
 // NewApiResponseWithDefaults instantiates a new ApiResponse object
 // This constructor will only assign default values to properties that have it defined,
 // but it doesn't guarantee that properties required by API are set
 func NewApiResponseWithDefaults() *ApiResponse {
-    this := ApiResponse{}
-    return &this
+	this := ApiResponse{}
+	return &this
 }
 
 // GetCode returns the Code field value if set, zero value otherwise.
@@ -46,14 +46,14 @@ func (o *ApiResponse) GetCode() int32 {
 	return *o.Code
 }
 
-// GetCodeOk returns a tuple with the Code field value if set, zero value otherwise
+// GetCodeOk returns a tuple with the Code field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *ApiResponse) GetCodeOk() (int32, bool) {
+
+func (o *ApiResponse) GetCodeOk() (*int32, bool) {
 	if o == nil || o.Code == nil {
-		var ret int32
-		return ret, false
+		return nil, false
 	}
-	return *o.Code, true
+	return o.Code, true
 }
 
 // HasCode returns a boolean if a field has been set.
@@ -79,14 +79,14 @@ func (o *ApiResponse) GetType() string {
 	return *o.Type
 }
 
-// GetTypeOk returns a tuple with the Type field value if set, zero value otherwise
+// GetTypeOk returns a tuple with the Type field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *ApiResponse) GetTypeOk() (string, bool) {
+
+func (o *ApiResponse) GetTypeOk() (*string, bool) {
 	if o == nil || o.Type == nil {
-		var ret string
-		return ret, false
+		return nil, false
 	}
-	return *o.Type, true
+	return o.Type, true
 }
 
 // HasType returns a boolean if a field has been set.
@@ -112,14 +112,14 @@ func (o *ApiResponse) GetMessage() string {
 	return *o.Message
 }
 
-// GetMessageOk returns a tuple with the Message field value if set, zero value otherwise
+// GetMessageOk returns a tuple with the Message field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *ApiResponse) GetMessageOk() (string, bool) {
+
+func (o *ApiResponse) GetMessageOk() (*string, bool) {
 	if o == nil || o.Message == nil {
-		var ret string
-		return ret, false
+		return nil, false
 	}
-	return *o.Message, true
+	return o.Message, true
 }
 
 // HasMessage returns a boolean if a field has been set.

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_array_of_array_of_number_only.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_array_of_array_of_number_only.go
@@ -51,12 +51,12 @@ func (o *ArrayOfArrayOfNumberOnly) GetArrayArrayNumberOk() ([][]float32, bool) {
 		var ret [][]float32
 		return ret, false
 	}
-    return *o.ArrayArrayNumber, true
+	return *o.ArrayArrayNumber, true
 }
 
 // HasArrayArrayNumber returns a boolean if a field has been set.
 func (o *ArrayOfArrayOfNumberOnly) HasArrayArrayNumber() bool {
-    if o != nil && o.ArrayArrayNumber != nil {
+	if o != nil && o.ArrayArrayNumber != nil {
 		return true
 	}
 
@@ -69,11 +69,11 @@ func (o *ArrayOfArrayOfNumberOnly) SetArrayArrayNumber(v [][]float32) {
 }
 
 func (o ArrayOfArrayOfNumberOnly) MarshalJSON() ([]byte, error) {
-    toSerialize := map[string]interface{}{}
-    if o.ArrayArrayNumber != nil {
-        toSerialize["ArrayArrayNumber"] = o.ArrayArrayNumber
-    }
-    return json.Marshal(toSerialize)
+	toSerialize := map[string]interface{}{}
+	if o.ArrayArrayNumber != nil {
+		toSerialize["ArrayArrayNumber"] = o.ArrayArrayNumber
+	}
+	return json.Marshal(toSerialize)
 }
 
 type NullableArrayOfArrayOfNumberOnly struct {
@@ -82,32 +82,32 @@ type NullableArrayOfArrayOfNumberOnly struct {
 }
 
 func (v NullableArrayOfArrayOfNumberOnly) Get() *ArrayOfArrayOfNumberOnly {
-    return v.value
+	return v.value
 }
 
 func (v NullableArrayOfArrayOfNumberOnly) Set(val *ArrayOfArrayOfNumberOnly) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableArrayOfArrayOfNumberOnly) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableArrayOfArrayOfNumberOnly) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableArrayOfArrayOfNumberOnly(val *ArrayOfArrayOfNumberOnly) *NullableArrayOfArrayOfNumberOnly {
-    return &NullableArrayOfArrayOfNumberOnly{value: val, isSet: true}
+	return &NullableArrayOfArrayOfNumberOnly{value: val, isSet: true}
 }
 
 func (v NullableArrayOfArrayOfNumberOnly) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableArrayOfArrayOfNumberOnly) UnmarshalJSON(src []byte) error {
-    v.isSet = true
+	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_array_of_array_of_number_only.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_array_of_array_of_number_only.go
@@ -85,7 +85,7 @@ func (v NullableArrayOfArrayOfNumberOnly) Get() *ArrayOfArrayOfNumberOnly {
 	return v.value
 }
 
-func (v NullableArrayOfArrayOfNumberOnly) Set(val *ArrayOfArrayOfNumberOnly) {
+func (v *NullableArrayOfArrayOfNumberOnly) Set(val *ArrayOfArrayOfNumberOnly) {
 	v.value = val
 	v.isSet = true
 }
@@ -94,7 +94,7 @@ func (v NullableArrayOfArrayOfNumberOnly) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableArrayOfArrayOfNumberOnly) Unset() {
+func (v *NullableArrayOfArrayOfNumberOnly) Unset() {
 	v.value = nil
 	v.isSet = false
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_array_of_array_of_number_only.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_array_of_array_of_number_only.go
@@ -23,16 +23,16 @@ type ArrayOfArrayOfNumberOnly struct {
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
 func NewArrayOfArrayOfNumberOnly() *ArrayOfArrayOfNumberOnly {
-    this := ArrayOfArrayOfNumberOnly{}
-    return &this
+	this := ArrayOfArrayOfNumberOnly{}
+	return &this
 }
 
 // NewArrayOfArrayOfNumberOnlyWithDefaults instantiates a new ArrayOfArrayOfNumberOnly object
 // This constructor will only assign default values to properties that have it defined,
 // but it doesn't guarantee that properties required by API are set
 func NewArrayOfArrayOfNumberOnlyWithDefaults() *ArrayOfArrayOfNumberOnly {
-    this := ArrayOfArrayOfNumberOnly{}
-    return &this
+	this := ArrayOfArrayOfNumberOnly{}
+	return &this
 }
 
 // GetArrayArrayNumber returns the ArrayArrayNumber field value if set, zero value otherwise.
@@ -44,14 +44,14 @@ func (o *ArrayOfArrayOfNumberOnly) GetArrayArrayNumber() [][]float32 {
 	return *o.ArrayArrayNumber
 }
 
-// GetArrayArrayNumberOk returns a tuple with the ArrayArrayNumber field value if set, zero value otherwise
+// GetArrayArrayNumberOk returns a tuple with the ArrayArrayNumber field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *ArrayOfArrayOfNumberOnly) GetArrayArrayNumberOk() ([][]float32, bool) {
+
+func (o *ArrayOfArrayOfNumberOnly) GetArrayArrayNumberOk() (*[][]float32, bool) {
 	if o == nil || o.ArrayArrayNumber == nil {
-		var ret [][]float32
-		return ret, false
+		return nil, false
 	}
-	return *o.ArrayArrayNumber, true
+	return o.ArrayArrayNumber, true
 }
 
 // HasArrayArrayNumber returns a boolean if a field has been set.

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_array_of_array_of_number_only.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_array_of_array_of_number_only.go
@@ -10,7 +10,6 @@
 package petstore
 
 import (
-	"bytes"
 	"encoding/json"
 )
 
@@ -52,12 +51,12 @@ func (o *ArrayOfArrayOfNumberOnly) GetArrayArrayNumberOk() ([][]float32, bool) {
 		var ret [][]float32
 		return ret, false
 	}
-	return *o.ArrayArrayNumber, true
+    return *o.ArrayArrayNumber, true
 }
 
 // HasArrayArrayNumber returns a boolean if a field has been set.
 func (o *ArrayOfArrayOfNumberOnly) HasArrayArrayNumber() bool {
-	if o != nil && o.ArrayArrayNumber != nil {
+    if o != nil && o.ArrayArrayNumber != nil {
 		return true
 	}
 
@@ -69,25 +68,46 @@ func (o *ArrayOfArrayOfNumberOnly) SetArrayArrayNumber(v [][]float32) {
 	o.ArrayArrayNumber = &v
 }
 
+func (o ArrayOfArrayOfNumberOnly) MarshalJSON() ([]byte, error) {
+    toSerialize := map[string]interface{}{}
+    if o.ArrayArrayNumber != nil {
+        toSerialize["ArrayArrayNumber"] = o.ArrayArrayNumber
+    }
+    return json.Marshal(toSerialize)
+}
+
 type NullableArrayOfArrayOfNumberOnly struct {
-	Value ArrayOfArrayOfNumberOnly
-	ExplicitNull bool
+	value *ArrayOfArrayOfNumberOnly
+	isSet bool
+}
+
+func (v NullableArrayOfArrayOfNumberOnly) Get() *ArrayOfArrayOfNumberOnly {
+    return v.value
+}
+
+func (v NullableArrayOfArrayOfNumberOnly) Set(val *ArrayOfArrayOfNumberOnly) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableArrayOfArrayOfNumberOnly) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableArrayOfArrayOfNumberOnly) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableArrayOfArrayOfNumberOnly(val *ArrayOfArrayOfNumberOnly) *NullableArrayOfArrayOfNumberOnly {
+    return &NullableArrayOfArrayOfNumberOnly{value: val, isSet: true}
 }
 
 func (v NullableArrayOfArrayOfNumberOnly) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-		return json.Marshal(v.Value)
-	}
+    return json.Marshal(v.value)
 }
 
 func (v *NullableArrayOfArrayOfNumberOnly) UnmarshalJSON(src []byte) error {
-	if bytes.Equal(src, []byte("null")) {
-		v.ExplicitNull = true
-		return nil
-	}
-
-	return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_array_of_array_of_number_only.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_array_of_array_of_number_only.go
@@ -46,7 +46,6 @@ func (o *ArrayOfArrayOfNumberOnly) GetArrayArrayNumber() [][]float32 {
 
 // GetArrayArrayNumberOk returns a tuple with the ArrayArrayNumber field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *ArrayOfArrayOfNumberOnly) GetArrayArrayNumberOk() (*[][]float32, bool) {
 	if o == nil || o.ArrayArrayNumber == nil {
 		return nil, false

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_array_of_number_only.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_array_of_number_only.go
@@ -51,12 +51,12 @@ func (o *ArrayOfNumberOnly) GetArrayNumberOk() ([]float32, bool) {
 		var ret []float32
 		return ret, false
 	}
-    return *o.ArrayNumber, true
+	return *o.ArrayNumber, true
 }
 
 // HasArrayNumber returns a boolean if a field has been set.
 func (o *ArrayOfNumberOnly) HasArrayNumber() bool {
-    if o != nil && o.ArrayNumber != nil {
+	if o != nil && o.ArrayNumber != nil {
 		return true
 	}
 
@@ -69,11 +69,11 @@ func (o *ArrayOfNumberOnly) SetArrayNumber(v []float32) {
 }
 
 func (o ArrayOfNumberOnly) MarshalJSON() ([]byte, error) {
-    toSerialize := map[string]interface{}{}
-    if o.ArrayNumber != nil {
-        toSerialize["ArrayNumber"] = o.ArrayNumber
-    }
-    return json.Marshal(toSerialize)
+	toSerialize := map[string]interface{}{}
+	if o.ArrayNumber != nil {
+		toSerialize["ArrayNumber"] = o.ArrayNumber
+	}
+	return json.Marshal(toSerialize)
 }
 
 type NullableArrayOfNumberOnly struct {
@@ -82,32 +82,32 @@ type NullableArrayOfNumberOnly struct {
 }
 
 func (v NullableArrayOfNumberOnly) Get() *ArrayOfNumberOnly {
-    return v.value
+	return v.value
 }
 
 func (v NullableArrayOfNumberOnly) Set(val *ArrayOfNumberOnly) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableArrayOfNumberOnly) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableArrayOfNumberOnly) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableArrayOfNumberOnly(val *ArrayOfNumberOnly) *NullableArrayOfNumberOnly {
-    return &NullableArrayOfNumberOnly{value: val, isSet: true}
+	return &NullableArrayOfNumberOnly{value: val, isSet: true}
 }
 
 func (v NullableArrayOfNumberOnly) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableArrayOfNumberOnly) UnmarshalJSON(src []byte) error {
-    v.isSet = true
+	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_array_of_number_only.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_array_of_number_only.go
@@ -85,7 +85,7 @@ func (v NullableArrayOfNumberOnly) Get() *ArrayOfNumberOnly {
 	return v.value
 }
 
-func (v NullableArrayOfNumberOnly) Set(val *ArrayOfNumberOnly) {
+func (v *NullableArrayOfNumberOnly) Set(val *ArrayOfNumberOnly) {
 	v.value = val
 	v.isSet = true
 }
@@ -94,7 +94,7 @@ func (v NullableArrayOfNumberOnly) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableArrayOfNumberOnly) Unset() {
+func (v *NullableArrayOfNumberOnly) Unset() {
 	v.value = nil
 	v.isSet = false
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_array_of_number_only.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_array_of_number_only.go
@@ -10,7 +10,6 @@
 package petstore
 
 import (
-	"bytes"
 	"encoding/json"
 )
 
@@ -52,12 +51,12 @@ func (o *ArrayOfNumberOnly) GetArrayNumberOk() ([]float32, bool) {
 		var ret []float32
 		return ret, false
 	}
-	return *o.ArrayNumber, true
+    return *o.ArrayNumber, true
 }
 
 // HasArrayNumber returns a boolean if a field has been set.
 func (o *ArrayOfNumberOnly) HasArrayNumber() bool {
-	if o != nil && o.ArrayNumber != nil {
+    if o != nil && o.ArrayNumber != nil {
 		return true
 	}
 
@@ -69,25 +68,46 @@ func (o *ArrayOfNumberOnly) SetArrayNumber(v []float32) {
 	o.ArrayNumber = &v
 }
 
+func (o ArrayOfNumberOnly) MarshalJSON() ([]byte, error) {
+    toSerialize := map[string]interface{}{}
+    if o.ArrayNumber != nil {
+        toSerialize["ArrayNumber"] = o.ArrayNumber
+    }
+    return json.Marshal(toSerialize)
+}
+
 type NullableArrayOfNumberOnly struct {
-	Value ArrayOfNumberOnly
-	ExplicitNull bool
+	value *ArrayOfNumberOnly
+	isSet bool
+}
+
+func (v NullableArrayOfNumberOnly) Get() *ArrayOfNumberOnly {
+    return v.value
+}
+
+func (v NullableArrayOfNumberOnly) Set(val *ArrayOfNumberOnly) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableArrayOfNumberOnly) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableArrayOfNumberOnly) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableArrayOfNumberOnly(val *ArrayOfNumberOnly) *NullableArrayOfNumberOnly {
+    return &NullableArrayOfNumberOnly{value: val, isSet: true}
 }
 
 func (v NullableArrayOfNumberOnly) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-		return json.Marshal(v.Value)
-	}
+    return json.Marshal(v.value)
 }
 
 func (v *NullableArrayOfNumberOnly) UnmarshalJSON(src []byte) error {
-	if bytes.Equal(src, []byte("null")) {
-		v.ExplicitNull = true
-		return nil
-	}
-
-	return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_array_of_number_only.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_array_of_number_only.go
@@ -23,16 +23,16 @@ type ArrayOfNumberOnly struct {
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
 func NewArrayOfNumberOnly() *ArrayOfNumberOnly {
-    this := ArrayOfNumberOnly{}
-    return &this
+	this := ArrayOfNumberOnly{}
+	return &this
 }
 
 // NewArrayOfNumberOnlyWithDefaults instantiates a new ArrayOfNumberOnly object
 // This constructor will only assign default values to properties that have it defined,
 // but it doesn't guarantee that properties required by API are set
 func NewArrayOfNumberOnlyWithDefaults() *ArrayOfNumberOnly {
-    this := ArrayOfNumberOnly{}
-    return &this
+	this := ArrayOfNumberOnly{}
+	return &this
 }
 
 // GetArrayNumber returns the ArrayNumber field value if set, zero value otherwise.
@@ -44,14 +44,14 @@ func (o *ArrayOfNumberOnly) GetArrayNumber() []float32 {
 	return *o.ArrayNumber
 }
 
-// GetArrayNumberOk returns a tuple with the ArrayNumber field value if set, zero value otherwise
+// GetArrayNumberOk returns a tuple with the ArrayNumber field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *ArrayOfNumberOnly) GetArrayNumberOk() ([]float32, bool) {
+
+func (o *ArrayOfNumberOnly) GetArrayNumberOk() (*[]float32, bool) {
 	if o == nil || o.ArrayNumber == nil {
-		var ret []float32
-		return ret, false
+		return nil, false
 	}
-	return *o.ArrayNumber, true
+	return o.ArrayNumber, true
 }
 
 // HasArrayNumber returns a boolean if a field has been set.

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_array_of_number_only.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_array_of_number_only.go
@@ -46,7 +46,6 @@ func (o *ArrayOfNumberOnly) GetArrayNumber() []float32 {
 
 // GetArrayNumberOk returns a tuple with the ArrayNumber field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *ArrayOfNumberOnly) GetArrayNumberOk() (*[]float32, bool) {
 	if o == nil || o.ArrayNumber == nil {
 		return nil, false

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_array_test_.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_array_test_.go
@@ -53,12 +53,12 @@ func (o *ArrayTest) GetArrayOfStringOk() ([]string, bool) {
 		var ret []string
 		return ret, false
 	}
-    return *o.ArrayOfString, true
+	return *o.ArrayOfString, true
 }
 
 // HasArrayOfString returns a boolean if a field has been set.
 func (o *ArrayTest) HasArrayOfString() bool {
-    if o != nil && o.ArrayOfString != nil {
+	if o != nil && o.ArrayOfString != nil {
 		return true
 	}
 
@@ -86,12 +86,12 @@ func (o *ArrayTest) GetArrayArrayOfIntegerOk() ([][]int64, bool) {
 		var ret [][]int64
 		return ret, false
 	}
-    return *o.ArrayArrayOfInteger, true
+	return *o.ArrayArrayOfInteger, true
 }
 
 // HasArrayArrayOfInteger returns a boolean if a field has been set.
 func (o *ArrayTest) HasArrayArrayOfInteger() bool {
-    if o != nil && o.ArrayArrayOfInteger != nil {
+	if o != nil && o.ArrayArrayOfInteger != nil {
 		return true
 	}
 
@@ -119,12 +119,12 @@ func (o *ArrayTest) GetArrayArrayOfModelOk() ([][]ReadOnlyFirst, bool) {
 		var ret [][]ReadOnlyFirst
 		return ret, false
 	}
-    return *o.ArrayArrayOfModel, true
+	return *o.ArrayArrayOfModel, true
 }
 
 // HasArrayArrayOfModel returns a boolean if a field has been set.
 func (o *ArrayTest) HasArrayArrayOfModel() bool {
-    if o != nil && o.ArrayArrayOfModel != nil {
+	if o != nil && o.ArrayArrayOfModel != nil {
 		return true
 	}
 
@@ -137,17 +137,17 @@ func (o *ArrayTest) SetArrayArrayOfModel(v [][]ReadOnlyFirst) {
 }
 
 func (o ArrayTest) MarshalJSON() ([]byte, error) {
-    toSerialize := map[string]interface{}{}
-    if o.ArrayOfString != nil {
-        toSerialize["array_of_string"] = o.ArrayOfString
-    }
-    if o.ArrayArrayOfInteger != nil {
-        toSerialize["array_array_of_integer"] = o.ArrayArrayOfInteger
-    }
-    if o.ArrayArrayOfModel != nil {
-        toSerialize["array_array_of_model"] = o.ArrayArrayOfModel
-    }
-    return json.Marshal(toSerialize)
+	toSerialize := map[string]interface{}{}
+	if o.ArrayOfString != nil {
+		toSerialize["array_of_string"] = o.ArrayOfString
+	}
+	if o.ArrayArrayOfInteger != nil {
+		toSerialize["array_array_of_integer"] = o.ArrayArrayOfInteger
+	}
+	if o.ArrayArrayOfModel != nil {
+		toSerialize["array_array_of_model"] = o.ArrayArrayOfModel
+	}
+	return json.Marshal(toSerialize)
 }
 
 type NullableArrayTest struct {
@@ -156,32 +156,32 @@ type NullableArrayTest struct {
 }
 
 func (v NullableArrayTest) Get() *ArrayTest {
-    return v.value
+	return v.value
 }
 
 func (v NullableArrayTest) Set(val *ArrayTest) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableArrayTest) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableArrayTest) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableArrayTest(val *ArrayTest) *NullableArrayTest {
-    return &NullableArrayTest{value: val, isSet: true}
+	return &NullableArrayTest{value: val, isSet: true}
 }
 
 func (v NullableArrayTest) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableArrayTest) UnmarshalJSON(src []byte) error {
-    v.isSet = true
+	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_array_test_.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_array_test_.go
@@ -10,7 +10,6 @@
 package petstore
 
 import (
-	"bytes"
 	"encoding/json"
 )
 
@@ -54,12 +53,12 @@ func (o *ArrayTest) GetArrayOfStringOk() ([]string, bool) {
 		var ret []string
 		return ret, false
 	}
-	return *o.ArrayOfString, true
+    return *o.ArrayOfString, true
 }
 
 // HasArrayOfString returns a boolean if a field has been set.
 func (o *ArrayTest) HasArrayOfString() bool {
-	if o != nil && o.ArrayOfString != nil {
+    if o != nil && o.ArrayOfString != nil {
 		return true
 	}
 
@@ -87,12 +86,12 @@ func (o *ArrayTest) GetArrayArrayOfIntegerOk() ([][]int64, bool) {
 		var ret [][]int64
 		return ret, false
 	}
-	return *o.ArrayArrayOfInteger, true
+    return *o.ArrayArrayOfInteger, true
 }
 
 // HasArrayArrayOfInteger returns a boolean if a field has been set.
 func (o *ArrayTest) HasArrayArrayOfInteger() bool {
-	if o != nil && o.ArrayArrayOfInteger != nil {
+    if o != nil && o.ArrayArrayOfInteger != nil {
 		return true
 	}
 
@@ -120,12 +119,12 @@ func (o *ArrayTest) GetArrayArrayOfModelOk() ([][]ReadOnlyFirst, bool) {
 		var ret [][]ReadOnlyFirst
 		return ret, false
 	}
-	return *o.ArrayArrayOfModel, true
+    return *o.ArrayArrayOfModel, true
 }
 
 // HasArrayArrayOfModel returns a boolean if a field has been set.
 func (o *ArrayTest) HasArrayArrayOfModel() bool {
-	if o != nil && o.ArrayArrayOfModel != nil {
+    if o != nil && o.ArrayArrayOfModel != nil {
 		return true
 	}
 
@@ -137,25 +136,52 @@ func (o *ArrayTest) SetArrayArrayOfModel(v [][]ReadOnlyFirst) {
 	o.ArrayArrayOfModel = &v
 }
 
+func (o ArrayTest) MarshalJSON() ([]byte, error) {
+    toSerialize := map[string]interface{}{}
+    if o.ArrayOfString != nil {
+        toSerialize["array_of_string"] = o.ArrayOfString
+    }
+    if o.ArrayArrayOfInteger != nil {
+        toSerialize["array_array_of_integer"] = o.ArrayArrayOfInteger
+    }
+    if o.ArrayArrayOfModel != nil {
+        toSerialize["array_array_of_model"] = o.ArrayArrayOfModel
+    }
+    return json.Marshal(toSerialize)
+}
+
 type NullableArrayTest struct {
-	Value ArrayTest
-	ExplicitNull bool
+	value *ArrayTest
+	isSet bool
+}
+
+func (v NullableArrayTest) Get() *ArrayTest {
+    return v.value
+}
+
+func (v NullableArrayTest) Set(val *ArrayTest) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableArrayTest) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableArrayTest) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableArrayTest(val *ArrayTest) *NullableArrayTest {
+    return &NullableArrayTest{value: val, isSet: true}
 }
 
 func (v NullableArrayTest) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-		return json.Marshal(v.Value)
-	}
+    return json.Marshal(v.value)
 }
 
 func (v *NullableArrayTest) UnmarshalJSON(src []byte) error {
-	if bytes.Equal(src, []byte("null")) {
-		v.ExplicitNull = true
-		return nil
-	}
-
-	return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_array_test_.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_array_test_.go
@@ -159,7 +159,7 @@ func (v NullableArrayTest) Get() *ArrayTest {
 	return v.value
 }
 
-func (v NullableArrayTest) Set(val *ArrayTest) {
+func (v *NullableArrayTest) Set(val *ArrayTest) {
 	v.value = val
 	v.isSet = true
 }
@@ -168,7 +168,7 @@ func (v NullableArrayTest) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableArrayTest) Unset() {
+func (v *NullableArrayTest) Unset() {
 	v.value = nil
 	v.isSet = false
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_array_test_.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_array_test_.go
@@ -48,7 +48,6 @@ func (o *ArrayTest) GetArrayOfString() []string {
 
 // GetArrayOfStringOk returns a tuple with the ArrayOfString field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *ArrayTest) GetArrayOfStringOk() (*[]string, bool) {
 	if o == nil || o.ArrayOfString == nil {
 		return nil, false
@@ -81,7 +80,6 @@ func (o *ArrayTest) GetArrayArrayOfInteger() [][]int64 {
 
 // GetArrayArrayOfIntegerOk returns a tuple with the ArrayArrayOfInteger field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *ArrayTest) GetArrayArrayOfIntegerOk() (*[][]int64, bool) {
 	if o == nil || o.ArrayArrayOfInteger == nil {
 		return nil, false
@@ -114,7 +112,6 @@ func (o *ArrayTest) GetArrayArrayOfModel() [][]ReadOnlyFirst {
 
 // GetArrayArrayOfModelOk returns a tuple with the ArrayArrayOfModel field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *ArrayTest) GetArrayArrayOfModelOk() (*[][]ReadOnlyFirst, bool) {
 	if o == nil || o.ArrayArrayOfModel == nil {
 		return nil, false

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_array_test_.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_array_test_.go
@@ -25,16 +25,16 @@ type ArrayTest struct {
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
 func NewArrayTest() *ArrayTest {
-    this := ArrayTest{}
-    return &this
+	this := ArrayTest{}
+	return &this
 }
 
 // NewArrayTestWithDefaults instantiates a new ArrayTest object
 // This constructor will only assign default values to properties that have it defined,
 // but it doesn't guarantee that properties required by API are set
 func NewArrayTestWithDefaults() *ArrayTest {
-    this := ArrayTest{}
-    return &this
+	this := ArrayTest{}
+	return &this
 }
 
 // GetArrayOfString returns the ArrayOfString field value if set, zero value otherwise.
@@ -46,14 +46,14 @@ func (o *ArrayTest) GetArrayOfString() []string {
 	return *o.ArrayOfString
 }
 
-// GetArrayOfStringOk returns a tuple with the ArrayOfString field value if set, zero value otherwise
+// GetArrayOfStringOk returns a tuple with the ArrayOfString field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *ArrayTest) GetArrayOfStringOk() ([]string, bool) {
+
+func (o *ArrayTest) GetArrayOfStringOk() (*[]string, bool) {
 	if o == nil || o.ArrayOfString == nil {
-		var ret []string
-		return ret, false
+		return nil, false
 	}
-	return *o.ArrayOfString, true
+	return o.ArrayOfString, true
 }
 
 // HasArrayOfString returns a boolean if a field has been set.
@@ -79,14 +79,14 @@ func (o *ArrayTest) GetArrayArrayOfInteger() [][]int64 {
 	return *o.ArrayArrayOfInteger
 }
 
-// GetArrayArrayOfIntegerOk returns a tuple with the ArrayArrayOfInteger field value if set, zero value otherwise
+// GetArrayArrayOfIntegerOk returns a tuple with the ArrayArrayOfInteger field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *ArrayTest) GetArrayArrayOfIntegerOk() ([][]int64, bool) {
+
+func (o *ArrayTest) GetArrayArrayOfIntegerOk() (*[][]int64, bool) {
 	if o == nil || o.ArrayArrayOfInteger == nil {
-		var ret [][]int64
-		return ret, false
+		return nil, false
 	}
-	return *o.ArrayArrayOfInteger, true
+	return o.ArrayArrayOfInteger, true
 }
 
 // HasArrayArrayOfInteger returns a boolean if a field has been set.
@@ -112,14 +112,14 @@ func (o *ArrayTest) GetArrayArrayOfModel() [][]ReadOnlyFirst {
 	return *o.ArrayArrayOfModel
 }
 
-// GetArrayArrayOfModelOk returns a tuple with the ArrayArrayOfModel field value if set, zero value otherwise
+// GetArrayArrayOfModelOk returns a tuple with the ArrayArrayOfModel field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *ArrayTest) GetArrayArrayOfModelOk() ([][]ReadOnlyFirst, bool) {
+
+func (o *ArrayTest) GetArrayArrayOfModelOk() (*[][]ReadOnlyFirst, bool) {
 	if o == nil || o.ArrayArrayOfModel == nil {
-		var ret [][]ReadOnlyFirst
-		return ret, false
+		return nil, false
 	}
-	return *o.ArrayArrayOfModel, true
+	return o.ArrayArrayOfModel, true
 }
 
 // HasArrayArrayOfModel returns a boolean if a field has been set.

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_capitalization.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_capitalization.go
@@ -57,12 +57,12 @@ func (o *Capitalization) GetSmallCamelOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-    return *o.SmallCamel, true
+	return *o.SmallCamel, true
 }
 
 // HasSmallCamel returns a boolean if a field has been set.
 func (o *Capitalization) HasSmallCamel() bool {
-    if o != nil && o.SmallCamel != nil {
+	if o != nil && o.SmallCamel != nil {
 		return true
 	}
 
@@ -90,12 +90,12 @@ func (o *Capitalization) GetCapitalCamelOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-    return *o.CapitalCamel, true
+	return *o.CapitalCamel, true
 }
 
 // HasCapitalCamel returns a boolean if a field has been set.
 func (o *Capitalization) HasCapitalCamel() bool {
-    if o != nil && o.CapitalCamel != nil {
+	if o != nil && o.CapitalCamel != nil {
 		return true
 	}
 
@@ -123,12 +123,12 @@ func (o *Capitalization) GetSmallSnakeOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-    return *o.SmallSnake, true
+	return *o.SmallSnake, true
 }
 
 // HasSmallSnake returns a boolean if a field has been set.
 func (o *Capitalization) HasSmallSnake() bool {
-    if o != nil && o.SmallSnake != nil {
+	if o != nil && o.SmallSnake != nil {
 		return true
 	}
 
@@ -156,12 +156,12 @@ func (o *Capitalization) GetCapitalSnakeOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-    return *o.CapitalSnake, true
+	return *o.CapitalSnake, true
 }
 
 // HasCapitalSnake returns a boolean if a field has been set.
 func (o *Capitalization) HasCapitalSnake() bool {
-    if o != nil && o.CapitalSnake != nil {
+	if o != nil && o.CapitalSnake != nil {
 		return true
 	}
 
@@ -189,12 +189,12 @@ func (o *Capitalization) GetSCAETHFlowPointsOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-    return *o.SCAETHFlowPoints, true
+	return *o.SCAETHFlowPoints, true
 }
 
 // HasSCAETHFlowPoints returns a boolean if a field has been set.
 func (o *Capitalization) HasSCAETHFlowPoints() bool {
-    if o != nil && o.SCAETHFlowPoints != nil {
+	if o != nil && o.SCAETHFlowPoints != nil {
 		return true
 	}
 
@@ -222,12 +222,12 @@ func (o *Capitalization) GetATT_NAMEOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-    return *o.ATT_NAME, true
+	return *o.ATT_NAME, true
 }
 
 // HasATT_NAME returns a boolean if a field has been set.
 func (o *Capitalization) HasATT_NAME() bool {
-    if o != nil && o.ATT_NAME != nil {
+	if o != nil && o.ATT_NAME != nil {
 		return true
 	}
 
@@ -240,26 +240,26 @@ func (o *Capitalization) SetATT_NAME(v string) {
 }
 
 func (o Capitalization) MarshalJSON() ([]byte, error) {
-    toSerialize := map[string]interface{}{}
-    if o.SmallCamel != nil {
-        toSerialize["smallCamel"] = o.SmallCamel
-    }
-    if o.CapitalCamel != nil {
-        toSerialize["CapitalCamel"] = o.CapitalCamel
-    }
-    if o.SmallSnake != nil {
-        toSerialize["small_Snake"] = o.SmallSnake
-    }
-    if o.CapitalSnake != nil {
-        toSerialize["Capital_Snake"] = o.CapitalSnake
-    }
-    if o.SCAETHFlowPoints != nil {
-        toSerialize["SCA_ETH_Flow_Points"] = o.SCAETHFlowPoints
-    }
-    if o.ATT_NAME != nil {
-        toSerialize["ATT_NAME"] = o.ATT_NAME
-    }
-    return json.Marshal(toSerialize)
+	toSerialize := map[string]interface{}{}
+	if o.SmallCamel != nil {
+		toSerialize["smallCamel"] = o.SmallCamel
+	}
+	if o.CapitalCamel != nil {
+		toSerialize["CapitalCamel"] = o.CapitalCamel
+	}
+	if o.SmallSnake != nil {
+		toSerialize["small_Snake"] = o.SmallSnake
+	}
+	if o.CapitalSnake != nil {
+		toSerialize["Capital_Snake"] = o.CapitalSnake
+	}
+	if o.SCAETHFlowPoints != nil {
+		toSerialize["SCA_ETH_Flow_Points"] = o.SCAETHFlowPoints
+	}
+	if o.ATT_NAME != nil {
+		toSerialize["ATT_NAME"] = o.ATT_NAME
+	}
+	return json.Marshal(toSerialize)
 }
 
 type NullableCapitalization struct {
@@ -268,32 +268,32 @@ type NullableCapitalization struct {
 }
 
 func (v NullableCapitalization) Get() *Capitalization {
-    return v.value
+	return v.value
 }
 
 func (v NullableCapitalization) Set(val *Capitalization) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableCapitalization) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableCapitalization) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableCapitalization(val *Capitalization) *NullableCapitalization {
-    return &NullableCapitalization{value: val, isSet: true}
+	return &NullableCapitalization{value: val, isSet: true}
 }
 
 func (v NullableCapitalization) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableCapitalization) UnmarshalJSON(src []byte) error {
-    v.isSet = true
+	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_capitalization.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_capitalization.go
@@ -271,7 +271,7 @@ func (v NullableCapitalization) Get() *Capitalization {
 	return v.value
 }
 
-func (v NullableCapitalization) Set(val *Capitalization) {
+func (v *NullableCapitalization) Set(val *Capitalization) {
 	v.value = val
 	v.isSet = true
 }
@@ -280,7 +280,7 @@ func (v NullableCapitalization) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableCapitalization) Unset() {
+func (v *NullableCapitalization) Unset() {
 	v.value = nil
 	v.isSet = false
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_capitalization.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_capitalization.go
@@ -52,7 +52,6 @@ func (o *Capitalization) GetSmallCamel() string {
 
 // GetSmallCamelOk returns a tuple with the SmallCamel field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *Capitalization) GetSmallCamelOk() (*string, bool) {
 	if o == nil || o.SmallCamel == nil {
 		return nil, false
@@ -85,7 +84,6 @@ func (o *Capitalization) GetCapitalCamel() string {
 
 // GetCapitalCamelOk returns a tuple with the CapitalCamel field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *Capitalization) GetCapitalCamelOk() (*string, bool) {
 	if o == nil || o.CapitalCamel == nil {
 		return nil, false
@@ -118,7 +116,6 @@ func (o *Capitalization) GetSmallSnake() string {
 
 // GetSmallSnakeOk returns a tuple with the SmallSnake field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *Capitalization) GetSmallSnakeOk() (*string, bool) {
 	if o == nil || o.SmallSnake == nil {
 		return nil, false
@@ -151,7 +148,6 @@ func (o *Capitalization) GetCapitalSnake() string {
 
 // GetCapitalSnakeOk returns a tuple with the CapitalSnake field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *Capitalization) GetCapitalSnakeOk() (*string, bool) {
 	if o == nil || o.CapitalSnake == nil {
 		return nil, false
@@ -184,7 +180,6 @@ func (o *Capitalization) GetSCAETHFlowPoints() string {
 
 // GetSCAETHFlowPointsOk returns a tuple with the SCAETHFlowPoints field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *Capitalization) GetSCAETHFlowPointsOk() (*string, bool) {
 	if o == nil || o.SCAETHFlowPoints == nil {
 		return nil, false
@@ -217,7 +212,6 @@ func (o *Capitalization) GetATT_NAME() string {
 
 // GetATT_NAMEOk returns a tuple with the ATT_NAME field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *Capitalization) GetATT_NAMEOk() (*string, bool) {
 	if o == nil || o.ATT_NAME == nil {
 		return nil, false

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_capitalization.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_capitalization.go
@@ -29,16 +29,16 @@ type Capitalization struct {
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
 func NewCapitalization() *Capitalization {
-    this := Capitalization{}
-    return &this
+	this := Capitalization{}
+	return &this
 }
 
 // NewCapitalizationWithDefaults instantiates a new Capitalization object
 // This constructor will only assign default values to properties that have it defined,
 // but it doesn't guarantee that properties required by API are set
 func NewCapitalizationWithDefaults() *Capitalization {
-    this := Capitalization{}
-    return &this
+	this := Capitalization{}
+	return &this
 }
 
 // GetSmallCamel returns the SmallCamel field value if set, zero value otherwise.
@@ -50,14 +50,14 @@ func (o *Capitalization) GetSmallCamel() string {
 	return *o.SmallCamel
 }
 
-// GetSmallCamelOk returns a tuple with the SmallCamel field value if set, zero value otherwise
+// GetSmallCamelOk returns a tuple with the SmallCamel field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *Capitalization) GetSmallCamelOk() (string, bool) {
+
+func (o *Capitalization) GetSmallCamelOk() (*string, bool) {
 	if o == nil || o.SmallCamel == nil {
-		var ret string
-		return ret, false
+		return nil, false
 	}
-	return *o.SmallCamel, true
+	return o.SmallCamel, true
 }
 
 // HasSmallCamel returns a boolean if a field has been set.
@@ -83,14 +83,14 @@ func (o *Capitalization) GetCapitalCamel() string {
 	return *o.CapitalCamel
 }
 
-// GetCapitalCamelOk returns a tuple with the CapitalCamel field value if set, zero value otherwise
+// GetCapitalCamelOk returns a tuple with the CapitalCamel field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *Capitalization) GetCapitalCamelOk() (string, bool) {
+
+func (o *Capitalization) GetCapitalCamelOk() (*string, bool) {
 	if o == nil || o.CapitalCamel == nil {
-		var ret string
-		return ret, false
+		return nil, false
 	}
-	return *o.CapitalCamel, true
+	return o.CapitalCamel, true
 }
 
 // HasCapitalCamel returns a boolean if a field has been set.
@@ -116,14 +116,14 @@ func (o *Capitalization) GetSmallSnake() string {
 	return *o.SmallSnake
 }
 
-// GetSmallSnakeOk returns a tuple with the SmallSnake field value if set, zero value otherwise
+// GetSmallSnakeOk returns a tuple with the SmallSnake field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *Capitalization) GetSmallSnakeOk() (string, bool) {
+
+func (o *Capitalization) GetSmallSnakeOk() (*string, bool) {
 	if o == nil || o.SmallSnake == nil {
-		var ret string
-		return ret, false
+		return nil, false
 	}
-	return *o.SmallSnake, true
+	return o.SmallSnake, true
 }
 
 // HasSmallSnake returns a boolean if a field has been set.
@@ -149,14 +149,14 @@ func (o *Capitalization) GetCapitalSnake() string {
 	return *o.CapitalSnake
 }
 
-// GetCapitalSnakeOk returns a tuple with the CapitalSnake field value if set, zero value otherwise
+// GetCapitalSnakeOk returns a tuple with the CapitalSnake field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *Capitalization) GetCapitalSnakeOk() (string, bool) {
+
+func (o *Capitalization) GetCapitalSnakeOk() (*string, bool) {
 	if o == nil || o.CapitalSnake == nil {
-		var ret string
-		return ret, false
+		return nil, false
 	}
-	return *o.CapitalSnake, true
+	return o.CapitalSnake, true
 }
 
 // HasCapitalSnake returns a boolean if a field has been set.
@@ -182,14 +182,14 @@ func (o *Capitalization) GetSCAETHFlowPoints() string {
 	return *o.SCAETHFlowPoints
 }
 
-// GetSCAETHFlowPointsOk returns a tuple with the SCAETHFlowPoints field value if set, zero value otherwise
+// GetSCAETHFlowPointsOk returns a tuple with the SCAETHFlowPoints field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *Capitalization) GetSCAETHFlowPointsOk() (string, bool) {
+
+func (o *Capitalization) GetSCAETHFlowPointsOk() (*string, bool) {
 	if o == nil || o.SCAETHFlowPoints == nil {
-		var ret string
-		return ret, false
+		return nil, false
 	}
-	return *o.SCAETHFlowPoints, true
+	return o.SCAETHFlowPoints, true
 }
 
 // HasSCAETHFlowPoints returns a boolean if a field has been set.
@@ -215,14 +215,14 @@ func (o *Capitalization) GetATT_NAME() string {
 	return *o.ATT_NAME
 }
 
-// GetATT_NAMEOk returns a tuple with the ATT_NAME field value if set, zero value otherwise
+// GetATT_NAMEOk returns a tuple with the ATT_NAME field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *Capitalization) GetATT_NAMEOk() (string, bool) {
+
+func (o *Capitalization) GetATT_NAMEOk() (*string, bool) {
 	if o == nil || o.ATT_NAME == nil {
-		var ret string
-		return ret, false
+		return nil, false
 	}
-	return *o.ATT_NAME, true
+	return o.ATT_NAME, true
 }
 
 // HasATT_NAME returns a boolean if a field has been set.

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_capitalization.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_capitalization.go
@@ -10,7 +10,6 @@
 package petstore
 
 import (
-	"bytes"
 	"encoding/json"
 )
 
@@ -58,12 +57,12 @@ func (o *Capitalization) GetSmallCamelOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-	return *o.SmallCamel, true
+    return *o.SmallCamel, true
 }
 
 // HasSmallCamel returns a boolean if a field has been set.
 func (o *Capitalization) HasSmallCamel() bool {
-	if o != nil && o.SmallCamel != nil {
+    if o != nil && o.SmallCamel != nil {
 		return true
 	}
 
@@ -91,12 +90,12 @@ func (o *Capitalization) GetCapitalCamelOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-	return *o.CapitalCamel, true
+    return *o.CapitalCamel, true
 }
 
 // HasCapitalCamel returns a boolean if a field has been set.
 func (o *Capitalization) HasCapitalCamel() bool {
-	if o != nil && o.CapitalCamel != nil {
+    if o != nil && o.CapitalCamel != nil {
 		return true
 	}
 
@@ -124,12 +123,12 @@ func (o *Capitalization) GetSmallSnakeOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-	return *o.SmallSnake, true
+    return *o.SmallSnake, true
 }
 
 // HasSmallSnake returns a boolean if a field has been set.
 func (o *Capitalization) HasSmallSnake() bool {
-	if o != nil && o.SmallSnake != nil {
+    if o != nil && o.SmallSnake != nil {
 		return true
 	}
 
@@ -157,12 +156,12 @@ func (o *Capitalization) GetCapitalSnakeOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-	return *o.CapitalSnake, true
+    return *o.CapitalSnake, true
 }
 
 // HasCapitalSnake returns a boolean if a field has been set.
 func (o *Capitalization) HasCapitalSnake() bool {
-	if o != nil && o.CapitalSnake != nil {
+    if o != nil && o.CapitalSnake != nil {
 		return true
 	}
 
@@ -190,12 +189,12 @@ func (o *Capitalization) GetSCAETHFlowPointsOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-	return *o.SCAETHFlowPoints, true
+    return *o.SCAETHFlowPoints, true
 }
 
 // HasSCAETHFlowPoints returns a boolean if a field has been set.
 func (o *Capitalization) HasSCAETHFlowPoints() bool {
-	if o != nil && o.SCAETHFlowPoints != nil {
+    if o != nil && o.SCAETHFlowPoints != nil {
 		return true
 	}
 
@@ -223,12 +222,12 @@ func (o *Capitalization) GetATT_NAMEOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-	return *o.ATT_NAME, true
+    return *o.ATT_NAME, true
 }
 
 // HasATT_NAME returns a boolean if a field has been set.
 func (o *Capitalization) HasATT_NAME() bool {
-	if o != nil && o.ATT_NAME != nil {
+    if o != nil && o.ATT_NAME != nil {
 		return true
 	}
 
@@ -240,25 +239,61 @@ func (o *Capitalization) SetATT_NAME(v string) {
 	o.ATT_NAME = &v
 }
 
+func (o Capitalization) MarshalJSON() ([]byte, error) {
+    toSerialize := map[string]interface{}{}
+    if o.SmallCamel != nil {
+        toSerialize["smallCamel"] = o.SmallCamel
+    }
+    if o.CapitalCamel != nil {
+        toSerialize["CapitalCamel"] = o.CapitalCamel
+    }
+    if o.SmallSnake != nil {
+        toSerialize["small_Snake"] = o.SmallSnake
+    }
+    if o.CapitalSnake != nil {
+        toSerialize["Capital_Snake"] = o.CapitalSnake
+    }
+    if o.SCAETHFlowPoints != nil {
+        toSerialize["SCA_ETH_Flow_Points"] = o.SCAETHFlowPoints
+    }
+    if o.ATT_NAME != nil {
+        toSerialize["ATT_NAME"] = o.ATT_NAME
+    }
+    return json.Marshal(toSerialize)
+}
+
 type NullableCapitalization struct {
-	Value Capitalization
-	ExplicitNull bool
+	value *Capitalization
+	isSet bool
+}
+
+func (v NullableCapitalization) Get() *Capitalization {
+    return v.value
+}
+
+func (v NullableCapitalization) Set(val *Capitalization) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableCapitalization) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableCapitalization) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableCapitalization(val *Capitalization) *NullableCapitalization {
+    return &NullableCapitalization{value: val, isSet: true}
 }
 
 func (v NullableCapitalization) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-		return json.Marshal(v.Value)
-	}
+    return json.Marshal(v.value)
 }
 
 func (v *NullableCapitalization) UnmarshalJSON(src []byte) error {
-	if bytes.Equal(src, []byte("null")) {
-		v.ExplicitNull = true
-		return nil
-	}
-
-	return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_cat.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_cat.go
@@ -24,16 +24,16 @@ type Cat struct {
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
 func NewCat() *Cat {
-    this := Cat{}
-    return &this
+	this := Cat{}
+	return &this
 }
 
 // NewCatWithDefaults instantiates a new Cat object
 // This constructor will only assign default values to properties that have it defined,
 // but it doesn't guarantee that properties required by API are set
 func NewCatWithDefaults() *Cat {
-    this := Cat{}
-    return &this
+	this := Cat{}
+	return &this
 }
 
 // GetDeclawed returns the Declawed field value if set, zero value otherwise.
@@ -45,14 +45,14 @@ func (o *Cat) GetDeclawed() bool {
 	return *o.Declawed
 }
 
-// GetDeclawedOk returns a tuple with the Declawed field value if set, zero value otherwise
+// GetDeclawedOk returns a tuple with the Declawed field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *Cat) GetDeclawedOk() (bool, bool) {
+
+func (o *Cat) GetDeclawedOk() (*bool, bool) {
 	if o == nil || o.Declawed == nil {
-		var ret bool
-		return ret, false
+		return nil, false
 	}
-	return *o.Declawed, true
+	return o.Declawed, true
 }
 
 // HasDeclawed returns a boolean if a field has been set.

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_cat.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_cat.go
@@ -52,12 +52,12 @@ func (o *Cat) GetDeclawedOk() (bool, bool) {
 		var ret bool
 		return ret, false
 	}
-    return *o.Declawed, true
+	return *o.Declawed, true
 }
 
 // HasDeclawed returns a boolean if a field has been set.
 func (o *Cat) HasDeclawed() bool {
-    if o != nil && o.Declawed != nil {
+	if o != nil && o.Declawed != nil {
 		return true
 	}
 
@@ -70,19 +70,19 @@ func (o *Cat) SetDeclawed(v bool) {
 }
 
 func (o Cat) MarshalJSON() ([]byte, error) {
-    toSerialize := map[string]interface{}{}
-    serializedAnimal, errAnimal := json.Marshal(o.Animal)
-    if errAnimal != nil {
-        return []byte{}, errAnimal
-    }
-    errAnimal = json.Unmarshal([]byte(serializedAnimal), &toSerialize)
-    if errAnimal != nil {
-       return []byte{}, errAnimal
-    }
-    if o.Declawed != nil {
-        toSerialize["declawed"] = o.Declawed
-    }
-    return json.Marshal(toSerialize)
+	toSerialize := map[string]interface{}{}
+	serializedAnimal, errAnimal := json.Marshal(o.Animal)
+	if errAnimal != nil {
+		return []byte{}, errAnimal
+	}
+	errAnimal = json.Unmarshal([]byte(serializedAnimal), &toSerialize)
+	if errAnimal != nil {
+		return []byte{}, errAnimal
+	}
+	if o.Declawed != nil {
+		toSerialize["declawed"] = o.Declawed
+	}
+	return json.Marshal(toSerialize)
 }
 
 type NullableCat struct {
@@ -91,32 +91,32 @@ type NullableCat struct {
 }
 
 func (v NullableCat) Get() *Cat {
-    return v.value
+	return v.value
 }
 
 func (v NullableCat) Set(val *Cat) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableCat) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableCat) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableCat(val *Cat) *NullableCat {
-    return &NullableCat{value: val, isSet: true}
+	return &NullableCat{value: val, isSet: true}
 }
 
 func (v NullableCat) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableCat) UnmarshalJSON(src []byte) error {
-    v.isSet = true
+	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_cat.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_cat.go
@@ -47,7 +47,6 @@ func (o *Cat) GetDeclawed() bool {
 
 // GetDeclawedOk returns a tuple with the Declawed field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *Cat) GetDeclawedOk() (*bool, bool) {
 	if o == nil || o.Declawed == nil {
 		return nil, false

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_cat.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_cat.go
@@ -10,7 +10,6 @@
 package petstore
 
 import (
-	"bytes"
 	"encoding/json"
 )
 
@@ -53,12 +52,12 @@ func (o *Cat) GetDeclawedOk() (bool, bool) {
 		var ret bool
 		return ret, false
 	}
-	return *o.Declawed, true
+    return *o.Declawed, true
 }
 
 // HasDeclawed returns a boolean if a field has been set.
 func (o *Cat) HasDeclawed() bool {
-	if o != nil && o.Declawed != nil {
+    if o != nil && o.Declawed != nil {
 		return true
 	}
 
@@ -70,25 +69,54 @@ func (o *Cat) SetDeclawed(v bool) {
 	o.Declawed = &v
 }
 
+func (o Cat) MarshalJSON() ([]byte, error) {
+    toSerialize := map[string]interface{}{}
+    serializedAnimal, errAnimal := json.Marshal(o.Animal)
+    if errAnimal != nil {
+        return []byte{}, errAnimal
+    }
+    errAnimal = json.Unmarshal([]byte(serializedAnimal), &toSerialize)
+    if errAnimal != nil {
+       return []byte{}, errAnimal
+    }
+    if o.Declawed != nil {
+        toSerialize["declawed"] = o.Declawed
+    }
+    return json.Marshal(toSerialize)
+}
+
 type NullableCat struct {
-	Value Cat
-	ExplicitNull bool
+	value *Cat
+	isSet bool
+}
+
+func (v NullableCat) Get() *Cat {
+    return v.value
+}
+
+func (v NullableCat) Set(val *Cat) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableCat) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableCat) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableCat(val *Cat) *NullableCat {
+    return &NullableCat{value: val, isSet: true}
 }
 
 func (v NullableCat) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-		return json.Marshal(v.Value)
-	}
+    return json.Marshal(v.value)
 }
 
 func (v *NullableCat) UnmarshalJSON(src []byte) error {
-	if bytes.Equal(src, []byte("null")) {
-		v.ExplicitNull = true
-		return nil
-	}
-
-	return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_cat.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_cat.go
@@ -94,7 +94,7 @@ func (v NullableCat) Get() *Cat {
 	return v.value
 }
 
-func (v NullableCat) Set(val *Cat) {
+func (v *NullableCat) Set(val *Cat) {
 	v.value = val
 	v.isSet = true
 }
@@ -103,7 +103,7 @@ func (v NullableCat) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableCat) Unset() {
+func (v *NullableCat) Unset() {
 	v.value = nil
 	v.isSet = false
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_cat_all_of.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_cat_all_of.go
@@ -51,12 +51,12 @@ func (o *CatAllOf) GetDeclawedOk() (bool, bool) {
 		var ret bool
 		return ret, false
 	}
-    return *o.Declawed, true
+	return *o.Declawed, true
 }
 
 // HasDeclawed returns a boolean if a field has been set.
 func (o *CatAllOf) HasDeclawed() bool {
-    if o != nil && o.Declawed != nil {
+	if o != nil && o.Declawed != nil {
 		return true
 	}
 
@@ -69,11 +69,11 @@ func (o *CatAllOf) SetDeclawed(v bool) {
 }
 
 func (o CatAllOf) MarshalJSON() ([]byte, error) {
-    toSerialize := map[string]interface{}{}
-    if o.Declawed != nil {
-        toSerialize["declawed"] = o.Declawed
-    }
-    return json.Marshal(toSerialize)
+	toSerialize := map[string]interface{}{}
+	if o.Declawed != nil {
+		toSerialize["declawed"] = o.Declawed
+	}
+	return json.Marshal(toSerialize)
 }
 
 type NullableCatAllOf struct {
@@ -82,32 +82,32 @@ type NullableCatAllOf struct {
 }
 
 func (v NullableCatAllOf) Get() *CatAllOf {
-    return v.value
+	return v.value
 }
 
 func (v NullableCatAllOf) Set(val *CatAllOf) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableCatAllOf) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableCatAllOf) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableCatAllOf(val *CatAllOf) *NullableCatAllOf {
-    return &NullableCatAllOf{value: val, isSet: true}
+	return &NullableCatAllOf{value: val, isSet: true}
 }
 
 func (v NullableCatAllOf) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableCatAllOf) UnmarshalJSON(src []byte) error {
-    v.isSet = true
+	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_cat_all_of.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_cat_all_of.go
@@ -85,7 +85,7 @@ func (v NullableCatAllOf) Get() *CatAllOf {
 	return v.value
 }
 
-func (v NullableCatAllOf) Set(val *CatAllOf) {
+func (v *NullableCatAllOf) Set(val *CatAllOf) {
 	v.value = val
 	v.isSet = true
 }
@@ -94,7 +94,7 @@ func (v NullableCatAllOf) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableCatAllOf) Unset() {
+func (v *NullableCatAllOf) Unset() {
 	v.value = nil
 	v.isSet = false
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_cat_all_of.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_cat_all_of.go
@@ -46,7 +46,6 @@ func (o *CatAllOf) GetDeclawed() bool {
 
 // GetDeclawedOk returns a tuple with the Declawed field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *CatAllOf) GetDeclawedOk() (*bool, bool) {
 	if o == nil || o.Declawed == nil {
 		return nil, false

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_cat_all_of.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_cat_all_of.go
@@ -10,7 +10,6 @@
 package petstore
 
 import (
-	"bytes"
 	"encoding/json"
 )
 
@@ -52,12 +51,12 @@ func (o *CatAllOf) GetDeclawedOk() (bool, bool) {
 		var ret bool
 		return ret, false
 	}
-	return *o.Declawed, true
+    return *o.Declawed, true
 }
 
 // HasDeclawed returns a boolean if a field has been set.
 func (o *CatAllOf) HasDeclawed() bool {
-	if o != nil && o.Declawed != nil {
+    if o != nil && o.Declawed != nil {
 		return true
 	}
 
@@ -69,25 +68,46 @@ func (o *CatAllOf) SetDeclawed(v bool) {
 	o.Declawed = &v
 }
 
+func (o CatAllOf) MarshalJSON() ([]byte, error) {
+    toSerialize := map[string]interface{}{}
+    if o.Declawed != nil {
+        toSerialize["declawed"] = o.Declawed
+    }
+    return json.Marshal(toSerialize)
+}
+
 type NullableCatAllOf struct {
-	Value CatAllOf
-	ExplicitNull bool
+	value *CatAllOf
+	isSet bool
+}
+
+func (v NullableCatAllOf) Get() *CatAllOf {
+    return v.value
+}
+
+func (v NullableCatAllOf) Set(val *CatAllOf) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableCatAllOf) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableCatAllOf) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableCatAllOf(val *CatAllOf) *NullableCatAllOf {
+    return &NullableCatAllOf{value: val, isSet: true}
 }
 
 func (v NullableCatAllOf) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-		return json.Marshal(v.Value)
-	}
+    return json.Marshal(v.value)
 }
 
 func (v *NullableCatAllOf) UnmarshalJSON(src []byte) error {
-	if bytes.Equal(src, []byte("null")) {
-		v.ExplicitNull = true
-		return nil
-	}
-
-	return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_cat_all_of.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_cat_all_of.go
@@ -23,16 +23,16 @@ type CatAllOf struct {
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
 func NewCatAllOf() *CatAllOf {
-    this := CatAllOf{}
-    return &this
+	this := CatAllOf{}
+	return &this
 }
 
 // NewCatAllOfWithDefaults instantiates a new CatAllOf object
 // This constructor will only assign default values to properties that have it defined,
 // but it doesn't guarantee that properties required by API are set
 func NewCatAllOfWithDefaults() *CatAllOf {
-    this := CatAllOf{}
-    return &this
+	this := CatAllOf{}
+	return &this
 }
 
 // GetDeclawed returns the Declawed field value if set, zero value otherwise.
@@ -44,14 +44,14 @@ func (o *CatAllOf) GetDeclawed() bool {
 	return *o.Declawed
 }
 
-// GetDeclawedOk returns a tuple with the Declawed field value if set, zero value otherwise
+// GetDeclawedOk returns a tuple with the Declawed field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *CatAllOf) GetDeclawedOk() (bool, bool) {
+
+func (o *CatAllOf) GetDeclawedOk() (*bool, bool) {
 	if o == nil || o.Declawed == nil {
-		var ret bool
-		return ret, false
+		return nil, false
 	}
-	return *o.Declawed, true
+	return o.Declawed, true
 }
 
 // HasDeclawed returns a boolean if a field has been set.

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_category.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_category.go
@@ -50,7 +50,6 @@ func (o *Category) GetId() int64 {
 
 // GetIdOk returns a tuple with the Id field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *Category) GetIdOk() (*int64, bool) {
 	if o == nil || o.Id == nil {
 		return nil, false
@@ -84,12 +83,11 @@ func (o *Category) GetName() string {
 
 // GetNameOk returns a tuple with the Name field value
 // and a boolean to check if the value has been set.
-
 func (o *Category) GetNameOk() (*string, bool) {
-    if o == nil  {
-        return nil, false
-    }
-    return &o.Name, true
+	if o == nil  {
+		return nil, false
+	}
+	return &o.Name, true
 }
 
 // SetName sets field value

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_category.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_category.go
@@ -107,7 +107,7 @@ func (v NullableCategory) Get() *Category {
 	return v.value
 }
 
-func (v NullableCategory) Set(val *Category) {
+func (v *NullableCategory) Set(val *Category) {
 	v.value = val
 	v.isSet = true
 }
@@ -116,7 +116,7 @@ func (v NullableCategory) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableCategory) Unset() {
+func (v *NullableCategory) Unset() {
 	v.value = nil
 	v.isSet = false
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_category.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_category.go
@@ -10,7 +10,6 @@
 package petstore
 
 import (
-	"bytes"
 	"encoding/json"
 )
 
@@ -56,12 +55,12 @@ func (o *Category) GetIdOk() (int64, bool) {
 		var ret int64
 		return ret, false
 	}
-	return *o.Id, true
+    return *o.Id, true
 }
 
 // HasId returns a boolean if a field has been set.
 func (o *Category) HasId() bool {
-	if o != nil && o.Id != nil {
+    if o != nil && o.Id != nil {
 		return true
 	}
 
@@ -88,25 +87,49 @@ func (o *Category) SetName(v string) {
 	o.Name = v
 }
 
+func (o Category) MarshalJSON() ([]byte, error) {
+    toSerialize := map[string]interface{}{}
+    if o.Id != nil {
+        toSerialize["id"] = o.Id
+    }
+    if true {
+        toSerialize["name"] = o.Name
+    }
+    return json.Marshal(toSerialize)
+}
+
 type NullableCategory struct {
-	Value Category
-	ExplicitNull bool
+	value *Category
+	isSet bool
+}
+
+func (v NullableCategory) Get() *Category {
+    return v.value
+}
+
+func (v NullableCategory) Set(val *Category) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableCategory) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableCategory) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableCategory(val *Category) *NullableCategory {
+    return &NullableCategory{value: val, isSet: true}
 }
 
 func (v NullableCategory) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-		return json.Marshal(v.Value)
-	}
+    return json.Marshal(v.value)
 }
 
 func (v *NullableCategory) UnmarshalJSON(src []byte) error {
-	if bytes.Equal(src, []byte("null")) {
-		v.ExplicitNull = true
-		return nil
-	}
-
-	return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_category.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_category.go
@@ -34,8 +34,8 @@ func NewCategory(name string, ) *Category {
 // but it doesn't guarantee that properties required by API are set
 func NewCategoryWithDefaults() *Category {
     this := Category{}
-    var name string = "default-name"
-    this.Name = name
+	var name string = "default-name"
+	this.Name = name
     return &this
 }
 
@@ -55,12 +55,12 @@ func (o *Category) GetIdOk() (int64, bool) {
 		var ret int64
 		return ret, false
 	}
-    return *o.Id, true
+	return *o.Id, true
 }
 
 // HasId returns a boolean if a field has been set.
 func (o *Category) HasId() bool {
-    if o != nil && o.Id != nil {
+	if o != nil && o.Id != nil {
 		return true
 	}
 
@@ -88,14 +88,14 @@ func (o *Category) SetName(v string) {
 }
 
 func (o Category) MarshalJSON() ([]byte, error) {
-    toSerialize := map[string]interface{}{}
-    if o.Id != nil {
-        toSerialize["id"] = o.Id
-    }
-    if true {
-        toSerialize["name"] = o.Name
-    }
-    return json.Marshal(toSerialize)
+	toSerialize := map[string]interface{}{}
+	if o.Id != nil {
+		toSerialize["id"] = o.Id
+	}
+	if true {
+		toSerialize["name"] = o.Name
+	}
+	return json.Marshal(toSerialize)
 }
 
 type NullableCategory struct {
@@ -104,32 +104,32 @@ type NullableCategory struct {
 }
 
 func (v NullableCategory) Get() *Category {
-    return v.value
+	return v.value
 }
 
 func (v NullableCategory) Set(val *Category) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableCategory) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableCategory) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableCategory(val *Category) *NullableCategory {
-    return &NullableCategory{value: val, isSet: true}
+	return &NullableCategory{value: val, isSet: true}
 }
 
 func (v NullableCategory) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableCategory) UnmarshalJSON(src []byte) error {
-    v.isSet = true
+	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_category.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_category.go
@@ -24,19 +24,19 @@ type Category struct {
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
 func NewCategory(name string, ) *Category {
-    this := Category{}
-    this.Name = name
-    return &this
+	this := Category{}
+	this.Name = name
+	return &this
 }
 
 // NewCategoryWithDefaults instantiates a new Category object
 // This constructor will only assign default values to properties that have it defined,
 // but it doesn't guarantee that properties required by API are set
 func NewCategoryWithDefaults() *Category {
-    this := Category{}
+	this := Category{}
 	var name string = "default-name"
 	this.Name = name
-    return &this
+	return &this
 }
 
 // GetId returns the Id field value if set, zero value otherwise.
@@ -48,14 +48,14 @@ func (o *Category) GetId() int64 {
 	return *o.Id
 }
 
-// GetIdOk returns a tuple with the Id field value if set, zero value otherwise
+// GetIdOk returns a tuple with the Id field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *Category) GetIdOk() (int64, bool) {
+
+func (o *Category) GetIdOk() (*int64, bool) {
 	if o == nil || o.Id == nil {
-		var ret int64
-		return ret, false
+		return nil, false
 	}
-	return *o.Id, true
+	return o.Id, true
 }
 
 // HasId returns a boolean if a field has been set.
@@ -74,12 +74,22 @@ func (o *Category) SetId(v int64) {
 
 // GetName returns the Name field value
 func (o *Category) GetName() string {
-	if o == nil {
+	if o == nil  {
 		var ret string
 		return ret
 	}
 
 	return o.Name
+}
+
+// GetNameOk returns a tuple with the Name field value
+// and a boolean to check if the value has been set.
+
+func (o *Category) GetNameOk() (*string, bool) {
+    if o == nil  {
+        return nil, false
+    }
+    return &o.Name, true
 }
 
 // SetName sets field value

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_class_model.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_class_model.go
@@ -85,7 +85,7 @@ func (v NullableClassModel) Get() *ClassModel {
 	return v.value
 }
 
-func (v NullableClassModel) Set(val *ClassModel) {
+func (v *NullableClassModel) Set(val *ClassModel) {
 	v.value = val
 	v.isSet = true
 }
@@ -94,7 +94,7 @@ func (v NullableClassModel) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableClassModel) Unset() {
+func (v *NullableClassModel) Unset() {
 	v.value = nil
 	v.isSet = false
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_class_model.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_class_model.go
@@ -46,7 +46,6 @@ func (o *ClassModel) GetClass() string {
 
 // GetClassOk returns a tuple with the Class field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *ClassModel) GetClassOk() (*string, bool) {
 	if o == nil || o.Class == nil {
 		return nil, false

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_class_model.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_class_model.go
@@ -10,7 +10,6 @@
 package petstore
 
 import (
-	"bytes"
 	"encoding/json"
 )
 
@@ -52,12 +51,12 @@ func (o *ClassModel) GetClassOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-	return *o.Class, true
+    return *o.Class, true
 }
 
 // HasClass returns a boolean if a field has been set.
 func (o *ClassModel) HasClass() bool {
-	if o != nil && o.Class != nil {
+    if o != nil && o.Class != nil {
 		return true
 	}
 
@@ -69,25 +68,46 @@ func (o *ClassModel) SetClass(v string) {
 	o.Class = &v
 }
 
+func (o ClassModel) MarshalJSON() ([]byte, error) {
+    toSerialize := map[string]interface{}{}
+    if o.Class != nil {
+        toSerialize["_class"] = o.Class
+    }
+    return json.Marshal(toSerialize)
+}
+
 type NullableClassModel struct {
-	Value ClassModel
-	ExplicitNull bool
+	value *ClassModel
+	isSet bool
+}
+
+func (v NullableClassModel) Get() *ClassModel {
+    return v.value
+}
+
+func (v NullableClassModel) Set(val *ClassModel) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableClassModel) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableClassModel) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableClassModel(val *ClassModel) *NullableClassModel {
+    return &NullableClassModel{value: val, isSet: true}
 }
 
 func (v NullableClassModel) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-		return json.Marshal(v.Value)
-	}
+    return json.Marshal(v.value)
 }
 
 func (v *NullableClassModel) UnmarshalJSON(src []byte) error {
-	if bytes.Equal(src, []byte("null")) {
-		v.ExplicitNull = true
-		return nil
-	}
-
-	return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_class_model.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_class_model.go
@@ -51,12 +51,12 @@ func (o *ClassModel) GetClassOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-    return *o.Class, true
+	return *o.Class, true
 }
 
 // HasClass returns a boolean if a field has been set.
 func (o *ClassModel) HasClass() bool {
-    if o != nil && o.Class != nil {
+	if o != nil && o.Class != nil {
 		return true
 	}
 
@@ -69,11 +69,11 @@ func (o *ClassModel) SetClass(v string) {
 }
 
 func (o ClassModel) MarshalJSON() ([]byte, error) {
-    toSerialize := map[string]interface{}{}
-    if o.Class != nil {
-        toSerialize["_class"] = o.Class
-    }
-    return json.Marshal(toSerialize)
+	toSerialize := map[string]interface{}{}
+	if o.Class != nil {
+		toSerialize["_class"] = o.Class
+	}
+	return json.Marshal(toSerialize)
 }
 
 type NullableClassModel struct {
@@ -82,32 +82,32 @@ type NullableClassModel struct {
 }
 
 func (v NullableClassModel) Get() *ClassModel {
-    return v.value
+	return v.value
 }
 
 func (v NullableClassModel) Set(val *ClassModel) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableClassModel) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableClassModel) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableClassModel(val *ClassModel) *NullableClassModel {
-    return &NullableClassModel{value: val, isSet: true}
+	return &NullableClassModel{value: val, isSet: true}
 }
 
 func (v NullableClassModel) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableClassModel) UnmarshalJSON(src []byte) error {
-    v.isSet = true
+	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_class_model.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_class_model.go
@@ -23,16 +23,16 @@ type ClassModel struct {
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
 func NewClassModel() *ClassModel {
-    this := ClassModel{}
-    return &this
+	this := ClassModel{}
+	return &this
 }
 
 // NewClassModelWithDefaults instantiates a new ClassModel object
 // This constructor will only assign default values to properties that have it defined,
 // but it doesn't guarantee that properties required by API are set
 func NewClassModelWithDefaults() *ClassModel {
-    this := ClassModel{}
-    return &this
+	this := ClassModel{}
+	return &this
 }
 
 // GetClass returns the Class field value if set, zero value otherwise.
@@ -44,14 +44,14 @@ func (o *ClassModel) GetClass() string {
 	return *o.Class
 }
 
-// GetClassOk returns a tuple with the Class field value if set, zero value otherwise
+// GetClassOk returns a tuple with the Class field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *ClassModel) GetClassOk() (string, bool) {
+
+func (o *ClassModel) GetClassOk() (*string, bool) {
 	if o == nil || o.Class == nil {
-		var ret string
-		return ret, false
+		return nil, false
 	}
-	return *o.Class, true
+	return o.Class, true
 }
 
 // HasClass returns a boolean if a field has been set.

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_client.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_client.go
@@ -23,16 +23,16 @@ type Client struct {
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
 func NewClient() *Client {
-    this := Client{}
-    return &this
+	this := Client{}
+	return &this
 }
 
 // NewClientWithDefaults instantiates a new Client object
 // This constructor will only assign default values to properties that have it defined,
 // but it doesn't guarantee that properties required by API are set
 func NewClientWithDefaults() *Client {
-    this := Client{}
-    return &this
+	this := Client{}
+	return &this
 }
 
 // GetClient returns the Client field value if set, zero value otherwise.
@@ -44,14 +44,14 @@ func (o *Client) GetClient() string {
 	return *o.Client
 }
 
-// GetClientOk returns a tuple with the Client field value if set, zero value otherwise
+// GetClientOk returns a tuple with the Client field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *Client) GetClientOk() (string, bool) {
+
+func (o *Client) GetClientOk() (*string, bool) {
 	if o == nil || o.Client == nil {
-		var ret string
-		return ret, false
+		return nil, false
 	}
-	return *o.Client, true
+	return o.Client, true
 }
 
 // HasClient returns a boolean if a field has been set.

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_client.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_client.go
@@ -46,7 +46,6 @@ func (o *Client) GetClient() string {
 
 // GetClientOk returns a tuple with the Client field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *Client) GetClientOk() (*string, bool) {
 	if o == nil || o.Client == nil {
 		return nil, false

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_client.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_client.go
@@ -85,7 +85,7 @@ func (v NullableClient) Get() *Client {
 	return v.value
 }
 
-func (v NullableClient) Set(val *Client) {
+func (v *NullableClient) Set(val *Client) {
 	v.value = val
 	v.isSet = true
 }
@@ -94,7 +94,7 @@ func (v NullableClient) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableClient) Unset() {
+func (v *NullableClient) Unset() {
 	v.value = nil
 	v.isSet = false
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_client.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_client.go
@@ -51,12 +51,12 @@ func (o *Client) GetClientOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-    return *o.Client, true
+	return *o.Client, true
 }
 
 // HasClient returns a boolean if a field has been set.
 func (o *Client) HasClient() bool {
-    if o != nil && o.Client != nil {
+	if o != nil && o.Client != nil {
 		return true
 	}
 
@@ -69,11 +69,11 @@ func (o *Client) SetClient(v string) {
 }
 
 func (o Client) MarshalJSON() ([]byte, error) {
-    toSerialize := map[string]interface{}{}
-    if o.Client != nil {
-        toSerialize["client"] = o.Client
-    }
-    return json.Marshal(toSerialize)
+	toSerialize := map[string]interface{}{}
+	if o.Client != nil {
+		toSerialize["client"] = o.Client
+	}
+	return json.Marshal(toSerialize)
 }
 
 type NullableClient struct {
@@ -82,32 +82,32 @@ type NullableClient struct {
 }
 
 func (v NullableClient) Get() *Client {
-    return v.value
+	return v.value
 }
 
 func (v NullableClient) Set(val *Client) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableClient) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableClient) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableClient(val *Client) *NullableClient {
-    return &NullableClient{value: val, isSet: true}
+	return &NullableClient{value: val, isSet: true}
 }
 
 func (v NullableClient) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableClient) UnmarshalJSON(src []byte) error {
-    v.isSet = true
+	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_client.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_client.go
@@ -10,7 +10,6 @@
 package petstore
 
 import (
-	"bytes"
 	"encoding/json"
 )
 
@@ -52,12 +51,12 @@ func (o *Client) GetClientOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-	return *o.Client, true
+    return *o.Client, true
 }
 
 // HasClient returns a boolean if a field has been set.
 func (o *Client) HasClient() bool {
-	if o != nil && o.Client != nil {
+    if o != nil && o.Client != nil {
 		return true
 	}
 
@@ -69,25 +68,46 @@ func (o *Client) SetClient(v string) {
 	o.Client = &v
 }
 
+func (o Client) MarshalJSON() ([]byte, error) {
+    toSerialize := map[string]interface{}{}
+    if o.Client != nil {
+        toSerialize["client"] = o.Client
+    }
+    return json.Marshal(toSerialize)
+}
+
 type NullableClient struct {
-	Value Client
-	ExplicitNull bool
+	value *Client
+	isSet bool
+}
+
+func (v NullableClient) Get() *Client {
+    return v.value
+}
+
+func (v NullableClient) Set(val *Client) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableClient) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableClient) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableClient(val *Client) *NullableClient {
+    return &NullableClient{value: val, isSet: true}
 }
 
 func (v NullableClient) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-		return json.Marshal(v.Value)
-	}
+    return json.Marshal(v.value)
 }
 
 func (v *NullableClient) UnmarshalJSON(src []byte) error {
-	if bytes.Equal(src, []byte("null")) {
-		v.ExplicitNull = true
-		return nil
-	}
-
-	return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_dog.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_dog.go
@@ -10,7 +10,6 @@
 package petstore
 
 import (
-	"bytes"
 	"encoding/json"
 )
 
@@ -53,12 +52,12 @@ func (o *Dog) GetBreedOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-	return *o.Breed, true
+    return *o.Breed, true
 }
 
 // HasBreed returns a boolean if a field has been set.
 func (o *Dog) HasBreed() bool {
-	if o != nil && o.Breed != nil {
+    if o != nil && o.Breed != nil {
 		return true
 	}
 
@@ -70,25 +69,54 @@ func (o *Dog) SetBreed(v string) {
 	o.Breed = &v
 }
 
+func (o Dog) MarshalJSON() ([]byte, error) {
+    toSerialize := map[string]interface{}{}
+    serializedAnimal, errAnimal := json.Marshal(o.Animal)
+    if errAnimal != nil {
+        return []byte{}, errAnimal
+    }
+    errAnimal = json.Unmarshal([]byte(serializedAnimal), &toSerialize)
+    if errAnimal != nil {
+       return []byte{}, errAnimal
+    }
+    if o.Breed != nil {
+        toSerialize["breed"] = o.Breed
+    }
+    return json.Marshal(toSerialize)
+}
+
 type NullableDog struct {
-	Value Dog
-	ExplicitNull bool
+	value *Dog
+	isSet bool
+}
+
+func (v NullableDog) Get() *Dog {
+    return v.value
+}
+
+func (v NullableDog) Set(val *Dog) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableDog) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableDog) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableDog(val *Dog) *NullableDog {
+    return &NullableDog{value: val, isSet: true}
 }
 
 func (v NullableDog) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-		return json.Marshal(v.Value)
-	}
+    return json.Marshal(v.value)
 }
 
 func (v *NullableDog) UnmarshalJSON(src []byte) error {
-	if bytes.Equal(src, []byte("null")) {
-		v.ExplicitNull = true
-		return nil
-	}
-
-	return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_dog.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_dog.go
@@ -24,16 +24,16 @@ type Dog struct {
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
 func NewDog() *Dog {
-    this := Dog{}
-    return &this
+	this := Dog{}
+	return &this
 }
 
 // NewDogWithDefaults instantiates a new Dog object
 // This constructor will only assign default values to properties that have it defined,
 // but it doesn't guarantee that properties required by API are set
 func NewDogWithDefaults() *Dog {
-    this := Dog{}
-    return &this
+	this := Dog{}
+	return &this
 }
 
 // GetBreed returns the Breed field value if set, zero value otherwise.
@@ -45,14 +45,14 @@ func (o *Dog) GetBreed() string {
 	return *o.Breed
 }
 
-// GetBreedOk returns a tuple with the Breed field value if set, zero value otherwise
+// GetBreedOk returns a tuple with the Breed field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *Dog) GetBreedOk() (string, bool) {
+
+func (o *Dog) GetBreedOk() (*string, bool) {
 	if o == nil || o.Breed == nil {
-		var ret string
-		return ret, false
+		return nil, false
 	}
-	return *o.Breed, true
+	return o.Breed, true
 }
 
 // HasBreed returns a boolean if a field has been set.

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_dog.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_dog.go
@@ -47,7 +47,6 @@ func (o *Dog) GetBreed() string {
 
 // GetBreedOk returns a tuple with the Breed field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *Dog) GetBreedOk() (*string, bool) {
 	if o == nil || o.Breed == nil {
 		return nil, false

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_dog.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_dog.go
@@ -52,12 +52,12 @@ func (o *Dog) GetBreedOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-    return *o.Breed, true
+	return *o.Breed, true
 }
 
 // HasBreed returns a boolean if a field has been set.
 func (o *Dog) HasBreed() bool {
-    if o != nil && o.Breed != nil {
+	if o != nil && o.Breed != nil {
 		return true
 	}
 
@@ -70,19 +70,19 @@ func (o *Dog) SetBreed(v string) {
 }
 
 func (o Dog) MarshalJSON() ([]byte, error) {
-    toSerialize := map[string]interface{}{}
-    serializedAnimal, errAnimal := json.Marshal(o.Animal)
-    if errAnimal != nil {
-        return []byte{}, errAnimal
-    }
-    errAnimal = json.Unmarshal([]byte(serializedAnimal), &toSerialize)
-    if errAnimal != nil {
-       return []byte{}, errAnimal
-    }
-    if o.Breed != nil {
-        toSerialize["breed"] = o.Breed
-    }
-    return json.Marshal(toSerialize)
+	toSerialize := map[string]interface{}{}
+	serializedAnimal, errAnimal := json.Marshal(o.Animal)
+	if errAnimal != nil {
+		return []byte{}, errAnimal
+	}
+	errAnimal = json.Unmarshal([]byte(serializedAnimal), &toSerialize)
+	if errAnimal != nil {
+		return []byte{}, errAnimal
+	}
+	if o.Breed != nil {
+		toSerialize["breed"] = o.Breed
+	}
+	return json.Marshal(toSerialize)
 }
 
 type NullableDog struct {
@@ -91,32 +91,32 @@ type NullableDog struct {
 }
 
 func (v NullableDog) Get() *Dog {
-    return v.value
+	return v.value
 }
 
 func (v NullableDog) Set(val *Dog) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableDog) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableDog) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableDog(val *Dog) *NullableDog {
-    return &NullableDog{value: val, isSet: true}
+	return &NullableDog{value: val, isSet: true}
 }
 
 func (v NullableDog) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableDog) UnmarshalJSON(src []byte) error {
-    v.isSet = true
+	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_dog.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_dog.go
@@ -94,7 +94,7 @@ func (v NullableDog) Get() *Dog {
 	return v.value
 }
 
-func (v NullableDog) Set(val *Dog) {
+func (v *NullableDog) Set(val *Dog) {
 	v.value = val
 	v.isSet = true
 }
@@ -103,7 +103,7 @@ func (v NullableDog) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableDog) Unset() {
+func (v *NullableDog) Unset() {
 	v.value = nil
 	v.isSet = false
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_dog_all_of.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_dog_all_of.go
@@ -46,7 +46,6 @@ func (o *DogAllOf) GetBreed() string {
 
 // GetBreedOk returns a tuple with the Breed field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *DogAllOf) GetBreedOk() (*string, bool) {
 	if o == nil || o.Breed == nil {
 		return nil, false

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_dog_all_of.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_dog_all_of.go
@@ -23,16 +23,16 @@ type DogAllOf struct {
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
 func NewDogAllOf() *DogAllOf {
-    this := DogAllOf{}
-    return &this
+	this := DogAllOf{}
+	return &this
 }
 
 // NewDogAllOfWithDefaults instantiates a new DogAllOf object
 // This constructor will only assign default values to properties that have it defined,
 // but it doesn't guarantee that properties required by API are set
 func NewDogAllOfWithDefaults() *DogAllOf {
-    this := DogAllOf{}
-    return &this
+	this := DogAllOf{}
+	return &this
 }
 
 // GetBreed returns the Breed field value if set, zero value otherwise.
@@ -44,14 +44,14 @@ func (o *DogAllOf) GetBreed() string {
 	return *o.Breed
 }
 
-// GetBreedOk returns a tuple with the Breed field value if set, zero value otherwise
+// GetBreedOk returns a tuple with the Breed field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *DogAllOf) GetBreedOk() (string, bool) {
+
+func (o *DogAllOf) GetBreedOk() (*string, bool) {
 	if o == nil || o.Breed == nil {
-		var ret string
-		return ret, false
+		return nil, false
 	}
-	return *o.Breed, true
+	return o.Breed, true
 }
 
 // HasBreed returns a boolean if a field has been set.

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_dog_all_of.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_dog_all_of.go
@@ -51,12 +51,12 @@ func (o *DogAllOf) GetBreedOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-    return *o.Breed, true
+	return *o.Breed, true
 }
 
 // HasBreed returns a boolean if a field has been set.
 func (o *DogAllOf) HasBreed() bool {
-    if o != nil && o.Breed != nil {
+	if o != nil && o.Breed != nil {
 		return true
 	}
 
@@ -69,11 +69,11 @@ func (o *DogAllOf) SetBreed(v string) {
 }
 
 func (o DogAllOf) MarshalJSON() ([]byte, error) {
-    toSerialize := map[string]interface{}{}
-    if o.Breed != nil {
-        toSerialize["breed"] = o.Breed
-    }
-    return json.Marshal(toSerialize)
+	toSerialize := map[string]interface{}{}
+	if o.Breed != nil {
+		toSerialize["breed"] = o.Breed
+	}
+	return json.Marshal(toSerialize)
 }
 
 type NullableDogAllOf struct {
@@ -82,32 +82,32 @@ type NullableDogAllOf struct {
 }
 
 func (v NullableDogAllOf) Get() *DogAllOf {
-    return v.value
+	return v.value
 }
 
 func (v NullableDogAllOf) Set(val *DogAllOf) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableDogAllOf) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableDogAllOf) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableDogAllOf(val *DogAllOf) *NullableDogAllOf {
-    return &NullableDogAllOf{value: val, isSet: true}
+	return &NullableDogAllOf{value: val, isSet: true}
 }
 
 func (v NullableDogAllOf) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableDogAllOf) UnmarshalJSON(src []byte) error {
-    v.isSet = true
+	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_dog_all_of.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_dog_all_of.go
@@ -85,7 +85,7 @@ func (v NullableDogAllOf) Get() *DogAllOf {
 	return v.value
 }
 
-func (v NullableDogAllOf) Set(val *DogAllOf) {
+func (v *NullableDogAllOf) Set(val *DogAllOf) {
 	v.value = val
 	v.isSet = true
 }
@@ -94,7 +94,7 @@ func (v NullableDogAllOf) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableDogAllOf) Unset() {
+func (v *NullableDogAllOf) Unset() {
 	v.value = nil
 	v.isSet = false
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_dog_all_of.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_dog_all_of.go
@@ -10,7 +10,6 @@
 package petstore
 
 import (
-	"bytes"
 	"encoding/json"
 )
 
@@ -52,12 +51,12 @@ func (o *DogAllOf) GetBreedOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-	return *o.Breed, true
+    return *o.Breed, true
 }
 
 // HasBreed returns a boolean if a field has been set.
 func (o *DogAllOf) HasBreed() bool {
-	if o != nil && o.Breed != nil {
+    if o != nil && o.Breed != nil {
 		return true
 	}
 
@@ -69,25 +68,46 @@ func (o *DogAllOf) SetBreed(v string) {
 	o.Breed = &v
 }
 
+func (o DogAllOf) MarshalJSON() ([]byte, error) {
+    toSerialize := map[string]interface{}{}
+    if o.Breed != nil {
+        toSerialize["breed"] = o.Breed
+    }
+    return json.Marshal(toSerialize)
+}
+
 type NullableDogAllOf struct {
-	Value DogAllOf
-	ExplicitNull bool
+	value *DogAllOf
+	isSet bool
+}
+
+func (v NullableDogAllOf) Get() *DogAllOf {
+    return v.value
+}
+
+func (v NullableDogAllOf) Set(val *DogAllOf) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableDogAllOf) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableDogAllOf) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableDogAllOf(val *DogAllOf) *NullableDogAllOf {
+    return &NullableDogAllOf{value: val, isSet: true}
 }
 
 func (v NullableDogAllOf) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-		return json.Marshal(v.Value)
-	}
+    return json.Marshal(v.value)
 }
 
 func (v *NullableDogAllOf) UnmarshalJSON(src []byte) error {
-	if bytes.Equal(src, []byte("null")) {
-		v.ExplicitNull = true
-		return nil
-	}
-
-	return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_enum_arrays.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_enum_arrays.go
@@ -10,7 +10,6 @@
 package petstore
 
 import (
-	"bytes"
 	"encoding/json"
 )
 
@@ -53,12 +52,12 @@ func (o *EnumArrays) GetJustSymbolOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-	return *o.JustSymbol, true
+    return *o.JustSymbol, true
 }
 
 // HasJustSymbol returns a boolean if a field has been set.
 func (o *EnumArrays) HasJustSymbol() bool {
-	if o != nil && o.JustSymbol != nil {
+    if o != nil && o.JustSymbol != nil {
 		return true
 	}
 
@@ -86,12 +85,12 @@ func (o *EnumArrays) GetArrayEnumOk() ([]string, bool) {
 		var ret []string
 		return ret, false
 	}
-	return *o.ArrayEnum, true
+    return *o.ArrayEnum, true
 }
 
 // HasArrayEnum returns a boolean if a field has been set.
 func (o *EnumArrays) HasArrayEnum() bool {
-	if o != nil && o.ArrayEnum != nil {
+    if o != nil && o.ArrayEnum != nil {
 		return true
 	}
 
@@ -103,25 +102,49 @@ func (o *EnumArrays) SetArrayEnum(v []string) {
 	o.ArrayEnum = &v
 }
 
+func (o EnumArrays) MarshalJSON() ([]byte, error) {
+    toSerialize := map[string]interface{}{}
+    if o.JustSymbol != nil {
+        toSerialize["just_symbol"] = o.JustSymbol
+    }
+    if o.ArrayEnum != nil {
+        toSerialize["array_enum"] = o.ArrayEnum
+    }
+    return json.Marshal(toSerialize)
+}
+
 type NullableEnumArrays struct {
-	Value EnumArrays
-	ExplicitNull bool
+	value *EnumArrays
+	isSet bool
+}
+
+func (v NullableEnumArrays) Get() *EnumArrays {
+    return v.value
+}
+
+func (v NullableEnumArrays) Set(val *EnumArrays) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableEnumArrays) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableEnumArrays) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableEnumArrays(val *EnumArrays) *NullableEnumArrays {
+    return &NullableEnumArrays{value: val, isSet: true}
 }
 
 func (v NullableEnumArrays) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-		return json.Marshal(v.Value)
-	}
+    return json.Marshal(v.value)
 }
 
 func (v *NullableEnumArrays) UnmarshalJSON(src []byte) error {
-	if bytes.Equal(src, []byte("null")) {
-		v.ExplicitNull = true
-		return nil
-	}
-
-	return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_enum_arrays.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_enum_arrays.go
@@ -24,16 +24,16 @@ type EnumArrays struct {
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
 func NewEnumArrays() *EnumArrays {
-    this := EnumArrays{}
-    return &this
+	this := EnumArrays{}
+	return &this
 }
 
 // NewEnumArraysWithDefaults instantiates a new EnumArrays object
 // This constructor will only assign default values to properties that have it defined,
 // but it doesn't guarantee that properties required by API are set
 func NewEnumArraysWithDefaults() *EnumArrays {
-    this := EnumArrays{}
-    return &this
+	this := EnumArrays{}
+	return &this
 }
 
 // GetJustSymbol returns the JustSymbol field value if set, zero value otherwise.
@@ -45,14 +45,14 @@ func (o *EnumArrays) GetJustSymbol() string {
 	return *o.JustSymbol
 }
 
-// GetJustSymbolOk returns a tuple with the JustSymbol field value if set, zero value otherwise
+// GetJustSymbolOk returns a tuple with the JustSymbol field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *EnumArrays) GetJustSymbolOk() (string, bool) {
+
+func (o *EnumArrays) GetJustSymbolOk() (*string, bool) {
 	if o == nil || o.JustSymbol == nil {
-		var ret string
-		return ret, false
+		return nil, false
 	}
-	return *o.JustSymbol, true
+	return o.JustSymbol, true
 }
 
 // HasJustSymbol returns a boolean if a field has been set.
@@ -78,14 +78,14 @@ func (o *EnumArrays) GetArrayEnum() []string {
 	return *o.ArrayEnum
 }
 
-// GetArrayEnumOk returns a tuple with the ArrayEnum field value if set, zero value otherwise
+// GetArrayEnumOk returns a tuple with the ArrayEnum field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *EnumArrays) GetArrayEnumOk() ([]string, bool) {
+
+func (o *EnumArrays) GetArrayEnumOk() (*[]string, bool) {
 	if o == nil || o.ArrayEnum == nil {
-		var ret []string
-		return ret, false
+		return nil, false
 	}
-	return *o.ArrayEnum, true
+	return o.ArrayEnum, true
 }
 
 // HasArrayEnum returns a boolean if a field has been set.

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_enum_arrays.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_enum_arrays.go
@@ -52,12 +52,12 @@ func (o *EnumArrays) GetJustSymbolOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-    return *o.JustSymbol, true
+	return *o.JustSymbol, true
 }
 
 // HasJustSymbol returns a boolean if a field has been set.
 func (o *EnumArrays) HasJustSymbol() bool {
-    if o != nil && o.JustSymbol != nil {
+	if o != nil && o.JustSymbol != nil {
 		return true
 	}
 
@@ -85,12 +85,12 @@ func (o *EnumArrays) GetArrayEnumOk() ([]string, bool) {
 		var ret []string
 		return ret, false
 	}
-    return *o.ArrayEnum, true
+	return *o.ArrayEnum, true
 }
 
 // HasArrayEnum returns a boolean if a field has been set.
 func (o *EnumArrays) HasArrayEnum() bool {
-    if o != nil && o.ArrayEnum != nil {
+	if o != nil && o.ArrayEnum != nil {
 		return true
 	}
 
@@ -103,14 +103,14 @@ func (o *EnumArrays) SetArrayEnum(v []string) {
 }
 
 func (o EnumArrays) MarshalJSON() ([]byte, error) {
-    toSerialize := map[string]interface{}{}
-    if o.JustSymbol != nil {
-        toSerialize["just_symbol"] = o.JustSymbol
-    }
-    if o.ArrayEnum != nil {
-        toSerialize["array_enum"] = o.ArrayEnum
-    }
-    return json.Marshal(toSerialize)
+	toSerialize := map[string]interface{}{}
+	if o.JustSymbol != nil {
+		toSerialize["just_symbol"] = o.JustSymbol
+	}
+	if o.ArrayEnum != nil {
+		toSerialize["array_enum"] = o.ArrayEnum
+	}
+	return json.Marshal(toSerialize)
 }
 
 type NullableEnumArrays struct {
@@ -119,32 +119,32 @@ type NullableEnumArrays struct {
 }
 
 func (v NullableEnumArrays) Get() *EnumArrays {
-    return v.value
+	return v.value
 }
 
 func (v NullableEnumArrays) Set(val *EnumArrays) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableEnumArrays) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableEnumArrays) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableEnumArrays(val *EnumArrays) *NullableEnumArrays {
-    return &NullableEnumArrays{value: val, isSet: true}
+	return &NullableEnumArrays{value: val, isSet: true}
 }
 
 func (v NullableEnumArrays) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableEnumArrays) UnmarshalJSON(src []byte) error {
-    v.isSet = true
+	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_enum_arrays.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_enum_arrays.go
@@ -47,7 +47,6 @@ func (o *EnumArrays) GetJustSymbol() string {
 
 // GetJustSymbolOk returns a tuple with the JustSymbol field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *EnumArrays) GetJustSymbolOk() (*string, bool) {
 	if o == nil || o.JustSymbol == nil {
 		return nil, false
@@ -80,7 +79,6 @@ func (o *EnumArrays) GetArrayEnum() []string {
 
 // GetArrayEnumOk returns a tuple with the ArrayEnum field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *EnumArrays) GetArrayEnumOk() (*[]string, bool) {
 	if o == nil || o.ArrayEnum == nil {
 		return nil, false

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_enum_arrays.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_enum_arrays.go
@@ -122,7 +122,7 @@ func (v NullableEnumArrays) Get() *EnumArrays {
 	return v.value
 }
 
-func (v NullableEnumArrays) Set(val *EnumArrays) {
+func (v *NullableEnumArrays) Set(val *EnumArrays) {
 	v.value = val
 	v.isSet = true
 }
@@ -131,7 +131,7 @@ func (v NullableEnumArrays) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableEnumArrays) Unset() {
+func (v *NullableEnumArrays) Unset() {
 	v.value = nil
 	v.isSet = false
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_enum_class.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_enum_class.go
@@ -10,7 +10,6 @@
 package petstore
 
 import (
-	"bytes"
 	"encoding/json"
 )
 
@@ -25,24 +24,37 @@ const (
 )
 
 type NullableEnumClass struct {
-	Value EnumClass
-	ExplicitNull bool
+	value *EnumClass
+	isSet bool
+}
+
+func (v NullableEnumClass) Get() *EnumClass {
+    return v.value
+}
+
+func (v NullableEnumClass) Set(val *EnumClass) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableEnumClass) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableEnumClass) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableEnumClass(val *EnumClass) *NullableEnumClass {
+    return &NullableEnumClass{value: val, isSet: true}
 }
 
 func (v NullableEnumClass) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-		return json.Marshal(v.Value)
-	}
+    return json.Marshal(v.value)
 }
 
 func (v *NullableEnumClass) UnmarshalJSON(src []byte) error {
-	if bytes.Equal(src, []byte("null")) {
-		v.ExplicitNull = true
-		return nil
-	}
-
-	return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_enum_class.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_enum_class.go
@@ -32,7 +32,7 @@ func (v NullableEnumClass) Get() *EnumClass {
 	return v.value
 }
 
-func (v NullableEnumClass) Set(val *EnumClass) {
+func (v *NullableEnumClass) Set(val *EnumClass) {
 	v.value = val
 	v.isSet = true
 }
@@ -41,7 +41,7 @@ func (v NullableEnumClass) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableEnumClass) Unset() {
+func (v *NullableEnumClass) Unset() {
 	v.value = nil
 	v.isSet = false
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_enum_class.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_enum_class.go
@@ -29,32 +29,32 @@ type NullableEnumClass struct {
 }
 
 func (v NullableEnumClass) Get() *EnumClass {
-    return v.value
+	return v.value
 }
 
 func (v NullableEnumClass) Set(val *EnumClass) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableEnumClass) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableEnumClass) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableEnumClass(val *EnumClass) *NullableEnumClass {
-    return &NullableEnumClass{value: val, isSet: true}
+	return &NullableEnumClass{value: val, isSet: true}
 }
 
 func (v NullableEnumClass) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableEnumClass) UnmarshalJSON(src []byte) error {
-    v.isSet = true
+	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_enum_test_.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_enum_test_.go
@@ -30,25 +30,25 @@ type EnumTest struct {
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
 func NewEnumTest(enumStringRequired string, ) *EnumTest {
-    this := EnumTest{}
-    this.EnumStringRequired = enumStringRequired
+	this := EnumTest{}
+	this.EnumStringRequired = enumStringRequired
 	var outerEnumDefaultValue OuterEnumDefaultValue = "placed"
 	this.OuterEnumDefaultValue = &outerEnumDefaultValue
 	var outerEnumIntegerDefaultValue OuterEnumIntegerDefaultValue = OUTERENUMINTEGERDEFAULTVALUE__0
 	this.OuterEnumIntegerDefaultValue = &outerEnumIntegerDefaultValue
-    return &this
+	return &this
 }
 
 // NewEnumTestWithDefaults instantiates a new EnumTest object
 // This constructor will only assign default values to properties that have it defined,
 // but it doesn't guarantee that properties required by API are set
 func NewEnumTestWithDefaults() *EnumTest {
-    this := EnumTest{}
+	this := EnumTest{}
 	var outerEnumDefaultValue OuterEnumDefaultValue = "placed"
 	this.OuterEnumDefaultValue = &outerEnumDefaultValue
 	var outerEnumIntegerDefaultValue OuterEnumIntegerDefaultValue = OUTERENUMINTEGERDEFAULTVALUE__0
 	this.OuterEnumIntegerDefaultValue = &outerEnumIntegerDefaultValue
-    return &this
+	return &this
 }
 
 // GetEnumString returns the EnumString field value if set, zero value otherwise.
@@ -60,14 +60,14 @@ func (o *EnumTest) GetEnumString() string {
 	return *o.EnumString
 }
 
-// GetEnumStringOk returns a tuple with the EnumString field value if set, zero value otherwise
+// GetEnumStringOk returns a tuple with the EnumString field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *EnumTest) GetEnumStringOk() (string, bool) {
+
+func (o *EnumTest) GetEnumStringOk() (*string, bool) {
 	if o == nil || o.EnumString == nil {
-		var ret string
-		return ret, false
+		return nil, false
 	}
-	return *o.EnumString, true
+	return o.EnumString, true
 }
 
 // HasEnumString returns a boolean if a field has been set.
@@ -86,12 +86,22 @@ func (o *EnumTest) SetEnumString(v string) {
 
 // GetEnumStringRequired returns the EnumStringRequired field value
 func (o *EnumTest) GetEnumStringRequired() string {
-	if o == nil {
+	if o == nil  {
 		var ret string
 		return ret
 	}
 
 	return o.EnumStringRequired
+}
+
+// GetEnumStringRequiredOk returns a tuple with the EnumStringRequired field value
+// and a boolean to check if the value has been set.
+
+func (o *EnumTest) GetEnumStringRequiredOk() (*string, bool) {
+    if o == nil  {
+        return nil, false
+    }
+    return &o.EnumStringRequired, true
 }
 
 // SetEnumStringRequired sets field value
@@ -108,14 +118,14 @@ func (o *EnumTest) GetEnumInteger() int32 {
 	return *o.EnumInteger
 }
 
-// GetEnumIntegerOk returns a tuple with the EnumInteger field value if set, zero value otherwise
+// GetEnumIntegerOk returns a tuple with the EnumInteger field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *EnumTest) GetEnumIntegerOk() (int32, bool) {
+
+func (o *EnumTest) GetEnumIntegerOk() (*int32, bool) {
 	if o == nil || o.EnumInteger == nil {
-		var ret int32
-		return ret, false
+		return nil, false
 	}
-	return *o.EnumInteger, true
+	return o.EnumInteger, true
 }
 
 // HasEnumInteger returns a boolean if a field has been set.
@@ -141,14 +151,14 @@ func (o *EnumTest) GetEnumNumber() float64 {
 	return *o.EnumNumber
 }
 
-// GetEnumNumberOk returns a tuple with the EnumNumber field value if set, zero value otherwise
+// GetEnumNumberOk returns a tuple with the EnumNumber field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *EnumTest) GetEnumNumberOk() (float64, bool) {
+
+func (o *EnumTest) GetEnumNumberOk() (*float64, bool) {
 	if o == nil || o.EnumNumber == nil {
-		var ret float64
-		return ret, false
+		return nil, false
 	}
-	return *o.EnumNumber, true
+	return o.EnumNumber, true
 }
 
 // HasEnumNumber returns a boolean if a field has been set.
@@ -165,23 +175,23 @@ func (o *EnumTest) SetEnumNumber(v float64) {
 	o.EnumNumber = &v
 }
 
-// GetOuterEnum returns the OuterEnum field value if set, zero value otherwise.
-func (o *EnumTest) GetOuterEnum() NullableOuterEnum {
-	if o == nil  {
-		var ret NullableOuterEnum
+// GetOuterEnum returns the OuterEnum field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *EnumTest) GetOuterEnum() OuterEnum {
+	if o == nil || o.OuterEnum.Get() == nil {
+		var ret OuterEnum
 		return ret
 	}
-	return o.OuterEnum
+	return *o.OuterEnum.Get()
 }
 
-// GetOuterEnumOk returns a tuple with the OuterEnum field value if set, zero value otherwise
+// GetOuterEnumOk returns a tuple with the OuterEnum field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *EnumTest) GetOuterEnumOk() (NullableOuterEnum, bool) {
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *EnumTest) GetOuterEnumOk() (*OuterEnum, bool) {
 	if o == nil  {
-		var ret NullableOuterEnum
-		return ret, false
+		return nil, false
 	}
-	return o.OuterEnum, o.OuterEnum.IsSet()
+	return o.OuterEnum.Get(), o.OuterEnum.IsSet()
 }
 
 // HasOuterEnum returns a boolean if a field has been set.
@@ -194,8 +204,17 @@ func (o *EnumTest) HasOuterEnum() bool {
 }
 
 // SetOuterEnum gets a reference to the given NullableOuterEnum and assigns it to the OuterEnum field.
-func (o *EnumTest) SetOuterEnum(v NullableOuterEnum) {
-	o.OuterEnum = v
+func (o *EnumTest) SetOuterEnum(v OuterEnum) {
+	o.OuterEnum.Set(&v)
+}
+// SetOuterEnumNil sets the value for OuterEnum to be an explicit nil
+func (o *EnumTest) SetOuterEnumNil() {
+	o.OuterEnum.Set(nil)
+}
+
+// UnsetOuterEnum ensures that no value is present for OuterEnum, not even an explicit nil
+func (o *EnumTest) UnsetOuterEnum() {
+	o.OuterEnum.Unset()
 }
 
 // GetOuterEnumInteger returns the OuterEnumInteger field value if set, zero value otherwise.
@@ -207,14 +226,14 @@ func (o *EnumTest) GetOuterEnumInteger() OuterEnumInteger {
 	return *o.OuterEnumInteger
 }
 
-// GetOuterEnumIntegerOk returns a tuple with the OuterEnumInteger field value if set, zero value otherwise
+// GetOuterEnumIntegerOk returns a tuple with the OuterEnumInteger field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *EnumTest) GetOuterEnumIntegerOk() (OuterEnumInteger, bool) {
+
+func (o *EnumTest) GetOuterEnumIntegerOk() (*OuterEnumInteger, bool) {
 	if o == nil || o.OuterEnumInteger == nil {
-		var ret OuterEnumInteger
-		return ret, false
+		return nil, false
 	}
-	return *o.OuterEnumInteger, true
+	return o.OuterEnumInteger, true
 }
 
 // HasOuterEnumInteger returns a boolean if a field has been set.
@@ -240,14 +259,14 @@ func (o *EnumTest) GetOuterEnumDefaultValue() OuterEnumDefaultValue {
 	return *o.OuterEnumDefaultValue
 }
 
-// GetOuterEnumDefaultValueOk returns a tuple with the OuterEnumDefaultValue field value if set, zero value otherwise
+// GetOuterEnumDefaultValueOk returns a tuple with the OuterEnumDefaultValue field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *EnumTest) GetOuterEnumDefaultValueOk() (OuterEnumDefaultValue, bool) {
+
+func (o *EnumTest) GetOuterEnumDefaultValueOk() (*OuterEnumDefaultValue, bool) {
 	if o == nil || o.OuterEnumDefaultValue == nil {
-		var ret OuterEnumDefaultValue
-		return ret, false
+		return nil, false
 	}
-	return *o.OuterEnumDefaultValue, true
+	return o.OuterEnumDefaultValue, true
 }
 
 // HasOuterEnumDefaultValue returns a boolean if a field has been set.
@@ -273,14 +292,14 @@ func (o *EnumTest) GetOuterEnumIntegerDefaultValue() OuterEnumIntegerDefaultValu
 	return *o.OuterEnumIntegerDefaultValue
 }
 
-// GetOuterEnumIntegerDefaultValueOk returns a tuple with the OuterEnumIntegerDefaultValue field value if set, zero value otherwise
+// GetOuterEnumIntegerDefaultValueOk returns a tuple with the OuterEnumIntegerDefaultValue field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *EnumTest) GetOuterEnumIntegerDefaultValueOk() (OuterEnumIntegerDefaultValue, bool) {
+
+func (o *EnumTest) GetOuterEnumIntegerDefaultValueOk() (*OuterEnumIntegerDefaultValue, bool) {
 	if o == nil || o.OuterEnumIntegerDefaultValue == nil {
-		var ret OuterEnumIntegerDefaultValue
-		return ret, false
+		return nil, false
 	}
-	return *o.OuterEnumIntegerDefaultValue, true
+	return o.OuterEnumIntegerDefaultValue, true
 }
 
 // HasOuterEnumIntegerDefaultValue returns a boolean if a field has been set.

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_enum_test_.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_enum_test_.go
@@ -32,10 +32,10 @@ type EnumTest struct {
 func NewEnumTest(enumStringRequired string, ) *EnumTest {
     this := EnumTest{}
     this.EnumStringRequired = enumStringRequired
-    var outerEnumDefaultValue OuterEnumDefaultValue = "placed"
-    this.OuterEnumDefaultValue = &outerEnumDefaultValue
-    var outerEnumIntegerDefaultValue OuterEnumIntegerDefaultValue = OUTERENUMINTEGERDEFAULTVALUE__0
-    this.OuterEnumIntegerDefaultValue = &outerEnumIntegerDefaultValue
+	var outerEnumDefaultValue OuterEnumDefaultValue = "placed"
+	this.OuterEnumDefaultValue = &outerEnumDefaultValue
+	var outerEnumIntegerDefaultValue OuterEnumIntegerDefaultValue = OUTERENUMINTEGERDEFAULTVALUE__0
+	this.OuterEnumIntegerDefaultValue = &outerEnumIntegerDefaultValue
     return &this
 }
 
@@ -44,10 +44,10 @@ func NewEnumTest(enumStringRequired string, ) *EnumTest {
 // but it doesn't guarantee that properties required by API are set
 func NewEnumTestWithDefaults() *EnumTest {
     this := EnumTest{}
-    var outerEnumDefaultValue OuterEnumDefaultValue = "placed"
-    this.OuterEnumDefaultValue = &outerEnumDefaultValue
-    var outerEnumIntegerDefaultValue OuterEnumIntegerDefaultValue = OUTERENUMINTEGERDEFAULTVALUE__0
-    this.OuterEnumIntegerDefaultValue = &outerEnumIntegerDefaultValue
+	var outerEnumDefaultValue OuterEnumDefaultValue = "placed"
+	this.OuterEnumDefaultValue = &outerEnumDefaultValue
+	var outerEnumIntegerDefaultValue OuterEnumIntegerDefaultValue = OUTERENUMINTEGERDEFAULTVALUE__0
+	this.OuterEnumIntegerDefaultValue = &outerEnumIntegerDefaultValue
     return &this
 }
 
@@ -67,12 +67,12 @@ func (o *EnumTest) GetEnumStringOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-    return *o.EnumString, true
+	return *o.EnumString, true
 }
 
 // HasEnumString returns a boolean if a field has been set.
 func (o *EnumTest) HasEnumString() bool {
-    if o != nil && o.EnumString != nil {
+	if o != nil && o.EnumString != nil {
 		return true
 	}
 
@@ -115,12 +115,12 @@ func (o *EnumTest) GetEnumIntegerOk() (int32, bool) {
 		var ret int32
 		return ret, false
 	}
-    return *o.EnumInteger, true
+	return *o.EnumInteger, true
 }
 
 // HasEnumInteger returns a boolean if a field has been set.
 func (o *EnumTest) HasEnumInteger() bool {
-    if o != nil && o.EnumInteger != nil {
+	if o != nil && o.EnumInteger != nil {
 		return true
 	}
 
@@ -148,12 +148,12 @@ func (o *EnumTest) GetEnumNumberOk() (float64, bool) {
 		var ret float64
 		return ret, false
 	}
-    return *o.EnumNumber, true
+	return *o.EnumNumber, true
 }
 
 // HasEnumNumber returns a boolean if a field has been set.
 func (o *EnumTest) HasEnumNumber() bool {
-    if o != nil && o.EnumNumber != nil {
+	if o != nil && o.EnumNumber != nil {
 		return true
 	}
 
@@ -181,12 +181,12 @@ func (o *EnumTest) GetOuterEnumOk() (NullableOuterEnum, bool) {
 		var ret NullableOuterEnum
 		return ret, false
 	}
-    return o.OuterEnum, o.OuterEnum.IsSet()
+	return o.OuterEnum, o.OuterEnum.IsSet()
 }
 
 // HasOuterEnum returns a boolean if a field has been set.
 func (o *EnumTest) HasOuterEnum() bool {
-    if o != nil && o.OuterEnum.IsSet() {
+	if o != nil && o.OuterEnum.IsSet() {
 		return true
 	}
 
@@ -214,12 +214,12 @@ func (o *EnumTest) GetOuterEnumIntegerOk() (OuterEnumInteger, bool) {
 		var ret OuterEnumInteger
 		return ret, false
 	}
-    return *o.OuterEnumInteger, true
+	return *o.OuterEnumInteger, true
 }
 
 // HasOuterEnumInteger returns a boolean if a field has been set.
 func (o *EnumTest) HasOuterEnumInteger() bool {
-    if o != nil && o.OuterEnumInteger != nil {
+	if o != nil && o.OuterEnumInteger != nil {
 		return true
 	}
 
@@ -247,12 +247,12 @@ func (o *EnumTest) GetOuterEnumDefaultValueOk() (OuterEnumDefaultValue, bool) {
 		var ret OuterEnumDefaultValue
 		return ret, false
 	}
-    return *o.OuterEnumDefaultValue, true
+	return *o.OuterEnumDefaultValue, true
 }
 
 // HasOuterEnumDefaultValue returns a boolean if a field has been set.
 func (o *EnumTest) HasOuterEnumDefaultValue() bool {
-    if o != nil && o.OuterEnumDefaultValue != nil {
+	if o != nil && o.OuterEnumDefaultValue != nil {
 		return true
 	}
 
@@ -280,12 +280,12 @@ func (o *EnumTest) GetOuterEnumIntegerDefaultValueOk() (OuterEnumIntegerDefaultV
 		var ret OuterEnumIntegerDefaultValue
 		return ret, false
 	}
-    return *o.OuterEnumIntegerDefaultValue, true
+	return *o.OuterEnumIntegerDefaultValue, true
 }
 
 // HasOuterEnumIntegerDefaultValue returns a boolean if a field has been set.
 func (o *EnumTest) HasOuterEnumIntegerDefaultValue() bool {
-    if o != nil && o.OuterEnumIntegerDefaultValue != nil {
+	if o != nil && o.OuterEnumIntegerDefaultValue != nil {
 		return true
 	}
 
@@ -298,32 +298,32 @@ func (o *EnumTest) SetOuterEnumIntegerDefaultValue(v OuterEnumIntegerDefaultValu
 }
 
 func (o EnumTest) MarshalJSON() ([]byte, error) {
-    toSerialize := map[string]interface{}{}
-    if o.EnumString != nil {
-        toSerialize["enum_string"] = o.EnumString
-    }
-    if true {
-        toSerialize["enum_string_required"] = o.EnumStringRequired
-    }
-    if o.EnumInteger != nil {
-        toSerialize["enum_integer"] = o.EnumInteger
-    }
-    if o.EnumNumber != nil {
-        toSerialize["enum_number"] = o.EnumNumber
-    }
-    if o.OuterEnum.IsSet() {
-        toSerialize["outerEnum"] = o.OuterEnum.Get()
-    }
-    if o.OuterEnumInteger != nil {
-        toSerialize["outerEnumInteger"] = o.OuterEnumInteger
-    }
-    if o.OuterEnumDefaultValue != nil {
-        toSerialize["outerEnumDefaultValue"] = o.OuterEnumDefaultValue
-    }
-    if o.OuterEnumIntegerDefaultValue != nil {
-        toSerialize["outerEnumIntegerDefaultValue"] = o.OuterEnumIntegerDefaultValue
-    }
-    return json.Marshal(toSerialize)
+	toSerialize := map[string]interface{}{}
+	if o.EnumString != nil {
+		toSerialize["enum_string"] = o.EnumString
+	}
+	if true {
+		toSerialize["enum_string_required"] = o.EnumStringRequired
+	}
+	if o.EnumInteger != nil {
+		toSerialize["enum_integer"] = o.EnumInteger
+	}
+	if o.EnumNumber != nil {
+		toSerialize["enum_number"] = o.EnumNumber
+	}
+	if o.OuterEnum.IsSet() {
+		toSerialize["outerEnum"] = o.OuterEnum.Get()
+	}
+	if o.OuterEnumInteger != nil {
+		toSerialize["outerEnumInteger"] = o.OuterEnumInteger
+	}
+	if o.OuterEnumDefaultValue != nil {
+		toSerialize["outerEnumDefaultValue"] = o.OuterEnumDefaultValue
+	}
+	if o.OuterEnumIntegerDefaultValue != nil {
+		toSerialize["outerEnumIntegerDefaultValue"] = o.OuterEnumIntegerDefaultValue
+	}
+	return json.Marshal(toSerialize)
 }
 
 type NullableEnumTest struct {
@@ -332,32 +332,32 @@ type NullableEnumTest struct {
 }
 
 func (v NullableEnumTest) Get() *EnumTest {
-    return v.value
+	return v.value
 }
 
 func (v NullableEnumTest) Set(val *EnumTest) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableEnumTest) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableEnumTest) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableEnumTest(val *EnumTest) *NullableEnumTest {
-    return &NullableEnumTest{value: val, isSet: true}
+	return &NullableEnumTest{value: val, isSet: true}
 }
 
 func (v NullableEnumTest) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableEnumTest) UnmarshalJSON(src []byte) error {
-    v.isSet = true
+	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_enum_test_.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_enum_test_.go
@@ -10,7 +10,6 @@
 package petstore
 
 import (
-	"bytes"
 	"encoding/json"
 )
 
@@ -20,7 +19,7 @@ type EnumTest struct {
 	EnumStringRequired string `json:"enum_string_required"`
 	EnumInteger *int32 `json:"enum_integer,omitempty"`
 	EnumNumber *float64 `json:"enum_number,omitempty"`
-	OuterEnum *NullableOuterEnum `json:"outerEnum,omitempty"`
+	OuterEnum NullableOuterEnum `json:"outerEnum,omitempty"`
 	OuterEnumInteger *OuterEnumInteger `json:"outerEnumInteger,omitempty"`
 	OuterEnumDefaultValue *OuterEnumDefaultValue `json:"outerEnumDefaultValue,omitempty"`
 	OuterEnumIntegerDefaultValue *OuterEnumIntegerDefaultValue `json:"outerEnumIntegerDefaultValue,omitempty"`
@@ -68,12 +67,12 @@ func (o *EnumTest) GetEnumStringOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-	return *o.EnumString, true
+    return *o.EnumString, true
 }
 
 // HasEnumString returns a boolean if a field has been set.
 func (o *EnumTest) HasEnumString() bool {
-	if o != nil && o.EnumString != nil {
+    if o != nil && o.EnumString != nil {
 		return true
 	}
 
@@ -116,12 +115,12 @@ func (o *EnumTest) GetEnumIntegerOk() (int32, bool) {
 		var ret int32
 		return ret, false
 	}
-	return *o.EnumInteger, true
+    return *o.EnumInteger, true
 }
 
 // HasEnumInteger returns a boolean if a field has been set.
 func (o *EnumTest) HasEnumInteger() bool {
-	if o != nil && o.EnumInteger != nil {
+    if o != nil && o.EnumInteger != nil {
 		return true
 	}
 
@@ -149,12 +148,12 @@ func (o *EnumTest) GetEnumNumberOk() (float64, bool) {
 		var ret float64
 		return ret, false
 	}
-	return *o.EnumNumber, true
+    return *o.EnumNumber, true
 }
 
 // HasEnumNumber returns a boolean if a field has been set.
 func (o *EnumTest) HasEnumNumber() bool {
-	if o != nil && o.EnumNumber != nil {
+    if o != nil && o.EnumNumber != nil {
 		return true
 	}
 
@@ -168,26 +167,26 @@ func (o *EnumTest) SetEnumNumber(v float64) {
 
 // GetOuterEnum returns the OuterEnum field value if set, zero value otherwise.
 func (o *EnumTest) GetOuterEnum() NullableOuterEnum {
-	if o == nil || o.OuterEnum == nil {
+	if o == nil  {
 		var ret NullableOuterEnum
 		return ret
 	}
-	return *o.OuterEnum
+	return o.OuterEnum
 }
 
 // GetOuterEnumOk returns a tuple with the OuterEnum field value if set, zero value otherwise
 // and a boolean to check if the value has been set.
 func (o *EnumTest) GetOuterEnumOk() (NullableOuterEnum, bool) {
-	if o == nil || o.OuterEnum == nil {
+	if o == nil  {
 		var ret NullableOuterEnum
 		return ret, false
 	}
-	return *o.OuterEnum, true
+    return o.OuterEnum, o.OuterEnum.IsSet()
 }
 
 // HasOuterEnum returns a boolean if a field has been set.
 func (o *EnumTest) HasOuterEnum() bool {
-	if o != nil && o.OuterEnum != nil {
+    if o != nil && o.OuterEnum.IsSet() {
 		return true
 	}
 
@@ -196,7 +195,7 @@ func (o *EnumTest) HasOuterEnum() bool {
 
 // SetOuterEnum gets a reference to the given NullableOuterEnum and assigns it to the OuterEnum field.
 func (o *EnumTest) SetOuterEnum(v NullableOuterEnum) {
-	o.OuterEnum = &v
+	o.OuterEnum = v
 }
 
 // GetOuterEnumInteger returns the OuterEnumInteger field value if set, zero value otherwise.
@@ -215,12 +214,12 @@ func (o *EnumTest) GetOuterEnumIntegerOk() (OuterEnumInteger, bool) {
 		var ret OuterEnumInteger
 		return ret, false
 	}
-	return *o.OuterEnumInteger, true
+    return *o.OuterEnumInteger, true
 }
 
 // HasOuterEnumInteger returns a boolean if a field has been set.
 func (o *EnumTest) HasOuterEnumInteger() bool {
-	if o != nil && o.OuterEnumInteger != nil {
+    if o != nil && o.OuterEnumInteger != nil {
 		return true
 	}
 
@@ -248,12 +247,12 @@ func (o *EnumTest) GetOuterEnumDefaultValueOk() (OuterEnumDefaultValue, bool) {
 		var ret OuterEnumDefaultValue
 		return ret, false
 	}
-	return *o.OuterEnumDefaultValue, true
+    return *o.OuterEnumDefaultValue, true
 }
 
 // HasOuterEnumDefaultValue returns a boolean if a field has been set.
 func (o *EnumTest) HasOuterEnumDefaultValue() bool {
-	if o != nil && o.OuterEnumDefaultValue != nil {
+    if o != nil && o.OuterEnumDefaultValue != nil {
 		return true
 	}
 
@@ -281,12 +280,12 @@ func (o *EnumTest) GetOuterEnumIntegerDefaultValueOk() (OuterEnumIntegerDefaultV
 		var ret OuterEnumIntegerDefaultValue
 		return ret, false
 	}
-	return *o.OuterEnumIntegerDefaultValue, true
+    return *o.OuterEnumIntegerDefaultValue, true
 }
 
 // HasOuterEnumIntegerDefaultValue returns a boolean if a field has been set.
 func (o *EnumTest) HasOuterEnumIntegerDefaultValue() bool {
-	if o != nil && o.OuterEnumIntegerDefaultValue != nil {
+    if o != nil && o.OuterEnumIntegerDefaultValue != nil {
 		return true
 	}
 
@@ -298,25 +297,67 @@ func (o *EnumTest) SetOuterEnumIntegerDefaultValue(v OuterEnumIntegerDefaultValu
 	o.OuterEnumIntegerDefaultValue = &v
 }
 
+func (o EnumTest) MarshalJSON() ([]byte, error) {
+    toSerialize := map[string]interface{}{}
+    if o.EnumString != nil {
+        toSerialize["enum_string"] = o.EnumString
+    }
+    if true {
+        toSerialize["enum_string_required"] = o.EnumStringRequired
+    }
+    if o.EnumInteger != nil {
+        toSerialize["enum_integer"] = o.EnumInteger
+    }
+    if o.EnumNumber != nil {
+        toSerialize["enum_number"] = o.EnumNumber
+    }
+    if o.OuterEnum.IsSet() {
+        toSerialize["outerEnum"] = o.OuterEnum.Get()
+    }
+    if o.OuterEnumInteger != nil {
+        toSerialize["outerEnumInteger"] = o.OuterEnumInteger
+    }
+    if o.OuterEnumDefaultValue != nil {
+        toSerialize["outerEnumDefaultValue"] = o.OuterEnumDefaultValue
+    }
+    if o.OuterEnumIntegerDefaultValue != nil {
+        toSerialize["outerEnumIntegerDefaultValue"] = o.OuterEnumIntegerDefaultValue
+    }
+    return json.Marshal(toSerialize)
+}
+
 type NullableEnumTest struct {
-	Value EnumTest
-	ExplicitNull bool
+	value *EnumTest
+	isSet bool
+}
+
+func (v NullableEnumTest) Get() *EnumTest {
+    return v.value
+}
+
+func (v NullableEnumTest) Set(val *EnumTest) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableEnumTest) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableEnumTest) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableEnumTest(val *EnumTest) *NullableEnumTest {
+    return &NullableEnumTest{value: val, isSet: true}
 }
 
 func (v NullableEnumTest) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-		return json.Marshal(v.Value)
-	}
+    return json.Marshal(v.value)
 }
 
 func (v *NullableEnumTest) UnmarshalJSON(src []byte) error {
-	if bytes.Equal(src, []byte("null")) {
-		v.ExplicitNull = true
-		return nil
-	}
-
-	return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_enum_test_.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_enum_test_.go
@@ -62,7 +62,6 @@ func (o *EnumTest) GetEnumString() string {
 
 // GetEnumStringOk returns a tuple with the EnumString field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *EnumTest) GetEnumStringOk() (*string, bool) {
 	if o == nil || o.EnumString == nil {
 		return nil, false
@@ -96,12 +95,11 @@ func (o *EnumTest) GetEnumStringRequired() string {
 
 // GetEnumStringRequiredOk returns a tuple with the EnumStringRequired field value
 // and a boolean to check if the value has been set.
-
 func (o *EnumTest) GetEnumStringRequiredOk() (*string, bool) {
-    if o == nil  {
-        return nil, false
-    }
-    return &o.EnumStringRequired, true
+	if o == nil  {
+		return nil, false
+	}
+	return &o.EnumStringRequired, true
 }
 
 // SetEnumStringRequired sets field value
@@ -120,7 +118,6 @@ func (o *EnumTest) GetEnumInteger() int32 {
 
 // GetEnumIntegerOk returns a tuple with the EnumInteger field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *EnumTest) GetEnumIntegerOk() (*int32, bool) {
 	if o == nil || o.EnumInteger == nil {
 		return nil, false
@@ -153,7 +150,6 @@ func (o *EnumTest) GetEnumNumber() float64 {
 
 // GetEnumNumberOk returns a tuple with the EnumNumber field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *EnumTest) GetEnumNumberOk() (*float64, bool) {
 	if o == nil || o.EnumNumber == nil {
 		return nil, false
@@ -228,7 +224,6 @@ func (o *EnumTest) GetOuterEnumInteger() OuterEnumInteger {
 
 // GetOuterEnumIntegerOk returns a tuple with the OuterEnumInteger field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *EnumTest) GetOuterEnumIntegerOk() (*OuterEnumInteger, bool) {
 	if o == nil || o.OuterEnumInteger == nil {
 		return nil, false
@@ -261,7 +256,6 @@ func (o *EnumTest) GetOuterEnumDefaultValue() OuterEnumDefaultValue {
 
 // GetOuterEnumDefaultValueOk returns a tuple with the OuterEnumDefaultValue field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *EnumTest) GetOuterEnumDefaultValueOk() (*OuterEnumDefaultValue, bool) {
 	if o == nil || o.OuterEnumDefaultValue == nil {
 		return nil, false
@@ -294,7 +288,6 @@ func (o *EnumTest) GetOuterEnumIntegerDefaultValue() OuterEnumIntegerDefaultValu
 
 // GetOuterEnumIntegerDefaultValueOk returns a tuple with the OuterEnumIntegerDefaultValue field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *EnumTest) GetOuterEnumIntegerDefaultValueOk() (*OuterEnumIntegerDefaultValue, bool) {
 	if o == nil || o.OuterEnumIntegerDefaultValue == nil {
 		return nil, false

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_enum_test_.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_enum_test_.go
@@ -335,7 +335,7 @@ func (v NullableEnumTest) Get() *EnumTest {
 	return v.value
 }
 
-func (v NullableEnumTest) Set(val *EnumTest) {
+func (v *NullableEnumTest) Set(val *EnumTest) {
 	v.value = val
 	v.isSet = true
 }
@@ -344,7 +344,7 @@ func (v NullableEnumTest) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableEnumTest) Unset() {
+func (v *NullableEnumTest) Unset() {
 	v.value = nil
 	v.isSet = false
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_file.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_file.go
@@ -86,7 +86,7 @@ func (v NullableFile) Get() *File {
 	return v.value
 }
 
-func (v NullableFile) Set(val *File) {
+func (v *NullableFile) Set(val *File) {
 	v.value = val
 	v.isSet = true
 }
@@ -95,7 +95,7 @@ func (v NullableFile) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableFile) Unset() {
+func (v *NullableFile) Unset() {
 	v.value = nil
 	v.isSet = false
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_file.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_file.go
@@ -47,7 +47,6 @@ func (o *File) GetSourceURI() string {
 
 // GetSourceURIOk returns a tuple with the SourceURI field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *File) GetSourceURIOk() (*string, bool) {
 	if o == nil || o.SourceURI == nil {
 		return nil, false

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_file.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_file.go
@@ -52,12 +52,12 @@ func (o *File) GetSourceURIOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-    return *o.SourceURI, true
+	return *o.SourceURI, true
 }
 
 // HasSourceURI returns a boolean if a field has been set.
 func (o *File) HasSourceURI() bool {
-    if o != nil && o.SourceURI != nil {
+	if o != nil && o.SourceURI != nil {
 		return true
 	}
 
@@ -70,11 +70,11 @@ func (o *File) SetSourceURI(v string) {
 }
 
 func (o File) MarshalJSON() ([]byte, error) {
-    toSerialize := map[string]interface{}{}
-    if o.SourceURI != nil {
-        toSerialize["sourceURI"] = o.SourceURI
-    }
-    return json.Marshal(toSerialize)
+	toSerialize := map[string]interface{}{}
+	if o.SourceURI != nil {
+		toSerialize["sourceURI"] = o.SourceURI
+	}
+	return json.Marshal(toSerialize)
 }
 
 type NullableFile struct {
@@ -83,32 +83,32 @@ type NullableFile struct {
 }
 
 func (v NullableFile) Get() *File {
-    return v.value
+	return v.value
 }
 
 func (v NullableFile) Set(val *File) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableFile) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableFile) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableFile(val *File) *NullableFile {
-    return &NullableFile{value: val, isSet: true}
+	return &NullableFile{value: val, isSet: true}
 }
 
 func (v NullableFile) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableFile) UnmarshalJSON(src []byte) error {
-    v.isSet = true
+	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_file.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_file.go
@@ -24,16 +24,16 @@ type File struct {
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
 func NewFile() *File {
-    this := File{}
-    return &this
+	this := File{}
+	return &this
 }
 
 // NewFileWithDefaults instantiates a new File object
 // This constructor will only assign default values to properties that have it defined,
 // but it doesn't guarantee that properties required by API are set
 func NewFileWithDefaults() *File {
-    this := File{}
-    return &this
+	this := File{}
+	return &this
 }
 
 // GetSourceURI returns the SourceURI field value if set, zero value otherwise.
@@ -45,14 +45,14 @@ func (o *File) GetSourceURI() string {
 	return *o.SourceURI
 }
 
-// GetSourceURIOk returns a tuple with the SourceURI field value if set, zero value otherwise
+// GetSourceURIOk returns a tuple with the SourceURI field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *File) GetSourceURIOk() (string, bool) {
+
+func (o *File) GetSourceURIOk() (*string, bool) {
 	if o == nil || o.SourceURI == nil {
-		var ret string
-		return ret, false
+		return nil, false
 	}
-	return *o.SourceURI, true
+	return o.SourceURI, true
 }
 
 // HasSourceURI returns a boolean if a field has been set.

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_file.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_file.go
@@ -10,7 +10,6 @@
 package petstore
 
 import (
-	"bytes"
 	"encoding/json"
 )
 
@@ -53,12 +52,12 @@ func (o *File) GetSourceURIOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-	return *o.SourceURI, true
+    return *o.SourceURI, true
 }
 
 // HasSourceURI returns a boolean if a field has been set.
 func (o *File) HasSourceURI() bool {
-	if o != nil && o.SourceURI != nil {
+    if o != nil && o.SourceURI != nil {
 		return true
 	}
 
@@ -70,25 +69,46 @@ func (o *File) SetSourceURI(v string) {
 	o.SourceURI = &v
 }
 
+func (o File) MarshalJSON() ([]byte, error) {
+    toSerialize := map[string]interface{}{}
+    if o.SourceURI != nil {
+        toSerialize["sourceURI"] = o.SourceURI
+    }
+    return json.Marshal(toSerialize)
+}
+
 type NullableFile struct {
-	Value File
-	ExplicitNull bool
+	value *File
+	isSet bool
+}
+
+func (v NullableFile) Get() *File {
+    return v.value
+}
+
+func (v NullableFile) Set(val *File) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableFile) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableFile) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableFile(val *File) *NullableFile {
+    return &NullableFile{value: val, isSet: true}
 }
 
 func (v NullableFile) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-		return json.Marshal(v.Value)
-	}
+    return json.Marshal(v.value)
 }
 
 func (v *NullableFile) UnmarshalJSON(src []byte) error {
-	if bytes.Equal(src, []byte("null")) {
-		v.ExplicitNull = true
-		return nil
-	}
-
-	return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_file_schema_test_class.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_file_schema_test_class.go
@@ -47,7 +47,6 @@ func (o *FileSchemaTestClass) GetFile() File {
 
 // GetFileOk returns a tuple with the File field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *FileSchemaTestClass) GetFileOk() (*File, bool) {
 	if o == nil || o.File == nil {
 		return nil, false
@@ -80,7 +79,6 @@ func (o *FileSchemaTestClass) GetFiles() []File {
 
 // GetFilesOk returns a tuple with the Files field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *FileSchemaTestClass) GetFilesOk() (*[]File, bool) {
 	if o == nil || o.Files == nil {
 		return nil, false

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_file_schema_test_class.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_file_schema_test_class.go
@@ -52,12 +52,12 @@ func (o *FileSchemaTestClass) GetFileOk() (File, bool) {
 		var ret File
 		return ret, false
 	}
-    return *o.File, true
+	return *o.File, true
 }
 
 // HasFile returns a boolean if a field has been set.
 func (o *FileSchemaTestClass) HasFile() bool {
-    if o != nil && o.File != nil {
+	if o != nil && o.File != nil {
 		return true
 	}
 
@@ -85,12 +85,12 @@ func (o *FileSchemaTestClass) GetFilesOk() ([]File, bool) {
 		var ret []File
 		return ret, false
 	}
-    return *o.Files, true
+	return *o.Files, true
 }
 
 // HasFiles returns a boolean if a field has been set.
 func (o *FileSchemaTestClass) HasFiles() bool {
-    if o != nil && o.Files != nil {
+	if o != nil && o.Files != nil {
 		return true
 	}
 
@@ -103,14 +103,14 @@ func (o *FileSchemaTestClass) SetFiles(v []File) {
 }
 
 func (o FileSchemaTestClass) MarshalJSON() ([]byte, error) {
-    toSerialize := map[string]interface{}{}
-    if o.File != nil {
-        toSerialize["file"] = o.File
-    }
-    if o.Files != nil {
-        toSerialize["files"] = o.Files
-    }
-    return json.Marshal(toSerialize)
+	toSerialize := map[string]interface{}{}
+	if o.File != nil {
+		toSerialize["file"] = o.File
+	}
+	if o.Files != nil {
+		toSerialize["files"] = o.Files
+	}
+	return json.Marshal(toSerialize)
 }
 
 type NullableFileSchemaTestClass struct {
@@ -119,32 +119,32 @@ type NullableFileSchemaTestClass struct {
 }
 
 func (v NullableFileSchemaTestClass) Get() *FileSchemaTestClass {
-    return v.value
+	return v.value
 }
 
 func (v NullableFileSchemaTestClass) Set(val *FileSchemaTestClass) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableFileSchemaTestClass) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableFileSchemaTestClass) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableFileSchemaTestClass(val *FileSchemaTestClass) *NullableFileSchemaTestClass {
-    return &NullableFileSchemaTestClass{value: val, isSet: true}
+	return &NullableFileSchemaTestClass{value: val, isSet: true}
 }
 
 func (v NullableFileSchemaTestClass) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableFileSchemaTestClass) UnmarshalJSON(src []byte) error {
-    v.isSet = true
+	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_file_schema_test_class.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_file_schema_test_class.go
@@ -122,7 +122,7 @@ func (v NullableFileSchemaTestClass) Get() *FileSchemaTestClass {
 	return v.value
 }
 
-func (v NullableFileSchemaTestClass) Set(val *FileSchemaTestClass) {
+func (v *NullableFileSchemaTestClass) Set(val *FileSchemaTestClass) {
 	v.value = val
 	v.isSet = true
 }
@@ -131,7 +131,7 @@ func (v NullableFileSchemaTestClass) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableFileSchemaTestClass) Unset() {
+func (v *NullableFileSchemaTestClass) Unset() {
 	v.value = nil
 	v.isSet = false
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_file_schema_test_class.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_file_schema_test_class.go
@@ -10,7 +10,6 @@
 package petstore
 
 import (
-	"bytes"
 	"encoding/json"
 )
 
@@ -53,12 +52,12 @@ func (o *FileSchemaTestClass) GetFileOk() (File, bool) {
 		var ret File
 		return ret, false
 	}
-	return *o.File, true
+    return *o.File, true
 }
 
 // HasFile returns a boolean if a field has been set.
 func (o *FileSchemaTestClass) HasFile() bool {
-	if o != nil && o.File != nil {
+    if o != nil && o.File != nil {
 		return true
 	}
 
@@ -86,12 +85,12 @@ func (o *FileSchemaTestClass) GetFilesOk() ([]File, bool) {
 		var ret []File
 		return ret, false
 	}
-	return *o.Files, true
+    return *o.Files, true
 }
 
 // HasFiles returns a boolean if a field has been set.
 func (o *FileSchemaTestClass) HasFiles() bool {
-	if o != nil && o.Files != nil {
+    if o != nil && o.Files != nil {
 		return true
 	}
 
@@ -103,25 +102,49 @@ func (o *FileSchemaTestClass) SetFiles(v []File) {
 	o.Files = &v
 }
 
+func (o FileSchemaTestClass) MarshalJSON() ([]byte, error) {
+    toSerialize := map[string]interface{}{}
+    if o.File != nil {
+        toSerialize["file"] = o.File
+    }
+    if o.Files != nil {
+        toSerialize["files"] = o.Files
+    }
+    return json.Marshal(toSerialize)
+}
+
 type NullableFileSchemaTestClass struct {
-	Value FileSchemaTestClass
-	ExplicitNull bool
+	value *FileSchemaTestClass
+	isSet bool
+}
+
+func (v NullableFileSchemaTestClass) Get() *FileSchemaTestClass {
+    return v.value
+}
+
+func (v NullableFileSchemaTestClass) Set(val *FileSchemaTestClass) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableFileSchemaTestClass) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableFileSchemaTestClass) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableFileSchemaTestClass(val *FileSchemaTestClass) *NullableFileSchemaTestClass {
+    return &NullableFileSchemaTestClass{value: val, isSet: true}
 }
 
 func (v NullableFileSchemaTestClass) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-		return json.Marshal(v.Value)
-	}
+    return json.Marshal(v.value)
 }
 
 func (v *NullableFileSchemaTestClass) UnmarshalJSON(src []byte) error {
-	if bytes.Equal(src, []byte("null")) {
-		v.ExplicitNull = true
-		return nil
-	}
-
-	return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_file_schema_test_class.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_file_schema_test_class.go
@@ -24,16 +24,16 @@ type FileSchemaTestClass struct {
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
 func NewFileSchemaTestClass() *FileSchemaTestClass {
-    this := FileSchemaTestClass{}
-    return &this
+	this := FileSchemaTestClass{}
+	return &this
 }
 
 // NewFileSchemaTestClassWithDefaults instantiates a new FileSchemaTestClass object
 // This constructor will only assign default values to properties that have it defined,
 // but it doesn't guarantee that properties required by API are set
 func NewFileSchemaTestClassWithDefaults() *FileSchemaTestClass {
-    this := FileSchemaTestClass{}
-    return &this
+	this := FileSchemaTestClass{}
+	return &this
 }
 
 // GetFile returns the File field value if set, zero value otherwise.
@@ -45,14 +45,14 @@ func (o *FileSchemaTestClass) GetFile() File {
 	return *o.File
 }
 
-// GetFileOk returns a tuple with the File field value if set, zero value otherwise
+// GetFileOk returns a tuple with the File field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *FileSchemaTestClass) GetFileOk() (File, bool) {
+
+func (o *FileSchemaTestClass) GetFileOk() (*File, bool) {
 	if o == nil || o.File == nil {
-		var ret File
-		return ret, false
+		return nil, false
 	}
-	return *o.File, true
+	return o.File, true
 }
 
 // HasFile returns a boolean if a field has been set.
@@ -78,14 +78,14 @@ func (o *FileSchemaTestClass) GetFiles() []File {
 	return *o.Files
 }
 
-// GetFilesOk returns a tuple with the Files field value if set, zero value otherwise
+// GetFilesOk returns a tuple with the Files field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *FileSchemaTestClass) GetFilesOk() ([]File, bool) {
+
+func (o *FileSchemaTestClass) GetFilesOk() (*[]File, bool) {
 	if o == nil || o.Files == nil {
-		var ret []File
-		return ret, false
+		return nil, false
 	}
-	return *o.Files, true
+	return o.Files, true
 }
 
 // HasFiles returns a boolean if a field has been set.

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_foo.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_foo.go
@@ -50,7 +50,6 @@ func (o *Foo) GetBar() string {
 
 // GetBarOk returns a tuple with the Bar field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *Foo) GetBarOk() (*string, bool) {
 	if o == nil || o.Bar == nil {
 		return nil, false

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_foo.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_foo.go
@@ -23,20 +23,20 @@ type Foo struct {
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
 func NewFoo() *Foo {
-    this := Foo{}
+	this := Foo{}
 	var bar string = "bar"
 	this.Bar = &bar
-    return &this
+	return &this
 }
 
 // NewFooWithDefaults instantiates a new Foo object
 // This constructor will only assign default values to properties that have it defined,
 // but it doesn't guarantee that properties required by API are set
 func NewFooWithDefaults() *Foo {
-    this := Foo{}
+	this := Foo{}
 	var bar string = "bar"
 	this.Bar = &bar
-    return &this
+	return &this
 }
 
 // GetBar returns the Bar field value if set, zero value otherwise.
@@ -48,14 +48,14 @@ func (o *Foo) GetBar() string {
 	return *o.Bar
 }
 
-// GetBarOk returns a tuple with the Bar field value if set, zero value otherwise
+// GetBarOk returns a tuple with the Bar field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *Foo) GetBarOk() (string, bool) {
+
+func (o *Foo) GetBarOk() (*string, bool) {
 	if o == nil || o.Bar == nil {
-		var ret string
-		return ret, false
+		return nil, false
 	}
-	return *o.Bar, true
+	return o.Bar, true
 }
 
 // HasBar returns a boolean if a field has been set.

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_foo.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_foo.go
@@ -24,8 +24,8 @@ type Foo struct {
 // will change when the set of required properties is changed
 func NewFoo() *Foo {
     this := Foo{}
-    var bar string = "bar"
-    this.Bar = &bar
+	var bar string = "bar"
+	this.Bar = &bar
     return &this
 }
 
@@ -34,8 +34,8 @@ func NewFoo() *Foo {
 // but it doesn't guarantee that properties required by API are set
 func NewFooWithDefaults() *Foo {
     this := Foo{}
-    var bar string = "bar"
-    this.Bar = &bar
+	var bar string = "bar"
+	this.Bar = &bar
     return &this
 }
 
@@ -55,12 +55,12 @@ func (o *Foo) GetBarOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-    return *o.Bar, true
+	return *o.Bar, true
 }
 
 // HasBar returns a boolean if a field has been set.
 func (o *Foo) HasBar() bool {
-    if o != nil && o.Bar != nil {
+	if o != nil && o.Bar != nil {
 		return true
 	}
 
@@ -73,11 +73,11 @@ func (o *Foo) SetBar(v string) {
 }
 
 func (o Foo) MarshalJSON() ([]byte, error) {
-    toSerialize := map[string]interface{}{}
-    if o.Bar != nil {
-        toSerialize["bar"] = o.Bar
-    }
-    return json.Marshal(toSerialize)
+	toSerialize := map[string]interface{}{}
+	if o.Bar != nil {
+		toSerialize["bar"] = o.Bar
+	}
+	return json.Marshal(toSerialize)
 }
 
 type NullableFoo struct {
@@ -86,32 +86,32 @@ type NullableFoo struct {
 }
 
 func (v NullableFoo) Get() *Foo {
-    return v.value
+	return v.value
 }
 
 func (v NullableFoo) Set(val *Foo) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableFoo) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableFoo) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableFoo(val *Foo) *NullableFoo {
-    return &NullableFoo{value: val, isSet: true}
+	return &NullableFoo{value: val, isSet: true}
 }
 
 func (v NullableFoo) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableFoo) UnmarshalJSON(src []byte) error {
-    v.isSet = true
+	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_foo.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_foo.go
@@ -10,7 +10,6 @@
 package petstore
 
 import (
-	"bytes"
 	"encoding/json"
 )
 
@@ -56,12 +55,12 @@ func (o *Foo) GetBarOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-	return *o.Bar, true
+    return *o.Bar, true
 }
 
 // HasBar returns a boolean if a field has been set.
 func (o *Foo) HasBar() bool {
-	if o != nil && o.Bar != nil {
+    if o != nil && o.Bar != nil {
 		return true
 	}
 
@@ -73,25 +72,46 @@ func (o *Foo) SetBar(v string) {
 	o.Bar = &v
 }
 
+func (o Foo) MarshalJSON() ([]byte, error) {
+    toSerialize := map[string]interface{}{}
+    if o.Bar != nil {
+        toSerialize["bar"] = o.Bar
+    }
+    return json.Marshal(toSerialize)
+}
+
 type NullableFoo struct {
-	Value Foo
-	ExplicitNull bool
+	value *Foo
+	isSet bool
+}
+
+func (v NullableFoo) Get() *Foo {
+    return v.value
+}
+
+func (v NullableFoo) Set(val *Foo) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableFoo) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableFoo) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableFoo(val *Foo) *NullableFoo {
+    return &NullableFoo{value: val, isSet: true}
 }
 
 func (v NullableFoo) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-		return json.Marshal(v.Value)
-	}
+    return json.Marshal(v.value)
 }
 
 func (v *NullableFoo) UnmarshalJSON(src []byte) error {
-	if bytes.Equal(src, []byte("null")) {
-		v.ExplicitNull = true
-		return nil
-	}
-
-	return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_foo.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_foo.go
@@ -89,7 +89,7 @@ func (v NullableFoo) Get() *Foo {
 	return v.value
 }
 
-func (v NullableFoo) Set(val *Foo) {
+func (v *NullableFoo) Set(val *Foo) {
 	v.value = val
 	v.isSet = true
 }
@@ -98,7 +98,7 @@ func (v NullableFoo) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableFoo) Unset() {
+func (v *NullableFoo) Unset() {
 	v.value = nil
 	v.isSet = false
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_format_test_.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_format_test_.go
@@ -41,20 +41,20 @@ type FormatTest struct {
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
 func NewFormatTest(number float32, byte_ string, date string, password string, ) *FormatTest {
-    this := FormatTest{}
-    this.Number = number
-    this.Byte = byte_
-    this.Date = date
-    this.Password = password
-    return &this
+	this := FormatTest{}
+	this.Number = number
+	this.Byte = byte_
+	this.Date = date
+	this.Password = password
+	return &this
 }
 
 // NewFormatTestWithDefaults instantiates a new FormatTest object
 // This constructor will only assign default values to properties that have it defined,
 // but it doesn't guarantee that properties required by API are set
 func NewFormatTestWithDefaults() *FormatTest {
-    this := FormatTest{}
-    return &this
+	this := FormatTest{}
+	return &this
 }
 
 // GetInteger returns the Integer field value if set, zero value otherwise.
@@ -66,14 +66,14 @@ func (o *FormatTest) GetInteger() int32 {
 	return *o.Integer
 }
 
-// GetIntegerOk returns a tuple with the Integer field value if set, zero value otherwise
+// GetIntegerOk returns a tuple with the Integer field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *FormatTest) GetIntegerOk() (int32, bool) {
+
+func (o *FormatTest) GetIntegerOk() (*int32, bool) {
 	if o == nil || o.Integer == nil {
-		var ret int32
-		return ret, false
+		return nil, false
 	}
-	return *o.Integer, true
+	return o.Integer, true
 }
 
 // HasInteger returns a boolean if a field has been set.
@@ -99,14 +99,14 @@ func (o *FormatTest) GetInt32() int32 {
 	return *o.Int32
 }
 
-// GetInt32Ok returns a tuple with the Int32 field value if set, zero value otherwise
+// GetInt32Ok returns a tuple with the Int32 field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *FormatTest) GetInt32Ok() (int32, bool) {
+
+func (o *FormatTest) GetInt32Ok() (*int32, bool) {
 	if o == nil || o.Int32 == nil {
-		var ret int32
-		return ret, false
+		return nil, false
 	}
-	return *o.Int32, true
+	return o.Int32, true
 }
 
 // HasInt32 returns a boolean if a field has been set.
@@ -132,14 +132,14 @@ func (o *FormatTest) GetInt64() int64 {
 	return *o.Int64
 }
 
-// GetInt64Ok returns a tuple with the Int64 field value if set, zero value otherwise
+// GetInt64Ok returns a tuple with the Int64 field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *FormatTest) GetInt64Ok() (int64, bool) {
+
+func (o *FormatTest) GetInt64Ok() (*int64, bool) {
 	if o == nil || o.Int64 == nil {
-		var ret int64
-		return ret, false
+		return nil, false
 	}
-	return *o.Int64, true
+	return o.Int64, true
 }
 
 // HasInt64 returns a boolean if a field has been set.
@@ -158,12 +158,22 @@ func (o *FormatTest) SetInt64(v int64) {
 
 // GetNumber returns the Number field value
 func (o *FormatTest) GetNumber() float32 {
-	if o == nil {
+	if o == nil  {
 		var ret float32
 		return ret
 	}
 
 	return o.Number
+}
+
+// GetNumberOk returns a tuple with the Number field value
+// and a boolean to check if the value has been set.
+
+func (o *FormatTest) GetNumberOk() (*float32, bool) {
+    if o == nil  {
+        return nil, false
+    }
+    return &o.Number, true
 }
 
 // SetNumber sets field value
@@ -180,14 +190,14 @@ func (o *FormatTest) GetFloat() float32 {
 	return *o.Float
 }
 
-// GetFloatOk returns a tuple with the Float field value if set, zero value otherwise
+// GetFloatOk returns a tuple with the Float field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *FormatTest) GetFloatOk() (float32, bool) {
+
+func (o *FormatTest) GetFloatOk() (*float32, bool) {
 	if o == nil || o.Float == nil {
-		var ret float32
-		return ret, false
+		return nil, false
 	}
-	return *o.Float, true
+	return o.Float, true
 }
 
 // HasFloat returns a boolean if a field has been set.
@@ -213,14 +223,14 @@ func (o *FormatTest) GetDouble() float64 {
 	return *o.Double
 }
 
-// GetDoubleOk returns a tuple with the Double field value if set, zero value otherwise
+// GetDoubleOk returns a tuple with the Double field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *FormatTest) GetDoubleOk() (float64, bool) {
+
+func (o *FormatTest) GetDoubleOk() (*float64, bool) {
 	if o == nil || o.Double == nil {
-		var ret float64
-		return ret, false
+		return nil, false
 	}
-	return *o.Double, true
+	return o.Double, true
 }
 
 // HasDouble returns a boolean if a field has been set.
@@ -246,14 +256,14 @@ func (o *FormatTest) GetString() string {
 	return *o.String
 }
 
-// GetStringOk returns a tuple with the String field value if set, zero value otherwise
+// GetStringOk returns a tuple with the String field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *FormatTest) GetStringOk() (string, bool) {
+
+func (o *FormatTest) GetStringOk() (*string, bool) {
 	if o == nil || o.String == nil {
-		var ret string
-		return ret, false
+		return nil, false
 	}
-	return *o.String, true
+	return o.String, true
 }
 
 // HasString returns a boolean if a field has been set.
@@ -272,12 +282,22 @@ func (o *FormatTest) SetString(v string) {
 
 // GetByte returns the Byte field value
 func (o *FormatTest) GetByte() string {
-	if o == nil {
+	if o == nil  {
 		var ret string
 		return ret
 	}
 
 	return o.Byte
+}
+
+// GetByteOk returns a tuple with the Byte field value
+// and a boolean to check if the value has been set.
+
+func (o *FormatTest) GetByteOk() (*string, bool) {
+    if o == nil  {
+        return nil, false
+    }
+    return &o.Byte, true
 }
 
 // SetByte sets field value
@@ -294,14 +314,14 @@ func (o *FormatTest) GetBinary() *os.File {
 	return *o.Binary
 }
 
-// GetBinaryOk returns a tuple with the Binary field value if set, zero value otherwise
+// GetBinaryOk returns a tuple with the Binary field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *FormatTest) GetBinaryOk() (*os.File, bool) {
+
+func (o *FormatTest) GetBinaryOk() (**os.File, bool) {
 	if o == nil || o.Binary == nil {
-		var ret *os.File
-		return ret, false
+		return nil, false
 	}
-	return *o.Binary, true
+	return o.Binary, true
 }
 
 // HasBinary returns a boolean if a field has been set.
@@ -320,12 +340,22 @@ func (o *FormatTest) SetBinary(v *os.File) {
 
 // GetDate returns the Date field value
 func (o *FormatTest) GetDate() string {
-	if o == nil {
+	if o == nil  {
 		var ret string
 		return ret
 	}
 
 	return o.Date
+}
+
+// GetDateOk returns a tuple with the Date field value
+// and a boolean to check if the value has been set.
+
+func (o *FormatTest) GetDateOk() (*string, bool) {
+    if o == nil  {
+        return nil, false
+    }
+    return &o.Date, true
 }
 
 // SetDate sets field value
@@ -342,14 +372,14 @@ func (o *FormatTest) GetDateTime() time.Time {
 	return *o.DateTime
 }
 
-// GetDateTimeOk returns a tuple with the DateTime field value if set, zero value otherwise
+// GetDateTimeOk returns a tuple with the DateTime field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *FormatTest) GetDateTimeOk() (time.Time, bool) {
+
+func (o *FormatTest) GetDateTimeOk() (*time.Time, bool) {
 	if o == nil || o.DateTime == nil {
-		var ret time.Time
-		return ret, false
+		return nil, false
 	}
-	return *o.DateTime, true
+	return o.DateTime, true
 }
 
 // HasDateTime returns a boolean if a field has been set.
@@ -375,14 +405,14 @@ func (o *FormatTest) GetUuid() string {
 	return *o.Uuid
 }
 
-// GetUuidOk returns a tuple with the Uuid field value if set, zero value otherwise
+// GetUuidOk returns a tuple with the Uuid field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *FormatTest) GetUuidOk() (string, bool) {
+
+func (o *FormatTest) GetUuidOk() (*string, bool) {
 	if o == nil || o.Uuid == nil {
-		var ret string
-		return ret, false
+		return nil, false
 	}
-	return *o.Uuid, true
+	return o.Uuid, true
 }
 
 // HasUuid returns a boolean if a field has been set.
@@ -401,12 +431,22 @@ func (o *FormatTest) SetUuid(v string) {
 
 // GetPassword returns the Password field value
 func (o *FormatTest) GetPassword() string {
-	if o == nil {
+	if o == nil  {
 		var ret string
 		return ret
 	}
 
 	return o.Password
+}
+
+// GetPasswordOk returns a tuple with the Password field value
+// and a boolean to check if the value has been set.
+
+func (o *FormatTest) GetPasswordOk() (*string, bool) {
+    if o == nil  {
+        return nil, false
+    }
+    return &o.Password, true
 }
 
 // SetPassword sets field value
@@ -423,14 +463,14 @@ func (o *FormatTest) GetPatternWithDigits() string {
 	return *o.PatternWithDigits
 }
 
-// GetPatternWithDigitsOk returns a tuple with the PatternWithDigits field value if set, zero value otherwise
+// GetPatternWithDigitsOk returns a tuple with the PatternWithDigits field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *FormatTest) GetPatternWithDigitsOk() (string, bool) {
+
+func (o *FormatTest) GetPatternWithDigitsOk() (*string, bool) {
 	if o == nil || o.PatternWithDigits == nil {
-		var ret string
-		return ret, false
+		return nil, false
 	}
-	return *o.PatternWithDigits, true
+	return o.PatternWithDigits, true
 }
 
 // HasPatternWithDigits returns a boolean if a field has been set.
@@ -456,14 +496,14 @@ func (o *FormatTest) GetPatternWithDigitsAndDelimiter() string {
 	return *o.PatternWithDigitsAndDelimiter
 }
 
-// GetPatternWithDigitsAndDelimiterOk returns a tuple with the PatternWithDigitsAndDelimiter field value if set, zero value otherwise
+// GetPatternWithDigitsAndDelimiterOk returns a tuple with the PatternWithDigitsAndDelimiter field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *FormatTest) GetPatternWithDigitsAndDelimiterOk() (string, bool) {
+
+func (o *FormatTest) GetPatternWithDigitsAndDelimiterOk() (*string, bool) {
 	if o == nil || o.PatternWithDigitsAndDelimiter == nil {
-		var ret string
-		return ret, false
+		return nil, false
 	}
-	return *o.PatternWithDigitsAndDelimiter, true
+	return o.PatternWithDigitsAndDelimiter, true
 }
 
 // HasPatternWithDigitsAndDelimiter returns a boolean if a field has been set.

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_format_test_.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_format_test_.go
@@ -68,7 +68,6 @@ func (o *FormatTest) GetInteger() int32 {
 
 // GetIntegerOk returns a tuple with the Integer field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *FormatTest) GetIntegerOk() (*int32, bool) {
 	if o == nil || o.Integer == nil {
 		return nil, false
@@ -101,7 +100,6 @@ func (o *FormatTest) GetInt32() int32 {
 
 // GetInt32Ok returns a tuple with the Int32 field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *FormatTest) GetInt32Ok() (*int32, bool) {
 	if o == nil || o.Int32 == nil {
 		return nil, false
@@ -134,7 +132,6 @@ func (o *FormatTest) GetInt64() int64 {
 
 // GetInt64Ok returns a tuple with the Int64 field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *FormatTest) GetInt64Ok() (*int64, bool) {
 	if o == nil || o.Int64 == nil {
 		return nil, false
@@ -168,12 +165,11 @@ func (o *FormatTest) GetNumber() float32 {
 
 // GetNumberOk returns a tuple with the Number field value
 // and a boolean to check if the value has been set.
-
 func (o *FormatTest) GetNumberOk() (*float32, bool) {
-    if o == nil  {
-        return nil, false
-    }
-    return &o.Number, true
+	if o == nil  {
+		return nil, false
+	}
+	return &o.Number, true
 }
 
 // SetNumber sets field value
@@ -192,7 +188,6 @@ func (o *FormatTest) GetFloat() float32 {
 
 // GetFloatOk returns a tuple with the Float field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *FormatTest) GetFloatOk() (*float32, bool) {
 	if o == nil || o.Float == nil {
 		return nil, false
@@ -225,7 +220,6 @@ func (o *FormatTest) GetDouble() float64 {
 
 // GetDoubleOk returns a tuple with the Double field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *FormatTest) GetDoubleOk() (*float64, bool) {
 	if o == nil || o.Double == nil {
 		return nil, false
@@ -258,7 +252,6 @@ func (o *FormatTest) GetString() string {
 
 // GetStringOk returns a tuple with the String field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *FormatTest) GetStringOk() (*string, bool) {
 	if o == nil || o.String == nil {
 		return nil, false
@@ -292,12 +285,11 @@ func (o *FormatTest) GetByte() string {
 
 // GetByteOk returns a tuple with the Byte field value
 // and a boolean to check if the value has been set.
-
 func (o *FormatTest) GetByteOk() (*string, bool) {
-    if o == nil  {
-        return nil, false
-    }
-    return &o.Byte, true
+	if o == nil  {
+		return nil, false
+	}
+	return &o.Byte, true
 }
 
 // SetByte sets field value
@@ -316,7 +308,6 @@ func (o *FormatTest) GetBinary() *os.File {
 
 // GetBinaryOk returns a tuple with the Binary field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *FormatTest) GetBinaryOk() (**os.File, bool) {
 	if o == nil || o.Binary == nil {
 		return nil, false
@@ -350,12 +341,11 @@ func (o *FormatTest) GetDate() string {
 
 // GetDateOk returns a tuple with the Date field value
 // and a boolean to check if the value has been set.
-
 func (o *FormatTest) GetDateOk() (*string, bool) {
-    if o == nil  {
-        return nil, false
-    }
-    return &o.Date, true
+	if o == nil  {
+		return nil, false
+	}
+	return &o.Date, true
 }
 
 // SetDate sets field value
@@ -374,7 +364,6 @@ func (o *FormatTest) GetDateTime() time.Time {
 
 // GetDateTimeOk returns a tuple with the DateTime field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *FormatTest) GetDateTimeOk() (*time.Time, bool) {
 	if o == nil || o.DateTime == nil {
 		return nil, false
@@ -407,7 +396,6 @@ func (o *FormatTest) GetUuid() string {
 
 // GetUuidOk returns a tuple with the Uuid field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *FormatTest) GetUuidOk() (*string, bool) {
 	if o == nil || o.Uuid == nil {
 		return nil, false
@@ -441,12 +429,11 @@ func (o *FormatTest) GetPassword() string {
 
 // GetPasswordOk returns a tuple with the Password field value
 // and a boolean to check if the value has been set.
-
 func (o *FormatTest) GetPasswordOk() (*string, bool) {
-    if o == nil  {
-        return nil, false
-    }
-    return &o.Password, true
+	if o == nil  {
+		return nil, false
+	}
+	return &o.Password, true
 }
 
 // SetPassword sets field value
@@ -465,7 +452,6 @@ func (o *FormatTest) GetPatternWithDigits() string {
 
 // GetPatternWithDigitsOk returns a tuple with the PatternWithDigits field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *FormatTest) GetPatternWithDigitsOk() (*string, bool) {
 	if o == nil || o.PatternWithDigits == nil {
 		return nil, false
@@ -498,7 +484,6 @@ func (o *FormatTest) GetPatternWithDigitsAndDelimiter() string {
 
 // GetPatternWithDigitsAndDelimiterOk returns a tuple with the PatternWithDigitsAndDelimiter field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *FormatTest) GetPatternWithDigitsAndDelimiterOk() (*string, bool) {
 	if o == nil || o.PatternWithDigitsAndDelimiter == nil {
 		return nil, false

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_format_test_.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_format_test_.go
@@ -539,7 +539,7 @@ func (v NullableFormatTest) Get() *FormatTest {
 	return v.value
 }
 
-func (v NullableFormatTest) Set(val *FormatTest) {
+func (v *NullableFormatTest) Set(val *FormatTest) {
 	v.value = val
 	v.isSet = true
 }
@@ -548,7 +548,7 @@ func (v NullableFormatTest) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableFormatTest) Unset() {
+func (v *NullableFormatTest) Unset() {
 	v.value = nil
 	v.isSet = false
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_format_test_.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_format_test_.go
@@ -73,12 +73,12 @@ func (o *FormatTest) GetIntegerOk() (int32, bool) {
 		var ret int32
 		return ret, false
 	}
-    return *o.Integer, true
+	return *o.Integer, true
 }
 
 // HasInteger returns a boolean if a field has been set.
 func (o *FormatTest) HasInteger() bool {
-    if o != nil && o.Integer != nil {
+	if o != nil && o.Integer != nil {
 		return true
 	}
 
@@ -106,12 +106,12 @@ func (o *FormatTest) GetInt32Ok() (int32, bool) {
 		var ret int32
 		return ret, false
 	}
-    return *o.Int32, true
+	return *o.Int32, true
 }
 
 // HasInt32 returns a boolean if a field has been set.
 func (o *FormatTest) HasInt32() bool {
-    if o != nil && o.Int32 != nil {
+	if o != nil && o.Int32 != nil {
 		return true
 	}
 
@@ -139,12 +139,12 @@ func (o *FormatTest) GetInt64Ok() (int64, bool) {
 		var ret int64
 		return ret, false
 	}
-    return *o.Int64, true
+	return *o.Int64, true
 }
 
 // HasInt64 returns a boolean if a field has been set.
 func (o *FormatTest) HasInt64() bool {
-    if o != nil && o.Int64 != nil {
+	if o != nil && o.Int64 != nil {
 		return true
 	}
 
@@ -187,12 +187,12 @@ func (o *FormatTest) GetFloatOk() (float32, bool) {
 		var ret float32
 		return ret, false
 	}
-    return *o.Float, true
+	return *o.Float, true
 }
 
 // HasFloat returns a boolean if a field has been set.
 func (o *FormatTest) HasFloat() bool {
-    if o != nil && o.Float != nil {
+	if o != nil && o.Float != nil {
 		return true
 	}
 
@@ -220,12 +220,12 @@ func (o *FormatTest) GetDoubleOk() (float64, bool) {
 		var ret float64
 		return ret, false
 	}
-    return *o.Double, true
+	return *o.Double, true
 }
 
 // HasDouble returns a boolean if a field has been set.
 func (o *FormatTest) HasDouble() bool {
-    if o != nil && o.Double != nil {
+	if o != nil && o.Double != nil {
 		return true
 	}
 
@@ -253,12 +253,12 @@ func (o *FormatTest) GetStringOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-    return *o.String, true
+	return *o.String, true
 }
 
 // HasString returns a boolean if a field has been set.
 func (o *FormatTest) HasString() bool {
-    if o != nil && o.String != nil {
+	if o != nil && o.String != nil {
 		return true
 	}
 
@@ -301,12 +301,12 @@ func (o *FormatTest) GetBinaryOk() (*os.File, bool) {
 		var ret *os.File
 		return ret, false
 	}
-    return *o.Binary, true
+	return *o.Binary, true
 }
 
 // HasBinary returns a boolean if a field has been set.
 func (o *FormatTest) HasBinary() bool {
-    if o != nil && o.Binary != nil {
+	if o != nil && o.Binary != nil {
 		return true
 	}
 
@@ -349,12 +349,12 @@ func (o *FormatTest) GetDateTimeOk() (time.Time, bool) {
 		var ret time.Time
 		return ret, false
 	}
-    return *o.DateTime, true
+	return *o.DateTime, true
 }
 
 // HasDateTime returns a boolean if a field has been set.
 func (o *FormatTest) HasDateTime() bool {
-    if o != nil && o.DateTime != nil {
+	if o != nil && o.DateTime != nil {
 		return true
 	}
 
@@ -382,12 +382,12 @@ func (o *FormatTest) GetUuidOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-    return *o.Uuid, true
+	return *o.Uuid, true
 }
 
 // HasUuid returns a boolean if a field has been set.
 func (o *FormatTest) HasUuid() bool {
-    if o != nil && o.Uuid != nil {
+	if o != nil && o.Uuid != nil {
 		return true
 	}
 
@@ -430,12 +430,12 @@ func (o *FormatTest) GetPatternWithDigitsOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-    return *o.PatternWithDigits, true
+	return *o.PatternWithDigits, true
 }
 
 // HasPatternWithDigits returns a boolean if a field has been set.
 func (o *FormatTest) HasPatternWithDigits() bool {
-    if o != nil && o.PatternWithDigits != nil {
+	if o != nil && o.PatternWithDigits != nil {
 		return true
 	}
 
@@ -463,12 +463,12 @@ func (o *FormatTest) GetPatternWithDigitsAndDelimiterOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-    return *o.PatternWithDigitsAndDelimiter, true
+	return *o.PatternWithDigitsAndDelimiter, true
 }
 
 // HasPatternWithDigitsAndDelimiter returns a boolean if a field has been set.
 func (o *FormatTest) HasPatternWithDigitsAndDelimiter() bool {
-    if o != nil && o.PatternWithDigitsAndDelimiter != nil {
+	if o != nil && o.PatternWithDigitsAndDelimiter != nil {
 		return true
 	}
 
@@ -481,53 +481,53 @@ func (o *FormatTest) SetPatternWithDigitsAndDelimiter(v string) {
 }
 
 func (o FormatTest) MarshalJSON() ([]byte, error) {
-    toSerialize := map[string]interface{}{}
-    if o.Integer != nil {
-        toSerialize["integer"] = o.Integer
-    }
-    if o.Int32 != nil {
-        toSerialize["int32"] = o.Int32
-    }
-    if o.Int64 != nil {
-        toSerialize["int64"] = o.Int64
-    }
-    if true {
-        toSerialize["number"] = o.Number
-    }
-    if o.Float != nil {
-        toSerialize["float"] = o.Float
-    }
-    if o.Double != nil {
-        toSerialize["double"] = o.Double
-    }
-    if o.String != nil {
-        toSerialize["string"] = o.String
-    }
-    if true {
-        toSerialize["byte"] = o.Byte
-    }
-    if o.Binary != nil {
-        toSerialize["binary"] = o.Binary
-    }
-    if true {
-        toSerialize["date"] = o.Date
-    }
-    if o.DateTime != nil {
-        toSerialize["dateTime"] = o.DateTime
-    }
-    if o.Uuid != nil {
-        toSerialize["uuid"] = o.Uuid
-    }
-    if true {
-        toSerialize["password"] = o.Password
-    }
-    if o.PatternWithDigits != nil {
-        toSerialize["pattern_with_digits"] = o.PatternWithDigits
-    }
-    if o.PatternWithDigitsAndDelimiter != nil {
-        toSerialize["pattern_with_digits_and_delimiter"] = o.PatternWithDigitsAndDelimiter
-    }
-    return json.Marshal(toSerialize)
+	toSerialize := map[string]interface{}{}
+	if o.Integer != nil {
+		toSerialize["integer"] = o.Integer
+	}
+	if o.Int32 != nil {
+		toSerialize["int32"] = o.Int32
+	}
+	if o.Int64 != nil {
+		toSerialize["int64"] = o.Int64
+	}
+	if true {
+		toSerialize["number"] = o.Number
+	}
+	if o.Float != nil {
+		toSerialize["float"] = o.Float
+	}
+	if o.Double != nil {
+		toSerialize["double"] = o.Double
+	}
+	if o.String != nil {
+		toSerialize["string"] = o.String
+	}
+	if true {
+		toSerialize["byte"] = o.Byte
+	}
+	if o.Binary != nil {
+		toSerialize["binary"] = o.Binary
+	}
+	if true {
+		toSerialize["date"] = o.Date
+	}
+	if o.DateTime != nil {
+		toSerialize["dateTime"] = o.DateTime
+	}
+	if o.Uuid != nil {
+		toSerialize["uuid"] = o.Uuid
+	}
+	if true {
+		toSerialize["password"] = o.Password
+	}
+	if o.PatternWithDigits != nil {
+		toSerialize["pattern_with_digits"] = o.PatternWithDigits
+	}
+	if o.PatternWithDigitsAndDelimiter != nil {
+		toSerialize["pattern_with_digits_and_delimiter"] = o.PatternWithDigitsAndDelimiter
+	}
+	return json.Marshal(toSerialize)
 }
 
 type NullableFormatTest struct {
@@ -536,32 +536,32 @@ type NullableFormatTest struct {
 }
 
 func (v NullableFormatTest) Get() *FormatTest {
-    return v.value
+	return v.value
 }
 
 func (v NullableFormatTest) Set(val *FormatTest) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableFormatTest) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableFormatTest) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableFormatTest(val *FormatTest) *NullableFormatTest {
-    return &NullableFormatTest{value: val, isSet: true}
+	return &NullableFormatTest{value: val, isSet: true}
 }
 
 func (v NullableFormatTest) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableFormatTest) UnmarshalJSON(src []byte) error {
-    v.isSet = true
+	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_format_test_.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_format_test_.go
@@ -10,7 +10,6 @@
 package petstore
 
 import (
-	"bytes"
 	"encoding/json"
 	"os"
 	"time"
@@ -74,12 +73,12 @@ func (o *FormatTest) GetIntegerOk() (int32, bool) {
 		var ret int32
 		return ret, false
 	}
-	return *o.Integer, true
+    return *o.Integer, true
 }
 
 // HasInteger returns a boolean if a field has been set.
 func (o *FormatTest) HasInteger() bool {
-	if o != nil && o.Integer != nil {
+    if o != nil && o.Integer != nil {
 		return true
 	}
 
@@ -107,12 +106,12 @@ func (o *FormatTest) GetInt32Ok() (int32, bool) {
 		var ret int32
 		return ret, false
 	}
-	return *o.Int32, true
+    return *o.Int32, true
 }
 
 // HasInt32 returns a boolean if a field has been set.
 func (o *FormatTest) HasInt32() bool {
-	if o != nil && o.Int32 != nil {
+    if o != nil && o.Int32 != nil {
 		return true
 	}
 
@@ -140,12 +139,12 @@ func (o *FormatTest) GetInt64Ok() (int64, bool) {
 		var ret int64
 		return ret, false
 	}
-	return *o.Int64, true
+    return *o.Int64, true
 }
 
 // HasInt64 returns a boolean if a field has been set.
 func (o *FormatTest) HasInt64() bool {
-	if o != nil && o.Int64 != nil {
+    if o != nil && o.Int64 != nil {
 		return true
 	}
 
@@ -188,12 +187,12 @@ func (o *FormatTest) GetFloatOk() (float32, bool) {
 		var ret float32
 		return ret, false
 	}
-	return *o.Float, true
+    return *o.Float, true
 }
 
 // HasFloat returns a boolean if a field has been set.
 func (o *FormatTest) HasFloat() bool {
-	if o != nil && o.Float != nil {
+    if o != nil && o.Float != nil {
 		return true
 	}
 
@@ -221,12 +220,12 @@ func (o *FormatTest) GetDoubleOk() (float64, bool) {
 		var ret float64
 		return ret, false
 	}
-	return *o.Double, true
+    return *o.Double, true
 }
 
 // HasDouble returns a boolean if a field has been set.
 func (o *FormatTest) HasDouble() bool {
-	if o != nil && o.Double != nil {
+    if o != nil && o.Double != nil {
 		return true
 	}
 
@@ -254,12 +253,12 @@ func (o *FormatTest) GetStringOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-	return *o.String, true
+    return *o.String, true
 }
 
 // HasString returns a boolean if a field has been set.
 func (o *FormatTest) HasString() bool {
-	if o != nil && o.String != nil {
+    if o != nil && o.String != nil {
 		return true
 	}
 
@@ -302,12 +301,12 @@ func (o *FormatTest) GetBinaryOk() (*os.File, bool) {
 		var ret *os.File
 		return ret, false
 	}
-	return *o.Binary, true
+    return *o.Binary, true
 }
 
 // HasBinary returns a boolean if a field has been set.
 func (o *FormatTest) HasBinary() bool {
-	if o != nil && o.Binary != nil {
+    if o != nil && o.Binary != nil {
 		return true
 	}
 
@@ -350,12 +349,12 @@ func (o *FormatTest) GetDateTimeOk() (time.Time, bool) {
 		var ret time.Time
 		return ret, false
 	}
-	return *o.DateTime, true
+    return *o.DateTime, true
 }
 
 // HasDateTime returns a boolean if a field has been set.
 func (o *FormatTest) HasDateTime() bool {
-	if o != nil && o.DateTime != nil {
+    if o != nil && o.DateTime != nil {
 		return true
 	}
 
@@ -383,12 +382,12 @@ func (o *FormatTest) GetUuidOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-	return *o.Uuid, true
+    return *o.Uuid, true
 }
 
 // HasUuid returns a boolean if a field has been set.
 func (o *FormatTest) HasUuid() bool {
-	if o != nil && o.Uuid != nil {
+    if o != nil && o.Uuid != nil {
 		return true
 	}
 
@@ -431,12 +430,12 @@ func (o *FormatTest) GetPatternWithDigitsOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-	return *o.PatternWithDigits, true
+    return *o.PatternWithDigits, true
 }
 
 // HasPatternWithDigits returns a boolean if a field has been set.
 func (o *FormatTest) HasPatternWithDigits() bool {
-	if o != nil && o.PatternWithDigits != nil {
+    if o != nil && o.PatternWithDigits != nil {
 		return true
 	}
 
@@ -464,12 +463,12 @@ func (o *FormatTest) GetPatternWithDigitsAndDelimiterOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-	return *o.PatternWithDigitsAndDelimiter, true
+    return *o.PatternWithDigitsAndDelimiter, true
 }
 
 // HasPatternWithDigitsAndDelimiter returns a boolean if a field has been set.
 func (o *FormatTest) HasPatternWithDigitsAndDelimiter() bool {
-	if o != nil && o.PatternWithDigitsAndDelimiter != nil {
+    if o != nil && o.PatternWithDigitsAndDelimiter != nil {
 		return true
 	}
 
@@ -481,25 +480,88 @@ func (o *FormatTest) SetPatternWithDigitsAndDelimiter(v string) {
 	o.PatternWithDigitsAndDelimiter = &v
 }
 
+func (o FormatTest) MarshalJSON() ([]byte, error) {
+    toSerialize := map[string]interface{}{}
+    if o.Integer != nil {
+        toSerialize["integer"] = o.Integer
+    }
+    if o.Int32 != nil {
+        toSerialize["int32"] = o.Int32
+    }
+    if o.Int64 != nil {
+        toSerialize["int64"] = o.Int64
+    }
+    if true {
+        toSerialize["number"] = o.Number
+    }
+    if o.Float != nil {
+        toSerialize["float"] = o.Float
+    }
+    if o.Double != nil {
+        toSerialize["double"] = o.Double
+    }
+    if o.String != nil {
+        toSerialize["string"] = o.String
+    }
+    if true {
+        toSerialize["byte"] = o.Byte
+    }
+    if o.Binary != nil {
+        toSerialize["binary"] = o.Binary
+    }
+    if true {
+        toSerialize["date"] = o.Date
+    }
+    if o.DateTime != nil {
+        toSerialize["dateTime"] = o.DateTime
+    }
+    if o.Uuid != nil {
+        toSerialize["uuid"] = o.Uuid
+    }
+    if true {
+        toSerialize["password"] = o.Password
+    }
+    if o.PatternWithDigits != nil {
+        toSerialize["pattern_with_digits"] = o.PatternWithDigits
+    }
+    if o.PatternWithDigitsAndDelimiter != nil {
+        toSerialize["pattern_with_digits_and_delimiter"] = o.PatternWithDigitsAndDelimiter
+    }
+    return json.Marshal(toSerialize)
+}
+
 type NullableFormatTest struct {
-	Value FormatTest
-	ExplicitNull bool
+	value *FormatTest
+	isSet bool
+}
+
+func (v NullableFormatTest) Get() *FormatTest {
+    return v.value
+}
+
+func (v NullableFormatTest) Set(val *FormatTest) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableFormatTest) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableFormatTest) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableFormatTest(val *FormatTest) *NullableFormatTest {
+    return &NullableFormatTest{value: val, isSet: true}
 }
 
 func (v NullableFormatTest) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-		return json.Marshal(v.Value)
-	}
+    return json.Marshal(v.value)
 }
 
 func (v *NullableFormatTest) UnmarshalJSON(src []byte) error {
-	if bytes.Equal(src, []byte("null")) {
-		v.ExplicitNull = true
-		return nil
-	}
-
-	return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_has_only_read_only.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_has_only_read_only.go
@@ -52,12 +52,12 @@ func (o *HasOnlyReadOnly) GetBarOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-    return *o.Bar, true
+	return *o.Bar, true
 }
 
 // HasBar returns a boolean if a field has been set.
 func (o *HasOnlyReadOnly) HasBar() bool {
-    if o != nil && o.Bar != nil {
+	if o != nil && o.Bar != nil {
 		return true
 	}
 
@@ -85,12 +85,12 @@ func (o *HasOnlyReadOnly) GetFooOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-    return *o.Foo, true
+	return *o.Foo, true
 }
 
 // HasFoo returns a boolean if a field has been set.
 func (o *HasOnlyReadOnly) HasFoo() bool {
-    if o != nil && o.Foo != nil {
+	if o != nil && o.Foo != nil {
 		return true
 	}
 
@@ -103,14 +103,14 @@ func (o *HasOnlyReadOnly) SetFoo(v string) {
 }
 
 func (o HasOnlyReadOnly) MarshalJSON() ([]byte, error) {
-    toSerialize := map[string]interface{}{}
-    if o.Bar != nil {
-        toSerialize["bar"] = o.Bar
-    }
-    if o.Foo != nil {
-        toSerialize["foo"] = o.Foo
-    }
-    return json.Marshal(toSerialize)
+	toSerialize := map[string]interface{}{}
+	if o.Bar != nil {
+		toSerialize["bar"] = o.Bar
+	}
+	if o.Foo != nil {
+		toSerialize["foo"] = o.Foo
+	}
+	return json.Marshal(toSerialize)
 }
 
 type NullableHasOnlyReadOnly struct {
@@ -119,32 +119,32 @@ type NullableHasOnlyReadOnly struct {
 }
 
 func (v NullableHasOnlyReadOnly) Get() *HasOnlyReadOnly {
-    return v.value
+	return v.value
 }
 
 func (v NullableHasOnlyReadOnly) Set(val *HasOnlyReadOnly) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableHasOnlyReadOnly) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableHasOnlyReadOnly) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableHasOnlyReadOnly(val *HasOnlyReadOnly) *NullableHasOnlyReadOnly {
-    return &NullableHasOnlyReadOnly{value: val, isSet: true}
+	return &NullableHasOnlyReadOnly{value: val, isSet: true}
 }
 
 func (v NullableHasOnlyReadOnly) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableHasOnlyReadOnly) UnmarshalJSON(src []byte) error {
-    v.isSet = true
+	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_has_only_read_only.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_has_only_read_only.go
@@ -47,7 +47,6 @@ func (o *HasOnlyReadOnly) GetBar() string {
 
 // GetBarOk returns a tuple with the Bar field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *HasOnlyReadOnly) GetBarOk() (*string, bool) {
 	if o == nil || o.Bar == nil {
 		return nil, false
@@ -80,7 +79,6 @@ func (o *HasOnlyReadOnly) GetFoo() string {
 
 // GetFooOk returns a tuple with the Foo field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *HasOnlyReadOnly) GetFooOk() (*string, bool) {
 	if o == nil || o.Foo == nil {
 		return nil, false

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_has_only_read_only.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_has_only_read_only.go
@@ -24,16 +24,16 @@ type HasOnlyReadOnly struct {
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
 func NewHasOnlyReadOnly() *HasOnlyReadOnly {
-    this := HasOnlyReadOnly{}
-    return &this
+	this := HasOnlyReadOnly{}
+	return &this
 }
 
 // NewHasOnlyReadOnlyWithDefaults instantiates a new HasOnlyReadOnly object
 // This constructor will only assign default values to properties that have it defined,
 // but it doesn't guarantee that properties required by API are set
 func NewHasOnlyReadOnlyWithDefaults() *HasOnlyReadOnly {
-    this := HasOnlyReadOnly{}
-    return &this
+	this := HasOnlyReadOnly{}
+	return &this
 }
 
 // GetBar returns the Bar field value if set, zero value otherwise.
@@ -45,14 +45,14 @@ func (o *HasOnlyReadOnly) GetBar() string {
 	return *o.Bar
 }
 
-// GetBarOk returns a tuple with the Bar field value if set, zero value otherwise
+// GetBarOk returns a tuple with the Bar field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *HasOnlyReadOnly) GetBarOk() (string, bool) {
+
+func (o *HasOnlyReadOnly) GetBarOk() (*string, bool) {
 	if o == nil || o.Bar == nil {
-		var ret string
-		return ret, false
+		return nil, false
 	}
-	return *o.Bar, true
+	return o.Bar, true
 }
 
 // HasBar returns a boolean if a field has been set.
@@ -78,14 +78,14 @@ func (o *HasOnlyReadOnly) GetFoo() string {
 	return *o.Foo
 }
 
-// GetFooOk returns a tuple with the Foo field value if set, zero value otherwise
+// GetFooOk returns a tuple with the Foo field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *HasOnlyReadOnly) GetFooOk() (string, bool) {
+
+func (o *HasOnlyReadOnly) GetFooOk() (*string, bool) {
 	if o == nil || o.Foo == nil {
-		var ret string
-		return ret, false
+		return nil, false
 	}
-	return *o.Foo, true
+	return o.Foo, true
 }
 
 // HasFoo returns a boolean if a field has been set.

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_has_only_read_only.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_has_only_read_only.go
@@ -122,7 +122,7 @@ func (v NullableHasOnlyReadOnly) Get() *HasOnlyReadOnly {
 	return v.value
 }
 
-func (v NullableHasOnlyReadOnly) Set(val *HasOnlyReadOnly) {
+func (v *NullableHasOnlyReadOnly) Set(val *HasOnlyReadOnly) {
 	v.value = val
 	v.isSet = true
 }
@@ -131,7 +131,7 @@ func (v NullableHasOnlyReadOnly) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableHasOnlyReadOnly) Unset() {
+func (v *NullableHasOnlyReadOnly) Unset() {
 	v.value = nil
 	v.isSet = false
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_has_only_read_only.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_has_only_read_only.go
@@ -10,7 +10,6 @@
 package petstore
 
 import (
-	"bytes"
 	"encoding/json"
 )
 
@@ -53,12 +52,12 @@ func (o *HasOnlyReadOnly) GetBarOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-	return *o.Bar, true
+    return *o.Bar, true
 }
 
 // HasBar returns a boolean if a field has been set.
 func (o *HasOnlyReadOnly) HasBar() bool {
-	if o != nil && o.Bar != nil {
+    if o != nil && o.Bar != nil {
 		return true
 	}
 
@@ -86,12 +85,12 @@ func (o *HasOnlyReadOnly) GetFooOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-	return *o.Foo, true
+    return *o.Foo, true
 }
 
 // HasFoo returns a boolean if a field has been set.
 func (o *HasOnlyReadOnly) HasFoo() bool {
-	if o != nil && o.Foo != nil {
+    if o != nil && o.Foo != nil {
 		return true
 	}
 
@@ -103,25 +102,49 @@ func (o *HasOnlyReadOnly) SetFoo(v string) {
 	o.Foo = &v
 }
 
+func (o HasOnlyReadOnly) MarshalJSON() ([]byte, error) {
+    toSerialize := map[string]interface{}{}
+    if o.Bar != nil {
+        toSerialize["bar"] = o.Bar
+    }
+    if o.Foo != nil {
+        toSerialize["foo"] = o.Foo
+    }
+    return json.Marshal(toSerialize)
+}
+
 type NullableHasOnlyReadOnly struct {
-	Value HasOnlyReadOnly
-	ExplicitNull bool
+	value *HasOnlyReadOnly
+	isSet bool
+}
+
+func (v NullableHasOnlyReadOnly) Get() *HasOnlyReadOnly {
+    return v.value
+}
+
+func (v NullableHasOnlyReadOnly) Set(val *HasOnlyReadOnly) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableHasOnlyReadOnly) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableHasOnlyReadOnly) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableHasOnlyReadOnly(val *HasOnlyReadOnly) *NullableHasOnlyReadOnly {
+    return &NullableHasOnlyReadOnly{value: val, isSet: true}
 }
 
 func (v NullableHasOnlyReadOnly) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-		return json.Marshal(v.Value)
-	}
+    return json.Marshal(v.value)
 }
 
 func (v *NullableHasOnlyReadOnly) UnmarshalJSON(src []byte) error {
-	if bytes.Equal(src, []byte("null")) {
-		v.ExplicitNull = true
-		return nil
-	}
-
-	return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_health_check_result.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_health_check_result.go
@@ -23,35 +23,35 @@ type HealthCheckResult struct {
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
 func NewHealthCheckResult() *HealthCheckResult {
-    this := HealthCheckResult{}
-    return &this
+	this := HealthCheckResult{}
+	return &this
 }
 
 // NewHealthCheckResultWithDefaults instantiates a new HealthCheckResult object
 // This constructor will only assign default values to properties that have it defined,
 // but it doesn't guarantee that properties required by API are set
 func NewHealthCheckResultWithDefaults() *HealthCheckResult {
-    this := HealthCheckResult{}
-    return &this
+	this := HealthCheckResult{}
+	return &this
 }
 
-// GetNullableMessage returns the NullableMessage field value if set, zero value otherwise.
-func (o *HealthCheckResult) GetNullableMessage() NullableString {
-	if o == nil  {
-		var ret NullableString
+// GetNullableMessage returns the NullableMessage field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *HealthCheckResult) GetNullableMessage() string {
+	if o == nil || o.NullableMessage.Get() == nil {
+		var ret string
 		return ret
 	}
-	return o.NullableMessage
+	return *o.NullableMessage.Get()
 }
 
-// GetNullableMessageOk returns a tuple with the NullableMessage field value if set, zero value otherwise
+// GetNullableMessageOk returns a tuple with the NullableMessage field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *HealthCheckResult) GetNullableMessageOk() (NullableString, bool) {
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *HealthCheckResult) GetNullableMessageOk() (*string, bool) {
 	if o == nil  {
-		var ret NullableString
-		return ret, false
+		return nil, false
 	}
-	return o.NullableMessage, o.NullableMessage.IsSet()
+	return o.NullableMessage.Get(), o.NullableMessage.IsSet()
 }
 
 // HasNullableMessage returns a boolean if a field has been set.
@@ -64,8 +64,17 @@ func (o *HealthCheckResult) HasNullableMessage() bool {
 }
 
 // SetNullableMessage gets a reference to the given NullableString and assigns it to the NullableMessage field.
-func (o *HealthCheckResult) SetNullableMessage(v NullableString) {
-	o.NullableMessage = v
+func (o *HealthCheckResult) SetNullableMessage(v string) {
+	o.NullableMessage.Set(&v)
+}
+// SetNullableMessageNil sets the value for NullableMessage to be an explicit nil
+func (o *HealthCheckResult) SetNullableMessageNil() {
+	o.NullableMessage.Set(nil)
+}
+
+// UnsetNullableMessage ensures that no value is present for NullableMessage, not even an explicit nil
+func (o *HealthCheckResult) UnsetNullableMessage() {
+	o.NullableMessage.Unset()
 }
 
 func (o HealthCheckResult) MarshalJSON() ([]byte, error) {

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_health_check_result.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_health_check_result.go
@@ -51,12 +51,12 @@ func (o *HealthCheckResult) GetNullableMessageOk() (NullableString, bool) {
 		var ret NullableString
 		return ret, false
 	}
-    return o.NullableMessage, o.NullableMessage.IsSet()
+	return o.NullableMessage, o.NullableMessage.IsSet()
 }
 
 // HasNullableMessage returns a boolean if a field has been set.
 func (o *HealthCheckResult) HasNullableMessage() bool {
-    if o != nil && o.NullableMessage.IsSet() {
+	if o != nil && o.NullableMessage.IsSet() {
 		return true
 	}
 
@@ -69,11 +69,11 @@ func (o *HealthCheckResult) SetNullableMessage(v NullableString) {
 }
 
 func (o HealthCheckResult) MarshalJSON() ([]byte, error) {
-    toSerialize := map[string]interface{}{}
-    if o.NullableMessage.IsSet() {
-        toSerialize["NullableMessage"] = o.NullableMessage.Get()
-    }
-    return json.Marshal(toSerialize)
+	toSerialize := map[string]interface{}{}
+	if o.NullableMessage.IsSet() {
+		toSerialize["NullableMessage"] = o.NullableMessage.Get()
+	}
+	return json.Marshal(toSerialize)
 }
 
 type NullableHealthCheckResult struct {
@@ -82,32 +82,32 @@ type NullableHealthCheckResult struct {
 }
 
 func (v NullableHealthCheckResult) Get() *HealthCheckResult {
-    return v.value
+	return v.value
 }
 
 func (v NullableHealthCheckResult) Set(val *HealthCheckResult) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableHealthCheckResult) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableHealthCheckResult) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableHealthCheckResult(val *HealthCheckResult) *NullableHealthCheckResult {
-    return &NullableHealthCheckResult{value: val, isSet: true}
+	return &NullableHealthCheckResult{value: val, isSet: true}
 }
 
 func (v NullableHealthCheckResult) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableHealthCheckResult) UnmarshalJSON(src []byte) error {
-    v.isSet = true
+	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_health_check_result.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_health_check_result.go
@@ -10,13 +10,12 @@
 package petstore
 
 import (
-	"bytes"
 	"encoding/json"
 )
 
 // HealthCheckResult Just a string to inform instance is up and running. Make it nullable in hope to get it as pointer in generated model.
 type HealthCheckResult struct {
-	NullableMessage *NullableString `json:"NullableMessage,omitempty"`
+	NullableMessage NullableString `json:"NullableMessage,omitempty"`
 }
 
 // NewHealthCheckResult instantiates a new HealthCheckResult object
@@ -38,26 +37,26 @@ func NewHealthCheckResultWithDefaults() *HealthCheckResult {
 
 // GetNullableMessage returns the NullableMessage field value if set, zero value otherwise.
 func (o *HealthCheckResult) GetNullableMessage() NullableString {
-	if o == nil || o.NullableMessage == nil {
+	if o == nil  {
 		var ret NullableString
 		return ret
 	}
-	return *o.NullableMessage
+	return o.NullableMessage
 }
 
 // GetNullableMessageOk returns a tuple with the NullableMessage field value if set, zero value otherwise
 // and a boolean to check if the value has been set.
 func (o *HealthCheckResult) GetNullableMessageOk() (NullableString, bool) {
-	if o == nil || o.NullableMessage == nil {
+	if o == nil  {
 		var ret NullableString
 		return ret, false
 	}
-	return *o.NullableMessage, true
+    return o.NullableMessage, o.NullableMessage.IsSet()
 }
 
 // HasNullableMessage returns a boolean if a field has been set.
 func (o *HealthCheckResult) HasNullableMessage() bool {
-	if o != nil && o.NullableMessage != nil {
+    if o != nil && o.NullableMessage.IsSet() {
 		return true
 	}
 
@@ -66,28 +65,49 @@ func (o *HealthCheckResult) HasNullableMessage() bool {
 
 // SetNullableMessage gets a reference to the given NullableString and assigns it to the NullableMessage field.
 func (o *HealthCheckResult) SetNullableMessage(v NullableString) {
-	o.NullableMessage = &v
+	o.NullableMessage = v
+}
+
+func (o HealthCheckResult) MarshalJSON() ([]byte, error) {
+    toSerialize := map[string]interface{}{}
+    if o.NullableMessage.IsSet() {
+        toSerialize["NullableMessage"] = o.NullableMessage.Get()
+    }
+    return json.Marshal(toSerialize)
 }
 
 type NullableHealthCheckResult struct {
-	Value HealthCheckResult
-	ExplicitNull bool
+	value *HealthCheckResult
+	isSet bool
+}
+
+func (v NullableHealthCheckResult) Get() *HealthCheckResult {
+    return v.value
+}
+
+func (v NullableHealthCheckResult) Set(val *HealthCheckResult) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableHealthCheckResult) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableHealthCheckResult) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableHealthCheckResult(val *HealthCheckResult) *NullableHealthCheckResult {
+    return &NullableHealthCheckResult{value: val, isSet: true}
 }
 
 func (v NullableHealthCheckResult) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-		return json.Marshal(v.Value)
-	}
+    return json.Marshal(v.value)
 }
 
 func (v *NullableHealthCheckResult) UnmarshalJSON(src []byte) error {
-	if bytes.Equal(src, []byte("null")) {
-		v.ExplicitNull = true
-		return nil
-	}
-
-	return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_health_check_result.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_health_check_result.go
@@ -85,7 +85,7 @@ func (v NullableHealthCheckResult) Get() *HealthCheckResult {
 	return v.value
 }
 
-func (v NullableHealthCheckResult) Set(val *HealthCheckResult) {
+func (v *NullableHealthCheckResult) Set(val *HealthCheckResult) {
 	v.value = val
 	v.isSet = true
 }
@@ -94,7 +94,7 @@ func (v NullableHealthCheckResult) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableHealthCheckResult) Unset() {
+func (v *NullableHealthCheckResult) Unset() {
 	v.value = nil
 	v.isSet = false
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_inline_object.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_inline_object.go
@@ -49,7 +49,6 @@ func (o *InlineObject) GetName() string {
 
 // GetNameOk returns a tuple with the Name field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *InlineObject) GetNameOk() (*string, bool) {
 	if o == nil || o.Name == nil {
 		return nil, false
@@ -82,7 +81,6 @@ func (o *InlineObject) GetStatus() string {
 
 // GetStatusOk returns a tuple with the Status field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *InlineObject) GetStatusOk() (*string, bool) {
 	if o == nil || o.Status == nil {
 		return nil, false

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_inline_object.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_inline_object.go
@@ -26,16 +26,16 @@ type InlineObject struct {
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
 func NewInlineObject() *InlineObject {
-    this := InlineObject{}
-    return &this
+	this := InlineObject{}
+	return &this
 }
 
 // NewInlineObjectWithDefaults instantiates a new InlineObject object
 // This constructor will only assign default values to properties that have it defined,
 // but it doesn't guarantee that properties required by API are set
 func NewInlineObjectWithDefaults() *InlineObject {
-    this := InlineObject{}
-    return &this
+	this := InlineObject{}
+	return &this
 }
 
 // GetName returns the Name field value if set, zero value otherwise.
@@ -47,14 +47,14 @@ func (o *InlineObject) GetName() string {
 	return *o.Name
 }
 
-// GetNameOk returns a tuple with the Name field value if set, zero value otherwise
+// GetNameOk returns a tuple with the Name field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *InlineObject) GetNameOk() (string, bool) {
+
+func (o *InlineObject) GetNameOk() (*string, bool) {
 	if o == nil || o.Name == nil {
-		var ret string
-		return ret, false
+		return nil, false
 	}
-	return *o.Name, true
+	return o.Name, true
 }
 
 // HasName returns a boolean if a field has been set.
@@ -80,14 +80,14 @@ func (o *InlineObject) GetStatus() string {
 	return *o.Status
 }
 
-// GetStatusOk returns a tuple with the Status field value if set, zero value otherwise
+// GetStatusOk returns a tuple with the Status field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *InlineObject) GetStatusOk() (string, bool) {
+
+func (o *InlineObject) GetStatusOk() (*string, bool) {
 	if o == nil || o.Status == nil {
-		var ret string
-		return ret, false
+		return nil, false
 	}
-	return *o.Status, true
+	return o.Status, true
 }
 
 // HasStatus returns a boolean if a field has been set.

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_inline_object.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_inline_object.go
@@ -10,7 +10,6 @@
 package petstore
 
 import (
-	"bytes"
 	"encoding/json"
 )
 
@@ -55,12 +54,12 @@ func (o *InlineObject) GetNameOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-	return *o.Name, true
+    return *o.Name, true
 }
 
 // HasName returns a boolean if a field has been set.
 func (o *InlineObject) HasName() bool {
-	if o != nil && o.Name != nil {
+    if o != nil && o.Name != nil {
 		return true
 	}
 
@@ -88,12 +87,12 @@ func (o *InlineObject) GetStatusOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-	return *o.Status, true
+    return *o.Status, true
 }
 
 // HasStatus returns a boolean if a field has been set.
 func (o *InlineObject) HasStatus() bool {
-	if o != nil && o.Status != nil {
+    if o != nil && o.Status != nil {
 		return true
 	}
 
@@ -105,25 +104,49 @@ func (o *InlineObject) SetStatus(v string) {
 	o.Status = &v
 }
 
+func (o InlineObject) MarshalJSON() ([]byte, error) {
+    toSerialize := map[string]interface{}{}
+    if o.Name != nil {
+        toSerialize["name"] = o.Name
+    }
+    if o.Status != nil {
+        toSerialize["status"] = o.Status
+    }
+    return json.Marshal(toSerialize)
+}
+
 type NullableInlineObject struct {
-	Value InlineObject
-	ExplicitNull bool
+	value *InlineObject
+	isSet bool
+}
+
+func (v NullableInlineObject) Get() *InlineObject {
+    return v.value
+}
+
+func (v NullableInlineObject) Set(val *InlineObject) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableInlineObject) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableInlineObject) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableInlineObject(val *InlineObject) *NullableInlineObject {
+    return &NullableInlineObject{value: val, isSet: true}
 }
 
 func (v NullableInlineObject) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-		return json.Marshal(v.Value)
-	}
+    return json.Marshal(v.value)
 }
 
 func (v *NullableInlineObject) UnmarshalJSON(src []byte) error {
-	if bytes.Equal(src, []byte("null")) {
-		v.ExplicitNull = true
-		return nil
-	}
-
-	return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_inline_object.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_inline_object.go
@@ -124,7 +124,7 @@ func (v NullableInlineObject) Get() *InlineObject {
 	return v.value
 }
 
-func (v NullableInlineObject) Set(val *InlineObject) {
+func (v *NullableInlineObject) Set(val *InlineObject) {
 	v.value = val
 	v.isSet = true
 }
@@ -133,7 +133,7 @@ func (v NullableInlineObject) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableInlineObject) Unset() {
+func (v *NullableInlineObject) Unset() {
 	v.value = nil
 	v.isSet = false
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_inline_object.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_inline_object.go
@@ -54,12 +54,12 @@ func (o *InlineObject) GetNameOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-    return *o.Name, true
+	return *o.Name, true
 }
 
 // HasName returns a boolean if a field has been set.
 func (o *InlineObject) HasName() bool {
-    if o != nil && o.Name != nil {
+	if o != nil && o.Name != nil {
 		return true
 	}
 
@@ -87,12 +87,12 @@ func (o *InlineObject) GetStatusOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-    return *o.Status, true
+	return *o.Status, true
 }
 
 // HasStatus returns a boolean if a field has been set.
 func (o *InlineObject) HasStatus() bool {
-    if o != nil && o.Status != nil {
+	if o != nil && o.Status != nil {
 		return true
 	}
 
@@ -105,14 +105,14 @@ func (o *InlineObject) SetStatus(v string) {
 }
 
 func (o InlineObject) MarshalJSON() ([]byte, error) {
-    toSerialize := map[string]interface{}{}
-    if o.Name != nil {
-        toSerialize["name"] = o.Name
-    }
-    if o.Status != nil {
-        toSerialize["status"] = o.Status
-    }
-    return json.Marshal(toSerialize)
+	toSerialize := map[string]interface{}{}
+	if o.Name != nil {
+		toSerialize["name"] = o.Name
+	}
+	if o.Status != nil {
+		toSerialize["status"] = o.Status
+	}
+	return json.Marshal(toSerialize)
 }
 
 type NullableInlineObject struct {
@@ -121,32 +121,32 @@ type NullableInlineObject struct {
 }
 
 func (v NullableInlineObject) Get() *InlineObject {
-    return v.value
+	return v.value
 }
 
 func (v NullableInlineObject) Set(val *InlineObject) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableInlineObject) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableInlineObject) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableInlineObject(val *InlineObject) *NullableInlineObject {
-    return &NullableInlineObject{value: val, isSet: true}
+	return &NullableInlineObject{value: val, isSet: true}
 }
 
 func (v NullableInlineObject) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableInlineObject) UnmarshalJSON(src []byte) error {
-    v.isSet = true
+	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_inline_object_1.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_inline_object_1.go
@@ -125,7 +125,7 @@ func (v NullableInlineObject1) Get() *InlineObject1 {
 	return v.value
 }
 
-func (v NullableInlineObject1) Set(val *InlineObject1) {
+func (v *NullableInlineObject1) Set(val *InlineObject1) {
 	v.value = val
 	v.isSet = true
 }
@@ -134,7 +134,7 @@ func (v NullableInlineObject1) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableInlineObject1) Unset() {
+func (v *NullableInlineObject1) Unset() {
 	v.value = nil
 	v.isSet = false
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_inline_object_1.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_inline_object_1.go
@@ -10,7 +10,6 @@
 package petstore
 
 import (
-	"bytes"
 	"encoding/json"
 	"os"
 )
@@ -56,12 +55,12 @@ func (o *InlineObject1) GetAdditionalMetadataOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-	return *o.AdditionalMetadata, true
+    return *o.AdditionalMetadata, true
 }
 
 // HasAdditionalMetadata returns a boolean if a field has been set.
 func (o *InlineObject1) HasAdditionalMetadata() bool {
-	if o != nil && o.AdditionalMetadata != nil {
+    if o != nil && o.AdditionalMetadata != nil {
 		return true
 	}
 
@@ -89,12 +88,12 @@ func (o *InlineObject1) GetFileOk() (*os.File, bool) {
 		var ret *os.File
 		return ret, false
 	}
-	return *o.File, true
+    return *o.File, true
 }
 
 // HasFile returns a boolean if a field has been set.
 func (o *InlineObject1) HasFile() bool {
-	if o != nil && o.File != nil {
+    if o != nil && o.File != nil {
 		return true
 	}
 
@@ -106,25 +105,49 @@ func (o *InlineObject1) SetFile(v *os.File) {
 	o.File = &v
 }
 
+func (o InlineObject1) MarshalJSON() ([]byte, error) {
+    toSerialize := map[string]interface{}{}
+    if o.AdditionalMetadata != nil {
+        toSerialize["additionalMetadata"] = o.AdditionalMetadata
+    }
+    if o.File != nil {
+        toSerialize["file"] = o.File
+    }
+    return json.Marshal(toSerialize)
+}
+
 type NullableInlineObject1 struct {
-	Value InlineObject1
-	ExplicitNull bool
+	value *InlineObject1
+	isSet bool
+}
+
+func (v NullableInlineObject1) Get() *InlineObject1 {
+    return v.value
+}
+
+func (v NullableInlineObject1) Set(val *InlineObject1) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableInlineObject1) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableInlineObject1) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableInlineObject1(val *InlineObject1) *NullableInlineObject1 {
+    return &NullableInlineObject1{value: val, isSet: true}
 }
 
 func (v NullableInlineObject1) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-		return json.Marshal(v.Value)
-	}
+    return json.Marshal(v.value)
 }
 
 func (v *NullableInlineObject1) UnmarshalJSON(src []byte) error {
-	if bytes.Equal(src, []byte("null")) {
-		v.ExplicitNull = true
-		return nil
-	}
-
-	return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_inline_object_1.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_inline_object_1.go
@@ -27,16 +27,16 @@ type InlineObject1 struct {
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
 func NewInlineObject1() *InlineObject1 {
-    this := InlineObject1{}
-    return &this
+	this := InlineObject1{}
+	return &this
 }
 
 // NewInlineObject1WithDefaults instantiates a new InlineObject1 object
 // This constructor will only assign default values to properties that have it defined,
 // but it doesn't guarantee that properties required by API are set
 func NewInlineObject1WithDefaults() *InlineObject1 {
-    this := InlineObject1{}
-    return &this
+	this := InlineObject1{}
+	return &this
 }
 
 // GetAdditionalMetadata returns the AdditionalMetadata field value if set, zero value otherwise.
@@ -48,14 +48,14 @@ func (o *InlineObject1) GetAdditionalMetadata() string {
 	return *o.AdditionalMetadata
 }
 
-// GetAdditionalMetadataOk returns a tuple with the AdditionalMetadata field value if set, zero value otherwise
+// GetAdditionalMetadataOk returns a tuple with the AdditionalMetadata field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *InlineObject1) GetAdditionalMetadataOk() (string, bool) {
+
+func (o *InlineObject1) GetAdditionalMetadataOk() (*string, bool) {
 	if o == nil || o.AdditionalMetadata == nil {
-		var ret string
-		return ret, false
+		return nil, false
 	}
-	return *o.AdditionalMetadata, true
+	return o.AdditionalMetadata, true
 }
 
 // HasAdditionalMetadata returns a boolean if a field has been set.
@@ -81,14 +81,14 @@ func (o *InlineObject1) GetFile() *os.File {
 	return *o.File
 }
 
-// GetFileOk returns a tuple with the File field value if set, zero value otherwise
+// GetFileOk returns a tuple with the File field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *InlineObject1) GetFileOk() (*os.File, bool) {
+
+func (o *InlineObject1) GetFileOk() (**os.File, bool) {
 	if o == nil || o.File == nil {
-		var ret *os.File
-		return ret, false
+		return nil, false
 	}
-	return *o.File, true
+	return o.File, true
 }
 
 // HasFile returns a boolean if a field has been set.

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_inline_object_1.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_inline_object_1.go
@@ -50,7 +50,6 @@ func (o *InlineObject1) GetAdditionalMetadata() string {
 
 // GetAdditionalMetadataOk returns a tuple with the AdditionalMetadata field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *InlineObject1) GetAdditionalMetadataOk() (*string, bool) {
 	if o == nil || o.AdditionalMetadata == nil {
 		return nil, false
@@ -83,7 +82,6 @@ func (o *InlineObject1) GetFile() *os.File {
 
 // GetFileOk returns a tuple with the File field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *InlineObject1) GetFileOk() (**os.File, bool) {
 	if o == nil || o.File == nil {
 		return nil, false

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_inline_object_1.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_inline_object_1.go
@@ -55,12 +55,12 @@ func (o *InlineObject1) GetAdditionalMetadataOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-    return *o.AdditionalMetadata, true
+	return *o.AdditionalMetadata, true
 }
 
 // HasAdditionalMetadata returns a boolean if a field has been set.
 func (o *InlineObject1) HasAdditionalMetadata() bool {
-    if o != nil && o.AdditionalMetadata != nil {
+	if o != nil && o.AdditionalMetadata != nil {
 		return true
 	}
 
@@ -88,12 +88,12 @@ func (o *InlineObject1) GetFileOk() (*os.File, bool) {
 		var ret *os.File
 		return ret, false
 	}
-    return *o.File, true
+	return *o.File, true
 }
 
 // HasFile returns a boolean if a field has been set.
 func (o *InlineObject1) HasFile() bool {
-    if o != nil && o.File != nil {
+	if o != nil && o.File != nil {
 		return true
 	}
 
@@ -106,14 +106,14 @@ func (o *InlineObject1) SetFile(v *os.File) {
 }
 
 func (o InlineObject1) MarshalJSON() ([]byte, error) {
-    toSerialize := map[string]interface{}{}
-    if o.AdditionalMetadata != nil {
-        toSerialize["additionalMetadata"] = o.AdditionalMetadata
-    }
-    if o.File != nil {
-        toSerialize["file"] = o.File
-    }
-    return json.Marshal(toSerialize)
+	toSerialize := map[string]interface{}{}
+	if o.AdditionalMetadata != nil {
+		toSerialize["additionalMetadata"] = o.AdditionalMetadata
+	}
+	if o.File != nil {
+		toSerialize["file"] = o.File
+	}
+	return json.Marshal(toSerialize)
 }
 
 type NullableInlineObject1 struct {
@@ -122,32 +122,32 @@ type NullableInlineObject1 struct {
 }
 
 func (v NullableInlineObject1) Get() *InlineObject1 {
-    return v.value
+	return v.value
 }
 
 func (v NullableInlineObject1) Set(val *InlineObject1) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableInlineObject1) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableInlineObject1) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableInlineObject1(val *InlineObject1) *NullableInlineObject1 {
-    return &NullableInlineObject1{value: val, isSet: true}
+	return &NullableInlineObject1{value: val, isSet: true}
 }
 
 func (v NullableInlineObject1) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableInlineObject1) UnmarshalJSON(src []byte) error {
-    v.isSet = true
+	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_inline_object_2.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_inline_object_2.go
@@ -27,8 +27,8 @@ type InlineObject2 struct {
 // will change when the set of required properties is changed
 func NewInlineObject2() *InlineObject2 {
     this := InlineObject2{}
-    var enumFormString string = "-efg"
-    this.EnumFormString = &enumFormString
+	var enumFormString string = "-efg"
+	this.EnumFormString = &enumFormString
     return &this
 }
 
@@ -37,8 +37,8 @@ func NewInlineObject2() *InlineObject2 {
 // but it doesn't guarantee that properties required by API are set
 func NewInlineObject2WithDefaults() *InlineObject2 {
     this := InlineObject2{}
-    var enumFormString string = "-efg"
-    this.EnumFormString = &enumFormString
+	var enumFormString string = "-efg"
+	this.EnumFormString = &enumFormString
     return &this
 }
 
@@ -58,12 +58,12 @@ func (o *InlineObject2) GetEnumFormStringArrayOk() ([]string, bool) {
 		var ret []string
 		return ret, false
 	}
-    return *o.EnumFormStringArray, true
+	return *o.EnumFormStringArray, true
 }
 
 // HasEnumFormStringArray returns a boolean if a field has been set.
 func (o *InlineObject2) HasEnumFormStringArray() bool {
-    if o != nil && o.EnumFormStringArray != nil {
+	if o != nil && o.EnumFormStringArray != nil {
 		return true
 	}
 
@@ -91,12 +91,12 @@ func (o *InlineObject2) GetEnumFormStringOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-    return *o.EnumFormString, true
+	return *o.EnumFormString, true
 }
 
 // HasEnumFormString returns a boolean if a field has been set.
 func (o *InlineObject2) HasEnumFormString() bool {
-    if o != nil && o.EnumFormString != nil {
+	if o != nil && o.EnumFormString != nil {
 		return true
 	}
 
@@ -109,14 +109,14 @@ func (o *InlineObject2) SetEnumFormString(v string) {
 }
 
 func (o InlineObject2) MarshalJSON() ([]byte, error) {
-    toSerialize := map[string]interface{}{}
-    if o.EnumFormStringArray != nil {
-        toSerialize["enum_form_string_array"] = o.EnumFormStringArray
-    }
-    if o.EnumFormString != nil {
-        toSerialize["enum_form_string"] = o.EnumFormString
-    }
-    return json.Marshal(toSerialize)
+	toSerialize := map[string]interface{}{}
+	if o.EnumFormStringArray != nil {
+		toSerialize["enum_form_string_array"] = o.EnumFormStringArray
+	}
+	if o.EnumFormString != nil {
+		toSerialize["enum_form_string"] = o.EnumFormString
+	}
+	return json.Marshal(toSerialize)
 }
 
 type NullableInlineObject2 struct {
@@ -125,32 +125,32 @@ type NullableInlineObject2 struct {
 }
 
 func (v NullableInlineObject2) Get() *InlineObject2 {
-    return v.value
+	return v.value
 }
 
 func (v NullableInlineObject2) Set(val *InlineObject2) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableInlineObject2) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableInlineObject2) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableInlineObject2(val *InlineObject2) *NullableInlineObject2 {
-    return &NullableInlineObject2{value: val, isSet: true}
+	return &NullableInlineObject2{value: val, isSet: true}
 }
 
 func (v NullableInlineObject2) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableInlineObject2) UnmarshalJSON(src []byte) error {
-    v.isSet = true
+	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_inline_object_2.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_inline_object_2.go
@@ -26,20 +26,20 @@ type InlineObject2 struct {
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
 func NewInlineObject2() *InlineObject2 {
-    this := InlineObject2{}
+	this := InlineObject2{}
 	var enumFormString string = "-efg"
 	this.EnumFormString = &enumFormString
-    return &this
+	return &this
 }
 
 // NewInlineObject2WithDefaults instantiates a new InlineObject2 object
 // This constructor will only assign default values to properties that have it defined,
 // but it doesn't guarantee that properties required by API are set
 func NewInlineObject2WithDefaults() *InlineObject2 {
-    this := InlineObject2{}
+	this := InlineObject2{}
 	var enumFormString string = "-efg"
 	this.EnumFormString = &enumFormString
-    return &this
+	return &this
 }
 
 // GetEnumFormStringArray returns the EnumFormStringArray field value if set, zero value otherwise.
@@ -51,14 +51,14 @@ func (o *InlineObject2) GetEnumFormStringArray() []string {
 	return *o.EnumFormStringArray
 }
 
-// GetEnumFormStringArrayOk returns a tuple with the EnumFormStringArray field value if set, zero value otherwise
+// GetEnumFormStringArrayOk returns a tuple with the EnumFormStringArray field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *InlineObject2) GetEnumFormStringArrayOk() ([]string, bool) {
+
+func (o *InlineObject2) GetEnumFormStringArrayOk() (*[]string, bool) {
 	if o == nil || o.EnumFormStringArray == nil {
-		var ret []string
-		return ret, false
+		return nil, false
 	}
-	return *o.EnumFormStringArray, true
+	return o.EnumFormStringArray, true
 }
 
 // HasEnumFormStringArray returns a boolean if a field has been set.
@@ -84,14 +84,14 @@ func (o *InlineObject2) GetEnumFormString() string {
 	return *o.EnumFormString
 }
 
-// GetEnumFormStringOk returns a tuple with the EnumFormString field value if set, zero value otherwise
+// GetEnumFormStringOk returns a tuple with the EnumFormString field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *InlineObject2) GetEnumFormStringOk() (string, bool) {
+
+func (o *InlineObject2) GetEnumFormStringOk() (*string, bool) {
 	if o == nil || o.EnumFormString == nil {
-		var ret string
-		return ret, false
+		return nil, false
 	}
-	return *o.EnumFormString, true
+	return o.EnumFormString, true
 }
 
 // HasEnumFormString returns a boolean if a field has been set.

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_inline_object_2.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_inline_object_2.go
@@ -10,7 +10,6 @@
 package petstore
 
 import (
-	"bytes"
 	"encoding/json"
 )
 
@@ -59,12 +58,12 @@ func (o *InlineObject2) GetEnumFormStringArrayOk() ([]string, bool) {
 		var ret []string
 		return ret, false
 	}
-	return *o.EnumFormStringArray, true
+    return *o.EnumFormStringArray, true
 }
 
 // HasEnumFormStringArray returns a boolean if a field has been set.
 func (o *InlineObject2) HasEnumFormStringArray() bool {
-	if o != nil && o.EnumFormStringArray != nil {
+    if o != nil && o.EnumFormStringArray != nil {
 		return true
 	}
 
@@ -92,12 +91,12 @@ func (o *InlineObject2) GetEnumFormStringOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-	return *o.EnumFormString, true
+    return *o.EnumFormString, true
 }
 
 // HasEnumFormString returns a boolean if a field has been set.
 func (o *InlineObject2) HasEnumFormString() bool {
-	if o != nil && o.EnumFormString != nil {
+    if o != nil && o.EnumFormString != nil {
 		return true
 	}
 
@@ -109,25 +108,49 @@ func (o *InlineObject2) SetEnumFormString(v string) {
 	o.EnumFormString = &v
 }
 
+func (o InlineObject2) MarshalJSON() ([]byte, error) {
+    toSerialize := map[string]interface{}{}
+    if o.EnumFormStringArray != nil {
+        toSerialize["enum_form_string_array"] = o.EnumFormStringArray
+    }
+    if o.EnumFormString != nil {
+        toSerialize["enum_form_string"] = o.EnumFormString
+    }
+    return json.Marshal(toSerialize)
+}
+
 type NullableInlineObject2 struct {
-	Value InlineObject2
-	ExplicitNull bool
+	value *InlineObject2
+	isSet bool
+}
+
+func (v NullableInlineObject2) Get() *InlineObject2 {
+    return v.value
+}
+
+func (v NullableInlineObject2) Set(val *InlineObject2) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableInlineObject2) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableInlineObject2) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableInlineObject2(val *InlineObject2) *NullableInlineObject2 {
+    return &NullableInlineObject2{value: val, isSet: true}
 }
 
 func (v NullableInlineObject2) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-		return json.Marshal(v.Value)
-	}
+    return json.Marshal(v.value)
 }
 
 func (v *NullableInlineObject2) UnmarshalJSON(src []byte) error {
-	if bytes.Equal(src, []byte("null")) {
-		v.ExplicitNull = true
-		return nil
-	}
-
-	return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_inline_object_2.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_inline_object_2.go
@@ -53,7 +53,6 @@ func (o *InlineObject2) GetEnumFormStringArray() []string {
 
 // GetEnumFormStringArrayOk returns a tuple with the EnumFormStringArray field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *InlineObject2) GetEnumFormStringArrayOk() (*[]string, bool) {
 	if o == nil || o.EnumFormStringArray == nil {
 		return nil, false
@@ -86,7 +85,6 @@ func (o *InlineObject2) GetEnumFormString() string {
 
 // GetEnumFormStringOk returns a tuple with the EnumFormString field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *InlineObject2) GetEnumFormStringOk() (*string, bool) {
 	if o == nil || o.EnumFormString == nil {
 		return nil, false

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_inline_object_2.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_inline_object_2.go
@@ -128,7 +128,7 @@ func (v NullableInlineObject2) Get() *InlineObject2 {
 	return v.value
 }
 
-func (v NullableInlineObject2) Set(val *InlineObject2) {
+func (v *NullableInlineObject2) Set(val *InlineObject2) {
 	v.value = val
 	v.isSet = true
 }
@@ -137,7 +137,7 @@ func (v NullableInlineObject2) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableInlineObject2) Unset() {
+func (v *NullableInlineObject2) Unset() {
 	v.value = nil
 	v.isSet = false
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_inline_object_3.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_inline_object_3.go
@@ -52,20 +52,20 @@ type InlineObject3 struct {
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
 func NewInlineObject3(number float32, double float64, patternWithoutDelimiter string, byte_ string, ) *InlineObject3 {
-    this := InlineObject3{}
-    this.Number = number
-    this.Double = double
-    this.PatternWithoutDelimiter = patternWithoutDelimiter
-    this.Byte = byte_
-    return &this
+	this := InlineObject3{}
+	this.Number = number
+	this.Double = double
+	this.PatternWithoutDelimiter = patternWithoutDelimiter
+	this.Byte = byte_
+	return &this
 }
 
 // NewInlineObject3WithDefaults instantiates a new InlineObject3 object
 // This constructor will only assign default values to properties that have it defined,
 // but it doesn't guarantee that properties required by API are set
 func NewInlineObject3WithDefaults() *InlineObject3 {
-    this := InlineObject3{}
-    return &this
+	this := InlineObject3{}
+	return &this
 }
 
 // GetInteger returns the Integer field value if set, zero value otherwise.
@@ -77,14 +77,14 @@ func (o *InlineObject3) GetInteger() int32 {
 	return *o.Integer
 }
 
-// GetIntegerOk returns a tuple with the Integer field value if set, zero value otherwise
+// GetIntegerOk returns a tuple with the Integer field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *InlineObject3) GetIntegerOk() (int32, bool) {
+
+func (o *InlineObject3) GetIntegerOk() (*int32, bool) {
 	if o == nil || o.Integer == nil {
-		var ret int32
-		return ret, false
+		return nil, false
 	}
-	return *o.Integer, true
+	return o.Integer, true
 }
 
 // HasInteger returns a boolean if a field has been set.
@@ -110,14 +110,14 @@ func (o *InlineObject3) GetInt32() int32 {
 	return *o.Int32
 }
 
-// GetInt32Ok returns a tuple with the Int32 field value if set, zero value otherwise
+// GetInt32Ok returns a tuple with the Int32 field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *InlineObject3) GetInt32Ok() (int32, bool) {
+
+func (o *InlineObject3) GetInt32Ok() (*int32, bool) {
 	if o == nil || o.Int32 == nil {
-		var ret int32
-		return ret, false
+		return nil, false
 	}
-	return *o.Int32, true
+	return o.Int32, true
 }
 
 // HasInt32 returns a boolean if a field has been set.
@@ -143,14 +143,14 @@ func (o *InlineObject3) GetInt64() int64 {
 	return *o.Int64
 }
 
-// GetInt64Ok returns a tuple with the Int64 field value if set, zero value otherwise
+// GetInt64Ok returns a tuple with the Int64 field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *InlineObject3) GetInt64Ok() (int64, bool) {
+
+func (o *InlineObject3) GetInt64Ok() (*int64, bool) {
 	if o == nil || o.Int64 == nil {
-		var ret int64
-		return ret, false
+		return nil, false
 	}
-	return *o.Int64, true
+	return o.Int64, true
 }
 
 // HasInt64 returns a boolean if a field has been set.
@@ -169,12 +169,22 @@ func (o *InlineObject3) SetInt64(v int64) {
 
 // GetNumber returns the Number field value
 func (o *InlineObject3) GetNumber() float32 {
-	if o == nil {
+	if o == nil  {
 		var ret float32
 		return ret
 	}
 
 	return o.Number
+}
+
+// GetNumberOk returns a tuple with the Number field value
+// and a boolean to check if the value has been set.
+
+func (o *InlineObject3) GetNumberOk() (*float32, bool) {
+    if o == nil  {
+        return nil, false
+    }
+    return &o.Number, true
 }
 
 // SetNumber sets field value
@@ -191,14 +201,14 @@ func (o *InlineObject3) GetFloat() float32 {
 	return *o.Float
 }
 
-// GetFloatOk returns a tuple with the Float field value if set, zero value otherwise
+// GetFloatOk returns a tuple with the Float field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *InlineObject3) GetFloatOk() (float32, bool) {
+
+func (o *InlineObject3) GetFloatOk() (*float32, bool) {
 	if o == nil || o.Float == nil {
-		var ret float32
-		return ret, false
+		return nil, false
 	}
-	return *o.Float, true
+	return o.Float, true
 }
 
 // HasFloat returns a boolean if a field has been set.
@@ -217,12 +227,22 @@ func (o *InlineObject3) SetFloat(v float32) {
 
 // GetDouble returns the Double field value
 func (o *InlineObject3) GetDouble() float64 {
-	if o == nil {
+	if o == nil  {
 		var ret float64
 		return ret
 	}
 
 	return o.Double
+}
+
+// GetDoubleOk returns a tuple with the Double field value
+// and a boolean to check if the value has been set.
+
+func (o *InlineObject3) GetDoubleOk() (*float64, bool) {
+    if o == nil  {
+        return nil, false
+    }
+    return &o.Double, true
 }
 
 // SetDouble sets field value
@@ -239,14 +259,14 @@ func (o *InlineObject3) GetString() string {
 	return *o.String
 }
 
-// GetStringOk returns a tuple with the String field value if set, zero value otherwise
+// GetStringOk returns a tuple with the String field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *InlineObject3) GetStringOk() (string, bool) {
+
+func (o *InlineObject3) GetStringOk() (*string, bool) {
 	if o == nil || o.String == nil {
-		var ret string
-		return ret, false
+		return nil, false
 	}
-	return *o.String, true
+	return o.String, true
 }
 
 // HasString returns a boolean if a field has been set.
@@ -265,12 +285,22 @@ func (o *InlineObject3) SetString(v string) {
 
 // GetPatternWithoutDelimiter returns the PatternWithoutDelimiter field value
 func (o *InlineObject3) GetPatternWithoutDelimiter() string {
-	if o == nil {
+	if o == nil  {
 		var ret string
 		return ret
 	}
 
 	return o.PatternWithoutDelimiter
+}
+
+// GetPatternWithoutDelimiterOk returns a tuple with the PatternWithoutDelimiter field value
+// and a boolean to check if the value has been set.
+
+func (o *InlineObject3) GetPatternWithoutDelimiterOk() (*string, bool) {
+    if o == nil  {
+        return nil, false
+    }
+    return &o.PatternWithoutDelimiter, true
 }
 
 // SetPatternWithoutDelimiter sets field value
@@ -280,12 +310,22 @@ func (o *InlineObject3) SetPatternWithoutDelimiter(v string) {
 
 // GetByte returns the Byte field value
 func (o *InlineObject3) GetByte() string {
-	if o == nil {
+	if o == nil  {
 		var ret string
 		return ret
 	}
 
 	return o.Byte
+}
+
+// GetByteOk returns a tuple with the Byte field value
+// and a boolean to check if the value has been set.
+
+func (o *InlineObject3) GetByteOk() (*string, bool) {
+    if o == nil  {
+        return nil, false
+    }
+    return &o.Byte, true
 }
 
 // SetByte sets field value
@@ -302,14 +342,14 @@ func (o *InlineObject3) GetBinary() *os.File {
 	return *o.Binary
 }
 
-// GetBinaryOk returns a tuple with the Binary field value if set, zero value otherwise
+// GetBinaryOk returns a tuple with the Binary field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *InlineObject3) GetBinaryOk() (*os.File, bool) {
+
+func (o *InlineObject3) GetBinaryOk() (**os.File, bool) {
 	if o == nil || o.Binary == nil {
-		var ret *os.File
-		return ret, false
+		return nil, false
 	}
-	return *o.Binary, true
+	return o.Binary, true
 }
 
 // HasBinary returns a boolean if a field has been set.
@@ -335,14 +375,14 @@ func (o *InlineObject3) GetDate() string {
 	return *o.Date
 }
 
-// GetDateOk returns a tuple with the Date field value if set, zero value otherwise
+// GetDateOk returns a tuple with the Date field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *InlineObject3) GetDateOk() (string, bool) {
+
+func (o *InlineObject3) GetDateOk() (*string, bool) {
 	if o == nil || o.Date == nil {
-		var ret string
-		return ret, false
+		return nil, false
 	}
-	return *o.Date, true
+	return o.Date, true
 }
 
 // HasDate returns a boolean if a field has been set.
@@ -368,14 +408,14 @@ func (o *InlineObject3) GetDateTime() time.Time {
 	return *o.DateTime
 }
 
-// GetDateTimeOk returns a tuple with the DateTime field value if set, zero value otherwise
+// GetDateTimeOk returns a tuple with the DateTime field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *InlineObject3) GetDateTimeOk() (time.Time, bool) {
+
+func (o *InlineObject3) GetDateTimeOk() (*time.Time, bool) {
 	if o == nil || o.DateTime == nil {
-		var ret time.Time
-		return ret, false
+		return nil, false
 	}
-	return *o.DateTime, true
+	return o.DateTime, true
 }
 
 // HasDateTime returns a boolean if a field has been set.
@@ -401,14 +441,14 @@ func (o *InlineObject3) GetPassword() string {
 	return *o.Password
 }
 
-// GetPasswordOk returns a tuple with the Password field value if set, zero value otherwise
+// GetPasswordOk returns a tuple with the Password field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *InlineObject3) GetPasswordOk() (string, bool) {
+
+func (o *InlineObject3) GetPasswordOk() (*string, bool) {
 	if o == nil || o.Password == nil {
-		var ret string
-		return ret, false
+		return nil, false
 	}
-	return *o.Password, true
+	return o.Password, true
 }
 
 // HasPassword returns a boolean if a field has been set.
@@ -434,14 +474,14 @@ func (o *InlineObject3) GetCallback() string {
 	return *o.Callback
 }
 
-// GetCallbackOk returns a tuple with the Callback field value if set, zero value otherwise
+// GetCallbackOk returns a tuple with the Callback field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *InlineObject3) GetCallbackOk() (string, bool) {
+
+func (o *InlineObject3) GetCallbackOk() (*string, bool) {
 	if o == nil || o.Callback == nil {
-		var ret string
-		return ret, false
+		return nil, false
 	}
-	return *o.Callback, true
+	return o.Callback, true
 }
 
 // HasCallback returns a boolean if a field has been set.

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_inline_object_3.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_inline_object_3.go
@@ -514,7 +514,7 @@ func (v NullableInlineObject3) Get() *InlineObject3 {
 	return v.value
 }
 
-func (v NullableInlineObject3) Set(val *InlineObject3) {
+func (v *NullableInlineObject3) Set(val *InlineObject3) {
 	v.value = val
 	v.isSet = true
 }
@@ -523,7 +523,7 @@ func (v NullableInlineObject3) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableInlineObject3) Unset() {
+func (v *NullableInlineObject3) Unset() {
 	v.value = nil
 	v.isSet = false
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_inline_object_3.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_inline_object_3.go
@@ -79,7 +79,6 @@ func (o *InlineObject3) GetInteger() int32 {
 
 // GetIntegerOk returns a tuple with the Integer field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *InlineObject3) GetIntegerOk() (*int32, bool) {
 	if o == nil || o.Integer == nil {
 		return nil, false
@@ -112,7 +111,6 @@ func (o *InlineObject3) GetInt32() int32 {
 
 // GetInt32Ok returns a tuple with the Int32 field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *InlineObject3) GetInt32Ok() (*int32, bool) {
 	if o == nil || o.Int32 == nil {
 		return nil, false
@@ -145,7 +143,6 @@ func (o *InlineObject3) GetInt64() int64 {
 
 // GetInt64Ok returns a tuple with the Int64 field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *InlineObject3) GetInt64Ok() (*int64, bool) {
 	if o == nil || o.Int64 == nil {
 		return nil, false
@@ -179,12 +176,11 @@ func (o *InlineObject3) GetNumber() float32 {
 
 // GetNumberOk returns a tuple with the Number field value
 // and a boolean to check if the value has been set.
-
 func (o *InlineObject3) GetNumberOk() (*float32, bool) {
-    if o == nil  {
-        return nil, false
-    }
-    return &o.Number, true
+	if o == nil  {
+		return nil, false
+	}
+	return &o.Number, true
 }
 
 // SetNumber sets field value
@@ -203,7 +199,6 @@ func (o *InlineObject3) GetFloat() float32 {
 
 // GetFloatOk returns a tuple with the Float field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *InlineObject3) GetFloatOk() (*float32, bool) {
 	if o == nil || o.Float == nil {
 		return nil, false
@@ -237,12 +232,11 @@ func (o *InlineObject3) GetDouble() float64 {
 
 // GetDoubleOk returns a tuple with the Double field value
 // and a boolean to check if the value has been set.
-
 func (o *InlineObject3) GetDoubleOk() (*float64, bool) {
-    if o == nil  {
-        return nil, false
-    }
-    return &o.Double, true
+	if o == nil  {
+		return nil, false
+	}
+	return &o.Double, true
 }
 
 // SetDouble sets field value
@@ -261,7 +255,6 @@ func (o *InlineObject3) GetString() string {
 
 // GetStringOk returns a tuple with the String field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *InlineObject3) GetStringOk() (*string, bool) {
 	if o == nil || o.String == nil {
 		return nil, false
@@ -295,12 +288,11 @@ func (o *InlineObject3) GetPatternWithoutDelimiter() string {
 
 // GetPatternWithoutDelimiterOk returns a tuple with the PatternWithoutDelimiter field value
 // and a boolean to check if the value has been set.
-
 func (o *InlineObject3) GetPatternWithoutDelimiterOk() (*string, bool) {
-    if o == nil  {
-        return nil, false
-    }
-    return &o.PatternWithoutDelimiter, true
+	if o == nil  {
+		return nil, false
+	}
+	return &o.PatternWithoutDelimiter, true
 }
 
 // SetPatternWithoutDelimiter sets field value
@@ -320,12 +312,11 @@ func (o *InlineObject3) GetByte() string {
 
 // GetByteOk returns a tuple with the Byte field value
 // and a boolean to check if the value has been set.
-
 func (o *InlineObject3) GetByteOk() (*string, bool) {
-    if o == nil  {
-        return nil, false
-    }
-    return &o.Byte, true
+	if o == nil  {
+		return nil, false
+	}
+	return &o.Byte, true
 }
 
 // SetByte sets field value
@@ -344,7 +335,6 @@ func (o *InlineObject3) GetBinary() *os.File {
 
 // GetBinaryOk returns a tuple with the Binary field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *InlineObject3) GetBinaryOk() (**os.File, bool) {
 	if o == nil || o.Binary == nil {
 		return nil, false
@@ -377,7 +367,6 @@ func (o *InlineObject3) GetDate() string {
 
 // GetDateOk returns a tuple with the Date field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *InlineObject3) GetDateOk() (*string, bool) {
 	if o == nil || o.Date == nil {
 		return nil, false
@@ -410,7 +399,6 @@ func (o *InlineObject3) GetDateTime() time.Time {
 
 // GetDateTimeOk returns a tuple with the DateTime field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *InlineObject3) GetDateTimeOk() (*time.Time, bool) {
 	if o == nil || o.DateTime == nil {
 		return nil, false
@@ -443,7 +431,6 @@ func (o *InlineObject3) GetPassword() string {
 
 // GetPasswordOk returns a tuple with the Password field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *InlineObject3) GetPasswordOk() (*string, bool) {
 	if o == nil || o.Password == nil {
 		return nil, false
@@ -476,7 +463,6 @@ func (o *InlineObject3) GetCallback() string {
 
 // GetCallbackOk returns a tuple with the Callback field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *InlineObject3) GetCallbackOk() (*string, bool) {
 	if o == nil || o.Callback == nil {
 		return nil, false

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_inline_object_3.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_inline_object_3.go
@@ -10,7 +10,6 @@
 package petstore
 
 import (
-	"bytes"
 	"encoding/json"
 	"os"
 	"time"
@@ -85,12 +84,12 @@ func (o *InlineObject3) GetIntegerOk() (int32, bool) {
 		var ret int32
 		return ret, false
 	}
-	return *o.Integer, true
+    return *o.Integer, true
 }
 
 // HasInteger returns a boolean if a field has been set.
 func (o *InlineObject3) HasInteger() bool {
-	if o != nil && o.Integer != nil {
+    if o != nil && o.Integer != nil {
 		return true
 	}
 
@@ -118,12 +117,12 @@ func (o *InlineObject3) GetInt32Ok() (int32, bool) {
 		var ret int32
 		return ret, false
 	}
-	return *o.Int32, true
+    return *o.Int32, true
 }
 
 // HasInt32 returns a boolean if a field has been set.
 func (o *InlineObject3) HasInt32() bool {
-	if o != nil && o.Int32 != nil {
+    if o != nil && o.Int32 != nil {
 		return true
 	}
 
@@ -151,12 +150,12 @@ func (o *InlineObject3) GetInt64Ok() (int64, bool) {
 		var ret int64
 		return ret, false
 	}
-	return *o.Int64, true
+    return *o.Int64, true
 }
 
 // HasInt64 returns a boolean if a field has been set.
 func (o *InlineObject3) HasInt64() bool {
-	if o != nil && o.Int64 != nil {
+    if o != nil && o.Int64 != nil {
 		return true
 	}
 
@@ -199,12 +198,12 @@ func (o *InlineObject3) GetFloatOk() (float32, bool) {
 		var ret float32
 		return ret, false
 	}
-	return *o.Float, true
+    return *o.Float, true
 }
 
 // HasFloat returns a boolean if a field has been set.
 func (o *InlineObject3) HasFloat() bool {
-	if o != nil && o.Float != nil {
+    if o != nil && o.Float != nil {
 		return true
 	}
 
@@ -247,12 +246,12 @@ func (o *InlineObject3) GetStringOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-	return *o.String, true
+    return *o.String, true
 }
 
 // HasString returns a boolean if a field has been set.
 func (o *InlineObject3) HasString() bool {
-	if o != nil && o.String != nil {
+    if o != nil && o.String != nil {
 		return true
 	}
 
@@ -310,12 +309,12 @@ func (o *InlineObject3) GetBinaryOk() (*os.File, bool) {
 		var ret *os.File
 		return ret, false
 	}
-	return *o.Binary, true
+    return *o.Binary, true
 }
 
 // HasBinary returns a boolean if a field has been set.
 func (o *InlineObject3) HasBinary() bool {
-	if o != nil && o.Binary != nil {
+    if o != nil && o.Binary != nil {
 		return true
 	}
 
@@ -343,12 +342,12 @@ func (o *InlineObject3) GetDateOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-	return *o.Date, true
+    return *o.Date, true
 }
 
 // HasDate returns a boolean if a field has been set.
 func (o *InlineObject3) HasDate() bool {
-	if o != nil && o.Date != nil {
+    if o != nil && o.Date != nil {
 		return true
 	}
 
@@ -376,12 +375,12 @@ func (o *InlineObject3) GetDateTimeOk() (time.Time, bool) {
 		var ret time.Time
 		return ret, false
 	}
-	return *o.DateTime, true
+    return *o.DateTime, true
 }
 
 // HasDateTime returns a boolean if a field has been set.
 func (o *InlineObject3) HasDateTime() bool {
-	if o != nil && o.DateTime != nil {
+    if o != nil && o.DateTime != nil {
 		return true
 	}
 
@@ -409,12 +408,12 @@ func (o *InlineObject3) GetPasswordOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-	return *o.Password, true
+    return *o.Password, true
 }
 
 // HasPassword returns a boolean if a field has been set.
 func (o *InlineObject3) HasPassword() bool {
-	if o != nil && o.Password != nil {
+    if o != nil && o.Password != nil {
 		return true
 	}
 
@@ -442,12 +441,12 @@ func (o *InlineObject3) GetCallbackOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-	return *o.Callback, true
+    return *o.Callback, true
 }
 
 // HasCallback returns a boolean if a field has been set.
 func (o *InlineObject3) HasCallback() bool {
-	if o != nil && o.Callback != nil {
+    if o != nil && o.Callback != nil {
 		return true
 	}
 
@@ -459,25 +458,85 @@ func (o *InlineObject3) SetCallback(v string) {
 	o.Callback = &v
 }
 
+func (o InlineObject3) MarshalJSON() ([]byte, error) {
+    toSerialize := map[string]interface{}{}
+    if o.Integer != nil {
+        toSerialize["integer"] = o.Integer
+    }
+    if o.Int32 != nil {
+        toSerialize["int32"] = o.Int32
+    }
+    if o.Int64 != nil {
+        toSerialize["int64"] = o.Int64
+    }
+    if true {
+        toSerialize["number"] = o.Number
+    }
+    if o.Float != nil {
+        toSerialize["float"] = o.Float
+    }
+    if true {
+        toSerialize["double"] = o.Double
+    }
+    if o.String != nil {
+        toSerialize["string"] = o.String
+    }
+    if true {
+        toSerialize["pattern_without_delimiter"] = o.PatternWithoutDelimiter
+    }
+    if true {
+        toSerialize["byte"] = o.Byte
+    }
+    if o.Binary != nil {
+        toSerialize["binary"] = o.Binary
+    }
+    if o.Date != nil {
+        toSerialize["date"] = o.Date
+    }
+    if o.DateTime != nil {
+        toSerialize["dateTime"] = o.DateTime
+    }
+    if o.Password != nil {
+        toSerialize["password"] = o.Password
+    }
+    if o.Callback != nil {
+        toSerialize["callback"] = o.Callback
+    }
+    return json.Marshal(toSerialize)
+}
+
 type NullableInlineObject3 struct {
-	Value InlineObject3
-	ExplicitNull bool
+	value *InlineObject3
+	isSet bool
+}
+
+func (v NullableInlineObject3) Get() *InlineObject3 {
+    return v.value
+}
+
+func (v NullableInlineObject3) Set(val *InlineObject3) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableInlineObject3) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableInlineObject3) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableInlineObject3(val *InlineObject3) *NullableInlineObject3 {
+    return &NullableInlineObject3{value: val, isSet: true}
 }
 
 func (v NullableInlineObject3) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-		return json.Marshal(v.Value)
-	}
+    return json.Marshal(v.value)
 }
 
 func (v *NullableInlineObject3) UnmarshalJSON(src []byte) error {
-	if bytes.Equal(src, []byte("null")) {
-		v.ExplicitNull = true
-		return nil
-	}
-
-	return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_inline_object_3.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_inline_object_3.go
@@ -84,12 +84,12 @@ func (o *InlineObject3) GetIntegerOk() (int32, bool) {
 		var ret int32
 		return ret, false
 	}
-    return *o.Integer, true
+	return *o.Integer, true
 }
 
 // HasInteger returns a boolean if a field has been set.
 func (o *InlineObject3) HasInteger() bool {
-    if o != nil && o.Integer != nil {
+	if o != nil && o.Integer != nil {
 		return true
 	}
 
@@ -117,12 +117,12 @@ func (o *InlineObject3) GetInt32Ok() (int32, bool) {
 		var ret int32
 		return ret, false
 	}
-    return *o.Int32, true
+	return *o.Int32, true
 }
 
 // HasInt32 returns a boolean if a field has been set.
 func (o *InlineObject3) HasInt32() bool {
-    if o != nil && o.Int32 != nil {
+	if o != nil && o.Int32 != nil {
 		return true
 	}
 
@@ -150,12 +150,12 @@ func (o *InlineObject3) GetInt64Ok() (int64, bool) {
 		var ret int64
 		return ret, false
 	}
-    return *o.Int64, true
+	return *o.Int64, true
 }
 
 // HasInt64 returns a boolean if a field has been set.
 func (o *InlineObject3) HasInt64() bool {
-    if o != nil && o.Int64 != nil {
+	if o != nil && o.Int64 != nil {
 		return true
 	}
 
@@ -198,12 +198,12 @@ func (o *InlineObject3) GetFloatOk() (float32, bool) {
 		var ret float32
 		return ret, false
 	}
-    return *o.Float, true
+	return *o.Float, true
 }
 
 // HasFloat returns a boolean if a field has been set.
 func (o *InlineObject3) HasFloat() bool {
-    if o != nil && o.Float != nil {
+	if o != nil && o.Float != nil {
 		return true
 	}
 
@@ -246,12 +246,12 @@ func (o *InlineObject3) GetStringOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-    return *o.String, true
+	return *o.String, true
 }
 
 // HasString returns a boolean if a field has been set.
 func (o *InlineObject3) HasString() bool {
-    if o != nil && o.String != nil {
+	if o != nil && o.String != nil {
 		return true
 	}
 
@@ -309,12 +309,12 @@ func (o *InlineObject3) GetBinaryOk() (*os.File, bool) {
 		var ret *os.File
 		return ret, false
 	}
-    return *o.Binary, true
+	return *o.Binary, true
 }
 
 // HasBinary returns a boolean if a field has been set.
 func (o *InlineObject3) HasBinary() bool {
-    if o != nil && o.Binary != nil {
+	if o != nil && o.Binary != nil {
 		return true
 	}
 
@@ -342,12 +342,12 @@ func (o *InlineObject3) GetDateOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-    return *o.Date, true
+	return *o.Date, true
 }
 
 // HasDate returns a boolean if a field has been set.
 func (o *InlineObject3) HasDate() bool {
-    if o != nil && o.Date != nil {
+	if o != nil && o.Date != nil {
 		return true
 	}
 
@@ -375,12 +375,12 @@ func (o *InlineObject3) GetDateTimeOk() (time.Time, bool) {
 		var ret time.Time
 		return ret, false
 	}
-    return *o.DateTime, true
+	return *o.DateTime, true
 }
 
 // HasDateTime returns a boolean if a field has been set.
 func (o *InlineObject3) HasDateTime() bool {
-    if o != nil && o.DateTime != nil {
+	if o != nil && o.DateTime != nil {
 		return true
 	}
 
@@ -408,12 +408,12 @@ func (o *InlineObject3) GetPasswordOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-    return *o.Password, true
+	return *o.Password, true
 }
 
 // HasPassword returns a boolean if a field has been set.
 func (o *InlineObject3) HasPassword() bool {
-    if o != nil && o.Password != nil {
+	if o != nil && o.Password != nil {
 		return true
 	}
 
@@ -441,12 +441,12 @@ func (o *InlineObject3) GetCallbackOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-    return *o.Callback, true
+	return *o.Callback, true
 }
 
 // HasCallback returns a boolean if a field has been set.
 func (o *InlineObject3) HasCallback() bool {
-    if o != nil && o.Callback != nil {
+	if o != nil && o.Callback != nil {
 		return true
 	}
 
@@ -459,50 +459,50 @@ func (o *InlineObject3) SetCallback(v string) {
 }
 
 func (o InlineObject3) MarshalJSON() ([]byte, error) {
-    toSerialize := map[string]interface{}{}
-    if o.Integer != nil {
-        toSerialize["integer"] = o.Integer
-    }
-    if o.Int32 != nil {
-        toSerialize["int32"] = o.Int32
-    }
-    if o.Int64 != nil {
-        toSerialize["int64"] = o.Int64
-    }
-    if true {
-        toSerialize["number"] = o.Number
-    }
-    if o.Float != nil {
-        toSerialize["float"] = o.Float
-    }
-    if true {
-        toSerialize["double"] = o.Double
-    }
-    if o.String != nil {
-        toSerialize["string"] = o.String
-    }
-    if true {
-        toSerialize["pattern_without_delimiter"] = o.PatternWithoutDelimiter
-    }
-    if true {
-        toSerialize["byte"] = o.Byte
-    }
-    if o.Binary != nil {
-        toSerialize["binary"] = o.Binary
-    }
-    if o.Date != nil {
-        toSerialize["date"] = o.Date
-    }
-    if o.DateTime != nil {
-        toSerialize["dateTime"] = o.DateTime
-    }
-    if o.Password != nil {
-        toSerialize["password"] = o.Password
-    }
-    if o.Callback != nil {
-        toSerialize["callback"] = o.Callback
-    }
-    return json.Marshal(toSerialize)
+	toSerialize := map[string]interface{}{}
+	if o.Integer != nil {
+		toSerialize["integer"] = o.Integer
+	}
+	if o.Int32 != nil {
+		toSerialize["int32"] = o.Int32
+	}
+	if o.Int64 != nil {
+		toSerialize["int64"] = o.Int64
+	}
+	if true {
+		toSerialize["number"] = o.Number
+	}
+	if o.Float != nil {
+		toSerialize["float"] = o.Float
+	}
+	if true {
+		toSerialize["double"] = o.Double
+	}
+	if o.String != nil {
+		toSerialize["string"] = o.String
+	}
+	if true {
+		toSerialize["pattern_without_delimiter"] = o.PatternWithoutDelimiter
+	}
+	if true {
+		toSerialize["byte"] = o.Byte
+	}
+	if o.Binary != nil {
+		toSerialize["binary"] = o.Binary
+	}
+	if o.Date != nil {
+		toSerialize["date"] = o.Date
+	}
+	if o.DateTime != nil {
+		toSerialize["dateTime"] = o.DateTime
+	}
+	if o.Password != nil {
+		toSerialize["password"] = o.Password
+	}
+	if o.Callback != nil {
+		toSerialize["callback"] = o.Callback
+	}
+	return json.Marshal(toSerialize)
 }
 
 type NullableInlineObject3 struct {
@@ -511,32 +511,32 @@ type NullableInlineObject3 struct {
 }
 
 func (v NullableInlineObject3) Get() *InlineObject3 {
-    return v.value
+	return v.value
 }
 
 func (v NullableInlineObject3) Set(val *InlineObject3) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableInlineObject3) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableInlineObject3) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableInlineObject3(val *InlineObject3) *NullableInlineObject3 {
-    return &NullableInlineObject3{value: val, isSet: true}
+	return &NullableInlineObject3{value: val, isSet: true}
 }
 
 func (v NullableInlineObject3) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableInlineObject3) UnmarshalJSON(src []byte) error {
-    v.isSet = true
+	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_inline_object_4.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_inline_object_4.go
@@ -71,14 +71,14 @@ func (o *InlineObject4) SetParam2(v string) {
 }
 
 func (o InlineObject4) MarshalJSON() ([]byte, error) {
-    toSerialize := map[string]interface{}{}
-    if true {
-        toSerialize["param"] = o.Param
-    }
-    if true {
-        toSerialize["param2"] = o.Param2
-    }
-    return json.Marshal(toSerialize)
+	toSerialize := map[string]interface{}{}
+	if true {
+		toSerialize["param"] = o.Param
+	}
+	if true {
+		toSerialize["param2"] = o.Param2
+	}
+	return json.Marshal(toSerialize)
 }
 
 type NullableInlineObject4 struct {
@@ -87,32 +87,32 @@ type NullableInlineObject4 struct {
 }
 
 func (v NullableInlineObject4) Get() *InlineObject4 {
-    return v.value
+	return v.value
 }
 
 func (v NullableInlineObject4) Set(val *InlineObject4) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableInlineObject4) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableInlineObject4) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableInlineObject4(val *InlineObject4) *NullableInlineObject4 {
-    return &NullableInlineObject4{value: val, isSet: true}
+	return &NullableInlineObject4{value: val, isSet: true}
 }
 
 func (v NullableInlineObject4) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableInlineObject4) UnmarshalJSON(src []byte) error {
-    v.isSet = true
+	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_inline_object_4.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_inline_object_4.go
@@ -26,28 +26,38 @@ type InlineObject4 struct {
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
 func NewInlineObject4(param string, param2 string, ) *InlineObject4 {
-    this := InlineObject4{}
-    this.Param = param
-    this.Param2 = param2
-    return &this
+	this := InlineObject4{}
+	this.Param = param
+	this.Param2 = param2
+	return &this
 }
 
 // NewInlineObject4WithDefaults instantiates a new InlineObject4 object
 // This constructor will only assign default values to properties that have it defined,
 // but it doesn't guarantee that properties required by API are set
 func NewInlineObject4WithDefaults() *InlineObject4 {
-    this := InlineObject4{}
-    return &this
+	this := InlineObject4{}
+	return &this
 }
 
 // GetParam returns the Param field value
 func (o *InlineObject4) GetParam() string {
-	if o == nil {
+	if o == nil  {
 		var ret string
 		return ret
 	}
 
 	return o.Param
+}
+
+// GetParamOk returns a tuple with the Param field value
+// and a boolean to check if the value has been set.
+
+func (o *InlineObject4) GetParamOk() (*string, bool) {
+    if o == nil  {
+        return nil, false
+    }
+    return &o.Param, true
 }
 
 // SetParam sets field value
@@ -57,12 +67,22 @@ func (o *InlineObject4) SetParam(v string) {
 
 // GetParam2 returns the Param2 field value
 func (o *InlineObject4) GetParam2() string {
-	if o == nil {
+	if o == nil  {
 		var ret string
 		return ret
 	}
 
 	return o.Param2
+}
+
+// GetParam2Ok returns a tuple with the Param2 field value
+// and a boolean to check if the value has been set.
+
+func (o *InlineObject4) GetParam2Ok() (*string, bool) {
+    if o == nil  {
+        return nil, false
+    }
+    return &o.Param2, true
 }
 
 // SetParam2 sets field value

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_inline_object_4.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_inline_object_4.go
@@ -90,7 +90,7 @@ func (v NullableInlineObject4) Get() *InlineObject4 {
 	return v.value
 }
 
-func (v NullableInlineObject4) Set(val *InlineObject4) {
+func (v *NullableInlineObject4) Set(val *InlineObject4) {
 	v.value = val
 	v.isSet = true
 }
@@ -99,7 +99,7 @@ func (v NullableInlineObject4) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableInlineObject4) Unset() {
+func (v *NullableInlineObject4) Unset() {
 	v.value = nil
 	v.isSet = false
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_inline_object_4.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_inline_object_4.go
@@ -10,7 +10,6 @@
 package petstore
 
 import (
-	"bytes"
 	"encoding/json"
 )
 
@@ -71,25 +70,49 @@ func (o *InlineObject4) SetParam2(v string) {
 	o.Param2 = v
 }
 
+func (o InlineObject4) MarshalJSON() ([]byte, error) {
+    toSerialize := map[string]interface{}{}
+    if true {
+        toSerialize["param"] = o.Param
+    }
+    if true {
+        toSerialize["param2"] = o.Param2
+    }
+    return json.Marshal(toSerialize)
+}
+
 type NullableInlineObject4 struct {
-	Value InlineObject4
-	ExplicitNull bool
+	value *InlineObject4
+	isSet bool
+}
+
+func (v NullableInlineObject4) Get() *InlineObject4 {
+    return v.value
+}
+
+func (v NullableInlineObject4) Set(val *InlineObject4) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableInlineObject4) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableInlineObject4) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableInlineObject4(val *InlineObject4) *NullableInlineObject4 {
+    return &NullableInlineObject4{value: val, isSet: true}
 }
 
 func (v NullableInlineObject4) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-		return json.Marshal(v.Value)
-	}
+    return json.Marshal(v.value)
 }
 
 func (v *NullableInlineObject4) UnmarshalJSON(src []byte) error {
-	if bytes.Equal(src, []byte("null")) {
-		v.ExplicitNull = true
-		return nil
-	}
-
-	return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_inline_object_4.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_inline_object_4.go
@@ -52,12 +52,11 @@ func (o *InlineObject4) GetParam() string {
 
 // GetParamOk returns a tuple with the Param field value
 // and a boolean to check if the value has been set.
-
 func (o *InlineObject4) GetParamOk() (*string, bool) {
-    if o == nil  {
-        return nil, false
-    }
-    return &o.Param, true
+	if o == nil  {
+		return nil, false
+	}
+	return &o.Param, true
 }
 
 // SetParam sets field value
@@ -77,12 +76,11 @@ func (o *InlineObject4) GetParam2() string {
 
 // GetParam2Ok returns a tuple with the Param2 field value
 // and a boolean to check if the value has been set.
-
 func (o *InlineObject4) GetParam2Ok() (*string, bool) {
-    if o == nil  {
-        return nil, false
-    }
-    return &o.Param2, true
+	if o == nil  {
+		return nil, false
+	}
+	return &o.Param2, true
 }
 
 // SetParam2 sets field value

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_inline_object_5.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_inline_object_5.go
@@ -27,17 +27,17 @@ type InlineObject5 struct {
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
 func NewInlineObject5(requiredFile *os.File, ) *InlineObject5 {
-    this := InlineObject5{}
-    this.RequiredFile = requiredFile
-    return &this
+	this := InlineObject5{}
+	this.RequiredFile = requiredFile
+	return &this
 }
 
 // NewInlineObject5WithDefaults instantiates a new InlineObject5 object
 // This constructor will only assign default values to properties that have it defined,
 // but it doesn't guarantee that properties required by API are set
 func NewInlineObject5WithDefaults() *InlineObject5 {
-    this := InlineObject5{}
-    return &this
+	this := InlineObject5{}
+	return &this
 }
 
 // GetAdditionalMetadata returns the AdditionalMetadata field value if set, zero value otherwise.
@@ -49,14 +49,14 @@ func (o *InlineObject5) GetAdditionalMetadata() string {
 	return *o.AdditionalMetadata
 }
 
-// GetAdditionalMetadataOk returns a tuple with the AdditionalMetadata field value if set, zero value otherwise
+// GetAdditionalMetadataOk returns a tuple with the AdditionalMetadata field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *InlineObject5) GetAdditionalMetadataOk() (string, bool) {
+
+func (o *InlineObject5) GetAdditionalMetadataOk() (*string, bool) {
 	if o == nil || o.AdditionalMetadata == nil {
-		var ret string
-		return ret, false
+		return nil, false
 	}
-	return *o.AdditionalMetadata, true
+	return o.AdditionalMetadata, true
 }
 
 // HasAdditionalMetadata returns a boolean if a field has been set.
@@ -75,12 +75,22 @@ func (o *InlineObject5) SetAdditionalMetadata(v string) {
 
 // GetRequiredFile returns the RequiredFile field value
 func (o *InlineObject5) GetRequiredFile() *os.File {
-	if o == nil {
+	if o == nil  {
 		var ret *os.File
 		return ret
 	}
 
 	return o.RequiredFile
+}
+
+// GetRequiredFileOk returns a tuple with the RequiredFile field value
+// and a boolean to check if the value has been set.
+
+func (o *InlineObject5) GetRequiredFileOk() (**os.File, bool) {
+    if o == nil  {
+        return nil, false
+    }
+    return &o.RequiredFile, true
 }
 
 // SetRequiredFile sets field value

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_inline_object_5.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_inline_object_5.go
@@ -51,7 +51,6 @@ func (o *InlineObject5) GetAdditionalMetadata() string {
 
 // GetAdditionalMetadataOk returns a tuple with the AdditionalMetadata field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *InlineObject5) GetAdditionalMetadataOk() (*string, bool) {
 	if o == nil || o.AdditionalMetadata == nil {
 		return nil, false
@@ -85,12 +84,11 @@ func (o *InlineObject5) GetRequiredFile() *os.File {
 
 // GetRequiredFileOk returns a tuple with the RequiredFile field value
 // and a boolean to check if the value has been set.
-
 func (o *InlineObject5) GetRequiredFileOk() (**os.File, bool) {
-    if o == nil  {
-        return nil, false
-    }
-    return &o.RequiredFile, true
+	if o == nil  {
+		return nil, false
+	}
+	return &o.RequiredFile, true
 }
 
 // SetRequiredFile sets field value

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_inline_object_5.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_inline_object_5.go
@@ -108,7 +108,7 @@ func (v NullableInlineObject5) Get() *InlineObject5 {
 	return v.value
 }
 
-func (v NullableInlineObject5) Set(val *InlineObject5) {
+func (v *NullableInlineObject5) Set(val *InlineObject5) {
 	v.value = val
 	v.isSet = true
 }
@@ -117,7 +117,7 @@ func (v NullableInlineObject5) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableInlineObject5) Unset() {
+func (v *NullableInlineObject5) Unset() {
 	v.value = nil
 	v.isSet = false
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_inline_object_5.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_inline_object_5.go
@@ -10,7 +10,6 @@
 package petstore
 
 import (
-	"bytes"
 	"encoding/json"
 	"os"
 )
@@ -57,12 +56,12 @@ func (o *InlineObject5) GetAdditionalMetadataOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-	return *o.AdditionalMetadata, true
+    return *o.AdditionalMetadata, true
 }
 
 // HasAdditionalMetadata returns a boolean if a field has been set.
 func (o *InlineObject5) HasAdditionalMetadata() bool {
-	if o != nil && o.AdditionalMetadata != nil {
+    if o != nil && o.AdditionalMetadata != nil {
 		return true
 	}
 
@@ -89,25 +88,49 @@ func (o *InlineObject5) SetRequiredFile(v *os.File) {
 	o.RequiredFile = v
 }
 
+func (o InlineObject5) MarshalJSON() ([]byte, error) {
+    toSerialize := map[string]interface{}{}
+    if o.AdditionalMetadata != nil {
+        toSerialize["additionalMetadata"] = o.AdditionalMetadata
+    }
+    if true {
+        toSerialize["requiredFile"] = o.RequiredFile
+    }
+    return json.Marshal(toSerialize)
+}
+
 type NullableInlineObject5 struct {
-	Value InlineObject5
-	ExplicitNull bool
+	value *InlineObject5
+	isSet bool
+}
+
+func (v NullableInlineObject5) Get() *InlineObject5 {
+    return v.value
+}
+
+func (v NullableInlineObject5) Set(val *InlineObject5) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableInlineObject5) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableInlineObject5) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableInlineObject5(val *InlineObject5) *NullableInlineObject5 {
+    return &NullableInlineObject5{value: val, isSet: true}
 }
 
 func (v NullableInlineObject5) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-		return json.Marshal(v.Value)
-	}
+    return json.Marshal(v.value)
 }
 
 func (v *NullableInlineObject5) UnmarshalJSON(src []byte) error {
-	if bytes.Equal(src, []byte("null")) {
-		v.ExplicitNull = true
-		return nil
-	}
-
-	return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_inline_object_5.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_inline_object_5.go
@@ -56,12 +56,12 @@ func (o *InlineObject5) GetAdditionalMetadataOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-    return *o.AdditionalMetadata, true
+	return *o.AdditionalMetadata, true
 }
 
 // HasAdditionalMetadata returns a boolean if a field has been set.
 func (o *InlineObject5) HasAdditionalMetadata() bool {
-    if o != nil && o.AdditionalMetadata != nil {
+	if o != nil && o.AdditionalMetadata != nil {
 		return true
 	}
 
@@ -89,14 +89,14 @@ func (o *InlineObject5) SetRequiredFile(v *os.File) {
 }
 
 func (o InlineObject5) MarshalJSON() ([]byte, error) {
-    toSerialize := map[string]interface{}{}
-    if o.AdditionalMetadata != nil {
-        toSerialize["additionalMetadata"] = o.AdditionalMetadata
-    }
-    if true {
-        toSerialize["requiredFile"] = o.RequiredFile
-    }
-    return json.Marshal(toSerialize)
+	toSerialize := map[string]interface{}{}
+	if o.AdditionalMetadata != nil {
+		toSerialize["additionalMetadata"] = o.AdditionalMetadata
+	}
+	if true {
+		toSerialize["requiredFile"] = o.RequiredFile
+	}
+	return json.Marshal(toSerialize)
 }
 
 type NullableInlineObject5 struct {
@@ -105,32 +105,32 @@ type NullableInlineObject5 struct {
 }
 
 func (v NullableInlineObject5) Get() *InlineObject5 {
-    return v.value
+	return v.value
 }
 
 func (v NullableInlineObject5) Set(val *InlineObject5) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableInlineObject5) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableInlineObject5) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableInlineObject5(val *InlineObject5) *NullableInlineObject5 {
-    return &NullableInlineObject5{value: val, isSet: true}
+	return &NullableInlineObject5{value: val, isSet: true}
 }
 
 func (v NullableInlineObject5) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableInlineObject5) UnmarshalJSON(src []byte) error {
-    v.isSet = true
+	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_inline_response_default.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_inline_response_default.go
@@ -23,16 +23,16 @@ type InlineResponseDefault struct {
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
 func NewInlineResponseDefault() *InlineResponseDefault {
-    this := InlineResponseDefault{}
-    return &this
+	this := InlineResponseDefault{}
+	return &this
 }
 
 // NewInlineResponseDefaultWithDefaults instantiates a new InlineResponseDefault object
 // This constructor will only assign default values to properties that have it defined,
 // but it doesn't guarantee that properties required by API are set
 func NewInlineResponseDefaultWithDefaults() *InlineResponseDefault {
-    this := InlineResponseDefault{}
-    return &this
+	this := InlineResponseDefault{}
+	return &this
 }
 
 // GetString returns the String field value if set, zero value otherwise.
@@ -44,14 +44,14 @@ func (o *InlineResponseDefault) GetString() Foo {
 	return *o.String
 }
 
-// GetStringOk returns a tuple with the String field value if set, zero value otherwise
+// GetStringOk returns a tuple with the String field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *InlineResponseDefault) GetStringOk() (Foo, bool) {
+
+func (o *InlineResponseDefault) GetStringOk() (*Foo, bool) {
 	if o == nil || o.String == nil {
-		var ret Foo
-		return ret, false
+		return nil, false
 	}
-	return *o.String, true
+	return o.String, true
 }
 
 // HasString returns a boolean if a field has been set.

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_inline_response_default.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_inline_response_default.go
@@ -51,12 +51,12 @@ func (o *InlineResponseDefault) GetStringOk() (Foo, bool) {
 		var ret Foo
 		return ret, false
 	}
-    return *o.String, true
+	return *o.String, true
 }
 
 // HasString returns a boolean if a field has been set.
 func (o *InlineResponseDefault) HasString() bool {
-    if o != nil && o.String != nil {
+	if o != nil && o.String != nil {
 		return true
 	}
 
@@ -69,11 +69,11 @@ func (o *InlineResponseDefault) SetString(v Foo) {
 }
 
 func (o InlineResponseDefault) MarshalJSON() ([]byte, error) {
-    toSerialize := map[string]interface{}{}
-    if o.String != nil {
-        toSerialize["string"] = o.String
-    }
-    return json.Marshal(toSerialize)
+	toSerialize := map[string]interface{}{}
+	if o.String != nil {
+		toSerialize["string"] = o.String
+	}
+	return json.Marshal(toSerialize)
 }
 
 type NullableInlineResponseDefault struct {
@@ -82,32 +82,32 @@ type NullableInlineResponseDefault struct {
 }
 
 func (v NullableInlineResponseDefault) Get() *InlineResponseDefault {
-    return v.value
+	return v.value
 }
 
 func (v NullableInlineResponseDefault) Set(val *InlineResponseDefault) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableInlineResponseDefault) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableInlineResponseDefault) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableInlineResponseDefault(val *InlineResponseDefault) *NullableInlineResponseDefault {
-    return &NullableInlineResponseDefault{value: val, isSet: true}
+	return &NullableInlineResponseDefault{value: val, isSet: true}
 }
 
 func (v NullableInlineResponseDefault) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableInlineResponseDefault) UnmarshalJSON(src []byte) error {
-    v.isSet = true
+	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_inline_response_default.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_inline_response_default.go
@@ -10,7 +10,6 @@
 package petstore
 
 import (
-	"bytes"
 	"encoding/json"
 )
 
@@ -52,12 +51,12 @@ func (o *InlineResponseDefault) GetStringOk() (Foo, bool) {
 		var ret Foo
 		return ret, false
 	}
-	return *o.String, true
+    return *o.String, true
 }
 
 // HasString returns a boolean if a field has been set.
 func (o *InlineResponseDefault) HasString() bool {
-	if o != nil && o.String != nil {
+    if o != nil && o.String != nil {
 		return true
 	}
 
@@ -69,25 +68,46 @@ func (o *InlineResponseDefault) SetString(v Foo) {
 	o.String = &v
 }
 
+func (o InlineResponseDefault) MarshalJSON() ([]byte, error) {
+    toSerialize := map[string]interface{}{}
+    if o.String != nil {
+        toSerialize["string"] = o.String
+    }
+    return json.Marshal(toSerialize)
+}
+
 type NullableInlineResponseDefault struct {
-	Value InlineResponseDefault
-	ExplicitNull bool
+	value *InlineResponseDefault
+	isSet bool
+}
+
+func (v NullableInlineResponseDefault) Get() *InlineResponseDefault {
+    return v.value
+}
+
+func (v NullableInlineResponseDefault) Set(val *InlineResponseDefault) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableInlineResponseDefault) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableInlineResponseDefault) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableInlineResponseDefault(val *InlineResponseDefault) *NullableInlineResponseDefault {
+    return &NullableInlineResponseDefault{value: val, isSet: true}
 }
 
 func (v NullableInlineResponseDefault) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-		return json.Marshal(v.Value)
-	}
+    return json.Marshal(v.value)
 }
 
 func (v *NullableInlineResponseDefault) UnmarshalJSON(src []byte) error {
-	if bytes.Equal(src, []byte("null")) {
-		v.ExplicitNull = true
-		return nil
-	}
-
-	return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_inline_response_default.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_inline_response_default.go
@@ -46,7 +46,6 @@ func (o *InlineResponseDefault) GetString() Foo {
 
 // GetStringOk returns a tuple with the String field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *InlineResponseDefault) GetStringOk() (*Foo, bool) {
 	if o == nil || o.String == nil {
 		return nil, false

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_inline_response_default.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_inline_response_default.go
@@ -85,7 +85,7 @@ func (v NullableInlineResponseDefault) Get() *InlineResponseDefault {
 	return v.value
 }
 
-func (v NullableInlineResponseDefault) Set(val *InlineResponseDefault) {
+func (v *NullableInlineResponseDefault) Set(val *InlineResponseDefault) {
 	v.value = val
 	v.isSet = true
 }
@@ -94,7 +94,7 @@ func (v NullableInlineResponseDefault) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableInlineResponseDefault) Unset() {
+func (v *NullableInlineResponseDefault) Unset() {
 	v.value = nil
 	v.isSet = false
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_list.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_list.go
@@ -85,7 +85,7 @@ func (v NullableList) Get() *List {
 	return v.value
 }
 
-func (v NullableList) Set(val *List) {
+func (v *NullableList) Set(val *List) {
 	v.value = val
 	v.isSet = true
 }
@@ -94,7 +94,7 @@ func (v NullableList) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableList) Unset() {
+func (v *NullableList) Unset() {
 	v.value = nil
 	v.isSet = false
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_list.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_list.go
@@ -10,7 +10,6 @@
 package petstore
 
 import (
-	"bytes"
 	"encoding/json"
 )
 
@@ -52,12 +51,12 @@ func (o *List) GetVar123ListOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-	return *o.Var123List, true
+    return *o.Var123List, true
 }
 
 // HasVar123List returns a boolean if a field has been set.
 func (o *List) HasVar123List() bool {
-	if o != nil && o.Var123List != nil {
+    if o != nil && o.Var123List != nil {
 		return true
 	}
 
@@ -69,25 +68,46 @@ func (o *List) SetVar123List(v string) {
 	o.Var123List = &v
 }
 
+func (o List) MarshalJSON() ([]byte, error) {
+    toSerialize := map[string]interface{}{}
+    if o.Var123List != nil {
+        toSerialize["123-list"] = o.Var123List
+    }
+    return json.Marshal(toSerialize)
+}
+
 type NullableList struct {
-	Value List
-	ExplicitNull bool
+	value *List
+	isSet bool
+}
+
+func (v NullableList) Get() *List {
+    return v.value
+}
+
+func (v NullableList) Set(val *List) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableList) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableList) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableList(val *List) *NullableList {
+    return &NullableList{value: val, isSet: true}
 }
 
 func (v NullableList) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-		return json.Marshal(v.Value)
-	}
+    return json.Marshal(v.value)
 }
 
 func (v *NullableList) UnmarshalJSON(src []byte) error {
-	if bytes.Equal(src, []byte("null")) {
-		v.ExplicitNull = true
-		return nil
-	}
-
-	return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_list.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_list.go
@@ -51,12 +51,12 @@ func (o *List) GetVar123ListOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-    return *o.Var123List, true
+	return *o.Var123List, true
 }
 
 // HasVar123List returns a boolean if a field has been set.
 func (o *List) HasVar123List() bool {
-    if o != nil && o.Var123List != nil {
+	if o != nil && o.Var123List != nil {
 		return true
 	}
 
@@ -69,11 +69,11 @@ func (o *List) SetVar123List(v string) {
 }
 
 func (o List) MarshalJSON() ([]byte, error) {
-    toSerialize := map[string]interface{}{}
-    if o.Var123List != nil {
-        toSerialize["123-list"] = o.Var123List
-    }
-    return json.Marshal(toSerialize)
+	toSerialize := map[string]interface{}{}
+	if o.Var123List != nil {
+		toSerialize["123-list"] = o.Var123List
+	}
+	return json.Marshal(toSerialize)
 }
 
 type NullableList struct {
@@ -82,32 +82,32 @@ type NullableList struct {
 }
 
 func (v NullableList) Get() *List {
-    return v.value
+	return v.value
 }
 
 func (v NullableList) Set(val *List) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableList) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableList) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableList(val *List) *NullableList {
-    return &NullableList{value: val, isSet: true}
+	return &NullableList{value: val, isSet: true}
 }
 
 func (v NullableList) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableList) UnmarshalJSON(src []byte) error {
-    v.isSet = true
+	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_list.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_list.go
@@ -46,7 +46,6 @@ func (o *List) GetVar123List() string {
 
 // GetVar123ListOk returns a tuple with the Var123List field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *List) GetVar123ListOk() (*string, bool) {
 	if o == nil || o.Var123List == nil {
 		return nil, false

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_list.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_list.go
@@ -23,16 +23,16 @@ type List struct {
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
 func NewList() *List {
-    this := List{}
-    return &this
+	this := List{}
+	return &this
 }
 
 // NewListWithDefaults instantiates a new List object
 // This constructor will only assign default values to properties that have it defined,
 // but it doesn't guarantee that properties required by API are set
 func NewListWithDefaults() *List {
-    this := List{}
-    return &this
+	this := List{}
+	return &this
 }
 
 // GetVar123List returns the Var123List field value if set, zero value otherwise.
@@ -44,14 +44,14 @@ func (o *List) GetVar123List() string {
 	return *o.Var123List
 }
 
-// GetVar123ListOk returns a tuple with the Var123List field value if set, zero value otherwise
+// GetVar123ListOk returns a tuple with the Var123List field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *List) GetVar123ListOk() (string, bool) {
+
+func (o *List) GetVar123ListOk() (*string, bool) {
 	if o == nil || o.Var123List == nil {
-		var ret string
-		return ret, false
+		return nil, false
 	}
-	return *o.Var123List, true
+	return o.Var123List, true
 }
 
 // HasVar123List returns a boolean if a field has been set.

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_map_test_.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_map_test_.go
@@ -196,7 +196,7 @@ func (v NullableMapTest) Get() *MapTest {
 	return v.value
 }
 
-func (v NullableMapTest) Set(val *MapTest) {
+func (v *NullableMapTest) Set(val *MapTest) {
 	v.value = val
 	v.isSet = true
 }
@@ -205,7 +205,7 @@ func (v NullableMapTest) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableMapTest) Unset() {
+func (v *NullableMapTest) Unset() {
 	v.value = nil
 	v.isSet = false
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_map_test_.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_map_test_.go
@@ -49,7 +49,6 @@ func (o *MapTest) GetMapMapOfString() map[string]map[string]string {
 
 // GetMapMapOfStringOk returns a tuple with the MapMapOfString field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *MapTest) GetMapMapOfStringOk() (*map[string]map[string]string, bool) {
 	if o == nil || o.MapMapOfString == nil {
 		return nil, false
@@ -82,7 +81,6 @@ func (o *MapTest) GetMapOfEnumString() map[string]string {
 
 // GetMapOfEnumStringOk returns a tuple with the MapOfEnumString field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *MapTest) GetMapOfEnumStringOk() (*map[string]string, bool) {
 	if o == nil || o.MapOfEnumString == nil {
 		return nil, false
@@ -115,7 +113,6 @@ func (o *MapTest) GetDirectMap() map[string]bool {
 
 // GetDirectMapOk returns a tuple with the DirectMap field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *MapTest) GetDirectMapOk() (*map[string]bool, bool) {
 	if o == nil || o.DirectMap == nil {
 		return nil, false
@@ -148,7 +145,6 @@ func (o *MapTest) GetIndirectMap() map[string]bool {
 
 // GetIndirectMapOk returns a tuple with the IndirectMap field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *MapTest) GetIndirectMapOk() (*map[string]bool, bool) {
 	if o == nil || o.IndirectMap == nil {
 		return nil, false

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_map_test_.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_map_test_.go
@@ -54,12 +54,12 @@ func (o *MapTest) GetMapMapOfStringOk() (map[string]map[string]string, bool) {
 		var ret map[string]map[string]string
 		return ret, false
 	}
-    return *o.MapMapOfString, true
+	return *o.MapMapOfString, true
 }
 
 // HasMapMapOfString returns a boolean if a field has been set.
 func (o *MapTest) HasMapMapOfString() bool {
-    if o != nil && o.MapMapOfString != nil {
+	if o != nil && o.MapMapOfString != nil {
 		return true
 	}
 
@@ -87,12 +87,12 @@ func (o *MapTest) GetMapOfEnumStringOk() (map[string]string, bool) {
 		var ret map[string]string
 		return ret, false
 	}
-    return *o.MapOfEnumString, true
+	return *o.MapOfEnumString, true
 }
 
 // HasMapOfEnumString returns a boolean if a field has been set.
 func (o *MapTest) HasMapOfEnumString() bool {
-    if o != nil && o.MapOfEnumString != nil {
+	if o != nil && o.MapOfEnumString != nil {
 		return true
 	}
 
@@ -120,12 +120,12 @@ func (o *MapTest) GetDirectMapOk() (map[string]bool, bool) {
 		var ret map[string]bool
 		return ret, false
 	}
-    return *o.DirectMap, true
+	return *o.DirectMap, true
 }
 
 // HasDirectMap returns a boolean if a field has been set.
 func (o *MapTest) HasDirectMap() bool {
-    if o != nil && o.DirectMap != nil {
+	if o != nil && o.DirectMap != nil {
 		return true
 	}
 
@@ -153,12 +153,12 @@ func (o *MapTest) GetIndirectMapOk() (map[string]bool, bool) {
 		var ret map[string]bool
 		return ret, false
 	}
-    return *o.IndirectMap, true
+	return *o.IndirectMap, true
 }
 
 // HasIndirectMap returns a boolean if a field has been set.
 func (o *MapTest) HasIndirectMap() bool {
-    if o != nil && o.IndirectMap != nil {
+	if o != nil && o.IndirectMap != nil {
 		return true
 	}
 
@@ -171,20 +171,20 @@ func (o *MapTest) SetIndirectMap(v map[string]bool) {
 }
 
 func (o MapTest) MarshalJSON() ([]byte, error) {
-    toSerialize := map[string]interface{}{}
-    if o.MapMapOfString != nil {
-        toSerialize["map_map_of_string"] = o.MapMapOfString
-    }
-    if o.MapOfEnumString != nil {
-        toSerialize["map_of_enum_string"] = o.MapOfEnumString
-    }
-    if o.DirectMap != nil {
-        toSerialize["direct_map"] = o.DirectMap
-    }
-    if o.IndirectMap != nil {
-        toSerialize["indirect_map"] = o.IndirectMap
-    }
-    return json.Marshal(toSerialize)
+	toSerialize := map[string]interface{}{}
+	if o.MapMapOfString != nil {
+		toSerialize["map_map_of_string"] = o.MapMapOfString
+	}
+	if o.MapOfEnumString != nil {
+		toSerialize["map_of_enum_string"] = o.MapOfEnumString
+	}
+	if o.DirectMap != nil {
+		toSerialize["direct_map"] = o.DirectMap
+	}
+	if o.IndirectMap != nil {
+		toSerialize["indirect_map"] = o.IndirectMap
+	}
+	return json.Marshal(toSerialize)
 }
 
 type NullableMapTest struct {
@@ -193,32 +193,32 @@ type NullableMapTest struct {
 }
 
 func (v NullableMapTest) Get() *MapTest {
-    return v.value
+	return v.value
 }
 
 func (v NullableMapTest) Set(val *MapTest) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableMapTest) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableMapTest) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableMapTest(val *MapTest) *NullableMapTest {
-    return &NullableMapTest{value: val, isSet: true}
+	return &NullableMapTest{value: val, isSet: true}
 }
 
 func (v NullableMapTest) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableMapTest) UnmarshalJSON(src []byte) error {
-    v.isSet = true
+	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_map_test_.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_map_test_.go
@@ -26,16 +26,16 @@ type MapTest struct {
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
 func NewMapTest() *MapTest {
-    this := MapTest{}
-    return &this
+	this := MapTest{}
+	return &this
 }
 
 // NewMapTestWithDefaults instantiates a new MapTest object
 // This constructor will only assign default values to properties that have it defined,
 // but it doesn't guarantee that properties required by API are set
 func NewMapTestWithDefaults() *MapTest {
-    this := MapTest{}
-    return &this
+	this := MapTest{}
+	return &this
 }
 
 // GetMapMapOfString returns the MapMapOfString field value if set, zero value otherwise.
@@ -47,14 +47,14 @@ func (o *MapTest) GetMapMapOfString() map[string]map[string]string {
 	return *o.MapMapOfString
 }
 
-// GetMapMapOfStringOk returns a tuple with the MapMapOfString field value if set, zero value otherwise
+// GetMapMapOfStringOk returns a tuple with the MapMapOfString field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *MapTest) GetMapMapOfStringOk() (map[string]map[string]string, bool) {
+
+func (o *MapTest) GetMapMapOfStringOk() (*map[string]map[string]string, bool) {
 	if o == nil || o.MapMapOfString == nil {
-		var ret map[string]map[string]string
-		return ret, false
+		return nil, false
 	}
-	return *o.MapMapOfString, true
+	return o.MapMapOfString, true
 }
 
 // HasMapMapOfString returns a boolean if a field has been set.
@@ -80,14 +80,14 @@ func (o *MapTest) GetMapOfEnumString() map[string]string {
 	return *o.MapOfEnumString
 }
 
-// GetMapOfEnumStringOk returns a tuple with the MapOfEnumString field value if set, zero value otherwise
+// GetMapOfEnumStringOk returns a tuple with the MapOfEnumString field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *MapTest) GetMapOfEnumStringOk() (map[string]string, bool) {
+
+func (o *MapTest) GetMapOfEnumStringOk() (*map[string]string, bool) {
 	if o == nil || o.MapOfEnumString == nil {
-		var ret map[string]string
-		return ret, false
+		return nil, false
 	}
-	return *o.MapOfEnumString, true
+	return o.MapOfEnumString, true
 }
 
 // HasMapOfEnumString returns a boolean if a field has been set.
@@ -113,14 +113,14 @@ func (o *MapTest) GetDirectMap() map[string]bool {
 	return *o.DirectMap
 }
 
-// GetDirectMapOk returns a tuple with the DirectMap field value if set, zero value otherwise
+// GetDirectMapOk returns a tuple with the DirectMap field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *MapTest) GetDirectMapOk() (map[string]bool, bool) {
+
+func (o *MapTest) GetDirectMapOk() (*map[string]bool, bool) {
 	if o == nil || o.DirectMap == nil {
-		var ret map[string]bool
-		return ret, false
+		return nil, false
 	}
-	return *o.DirectMap, true
+	return o.DirectMap, true
 }
 
 // HasDirectMap returns a boolean if a field has been set.
@@ -146,14 +146,14 @@ func (o *MapTest) GetIndirectMap() map[string]bool {
 	return *o.IndirectMap
 }
 
-// GetIndirectMapOk returns a tuple with the IndirectMap field value if set, zero value otherwise
+// GetIndirectMapOk returns a tuple with the IndirectMap field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *MapTest) GetIndirectMapOk() (map[string]bool, bool) {
+
+func (o *MapTest) GetIndirectMapOk() (*map[string]bool, bool) {
 	if o == nil || o.IndirectMap == nil {
-		var ret map[string]bool
-		return ret, false
+		return nil, false
 	}
-	return *o.IndirectMap, true
+	return o.IndirectMap, true
 }
 
 // HasIndirectMap returns a boolean if a field has been set.

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_map_test_.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_map_test_.go
@@ -10,7 +10,6 @@
 package petstore
 
 import (
-	"bytes"
 	"encoding/json"
 )
 
@@ -55,12 +54,12 @@ func (o *MapTest) GetMapMapOfStringOk() (map[string]map[string]string, bool) {
 		var ret map[string]map[string]string
 		return ret, false
 	}
-	return *o.MapMapOfString, true
+    return *o.MapMapOfString, true
 }
 
 // HasMapMapOfString returns a boolean if a field has been set.
 func (o *MapTest) HasMapMapOfString() bool {
-	if o != nil && o.MapMapOfString != nil {
+    if o != nil && o.MapMapOfString != nil {
 		return true
 	}
 
@@ -88,12 +87,12 @@ func (o *MapTest) GetMapOfEnumStringOk() (map[string]string, bool) {
 		var ret map[string]string
 		return ret, false
 	}
-	return *o.MapOfEnumString, true
+    return *o.MapOfEnumString, true
 }
 
 // HasMapOfEnumString returns a boolean if a field has been set.
 func (o *MapTest) HasMapOfEnumString() bool {
-	if o != nil && o.MapOfEnumString != nil {
+    if o != nil && o.MapOfEnumString != nil {
 		return true
 	}
 
@@ -121,12 +120,12 @@ func (o *MapTest) GetDirectMapOk() (map[string]bool, bool) {
 		var ret map[string]bool
 		return ret, false
 	}
-	return *o.DirectMap, true
+    return *o.DirectMap, true
 }
 
 // HasDirectMap returns a boolean if a field has been set.
 func (o *MapTest) HasDirectMap() bool {
-	if o != nil && o.DirectMap != nil {
+    if o != nil && o.DirectMap != nil {
 		return true
 	}
 
@@ -154,12 +153,12 @@ func (o *MapTest) GetIndirectMapOk() (map[string]bool, bool) {
 		var ret map[string]bool
 		return ret, false
 	}
-	return *o.IndirectMap, true
+    return *o.IndirectMap, true
 }
 
 // HasIndirectMap returns a boolean if a field has been set.
 func (o *MapTest) HasIndirectMap() bool {
-	if o != nil && o.IndirectMap != nil {
+    if o != nil && o.IndirectMap != nil {
 		return true
 	}
 
@@ -171,25 +170,55 @@ func (o *MapTest) SetIndirectMap(v map[string]bool) {
 	o.IndirectMap = &v
 }
 
+func (o MapTest) MarshalJSON() ([]byte, error) {
+    toSerialize := map[string]interface{}{}
+    if o.MapMapOfString != nil {
+        toSerialize["map_map_of_string"] = o.MapMapOfString
+    }
+    if o.MapOfEnumString != nil {
+        toSerialize["map_of_enum_string"] = o.MapOfEnumString
+    }
+    if o.DirectMap != nil {
+        toSerialize["direct_map"] = o.DirectMap
+    }
+    if o.IndirectMap != nil {
+        toSerialize["indirect_map"] = o.IndirectMap
+    }
+    return json.Marshal(toSerialize)
+}
+
 type NullableMapTest struct {
-	Value MapTest
-	ExplicitNull bool
+	value *MapTest
+	isSet bool
+}
+
+func (v NullableMapTest) Get() *MapTest {
+    return v.value
+}
+
+func (v NullableMapTest) Set(val *MapTest) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableMapTest) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableMapTest) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableMapTest(val *MapTest) *NullableMapTest {
+    return &NullableMapTest{value: val, isSet: true}
 }
 
 func (v NullableMapTest) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-		return json.Marshal(v.Value)
-	}
+    return json.Marshal(v.value)
 }
 
 func (v *NullableMapTest) UnmarshalJSON(src []byte) error {
-	if bytes.Equal(src, []byte("null")) {
-		v.ExplicitNull = true
-		return nil
-	}
-
-	return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_mixed_properties_and_additional_properties_class.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_mixed_properties_and_additional_properties_class.go
@@ -26,16 +26,16 @@ type MixedPropertiesAndAdditionalPropertiesClass struct {
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
 func NewMixedPropertiesAndAdditionalPropertiesClass() *MixedPropertiesAndAdditionalPropertiesClass {
-    this := MixedPropertiesAndAdditionalPropertiesClass{}
-    return &this
+	this := MixedPropertiesAndAdditionalPropertiesClass{}
+	return &this
 }
 
 // NewMixedPropertiesAndAdditionalPropertiesClassWithDefaults instantiates a new MixedPropertiesAndAdditionalPropertiesClass object
 // This constructor will only assign default values to properties that have it defined,
 // but it doesn't guarantee that properties required by API are set
 func NewMixedPropertiesAndAdditionalPropertiesClassWithDefaults() *MixedPropertiesAndAdditionalPropertiesClass {
-    this := MixedPropertiesAndAdditionalPropertiesClass{}
-    return &this
+	this := MixedPropertiesAndAdditionalPropertiesClass{}
+	return &this
 }
 
 // GetUuid returns the Uuid field value if set, zero value otherwise.
@@ -47,14 +47,14 @@ func (o *MixedPropertiesAndAdditionalPropertiesClass) GetUuid() string {
 	return *o.Uuid
 }
 
-// GetUuidOk returns a tuple with the Uuid field value if set, zero value otherwise
+// GetUuidOk returns a tuple with the Uuid field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *MixedPropertiesAndAdditionalPropertiesClass) GetUuidOk() (string, bool) {
+
+func (o *MixedPropertiesAndAdditionalPropertiesClass) GetUuidOk() (*string, bool) {
 	if o == nil || o.Uuid == nil {
-		var ret string
-		return ret, false
+		return nil, false
 	}
-	return *o.Uuid, true
+	return o.Uuid, true
 }
 
 // HasUuid returns a boolean if a field has been set.
@@ -80,14 +80,14 @@ func (o *MixedPropertiesAndAdditionalPropertiesClass) GetDateTime() time.Time {
 	return *o.DateTime
 }
 
-// GetDateTimeOk returns a tuple with the DateTime field value if set, zero value otherwise
+// GetDateTimeOk returns a tuple with the DateTime field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *MixedPropertiesAndAdditionalPropertiesClass) GetDateTimeOk() (time.Time, bool) {
+
+func (o *MixedPropertiesAndAdditionalPropertiesClass) GetDateTimeOk() (*time.Time, bool) {
 	if o == nil || o.DateTime == nil {
-		var ret time.Time
-		return ret, false
+		return nil, false
 	}
-	return *o.DateTime, true
+	return o.DateTime, true
 }
 
 // HasDateTime returns a boolean if a field has been set.
@@ -113,14 +113,14 @@ func (o *MixedPropertiesAndAdditionalPropertiesClass) GetMap() map[string]Animal
 	return *o.Map
 }
 
-// GetMapOk returns a tuple with the Map field value if set, zero value otherwise
+// GetMapOk returns a tuple with the Map field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *MixedPropertiesAndAdditionalPropertiesClass) GetMapOk() (map[string]Animal, bool) {
+
+func (o *MixedPropertiesAndAdditionalPropertiesClass) GetMapOk() (*map[string]Animal, bool) {
 	if o == nil || o.Map == nil {
-		var ret map[string]Animal
-		return ret, false
+		return nil, false
 	}
-	return *o.Map, true
+	return o.Map, true
 }
 
 // HasMap returns a boolean if a field has been set.

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_mixed_properties_and_additional_properties_class.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_mixed_properties_and_additional_properties_class.go
@@ -10,7 +10,6 @@
 package petstore
 
 import (
-	"bytes"
 	"encoding/json"
 	"time"
 )
@@ -55,12 +54,12 @@ func (o *MixedPropertiesAndAdditionalPropertiesClass) GetUuidOk() (string, bool)
 		var ret string
 		return ret, false
 	}
-	return *o.Uuid, true
+    return *o.Uuid, true
 }
 
 // HasUuid returns a boolean if a field has been set.
 func (o *MixedPropertiesAndAdditionalPropertiesClass) HasUuid() bool {
-	if o != nil && o.Uuid != nil {
+    if o != nil && o.Uuid != nil {
 		return true
 	}
 
@@ -88,12 +87,12 @@ func (o *MixedPropertiesAndAdditionalPropertiesClass) GetDateTimeOk() (time.Time
 		var ret time.Time
 		return ret, false
 	}
-	return *o.DateTime, true
+    return *o.DateTime, true
 }
 
 // HasDateTime returns a boolean if a field has been set.
 func (o *MixedPropertiesAndAdditionalPropertiesClass) HasDateTime() bool {
-	if o != nil && o.DateTime != nil {
+    if o != nil && o.DateTime != nil {
 		return true
 	}
 
@@ -121,12 +120,12 @@ func (o *MixedPropertiesAndAdditionalPropertiesClass) GetMapOk() (map[string]Ani
 		var ret map[string]Animal
 		return ret, false
 	}
-	return *o.Map, true
+    return *o.Map, true
 }
 
 // HasMap returns a boolean if a field has been set.
 func (o *MixedPropertiesAndAdditionalPropertiesClass) HasMap() bool {
-	if o != nil && o.Map != nil {
+    if o != nil && o.Map != nil {
 		return true
 	}
 
@@ -138,25 +137,52 @@ func (o *MixedPropertiesAndAdditionalPropertiesClass) SetMap(v map[string]Animal
 	o.Map = &v
 }
 
+func (o MixedPropertiesAndAdditionalPropertiesClass) MarshalJSON() ([]byte, error) {
+    toSerialize := map[string]interface{}{}
+    if o.Uuid != nil {
+        toSerialize["uuid"] = o.Uuid
+    }
+    if o.DateTime != nil {
+        toSerialize["dateTime"] = o.DateTime
+    }
+    if o.Map != nil {
+        toSerialize["map"] = o.Map
+    }
+    return json.Marshal(toSerialize)
+}
+
 type NullableMixedPropertiesAndAdditionalPropertiesClass struct {
-	Value MixedPropertiesAndAdditionalPropertiesClass
-	ExplicitNull bool
+	value *MixedPropertiesAndAdditionalPropertiesClass
+	isSet bool
+}
+
+func (v NullableMixedPropertiesAndAdditionalPropertiesClass) Get() *MixedPropertiesAndAdditionalPropertiesClass {
+    return v.value
+}
+
+func (v NullableMixedPropertiesAndAdditionalPropertiesClass) Set(val *MixedPropertiesAndAdditionalPropertiesClass) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableMixedPropertiesAndAdditionalPropertiesClass) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableMixedPropertiesAndAdditionalPropertiesClass) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableMixedPropertiesAndAdditionalPropertiesClass(val *MixedPropertiesAndAdditionalPropertiesClass) *NullableMixedPropertiesAndAdditionalPropertiesClass {
+    return &NullableMixedPropertiesAndAdditionalPropertiesClass{value: val, isSet: true}
 }
 
 func (v NullableMixedPropertiesAndAdditionalPropertiesClass) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-		return json.Marshal(v.Value)
-	}
+    return json.Marshal(v.value)
 }
 
 func (v *NullableMixedPropertiesAndAdditionalPropertiesClass) UnmarshalJSON(src []byte) error {
-	if bytes.Equal(src, []byte("null")) {
-		v.ExplicitNull = true
-		return nil
-	}
-
-	return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_mixed_properties_and_additional_properties_class.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_mixed_properties_and_additional_properties_class.go
@@ -49,7 +49,6 @@ func (o *MixedPropertiesAndAdditionalPropertiesClass) GetUuid() string {
 
 // GetUuidOk returns a tuple with the Uuid field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *MixedPropertiesAndAdditionalPropertiesClass) GetUuidOk() (*string, bool) {
 	if o == nil || o.Uuid == nil {
 		return nil, false
@@ -82,7 +81,6 @@ func (o *MixedPropertiesAndAdditionalPropertiesClass) GetDateTime() time.Time {
 
 // GetDateTimeOk returns a tuple with the DateTime field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *MixedPropertiesAndAdditionalPropertiesClass) GetDateTimeOk() (*time.Time, bool) {
 	if o == nil || o.DateTime == nil {
 		return nil, false
@@ -115,7 +113,6 @@ func (o *MixedPropertiesAndAdditionalPropertiesClass) GetMap() map[string]Animal
 
 // GetMapOk returns a tuple with the Map field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *MixedPropertiesAndAdditionalPropertiesClass) GetMapOk() (*map[string]Animal, bool) {
 	if o == nil || o.Map == nil {
 		return nil, false

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_mixed_properties_and_additional_properties_class.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_mixed_properties_and_additional_properties_class.go
@@ -160,7 +160,7 @@ func (v NullableMixedPropertiesAndAdditionalPropertiesClass) Get() *MixedPropert
 	return v.value
 }
 
-func (v NullableMixedPropertiesAndAdditionalPropertiesClass) Set(val *MixedPropertiesAndAdditionalPropertiesClass) {
+func (v *NullableMixedPropertiesAndAdditionalPropertiesClass) Set(val *MixedPropertiesAndAdditionalPropertiesClass) {
 	v.value = val
 	v.isSet = true
 }
@@ -169,7 +169,7 @@ func (v NullableMixedPropertiesAndAdditionalPropertiesClass) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableMixedPropertiesAndAdditionalPropertiesClass) Unset() {
+func (v *NullableMixedPropertiesAndAdditionalPropertiesClass) Unset() {
 	v.value = nil
 	v.isSet = false
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_mixed_properties_and_additional_properties_class.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_mixed_properties_and_additional_properties_class.go
@@ -54,12 +54,12 @@ func (o *MixedPropertiesAndAdditionalPropertiesClass) GetUuidOk() (string, bool)
 		var ret string
 		return ret, false
 	}
-    return *o.Uuid, true
+	return *o.Uuid, true
 }
 
 // HasUuid returns a boolean if a field has been set.
 func (o *MixedPropertiesAndAdditionalPropertiesClass) HasUuid() bool {
-    if o != nil && o.Uuid != nil {
+	if o != nil && o.Uuid != nil {
 		return true
 	}
 
@@ -87,12 +87,12 @@ func (o *MixedPropertiesAndAdditionalPropertiesClass) GetDateTimeOk() (time.Time
 		var ret time.Time
 		return ret, false
 	}
-    return *o.DateTime, true
+	return *o.DateTime, true
 }
 
 // HasDateTime returns a boolean if a field has been set.
 func (o *MixedPropertiesAndAdditionalPropertiesClass) HasDateTime() bool {
-    if o != nil && o.DateTime != nil {
+	if o != nil && o.DateTime != nil {
 		return true
 	}
 
@@ -120,12 +120,12 @@ func (o *MixedPropertiesAndAdditionalPropertiesClass) GetMapOk() (map[string]Ani
 		var ret map[string]Animal
 		return ret, false
 	}
-    return *o.Map, true
+	return *o.Map, true
 }
 
 // HasMap returns a boolean if a field has been set.
 func (o *MixedPropertiesAndAdditionalPropertiesClass) HasMap() bool {
-    if o != nil && o.Map != nil {
+	if o != nil && o.Map != nil {
 		return true
 	}
 
@@ -138,17 +138,17 @@ func (o *MixedPropertiesAndAdditionalPropertiesClass) SetMap(v map[string]Animal
 }
 
 func (o MixedPropertiesAndAdditionalPropertiesClass) MarshalJSON() ([]byte, error) {
-    toSerialize := map[string]interface{}{}
-    if o.Uuid != nil {
-        toSerialize["uuid"] = o.Uuid
-    }
-    if o.DateTime != nil {
-        toSerialize["dateTime"] = o.DateTime
-    }
-    if o.Map != nil {
-        toSerialize["map"] = o.Map
-    }
-    return json.Marshal(toSerialize)
+	toSerialize := map[string]interface{}{}
+	if o.Uuid != nil {
+		toSerialize["uuid"] = o.Uuid
+	}
+	if o.DateTime != nil {
+		toSerialize["dateTime"] = o.DateTime
+	}
+	if o.Map != nil {
+		toSerialize["map"] = o.Map
+	}
+	return json.Marshal(toSerialize)
 }
 
 type NullableMixedPropertiesAndAdditionalPropertiesClass struct {
@@ -157,32 +157,32 @@ type NullableMixedPropertiesAndAdditionalPropertiesClass struct {
 }
 
 func (v NullableMixedPropertiesAndAdditionalPropertiesClass) Get() *MixedPropertiesAndAdditionalPropertiesClass {
-    return v.value
+	return v.value
 }
 
 func (v NullableMixedPropertiesAndAdditionalPropertiesClass) Set(val *MixedPropertiesAndAdditionalPropertiesClass) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableMixedPropertiesAndAdditionalPropertiesClass) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableMixedPropertiesAndAdditionalPropertiesClass) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableMixedPropertiesAndAdditionalPropertiesClass(val *MixedPropertiesAndAdditionalPropertiesClass) *NullableMixedPropertiesAndAdditionalPropertiesClass {
-    return &NullableMixedPropertiesAndAdditionalPropertiesClass{value: val, isSet: true}
+	return &NullableMixedPropertiesAndAdditionalPropertiesClass{value: val, isSet: true}
 }
 
 func (v NullableMixedPropertiesAndAdditionalPropertiesClass) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableMixedPropertiesAndAdditionalPropertiesClass) UnmarshalJSON(src []byte) error {
-    v.isSet = true
+	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_name.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_name.go
@@ -179,7 +179,7 @@ func (v NullableName) Get() *Name {
 	return v.value
 }
 
-func (v NullableName) Set(val *Name) {
+func (v *NullableName) Set(val *Name) {
 	v.value = val
 	v.isSet = true
 }
@@ -188,7 +188,7 @@ func (v NullableName) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableName) Unset() {
+func (v *NullableName) Unset() {
 	v.value = nil
 	v.isSet = false
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_name.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_name.go
@@ -51,12 +51,11 @@ func (o *Name) GetName() int32 {
 
 // GetNameOk returns a tuple with the Name field value
 // and a boolean to check if the value has been set.
-
 func (o *Name) GetNameOk() (*int32, bool) {
-    if o == nil  {
-        return nil, false
-    }
-    return &o.Name, true
+	if o == nil  {
+		return nil, false
+	}
+	return &o.Name, true
 }
 
 // SetName sets field value
@@ -75,7 +74,6 @@ func (o *Name) GetSnakeCase() int32 {
 
 // GetSnakeCaseOk returns a tuple with the SnakeCase field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *Name) GetSnakeCaseOk() (*int32, bool) {
 	if o == nil || o.SnakeCase == nil {
 		return nil, false
@@ -108,7 +106,6 @@ func (o *Name) GetProperty() string {
 
 // GetPropertyOk returns a tuple with the Property field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *Name) GetPropertyOk() (*string, bool) {
 	if o == nil || o.Property == nil {
 		return nil, false
@@ -141,7 +138,6 @@ func (o *Name) GetVar123Number() int32 {
 
 // GetVar123NumberOk returns a tuple with the Var123Number field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *Name) GetVar123NumberOk() (*int32, bool) {
 	if o == nil || o.Var123Number == nil {
 		return nil, false

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_name.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_name.go
@@ -10,7 +10,6 @@
 package petstore
 
 import (
-	"bytes"
 	"encoding/json"
 )
 
@@ -71,12 +70,12 @@ func (o *Name) GetSnakeCaseOk() (int32, bool) {
 		var ret int32
 		return ret, false
 	}
-	return *o.SnakeCase, true
+    return *o.SnakeCase, true
 }
 
 // HasSnakeCase returns a boolean if a field has been set.
 func (o *Name) HasSnakeCase() bool {
-	if o != nil && o.SnakeCase != nil {
+    if o != nil && o.SnakeCase != nil {
 		return true
 	}
 
@@ -104,12 +103,12 @@ func (o *Name) GetPropertyOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-	return *o.Property, true
+    return *o.Property, true
 }
 
 // HasProperty returns a boolean if a field has been set.
 func (o *Name) HasProperty() bool {
-	if o != nil && o.Property != nil {
+    if o != nil && o.Property != nil {
 		return true
 	}
 
@@ -137,12 +136,12 @@ func (o *Name) GetVar123NumberOk() (int32, bool) {
 		var ret int32
 		return ret, false
 	}
-	return *o.Var123Number, true
+    return *o.Var123Number, true
 }
 
 // HasVar123Number returns a boolean if a field has been set.
 func (o *Name) HasVar123Number() bool {
-	if o != nil && o.Var123Number != nil {
+    if o != nil && o.Var123Number != nil {
 		return true
 	}
 
@@ -154,25 +153,55 @@ func (o *Name) SetVar123Number(v int32) {
 	o.Var123Number = &v
 }
 
+func (o Name) MarshalJSON() ([]byte, error) {
+    toSerialize := map[string]interface{}{}
+    if true {
+        toSerialize["name"] = o.Name
+    }
+    if o.SnakeCase != nil {
+        toSerialize["snake_case"] = o.SnakeCase
+    }
+    if o.Property != nil {
+        toSerialize["property"] = o.Property
+    }
+    if o.Var123Number != nil {
+        toSerialize["123Number"] = o.Var123Number
+    }
+    return json.Marshal(toSerialize)
+}
+
 type NullableName struct {
-	Value Name
-	ExplicitNull bool
+	value *Name
+	isSet bool
+}
+
+func (v NullableName) Get() *Name {
+    return v.value
+}
+
+func (v NullableName) Set(val *Name) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableName) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableName) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableName(val *Name) *NullableName {
+    return &NullableName{value: val, isSet: true}
 }
 
 func (v NullableName) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-		return json.Marshal(v.Value)
-	}
+    return json.Marshal(v.value)
 }
 
 func (v *NullableName) UnmarshalJSON(src []byte) error {
-	if bytes.Equal(src, []byte("null")) {
-		v.ExplicitNull = true
-		return nil
-	}
-
-	return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_name.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_name.go
@@ -70,12 +70,12 @@ func (o *Name) GetSnakeCaseOk() (int32, bool) {
 		var ret int32
 		return ret, false
 	}
-    return *o.SnakeCase, true
+	return *o.SnakeCase, true
 }
 
 // HasSnakeCase returns a boolean if a field has been set.
 func (o *Name) HasSnakeCase() bool {
-    if o != nil && o.SnakeCase != nil {
+	if o != nil && o.SnakeCase != nil {
 		return true
 	}
 
@@ -103,12 +103,12 @@ func (o *Name) GetPropertyOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-    return *o.Property, true
+	return *o.Property, true
 }
 
 // HasProperty returns a boolean if a field has been set.
 func (o *Name) HasProperty() bool {
-    if o != nil && o.Property != nil {
+	if o != nil && o.Property != nil {
 		return true
 	}
 
@@ -136,12 +136,12 @@ func (o *Name) GetVar123NumberOk() (int32, bool) {
 		var ret int32
 		return ret, false
 	}
-    return *o.Var123Number, true
+	return *o.Var123Number, true
 }
 
 // HasVar123Number returns a boolean if a field has been set.
 func (o *Name) HasVar123Number() bool {
-    if o != nil && o.Var123Number != nil {
+	if o != nil && o.Var123Number != nil {
 		return true
 	}
 
@@ -154,20 +154,20 @@ func (o *Name) SetVar123Number(v int32) {
 }
 
 func (o Name) MarshalJSON() ([]byte, error) {
-    toSerialize := map[string]interface{}{}
-    if true {
-        toSerialize["name"] = o.Name
-    }
-    if o.SnakeCase != nil {
-        toSerialize["snake_case"] = o.SnakeCase
-    }
-    if o.Property != nil {
-        toSerialize["property"] = o.Property
-    }
-    if o.Var123Number != nil {
-        toSerialize["123Number"] = o.Var123Number
-    }
-    return json.Marshal(toSerialize)
+	toSerialize := map[string]interface{}{}
+	if true {
+		toSerialize["name"] = o.Name
+	}
+	if o.SnakeCase != nil {
+		toSerialize["snake_case"] = o.SnakeCase
+	}
+	if o.Property != nil {
+		toSerialize["property"] = o.Property
+	}
+	if o.Var123Number != nil {
+		toSerialize["123Number"] = o.Var123Number
+	}
+	return json.Marshal(toSerialize)
 }
 
 type NullableName struct {
@@ -176,32 +176,32 @@ type NullableName struct {
 }
 
 func (v NullableName) Get() *Name {
-    return v.value
+	return v.value
 }
 
 func (v NullableName) Set(val *Name) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableName) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableName) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableName(val *Name) *NullableName {
-    return &NullableName{value: val, isSet: true}
+	return &NullableName{value: val, isSet: true}
 }
 
 func (v NullableName) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableName) UnmarshalJSON(src []byte) error {
-    v.isSet = true
+	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_name.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_name.go
@@ -26,27 +26,37 @@ type Name struct {
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
 func NewName(name int32, ) *Name {
-    this := Name{}
-    this.Name = name
-    return &this
+	this := Name{}
+	this.Name = name
+	return &this
 }
 
 // NewNameWithDefaults instantiates a new Name object
 // This constructor will only assign default values to properties that have it defined,
 // but it doesn't guarantee that properties required by API are set
 func NewNameWithDefaults() *Name {
-    this := Name{}
-    return &this
+	this := Name{}
+	return &this
 }
 
 // GetName returns the Name field value
 func (o *Name) GetName() int32 {
-	if o == nil {
+	if o == nil  {
 		var ret int32
 		return ret
 	}
 
 	return o.Name
+}
+
+// GetNameOk returns a tuple with the Name field value
+// and a boolean to check if the value has been set.
+
+func (o *Name) GetNameOk() (*int32, bool) {
+    if o == nil  {
+        return nil, false
+    }
+    return &o.Name, true
 }
 
 // SetName sets field value
@@ -63,14 +73,14 @@ func (o *Name) GetSnakeCase() int32 {
 	return *o.SnakeCase
 }
 
-// GetSnakeCaseOk returns a tuple with the SnakeCase field value if set, zero value otherwise
+// GetSnakeCaseOk returns a tuple with the SnakeCase field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *Name) GetSnakeCaseOk() (int32, bool) {
+
+func (o *Name) GetSnakeCaseOk() (*int32, bool) {
 	if o == nil || o.SnakeCase == nil {
-		var ret int32
-		return ret, false
+		return nil, false
 	}
-	return *o.SnakeCase, true
+	return o.SnakeCase, true
 }
 
 // HasSnakeCase returns a boolean if a field has been set.
@@ -96,14 +106,14 @@ func (o *Name) GetProperty() string {
 	return *o.Property
 }
 
-// GetPropertyOk returns a tuple with the Property field value if set, zero value otherwise
+// GetPropertyOk returns a tuple with the Property field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *Name) GetPropertyOk() (string, bool) {
+
+func (o *Name) GetPropertyOk() (*string, bool) {
 	if o == nil || o.Property == nil {
-		var ret string
-		return ret, false
+		return nil, false
 	}
-	return *o.Property, true
+	return o.Property, true
 }
 
 // HasProperty returns a boolean if a field has been set.
@@ -129,14 +139,14 @@ func (o *Name) GetVar123Number() int32 {
 	return *o.Var123Number
 }
 
-// GetVar123NumberOk returns a tuple with the Var123Number field value if set, zero value otherwise
+// GetVar123NumberOk returns a tuple with the Var123Number field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *Name) GetVar123NumberOk() (int32, bool) {
+
+func (o *Name) GetVar123NumberOk() (*int32, bool) {
 	if o == nil || o.Var123Number == nil {
-		var ret int32
-		return ret, false
+		return nil, false
 	}
-	return *o.Var123Number, true
+	return o.Var123Number, true
 }
 
 // HasVar123Number returns a boolean if a field has been set.

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_nullable_class.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_nullable_class.go
@@ -62,12 +62,12 @@ func (o *NullableClass) GetIntegerPropOk() (NullableInt32, bool) {
 		var ret NullableInt32
 		return ret, false
 	}
-    return o.IntegerProp, o.IntegerProp.IsSet()
+	return o.IntegerProp, o.IntegerProp.IsSet()
 }
 
 // HasIntegerProp returns a boolean if a field has been set.
 func (o *NullableClass) HasIntegerProp() bool {
-    if o != nil && o.IntegerProp.IsSet() {
+	if o != nil && o.IntegerProp.IsSet() {
 		return true
 	}
 
@@ -95,12 +95,12 @@ func (o *NullableClass) GetNumberPropOk() (NullableFloat32, bool) {
 		var ret NullableFloat32
 		return ret, false
 	}
-    return o.NumberProp, o.NumberProp.IsSet()
+	return o.NumberProp, o.NumberProp.IsSet()
 }
 
 // HasNumberProp returns a boolean if a field has been set.
 func (o *NullableClass) HasNumberProp() bool {
-    if o != nil && o.NumberProp.IsSet() {
+	if o != nil && o.NumberProp.IsSet() {
 		return true
 	}
 
@@ -128,12 +128,12 @@ func (o *NullableClass) GetBooleanPropOk() (NullableBool, bool) {
 		var ret NullableBool
 		return ret, false
 	}
-    return o.BooleanProp, o.BooleanProp.IsSet()
+	return o.BooleanProp, o.BooleanProp.IsSet()
 }
 
 // HasBooleanProp returns a boolean if a field has been set.
 func (o *NullableClass) HasBooleanProp() bool {
-    if o != nil && o.BooleanProp.IsSet() {
+	if o != nil && o.BooleanProp.IsSet() {
 		return true
 	}
 
@@ -161,12 +161,12 @@ func (o *NullableClass) GetStringPropOk() (NullableString, bool) {
 		var ret NullableString
 		return ret, false
 	}
-    return o.StringProp, o.StringProp.IsSet()
+	return o.StringProp, o.StringProp.IsSet()
 }
 
 // HasStringProp returns a boolean if a field has been set.
 func (o *NullableClass) HasStringProp() bool {
-    if o != nil && o.StringProp.IsSet() {
+	if o != nil && o.StringProp.IsSet() {
 		return true
 	}
 
@@ -194,12 +194,12 @@ func (o *NullableClass) GetDatePropOk() (NullableString, bool) {
 		var ret NullableString
 		return ret, false
 	}
-    return o.DateProp, o.DateProp.IsSet()
+	return o.DateProp, o.DateProp.IsSet()
 }
 
 // HasDateProp returns a boolean if a field has been set.
 func (o *NullableClass) HasDateProp() bool {
-    if o != nil && o.DateProp.IsSet() {
+	if o != nil && o.DateProp.IsSet() {
 		return true
 	}
 
@@ -227,12 +227,12 @@ func (o *NullableClass) GetDatetimePropOk() (NullableTime, bool) {
 		var ret NullableTime
 		return ret, false
 	}
-    return o.DatetimeProp, o.DatetimeProp.IsSet()
+	return o.DatetimeProp, o.DatetimeProp.IsSet()
 }
 
 // HasDatetimeProp returns a boolean if a field has been set.
 func (o *NullableClass) HasDatetimeProp() bool {
-    if o != nil && o.DatetimeProp.IsSet() {
+	if o != nil && o.DatetimeProp.IsSet() {
 		return true
 	}
 
@@ -260,12 +260,12 @@ func (o *NullableClass) GetArrayNullablePropOk() ([]map[string]interface{}, bool
 		var ret []map[string]interface{}
 		return ret, false
 	}
-    return o.ArrayNullableProp, o.ArrayNullableProp == nil
+	return o.ArrayNullableProp, o.ArrayNullableProp == nil
 }
 
 // HasArrayNullableProp returns a boolean if a field has been set.
 func (o *NullableClass) HasArrayNullableProp() bool {
-    if o != nil && o.ArrayNullableProp != nil {
+	if o != nil && o.ArrayNullableProp != nil {
 		return true
 	}
 
@@ -293,12 +293,12 @@ func (o *NullableClass) GetArrayAndItemsNullablePropOk() ([]map[string]interface
 		var ret []map[string]interface{}
 		return ret, false
 	}
-    return o.ArrayAndItemsNullableProp, o.ArrayAndItemsNullableProp == nil
+	return o.ArrayAndItemsNullableProp, o.ArrayAndItemsNullableProp == nil
 }
 
 // HasArrayAndItemsNullableProp returns a boolean if a field has been set.
 func (o *NullableClass) HasArrayAndItemsNullableProp() bool {
-    if o != nil && o.ArrayAndItemsNullableProp != nil {
+	if o != nil && o.ArrayAndItemsNullableProp != nil {
 		return true
 	}
 
@@ -326,12 +326,12 @@ func (o *NullableClass) GetArrayItemsNullableOk() ([]map[string]interface{}, boo
 		var ret []map[string]interface{}
 		return ret, false
 	}
-    return *o.ArrayItemsNullable, true
+	return *o.ArrayItemsNullable, true
 }
 
 // HasArrayItemsNullable returns a boolean if a field has been set.
 func (o *NullableClass) HasArrayItemsNullable() bool {
-    if o != nil && o.ArrayItemsNullable != nil {
+	if o != nil && o.ArrayItemsNullable != nil {
 		return true
 	}
 
@@ -359,12 +359,12 @@ func (o *NullableClass) GetObjectNullablePropOk() (map[string]map[string]interfa
 		var ret map[string]map[string]interface{}
 		return ret, false
 	}
-    return o.ObjectNullableProp, o.ObjectNullableProp == nil
+	return o.ObjectNullableProp, o.ObjectNullableProp == nil
 }
 
 // HasObjectNullableProp returns a boolean if a field has been set.
 func (o *NullableClass) HasObjectNullableProp() bool {
-    if o != nil && o.ObjectNullableProp != nil {
+	if o != nil && o.ObjectNullableProp != nil {
 		return true
 	}
 
@@ -392,12 +392,12 @@ func (o *NullableClass) GetObjectAndItemsNullablePropOk() (map[string]map[string
 		var ret map[string]map[string]interface{}
 		return ret, false
 	}
-    return o.ObjectAndItemsNullableProp, o.ObjectAndItemsNullableProp == nil
+	return o.ObjectAndItemsNullableProp, o.ObjectAndItemsNullableProp == nil
 }
 
 // HasObjectAndItemsNullableProp returns a boolean if a field has been set.
 func (o *NullableClass) HasObjectAndItemsNullableProp() bool {
-    if o != nil && o.ObjectAndItemsNullableProp != nil {
+	if o != nil && o.ObjectAndItemsNullableProp != nil {
 		return true
 	}
 
@@ -425,12 +425,12 @@ func (o *NullableClass) GetObjectItemsNullableOk() (map[string]map[string]interf
 		var ret map[string]map[string]interface{}
 		return ret, false
 	}
-    return *o.ObjectItemsNullable, true
+	return *o.ObjectItemsNullable, true
 }
 
 // HasObjectItemsNullable returns a boolean if a field has been set.
 func (o *NullableClass) HasObjectItemsNullable() bool {
-    if o != nil && o.ObjectItemsNullable != nil {
+	if o != nil && o.ObjectItemsNullable != nil {
 		return true
 	}
 
@@ -443,44 +443,44 @@ func (o *NullableClass) SetObjectItemsNullable(v map[string]map[string]interface
 }
 
 func (o NullableClass) MarshalJSON() ([]byte, error) {
-    toSerialize := map[string]interface{}{}
-    if o.IntegerProp.IsSet() {
-        toSerialize["integer_prop"] = o.IntegerProp.Get()
-    }
-    if o.NumberProp.IsSet() {
-        toSerialize["number_prop"] = o.NumberProp.Get()
-    }
-    if o.BooleanProp.IsSet() {
-        toSerialize["boolean_prop"] = o.BooleanProp.Get()
-    }
-    if o.StringProp.IsSet() {
-        toSerialize["string_prop"] = o.StringProp.Get()
-    }
-    if o.DateProp.IsSet() {
-        toSerialize["date_prop"] = o.DateProp.Get()
-    }
-    if o.DatetimeProp.IsSet() {
-        toSerialize["datetime_prop"] = o.DatetimeProp.Get()
-    }
-    if o.ArrayNullableProp != nil {
-        toSerialize["array_nullable_prop"] = o.ArrayNullableProp
-    }
-    if o.ArrayAndItemsNullableProp != nil {
-        toSerialize["array_and_items_nullable_prop"] = o.ArrayAndItemsNullableProp
-    }
-    if o.ArrayItemsNullable != nil {
-        toSerialize["array_items_nullable"] = o.ArrayItemsNullable
-    }
-    if o.ObjectNullableProp != nil {
-        toSerialize["object_nullable_prop"] = o.ObjectNullableProp
-    }
-    if o.ObjectAndItemsNullableProp != nil {
-        toSerialize["object_and_items_nullable_prop"] = o.ObjectAndItemsNullableProp
-    }
-    if o.ObjectItemsNullable != nil {
-        toSerialize["object_items_nullable"] = o.ObjectItemsNullable
-    }
-    return json.Marshal(toSerialize)
+	toSerialize := map[string]interface{}{}
+	if o.IntegerProp.IsSet() {
+		toSerialize["integer_prop"] = o.IntegerProp.Get()
+	}
+	if o.NumberProp.IsSet() {
+		toSerialize["number_prop"] = o.NumberProp.Get()
+	}
+	if o.BooleanProp.IsSet() {
+		toSerialize["boolean_prop"] = o.BooleanProp.Get()
+	}
+	if o.StringProp.IsSet() {
+		toSerialize["string_prop"] = o.StringProp.Get()
+	}
+	if o.DateProp.IsSet() {
+		toSerialize["date_prop"] = o.DateProp.Get()
+	}
+	if o.DatetimeProp.IsSet() {
+		toSerialize["datetime_prop"] = o.DatetimeProp.Get()
+	}
+	if o.ArrayNullableProp != nil {
+		toSerialize["array_nullable_prop"] = o.ArrayNullableProp
+	}
+	if o.ArrayAndItemsNullableProp != nil {
+		toSerialize["array_and_items_nullable_prop"] = o.ArrayAndItemsNullableProp
+	}
+	if o.ArrayItemsNullable != nil {
+		toSerialize["array_items_nullable"] = o.ArrayItemsNullable
+	}
+	if o.ObjectNullableProp != nil {
+		toSerialize["object_nullable_prop"] = o.ObjectNullableProp
+	}
+	if o.ObjectAndItemsNullableProp != nil {
+		toSerialize["object_and_items_nullable_prop"] = o.ObjectAndItemsNullableProp
+	}
+	if o.ObjectItemsNullable != nil {
+		toSerialize["object_items_nullable"] = o.ObjectItemsNullable
+	}
+	return json.Marshal(toSerialize)
 }
 
 type NullableNullableClass struct {
@@ -489,32 +489,32 @@ type NullableNullableClass struct {
 }
 
 func (v NullableNullableClass) Get() *NullableClass {
-    return v.value
+	return v.value
 }
 
 func (v NullableNullableClass) Set(val *NullableClass) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableNullableClass) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableNullableClass) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableNullableClass(val *NullableClass) *NullableNullableClass {
-    return &NullableNullableClass{value: val, isSet: true}
+	return &NullableNullableClass{value: val, isSet: true}
 }
 
 func (v NullableNullableClass) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableNullableClass) UnmarshalJSON(src []byte) error {
-    v.isSet = true
+	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_nullable_class.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_nullable_class.go
@@ -11,6 +11,7 @@ package petstore
 
 import (
 	"encoding/json"
+	"time"
 )
 
 // NullableClass struct for NullableClass
@@ -34,35 +35,35 @@ type NullableClass struct {
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
 func NewNullableClass() *NullableClass {
-    this := NullableClass{}
-    return &this
+	this := NullableClass{}
+	return &this
 }
 
 // NewNullableClassWithDefaults instantiates a new NullableClass object
 // This constructor will only assign default values to properties that have it defined,
 // but it doesn't guarantee that properties required by API are set
 func NewNullableClassWithDefaults() *NullableClass {
-    this := NullableClass{}
-    return &this
+	this := NullableClass{}
+	return &this
 }
 
-// GetIntegerProp returns the IntegerProp field value if set, zero value otherwise.
-func (o *NullableClass) GetIntegerProp() NullableInt32 {
-	if o == nil  {
-		var ret NullableInt32
+// GetIntegerProp returns the IntegerProp field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *NullableClass) GetIntegerProp() int32 {
+	if o == nil || o.IntegerProp.Get() == nil {
+		var ret int32
 		return ret
 	}
-	return o.IntegerProp
+	return *o.IntegerProp.Get()
 }
 
-// GetIntegerPropOk returns a tuple with the IntegerProp field value if set, zero value otherwise
+// GetIntegerPropOk returns a tuple with the IntegerProp field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *NullableClass) GetIntegerPropOk() (NullableInt32, bool) {
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *NullableClass) GetIntegerPropOk() (*int32, bool) {
 	if o == nil  {
-		var ret NullableInt32
-		return ret, false
+		return nil, false
 	}
-	return o.IntegerProp, o.IntegerProp.IsSet()
+	return o.IntegerProp.Get(), o.IntegerProp.IsSet()
 }
 
 // HasIntegerProp returns a boolean if a field has been set.
@@ -75,27 +76,36 @@ func (o *NullableClass) HasIntegerProp() bool {
 }
 
 // SetIntegerProp gets a reference to the given NullableInt32 and assigns it to the IntegerProp field.
-func (o *NullableClass) SetIntegerProp(v NullableInt32) {
-	o.IntegerProp = v
+func (o *NullableClass) SetIntegerProp(v int32) {
+	o.IntegerProp.Set(&v)
+}
+// SetIntegerPropNil sets the value for IntegerProp to be an explicit nil
+func (o *NullableClass) SetIntegerPropNil() {
+	o.IntegerProp.Set(nil)
 }
 
-// GetNumberProp returns the NumberProp field value if set, zero value otherwise.
-func (o *NullableClass) GetNumberProp() NullableFloat32 {
-	if o == nil  {
-		var ret NullableFloat32
+// UnsetIntegerProp ensures that no value is present for IntegerProp, not even an explicit nil
+func (o *NullableClass) UnsetIntegerProp() {
+	o.IntegerProp.Unset()
+}
+
+// GetNumberProp returns the NumberProp field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *NullableClass) GetNumberProp() float32 {
+	if o == nil || o.NumberProp.Get() == nil {
+		var ret float32
 		return ret
 	}
-	return o.NumberProp
+	return *o.NumberProp.Get()
 }
 
-// GetNumberPropOk returns a tuple with the NumberProp field value if set, zero value otherwise
+// GetNumberPropOk returns a tuple with the NumberProp field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *NullableClass) GetNumberPropOk() (NullableFloat32, bool) {
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *NullableClass) GetNumberPropOk() (*float32, bool) {
 	if o == nil  {
-		var ret NullableFloat32
-		return ret, false
+		return nil, false
 	}
-	return o.NumberProp, o.NumberProp.IsSet()
+	return o.NumberProp.Get(), o.NumberProp.IsSet()
 }
 
 // HasNumberProp returns a boolean if a field has been set.
@@ -108,27 +118,36 @@ func (o *NullableClass) HasNumberProp() bool {
 }
 
 // SetNumberProp gets a reference to the given NullableFloat32 and assigns it to the NumberProp field.
-func (o *NullableClass) SetNumberProp(v NullableFloat32) {
-	o.NumberProp = v
+func (o *NullableClass) SetNumberProp(v float32) {
+	o.NumberProp.Set(&v)
+}
+// SetNumberPropNil sets the value for NumberProp to be an explicit nil
+func (o *NullableClass) SetNumberPropNil() {
+	o.NumberProp.Set(nil)
 }
 
-// GetBooleanProp returns the BooleanProp field value if set, zero value otherwise.
-func (o *NullableClass) GetBooleanProp() NullableBool {
-	if o == nil  {
-		var ret NullableBool
+// UnsetNumberProp ensures that no value is present for NumberProp, not even an explicit nil
+func (o *NullableClass) UnsetNumberProp() {
+	o.NumberProp.Unset()
+}
+
+// GetBooleanProp returns the BooleanProp field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *NullableClass) GetBooleanProp() bool {
+	if o == nil || o.BooleanProp.Get() == nil {
+		var ret bool
 		return ret
 	}
-	return o.BooleanProp
+	return *o.BooleanProp.Get()
 }
 
-// GetBooleanPropOk returns a tuple with the BooleanProp field value if set, zero value otherwise
+// GetBooleanPropOk returns a tuple with the BooleanProp field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *NullableClass) GetBooleanPropOk() (NullableBool, bool) {
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *NullableClass) GetBooleanPropOk() (*bool, bool) {
 	if o == nil  {
-		var ret NullableBool
-		return ret, false
+		return nil, false
 	}
-	return o.BooleanProp, o.BooleanProp.IsSet()
+	return o.BooleanProp.Get(), o.BooleanProp.IsSet()
 }
 
 // HasBooleanProp returns a boolean if a field has been set.
@@ -141,27 +160,36 @@ func (o *NullableClass) HasBooleanProp() bool {
 }
 
 // SetBooleanProp gets a reference to the given NullableBool and assigns it to the BooleanProp field.
-func (o *NullableClass) SetBooleanProp(v NullableBool) {
-	o.BooleanProp = v
+func (o *NullableClass) SetBooleanProp(v bool) {
+	o.BooleanProp.Set(&v)
+}
+// SetBooleanPropNil sets the value for BooleanProp to be an explicit nil
+func (o *NullableClass) SetBooleanPropNil() {
+	o.BooleanProp.Set(nil)
 }
 
-// GetStringProp returns the StringProp field value if set, zero value otherwise.
-func (o *NullableClass) GetStringProp() NullableString {
-	if o == nil  {
-		var ret NullableString
+// UnsetBooleanProp ensures that no value is present for BooleanProp, not even an explicit nil
+func (o *NullableClass) UnsetBooleanProp() {
+	o.BooleanProp.Unset()
+}
+
+// GetStringProp returns the StringProp field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *NullableClass) GetStringProp() string {
+	if o == nil || o.StringProp.Get() == nil {
+		var ret string
 		return ret
 	}
-	return o.StringProp
+	return *o.StringProp.Get()
 }
 
-// GetStringPropOk returns a tuple with the StringProp field value if set, zero value otherwise
+// GetStringPropOk returns a tuple with the StringProp field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *NullableClass) GetStringPropOk() (NullableString, bool) {
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *NullableClass) GetStringPropOk() (*string, bool) {
 	if o == nil  {
-		var ret NullableString
-		return ret, false
+		return nil, false
 	}
-	return o.StringProp, o.StringProp.IsSet()
+	return o.StringProp.Get(), o.StringProp.IsSet()
 }
 
 // HasStringProp returns a boolean if a field has been set.
@@ -174,27 +202,36 @@ func (o *NullableClass) HasStringProp() bool {
 }
 
 // SetStringProp gets a reference to the given NullableString and assigns it to the StringProp field.
-func (o *NullableClass) SetStringProp(v NullableString) {
-	o.StringProp = v
+func (o *NullableClass) SetStringProp(v string) {
+	o.StringProp.Set(&v)
+}
+// SetStringPropNil sets the value for StringProp to be an explicit nil
+func (o *NullableClass) SetStringPropNil() {
+	o.StringProp.Set(nil)
 }
 
-// GetDateProp returns the DateProp field value if set, zero value otherwise.
-func (o *NullableClass) GetDateProp() NullableString {
-	if o == nil  {
-		var ret NullableString
+// UnsetStringProp ensures that no value is present for StringProp, not even an explicit nil
+func (o *NullableClass) UnsetStringProp() {
+	o.StringProp.Unset()
+}
+
+// GetDateProp returns the DateProp field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *NullableClass) GetDateProp() string {
+	if o == nil || o.DateProp.Get() == nil {
+		var ret string
 		return ret
 	}
-	return o.DateProp
+	return *o.DateProp.Get()
 }
 
-// GetDatePropOk returns a tuple with the DateProp field value if set, zero value otherwise
+// GetDatePropOk returns a tuple with the DateProp field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *NullableClass) GetDatePropOk() (NullableString, bool) {
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *NullableClass) GetDatePropOk() (*string, bool) {
 	if o == nil  {
-		var ret NullableString
-		return ret, false
+		return nil, false
 	}
-	return o.DateProp, o.DateProp.IsSet()
+	return o.DateProp.Get(), o.DateProp.IsSet()
 }
 
 // HasDateProp returns a boolean if a field has been set.
@@ -207,27 +244,36 @@ func (o *NullableClass) HasDateProp() bool {
 }
 
 // SetDateProp gets a reference to the given NullableString and assigns it to the DateProp field.
-func (o *NullableClass) SetDateProp(v NullableString) {
-	o.DateProp = v
+func (o *NullableClass) SetDateProp(v string) {
+	o.DateProp.Set(&v)
+}
+// SetDatePropNil sets the value for DateProp to be an explicit nil
+func (o *NullableClass) SetDatePropNil() {
+	o.DateProp.Set(nil)
 }
 
-// GetDatetimeProp returns the DatetimeProp field value if set, zero value otherwise.
-func (o *NullableClass) GetDatetimeProp() NullableTime {
-	if o == nil  {
-		var ret NullableTime
+// UnsetDateProp ensures that no value is present for DateProp, not even an explicit nil
+func (o *NullableClass) UnsetDateProp() {
+	o.DateProp.Unset()
+}
+
+// GetDatetimeProp returns the DatetimeProp field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *NullableClass) GetDatetimeProp() time.Time {
+	if o == nil || o.DatetimeProp.Get() == nil {
+		var ret time.Time
 		return ret
 	}
-	return o.DatetimeProp
+	return *o.DatetimeProp.Get()
 }
 
-// GetDatetimePropOk returns a tuple with the DatetimeProp field value if set, zero value otherwise
+// GetDatetimePropOk returns a tuple with the DatetimeProp field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *NullableClass) GetDatetimePropOk() (NullableTime, bool) {
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *NullableClass) GetDatetimePropOk() (*time.Time, bool) {
 	if o == nil  {
-		var ret NullableTime
-		return ret, false
+		return nil, false
 	}
-	return o.DatetimeProp, o.DatetimeProp.IsSet()
+	return o.DatetimeProp.Get(), o.DatetimeProp.IsSet()
 }
 
 // HasDatetimeProp returns a boolean if a field has been set.
@@ -240,11 +286,20 @@ func (o *NullableClass) HasDatetimeProp() bool {
 }
 
 // SetDatetimeProp gets a reference to the given NullableTime and assigns it to the DatetimeProp field.
-func (o *NullableClass) SetDatetimeProp(v NullableTime) {
-	o.DatetimeProp = v
+func (o *NullableClass) SetDatetimeProp(v time.Time) {
+	o.DatetimeProp.Set(&v)
+}
+// SetDatetimePropNil sets the value for DatetimeProp to be an explicit nil
+func (o *NullableClass) SetDatetimePropNil() {
+	o.DatetimeProp.Set(nil)
 }
 
-// GetArrayNullableProp returns the ArrayNullableProp field value if set, zero value otherwise.
+// UnsetDatetimeProp ensures that no value is present for DatetimeProp, not even an explicit nil
+func (o *NullableClass) UnsetDatetimeProp() {
+	o.DatetimeProp.Unset()
+}
+
+// GetArrayNullableProp returns the ArrayNullableProp field value if set, zero value otherwise (both if not set or set to explicit null).
 func (o *NullableClass) GetArrayNullableProp() []map[string]interface{} {
 	if o == nil  {
 		var ret []map[string]interface{}
@@ -253,14 +308,14 @@ func (o *NullableClass) GetArrayNullableProp() []map[string]interface{} {
 	return o.ArrayNullableProp
 }
 
-// GetArrayNullablePropOk returns a tuple with the ArrayNullableProp field value if set, zero value otherwise
+// GetArrayNullablePropOk returns a tuple with the ArrayNullableProp field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *NullableClass) GetArrayNullablePropOk() ([]map[string]interface{}, bool) {
-	if o == nil  {
-		var ret []map[string]interface{}
-		return ret, false
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *NullableClass) GetArrayNullablePropOk() (*[]map[string]interface{}, bool) {
+	if o == nil || o.ArrayNullableProp == nil {
+		return nil, false
 	}
-	return o.ArrayNullableProp, o.ArrayNullableProp == nil
+	return &o.ArrayNullableProp, true
 }
 
 // HasArrayNullableProp returns a boolean if a field has been set.
@@ -277,7 +332,7 @@ func (o *NullableClass) SetArrayNullableProp(v []map[string]interface{}) {
 	o.ArrayNullableProp = v
 }
 
-// GetArrayAndItemsNullableProp returns the ArrayAndItemsNullableProp field value if set, zero value otherwise.
+// GetArrayAndItemsNullableProp returns the ArrayAndItemsNullableProp field value if set, zero value otherwise (both if not set or set to explicit null).
 func (o *NullableClass) GetArrayAndItemsNullableProp() []map[string]interface{} {
 	if o == nil  {
 		var ret []map[string]interface{}
@@ -286,14 +341,14 @@ func (o *NullableClass) GetArrayAndItemsNullableProp() []map[string]interface{} 
 	return o.ArrayAndItemsNullableProp
 }
 
-// GetArrayAndItemsNullablePropOk returns a tuple with the ArrayAndItemsNullableProp field value if set, zero value otherwise
+// GetArrayAndItemsNullablePropOk returns a tuple with the ArrayAndItemsNullableProp field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *NullableClass) GetArrayAndItemsNullablePropOk() ([]map[string]interface{}, bool) {
-	if o == nil  {
-		var ret []map[string]interface{}
-		return ret, false
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *NullableClass) GetArrayAndItemsNullablePropOk() (*[]map[string]interface{}, bool) {
+	if o == nil || o.ArrayAndItemsNullableProp == nil {
+		return nil, false
 	}
-	return o.ArrayAndItemsNullableProp, o.ArrayAndItemsNullableProp == nil
+	return &o.ArrayAndItemsNullableProp, true
 }
 
 // HasArrayAndItemsNullableProp returns a boolean if a field has been set.
@@ -319,14 +374,14 @@ func (o *NullableClass) GetArrayItemsNullable() []map[string]interface{} {
 	return *o.ArrayItemsNullable
 }
 
-// GetArrayItemsNullableOk returns a tuple with the ArrayItemsNullable field value if set, zero value otherwise
+// GetArrayItemsNullableOk returns a tuple with the ArrayItemsNullable field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *NullableClass) GetArrayItemsNullableOk() ([]map[string]interface{}, bool) {
+
+func (o *NullableClass) GetArrayItemsNullableOk() (*[]map[string]interface{}, bool) {
 	if o == nil || o.ArrayItemsNullable == nil {
-		var ret []map[string]interface{}
-		return ret, false
+		return nil, false
 	}
-	return *o.ArrayItemsNullable, true
+	return o.ArrayItemsNullable, true
 }
 
 // HasArrayItemsNullable returns a boolean if a field has been set.
@@ -343,7 +398,7 @@ func (o *NullableClass) SetArrayItemsNullable(v []map[string]interface{}) {
 	o.ArrayItemsNullable = &v
 }
 
-// GetObjectNullableProp returns the ObjectNullableProp field value if set, zero value otherwise.
+// GetObjectNullableProp returns the ObjectNullableProp field value if set, zero value otherwise (both if not set or set to explicit null).
 func (o *NullableClass) GetObjectNullableProp() map[string]map[string]interface{} {
 	if o == nil  {
 		var ret map[string]map[string]interface{}
@@ -352,14 +407,14 @@ func (o *NullableClass) GetObjectNullableProp() map[string]map[string]interface{
 	return o.ObjectNullableProp
 }
 
-// GetObjectNullablePropOk returns a tuple with the ObjectNullableProp field value if set, zero value otherwise
+// GetObjectNullablePropOk returns a tuple with the ObjectNullableProp field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *NullableClass) GetObjectNullablePropOk() (map[string]map[string]interface{}, bool) {
-	if o == nil  {
-		var ret map[string]map[string]interface{}
-		return ret, false
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *NullableClass) GetObjectNullablePropOk() (*map[string]map[string]interface{}, bool) {
+	if o == nil || o.ObjectNullableProp == nil {
+		return nil, false
 	}
-	return o.ObjectNullableProp, o.ObjectNullableProp == nil
+	return &o.ObjectNullableProp, true
 }
 
 // HasObjectNullableProp returns a boolean if a field has been set.
@@ -376,7 +431,7 @@ func (o *NullableClass) SetObjectNullableProp(v map[string]map[string]interface{
 	o.ObjectNullableProp = v
 }
 
-// GetObjectAndItemsNullableProp returns the ObjectAndItemsNullableProp field value if set, zero value otherwise.
+// GetObjectAndItemsNullableProp returns the ObjectAndItemsNullableProp field value if set, zero value otherwise (both if not set or set to explicit null).
 func (o *NullableClass) GetObjectAndItemsNullableProp() map[string]map[string]interface{} {
 	if o == nil  {
 		var ret map[string]map[string]interface{}
@@ -385,14 +440,14 @@ func (o *NullableClass) GetObjectAndItemsNullableProp() map[string]map[string]in
 	return o.ObjectAndItemsNullableProp
 }
 
-// GetObjectAndItemsNullablePropOk returns a tuple with the ObjectAndItemsNullableProp field value if set, zero value otherwise
+// GetObjectAndItemsNullablePropOk returns a tuple with the ObjectAndItemsNullableProp field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *NullableClass) GetObjectAndItemsNullablePropOk() (map[string]map[string]interface{}, bool) {
-	if o == nil  {
-		var ret map[string]map[string]interface{}
-		return ret, false
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *NullableClass) GetObjectAndItemsNullablePropOk() (*map[string]map[string]interface{}, bool) {
+	if o == nil || o.ObjectAndItemsNullableProp == nil {
+		return nil, false
 	}
-	return o.ObjectAndItemsNullableProp, o.ObjectAndItemsNullableProp == nil
+	return &o.ObjectAndItemsNullableProp, true
 }
 
 // HasObjectAndItemsNullableProp returns a boolean if a field has been set.
@@ -418,14 +473,14 @@ func (o *NullableClass) GetObjectItemsNullable() map[string]map[string]interface
 	return *o.ObjectItemsNullable
 }
 
-// GetObjectItemsNullableOk returns a tuple with the ObjectItemsNullable field value if set, zero value otherwise
+// GetObjectItemsNullableOk returns a tuple with the ObjectItemsNullable field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *NullableClass) GetObjectItemsNullableOk() (map[string]map[string]interface{}, bool) {
+
+func (o *NullableClass) GetObjectItemsNullableOk() (*map[string]map[string]interface{}, bool) {
 	if o == nil || o.ObjectItemsNullable == nil {
-		var ret map[string]map[string]interface{}
-		return ret, false
+		return nil, false
 	}
-	return *o.ObjectItemsNullable, true
+	return o.ObjectItemsNullable, true
 }
 
 // HasObjectItemsNullable returns a boolean if a field has been set.

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_nullable_class.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_nullable_class.go
@@ -376,7 +376,6 @@ func (o *NullableClass) GetArrayItemsNullable() []map[string]interface{} {
 
 // GetArrayItemsNullableOk returns a tuple with the ArrayItemsNullable field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *NullableClass) GetArrayItemsNullableOk() (*[]map[string]interface{}, bool) {
 	if o == nil || o.ArrayItemsNullable == nil {
 		return nil, false
@@ -475,7 +474,6 @@ func (o *NullableClass) GetObjectItemsNullable() map[string]map[string]interface
 
 // GetObjectItemsNullableOk returns a tuple with the ObjectItemsNullable field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *NullableClass) GetObjectItemsNullableOk() (*map[string]map[string]interface{}, bool) {
 	if o == nil || o.ObjectItemsNullable == nil {
 		return nil, false

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_nullable_class.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_nullable_class.go
@@ -10,23 +10,22 @@
 package petstore
 
 import (
-	"bytes"
 	"encoding/json"
 )
 
 // NullableClass struct for NullableClass
 type NullableClass struct {
-	IntegerProp *NullableInt32 `json:"integer_prop,omitempty"`
-	NumberProp *NullableFloat32 `json:"number_prop,omitempty"`
-	BooleanProp *NullableBool `json:"boolean_prop,omitempty"`
-	StringProp *NullableString `json:"string_prop,omitempty"`
-	DateProp *NullableString `json:"date_prop,omitempty"`
-	DatetimeProp *NullableTime `json:"datetime_prop,omitempty"`
-	ArrayNullableProp *[]map[string]interface{} `json:"array_nullable_prop,omitempty"`
-	ArrayAndItemsNullableProp *[]map[string]interface{} `json:"array_and_items_nullable_prop,omitempty"`
+	IntegerProp NullableInt32 `json:"integer_prop,omitempty"`
+	NumberProp NullableFloat32 `json:"number_prop,omitempty"`
+	BooleanProp NullableBool `json:"boolean_prop,omitempty"`
+	StringProp NullableString `json:"string_prop,omitempty"`
+	DateProp NullableString `json:"date_prop,omitempty"`
+	DatetimeProp NullableTime `json:"datetime_prop,omitempty"`
+	ArrayNullableProp []map[string]interface{} `json:"array_nullable_prop,omitempty"`
+	ArrayAndItemsNullableProp []map[string]interface{} `json:"array_and_items_nullable_prop,omitempty"`
 	ArrayItemsNullable *[]map[string]interface{} `json:"array_items_nullable,omitempty"`
-	ObjectNullableProp *map[string]map[string]interface{} `json:"object_nullable_prop,omitempty"`
-	ObjectAndItemsNullableProp *map[string]map[string]interface{} `json:"object_and_items_nullable_prop,omitempty"`
+	ObjectNullableProp map[string]map[string]interface{} `json:"object_nullable_prop,omitempty"`
+	ObjectAndItemsNullableProp map[string]map[string]interface{} `json:"object_and_items_nullable_prop,omitempty"`
 	ObjectItemsNullable *map[string]map[string]interface{} `json:"object_items_nullable,omitempty"`
 }
 
@@ -49,26 +48,26 @@ func NewNullableClassWithDefaults() *NullableClass {
 
 // GetIntegerProp returns the IntegerProp field value if set, zero value otherwise.
 func (o *NullableClass) GetIntegerProp() NullableInt32 {
-	if o == nil || o.IntegerProp == nil {
+	if o == nil  {
 		var ret NullableInt32
 		return ret
 	}
-	return *o.IntegerProp
+	return o.IntegerProp
 }
 
 // GetIntegerPropOk returns a tuple with the IntegerProp field value if set, zero value otherwise
 // and a boolean to check if the value has been set.
 func (o *NullableClass) GetIntegerPropOk() (NullableInt32, bool) {
-	if o == nil || o.IntegerProp == nil {
+	if o == nil  {
 		var ret NullableInt32
 		return ret, false
 	}
-	return *o.IntegerProp, true
+    return o.IntegerProp, o.IntegerProp.IsSet()
 }
 
 // HasIntegerProp returns a boolean if a field has been set.
 func (o *NullableClass) HasIntegerProp() bool {
-	if o != nil && o.IntegerProp != nil {
+    if o != nil && o.IntegerProp.IsSet() {
 		return true
 	}
 
@@ -77,31 +76,31 @@ func (o *NullableClass) HasIntegerProp() bool {
 
 // SetIntegerProp gets a reference to the given NullableInt32 and assigns it to the IntegerProp field.
 func (o *NullableClass) SetIntegerProp(v NullableInt32) {
-	o.IntegerProp = &v
+	o.IntegerProp = v
 }
 
 // GetNumberProp returns the NumberProp field value if set, zero value otherwise.
 func (o *NullableClass) GetNumberProp() NullableFloat32 {
-	if o == nil || o.NumberProp == nil {
+	if o == nil  {
 		var ret NullableFloat32
 		return ret
 	}
-	return *o.NumberProp
+	return o.NumberProp
 }
 
 // GetNumberPropOk returns a tuple with the NumberProp field value if set, zero value otherwise
 // and a boolean to check if the value has been set.
 func (o *NullableClass) GetNumberPropOk() (NullableFloat32, bool) {
-	if o == nil || o.NumberProp == nil {
+	if o == nil  {
 		var ret NullableFloat32
 		return ret, false
 	}
-	return *o.NumberProp, true
+    return o.NumberProp, o.NumberProp.IsSet()
 }
 
 // HasNumberProp returns a boolean if a field has been set.
 func (o *NullableClass) HasNumberProp() bool {
-	if o != nil && o.NumberProp != nil {
+    if o != nil && o.NumberProp.IsSet() {
 		return true
 	}
 
@@ -110,31 +109,31 @@ func (o *NullableClass) HasNumberProp() bool {
 
 // SetNumberProp gets a reference to the given NullableFloat32 and assigns it to the NumberProp field.
 func (o *NullableClass) SetNumberProp(v NullableFloat32) {
-	o.NumberProp = &v
+	o.NumberProp = v
 }
 
 // GetBooleanProp returns the BooleanProp field value if set, zero value otherwise.
 func (o *NullableClass) GetBooleanProp() NullableBool {
-	if o == nil || o.BooleanProp == nil {
+	if o == nil  {
 		var ret NullableBool
 		return ret
 	}
-	return *o.BooleanProp
+	return o.BooleanProp
 }
 
 // GetBooleanPropOk returns a tuple with the BooleanProp field value if set, zero value otherwise
 // and a boolean to check if the value has been set.
 func (o *NullableClass) GetBooleanPropOk() (NullableBool, bool) {
-	if o == nil || o.BooleanProp == nil {
+	if o == nil  {
 		var ret NullableBool
 		return ret, false
 	}
-	return *o.BooleanProp, true
+    return o.BooleanProp, o.BooleanProp.IsSet()
 }
 
 // HasBooleanProp returns a boolean if a field has been set.
 func (o *NullableClass) HasBooleanProp() bool {
-	if o != nil && o.BooleanProp != nil {
+    if o != nil && o.BooleanProp.IsSet() {
 		return true
 	}
 
@@ -143,31 +142,31 @@ func (o *NullableClass) HasBooleanProp() bool {
 
 // SetBooleanProp gets a reference to the given NullableBool and assigns it to the BooleanProp field.
 func (o *NullableClass) SetBooleanProp(v NullableBool) {
-	o.BooleanProp = &v
+	o.BooleanProp = v
 }
 
 // GetStringProp returns the StringProp field value if set, zero value otherwise.
 func (o *NullableClass) GetStringProp() NullableString {
-	if o == nil || o.StringProp == nil {
+	if o == nil  {
 		var ret NullableString
 		return ret
 	}
-	return *o.StringProp
+	return o.StringProp
 }
 
 // GetStringPropOk returns a tuple with the StringProp field value if set, zero value otherwise
 // and a boolean to check if the value has been set.
 func (o *NullableClass) GetStringPropOk() (NullableString, bool) {
-	if o == nil || o.StringProp == nil {
+	if o == nil  {
 		var ret NullableString
 		return ret, false
 	}
-	return *o.StringProp, true
+    return o.StringProp, o.StringProp.IsSet()
 }
 
 // HasStringProp returns a boolean if a field has been set.
 func (o *NullableClass) HasStringProp() bool {
-	if o != nil && o.StringProp != nil {
+    if o != nil && o.StringProp.IsSet() {
 		return true
 	}
 
@@ -176,31 +175,31 @@ func (o *NullableClass) HasStringProp() bool {
 
 // SetStringProp gets a reference to the given NullableString and assigns it to the StringProp field.
 func (o *NullableClass) SetStringProp(v NullableString) {
-	o.StringProp = &v
+	o.StringProp = v
 }
 
 // GetDateProp returns the DateProp field value if set, zero value otherwise.
 func (o *NullableClass) GetDateProp() NullableString {
-	if o == nil || o.DateProp == nil {
+	if o == nil  {
 		var ret NullableString
 		return ret
 	}
-	return *o.DateProp
+	return o.DateProp
 }
 
 // GetDatePropOk returns a tuple with the DateProp field value if set, zero value otherwise
 // and a boolean to check if the value has been set.
 func (o *NullableClass) GetDatePropOk() (NullableString, bool) {
-	if o == nil || o.DateProp == nil {
+	if o == nil  {
 		var ret NullableString
 		return ret, false
 	}
-	return *o.DateProp, true
+    return o.DateProp, o.DateProp.IsSet()
 }
 
 // HasDateProp returns a boolean if a field has been set.
 func (o *NullableClass) HasDateProp() bool {
-	if o != nil && o.DateProp != nil {
+    if o != nil && o.DateProp.IsSet() {
 		return true
 	}
 
@@ -209,31 +208,31 @@ func (o *NullableClass) HasDateProp() bool {
 
 // SetDateProp gets a reference to the given NullableString and assigns it to the DateProp field.
 func (o *NullableClass) SetDateProp(v NullableString) {
-	o.DateProp = &v
+	o.DateProp = v
 }
 
 // GetDatetimeProp returns the DatetimeProp field value if set, zero value otherwise.
 func (o *NullableClass) GetDatetimeProp() NullableTime {
-	if o == nil || o.DatetimeProp == nil {
+	if o == nil  {
 		var ret NullableTime
 		return ret
 	}
-	return *o.DatetimeProp
+	return o.DatetimeProp
 }
 
 // GetDatetimePropOk returns a tuple with the DatetimeProp field value if set, zero value otherwise
 // and a boolean to check if the value has been set.
 func (o *NullableClass) GetDatetimePropOk() (NullableTime, bool) {
-	if o == nil || o.DatetimeProp == nil {
+	if o == nil  {
 		var ret NullableTime
 		return ret, false
 	}
-	return *o.DatetimeProp, true
+    return o.DatetimeProp, o.DatetimeProp.IsSet()
 }
 
 // HasDatetimeProp returns a boolean if a field has been set.
 func (o *NullableClass) HasDatetimeProp() bool {
-	if o != nil && o.DatetimeProp != nil {
+    if o != nil && o.DatetimeProp.IsSet() {
 		return true
 	}
 
@@ -242,31 +241,31 @@ func (o *NullableClass) HasDatetimeProp() bool {
 
 // SetDatetimeProp gets a reference to the given NullableTime and assigns it to the DatetimeProp field.
 func (o *NullableClass) SetDatetimeProp(v NullableTime) {
-	o.DatetimeProp = &v
+	o.DatetimeProp = v
 }
 
 // GetArrayNullableProp returns the ArrayNullableProp field value if set, zero value otherwise.
 func (o *NullableClass) GetArrayNullableProp() []map[string]interface{} {
-	if o == nil || o.ArrayNullableProp == nil {
+	if o == nil  {
 		var ret []map[string]interface{}
 		return ret
 	}
-	return *o.ArrayNullableProp
+	return o.ArrayNullableProp
 }
 
 // GetArrayNullablePropOk returns a tuple with the ArrayNullableProp field value if set, zero value otherwise
 // and a boolean to check if the value has been set.
 func (o *NullableClass) GetArrayNullablePropOk() ([]map[string]interface{}, bool) {
-	if o == nil || o.ArrayNullableProp == nil {
+	if o == nil  {
 		var ret []map[string]interface{}
 		return ret, false
 	}
-	return *o.ArrayNullableProp, true
+    return o.ArrayNullableProp, o.ArrayNullableProp == nil
 }
 
 // HasArrayNullableProp returns a boolean if a field has been set.
 func (o *NullableClass) HasArrayNullableProp() bool {
-	if o != nil && o.ArrayNullableProp != nil {
+    if o != nil && o.ArrayNullableProp != nil {
 		return true
 	}
 
@@ -275,31 +274,31 @@ func (o *NullableClass) HasArrayNullableProp() bool {
 
 // SetArrayNullableProp gets a reference to the given []map[string]interface{} and assigns it to the ArrayNullableProp field.
 func (o *NullableClass) SetArrayNullableProp(v []map[string]interface{}) {
-	o.ArrayNullableProp = &v
+	o.ArrayNullableProp = v
 }
 
 // GetArrayAndItemsNullableProp returns the ArrayAndItemsNullableProp field value if set, zero value otherwise.
 func (o *NullableClass) GetArrayAndItemsNullableProp() []map[string]interface{} {
-	if o == nil || o.ArrayAndItemsNullableProp == nil {
+	if o == nil  {
 		var ret []map[string]interface{}
 		return ret
 	}
-	return *o.ArrayAndItemsNullableProp
+	return o.ArrayAndItemsNullableProp
 }
 
 // GetArrayAndItemsNullablePropOk returns a tuple with the ArrayAndItemsNullableProp field value if set, zero value otherwise
 // and a boolean to check if the value has been set.
 func (o *NullableClass) GetArrayAndItemsNullablePropOk() ([]map[string]interface{}, bool) {
-	if o == nil || o.ArrayAndItemsNullableProp == nil {
+	if o == nil  {
 		var ret []map[string]interface{}
 		return ret, false
 	}
-	return *o.ArrayAndItemsNullableProp, true
+    return o.ArrayAndItemsNullableProp, o.ArrayAndItemsNullableProp == nil
 }
 
 // HasArrayAndItemsNullableProp returns a boolean if a field has been set.
 func (o *NullableClass) HasArrayAndItemsNullableProp() bool {
-	if o != nil && o.ArrayAndItemsNullableProp != nil {
+    if o != nil && o.ArrayAndItemsNullableProp != nil {
 		return true
 	}
 
@@ -308,7 +307,7 @@ func (o *NullableClass) HasArrayAndItemsNullableProp() bool {
 
 // SetArrayAndItemsNullableProp gets a reference to the given []map[string]interface{} and assigns it to the ArrayAndItemsNullableProp field.
 func (o *NullableClass) SetArrayAndItemsNullableProp(v []map[string]interface{}) {
-	o.ArrayAndItemsNullableProp = &v
+	o.ArrayAndItemsNullableProp = v
 }
 
 // GetArrayItemsNullable returns the ArrayItemsNullable field value if set, zero value otherwise.
@@ -327,12 +326,12 @@ func (o *NullableClass) GetArrayItemsNullableOk() ([]map[string]interface{}, boo
 		var ret []map[string]interface{}
 		return ret, false
 	}
-	return *o.ArrayItemsNullable, true
+    return *o.ArrayItemsNullable, true
 }
 
 // HasArrayItemsNullable returns a boolean if a field has been set.
 func (o *NullableClass) HasArrayItemsNullable() bool {
-	if o != nil && o.ArrayItemsNullable != nil {
+    if o != nil && o.ArrayItemsNullable != nil {
 		return true
 	}
 
@@ -346,26 +345,26 @@ func (o *NullableClass) SetArrayItemsNullable(v []map[string]interface{}) {
 
 // GetObjectNullableProp returns the ObjectNullableProp field value if set, zero value otherwise.
 func (o *NullableClass) GetObjectNullableProp() map[string]map[string]interface{} {
-	if o == nil || o.ObjectNullableProp == nil {
+	if o == nil  {
 		var ret map[string]map[string]interface{}
 		return ret
 	}
-	return *o.ObjectNullableProp
+	return o.ObjectNullableProp
 }
 
 // GetObjectNullablePropOk returns a tuple with the ObjectNullableProp field value if set, zero value otherwise
 // and a boolean to check if the value has been set.
 func (o *NullableClass) GetObjectNullablePropOk() (map[string]map[string]interface{}, bool) {
-	if o == nil || o.ObjectNullableProp == nil {
+	if o == nil  {
 		var ret map[string]map[string]interface{}
 		return ret, false
 	}
-	return *o.ObjectNullableProp, true
+    return o.ObjectNullableProp, o.ObjectNullableProp == nil
 }
 
 // HasObjectNullableProp returns a boolean if a field has been set.
 func (o *NullableClass) HasObjectNullableProp() bool {
-	if o != nil && o.ObjectNullableProp != nil {
+    if o != nil && o.ObjectNullableProp != nil {
 		return true
 	}
 
@@ -374,31 +373,31 @@ func (o *NullableClass) HasObjectNullableProp() bool {
 
 // SetObjectNullableProp gets a reference to the given map[string]map[string]interface{} and assigns it to the ObjectNullableProp field.
 func (o *NullableClass) SetObjectNullableProp(v map[string]map[string]interface{}) {
-	o.ObjectNullableProp = &v
+	o.ObjectNullableProp = v
 }
 
 // GetObjectAndItemsNullableProp returns the ObjectAndItemsNullableProp field value if set, zero value otherwise.
 func (o *NullableClass) GetObjectAndItemsNullableProp() map[string]map[string]interface{} {
-	if o == nil || o.ObjectAndItemsNullableProp == nil {
+	if o == nil  {
 		var ret map[string]map[string]interface{}
 		return ret
 	}
-	return *o.ObjectAndItemsNullableProp
+	return o.ObjectAndItemsNullableProp
 }
 
 // GetObjectAndItemsNullablePropOk returns a tuple with the ObjectAndItemsNullableProp field value if set, zero value otherwise
 // and a boolean to check if the value has been set.
 func (o *NullableClass) GetObjectAndItemsNullablePropOk() (map[string]map[string]interface{}, bool) {
-	if o == nil || o.ObjectAndItemsNullableProp == nil {
+	if o == nil  {
 		var ret map[string]map[string]interface{}
 		return ret, false
 	}
-	return *o.ObjectAndItemsNullableProp, true
+    return o.ObjectAndItemsNullableProp, o.ObjectAndItemsNullableProp == nil
 }
 
 // HasObjectAndItemsNullableProp returns a boolean if a field has been set.
 func (o *NullableClass) HasObjectAndItemsNullableProp() bool {
-	if o != nil && o.ObjectAndItemsNullableProp != nil {
+    if o != nil && o.ObjectAndItemsNullableProp != nil {
 		return true
 	}
 
@@ -407,7 +406,7 @@ func (o *NullableClass) HasObjectAndItemsNullableProp() bool {
 
 // SetObjectAndItemsNullableProp gets a reference to the given map[string]map[string]interface{} and assigns it to the ObjectAndItemsNullableProp field.
 func (o *NullableClass) SetObjectAndItemsNullableProp(v map[string]map[string]interface{}) {
-	o.ObjectAndItemsNullableProp = &v
+	o.ObjectAndItemsNullableProp = v
 }
 
 // GetObjectItemsNullable returns the ObjectItemsNullable field value if set, zero value otherwise.
@@ -426,12 +425,12 @@ func (o *NullableClass) GetObjectItemsNullableOk() (map[string]map[string]interf
 		var ret map[string]map[string]interface{}
 		return ret, false
 	}
-	return *o.ObjectItemsNullable, true
+    return *o.ObjectItemsNullable, true
 }
 
 // HasObjectItemsNullable returns a boolean if a field has been set.
 func (o *NullableClass) HasObjectItemsNullable() bool {
-	if o != nil && o.ObjectItemsNullable != nil {
+    if o != nil && o.ObjectItemsNullable != nil {
 		return true
 	}
 
@@ -443,25 +442,79 @@ func (o *NullableClass) SetObjectItemsNullable(v map[string]map[string]interface
 	o.ObjectItemsNullable = &v
 }
 
+func (o NullableClass) MarshalJSON() ([]byte, error) {
+    toSerialize := map[string]interface{}{}
+    if o.IntegerProp.IsSet() {
+        toSerialize["integer_prop"] = o.IntegerProp.Get()
+    }
+    if o.NumberProp.IsSet() {
+        toSerialize["number_prop"] = o.NumberProp.Get()
+    }
+    if o.BooleanProp.IsSet() {
+        toSerialize["boolean_prop"] = o.BooleanProp.Get()
+    }
+    if o.StringProp.IsSet() {
+        toSerialize["string_prop"] = o.StringProp.Get()
+    }
+    if o.DateProp.IsSet() {
+        toSerialize["date_prop"] = o.DateProp.Get()
+    }
+    if o.DatetimeProp.IsSet() {
+        toSerialize["datetime_prop"] = o.DatetimeProp.Get()
+    }
+    if o.ArrayNullableProp != nil {
+        toSerialize["array_nullable_prop"] = o.ArrayNullableProp
+    }
+    if o.ArrayAndItemsNullableProp != nil {
+        toSerialize["array_and_items_nullable_prop"] = o.ArrayAndItemsNullableProp
+    }
+    if o.ArrayItemsNullable != nil {
+        toSerialize["array_items_nullable"] = o.ArrayItemsNullable
+    }
+    if o.ObjectNullableProp != nil {
+        toSerialize["object_nullable_prop"] = o.ObjectNullableProp
+    }
+    if o.ObjectAndItemsNullableProp != nil {
+        toSerialize["object_and_items_nullable_prop"] = o.ObjectAndItemsNullableProp
+    }
+    if o.ObjectItemsNullable != nil {
+        toSerialize["object_items_nullable"] = o.ObjectItemsNullable
+    }
+    return json.Marshal(toSerialize)
+}
+
 type NullableNullableClass struct {
-	Value NullableClass
-	ExplicitNull bool
+	value *NullableClass
+	isSet bool
+}
+
+func (v NullableNullableClass) Get() *NullableClass {
+    return v.value
+}
+
+func (v NullableNullableClass) Set(val *NullableClass) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableNullableClass) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableNullableClass) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableNullableClass(val *NullableClass) *NullableNullableClass {
+    return &NullableNullableClass{value: val, isSet: true}
 }
 
 func (v NullableNullableClass) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-		return json.Marshal(v.Value)
-	}
+    return json.Marshal(v.value)
 }
 
 func (v *NullableNullableClass) UnmarshalJSON(src []byte) error {
-	if bytes.Equal(src, []byte("null")) {
-		v.ExplicitNull = true
-		return nil
-	}
-
-	return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_nullable_class.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_nullable_class.go
@@ -492,7 +492,7 @@ func (v NullableNullableClass) Get() *NullableClass {
 	return v.value
 }
 
-func (v NullableNullableClass) Set(val *NullableClass) {
+func (v *NullableNullableClass) Set(val *NullableClass) {
 	v.value = val
 	v.isSet = true
 }
@@ -501,7 +501,7 @@ func (v NullableNullableClass) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableNullableClass) Unset() {
+func (v *NullableNullableClass) Unset() {
 	v.value = nil
 	v.isSet = false
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_number_only.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_number_only.go
@@ -85,7 +85,7 @@ func (v NullableNumberOnly) Get() *NumberOnly {
 	return v.value
 }
 
-func (v NullableNumberOnly) Set(val *NumberOnly) {
+func (v *NullableNumberOnly) Set(val *NumberOnly) {
 	v.value = val
 	v.isSet = true
 }
@@ -94,7 +94,7 @@ func (v NullableNumberOnly) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableNumberOnly) Unset() {
+func (v *NullableNumberOnly) Unset() {
 	v.value = nil
 	v.isSet = false
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_number_only.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_number_only.go
@@ -51,12 +51,12 @@ func (o *NumberOnly) GetJustNumberOk() (float32, bool) {
 		var ret float32
 		return ret, false
 	}
-    return *o.JustNumber, true
+	return *o.JustNumber, true
 }
 
 // HasJustNumber returns a boolean if a field has been set.
 func (o *NumberOnly) HasJustNumber() bool {
-    if o != nil && o.JustNumber != nil {
+	if o != nil && o.JustNumber != nil {
 		return true
 	}
 
@@ -69,11 +69,11 @@ func (o *NumberOnly) SetJustNumber(v float32) {
 }
 
 func (o NumberOnly) MarshalJSON() ([]byte, error) {
-    toSerialize := map[string]interface{}{}
-    if o.JustNumber != nil {
-        toSerialize["JustNumber"] = o.JustNumber
-    }
-    return json.Marshal(toSerialize)
+	toSerialize := map[string]interface{}{}
+	if o.JustNumber != nil {
+		toSerialize["JustNumber"] = o.JustNumber
+	}
+	return json.Marshal(toSerialize)
 }
 
 type NullableNumberOnly struct {
@@ -82,32 +82,32 @@ type NullableNumberOnly struct {
 }
 
 func (v NullableNumberOnly) Get() *NumberOnly {
-    return v.value
+	return v.value
 }
 
 func (v NullableNumberOnly) Set(val *NumberOnly) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableNumberOnly) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableNumberOnly) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableNumberOnly(val *NumberOnly) *NullableNumberOnly {
-    return &NullableNumberOnly{value: val, isSet: true}
+	return &NullableNumberOnly{value: val, isSet: true}
 }
 
 func (v NullableNumberOnly) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableNumberOnly) UnmarshalJSON(src []byte) error {
-    v.isSet = true
+	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_number_only.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_number_only.go
@@ -10,7 +10,6 @@
 package petstore
 
 import (
-	"bytes"
 	"encoding/json"
 )
 
@@ -52,12 +51,12 @@ func (o *NumberOnly) GetJustNumberOk() (float32, bool) {
 		var ret float32
 		return ret, false
 	}
-	return *o.JustNumber, true
+    return *o.JustNumber, true
 }
 
 // HasJustNumber returns a boolean if a field has been set.
 func (o *NumberOnly) HasJustNumber() bool {
-	if o != nil && o.JustNumber != nil {
+    if o != nil && o.JustNumber != nil {
 		return true
 	}
 
@@ -69,25 +68,46 @@ func (o *NumberOnly) SetJustNumber(v float32) {
 	o.JustNumber = &v
 }
 
+func (o NumberOnly) MarshalJSON() ([]byte, error) {
+    toSerialize := map[string]interface{}{}
+    if o.JustNumber != nil {
+        toSerialize["JustNumber"] = o.JustNumber
+    }
+    return json.Marshal(toSerialize)
+}
+
 type NullableNumberOnly struct {
-	Value NumberOnly
-	ExplicitNull bool
+	value *NumberOnly
+	isSet bool
+}
+
+func (v NullableNumberOnly) Get() *NumberOnly {
+    return v.value
+}
+
+func (v NullableNumberOnly) Set(val *NumberOnly) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableNumberOnly) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableNumberOnly) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableNumberOnly(val *NumberOnly) *NullableNumberOnly {
+    return &NullableNumberOnly{value: val, isSet: true}
 }
 
 func (v NullableNumberOnly) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-		return json.Marshal(v.Value)
-	}
+    return json.Marshal(v.value)
 }
 
 func (v *NullableNumberOnly) UnmarshalJSON(src []byte) error {
-	if bytes.Equal(src, []byte("null")) {
-		v.ExplicitNull = true
-		return nil
-	}
-
-	return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_number_only.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_number_only.go
@@ -23,16 +23,16 @@ type NumberOnly struct {
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
 func NewNumberOnly() *NumberOnly {
-    this := NumberOnly{}
-    return &this
+	this := NumberOnly{}
+	return &this
 }
 
 // NewNumberOnlyWithDefaults instantiates a new NumberOnly object
 // This constructor will only assign default values to properties that have it defined,
 // but it doesn't guarantee that properties required by API are set
 func NewNumberOnlyWithDefaults() *NumberOnly {
-    this := NumberOnly{}
-    return &this
+	this := NumberOnly{}
+	return &this
 }
 
 // GetJustNumber returns the JustNumber field value if set, zero value otherwise.
@@ -44,14 +44,14 @@ func (o *NumberOnly) GetJustNumber() float32 {
 	return *o.JustNumber
 }
 
-// GetJustNumberOk returns a tuple with the JustNumber field value if set, zero value otherwise
+// GetJustNumberOk returns a tuple with the JustNumber field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *NumberOnly) GetJustNumberOk() (float32, bool) {
+
+func (o *NumberOnly) GetJustNumberOk() (*float32, bool) {
 	if o == nil || o.JustNumber == nil {
-		var ret float32
-		return ret, false
+		return nil, false
 	}
-	return *o.JustNumber, true
+	return o.JustNumber, true
 }
 
 // HasJustNumber returns a boolean if a field has been set.

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_number_only.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_number_only.go
@@ -46,7 +46,6 @@ func (o *NumberOnly) GetJustNumber() float32 {
 
 // GetJustNumberOk returns a tuple with the JustNumber field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *NumberOnly) GetJustNumberOk() (*float32, bool) {
 	if o == nil || o.JustNumber == nil {
 		return nil, false

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_order.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_order.go
@@ -276,7 +276,7 @@ func (v NullableOrder) Get() *Order {
 	return v.value
 }
 
-func (v NullableOrder) Set(val *Order) {
+func (v *NullableOrder) Set(val *Order) {
 	v.value = val
 	v.isSet = true
 }
@@ -285,7 +285,7 @@ func (v NullableOrder) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableOrder) Unset() {
+func (v *NullableOrder) Unset() {
 	v.value = nil
 	v.isSet = false
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_order.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_order.go
@@ -31,8 +31,8 @@ type Order struct {
 // will change when the set of required properties is changed
 func NewOrder() *Order {
     this := Order{}
-    var complete bool = false
-    this.Complete = &complete
+	var complete bool = false
+	this.Complete = &complete
     return &this
 }
 
@@ -41,8 +41,8 @@ func NewOrder() *Order {
 // but it doesn't guarantee that properties required by API are set
 func NewOrderWithDefaults() *Order {
     this := Order{}
-    var complete bool = false
-    this.Complete = &complete
+	var complete bool = false
+	this.Complete = &complete
     return &this
 }
 
@@ -62,12 +62,12 @@ func (o *Order) GetIdOk() (int64, bool) {
 		var ret int64
 		return ret, false
 	}
-    return *o.Id, true
+	return *o.Id, true
 }
 
 // HasId returns a boolean if a field has been set.
 func (o *Order) HasId() bool {
-    if o != nil && o.Id != nil {
+	if o != nil && o.Id != nil {
 		return true
 	}
 
@@ -95,12 +95,12 @@ func (o *Order) GetPetIdOk() (int64, bool) {
 		var ret int64
 		return ret, false
 	}
-    return *o.PetId, true
+	return *o.PetId, true
 }
 
 // HasPetId returns a boolean if a field has been set.
 func (o *Order) HasPetId() bool {
-    if o != nil && o.PetId != nil {
+	if o != nil && o.PetId != nil {
 		return true
 	}
 
@@ -128,12 +128,12 @@ func (o *Order) GetQuantityOk() (int32, bool) {
 		var ret int32
 		return ret, false
 	}
-    return *o.Quantity, true
+	return *o.Quantity, true
 }
 
 // HasQuantity returns a boolean if a field has been set.
 func (o *Order) HasQuantity() bool {
-    if o != nil && o.Quantity != nil {
+	if o != nil && o.Quantity != nil {
 		return true
 	}
 
@@ -161,12 +161,12 @@ func (o *Order) GetShipDateOk() (time.Time, bool) {
 		var ret time.Time
 		return ret, false
 	}
-    return *o.ShipDate, true
+	return *o.ShipDate, true
 }
 
 // HasShipDate returns a boolean if a field has been set.
 func (o *Order) HasShipDate() bool {
-    if o != nil && o.ShipDate != nil {
+	if o != nil && o.ShipDate != nil {
 		return true
 	}
 
@@ -194,12 +194,12 @@ func (o *Order) GetStatusOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-    return *o.Status, true
+	return *o.Status, true
 }
 
 // HasStatus returns a boolean if a field has been set.
 func (o *Order) HasStatus() bool {
-    if o != nil && o.Status != nil {
+	if o != nil && o.Status != nil {
 		return true
 	}
 
@@ -227,12 +227,12 @@ func (o *Order) GetCompleteOk() (bool, bool) {
 		var ret bool
 		return ret, false
 	}
-    return *o.Complete, true
+	return *o.Complete, true
 }
 
 // HasComplete returns a boolean if a field has been set.
 func (o *Order) HasComplete() bool {
-    if o != nil && o.Complete != nil {
+	if o != nil && o.Complete != nil {
 		return true
 	}
 
@@ -245,26 +245,26 @@ func (o *Order) SetComplete(v bool) {
 }
 
 func (o Order) MarshalJSON() ([]byte, error) {
-    toSerialize := map[string]interface{}{}
-    if o.Id != nil {
-        toSerialize["id"] = o.Id
-    }
-    if o.PetId != nil {
-        toSerialize["petId"] = o.PetId
-    }
-    if o.Quantity != nil {
-        toSerialize["quantity"] = o.Quantity
-    }
-    if o.ShipDate != nil {
-        toSerialize["shipDate"] = o.ShipDate
-    }
-    if o.Status != nil {
-        toSerialize["status"] = o.Status
-    }
-    if o.Complete != nil {
-        toSerialize["complete"] = o.Complete
-    }
-    return json.Marshal(toSerialize)
+	toSerialize := map[string]interface{}{}
+	if o.Id != nil {
+		toSerialize["id"] = o.Id
+	}
+	if o.PetId != nil {
+		toSerialize["petId"] = o.PetId
+	}
+	if o.Quantity != nil {
+		toSerialize["quantity"] = o.Quantity
+	}
+	if o.ShipDate != nil {
+		toSerialize["shipDate"] = o.ShipDate
+	}
+	if o.Status != nil {
+		toSerialize["status"] = o.Status
+	}
+	if o.Complete != nil {
+		toSerialize["complete"] = o.Complete
+	}
+	return json.Marshal(toSerialize)
 }
 
 type NullableOrder struct {
@@ -273,32 +273,32 @@ type NullableOrder struct {
 }
 
 func (v NullableOrder) Get() *Order {
-    return v.value
+	return v.value
 }
 
 func (v NullableOrder) Set(val *Order) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableOrder) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableOrder) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableOrder(val *Order) *NullableOrder {
-    return &NullableOrder{value: val, isSet: true}
+	return &NullableOrder{value: val, isSet: true}
 }
 
 func (v NullableOrder) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableOrder) UnmarshalJSON(src []byte) error {
-    v.isSet = true
+	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_order.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_order.go
@@ -30,20 +30,20 @@ type Order struct {
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
 func NewOrder() *Order {
-    this := Order{}
+	this := Order{}
 	var complete bool = false
 	this.Complete = &complete
-    return &this
+	return &this
 }
 
 // NewOrderWithDefaults instantiates a new Order object
 // This constructor will only assign default values to properties that have it defined,
 // but it doesn't guarantee that properties required by API are set
 func NewOrderWithDefaults() *Order {
-    this := Order{}
+	this := Order{}
 	var complete bool = false
 	this.Complete = &complete
-    return &this
+	return &this
 }
 
 // GetId returns the Id field value if set, zero value otherwise.
@@ -55,14 +55,14 @@ func (o *Order) GetId() int64 {
 	return *o.Id
 }
 
-// GetIdOk returns a tuple with the Id field value if set, zero value otherwise
+// GetIdOk returns a tuple with the Id field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *Order) GetIdOk() (int64, bool) {
+
+func (o *Order) GetIdOk() (*int64, bool) {
 	if o == nil || o.Id == nil {
-		var ret int64
-		return ret, false
+		return nil, false
 	}
-	return *o.Id, true
+	return o.Id, true
 }
 
 // HasId returns a boolean if a field has been set.
@@ -88,14 +88,14 @@ func (o *Order) GetPetId() int64 {
 	return *o.PetId
 }
 
-// GetPetIdOk returns a tuple with the PetId field value if set, zero value otherwise
+// GetPetIdOk returns a tuple with the PetId field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *Order) GetPetIdOk() (int64, bool) {
+
+func (o *Order) GetPetIdOk() (*int64, bool) {
 	if o == nil || o.PetId == nil {
-		var ret int64
-		return ret, false
+		return nil, false
 	}
-	return *o.PetId, true
+	return o.PetId, true
 }
 
 // HasPetId returns a boolean if a field has been set.
@@ -121,14 +121,14 @@ func (o *Order) GetQuantity() int32 {
 	return *o.Quantity
 }
 
-// GetQuantityOk returns a tuple with the Quantity field value if set, zero value otherwise
+// GetQuantityOk returns a tuple with the Quantity field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *Order) GetQuantityOk() (int32, bool) {
+
+func (o *Order) GetQuantityOk() (*int32, bool) {
 	if o == nil || o.Quantity == nil {
-		var ret int32
-		return ret, false
+		return nil, false
 	}
-	return *o.Quantity, true
+	return o.Quantity, true
 }
 
 // HasQuantity returns a boolean if a field has been set.
@@ -154,14 +154,14 @@ func (o *Order) GetShipDate() time.Time {
 	return *o.ShipDate
 }
 
-// GetShipDateOk returns a tuple with the ShipDate field value if set, zero value otherwise
+// GetShipDateOk returns a tuple with the ShipDate field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *Order) GetShipDateOk() (time.Time, bool) {
+
+func (o *Order) GetShipDateOk() (*time.Time, bool) {
 	if o == nil || o.ShipDate == nil {
-		var ret time.Time
-		return ret, false
+		return nil, false
 	}
-	return *o.ShipDate, true
+	return o.ShipDate, true
 }
 
 // HasShipDate returns a boolean if a field has been set.
@@ -187,14 +187,14 @@ func (o *Order) GetStatus() string {
 	return *o.Status
 }
 
-// GetStatusOk returns a tuple with the Status field value if set, zero value otherwise
+// GetStatusOk returns a tuple with the Status field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *Order) GetStatusOk() (string, bool) {
+
+func (o *Order) GetStatusOk() (*string, bool) {
 	if o == nil || o.Status == nil {
-		var ret string
-		return ret, false
+		return nil, false
 	}
-	return *o.Status, true
+	return o.Status, true
 }
 
 // HasStatus returns a boolean if a field has been set.
@@ -220,14 +220,14 @@ func (o *Order) GetComplete() bool {
 	return *o.Complete
 }
 
-// GetCompleteOk returns a tuple with the Complete field value if set, zero value otherwise
+// GetCompleteOk returns a tuple with the Complete field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *Order) GetCompleteOk() (bool, bool) {
+
+func (o *Order) GetCompleteOk() (*bool, bool) {
 	if o == nil || o.Complete == nil {
-		var ret bool
-		return ret, false
+		return nil, false
 	}
-	return *o.Complete, true
+	return o.Complete, true
 }
 
 // HasComplete returns a boolean if a field has been set.

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_order.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_order.go
@@ -10,7 +10,6 @@
 package petstore
 
 import (
-	"bytes"
 	"encoding/json"
 	"time"
 )
@@ -63,12 +62,12 @@ func (o *Order) GetIdOk() (int64, bool) {
 		var ret int64
 		return ret, false
 	}
-	return *o.Id, true
+    return *o.Id, true
 }
 
 // HasId returns a boolean if a field has been set.
 func (o *Order) HasId() bool {
-	if o != nil && o.Id != nil {
+    if o != nil && o.Id != nil {
 		return true
 	}
 
@@ -96,12 +95,12 @@ func (o *Order) GetPetIdOk() (int64, bool) {
 		var ret int64
 		return ret, false
 	}
-	return *o.PetId, true
+    return *o.PetId, true
 }
 
 // HasPetId returns a boolean if a field has been set.
 func (o *Order) HasPetId() bool {
-	if o != nil && o.PetId != nil {
+    if o != nil && o.PetId != nil {
 		return true
 	}
 
@@ -129,12 +128,12 @@ func (o *Order) GetQuantityOk() (int32, bool) {
 		var ret int32
 		return ret, false
 	}
-	return *o.Quantity, true
+    return *o.Quantity, true
 }
 
 // HasQuantity returns a boolean if a field has been set.
 func (o *Order) HasQuantity() bool {
-	if o != nil && o.Quantity != nil {
+    if o != nil && o.Quantity != nil {
 		return true
 	}
 
@@ -162,12 +161,12 @@ func (o *Order) GetShipDateOk() (time.Time, bool) {
 		var ret time.Time
 		return ret, false
 	}
-	return *o.ShipDate, true
+    return *o.ShipDate, true
 }
 
 // HasShipDate returns a boolean if a field has been set.
 func (o *Order) HasShipDate() bool {
-	if o != nil && o.ShipDate != nil {
+    if o != nil && o.ShipDate != nil {
 		return true
 	}
 
@@ -195,12 +194,12 @@ func (o *Order) GetStatusOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-	return *o.Status, true
+    return *o.Status, true
 }
 
 // HasStatus returns a boolean if a field has been set.
 func (o *Order) HasStatus() bool {
-	if o != nil && o.Status != nil {
+    if o != nil && o.Status != nil {
 		return true
 	}
 
@@ -228,12 +227,12 @@ func (o *Order) GetCompleteOk() (bool, bool) {
 		var ret bool
 		return ret, false
 	}
-	return *o.Complete, true
+    return *o.Complete, true
 }
 
 // HasComplete returns a boolean if a field has been set.
 func (o *Order) HasComplete() bool {
-	if o != nil && o.Complete != nil {
+    if o != nil && o.Complete != nil {
 		return true
 	}
 
@@ -245,25 +244,61 @@ func (o *Order) SetComplete(v bool) {
 	o.Complete = &v
 }
 
+func (o Order) MarshalJSON() ([]byte, error) {
+    toSerialize := map[string]interface{}{}
+    if o.Id != nil {
+        toSerialize["id"] = o.Id
+    }
+    if o.PetId != nil {
+        toSerialize["petId"] = o.PetId
+    }
+    if o.Quantity != nil {
+        toSerialize["quantity"] = o.Quantity
+    }
+    if o.ShipDate != nil {
+        toSerialize["shipDate"] = o.ShipDate
+    }
+    if o.Status != nil {
+        toSerialize["status"] = o.Status
+    }
+    if o.Complete != nil {
+        toSerialize["complete"] = o.Complete
+    }
+    return json.Marshal(toSerialize)
+}
+
 type NullableOrder struct {
-	Value Order
-	ExplicitNull bool
+	value *Order
+	isSet bool
+}
+
+func (v NullableOrder) Get() *Order {
+    return v.value
+}
+
+func (v NullableOrder) Set(val *Order) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableOrder) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableOrder) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableOrder(val *Order) *NullableOrder {
+    return &NullableOrder{value: val, isSet: true}
 }
 
 func (v NullableOrder) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-		return json.Marshal(v.Value)
-	}
+    return json.Marshal(v.value)
 }
 
 func (v *NullableOrder) UnmarshalJSON(src []byte) error {
-	if bytes.Equal(src, []byte("null")) {
-		v.ExplicitNull = true
-		return nil
-	}
-
-	return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_order.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_order.go
@@ -57,7 +57,6 @@ func (o *Order) GetId() int64 {
 
 // GetIdOk returns a tuple with the Id field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *Order) GetIdOk() (*int64, bool) {
 	if o == nil || o.Id == nil {
 		return nil, false
@@ -90,7 +89,6 @@ func (o *Order) GetPetId() int64 {
 
 // GetPetIdOk returns a tuple with the PetId field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *Order) GetPetIdOk() (*int64, bool) {
 	if o == nil || o.PetId == nil {
 		return nil, false
@@ -123,7 +121,6 @@ func (o *Order) GetQuantity() int32 {
 
 // GetQuantityOk returns a tuple with the Quantity field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *Order) GetQuantityOk() (*int32, bool) {
 	if o == nil || o.Quantity == nil {
 		return nil, false
@@ -156,7 +153,6 @@ func (o *Order) GetShipDate() time.Time {
 
 // GetShipDateOk returns a tuple with the ShipDate field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *Order) GetShipDateOk() (*time.Time, bool) {
 	if o == nil || o.ShipDate == nil {
 		return nil, false
@@ -189,7 +185,6 @@ func (o *Order) GetStatus() string {
 
 // GetStatusOk returns a tuple with the Status field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *Order) GetStatusOk() (*string, bool) {
 	if o == nil || o.Status == nil {
 		return nil, false
@@ -222,7 +217,6 @@ func (o *Order) GetComplete() bool {
 
 // GetCompleteOk returns a tuple with the Complete field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *Order) GetCompleteOk() (*bool, bool) {
 	if o == nil || o.Complete == nil {
 		return nil, false

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_outer_composite.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_outer_composite.go
@@ -25,16 +25,16 @@ type OuterComposite struct {
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
 func NewOuterComposite() *OuterComposite {
-    this := OuterComposite{}
-    return &this
+	this := OuterComposite{}
+	return &this
 }
 
 // NewOuterCompositeWithDefaults instantiates a new OuterComposite object
 // This constructor will only assign default values to properties that have it defined,
 // but it doesn't guarantee that properties required by API are set
 func NewOuterCompositeWithDefaults() *OuterComposite {
-    this := OuterComposite{}
-    return &this
+	this := OuterComposite{}
+	return &this
 }
 
 // GetMyNumber returns the MyNumber field value if set, zero value otherwise.
@@ -46,14 +46,14 @@ func (o *OuterComposite) GetMyNumber() float32 {
 	return *o.MyNumber
 }
 
-// GetMyNumberOk returns a tuple with the MyNumber field value if set, zero value otherwise
+// GetMyNumberOk returns a tuple with the MyNumber field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *OuterComposite) GetMyNumberOk() (float32, bool) {
+
+func (o *OuterComposite) GetMyNumberOk() (*float32, bool) {
 	if o == nil || o.MyNumber == nil {
-		var ret float32
-		return ret, false
+		return nil, false
 	}
-	return *o.MyNumber, true
+	return o.MyNumber, true
 }
 
 // HasMyNumber returns a boolean if a field has been set.
@@ -79,14 +79,14 @@ func (o *OuterComposite) GetMyString() string {
 	return *o.MyString
 }
 
-// GetMyStringOk returns a tuple with the MyString field value if set, zero value otherwise
+// GetMyStringOk returns a tuple with the MyString field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *OuterComposite) GetMyStringOk() (string, bool) {
+
+func (o *OuterComposite) GetMyStringOk() (*string, bool) {
 	if o == nil || o.MyString == nil {
-		var ret string
-		return ret, false
+		return nil, false
 	}
-	return *o.MyString, true
+	return o.MyString, true
 }
 
 // HasMyString returns a boolean if a field has been set.
@@ -112,14 +112,14 @@ func (o *OuterComposite) GetMyBoolean() bool {
 	return *o.MyBoolean
 }
 
-// GetMyBooleanOk returns a tuple with the MyBoolean field value if set, zero value otherwise
+// GetMyBooleanOk returns a tuple with the MyBoolean field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *OuterComposite) GetMyBooleanOk() (bool, bool) {
+
+func (o *OuterComposite) GetMyBooleanOk() (*bool, bool) {
 	if o == nil || o.MyBoolean == nil {
-		var ret bool
-		return ret, false
+		return nil, false
 	}
-	return *o.MyBoolean, true
+	return o.MyBoolean, true
 }
 
 // HasMyBoolean returns a boolean if a field has been set.

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_outer_composite.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_outer_composite.go
@@ -10,7 +10,6 @@
 package petstore
 
 import (
-	"bytes"
 	"encoding/json"
 )
 
@@ -54,12 +53,12 @@ func (o *OuterComposite) GetMyNumberOk() (float32, bool) {
 		var ret float32
 		return ret, false
 	}
-	return *o.MyNumber, true
+    return *o.MyNumber, true
 }
 
 // HasMyNumber returns a boolean if a field has been set.
 func (o *OuterComposite) HasMyNumber() bool {
-	if o != nil && o.MyNumber != nil {
+    if o != nil && o.MyNumber != nil {
 		return true
 	}
 
@@ -87,12 +86,12 @@ func (o *OuterComposite) GetMyStringOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-	return *o.MyString, true
+    return *o.MyString, true
 }
 
 // HasMyString returns a boolean if a field has been set.
 func (o *OuterComposite) HasMyString() bool {
-	if o != nil && o.MyString != nil {
+    if o != nil && o.MyString != nil {
 		return true
 	}
 
@@ -120,12 +119,12 @@ func (o *OuterComposite) GetMyBooleanOk() (bool, bool) {
 		var ret bool
 		return ret, false
 	}
-	return *o.MyBoolean, true
+    return *o.MyBoolean, true
 }
 
 // HasMyBoolean returns a boolean if a field has been set.
 func (o *OuterComposite) HasMyBoolean() bool {
-	if o != nil && o.MyBoolean != nil {
+    if o != nil && o.MyBoolean != nil {
 		return true
 	}
 
@@ -137,25 +136,52 @@ func (o *OuterComposite) SetMyBoolean(v bool) {
 	o.MyBoolean = &v
 }
 
+func (o OuterComposite) MarshalJSON() ([]byte, error) {
+    toSerialize := map[string]interface{}{}
+    if o.MyNumber != nil {
+        toSerialize["my_number"] = o.MyNumber
+    }
+    if o.MyString != nil {
+        toSerialize["my_string"] = o.MyString
+    }
+    if o.MyBoolean != nil {
+        toSerialize["my_boolean"] = o.MyBoolean
+    }
+    return json.Marshal(toSerialize)
+}
+
 type NullableOuterComposite struct {
-	Value OuterComposite
-	ExplicitNull bool
+	value *OuterComposite
+	isSet bool
+}
+
+func (v NullableOuterComposite) Get() *OuterComposite {
+    return v.value
+}
+
+func (v NullableOuterComposite) Set(val *OuterComposite) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableOuterComposite) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableOuterComposite) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableOuterComposite(val *OuterComposite) *NullableOuterComposite {
+    return &NullableOuterComposite{value: val, isSet: true}
 }
 
 func (v NullableOuterComposite) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-		return json.Marshal(v.Value)
-	}
+    return json.Marshal(v.value)
 }
 
 func (v *NullableOuterComposite) UnmarshalJSON(src []byte) error {
-	if bytes.Equal(src, []byte("null")) {
-		v.ExplicitNull = true
-		return nil
-	}
-
-	return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_outer_composite.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_outer_composite.go
@@ -48,7 +48,6 @@ func (o *OuterComposite) GetMyNumber() float32 {
 
 // GetMyNumberOk returns a tuple with the MyNumber field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *OuterComposite) GetMyNumberOk() (*float32, bool) {
 	if o == nil || o.MyNumber == nil {
 		return nil, false
@@ -81,7 +80,6 @@ func (o *OuterComposite) GetMyString() string {
 
 // GetMyStringOk returns a tuple with the MyString field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *OuterComposite) GetMyStringOk() (*string, bool) {
 	if o == nil || o.MyString == nil {
 		return nil, false
@@ -114,7 +112,6 @@ func (o *OuterComposite) GetMyBoolean() bool {
 
 // GetMyBooleanOk returns a tuple with the MyBoolean field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *OuterComposite) GetMyBooleanOk() (*bool, bool) {
 	if o == nil || o.MyBoolean == nil {
 		return nil, false

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_outer_composite.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_outer_composite.go
@@ -53,12 +53,12 @@ func (o *OuterComposite) GetMyNumberOk() (float32, bool) {
 		var ret float32
 		return ret, false
 	}
-    return *o.MyNumber, true
+	return *o.MyNumber, true
 }
 
 // HasMyNumber returns a boolean if a field has been set.
 func (o *OuterComposite) HasMyNumber() bool {
-    if o != nil && o.MyNumber != nil {
+	if o != nil && o.MyNumber != nil {
 		return true
 	}
 
@@ -86,12 +86,12 @@ func (o *OuterComposite) GetMyStringOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-    return *o.MyString, true
+	return *o.MyString, true
 }
 
 // HasMyString returns a boolean if a field has been set.
 func (o *OuterComposite) HasMyString() bool {
-    if o != nil && o.MyString != nil {
+	if o != nil && o.MyString != nil {
 		return true
 	}
 
@@ -119,12 +119,12 @@ func (o *OuterComposite) GetMyBooleanOk() (bool, bool) {
 		var ret bool
 		return ret, false
 	}
-    return *o.MyBoolean, true
+	return *o.MyBoolean, true
 }
 
 // HasMyBoolean returns a boolean if a field has been set.
 func (o *OuterComposite) HasMyBoolean() bool {
-    if o != nil && o.MyBoolean != nil {
+	if o != nil && o.MyBoolean != nil {
 		return true
 	}
 
@@ -137,17 +137,17 @@ func (o *OuterComposite) SetMyBoolean(v bool) {
 }
 
 func (o OuterComposite) MarshalJSON() ([]byte, error) {
-    toSerialize := map[string]interface{}{}
-    if o.MyNumber != nil {
-        toSerialize["my_number"] = o.MyNumber
-    }
-    if o.MyString != nil {
-        toSerialize["my_string"] = o.MyString
-    }
-    if o.MyBoolean != nil {
-        toSerialize["my_boolean"] = o.MyBoolean
-    }
-    return json.Marshal(toSerialize)
+	toSerialize := map[string]interface{}{}
+	if o.MyNumber != nil {
+		toSerialize["my_number"] = o.MyNumber
+	}
+	if o.MyString != nil {
+		toSerialize["my_string"] = o.MyString
+	}
+	if o.MyBoolean != nil {
+		toSerialize["my_boolean"] = o.MyBoolean
+	}
+	return json.Marshal(toSerialize)
 }
 
 type NullableOuterComposite struct {
@@ -156,32 +156,32 @@ type NullableOuterComposite struct {
 }
 
 func (v NullableOuterComposite) Get() *OuterComposite {
-    return v.value
+	return v.value
 }
 
 func (v NullableOuterComposite) Set(val *OuterComposite) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableOuterComposite) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableOuterComposite) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableOuterComposite(val *OuterComposite) *NullableOuterComposite {
-    return &NullableOuterComposite{value: val, isSet: true}
+	return &NullableOuterComposite{value: val, isSet: true}
 }
 
 func (v NullableOuterComposite) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableOuterComposite) UnmarshalJSON(src []byte) error {
-    v.isSet = true
+	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_outer_composite.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_outer_composite.go
@@ -159,7 +159,7 @@ func (v NullableOuterComposite) Get() *OuterComposite {
 	return v.value
 }
 
-func (v NullableOuterComposite) Set(val *OuterComposite) {
+func (v *NullableOuterComposite) Set(val *OuterComposite) {
 	v.value = val
 	v.isSet = true
 }
@@ -168,7 +168,7 @@ func (v NullableOuterComposite) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableOuterComposite) Unset() {
+func (v *NullableOuterComposite) Unset() {
 	v.value = nil
 	v.isSet = false
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_outer_enum.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_outer_enum.go
@@ -32,7 +32,7 @@ func (v NullableOuterEnum) Get() *OuterEnum {
 	return v.value
 }
 
-func (v NullableOuterEnum) Set(val *OuterEnum) {
+func (v *NullableOuterEnum) Set(val *OuterEnum) {
 	v.value = val
 	v.isSet = true
 }
@@ -41,7 +41,7 @@ func (v NullableOuterEnum) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableOuterEnum) Unset() {
+func (v *NullableOuterEnum) Unset() {
 	v.value = nil
 	v.isSet = false
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_outer_enum.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_outer_enum.go
@@ -29,32 +29,32 @@ type NullableOuterEnum struct {
 }
 
 func (v NullableOuterEnum) Get() *OuterEnum {
-    return v.value
+	return v.value
 }
 
 func (v NullableOuterEnum) Set(val *OuterEnum) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableOuterEnum) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableOuterEnum) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableOuterEnum(val *OuterEnum) *NullableOuterEnum {
-    return &NullableOuterEnum{value: val, isSet: true}
+	return &NullableOuterEnum{value: val, isSet: true}
 }
 
 func (v NullableOuterEnum) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableOuterEnum) UnmarshalJSON(src []byte) error {
-    v.isSet = true
+	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_outer_enum.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_outer_enum.go
@@ -10,7 +10,6 @@
 package petstore
 
 import (
-	"bytes"
 	"encoding/json"
 )
 
@@ -25,24 +24,37 @@ const (
 )
 
 type NullableOuterEnum struct {
-	Value OuterEnum
-	ExplicitNull bool
+	value *OuterEnum
+	isSet bool
+}
+
+func (v NullableOuterEnum) Get() *OuterEnum {
+    return v.value
+}
+
+func (v NullableOuterEnum) Set(val *OuterEnum) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableOuterEnum) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableOuterEnum) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableOuterEnum(val *OuterEnum) *NullableOuterEnum {
+    return &NullableOuterEnum{value: val, isSet: true}
 }
 
 func (v NullableOuterEnum) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-		return json.Marshal(v.Value)
-	}
+    return json.Marshal(v.value)
 }
 
 func (v *NullableOuterEnum) UnmarshalJSON(src []byte) error {
-	if bytes.Equal(src, []byte("null")) {
-		v.ExplicitNull = true
-		return nil
-	}
-
-	return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_outer_enum_default_value.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_outer_enum_default_value.go
@@ -29,32 +29,32 @@ type NullableOuterEnumDefaultValue struct {
 }
 
 func (v NullableOuterEnumDefaultValue) Get() *OuterEnumDefaultValue {
-    return v.value
+	return v.value
 }
 
 func (v NullableOuterEnumDefaultValue) Set(val *OuterEnumDefaultValue) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableOuterEnumDefaultValue) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableOuterEnumDefaultValue) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableOuterEnumDefaultValue(val *OuterEnumDefaultValue) *NullableOuterEnumDefaultValue {
-    return &NullableOuterEnumDefaultValue{value: val, isSet: true}
+	return &NullableOuterEnumDefaultValue{value: val, isSet: true}
 }
 
 func (v NullableOuterEnumDefaultValue) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableOuterEnumDefaultValue) UnmarshalJSON(src []byte) error {
-    v.isSet = true
+	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_outer_enum_default_value.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_outer_enum_default_value.go
@@ -32,7 +32,7 @@ func (v NullableOuterEnumDefaultValue) Get() *OuterEnumDefaultValue {
 	return v.value
 }
 
-func (v NullableOuterEnumDefaultValue) Set(val *OuterEnumDefaultValue) {
+func (v *NullableOuterEnumDefaultValue) Set(val *OuterEnumDefaultValue) {
 	v.value = val
 	v.isSet = true
 }
@@ -41,7 +41,7 @@ func (v NullableOuterEnumDefaultValue) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableOuterEnumDefaultValue) Unset() {
+func (v *NullableOuterEnumDefaultValue) Unset() {
 	v.value = nil
 	v.isSet = false
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_outer_enum_default_value.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_outer_enum_default_value.go
@@ -10,7 +10,6 @@
 package petstore
 
 import (
-	"bytes"
 	"encoding/json"
 )
 
@@ -25,24 +24,37 @@ const (
 )
 
 type NullableOuterEnumDefaultValue struct {
-	Value OuterEnumDefaultValue
-	ExplicitNull bool
+	value *OuterEnumDefaultValue
+	isSet bool
+}
+
+func (v NullableOuterEnumDefaultValue) Get() *OuterEnumDefaultValue {
+    return v.value
+}
+
+func (v NullableOuterEnumDefaultValue) Set(val *OuterEnumDefaultValue) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableOuterEnumDefaultValue) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableOuterEnumDefaultValue) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableOuterEnumDefaultValue(val *OuterEnumDefaultValue) *NullableOuterEnumDefaultValue {
+    return &NullableOuterEnumDefaultValue{value: val, isSet: true}
 }
 
 func (v NullableOuterEnumDefaultValue) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-		return json.Marshal(v.Value)
-	}
+    return json.Marshal(v.value)
 }
 
 func (v *NullableOuterEnumDefaultValue) UnmarshalJSON(src []byte) error {
-	if bytes.Equal(src, []byte("null")) {
-		v.ExplicitNull = true
-		return nil
-	}
-
-	return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_outer_enum_integer.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_outer_enum_integer.go
@@ -10,7 +10,6 @@
 package petstore
 
 import (
-	"bytes"
 	"encoding/json"
 )
 
@@ -25,24 +24,37 @@ const (
 )
 
 type NullableOuterEnumInteger struct {
-	Value OuterEnumInteger
-	ExplicitNull bool
+	value *OuterEnumInteger
+	isSet bool
+}
+
+func (v NullableOuterEnumInteger) Get() *OuterEnumInteger {
+    return v.value
+}
+
+func (v NullableOuterEnumInteger) Set(val *OuterEnumInteger) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableOuterEnumInteger) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableOuterEnumInteger) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableOuterEnumInteger(val *OuterEnumInteger) *NullableOuterEnumInteger {
+    return &NullableOuterEnumInteger{value: val, isSet: true}
 }
 
 func (v NullableOuterEnumInteger) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-		return json.Marshal(v.Value)
-	}
+    return json.Marshal(v.value)
 }
 
 func (v *NullableOuterEnumInteger) UnmarshalJSON(src []byte) error {
-	if bytes.Equal(src, []byte("null")) {
-		v.ExplicitNull = true
-		return nil
-	}
-
-	return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_outer_enum_integer.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_outer_enum_integer.go
@@ -29,32 +29,32 @@ type NullableOuterEnumInteger struct {
 }
 
 func (v NullableOuterEnumInteger) Get() *OuterEnumInteger {
-    return v.value
+	return v.value
 }
 
 func (v NullableOuterEnumInteger) Set(val *OuterEnumInteger) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableOuterEnumInteger) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableOuterEnumInteger) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableOuterEnumInteger(val *OuterEnumInteger) *NullableOuterEnumInteger {
-    return &NullableOuterEnumInteger{value: val, isSet: true}
+	return &NullableOuterEnumInteger{value: val, isSet: true}
 }
 
 func (v NullableOuterEnumInteger) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableOuterEnumInteger) UnmarshalJSON(src []byte) error {
-    v.isSet = true
+	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_outer_enum_integer.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_outer_enum_integer.go
@@ -32,7 +32,7 @@ func (v NullableOuterEnumInteger) Get() *OuterEnumInteger {
 	return v.value
 }
 
-func (v NullableOuterEnumInteger) Set(val *OuterEnumInteger) {
+func (v *NullableOuterEnumInteger) Set(val *OuterEnumInteger) {
 	v.value = val
 	v.isSet = true
 }
@@ -41,7 +41,7 @@ func (v NullableOuterEnumInteger) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableOuterEnumInteger) Unset() {
+func (v *NullableOuterEnumInteger) Unset() {
 	v.value = nil
 	v.isSet = false
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_outer_enum_integer_default_value.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_outer_enum_integer_default_value.go
@@ -29,32 +29,32 @@ type NullableOuterEnumIntegerDefaultValue struct {
 }
 
 func (v NullableOuterEnumIntegerDefaultValue) Get() *OuterEnumIntegerDefaultValue {
-    return v.value
+	return v.value
 }
 
 func (v NullableOuterEnumIntegerDefaultValue) Set(val *OuterEnumIntegerDefaultValue) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableOuterEnumIntegerDefaultValue) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableOuterEnumIntegerDefaultValue) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableOuterEnumIntegerDefaultValue(val *OuterEnumIntegerDefaultValue) *NullableOuterEnumIntegerDefaultValue {
-    return &NullableOuterEnumIntegerDefaultValue{value: val, isSet: true}
+	return &NullableOuterEnumIntegerDefaultValue{value: val, isSet: true}
 }
 
 func (v NullableOuterEnumIntegerDefaultValue) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableOuterEnumIntegerDefaultValue) UnmarshalJSON(src []byte) error {
-    v.isSet = true
+	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_outer_enum_integer_default_value.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_outer_enum_integer_default_value.go
@@ -10,7 +10,6 @@
 package petstore
 
 import (
-	"bytes"
 	"encoding/json"
 )
 
@@ -25,24 +24,37 @@ const (
 )
 
 type NullableOuterEnumIntegerDefaultValue struct {
-	Value OuterEnumIntegerDefaultValue
-	ExplicitNull bool
+	value *OuterEnumIntegerDefaultValue
+	isSet bool
+}
+
+func (v NullableOuterEnumIntegerDefaultValue) Get() *OuterEnumIntegerDefaultValue {
+    return v.value
+}
+
+func (v NullableOuterEnumIntegerDefaultValue) Set(val *OuterEnumIntegerDefaultValue) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableOuterEnumIntegerDefaultValue) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableOuterEnumIntegerDefaultValue) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableOuterEnumIntegerDefaultValue(val *OuterEnumIntegerDefaultValue) *NullableOuterEnumIntegerDefaultValue {
+    return &NullableOuterEnumIntegerDefaultValue{value: val, isSet: true}
 }
 
 func (v NullableOuterEnumIntegerDefaultValue) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-		return json.Marshal(v.Value)
-	}
+    return json.Marshal(v.value)
 }
 
 func (v *NullableOuterEnumIntegerDefaultValue) UnmarshalJSON(src []byte) error {
-	if bytes.Equal(src, []byte("null")) {
-		v.ExplicitNull = true
-		return nil
-	}
-
-	return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_outer_enum_integer_default_value.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_outer_enum_integer_default_value.go
@@ -32,7 +32,7 @@ func (v NullableOuterEnumIntegerDefaultValue) Get() *OuterEnumIntegerDefaultValu
 	return v.value
 }
 
-func (v NullableOuterEnumIntegerDefaultValue) Set(val *OuterEnumIntegerDefaultValue) {
+func (v *NullableOuterEnumIntegerDefaultValue) Set(val *OuterEnumIntegerDefaultValue) {
 	v.value = val
 	v.isSet = true
 }
@@ -41,7 +41,7 @@ func (v NullableOuterEnumIntegerDefaultValue) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableOuterEnumIntegerDefaultValue) Unset() {
+func (v *NullableOuterEnumIntegerDefaultValue) Unset() {
 	v.value = nil
 	v.isSet = false
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_pet.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_pet.go
@@ -54,7 +54,6 @@ func (o *Pet) GetId() int64 {
 
 // GetIdOk returns a tuple with the Id field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *Pet) GetIdOk() (*int64, bool) {
 	if o == nil || o.Id == nil {
 		return nil, false
@@ -87,7 +86,6 @@ func (o *Pet) GetCategory() Category {
 
 // GetCategoryOk returns a tuple with the Category field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *Pet) GetCategoryOk() (*Category, bool) {
 	if o == nil || o.Category == nil {
 		return nil, false
@@ -121,12 +119,11 @@ func (o *Pet) GetName() string {
 
 // GetNameOk returns a tuple with the Name field value
 // and a boolean to check if the value has been set.
-
 func (o *Pet) GetNameOk() (*string, bool) {
-    if o == nil  {
-        return nil, false
-    }
-    return &o.Name, true
+	if o == nil  {
+		return nil, false
+	}
+	return &o.Name, true
 }
 
 // SetName sets field value
@@ -146,12 +143,11 @@ func (o *Pet) GetPhotoUrls() []string {
 
 // GetPhotoUrlsOk returns a tuple with the PhotoUrls field value
 // and a boolean to check if the value has been set.
-
 func (o *Pet) GetPhotoUrlsOk() (*[]string, bool) {
-    if o == nil  {
-        return nil, false
-    }
-    return &o.PhotoUrls, true
+	if o == nil  {
+		return nil, false
+	}
+	return &o.PhotoUrls, true
 }
 
 // SetPhotoUrls sets field value
@@ -170,7 +166,6 @@ func (o *Pet) GetTags() []Tag {
 
 // GetTagsOk returns a tuple with the Tags field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *Pet) GetTagsOk() (*[]Tag, bool) {
 	if o == nil || o.Tags == nil {
 		return nil, false
@@ -203,7 +198,6 @@ func (o *Pet) GetStatus() string {
 
 // GetStatusOk returns a tuple with the Status field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *Pet) GetStatusOk() (*string, bool) {
 	if o == nil || o.Status == nil {
 		return nil, false

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_pet.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_pet.go
@@ -10,7 +10,6 @@
 package petstore
 
 import (
-	"bytes"
 	"encoding/json"
 )
 
@@ -60,12 +59,12 @@ func (o *Pet) GetIdOk() (int64, bool) {
 		var ret int64
 		return ret, false
 	}
-	return *o.Id, true
+    return *o.Id, true
 }
 
 // HasId returns a boolean if a field has been set.
 func (o *Pet) HasId() bool {
-	if o != nil && o.Id != nil {
+    if o != nil && o.Id != nil {
 		return true
 	}
 
@@ -93,12 +92,12 @@ func (o *Pet) GetCategoryOk() (Category, bool) {
 		var ret Category
 		return ret, false
 	}
-	return *o.Category, true
+    return *o.Category, true
 }
 
 // HasCategory returns a boolean if a field has been set.
 func (o *Pet) HasCategory() bool {
-	if o != nil && o.Category != nil {
+    if o != nil && o.Category != nil {
 		return true
 	}
 
@@ -156,12 +155,12 @@ func (o *Pet) GetTagsOk() ([]Tag, bool) {
 		var ret []Tag
 		return ret, false
 	}
-	return *o.Tags, true
+    return *o.Tags, true
 }
 
 // HasTags returns a boolean if a field has been set.
 func (o *Pet) HasTags() bool {
-	if o != nil && o.Tags != nil {
+    if o != nil && o.Tags != nil {
 		return true
 	}
 
@@ -189,12 +188,12 @@ func (o *Pet) GetStatusOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-	return *o.Status, true
+    return *o.Status, true
 }
 
 // HasStatus returns a boolean if a field has been set.
 func (o *Pet) HasStatus() bool {
-	if o != nil && o.Status != nil {
+    if o != nil && o.Status != nil {
 		return true
 	}
 
@@ -206,25 +205,61 @@ func (o *Pet) SetStatus(v string) {
 	o.Status = &v
 }
 
+func (o Pet) MarshalJSON() ([]byte, error) {
+    toSerialize := map[string]interface{}{}
+    if o.Id != nil {
+        toSerialize["id"] = o.Id
+    }
+    if o.Category != nil {
+        toSerialize["category"] = o.Category
+    }
+    if true {
+        toSerialize["name"] = o.Name
+    }
+    if true {
+        toSerialize["photoUrls"] = o.PhotoUrls
+    }
+    if o.Tags != nil {
+        toSerialize["tags"] = o.Tags
+    }
+    if o.Status != nil {
+        toSerialize["status"] = o.Status
+    }
+    return json.Marshal(toSerialize)
+}
+
 type NullablePet struct {
-	Value Pet
-	ExplicitNull bool
+	value *Pet
+	isSet bool
+}
+
+func (v NullablePet) Get() *Pet {
+    return v.value
+}
+
+func (v NullablePet) Set(val *Pet) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullablePet) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullablePet) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullablePet(val *Pet) *NullablePet {
+    return &NullablePet{value: val, isSet: true}
 }
 
 func (v NullablePet) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-		return json.Marshal(v.Value)
-	}
+    return json.Marshal(v.value)
 }
 
 func (v *NullablePet) UnmarshalJSON(src []byte) error {
-	if bytes.Equal(src, []byte("null")) {
-		v.ExplicitNull = true
-		return nil
-	}
-
-	return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_pet.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_pet.go
@@ -29,18 +29,18 @@ type Pet struct {
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
 func NewPet(name string, photoUrls []string, ) *Pet {
-    this := Pet{}
-    this.Name = name
-    this.PhotoUrls = photoUrls
-    return &this
+	this := Pet{}
+	this.Name = name
+	this.PhotoUrls = photoUrls
+	return &this
 }
 
 // NewPetWithDefaults instantiates a new Pet object
 // This constructor will only assign default values to properties that have it defined,
 // but it doesn't guarantee that properties required by API are set
 func NewPetWithDefaults() *Pet {
-    this := Pet{}
-    return &this
+	this := Pet{}
+	return &this
 }
 
 // GetId returns the Id field value if set, zero value otherwise.
@@ -52,14 +52,14 @@ func (o *Pet) GetId() int64 {
 	return *o.Id
 }
 
-// GetIdOk returns a tuple with the Id field value if set, zero value otherwise
+// GetIdOk returns a tuple with the Id field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *Pet) GetIdOk() (int64, bool) {
+
+func (o *Pet) GetIdOk() (*int64, bool) {
 	if o == nil || o.Id == nil {
-		var ret int64
-		return ret, false
+		return nil, false
 	}
-	return *o.Id, true
+	return o.Id, true
 }
 
 // HasId returns a boolean if a field has been set.
@@ -85,14 +85,14 @@ func (o *Pet) GetCategory() Category {
 	return *o.Category
 }
 
-// GetCategoryOk returns a tuple with the Category field value if set, zero value otherwise
+// GetCategoryOk returns a tuple with the Category field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *Pet) GetCategoryOk() (Category, bool) {
+
+func (o *Pet) GetCategoryOk() (*Category, bool) {
 	if o == nil || o.Category == nil {
-		var ret Category
-		return ret, false
+		return nil, false
 	}
-	return *o.Category, true
+	return o.Category, true
 }
 
 // HasCategory returns a boolean if a field has been set.
@@ -111,12 +111,22 @@ func (o *Pet) SetCategory(v Category) {
 
 // GetName returns the Name field value
 func (o *Pet) GetName() string {
-	if o == nil {
+	if o == nil  {
 		var ret string
 		return ret
 	}
 
 	return o.Name
+}
+
+// GetNameOk returns a tuple with the Name field value
+// and a boolean to check if the value has been set.
+
+func (o *Pet) GetNameOk() (*string, bool) {
+    if o == nil  {
+        return nil, false
+    }
+    return &o.Name, true
 }
 
 // SetName sets field value
@@ -126,12 +136,22 @@ func (o *Pet) SetName(v string) {
 
 // GetPhotoUrls returns the PhotoUrls field value
 func (o *Pet) GetPhotoUrls() []string {
-	if o == nil {
+	if o == nil  {
 		var ret []string
 		return ret
 	}
 
 	return o.PhotoUrls
+}
+
+// GetPhotoUrlsOk returns a tuple with the PhotoUrls field value
+// and a boolean to check if the value has been set.
+
+func (o *Pet) GetPhotoUrlsOk() (*[]string, bool) {
+    if o == nil  {
+        return nil, false
+    }
+    return &o.PhotoUrls, true
 }
 
 // SetPhotoUrls sets field value
@@ -148,14 +168,14 @@ func (o *Pet) GetTags() []Tag {
 	return *o.Tags
 }
 
-// GetTagsOk returns a tuple with the Tags field value if set, zero value otherwise
+// GetTagsOk returns a tuple with the Tags field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *Pet) GetTagsOk() ([]Tag, bool) {
+
+func (o *Pet) GetTagsOk() (*[]Tag, bool) {
 	if o == nil || o.Tags == nil {
-		var ret []Tag
-		return ret, false
+		return nil, false
 	}
-	return *o.Tags, true
+	return o.Tags, true
 }
 
 // HasTags returns a boolean if a field has been set.
@@ -181,14 +201,14 @@ func (o *Pet) GetStatus() string {
 	return *o.Status
 }
 
-// GetStatusOk returns a tuple with the Status field value if set, zero value otherwise
+// GetStatusOk returns a tuple with the Status field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *Pet) GetStatusOk() (string, bool) {
+
+func (o *Pet) GetStatusOk() (*string, bool) {
 	if o == nil || o.Status == nil {
-		var ret string
-		return ret, false
+		return nil, false
 	}
-	return *o.Status, true
+	return o.Status, true
 }
 
 // HasStatus returns a boolean if a field has been set.

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_pet.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_pet.go
@@ -237,7 +237,7 @@ func (v NullablePet) Get() *Pet {
 	return v.value
 }
 
-func (v NullablePet) Set(val *Pet) {
+func (v *NullablePet) Set(val *Pet) {
 	v.value = val
 	v.isSet = true
 }
@@ -246,7 +246,7 @@ func (v NullablePet) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullablePet) Unset() {
+func (v *NullablePet) Unset() {
 	v.value = nil
 	v.isSet = false
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_pet.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_pet.go
@@ -59,12 +59,12 @@ func (o *Pet) GetIdOk() (int64, bool) {
 		var ret int64
 		return ret, false
 	}
-    return *o.Id, true
+	return *o.Id, true
 }
 
 // HasId returns a boolean if a field has been set.
 func (o *Pet) HasId() bool {
-    if o != nil && o.Id != nil {
+	if o != nil && o.Id != nil {
 		return true
 	}
 
@@ -92,12 +92,12 @@ func (o *Pet) GetCategoryOk() (Category, bool) {
 		var ret Category
 		return ret, false
 	}
-    return *o.Category, true
+	return *o.Category, true
 }
 
 // HasCategory returns a boolean if a field has been set.
 func (o *Pet) HasCategory() bool {
-    if o != nil && o.Category != nil {
+	if o != nil && o.Category != nil {
 		return true
 	}
 
@@ -155,12 +155,12 @@ func (o *Pet) GetTagsOk() ([]Tag, bool) {
 		var ret []Tag
 		return ret, false
 	}
-    return *o.Tags, true
+	return *o.Tags, true
 }
 
 // HasTags returns a boolean if a field has been set.
 func (o *Pet) HasTags() bool {
-    if o != nil && o.Tags != nil {
+	if o != nil && o.Tags != nil {
 		return true
 	}
 
@@ -188,12 +188,12 @@ func (o *Pet) GetStatusOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-    return *o.Status, true
+	return *o.Status, true
 }
 
 // HasStatus returns a boolean if a field has been set.
 func (o *Pet) HasStatus() bool {
-    if o != nil && o.Status != nil {
+	if o != nil && o.Status != nil {
 		return true
 	}
 
@@ -206,26 +206,26 @@ func (o *Pet) SetStatus(v string) {
 }
 
 func (o Pet) MarshalJSON() ([]byte, error) {
-    toSerialize := map[string]interface{}{}
-    if o.Id != nil {
-        toSerialize["id"] = o.Id
-    }
-    if o.Category != nil {
-        toSerialize["category"] = o.Category
-    }
-    if true {
-        toSerialize["name"] = o.Name
-    }
-    if true {
-        toSerialize["photoUrls"] = o.PhotoUrls
-    }
-    if o.Tags != nil {
-        toSerialize["tags"] = o.Tags
-    }
-    if o.Status != nil {
-        toSerialize["status"] = o.Status
-    }
-    return json.Marshal(toSerialize)
+	toSerialize := map[string]interface{}{}
+	if o.Id != nil {
+		toSerialize["id"] = o.Id
+	}
+	if o.Category != nil {
+		toSerialize["category"] = o.Category
+	}
+	if true {
+		toSerialize["name"] = o.Name
+	}
+	if true {
+		toSerialize["photoUrls"] = o.PhotoUrls
+	}
+	if o.Tags != nil {
+		toSerialize["tags"] = o.Tags
+	}
+	if o.Status != nil {
+		toSerialize["status"] = o.Status
+	}
+	return json.Marshal(toSerialize)
 }
 
 type NullablePet struct {
@@ -234,32 +234,32 @@ type NullablePet struct {
 }
 
 func (v NullablePet) Get() *Pet {
-    return v.value
+	return v.value
 }
 
 func (v NullablePet) Set(val *Pet) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullablePet) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullablePet) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullablePet(val *Pet) *NullablePet {
-    return &NullablePet{value: val, isSet: true}
+	return &NullablePet{value: val, isSet: true}
 }
 
 func (v NullablePet) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullablePet) UnmarshalJSON(src []byte) error {
-    v.isSet = true
+	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_read_only_first.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_read_only_first.go
@@ -24,16 +24,16 @@ type ReadOnlyFirst struct {
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
 func NewReadOnlyFirst() *ReadOnlyFirst {
-    this := ReadOnlyFirst{}
-    return &this
+	this := ReadOnlyFirst{}
+	return &this
 }
 
 // NewReadOnlyFirstWithDefaults instantiates a new ReadOnlyFirst object
 // This constructor will only assign default values to properties that have it defined,
 // but it doesn't guarantee that properties required by API are set
 func NewReadOnlyFirstWithDefaults() *ReadOnlyFirst {
-    this := ReadOnlyFirst{}
-    return &this
+	this := ReadOnlyFirst{}
+	return &this
 }
 
 // GetBar returns the Bar field value if set, zero value otherwise.
@@ -45,14 +45,14 @@ func (o *ReadOnlyFirst) GetBar() string {
 	return *o.Bar
 }
 
-// GetBarOk returns a tuple with the Bar field value if set, zero value otherwise
+// GetBarOk returns a tuple with the Bar field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *ReadOnlyFirst) GetBarOk() (string, bool) {
+
+func (o *ReadOnlyFirst) GetBarOk() (*string, bool) {
 	if o == nil || o.Bar == nil {
-		var ret string
-		return ret, false
+		return nil, false
 	}
-	return *o.Bar, true
+	return o.Bar, true
 }
 
 // HasBar returns a boolean if a field has been set.
@@ -78,14 +78,14 @@ func (o *ReadOnlyFirst) GetBaz() string {
 	return *o.Baz
 }
 
-// GetBazOk returns a tuple with the Baz field value if set, zero value otherwise
+// GetBazOk returns a tuple with the Baz field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *ReadOnlyFirst) GetBazOk() (string, bool) {
+
+func (o *ReadOnlyFirst) GetBazOk() (*string, bool) {
 	if o == nil || o.Baz == nil {
-		var ret string
-		return ret, false
+		return nil, false
 	}
-	return *o.Baz, true
+	return o.Baz, true
 }
 
 // HasBaz returns a boolean if a field has been set.

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_read_only_first.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_read_only_first.go
@@ -10,7 +10,6 @@
 package petstore
 
 import (
-	"bytes"
 	"encoding/json"
 )
 
@@ -53,12 +52,12 @@ func (o *ReadOnlyFirst) GetBarOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-	return *o.Bar, true
+    return *o.Bar, true
 }
 
 // HasBar returns a boolean if a field has been set.
 func (o *ReadOnlyFirst) HasBar() bool {
-	if o != nil && o.Bar != nil {
+    if o != nil && o.Bar != nil {
 		return true
 	}
 
@@ -86,12 +85,12 @@ func (o *ReadOnlyFirst) GetBazOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-	return *o.Baz, true
+    return *o.Baz, true
 }
 
 // HasBaz returns a boolean if a field has been set.
 func (o *ReadOnlyFirst) HasBaz() bool {
-	if o != nil && o.Baz != nil {
+    if o != nil && o.Baz != nil {
 		return true
 	}
 
@@ -103,25 +102,49 @@ func (o *ReadOnlyFirst) SetBaz(v string) {
 	o.Baz = &v
 }
 
+func (o ReadOnlyFirst) MarshalJSON() ([]byte, error) {
+    toSerialize := map[string]interface{}{}
+    if o.Bar != nil {
+        toSerialize["bar"] = o.Bar
+    }
+    if o.Baz != nil {
+        toSerialize["baz"] = o.Baz
+    }
+    return json.Marshal(toSerialize)
+}
+
 type NullableReadOnlyFirst struct {
-	Value ReadOnlyFirst
-	ExplicitNull bool
+	value *ReadOnlyFirst
+	isSet bool
+}
+
+func (v NullableReadOnlyFirst) Get() *ReadOnlyFirst {
+    return v.value
+}
+
+func (v NullableReadOnlyFirst) Set(val *ReadOnlyFirst) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableReadOnlyFirst) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableReadOnlyFirst) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableReadOnlyFirst(val *ReadOnlyFirst) *NullableReadOnlyFirst {
+    return &NullableReadOnlyFirst{value: val, isSet: true}
 }
 
 func (v NullableReadOnlyFirst) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-		return json.Marshal(v.Value)
-	}
+    return json.Marshal(v.value)
 }
 
 func (v *NullableReadOnlyFirst) UnmarshalJSON(src []byte) error {
-	if bytes.Equal(src, []byte("null")) {
-		v.ExplicitNull = true
-		return nil
-	}
-
-	return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_read_only_first.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_read_only_first.go
@@ -52,12 +52,12 @@ func (o *ReadOnlyFirst) GetBarOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-    return *o.Bar, true
+	return *o.Bar, true
 }
 
 // HasBar returns a boolean if a field has been set.
 func (o *ReadOnlyFirst) HasBar() bool {
-    if o != nil && o.Bar != nil {
+	if o != nil && o.Bar != nil {
 		return true
 	}
 
@@ -85,12 +85,12 @@ func (o *ReadOnlyFirst) GetBazOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-    return *o.Baz, true
+	return *o.Baz, true
 }
 
 // HasBaz returns a boolean if a field has been set.
 func (o *ReadOnlyFirst) HasBaz() bool {
-    if o != nil && o.Baz != nil {
+	if o != nil && o.Baz != nil {
 		return true
 	}
 
@@ -103,14 +103,14 @@ func (o *ReadOnlyFirst) SetBaz(v string) {
 }
 
 func (o ReadOnlyFirst) MarshalJSON() ([]byte, error) {
-    toSerialize := map[string]interface{}{}
-    if o.Bar != nil {
-        toSerialize["bar"] = o.Bar
-    }
-    if o.Baz != nil {
-        toSerialize["baz"] = o.Baz
-    }
-    return json.Marshal(toSerialize)
+	toSerialize := map[string]interface{}{}
+	if o.Bar != nil {
+		toSerialize["bar"] = o.Bar
+	}
+	if o.Baz != nil {
+		toSerialize["baz"] = o.Baz
+	}
+	return json.Marshal(toSerialize)
 }
 
 type NullableReadOnlyFirst struct {
@@ -119,32 +119,32 @@ type NullableReadOnlyFirst struct {
 }
 
 func (v NullableReadOnlyFirst) Get() *ReadOnlyFirst {
-    return v.value
+	return v.value
 }
 
 func (v NullableReadOnlyFirst) Set(val *ReadOnlyFirst) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableReadOnlyFirst) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableReadOnlyFirst) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableReadOnlyFirst(val *ReadOnlyFirst) *NullableReadOnlyFirst {
-    return &NullableReadOnlyFirst{value: val, isSet: true}
+	return &NullableReadOnlyFirst{value: val, isSet: true}
 }
 
 func (v NullableReadOnlyFirst) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableReadOnlyFirst) UnmarshalJSON(src []byte) error {
-    v.isSet = true
+	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_read_only_first.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_read_only_first.go
@@ -47,7 +47,6 @@ func (o *ReadOnlyFirst) GetBar() string {
 
 // GetBarOk returns a tuple with the Bar field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *ReadOnlyFirst) GetBarOk() (*string, bool) {
 	if o == nil || o.Bar == nil {
 		return nil, false
@@ -80,7 +79,6 @@ func (o *ReadOnlyFirst) GetBaz() string {
 
 // GetBazOk returns a tuple with the Baz field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *ReadOnlyFirst) GetBazOk() (*string, bool) {
 	if o == nil || o.Baz == nil {
 		return nil, false

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_read_only_first.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_read_only_first.go
@@ -122,7 +122,7 @@ func (v NullableReadOnlyFirst) Get() *ReadOnlyFirst {
 	return v.value
 }
 
-func (v NullableReadOnlyFirst) Set(val *ReadOnlyFirst) {
+func (v *NullableReadOnlyFirst) Set(val *ReadOnlyFirst) {
 	v.value = val
 	v.isSet = true
 }
@@ -131,7 +131,7 @@ func (v NullableReadOnlyFirst) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableReadOnlyFirst) Unset() {
+func (v *NullableReadOnlyFirst) Unset() {
 	v.value = nil
 	v.isSet = false
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_return.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_return.go
@@ -23,16 +23,16 @@ type Return struct {
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
 func NewReturn() *Return {
-    this := Return{}
-    return &this
+	this := Return{}
+	return &this
 }
 
 // NewReturnWithDefaults instantiates a new Return object
 // This constructor will only assign default values to properties that have it defined,
 // but it doesn't guarantee that properties required by API are set
 func NewReturnWithDefaults() *Return {
-    this := Return{}
-    return &this
+	this := Return{}
+	return &this
 }
 
 // GetReturn returns the Return field value if set, zero value otherwise.
@@ -44,14 +44,14 @@ func (o *Return) GetReturn() int32 {
 	return *o.Return
 }
 
-// GetReturnOk returns a tuple with the Return field value if set, zero value otherwise
+// GetReturnOk returns a tuple with the Return field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *Return) GetReturnOk() (int32, bool) {
+
+func (o *Return) GetReturnOk() (*int32, bool) {
 	if o == nil || o.Return == nil {
-		var ret int32
-		return ret, false
+		return nil, false
 	}
-	return *o.Return, true
+	return o.Return, true
 }
 
 // HasReturn returns a boolean if a field has been set.

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_return.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_return.go
@@ -10,7 +10,6 @@
 package petstore
 
 import (
-	"bytes"
 	"encoding/json"
 )
 
@@ -52,12 +51,12 @@ func (o *Return) GetReturnOk() (int32, bool) {
 		var ret int32
 		return ret, false
 	}
-	return *o.Return, true
+    return *o.Return, true
 }
 
 // HasReturn returns a boolean if a field has been set.
 func (o *Return) HasReturn() bool {
-	if o != nil && o.Return != nil {
+    if o != nil && o.Return != nil {
 		return true
 	}
 
@@ -69,25 +68,46 @@ func (o *Return) SetReturn(v int32) {
 	o.Return = &v
 }
 
+func (o Return) MarshalJSON() ([]byte, error) {
+    toSerialize := map[string]interface{}{}
+    if o.Return != nil {
+        toSerialize["return"] = o.Return
+    }
+    return json.Marshal(toSerialize)
+}
+
 type NullableReturn struct {
-	Value Return
-	ExplicitNull bool
+	value *Return
+	isSet bool
+}
+
+func (v NullableReturn) Get() *Return {
+    return v.value
+}
+
+func (v NullableReturn) Set(val *Return) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableReturn) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableReturn) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableReturn(val *Return) *NullableReturn {
+    return &NullableReturn{value: val, isSet: true}
 }
 
 func (v NullableReturn) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-		return json.Marshal(v.Value)
-	}
+    return json.Marshal(v.value)
 }
 
 func (v *NullableReturn) UnmarshalJSON(src []byte) error {
-	if bytes.Equal(src, []byte("null")) {
-		v.ExplicitNull = true
-		return nil
-	}
-
-	return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_return.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_return.go
@@ -85,7 +85,7 @@ func (v NullableReturn) Get() *Return {
 	return v.value
 }
 
-func (v NullableReturn) Set(val *Return) {
+func (v *NullableReturn) Set(val *Return) {
 	v.value = val
 	v.isSet = true
 }
@@ -94,7 +94,7 @@ func (v NullableReturn) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableReturn) Unset() {
+func (v *NullableReturn) Unset() {
 	v.value = nil
 	v.isSet = false
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_return.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_return.go
@@ -51,12 +51,12 @@ func (o *Return) GetReturnOk() (int32, bool) {
 		var ret int32
 		return ret, false
 	}
-    return *o.Return, true
+	return *o.Return, true
 }
 
 // HasReturn returns a boolean if a field has been set.
 func (o *Return) HasReturn() bool {
-    if o != nil && o.Return != nil {
+	if o != nil && o.Return != nil {
 		return true
 	}
 
@@ -69,11 +69,11 @@ func (o *Return) SetReturn(v int32) {
 }
 
 func (o Return) MarshalJSON() ([]byte, error) {
-    toSerialize := map[string]interface{}{}
-    if o.Return != nil {
-        toSerialize["return"] = o.Return
-    }
-    return json.Marshal(toSerialize)
+	toSerialize := map[string]interface{}{}
+	if o.Return != nil {
+		toSerialize["return"] = o.Return
+	}
+	return json.Marshal(toSerialize)
 }
 
 type NullableReturn struct {
@@ -82,32 +82,32 @@ type NullableReturn struct {
 }
 
 func (v NullableReturn) Get() *Return {
-    return v.value
+	return v.value
 }
 
 func (v NullableReturn) Set(val *Return) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableReturn) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableReturn) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableReturn(val *Return) *NullableReturn {
-    return &NullableReturn{value: val, isSet: true}
+	return &NullableReturn{value: val, isSet: true}
 }
 
 func (v NullableReturn) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableReturn) UnmarshalJSON(src []byte) error {
-    v.isSet = true
+	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_return.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_return.go
@@ -46,7 +46,6 @@ func (o *Return) GetReturn() int32 {
 
 // GetReturnOk returns a tuple with the Return field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *Return) GetReturnOk() (*int32, bool) {
 	if o == nil || o.Return == nil {
 		return nil, false

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_tag.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_tag.go
@@ -47,7 +47,6 @@ func (o *Tag) GetId() int64 {
 
 // GetIdOk returns a tuple with the Id field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *Tag) GetIdOk() (*int64, bool) {
 	if o == nil || o.Id == nil {
 		return nil, false
@@ -80,7 +79,6 @@ func (o *Tag) GetName() string {
 
 // GetNameOk returns a tuple with the Name field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *Tag) GetNameOk() (*string, bool) {
 	if o == nil || o.Name == nil {
 		return nil, false

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_tag.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_tag.go
@@ -24,16 +24,16 @@ type Tag struct {
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
 func NewTag() *Tag {
-    this := Tag{}
-    return &this
+	this := Tag{}
+	return &this
 }
 
 // NewTagWithDefaults instantiates a new Tag object
 // This constructor will only assign default values to properties that have it defined,
 // but it doesn't guarantee that properties required by API are set
 func NewTagWithDefaults() *Tag {
-    this := Tag{}
-    return &this
+	this := Tag{}
+	return &this
 }
 
 // GetId returns the Id field value if set, zero value otherwise.
@@ -45,14 +45,14 @@ func (o *Tag) GetId() int64 {
 	return *o.Id
 }
 
-// GetIdOk returns a tuple with the Id field value if set, zero value otherwise
+// GetIdOk returns a tuple with the Id field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *Tag) GetIdOk() (int64, bool) {
+
+func (o *Tag) GetIdOk() (*int64, bool) {
 	if o == nil || o.Id == nil {
-		var ret int64
-		return ret, false
+		return nil, false
 	}
-	return *o.Id, true
+	return o.Id, true
 }
 
 // HasId returns a boolean if a field has been set.
@@ -78,14 +78,14 @@ func (o *Tag) GetName() string {
 	return *o.Name
 }
 
-// GetNameOk returns a tuple with the Name field value if set, zero value otherwise
+// GetNameOk returns a tuple with the Name field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *Tag) GetNameOk() (string, bool) {
+
+func (o *Tag) GetNameOk() (*string, bool) {
 	if o == nil || o.Name == nil {
-		var ret string
-		return ret, false
+		return nil, false
 	}
-	return *o.Name, true
+	return o.Name, true
 }
 
 // HasName returns a boolean if a field has been set.

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_tag.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_tag.go
@@ -52,12 +52,12 @@ func (o *Tag) GetIdOk() (int64, bool) {
 		var ret int64
 		return ret, false
 	}
-    return *o.Id, true
+	return *o.Id, true
 }
 
 // HasId returns a boolean if a field has been set.
 func (o *Tag) HasId() bool {
-    if o != nil && o.Id != nil {
+	if o != nil && o.Id != nil {
 		return true
 	}
 
@@ -85,12 +85,12 @@ func (o *Tag) GetNameOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-    return *o.Name, true
+	return *o.Name, true
 }
 
 // HasName returns a boolean if a field has been set.
 func (o *Tag) HasName() bool {
-    if o != nil && o.Name != nil {
+	if o != nil && o.Name != nil {
 		return true
 	}
 
@@ -103,14 +103,14 @@ func (o *Tag) SetName(v string) {
 }
 
 func (o Tag) MarshalJSON() ([]byte, error) {
-    toSerialize := map[string]interface{}{}
-    if o.Id != nil {
-        toSerialize["id"] = o.Id
-    }
-    if o.Name != nil {
-        toSerialize["name"] = o.Name
-    }
-    return json.Marshal(toSerialize)
+	toSerialize := map[string]interface{}{}
+	if o.Id != nil {
+		toSerialize["id"] = o.Id
+	}
+	if o.Name != nil {
+		toSerialize["name"] = o.Name
+	}
+	return json.Marshal(toSerialize)
 }
 
 type NullableTag struct {
@@ -119,32 +119,32 @@ type NullableTag struct {
 }
 
 func (v NullableTag) Get() *Tag {
-    return v.value
+	return v.value
 }
 
 func (v NullableTag) Set(val *Tag) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableTag) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableTag) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableTag(val *Tag) *NullableTag {
-    return &NullableTag{value: val, isSet: true}
+	return &NullableTag{value: val, isSet: true}
 }
 
 func (v NullableTag) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableTag) UnmarshalJSON(src []byte) error {
-    v.isSet = true
+	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_tag.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_tag.go
@@ -122,7 +122,7 @@ func (v NullableTag) Get() *Tag {
 	return v.value
 }
 
-func (v NullableTag) Set(val *Tag) {
+func (v *NullableTag) Set(val *Tag) {
 	v.value = val
 	v.isSet = true
 }
@@ -131,7 +131,7 @@ func (v NullableTag) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableTag) Unset() {
+func (v *NullableTag) Unset() {
 	v.value = nil
 	v.isSet = false
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_tag.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_tag.go
@@ -10,7 +10,6 @@
 package petstore
 
 import (
-	"bytes"
 	"encoding/json"
 )
 
@@ -53,12 +52,12 @@ func (o *Tag) GetIdOk() (int64, bool) {
 		var ret int64
 		return ret, false
 	}
-	return *o.Id, true
+    return *o.Id, true
 }
 
 // HasId returns a boolean if a field has been set.
 func (o *Tag) HasId() bool {
-	if o != nil && o.Id != nil {
+    if o != nil && o.Id != nil {
 		return true
 	}
 
@@ -86,12 +85,12 @@ func (o *Tag) GetNameOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-	return *o.Name, true
+    return *o.Name, true
 }
 
 // HasName returns a boolean if a field has been set.
 func (o *Tag) HasName() bool {
-	if o != nil && o.Name != nil {
+    if o != nil && o.Name != nil {
 		return true
 	}
 
@@ -103,25 +102,49 @@ func (o *Tag) SetName(v string) {
 	o.Name = &v
 }
 
+func (o Tag) MarshalJSON() ([]byte, error) {
+    toSerialize := map[string]interface{}{}
+    if o.Id != nil {
+        toSerialize["id"] = o.Id
+    }
+    if o.Name != nil {
+        toSerialize["name"] = o.Name
+    }
+    return json.Marshal(toSerialize)
+}
+
 type NullableTag struct {
-	Value Tag
-	ExplicitNull bool
+	value *Tag
+	isSet bool
+}
+
+func (v NullableTag) Get() *Tag {
+    return v.value
+}
+
+func (v NullableTag) Set(val *Tag) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableTag) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableTag) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableTag(val *Tag) *NullableTag {
+    return &NullableTag{value: val, isSet: true}
 }
 
 func (v NullableTag) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-		return json.Marshal(v.Value)
-	}
+    return json.Marshal(v.value)
 }
 
 func (v *NullableTag) UnmarshalJSON(src []byte) error {
-	if bytes.Equal(src, []byte("null")) {
-		v.ExplicitNull = true
-		return nil
-	}
-
-	return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_user.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_user.go
@@ -345,7 +345,7 @@ func (v NullableUser) Get() *User {
 	return v.value
 }
 
-func (v NullableUser) Set(val *User) {
+func (v *NullableUser) Set(val *User) {
 	v.value = val
 	v.isSet = true
 }
@@ -354,7 +354,7 @@ func (v NullableUser) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableUser) Unset() {
+func (v *NullableUser) Unset() {
 	v.value = nil
 	v.isSet = false
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_user.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_user.go
@@ -59,12 +59,12 @@ func (o *User) GetIdOk() (int64, bool) {
 		var ret int64
 		return ret, false
 	}
-    return *o.Id, true
+	return *o.Id, true
 }
 
 // HasId returns a boolean if a field has been set.
 func (o *User) HasId() bool {
-    if o != nil && o.Id != nil {
+	if o != nil && o.Id != nil {
 		return true
 	}
 
@@ -92,12 +92,12 @@ func (o *User) GetUsernameOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-    return *o.Username, true
+	return *o.Username, true
 }
 
 // HasUsername returns a boolean if a field has been set.
 func (o *User) HasUsername() bool {
-    if o != nil && o.Username != nil {
+	if o != nil && o.Username != nil {
 		return true
 	}
 
@@ -125,12 +125,12 @@ func (o *User) GetFirstNameOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-    return *o.FirstName, true
+	return *o.FirstName, true
 }
 
 // HasFirstName returns a boolean if a field has been set.
 func (o *User) HasFirstName() bool {
-    if o != nil && o.FirstName != nil {
+	if o != nil && o.FirstName != nil {
 		return true
 	}
 
@@ -158,12 +158,12 @@ func (o *User) GetLastNameOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-    return *o.LastName, true
+	return *o.LastName, true
 }
 
 // HasLastName returns a boolean if a field has been set.
 func (o *User) HasLastName() bool {
-    if o != nil && o.LastName != nil {
+	if o != nil && o.LastName != nil {
 		return true
 	}
 
@@ -191,12 +191,12 @@ func (o *User) GetEmailOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-    return *o.Email, true
+	return *o.Email, true
 }
 
 // HasEmail returns a boolean if a field has been set.
 func (o *User) HasEmail() bool {
-    if o != nil && o.Email != nil {
+	if o != nil && o.Email != nil {
 		return true
 	}
 
@@ -224,12 +224,12 @@ func (o *User) GetPasswordOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-    return *o.Password, true
+	return *o.Password, true
 }
 
 // HasPassword returns a boolean if a field has been set.
 func (o *User) HasPassword() bool {
-    if o != nil && o.Password != nil {
+	if o != nil && o.Password != nil {
 		return true
 	}
 
@@ -257,12 +257,12 @@ func (o *User) GetPhoneOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-    return *o.Phone, true
+	return *o.Phone, true
 }
 
 // HasPhone returns a boolean if a field has been set.
 func (o *User) HasPhone() bool {
-    if o != nil && o.Phone != nil {
+	if o != nil && o.Phone != nil {
 		return true
 	}
 
@@ -290,12 +290,12 @@ func (o *User) GetUserStatusOk() (int32, bool) {
 		var ret int32
 		return ret, false
 	}
-    return *o.UserStatus, true
+	return *o.UserStatus, true
 }
 
 // HasUserStatus returns a boolean if a field has been set.
 func (o *User) HasUserStatus() bool {
-    if o != nil && o.UserStatus != nil {
+	if o != nil && o.UserStatus != nil {
 		return true
 	}
 
@@ -308,32 +308,32 @@ func (o *User) SetUserStatus(v int32) {
 }
 
 func (o User) MarshalJSON() ([]byte, error) {
-    toSerialize := map[string]interface{}{}
-    if o.Id != nil {
-        toSerialize["id"] = o.Id
-    }
-    if o.Username != nil {
-        toSerialize["username"] = o.Username
-    }
-    if o.FirstName != nil {
-        toSerialize["firstName"] = o.FirstName
-    }
-    if o.LastName != nil {
-        toSerialize["lastName"] = o.LastName
-    }
-    if o.Email != nil {
-        toSerialize["email"] = o.Email
-    }
-    if o.Password != nil {
-        toSerialize["password"] = o.Password
-    }
-    if o.Phone != nil {
-        toSerialize["phone"] = o.Phone
-    }
-    if o.UserStatus != nil {
-        toSerialize["userStatus"] = o.UserStatus
-    }
-    return json.Marshal(toSerialize)
+	toSerialize := map[string]interface{}{}
+	if o.Id != nil {
+		toSerialize["id"] = o.Id
+	}
+	if o.Username != nil {
+		toSerialize["username"] = o.Username
+	}
+	if o.FirstName != nil {
+		toSerialize["firstName"] = o.FirstName
+	}
+	if o.LastName != nil {
+		toSerialize["lastName"] = o.LastName
+	}
+	if o.Email != nil {
+		toSerialize["email"] = o.Email
+	}
+	if o.Password != nil {
+		toSerialize["password"] = o.Password
+	}
+	if o.Phone != nil {
+		toSerialize["phone"] = o.Phone
+	}
+	if o.UserStatus != nil {
+		toSerialize["userStatus"] = o.UserStatus
+	}
+	return json.Marshal(toSerialize)
 }
 
 type NullableUser struct {
@@ -342,32 +342,32 @@ type NullableUser struct {
 }
 
 func (v NullableUser) Get() *User {
-    return v.value
+	return v.value
 }
 
 func (v NullableUser) Set(val *User) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableUser) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableUser) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableUser(val *User) *NullableUser {
-    return &NullableUser{value: val, isSet: true}
+	return &NullableUser{value: val, isSet: true}
 }
 
 func (v NullableUser) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableUser) UnmarshalJSON(src []byte) error {
-    v.isSet = true
+	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_user.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_user.go
@@ -54,7 +54,6 @@ func (o *User) GetId() int64 {
 
 // GetIdOk returns a tuple with the Id field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *User) GetIdOk() (*int64, bool) {
 	if o == nil || o.Id == nil {
 		return nil, false
@@ -87,7 +86,6 @@ func (o *User) GetUsername() string {
 
 // GetUsernameOk returns a tuple with the Username field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *User) GetUsernameOk() (*string, bool) {
 	if o == nil || o.Username == nil {
 		return nil, false
@@ -120,7 +118,6 @@ func (o *User) GetFirstName() string {
 
 // GetFirstNameOk returns a tuple with the FirstName field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *User) GetFirstNameOk() (*string, bool) {
 	if o == nil || o.FirstName == nil {
 		return nil, false
@@ -153,7 +150,6 @@ func (o *User) GetLastName() string {
 
 // GetLastNameOk returns a tuple with the LastName field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *User) GetLastNameOk() (*string, bool) {
 	if o == nil || o.LastName == nil {
 		return nil, false
@@ -186,7 +182,6 @@ func (o *User) GetEmail() string {
 
 // GetEmailOk returns a tuple with the Email field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *User) GetEmailOk() (*string, bool) {
 	if o == nil || o.Email == nil {
 		return nil, false
@@ -219,7 +214,6 @@ func (o *User) GetPassword() string {
 
 // GetPasswordOk returns a tuple with the Password field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *User) GetPasswordOk() (*string, bool) {
 	if o == nil || o.Password == nil {
 		return nil, false
@@ -252,7 +246,6 @@ func (o *User) GetPhone() string {
 
 // GetPhoneOk returns a tuple with the Phone field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *User) GetPhoneOk() (*string, bool) {
 	if o == nil || o.Phone == nil {
 		return nil, false
@@ -285,7 +278,6 @@ func (o *User) GetUserStatus() int32 {
 
 // GetUserStatusOk returns a tuple with the UserStatus field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-
 func (o *User) GetUserStatusOk() (*int32, bool) {
 	if o == nil || o.UserStatus == nil {
 		return nil, false

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_user.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_user.go
@@ -10,7 +10,6 @@
 package petstore
 
 import (
-	"bytes"
 	"encoding/json"
 )
 
@@ -60,12 +59,12 @@ func (o *User) GetIdOk() (int64, bool) {
 		var ret int64
 		return ret, false
 	}
-	return *o.Id, true
+    return *o.Id, true
 }
 
 // HasId returns a boolean if a field has been set.
 func (o *User) HasId() bool {
-	if o != nil && o.Id != nil {
+    if o != nil && o.Id != nil {
 		return true
 	}
 
@@ -93,12 +92,12 @@ func (o *User) GetUsernameOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-	return *o.Username, true
+    return *o.Username, true
 }
 
 // HasUsername returns a boolean if a field has been set.
 func (o *User) HasUsername() bool {
-	if o != nil && o.Username != nil {
+    if o != nil && o.Username != nil {
 		return true
 	}
 
@@ -126,12 +125,12 @@ func (o *User) GetFirstNameOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-	return *o.FirstName, true
+    return *o.FirstName, true
 }
 
 // HasFirstName returns a boolean if a field has been set.
 func (o *User) HasFirstName() bool {
-	if o != nil && o.FirstName != nil {
+    if o != nil && o.FirstName != nil {
 		return true
 	}
 
@@ -159,12 +158,12 @@ func (o *User) GetLastNameOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-	return *o.LastName, true
+    return *o.LastName, true
 }
 
 // HasLastName returns a boolean if a field has been set.
 func (o *User) HasLastName() bool {
-	if o != nil && o.LastName != nil {
+    if o != nil && o.LastName != nil {
 		return true
 	}
 
@@ -192,12 +191,12 @@ func (o *User) GetEmailOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-	return *o.Email, true
+    return *o.Email, true
 }
 
 // HasEmail returns a boolean if a field has been set.
 func (o *User) HasEmail() bool {
-	if o != nil && o.Email != nil {
+    if o != nil && o.Email != nil {
 		return true
 	}
 
@@ -225,12 +224,12 @@ func (o *User) GetPasswordOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-	return *o.Password, true
+    return *o.Password, true
 }
 
 // HasPassword returns a boolean if a field has been set.
 func (o *User) HasPassword() bool {
-	if o != nil && o.Password != nil {
+    if o != nil && o.Password != nil {
 		return true
 	}
 
@@ -258,12 +257,12 @@ func (o *User) GetPhoneOk() (string, bool) {
 		var ret string
 		return ret, false
 	}
-	return *o.Phone, true
+    return *o.Phone, true
 }
 
 // HasPhone returns a boolean if a field has been set.
 func (o *User) HasPhone() bool {
-	if o != nil && o.Phone != nil {
+    if o != nil && o.Phone != nil {
 		return true
 	}
 
@@ -291,12 +290,12 @@ func (o *User) GetUserStatusOk() (int32, bool) {
 		var ret int32
 		return ret, false
 	}
-	return *o.UserStatus, true
+    return *o.UserStatus, true
 }
 
 // HasUserStatus returns a boolean if a field has been set.
 func (o *User) HasUserStatus() bool {
-	if o != nil && o.UserStatus != nil {
+    if o != nil && o.UserStatus != nil {
 		return true
 	}
 
@@ -308,25 +307,67 @@ func (o *User) SetUserStatus(v int32) {
 	o.UserStatus = &v
 }
 
+func (o User) MarshalJSON() ([]byte, error) {
+    toSerialize := map[string]interface{}{}
+    if o.Id != nil {
+        toSerialize["id"] = o.Id
+    }
+    if o.Username != nil {
+        toSerialize["username"] = o.Username
+    }
+    if o.FirstName != nil {
+        toSerialize["firstName"] = o.FirstName
+    }
+    if o.LastName != nil {
+        toSerialize["lastName"] = o.LastName
+    }
+    if o.Email != nil {
+        toSerialize["email"] = o.Email
+    }
+    if o.Password != nil {
+        toSerialize["password"] = o.Password
+    }
+    if o.Phone != nil {
+        toSerialize["phone"] = o.Phone
+    }
+    if o.UserStatus != nil {
+        toSerialize["userStatus"] = o.UserStatus
+    }
+    return json.Marshal(toSerialize)
+}
+
 type NullableUser struct {
-	Value User
-	ExplicitNull bool
+	value *User
+	isSet bool
+}
+
+func (v NullableUser) Get() *User {
+    return v.value
+}
+
+func (v NullableUser) Set(val *User) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableUser) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableUser) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableUser(val *User) *NullableUser {
+    return &NullableUser{value: val, isSet: true}
 }
 
 func (v NullableUser) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-		return json.Marshal(v.Value)
-	}
+    return json.Marshal(v.value)
 }
 
 func (v *NullableUser) UnmarshalJSON(src []byte) error {
-	if bytes.Equal(src, []byte("null")) {
-		v.ExplicitNull = true
-		return nil
-	}
-
-	return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_user.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_user.go
@@ -31,16 +31,16 @@ type User struct {
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
 func NewUser() *User {
-    this := User{}
-    return &this
+	this := User{}
+	return &this
 }
 
 // NewUserWithDefaults instantiates a new User object
 // This constructor will only assign default values to properties that have it defined,
 // but it doesn't guarantee that properties required by API are set
 func NewUserWithDefaults() *User {
-    this := User{}
-    return &this
+	this := User{}
+	return &this
 }
 
 // GetId returns the Id field value if set, zero value otherwise.
@@ -52,14 +52,14 @@ func (o *User) GetId() int64 {
 	return *o.Id
 }
 
-// GetIdOk returns a tuple with the Id field value if set, zero value otherwise
+// GetIdOk returns a tuple with the Id field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *User) GetIdOk() (int64, bool) {
+
+func (o *User) GetIdOk() (*int64, bool) {
 	if o == nil || o.Id == nil {
-		var ret int64
-		return ret, false
+		return nil, false
 	}
-	return *o.Id, true
+	return o.Id, true
 }
 
 // HasId returns a boolean if a field has been set.
@@ -85,14 +85,14 @@ func (o *User) GetUsername() string {
 	return *o.Username
 }
 
-// GetUsernameOk returns a tuple with the Username field value if set, zero value otherwise
+// GetUsernameOk returns a tuple with the Username field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *User) GetUsernameOk() (string, bool) {
+
+func (o *User) GetUsernameOk() (*string, bool) {
 	if o == nil || o.Username == nil {
-		var ret string
-		return ret, false
+		return nil, false
 	}
-	return *o.Username, true
+	return o.Username, true
 }
 
 // HasUsername returns a boolean if a field has been set.
@@ -118,14 +118,14 @@ func (o *User) GetFirstName() string {
 	return *o.FirstName
 }
 
-// GetFirstNameOk returns a tuple with the FirstName field value if set, zero value otherwise
+// GetFirstNameOk returns a tuple with the FirstName field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *User) GetFirstNameOk() (string, bool) {
+
+func (o *User) GetFirstNameOk() (*string, bool) {
 	if o == nil || o.FirstName == nil {
-		var ret string
-		return ret, false
+		return nil, false
 	}
-	return *o.FirstName, true
+	return o.FirstName, true
 }
 
 // HasFirstName returns a boolean if a field has been set.
@@ -151,14 +151,14 @@ func (o *User) GetLastName() string {
 	return *o.LastName
 }
 
-// GetLastNameOk returns a tuple with the LastName field value if set, zero value otherwise
+// GetLastNameOk returns a tuple with the LastName field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *User) GetLastNameOk() (string, bool) {
+
+func (o *User) GetLastNameOk() (*string, bool) {
 	if o == nil || o.LastName == nil {
-		var ret string
-		return ret, false
+		return nil, false
 	}
-	return *o.LastName, true
+	return o.LastName, true
 }
 
 // HasLastName returns a boolean if a field has been set.
@@ -184,14 +184,14 @@ func (o *User) GetEmail() string {
 	return *o.Email
 }
 
-// GetEmailOk returns a tuple with the Email field value if set, zero value otherwise
+// GetEmailOk returns a tuple with the Email field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *User) GetEmailOk() (string, bool) {
+
+func (o *User) GetEmailOk() (*string, bool) {
 	if o == nil || o.Email == nil {
-		var ret string
-		return ret, false
+		return nil, false
 	}
-	return *o.Email, true
+	return o.Email, true
 }
 
 // HasEmail returns a boolean if a field has been set.
@@ -217,14 +217,14 @@ func (o *User) GetPassword() string {
 	return *o.Password
 }
 
-// GetPasswordOk returns a tuple with the Password field value if set, zero value otherwise
+// GetPasswordOk returns a tuple with the Password field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *User) GetPasswordOk() (string, bool) {
+
+func (o *User) GetPasswordOk() (*string, bool) {
 	if o == nil || o.Password == nil {
-		var ret string
-		return ret, false
+		return nil, false
 	}
-	return *o.Password, true
+	return o.Password, true
 }
 
 // HasPassword returns a boolean if a field has been set.
@@ -250,14 +250,14 @@ func (o *User) GetPhone() string {
 	return *o.Phone
 }
 
-// GetPhoneOk returns a tuple with the Phone field value if set, zero value otherwise
+// GetPhoneOk returns a tuple with the Phone field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *User) GetPhoneOk() (string, bool) {
+
+func (o *User) GetPhoneOk() (*string, bool) {
 	if o == nil || o.Phone == nil {
-		var ret string
-		return ret, false
+		return nil, false
 	}
-	return *o.Phone, true
+	return o.Phone, true
 }
 
 // HasPhone returns a boolean if a field has been set.
@@ -283,14 +283,14 @@ func (o *User) GetUserStatus() int32 {
 	return *o.UserStatus
 }
 
-// GetUserStatusOk returns a tuple with the UserStatus field value if set, zero value otherwise
+// GetUserStatusOk returns a tuple with the UserStatus field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *User) GetUserStatusOk() (int32, bool) {
+
+func (o *User) GetUserStatusOk() (*int32, bool) {
 	if o == nil || o.UserStatus == nil {
-		var ret int32
-		return ret, false
+		return nil, false
 	}
-	return *o.UserStatus, true
+	return o.UserStatus, true
 }
 
 // HasUserStatus returns a boolean if a field has been set.

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/utils.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/utils.go
@@ -10,13 +10,9 @@
 package petstore
 
 import (
-    "bytes"
     "encoding/json"
-    "errors"
     "time"
 )
-
-var ErrInvalidNullable = errors.New("nullable cannot have non-zero Value and ExplicitNull simultaneously")
 
 // PtrBool is a helper routine that returns a pointer to given integer value.
 func PtrBool(v bool) *bool { return &v }
@@ -43,202 +39,296 @@ func PtrString(v string) *string { return &v }
 func PtrTime(v time.Time) *time.Time { return &v }
 
 type NullableBool struct {
-    Value bool
-    ExplicitNull bool
+    value *bool
+    isSet bool
+}
+
+func (v NullableBool) Get() *bool {
+    return v.value
+}
+
+func (v NullableBool) Set(val *bool) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableBool) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableBool) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableBool(val *bool) *NullableBool {
+    return &NullableBool{value: val, isSet: true}
 }
 
 func (v NullableBool) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull && v.Value:
-        return nil, ErrInvalidNullable
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-        return json.Marshal(v.Value)
-    }
+    return json.Marshal(v.value)
 }
 
 func (v *NullableBool) UnmarshalJSON(src []byte) error {
-    if bytes.Equal(src, []byte("null")) {
-        v.ExplicitNull = true
-        return nil
-    }
-
-    return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+    return json.Unmarshal(src, &v.value)
 }
 
+
 type NullableInt struct {
-    Value int
-    ExplicitNull bool
+    value *int
+    isSet bool
+}
+
+func (v NullableInt) Get() *int {
+    return v.value
+}
+
+func (v NullableInt) Set(val *int) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableInt) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableInt) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableInt(val *int) *NullableInt {
+    return &NullableInt{value: val, isSet: true}
 }
 
 func (v NullableInt) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull && v.Value != 0:
-        return nil, ErrInvalidNullable
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-        return json.Marshal(v.Value)
-    }
+    return json.Marshal(v.value)
 }
-
 
 func (v *NullableInt) UnmarshalJSON(src []byte) error {
-    if bytes.Equal(src, []byte("null")) {
-        v.ExplicitNull = true
-        return nil
-    }
-
-    return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+    return json.Unmarshal(src, &v.value)
 }
 
+
 type NullableInt32 struct {
-    Value int32
-    ExplicitNull bool
+    value *int32
+    isSet bool
+}
+
+func (v NullableInt32) Get() *int32 {
+    return v.value
+}
+
+func (v NullableInt32) Set(val *int32) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableInt32) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableInt32) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableInt32(val *int32) *NullableInt32 {
+    return &NullableInt32{value: val, isSet: true}
 }
 
 func (v NullableInt32) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull && v.Value != 0:
-        return nil, ErrInvalidNullable
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-        return json.Marshal(v.Value)
-    }
+    return json.Marshal(v.value)
 }
 
 func (v *NullableInt32) UnmarshalJSON(src []byte) error {
-    if bytes.Equal(src, []byte("null")) {
-        v.ExplicitNull = true
-        return nil
-    }
-
-    return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+    return json.Unmarshal(src, &v.value)
 }
 
+
 type NullableInt64 struct {
-    Value int64
-    ExplicitNull bool
+    value *int64
+    isSet bool
+}
+
+func (v NullableInt64) Get() *int64 {
+    return v.value
+}
+
+func (v NullableInt64) Set(val *int64) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableInt64) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableInt64) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableInt64(val *int64) *NullableInt64 {
+    return &NullableInt64{value: val, isSet: true}
 }
 
 func (v NullableInt64) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull && v.Value != 0:
-        return nil, ErrInvalidNullable
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-        return json.Marshal(v.Value)
-    }
+    return json.Marshal(v.value)
 }
 
 func (v *NullableInt64) UnmarshalJSON(src []byte) error {
-    if bytes.Equal(src, []byte("null")) {
-        v.ExplicitNull = true
-        return nil
-    }
-
-    return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+    return json.Unmarshal(src, &v.value)
 }
 
+
 type NullableFloat32 struct {
-    Value float32
-    ExplicitNull bool
+    value *float32
+    isSet bool
+}
+
+func (v NullableFloat32) Get() *float32 {
+    return v.value
+}
+
+func (v NullableFloat32) Set(val *float32) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableFloat32) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableFloat32) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableFloat32(val *float32) *NullableFloat32 {
+    return &NullableFloat32{value: val, isSet: true}
 }
 
 func (v NullableFloat32) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull && v.Value != 0.0:
-        return nil, ErrInvalidNullable
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-        return json.Marshal(v.Value)
-    }
+    return json.Marshal(v.value)
 }
 
 func (v *NullableFloat32) UnmarshalJSON(src []byte) error {
-    if bytes.Equal(src, []byte("null")) {
-        v.ExplicitNull = true
-        return nil
-    }
-
-    return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+    return json.Unmarshal(src, &v.value)
 }
 
+
 type NullableFloat64 struct {
-    Value float64
-    ExplicitNull bool
+    value *float64
+    isSet bool
+}
+
+func (v NullableFloat64) Get() *float64 {
+    return v.value
+}
+
+func (v NullableFloat64) Set(val *float64) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableFloat64) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableFloat64) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableFloat64(val *float64) *NullableFloat64 {
+    return &NullableFloat64{value: val, isSet: true}
 }
 
 func (v NullableFloat64) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull && v.Value != 0.0:
-        return nil, ErrInvalidNullable
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-        return json.Marshal(v.Value)
-    }
+    return json.Marshal(v.value)
 }
 
 func (v *NullableFloat64) UnmarshalJSON(src []byte) error {
-    if bytes.Equal(src, []byte("null")) {
-        v.ExplicitNull = true
-        return nil
-    }
-
-    return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+    return json.Unmarshal(src, &v.value)
 }
 
+
 type NullableString struct {
-    Value string
-    ExplicitNull bool
+    value *string
+    isSet bool
+}
+
+func (v NullableString) Get() *string {
+    return v.value
+}
+
+func (v NullableString) Set(val *string) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableString) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableString) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableString(val *string) *NullableString {
+    return &NullableString{value: val, isSet: true}
 }
 
 func (v NullableString) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull && v.Value != "":
-        return nil, ErrInvalidNullable
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-        return json.Marshal(v.Value)
-    }
+    return json.Marshal(v.value)
 }
 
 func (v *NullableString) UnmarshalJSON(src []byte) error {
-    if bytes.Equal(src, []byte("null")) {
-        v.ExplicitNull = true
-        return nil
-    }
-
-    return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+    return json.Unmarshal(src, &v.value)
 }
 
+
 type NullableTime struct {
-    Value time.Time
-    ExplicitNull bool
+    value *time.Time
+    isSet bool
+}
+
+func (v NullableTime) Get() *time.Time {
+    return v.value
+}
+
+func (v NullableTime) Set(val *time.Time) {
+    v.value = val
+    v.isSet = true
+}
+
+func (v NullableTime) IsSet() bool {
+    return v.isSet
+}
+
+func (v NullableTime) Unset() {
+    v.value = nil
+    v.isSet = false
+}
+
+func NewNullableTime(val *time.Time) *NullableTime {
+    return &NullableTime{value: val, isSet: true}
 }
 
 func (v NullableTime) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull && !v.Value.IsZero():
-        return nil, ErrInvalidNullable
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-        return v.Value.MarshalJSON()
-    }
+    return v.value.MarshalJSON()
 }
 
 func (v *NullableTime) UnmarshalJSON(src []byte) error {
-    if bytes.Equal(src, []byte("null")) {
-        v.ExplicitNull = true
-        return nil
-    }
-
-    return json.Unmarshal(src, &v.Value)
+    v.isSet = true
+    return json.Unmarshal(src, &v.value)
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/utils.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/utils.go
@@ -47,7 +47,7 @@ func (v NullableBool) Get() *bool {
 	return v.value
 }
 
-func (v NullableBool) Set(val *bool) {
+func (v *NullableBool) Set(val *bool) {
 	v.value = val
 	v.isSet = true
 }
@@ -56,7 +56,7 @@ func (v NullableBool) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableBool) Unset() {
+func (v *NullableBool) Unset() {
 	v.value = nil
 	v.isSet = false
 }
@@ -84,7 +84,7 @@ func (v NullableInt) Get() *int {
 	return v.value
 }
 
-func (v NullableInt) Set(val *int) {
+func (v *NullableInt) Set(val *int) {
 	v.value = val
 	v.isSet = true
 }
@@ -93,7 +93,7 @@ func (v NullableInt) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableInt) Unset() {
+func (v *NullableInt) Unset() {
 	v.value = nil
 	v.isSet = false
 }
@@ -121,7 +121,7 @@ func (v NullableInt32) Get() *int32 {
 	return v.value
 }
 
-func (v NullableInt32) Set(val *int32) {
+func (v *NullableInt32) Set(val *int32) {
 	v.value = val
 	v.isSet = true
 }
@@ -130,7 +130,7 @@ func (v NullableInt32) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableInt32) Unset() {
+func (v *NullableInt32) Unset() {
 	v.value = nil
 	v.isSet = false
 }
@@ -158,7 +158,7 @@ func (v NullableInt64) Get() *int64 {
 	return v.value
 }
 
-func (v NullableInt64) Set(val *int64) {
+func (v *NullableInt64) Set(val *int64) {
 	v.value = val
 	v.isSet = true
 }
@@ -167,7 +167,7 @@ func (v NullableInt64) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableInt64) Unset() {
+func (v *NullableInt64) Unset() {
 	v.value = nil
 	v.isSet = false
 }
@@ -195,7 +195,7 @@ func (v NullableFloat32) Get() *float32 {
 	return v.value
 }
 
-func (v NullableFloat32) Set(val *float32) {
+func (v *NullableFloat32) Set(val *float32) {
 	v.value = val
 	v.isSet = true
 }
@@ -204,7 +204,7 @@ func (v NullableFloat32) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableFloat32) Unset() {
+func (v *NullableFloat32) Unset() {
 	v.value = nil
 	v.isSet = false
 }
@@ -232,7 +232,7 @@ func (v NullableFloat64) Get() *float64 {
 	return v.value
 }
 
-func (v NullableFloat64) Set(val *float64) {
+func (v *NullableFloat64) Set(val *float64) {
 	v.value = val
 	v.isSet = true
 }
@@ -241,7 +241,7 @@ func (v NullableFloat64) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableFloat64) Unset() {
+func (v *NullableFloat64) Unset() {
 	v.value = nil
 	v.isSet = false
 }
@@ -269,7 +269,7 @@ func (v NullableString) Get() *string {
 	return v.value
 }
 
-func (v NullableString) Set(val *string) {
+func (v *NullableString) Set(val *string) {
 	v.value = val
 	v.isSet = true
 }
@@ -278,7 +278,7 @@ func (v NullableString) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableString) Unset() {
+func (v *NullableString) Unset() {
 	v.value = nil
 	v.isSet = false
 }
@@ -306,7 +306,7 @@ func (v NullableTime) Get() *time.Time {
 	return v.value
 }
 
-func (v NullableTime) Set(val *time.Time) {
+func (v *NullableTime) Set(val *time.Time) {
 	v.value = val
 	v.isSet = true
 }
@@ -315,7 +315,7 @@ func (v NullableTime) IsSet() bool {
 	return v.isSet
 }
 
-func (v NullableTime) Unset() {
+func (v *NullableTime) Unset() {
 	v.value = nil
 	v.isSet = false
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/utils.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/utils.go
@@ -10,8 +10,8 @@
 package petstore
 
 import (
-    "encoding/json"
-    "time"
+	"encoding/json"
+	"time"
 )
 
 // PtrBool is a helper routine that returns a pointer to given integer value.
@@ -39,296 +39,296 @@ func PtrString(v string) *string { return &v }
 func PtrTime(v time.Time) *time.Time { return &v }
 
 type NullableBool struct {
-    value *bool
-    isSet bool
+	value *bool
+	isSet bool
 }
 
 func (v NullableBool) Get() *bool {
-    return v.value
+	return v.value
 }
 
 func (v NullableBool) Set(val *bool) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableBool) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableBool) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableBool(val *bool) *NullableBool {
-    return &NullableBool{value: val, isSet: true}
+	return &NullableBool{value: val, isSet: true}
 }
 
 func (v NullableBool) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableBool) UnmarshalJSON(src []byte) error {
-    v.isSet = true
-    return json.Unmarshal(src, &v.value)
+	v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }
 
 
 type NullableInt struct {
-    value *int
-    isSet bool
+	value *int
+	isSet bool
 }
 
 func (v NullableInt) Get() *int {
-    return v.value
+	return v.value
 }
 
 func (v NullableInt) Set(val *int) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableInt) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableInt) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableInt(val *int) *NullableInt {
-    return &NullableInt{value: val, isSet: true}
+	return &NullableInt{value: val, isSet: true}
 }
 
 func (v NullableInt) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableInt) UnmarshalJSON(src []byte) error {
-    v.isSet = true
-    return json.Unmarshal(src, &v.value)
+	v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }
 
 
 type NullableInt32 struct {
-    value *int32
-    isSet bool
+	value *int32
+	isSet bool
 }
 
 func (v NullableInt32) Get() *int32 {
-    return v.value
+	return v.value
 }
 
 func (v NullableInt32) Set(val *int32) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableInt32) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableInt32) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableInt32(val *int32) *NullableInt32 {
-    return &NullableInt32{value: val, isSet: true}
+	return &NullableInt32{value: val, isSet: true}
 }
 
 func (v NullableInt32) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableInt32) UnmarshalJSON(src []byte) error {
-    v.isSet = true
-    return json.Unmarshal(src, &v.value)
+	v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }
 
 
 type NullableInt64 struct {
-    value *int64
-    isSet bool
+	value *int64
+	isSet bool
 }
 
 func (v NullableInt64) Get() *int64 {
-    return v.value
+	return v.value
 }
 
 func (v NullableInt64) Set(val *int64) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableInt64) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableInt64) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableInt64(val *int64) *NullableInt64 {
-    return &NullableInt64{value: val, isSet: true}
+	return &NullableInt64{value: val, isSet: true}
 }
 
 func (v NullableInt64) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableInt64) UnmarshalJSON(src []byte) error {
-    v.isSet = true
-    return json.Unmarshal(src, &v.value)
+	v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }
 
 
 type NullableFloat32 struct {
-    value *float32
-    isSet bool
+	value *float32
+	isSet bool
 }
 
 func (v NullableFloat32) Get() *float32 {
-    return v.value
+	return v.value
 }
 
 func (v NullableFloat32) Set(val *float32) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableFloat32) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableFloat32) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableFloat32(val *float32) *NullableFloat32 {
-    return &NullableFloat32{value: val, isSet: true}
+	return &NullableFloat32{value: val, isSet: true}
 }
 
 func (v NullableFloat32) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableFloat32) UnmarshalJSON(src []byte) error {
-    v.isSet = true
-    return json.Unmarshal(src, &v.value)
+	v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }
 
 
 type NullableFloat64 struct {
-    value *float64
-    isSet bool
+	value *float64
+	isSet bool
 }
 
 func (v NullableFloat64) Get() *float64 {
-    return v.value
+	return v.value
 }
 
 func (v NullableFloat64) Set(val *float64) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableFloat64) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableFloat64) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableFloat64(val *float64) *NullableFloat64 {
-    return &NullableFloat64{value: val, isSet: true}
+	return &NullableFloat64{value: val, isSet: true}
 }
 
 func (v NullableFloat64) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableFloat64) UnmarshalJSON(src []byte) error {
-    v.isSet = true
-    return json.Unmarshal(src, &v.value)
+	v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }
 
 
 type NullableString struct {
-    value *string
-    isSet bool
+	value *string
+	isSet bool
 }
 
 func (v NullableString) Get() *string {
-    return v.value
+	return v.value
 }
 
 func (v NullableString) Set(val *string) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableString) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableString) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableString(val *string) *NullableString {
-    return &NullableString{value: val, isSet: true}
+	return &NullableString{value: val, isSet: true}
 }
 
 func (v NullableString) MarshalJSON() ([]byte, error) {
-    return json.Marshal(v.value)
+	return json.Marshal(v.value)
 }
 
 func (v *NullableString) UnmarshalJSON(src []byte) error {
-    v.isSet = true
-    return json.Unmarshal(src, &v.value)
+	v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }
 
 
 type NullableTime struct {
-    value *time.Time
-    isSet bool
+	value *time.Time
+	isSet bool
 }
 
 func (v NullableTime) Get() *time.Time {
-    return v.value
+	return v.value
 }
 
 func (v NullableTime) Set(val *time.Time) {
-    v.value = val
-    v.isSet = true
+	v.value = val
+	v.isSet = true
 }
 
 func (v NullableTime) IsSet() bool {
-    return v.isSet
+	return v.isSet
 }
 
 func (v NullableTime) Unset() {
-    v.value = nil
-    v.isSet = false
+	v.value = nil
+	v.isSet = false
 }
 
 func NewNullableTime(val *time.Time) *NullableTime {
-    return &NullableTime{value: val, isSet: true}
+	return &NullableTime{value: val, isSet: true}
 }
 
 func (v NullableTime) MarshalJSON() ([]byte, error) {
-    return v.value.MarshalJSON()
+	return v.value.MarshalJSON()
 }
 
 func (v *NullableTime) UnmarshalJSON(src []byte) error {
-    v.isSet = true
-    return json.Unmarshal(src, &v.value)
+	v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }

--- a/samples/openapi3/client/petstore/go-experimental/nullable_marshalling_test.go
+++ b/samples/openapi3/client/petstore/go-experimental/nullable_marshalling_test.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+    "encoding/json"
+    "fmt"
+    "testing"
+
+	sw "./go-petstore"
+)
+
+func TestNullableMarshalling(t *testing.T) {
+    var fv float32 = 1.1
+    nc := sw.NullableClass{
+        IntegerProp: *sw.NewNullableInt32(nil),
+        NumberProp: *sw.NewNullableFloat32(&fv),
+        // BooleanProp is also nullable, but we leave it unset, so it shouldn't be in the JSON
+    }
+    res, err := json.Marshal(nc)
+    if err != nil {
+        t.Errorf("Error while marshalling structure with Nullables: %v", err)
+    }
+    expected := `{"integer_prop":null,"number_prop":1.1}`
+    assertStringsEqual(t, expected, string(res))
+    // try unmarshalling now
+    var unc sw.NullableClass
+    err = json.Unmarshal(res, &unc)
+    if err != nil {
+        t.Errorf("Error while unmarshalling structure with Nullables: %v", err)
+    }
+    if unc.BooleanProp.IsSet() || unc.BooleanProp.Get() != nil {
+        t.Errorf("Unmarshalled BooleanProp not empty+unset: %+v", unc.BooleanProp)
+    }
+    if !unc.IntegerProp.IsSet() || unc.IntegerProp.Get() != nil {
+        t.Errorf("Unmarshalled IntegerProp not explicit null: %+v", unc.IntegerProp)
+    }
+    if !unc.NumberProp.IsSet() || *unc.NumberProp.Get() != fv {
+        t.Errorf("Unmarshalled NumberProp not set to value 1.1: %+v", unc.NumberProp)
+    }
+
+    // change the values a bit to make sure the Set/Unset methods work correctly
+    nc.IntegerProp.Unset()
+    bv := false
+    nc.BooleanProp.Set(&bv)
+    res, err = json.Marshal(nc)
+    if err != nil {
+        t.Errorf("Error while marshalling structure with Nullables: %v", err)
+    }
+    expected = `{"boolean_prop":false,"number_prop":1.1}`
+    assertStringsEqual(t, expected, string(res))
+    // try unmarshalling now
+    var unc2 sw.NullableClass
+    err = json.Unmarshal(res, &unc2)
+    if err != nil {
+        t.Errorf("Error while unmarshalling structure with Nullables: %v", err)
+    }
+    if !unc2.BooleanProp.IsSet() || *unc2.BooleanProp.Get() != false {
+        t.Errorf("Unmarshalled BooleanProp not empty+unset: %+v", unc2.BooleanProp)
+    }
+    if unc2.IntegerProp.IsSet() || unc2.IntegerProp.Get() != nil {
+        t.Errorf("Unmarshalled IntegerProp not explicit null: %+v", unc2.IntegerProp)
+    }
+    if !unc.NumberProp.IsSet() || *unc.NumberProp.Get() != fv {
+        t.Errorf("Unmarshalled NumberProp not set to value 1.1: %+v", unc.NumberProp)
+    }
+}
+
+func assertStringsEqual(t *testing.T, expected, actual string) {
+    if expected != actual {
+        t.Errorf(fmt.Sprintf("`%s` (expected) != `%s` (actual)", expected, actual))
+    }
+}


### PR DESCRIPTION
This fixes [1] while also making the support for explicit nulls much more similar to what we have for Java clients with jackson-databind-nullable.

Notes:
* Support for container fields is not implemented due to lack of generics in Go. This might become possible with more work, but I didn't want to further complicate this PR.
* The performance of generated clients might get hit a bit because of the newly added custom marshalling functions. This is a tradeoff taken to achieve correctness of the implementation (see the description of [1] for reasoning of why this is needed).

[1] https://github.com/OpenAPITools/openapi-generator/issues/5278

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@antihax (2017/11) @bvwells (2017/12) @grokify (2018/07) @kemokemo (2018/09) @bkabrda (2019/07)