### PR TITLE
[Rust Server] Don't change the API version

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustServerCodegen.java
@@ -265,7 +265,6 @@ public class RustServerCodegen extends DefaultCodegen implements CodegenConfig {
         additionalProperties.put("modelDocPath", modelDocPath);
 
         additionalProperties.put(CodegenConstants.PACKAGE_NAME, packageName);
-        additionalProperties.put(CodegenConstants.PACKAGE_VERSION, packageVersion);
         additionalProperties.put("externCrateName", externCrateName);
     }
 
@@ -320,19 +319,26 @@ public class RustServerCodegen extends DefaultCodegen implements CodegenConfig {
 
     @Override
     public void preprocessOpenAPI(OpenAPI openAPI) {
+
         Info info = openAPI.getInfo();
-        List<String> versionComponents = new ArrayList<>(Arrays.asList(info.getVersion().split("[.]")));
-        if (versionComponents.size() < 1) {
-            versionComponents.add("1");
-        }
-        while (versionComponents.size() < 3) {
-            versionComponents.add("0");
-        }
-        info.setVersion(StringUtils.join(versionComponents, "."));
 
         URL url = URLPathUtils.getServerURL(openAPI, serverVariableOverrides());
         additionalProperties.put("serverHost", url.getHost());
         additionalProperties.put("serverPort", URLPathUtils.getPort(url, 80));
+
+        if (packageVersion == null || "".equals(packageVersion)) {
+            List<String> versionComponents = new ArrayList<>(Arrays.asList(info.getVersion().split("[.]")));
+            if (versionComponents.size() < 1) {
+                versionComponents.add("1");
+            }
+            while (versionComponents.size() < 3) {
+                versionComponents.add("0");
+            }
+
+            setPackageVersion(StringUtils.join(versionComponents, "."));
+        }
+
+        additionalProperties.put(CodegenConstants.PACKAGE_VERSION, packageVersion);
     }
 
     @Override

--- a/modules/openapi-generator/src/main/resources/rust-server/Cargo.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/Cargo.mustache
@@ -1,6 +1,6 @@
 [package]
 name = "{{{packageName}}}"
-version = {{#packageVersion}}"{{{packageVersion}}}"{{/packageVersion}}{{^packageVersion}}"{{{appVersion}}}"{{/packageVersion}}{{! Fill in with packageVersion if defined, which can be passed via a command line argument, Else use appVersion from the Open API spec, which defaults to 1.0.0 if not present.}}
+version = "{{{packageVersion}}}"
 authors = [{{#infoEmail}}"{{{infoEmail}}}"{{/infoEmail}}]
 {{#appDescription}}
 description = "{{{appDescription}}}"

--- a/modules/openapi-generator/src/main/resources/rust-server/lib.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/lib.mustache
@@ -88,7 +88,9 @@ pub use swagger::{ApiError, ContextWrapper};
 pub use futures::Future;
 
 pub const BASE_PATH: &'static str = "{{{basePathWithoutHost}}}";
+{{#appVersion}}
 pub const API_VERSION: &'static str = "{{{appVersion}}}";
+{{/appVersion}}
 
 {{#apiInfo}}{{#apis}}{{#operations}}{{#operation}}
 #[derive(Debug, PartialEq)]


### PR DESCRIPTION
Don't change the API version which is exposed in `crate::API_VERSION`.

This is useful, because often the API version needs to be passed on the API (e.g. as a query parameter), at which point it's useful if you can use the API version which the library itself is exposing.

As such, we change the logic such that:

- If the API version isn't set, we don't expose it.

- If it is set, we leave it well alone.

- Always pass a package version:
   - Pass in the passed package version by preference
   - Pass in the API version if it's not.
       - If the API version isn't set, we use 1.0.0
       - If it is set, and isn't a valid semver, we append .0 such that we have
     something with three digits (so that an API version of 1 works).

This is obviously breaking, as we are changing the exposed API version for a bunch of crates, but it's the right long term fix.

### Rust Server Technical Committee

- @frol
- @farcaller 
- @bjgill

### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [X] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [X] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.