### PR TITLE
[Ruby] Add error output

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractRubyCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractRubyCodegen.java
@@ -30,6 +30,7 @@ import org.slf4j.LoggerFactory;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Locale;
 
@@ -202,7 +203,7 @@ abstract public class AbstractRubyCodegen extends DefaultCodegen implements Code
                 Process p = Runtime.getRuntime().exec(command);
                 int exitValue = p.waitFor();
                 if (exitValue != 0) {
-                    BufferedReader br = new BufferedReader(new InputStreamReader(p.getErrorStream()));
+                    BufferedReader br = new BufferedReader(new InputStreamReader(p.getErrorStream(), StandardCharsets.UTF_8));
                     StringBuilder sb = new StringBuilder();
                     String line;
                     while ((line = br.readLine()) != null) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractRubyCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractRubyCodegen.java
@@ -27,7 +27,9 @@ import org.openapitools.codegen.utils.ModelUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.BufferedReader;
 import java.io.File;
+import java.io.InputStreamReader;
 import java.util.Arrays;
 import java.util.Locale;
 
@@ -200,7 +202,13 @@ abstract public class AbstractRubyCodegen extends DefaultCodegen implements Code
                 Process p = Runtime.getRuntime().exec(command);
                 int exitValue = p.waitFor();
                 if (exitValue != 0) {
-                    LOGGER.error("Error running the command ({}). Exit value: {}", command, exitValue);
+                    BufferedReader br = new BufferedReader(new InputStreamReader(p.getErrorStream()));
+                    StringBuilder sb = new StringBuilder();
+                    String line;
+                    while ((line = br.readLine()) != null) {
+                        sb.append(line);
+                    }
+                    LOGGER.error("Error running the command ({}). Exit value: {}, Error output: {}", command, exitValue, sb.toString());
                 } else {
                     LOGGER.info("Successfully executed: " + command);
                 }


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

Related issue: https://github.com/OpenAPITools/openapi-generator/issues/5417

Add error output to the log so that we can make sure why the error occured, when the command passed via RUBY_POST_PROCESS_FILE failed.

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.


```sh
# Rubocop
$ which rubocop
/usr/local/bin/rubocop
$ rubocop -v
0.80.0

# Generate ruby client with a RUBY_POST_PROCESS_FILE environment variable
$ env RUBY_POST_PROCESS_FILE="/usr/local/bin/rubocop -a" \
  java -jar modules/openapi-generator-cli/target/openapi-generator-cli.jar \
  generate \
  -g ruby \
  -o /tmp/issue/5417 \
  -i http://petstore.swagger.io:8080/api/v3/openapi.json \
  --enable-post-process-file
```

Before:
```
[main] ERROR o.o.c.languages.AbstractRubyCodegen - Error running the command (/usr/local/bin/rubocop -a /tmp/issue/5417/lib/openapi_client/models/address.rb). Exit value: 2
```

After:
the error output shows why rubocop resulted in error
```
[main] ERROR o.o.c.languages.AbstractRubyCodegen - Error running the command (/usr/local/bin/rubocop -a /tmp/issue/5417/lib/openapi_client/api_client.rb). Exit value: 2, Error output: Error: The `Layout/IndentFirstArgument` cop has been renamed to `Layout/FirstArgumentIndentation`.(obsolete configuration found in /tmp/issue/5417/.rubocop.yml, please update it)The `Layout/TrailingBlankLines` cop has been renamed to `Layout/TrailingEmptyLines`.(obsolete configuration found in /tmp/issue/5417/.rubocop.yml, please update it)The `Style/UnneededPercentQ` cop has been renamed to `Style/RedundantPercentQ`.(obsolete configuration found in /tmp/issue/5417/.rubocop.yml, please update it)The `Style/BracesAroundHashParameters` cop has been removed.(obsolete configuration found in /tmp/issue/5417/.rubocop.yml, please update it)obsolete `EnforcedStyle: rails` (for Layout/IndentationConsistency) found in /tmp/issue/5417/.rubocop.yml`EnforcedStyle: rails` has been renamed to `EnforcedStyle: indented_internal_methods`
```
