### PR TITLE
[Rust Server] Suffix reserved words with _

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustServerCodegen.java
@@ -354,7 +354,7 @@ public class RustServerCodegen extends DefaultCodegen implements CodegenConfig {
         if (this.reservedWordsMappings().containsKey(name)) {
             return this.reservedWordsMappings().get(name);
         }
-        return "_" + name; // add an underscore to the name
+        return name + "_"; // add an underscore _suffix_ to the name - a prefix implies unused
     }
 
     /**
@@ -398,9 +398,13 @@ public class RustServerCodegen extends DefaultCodegen implements CodegenConfig {
     @Override
     public String toVarName(String name) {
         String sanitizedName = super.sanitizeName(name);
-        // for reserved word or word starting with number, append _
-        if (isReservedWord(sanitizedName) || sanitizedName.matches("^\\d.*")) {
+        // for reserved word, append _
+        if (isReservedWord(sanitizedName)) {
             sanitizedName = escapeReservedWord(sanitizedName);
+        }
+        // for word starting with number, prepend "param_"
+        else if (sanitizedName.matches("^\\d.*")) {
+            sanitizedName = "param_" + sanitizedName;
         }
 
         return underscore(sanitizedName);

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/docs/ApiResponse.md
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/docs/ApiResponse.md
@@ -4,7 +4,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **code** | **i32** |  | [optional] [default to None]
-**_type** | **String** |  | [optional] [default to None]
+**type_** | **String** |  | [optional] [default to None]
 **message** | **String** |  | [optional] [default to None]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/docs/List.md
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/docs/List.md
@@ -3,7 +3,7 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**_123_list** | **String** |  | [optional] [default to None]
+**param_123_list** | **String** |  | [optional] [default to None]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/docs/ModelReturn.md
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/docs/ModelReturn.md
@@ -3,7 +3,7 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**_return** | **i32** |  | [optional] [default to None]
+**return_** | **i32** |  | [optional] [default to None]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/docs/Name.md
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/docs/Name.md
@@ -6,7 +6,7 @@ Name | Type | Description | Notes
 **name** | **i32** |  | 
 **snake_case** | **i32** |  | [optional] [readonly] [default to None]
 **property** | **String** |  | [optional] [default to None]
-**_123_number** | **isize** |  | [optional] [readonly] [default to None]
+**param_123_number** | **isize** |  | [optional] [readonly] [default to None]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/src/models.rs
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/src/models.rs
@@ -374,7 +374,7 @@ pub struct ApiResponse {
 
     #[serde(rename = "type")]
     #[serde(skip_serializing_if="Option::is_none")]
-    pub _type: Option<String>,
+    pub type_: Option<String>,
 
     #[serde(rename = "message")]
     #[serde(skip_serializing_if="Option::is_none")]
@@ -386,7 +386,7 @@ impl ApiResponse {
     pub fn new() -> ApiResponse {
         ApiResponse {
             code: None,
-            _type: None,
+            type_: None,
             message: None,
         }
     }
@@ -405,9 +405,9 @@ impl ::std::string::ToString for ApiResponse {
         }
 
 
-        if let Some(ref _type) = self._type {
+        if let Some(ref type_) = self.type_ {
             params.push("type".to_string());
-            params.push(_type.to_string());
+            params.push(type_.to_string());
         }
 
 
@@ -431,7 +431,7 @@ impl ::std::str::FromStr for ApiResponse {
         // An intermediate representation of the struct to use for parsing.
         struct IntermediateRep {
             pub code: Vec<i32>,
-            pub _type: Vec<String>,
+            pub type_: Vec<String>,
             pub message: Vec<String>,
         }
 
@@ -453,7 +453,7 @@ impl ::std::str::FromStr for ApiResponse {
                     "code" => intermediate_rep.code.push(i32::from_str(val).map_err(|x| ())?),
                     
                     
-                    "type" => intermediate_rep._type.push(String::from_str(val).map_err(|x| ())?),
+                    "type" => intermediate_rep.type_.push(String::from_str(val).map_err(|x| ())?),
                     
                     
                     "message" => intermediate_rep.message.push(String::from_str(val).map_err(|x| ())?),
@@ -469,7 +469,7 @@ impl ::std::str::FromStr for ApiResponse {
         // Use the intermediate representation to return the struct
         Ok(ApiResponse {
             code: intermediate_rep.code.into_iter().next(),
-            _type: intermediate_rep._type.into_iter().next(),
+            type_: intermediate_rep.type_.into_iter().next(),
             message: intermediate_rep.message.into_iter().next(),
         })
     }
@@ -2555,14 +2555,14 @@ impl From<HeaderValue> for IntoHeaderValue<List> {
 pub struct List {
     #[serde(rename = "123-list")]
     #[serde(skip_serializing_if="Option::is_none")]
-    pub _123_list: Option<String>,
+    pub param_123_list: Option<String>,
 
 }
 
 impl List {
     pub fn new() -> List {
         List {
-            _123_list: None,
+            param_123_list: None,
         }
     }
 }
@@ -2574,9 +2574,9 @@ impl ::std::string::ToString for List {
     fn to_string(&self) -> String {
         let mut params: Vec<String> = vec![];
 
-        if let Some(ref _123_list) = self._123_list {
+        if let Some(ref param_123_list) = self.param_123_list {
             params.push("123-list".to_string());
-            params.push(_123_list.to_string());
+            params.push(param_123_list.to_string());
         }
 
         params.join(",").to_string()
@@ -2593,7 +2593,7 @@ impl ::std::str::FromStr for List {
         #[derive(Default)]
         // An intermediate representation of the struct to use for parsing.
         struct IntermediateRep {
-            pub _123_list: Vec<String>,
+            pub param_123_list: Vec<String>,
         }
 
         let mut intermediate_rep = IntermediateRep::default();
@@ -2611,7 +2611,7 @@ impl ::std::str::FromStr for List {
             if let Some(key) = key_result {
                 match key {
                     
-                    "123-list" => intermediate_rep._123_list.push(String::from_str(val).map_err(|x| ())?),
+                    "123-list" => intermediate_rep.param_123_list.push(String::from_str(val).map_err(|x| ())?),
                     
                     _ => return Err(()) // Parse error - unexpected key
                 }
@@ -2623,7 +2623,7 @@ impl ::std::str::FromStr for List {
 
         // Use the intermediate representation to return the struct
         Ok(List {
-            _123_list: intermediate_rep._123_list.into_iter().next(),
+            param_123_list: intermediate_rep.param_123_list.into_iter().next(),
         })
     }
 }
@@ -3028,14 +3028,14 @@ impl From<HeaderValue> for IntoHeaderValue<ModelReturn> {
 pub struct ModelReturn {
     #[serde(rename = "return")]
     #[serde(skip_serializing_if="Option::is_none")]
-    pub _return: Option<i32>,
+    pub return_: Option<i32>,
 
 }
 
 impl ModelReturn {
     pub fn new() -> ModelReturn {
         ModelReturn {
-            _return: None,
+            return_: None,
         }
     }
 }
@@ -3047,9 +3047,9 @@ impl ::std::string::ToString for ModelReturn {
     fn to_string(&self) -> String {
         let mut params: Vec<String> = vec![];
 
-        if let Some(ref _return) = self._return {
+        if let Some(ref return_) = self.return_ {
             params.push("return".to_string());
-            params.push(_return.to_string());
+            params.push(return_.to_string());
         }
 
         params.join(",").to_string()
@@ -3066,7 +3066,7 @@ impl ::std::str::FromStr for ModelReturn {
         #[derive(Default)]
         // An intermediate representation of the struct to use for parsing.
         struct IntermediateRep {
-            pub _return: Vec<i32>,
+            pub return_: Vec<i32>,
         }
 
         let mut intermediate_rep = IntermediateRep::default();
@@ -3084,7 +3084,7 @@ impl ::std::str::FromStr for ModelReturn {
             if let Some(key) = key_result {
                 match key {
                     
-                    "return" => intermediate_rep._return.push(i32::from_str(val).map_err(|x| ())?),
+                    "return" => intermediate_rep.return_.push(i32::from_str(val).map_err(|x| ())?),
                     
                     _ => return Err(()) // Parse error - unexpected key
                 }
@@ -3096,7 +3096,7 @@ impl ::std::str::FromStr for ModelReturn {
 
         // Use the intermediate representation to return the struct
         Ok(ModelReturn {
-            _return: intermediate_rep._return.into_iter().next(),
+            return_: intermediate_rep.return_.into_iter().next(),
         })
     }
 }
@@ -3144,7 +3144,7 @@ pub struct Name {
 
     #[serde(rename = "123Number")]
     #[serde(skip_serializing_if="Option::is_none")]
-    pub _123_number: Option<isize>,
+    pub param_123_number: Option<isize>,
 
 }
 
@@ -3154,7 +3154,7 @@ impl Name {
             name: name,
             snake_case: None,
             property: None,
-            _123_number: None,
+            param_123_number: None,
         }
     }
 }
@@ -3182,9 +3182,9 @@ impl ::std::string::ToString for Name {
         }
 
 
-        if let Some(ref _123_number) = self._123_number {
+        if let Some(ref param_123_number) = self.param_123_number {
             params.push("123Number".to_string());
-            params.push(_123_number.to_string());
+            params.push(param_123_number.to_string());
         }
 
         params.join(",").to_string()
@@ -3204,7 +3204,7 @@ impl ::std::str::FromStr for Name {
             pub name: Vec<i32>,
             pub snake_case: Vec<i32>,
             pub property: Vec<String>,
-            pub _123_number: Vec<isize>,
+            pub param_123_number: Vec<isize>,
         }
 
         let mut intermediate_rep = IntermediateRep::default();
@@ -3231,7 +3231,7 @@ impl ::std::str::FromStr for Name {
                     "property" => intermediate_rep.property.push(String::from_str(val).map_err(|x| ())?),
                     
                     
-                    "123Number" => intermediate_rep._123_number.push(isize::from_str(val).map_err(|x| ())?),
+                    "123Number" => intermediate_rep.param_123_number.push(isize::from_str(val).map_err(|x| ())?),
                     
                     _ => return Err(()) // Parse error - unexpected key
                 }
@@ -3246,7 +3246,7 @@ impl ::std::str::FromStr for Name {
             name: intermediate_rep.name.into_iter().next().ok_or(())?,
             snake_case: intermediate_rep.snake_case.into_iter().next(),
             property: intermediate_rep.property.into_iter().next(),
-            _123_number: intermediate_rep._123_number.into_iter().next(),
+            param_123_number: intermediate_rep.param_123_number.into_iter().next(),
         })
     }
 }


### PR DESCRIPTION
Currently a field which matches a Rust keyword e.g. `type` is rendered as the Rust variable `_type` in order to produce valid Rust. This is confusing, because a leading underscore indicated an unused variable in Rust code.

Instead we match convention in the Rust community and suffix variables with an `_` instead. For fields which begin with a number (e.g. `1234word`), we prefix them with `param_` to avoid this problem, and avoid being unable to to start with a number.

### Rust Server Technical Committee

- @frol
- @farcaller 
- @bjgill

### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [X] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [X] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.