### PR TITLE
Add reserved word option to Pistache and Restbed generators

### DIFF
--- a/docs/generators/cpp-pistache-server.md
+++ b/docs/generators/cpp-pistache-server.md
@@ -7,6 +7,7 @@ sidebar_label: cpp-pistache-server
 | ------ | ----------- | ------ | ------- |
 |addExternalLibs|Add the Possibility to fetch and compile external Libraries needed by this Framework.| |true|
 |helpersPackage|Specify the package name to be used for the helpers (e.g. org.openapitools.server.helpers).| |org.openapitools.server.helpers|
+|reservedWordPrefix|Prefix to prepend to reserved words in order to avoid conflicts| |r_|
 |useStructModel|Use struct-based model template instead of get/set-based model template| |false|
 
 ## IMPORT MAPPING

--- a/docs/generators/cpp-restbed-server.md
+++ b/docs/generators/cpp-restbed-server.md
@@ -10,6 +10,7 @@ sidebar_label: cpp-restbed-server
 |defaultInclude|The default include statement that should be placed in all headers for including things like the declspec (convention: #include &quot;Commons.h&quot; | ||
 |modelPackage|C++ namespace for models (convention: name.space.model).| |org.openapitools.server.model|
 |packageVersion|C++ package version.| |1.0.0|
+|reservedWordPrefix|Prefix to prepend to reserved words in order to avoid conflicts| |r_|
 
 ## IMPORT MAPPING
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppPistacheServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppPistacheServerCodegen.java
@@ -104,6 +104,7 @@ public class CppPistacheServerCodegen extends AbstractCppCodegen {
         cliOptions.clear();
         addSwitch(OPTIONAL_EXTERNAL_LIB, OPTIONAL_EXTERNAL_LIB_DESC, this.isAddExternalLibs);
         addOption(HELPERS_PACKAGE_NAME, HELPERS_PACKAGE_NAME_DESC, this.helpersPackage);
+        addOption(RESERVED_WORD_PREFIX_OPTION, RESERVED_WORD_PREFIX_DESC, this.reservedWordPrefix);
         addSwitch(OPTION_USE_STRUCT_MODEL, OPTION_USE_STRUCT_MODEL_DESC, this.isUseStructModel);
 
         reservedWords = new HashSet<>();
@@ -156,12 +157,18 @@ public class CppPistacheServerCodegen extends AbstractCppCodegen {
             supportingFiles.add(new SupportingFile("cmake.mustache", "", "CMakeLists.txt"));
             supportingFiles.add(new SupportingFile("README.mustache", "", "README.md"));
         }
+        if (additionalProperties.containsKey(RESERVED_WORD_PREFIX_OPTION))
+        {
+            reservedWordPrefix = (String) additionalProperties.get(RESERVED_WORD_PREFIX_OPTION);
+        }
+
         additionalProperties.put("modelNamespaceDeclarations", modelPackage.split("\\."));
         additionalProperties.put("modelNamespace", modelPackage.replaceAll("\\.", "::"));
         additionalProperties.put("apiNamespaceDeclarations", apiPackage.split("\\."));
         additionalProperties.put("apiNamespace", apiPackage.replaceAll("\\.", "::"));  
         additionalProperties.put("helpersNamespaceDeclarations", helpersPackage.split("\\."));
-        additionalProperties.put("helpersNamespace", helpersPackage.replaceAll("\\.", "::")); 
+        additionalProperties.put("helpersNamespace", helpersPackage.replaceAll("\\.", "::"));
+        additionalProperties.put(RESERVED_WORD_PREFIX_OPTION, reservedWordPrefix);
                 
         if (additionalProperties.containsKey(OPTIONAL_EXTERNAL_LIB)) {
             setAddExternalLibs(convertPropertyToBooleanAndWriteBack(OPTIONAL_EXTERNAL_LIB));

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppRestbedServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppRestbedServerCodegen.java
@@ -89,6 +89,9 @@ public class CppRestbedServerCodegen extends AbstractCppCodegen {
         addOption(DEFAULT_INCLUDE,
                 "The default include statement that should be placed in all headers for including things like the declspec (convention: #include \"Commons.h\" ",
                 this.defaultInclude);
+        addOption(RESERVED_WORD_PREFIX_OPTION,
+                RESERVED_WORD_PREFIX_DESC,
+                this.reservedWordPrefix);
 
         supportingFiles.add(new SupportingFile("gitignore.mustache", "", ".gitignore"));
         supportingFiles.add(new SupportingFile("git_push.sh.mustache", "", "git_push.sh"));
@@ -209,12 +212,17 @@ public class CppRestbedServerCodegen extends AbstractCppCodegen {
             defaultInclude = additionalProperties.get(DEFAULT_INCLUDE).toString();
         }
 
+        if (additionalProperties.containsKey(RESERVED_WORD_PREFIX_OPTION)) {
+            reservedWordPrefix = additionalProperties.get(RESERVED_WORD_PREFIX_OPTION).toString();
+        }
+
         additionalProperties.put("modelNamespaceDeclarations", modelPackage.split("\\."));
         additionalProperties.put("modelNamespace", modelPackage.replaceAll("\\.", "::"));
         additionalProperties.put("apiNamespaceDeclarations", apiPackage.split("\\."));
         additionalProperties.put("apiNamespace", apiPackage.replaceAll("\\.", "::"));
         additionalProperties.put("declspec", declspec);
         additionalProperties.put("defaultInclude", defaultInclude);
+        additionalProperties.put(RESERVED_WORD_PREFIX_OPTION, reservedWordPrefix);
     }
 
     /**


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

Completes a leftover task for #5269. That PR fixed issue #5268, but did not propagate the fix into all code generators, since some of them clear the base class's CLI options. This ensures that the added CLI option in the linked PR also appears in the Restbed and Pistache C++ generators.

<!-- Please check the completed items below -->
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [X] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
