### PR TITLE
[Rust Server] Support RFC 7386

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustServerCodegen.java
@@ -72,6 +72,9 @@ public class RustServerCodegen extends DefaultCodegen implements CodegenConfig {
     private static final String plainTextMimeType = "text/plain";
     private static final String jsonMimeType = "application/json";
 
+    // RFC 7386 support
+    private static final String mergePatchJsonMimeType = "application/merge-patch+json";
+
     // RFC 7807 Support
     private static final String problemJsonMimeType = "application/problem+json";
     private static final String problemXmlMimeType = "application/problem+xml";
@@ -534,6 +537,7 @@ public class RustServerCodegen extends DefaultCodegen implements CodegenConfig {
 
     private boolean isMimetypeJson(String mimetype) {
         return mimetype.toLowerCase(Locale.ROOT).startsWith(jsonMimeType) ||
+               mimetype.toLowerCase(Locale.ROOT).startsWith(mergePatchJsonMimeType) ||
                mimetype.toLowerCase(Locale.ROOT).startsWith(problemJsonMimeType);
     }
 

--- a/modules/openapi-generator/src/test/resources/3_0/rust-server/openapi-v3.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/rust-server/openapi-v3.yaml
@@ -267,7 +267,15 @@ paths:
             application/problem+xml:
               schema:
                 $ref: '#/components/schemas/ObjectWithArrayOfObjects'
-
+  /merge-patch-json:
+    get:
+      responses:
+        200:
+          description: merge-patch+json-encoded response
+          content:
+            application/merge-patch+json:
+              schema:
+                $ref: "#/components/schemas/anotherXmlObject"
 components:
   securitySchemes:
     authScheme:

--- a/samples/server/petstore/rust-server/output/openapi-v3/README.md
+++ b/samples/server/petstore/rust-server/output/openapi-v3/README.md
@@ -62,6 +62,7 @@ To run a client, follow one of the following simple steps:
 
 ```
 cargo run --example client MandatoryRequestHeaderGet
+cargo run --example client MergePatchJsonGet
 cargo run --example client MultigetGet
 cargo run --example client MultipleAuthSchemeGet
 cargo run --example client ParamgetGet
@@ -110,6 +111,7 @@ All URIs are relative to *http://localhost*
 Method | HTTP request | Description
 ------------- | ------------- | -------------
 [****](docs/default_api.md#) | **GET** /mandatory-request-header | 
+[****](docs/default_api.md#) | **GET** /merge-patch-json | 
 [****](docs/default_api.md#) | **GET** /multiget | Get some stuff.
 [****](docs/default_api.md#) | **GET** /multiple_auth_scheme | 
 [****](docs/default_api.md#) | **GET** /paramget | Get some stuff with parameters.

--- a/samples/server/petstore/rust-server/output/openapi-v3/api/openapi.yaml
+++ b/samples/server/petstore/rust-server/output/openapi-v3/api/openapi.yaml
@@ -262,6 +262,15 @@ paths:
               schema:
                 $ref: '#/components/schemas/ObjectWithArrayOfObjects'
           description: NotAcceptable
+  /merge-patch-json:
+    get:
+      responses:
+        "200":
+          content:
+            application/merge-patch+json:
+              schema:
+                $ref: '#/components/schemas/anotherXmlObject'
+          description: merge-patch+json-encoded response
 components:
   schemas:
     EnumWithStarObject:

--- a/samples/server/petstore/rust-server/output/openapi-v3/docs/default_api.md
+++ b/samples/server/petstore/rust-server/output/openapi-v3/docs/default_api.md
@@ -5,6 +5,7 @@ All URIs are relative to *http://localhost*
 Method | HTTP request | Description
 ------------- | ------------- | -------------
 ****](default_api.md#) | **GET** /mandatory-request-header | 
+****](default_api.md#) | **GET** /merge-patch-json | 
 ****](default_api.md#) | **GET** /multiget | Get some stuff.
 ****](default_api.md#) | **GET** /multiple_auth_scheme | 
 ****](default_api.md#) | **GET** /paramget | Get some stuff with parameters.
@@ -43,6 +44,28 @@ No authorization required
 
  - **Content-Type**: Not defined
  - **Accept**: Not defined
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+# ****
+> models::AnotherXmlObject ()
+
+
+### Required Parameters
+This endpoint does not need any parameter.
+
+### Return type
+
+[**models::AnotherXmlObject**](anotherXmlObject.md)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: application/merge-patch+json, 
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 

--- a/samples/server/petstore/rust-server/output/openapi-v3/examples/client.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/examples/client.rs
@@ -15,6 +15,7 @@ use futures::{Future, future, Stream, stream};
 use openapi_v3::{Api, ApiNoContext, Client, ContextWrapperExt,
                       ApiError,
                       MandatoryRequestHeaderGetResponse,
+                      MergePatchJsonGetResponse,
                       MultigetGetResponse,
                       MultipleAuthSchemeGetResponse,
                       ParamgetGetResponse,
@@ -39,6 +40,8 @@ fn main() {
             .possible_values(&[
 
                 "MandatoryRequestHeaderGet",
+
+                "MergePatchJsonGet",
 
                 "MultigetGet",
 
@@ -116,6 +119,13 @@ fn main() {
             let mut rt = tokio::runtime::Runtime::new().unwrap();
             let result = rt.block_on(client.mandatory_request_header_get(
                   "x_header_example".to_string()
+            ));
+            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
+        },
+
+        Some("MergePatchJsonGet") => {
+            let mut rt = tokio::runtime::Runtime::new().unwrap();
+            let result = rt.block_on(client.merge_patch_json_get(
             ));
             println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },

--- a/samples/server/petstore/rust-server/output/openapi-v3/examples/server_lib/mod.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/examples/server_lib/mod.rs
@@ -18,6 +18,7 @@ use swagger::{Has, XSpanIdString};
 
 use openapi_v3::{Api, ApiError,
                       MandatoryRequestHeaderGetResponse,
+                      MergePatchJsonGetResponse,
                       MultigetGetResponse,
                       MultipleAuthSchemeGetResponse,
                       ParamgetGetResponse,
@@ -52,6 +53,13 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
     fn mandatory_request_header_get(&self, x_header: String, context: &C) -> Box<Future<Item=MandatoryRequestHeaderGetResponse, Error=ApiError> + Send> {
         let context = context.clone();
         println!("mandatory_request_header_get(\"{}\") - X-Span-ID: {:?}", x_header, context.get().0.clone());
+        Box::new(futures::failed("Generic failure".into()))
+    }
+
+
+    fn merge_patch_json_get(&self, context: &C) -> Box<Future<Item=MergePatchJsonGetResponse, Error=ApiError> + Send> {
+        let context = context.clone();
+        println!("merge_patch_json_get() - X-Span-ID: {:?}", context.get().0.clone());
         Box::new(futures::failed("Generic failure".into()))
     }
 

--- a/samples/server/petstore/rust-server/output/openapi-v3/src/client/mod.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/src/client/mod.rs
@@ -30,6 +30,7 @@ use serde_xml_rs;
 
 use {Api,
      MandatoryRequestHeaderGetResponse,
+     MergePatchJsonGetResponse,
      MultigetGetResponse,
      MultipleAuthSchemeGetResponse,
      ParamgetGetResponse,
@@ -260,6 +261,89 @@ impl<C, F> Api<C> for Client<F> where
                         future::ok(
                             MandatoryRequestHeaderGetResponse::Success
                         )
+                    ) as Box<dyn Future<Item=_, Error=_> + Send>
+                },
+                code => {
+                    let headers = response.headers().clone();
+                    Box::new(response.into_body()
+                            .take(100)
+                            .concat2()
+                            .then(move |body|
+                                future::err(ApiError(format!("Unexpected response code {}:\n{:?}\n\n{}",
+                                    code,
+                                    headers,
+                                    match body {
+                                        Ok(ref body) => match str::from_utf8(body) {
+                                            Ok(body) => Cow::from(body),
+                                            Err(e) => Cow::from(format!("<Body was not UTF8: {:?}>", e)),
+                                        },
+                                        Err(e) => Cow::from(format!("<Failed to read body: {}>", e)),
+                                    })))
+                            )
+                    ) as Box<dyn Future<Item=_, Error=_> + Send>
+                }
+            }
+        }))
+
+    }
+
+    fn merge_patch_json_get(&self, context: &C) -> Box<dyn Future<Item=MergePatchJsonGetResponse, Error=ApiError> + Send> {
+        let mut uri = format!(
+            "{}/merge-patch-json",
+            self.base_path
+        );
+
+        // Query parameters
+        let mut query_string = url::form_urlencoded::Serializer::new("".to_owned());
+        let query_string_str = query_string.finish();
+        if !query_string_str.is_empty() {
+            uri += "?";
+            uri += &query_string_str;
+        }
+
+        let uri = match Uri::from_str(&uri) {
+            Ok(uri) => uri,
+            Err(err) => return Box::new(future::err(ApiError(format!("Unable to build URI: {}", err)))),
+        };
+
+        let mut request = match hyper::Request::builder()
+            .method("GET")
+            .uri(uri)
+            .body(Body::empty()) {
+                Ok(req) => req,
+                Err(e) => return Box::new(future::err(ApiError(format!("Unable to create request: {}", e))))
+        };
+
+
+        let header = HeaderValue::from_str((context as &dyn Has<XSpanIdString>).get().0.clone().to_string().as_str());
+        request.headers_mut().insert(HeaderName::from_static("x-span-id"), match header {
+            Ok(h) => h,
+            Err(e) => return Box::new(future::err(ApiError(format!("Unable to create X-Span ID header value: {}", e))))
+        });
+
+
+        Box::new(self.client_service.request(request)
+                             .map_err(|e| ApiError(format!("No response received: {}", e)))
+                             .and_then(|mut response| {
+            match response.status().as_u16() {
+                200 => {
+                    let body = response.into_body();
+                    Box::new(
+                        body
+                        .concat2()
+                        .map_err(|e| ApiError(format!("Failed to read response: {}", e)))
+                        .and_then(|body|
+                            str::from_utf8(&body)
+                            .map_err(|e| ApiError(format!("Response was not valid UTF8: {}", e)))
+                            .and_then(|body|
+                                serde_json::from_str::<models::AnotherXmlObject>(body)
+                                .map_err(|e| e.into())
+                            )
+                        )
+                        .map(move |body| {
+                            MergePatchJsonGetResponse::Merge
+                            (body)
+                        })
                     ) as Box<dyn Future<Item=_, Error=_> + Send>
                 },
                 code => {

--- a/samples/server/petstore/rust-server/output/openapi-v3/src/lib.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/src/lib.rs
@@ -81,6 +81,13 @@ pub enum MandatoryRequestHeaderGetResponse {
 }
 
 #[derive(Debug, PartialEq)]
+pub enum MergePatchJsonGetResponse {
+    /// merge-patch+json-encoded response
+    Merge
+            ( models::AnotherXmlObject )
+}
+
+#[derive(Debug, PartialEq)]
 pub enum MultigetGetResponse {
     /// JSON rsp
     JSONRsp
@@ -234,6 +241,9 @@ pub trait Api<C> {
 
     fn mandatory_request_header_get(&self, x_header: String, context: &C) -> Box<dyn Future<Item=MandatoryRequestHeaderGetResponse, Error=ApiError> + Send>;
 
+
+    fn merge_patch_json_get(&self, context: &C) -> Box<dyn Future<Item=MergePatchJsonGetResponse, Error=ApiError> + Send>;
+
     /// Get some stuff.
     fn multiget_get(&self, context: &C) -> Box<dyn Future<Item=MultigetGetResponse, Error=ApiError> + Send>;
 
@@ -283,6 +293,9 @@ pub trait ApiNoContext {
 
 
     fn mandatory_request_header_get(&self, x_header: String) -> Box<dyn Future<Item=MandatoryRequestHeaderGetResponse, Error=ApiError> + Send>;
+
+
+    fn merge_patch_json_get(&self) -> Box<dyn Future<Item=MergePatchJsonGetResponse, Error=ApiError> + Send>;
 
     /// Get some stuff.
     fn multiget_get(&self) -> Box<dyn Future<Item=MultigetGetResponse, Error=ApiError> + Send>;
@@ -345,6 +358,11 @@ impl<'a, T: Api<C>, C> ApiNoContext for ContextWrapper<'a, T, C> {
 
     fn mandatory_request_header_get(&self, x_header: String) -> Box<dyn Future<Item=MandatoryRequestHeaderGetResponse, Error=ApiError> + Send> {
         self.api().mandatory_request_header_get(x_header, &self.context())
+    }
+
+
+    fn merge_patch_json_get(&self) -> Box<dyn Future<Item=MergePatchJsonGetResponse, Error=ApiError> + Send> {
+        self.api().merge_patch_json_get(&self.context())
     }
 
     /// Get some stuff.

--- a/samples/server/petstore/rust-server/output/openapi-v3/src/mimetypes.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/src/mimetypes.rs
@@ -3,6 +3,9 @@
 pub mod responses {
 
 
+    /// Create &str objects for the response content types for MergePatchJsonGet
+    pub static MERGE_PATCH_JSON_GET_MERGE: &str = "application/merge-patch+json";
+
     /// Create &str objects for the response content types for MultigetGet
     pub static MULTIGET_GET_JSON_RSP: &str = "application/json";
 


### PR DESCRIPTION
Support application/merge-patch+json as defined by RFC 7386 -
https://tools.ietf.org/html/rfc7386

Handle exactly the same as application/json - similarly to https://github.com/OpenAPITools/openapi-generator/pull/5407

### Rust Server Technical Committee

- @frol
- @farcaller 
- @bjgill

### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [X] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [X] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.