### PR TITLE
[Core] Only debug log what files are created

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/AbstractGenerator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/AbstractGenerator.java
@@ -75,11 +75,11 @@ public abstract class AbstractGenerator implements TemplatingGenerator {
             try {
                 tempFile = writeToFileRaw(tempFilename, contents);
                 if (!filesEqual(tempFile, outputFile)) {
-                    LOGGER.info("writing file " + filename);
+                    LOGGER.debug("writing file " + filename);
                     Files.move(tempFile.toPath(), outputFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
                     tempFile = null;
                 } else {
-                    LOGGER.info("skipping unchanged file " + filename);
+                    LOGGER.debug("skipping unchanged file " + filename);
                 }
             } finally {
                 if (tempFile != null && tempFile.exists()) {
@@ -92,7 +92,7 @@ public abstract class AbstractGenerator implements TemplatingGenerator {
             }
             return outputFile;
         } else {
-            LOGGER.info("writing file " + filename);
+            LOGGER.debug("writing file " + filename);
             return writeToFileRaw(filename, contents);
         }
     }


### PR DESCRIPTION
Currently the generator is quite spammy about what files are being created, which can be a large number, which makes it difficult to see warnings emitted.

It feels like this isn't really worth an info level log - and could be a debug level log.

Thoughts?

@OpenAPITools/generator-core-team 

### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [X] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [X] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.