### PR TITLE
[kotlin][client] Add Jackson to interface properties and remove extra line feed

### DIFF
--- a/modules/openapi-generator/src/main/resources/kotlin-client/data_class.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/data_class.mustache
@@ -10,7 +10,10 @@ import com.squareup.moshi.JsonClass
 {{/moshi}}
 {{#jackson}}
 import com.fasterxml.jackson.annotation.JsonProperty
-import com.fasterxml.jackson.annotation.JsonFormat
+{{#discriminator}}
+import com.fasterxml.jackson.annotation.JsonSubTypes
+import com.fasterxml.jackson.annotation.JsonTypeInfo
+{{/discriminator}}
 {{/jackson}}
 {{#parcelizeModels}}
 import android.os.Parcelable
@@ -34,7 +37,7 @@ import java.io.Serializable
 {{#parcelizeModels}}
 @Parcelize
 {{/parcelizeModels}}
-{{#multiplatform}}@Serializable{{/multiplatform}}{{#moshi}}{{#moshiCodeGen}}@JsonClass(generateAdapter = true){{/moshiCodeGen}}{{/moshi}}
+{{#multiplatform}}@Serializable{{/multiplatform}}{{#moshi}}{{#moshiCodeGen}}@JsonClass(generateAdapter = true){{/moshiCodeGen}}{{/moshi}}{{#jackson}}{{#discriminator}}{{>typeInfoAnnotation}}{{/discriminator}}{{/jackson}}
 {{#nonPublicApi}}internal {{/nonPublicApi}}{{#discriminator}}interface{{/discriminator}}{{^discriminator}}data class{{/discriminator}} {{classname}}{{^discriminator}} (
 {{#vars}}
 {{#required}}{{>data_class_req_var}}{{/required}}{{^required}}{{>data_class_opt_var}}{{/required}}{{^-last}},{{/-last}}
@@ -57,7 +60,6 @@ import java.io.Serializable
     * Values: {{#allowableValues}}{{#enumVars}}{{&name}}{{^-last}},{{/-last}}{{/enumVars}}{{/allowableValues}}
     */
     {{#multiplatform}}@Serializable(with = {{nameInCamelCase}}.Serializer::class){{/multiplatform}}
-    {{#jackson}}{{#isPrimitiveType}}@JsonFormat(shape = JsonFormat.Shape.NATURAL){{/isPrimitiveType}}{{^isPrimitiveType}}@JsonFormat(shape = JsonFormat.Shape.OBJECT){{/isPrimitiveType}}{{/jackson}}
     {{#nonPublicApi}}internal {{/nonPublicApi}}enum class {{{nameInCamelCase}}}(val value: {{#isListContainer}}{{{ nestedType }}}{{/isListContainer}}{{^isListContainer}}{{{dataType}}}{{/isListContainer}}){
     {{#allowableValues}}
     {{#enumVars}}

--- a/modules/openapi-generator/src/main/resources/kotlin-client/data_class_opt_var.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/data_class_opt_var.mustache
@@ -10,8 +10,7 @@
     {{/gson}}
     {{#jackson}}
     {{#isDateTime}}
-    @JsonFormat
-    (shape = JsonFormat.Shape.STRING, pattern = "dd-MM-yyyy hh:mm:ss")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "dd-MM-yyyy hh:mm:ss")
     {{/isDateTime}}
     @JsonProperty("{{{vendorExtensions.x-base-name-literal}}}")
     {{/jackson}}

--- a/modules/openapi-generator/src/main/resources/kotlin-client/data_class_opt_var.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/data_class_opt_var.mustache
@@ -9,9 +9,6 @@
     @SerializedName("{{{vendorExtensions.x-base-name-literal}}}")
     {{/gson}}
     {{#jackson}}
-    {{#isDateTime}}
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "dd-MM-yyyy hh:mm:ss")
-    {{/isDateTime}}
     @JsonProperty("{{{vendorExtensions.x-base-name-literal}}}")
     {{/jackson}}
     {{/multiplatform}}

--- a/modules/openapi-generator/src/main/resources/kotlin-client/data_class_req_var.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/data_class_req_var.mustache
@@ -9,9 +9,6 @@
     @SerializedName("{{{vendorExtensions.x-base-name-literal}}}")
     {{/gson}}
     {{#jackson}}
-    {{#isDateTime}}
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "dd-MM-yyyy hh:mm:ss")
-    {{/isDateTime}}
     @JsonProperty("{{{vendorExtensions.x-base-name-literal}}}")
     {{/jackson}}
     {{/multiplatform}}

--- a/modules/openapi-generator/src/main/resources/kotlin-client/data_class_req_var.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/data_class_req_var.mustache
@@ -9,6 +9,9 @@
     @SerializedName("{{{vendorExtensions.x-base-name-literal}}}")
     {{/gson}}
     {{#jackson}}
+    {{#isDateTime}}
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "dd-MM-yyyy hh:mm:ss")
+    {{/isDateTime}}
     @JsonProperty("{{{vendorExtensions.x-base-name-literal}}}")
     {{/jackson}}
     {{/multiplatform}}

--- a/modules/openapi-generator/src/main/resources/kotlin-client/enum_class.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/enum_class.mustache
@@ -5,6 +5,9 @@ import com.google.gson.annotations.SerializedName
 {{#moshi}}
 import com.squareup.moshi.Json
 {{/moshi}}
+{{#jackson}}
+import com.fasterxml.jackson.annotation.JsonProperty
+{{/jackson}}
 {{/multiplatform}}
 {{#multiplatform}}
 import kotlinx.serialization.*
@@ -16,7 +19,6 @@ import kotlinx.serialization.internal.CommonEnumSerializer
 * Values: {{#allowableValues}}{{#enumVars}}{{&name}}{{^-last}},{{/-last}}{{/enumVars}}{{/allowableValues}}
 */
 {{#multiplatform}}@Serializable(with = {{classname}}.Serializer::class){{/multiplatform}}
-{{#jackson}}@JsonFormat(shape = JsonFormat.Shape.OBJECT){{/jackson}}
 {{#nonPublicApi}}internal {{/nonPublicApi}}enum class {{classname}}(val value: {{{dataType}}}){
 
 {{#allowableValues}}{{#enumVars}}

--- a/modules/openapi-generator/src/main/resources/kotlin-client/interface_opt_var.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/interface_opt_var.mustache
@@ -9,10 +9,7 @@
     @SerializedName("{{{vendorExtensions.x-base-name-literal}}}")
     {{/gson}}
     {{#jackson}}
-    {{#isDateTime}}
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "dd-MM-yyyy hh:mm:ss")
-    {{/isDateTime}}
-    @JsonProperty("{{{vendorExtensions.x-base-name-literal}}}")
+    @get:JsonProperty("{{{vendorExtensions.x-base-name-literal}}}")
     {{/jackson}}
     {{/multiplatform}}
     {{#multiplatform}}@SerialName(value = "{{{vendorExtensions.x-base-name-literal}}}") {{/multiplatform}}{{>modelMutable}} {{{name}}}: {{#isEnum}}{{#isListContainer}}{{#isList}}kotlin.collections.List{{/isList}}{{^isList}}kotlin.Array{{/isList}}<{{classname}}.{{{nameInCamelCase}}}>{{/isListContainer}}{{^isListContainer}}{{classname}}.{{{nameInCamelCase}}}{{/isListContainer}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}?

--- a/modules/openapi-generator/src/main/resources/kotlin-client/interface_opt_var.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/interface_opt_var.mustache
@@ -8,5 +8,11 @@
     {{#gson}}
     @SerializedName("{{{vendorExtensions.x-base-name-literal}}}")
     {{/gson}}
+    {{#jackson}}
+    {{#isDateTime}}
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "dd-MM-yyyy hh:mm:ss")
+    {{/isDateTime}}
+    @JsonProperty("{{{vendorExtensions.x-base-name-literal}}}")
+    {{/jackson}}
     {{/multiplatform}}
     {{#multiplatform}}@SerialName(value = "{{{vendorExtensions.x-base-name-literal}}}") {{/multiplatform}}{{>modelMutable}} {{{name}}}: {{#isEnum}}{{#isListContainer}}{{#isList}}kotlin.collections.List{{/isList}}{{^isList}}kotlin.Array{{/isList}}<{{classname}}.{{{nameInCamelCase}}}>{{/isListContainer}}{{^isListContainer}}{{classname}}.{{{nameInCamelCase}}}{{/isListContainer}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}?

--- a/modules/openapi-generator/src/main/resources/kotlin-client/interface_req_var.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/interface_req_var.mustache
@@ -9,10 +9,7 @@
     @SerializedName("{{{vendorExtensions.x-base-name-literal}}}")
     {{/gson}}
     {{#jackson}}
-    {{#isDateTime}}
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "dd-MM-yyyy hh:mm:ss")
-    {{/isDateTime}}
-    @JsonProperty("{{{vendorExtensions.x-base-name-literal}}}")
+    @get:JsonProperty("{{{vendorExtensions.x-base-name-literal}}}")
     {{/jackson}}
     {{/multiplatform}}
     {{#multiplatform}}@SerialName(value = "{{{vendorExtensions.x-base-name-literal}}}") @Required {{/multiplatform}}{{>modelMutable}} {{{name}}}: {{#isEnum}}{{#isListContainer}}{{#isList}}kotlin.collections.List{{/isList}}{{^isList}}kotlin.Array{{/isList}}<{{classname}}.{{{nameInCamelCase}}}>{{/isListContainer}}{{^isListContainer}}{{classname}}.{{{nameInCamelCase}}}{{/isListContainer}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}{{#isNullable}}?{{/isNullable}}

--- a/modules/openapi-generator/src/main/resources/kotlin-client/interface_req_var.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/interface_req_var.mustache
@@ -8,5 +8,11 @@
     {{#gson}}
     @SerializedName("{{{vendorExtensions.x-base-name-literal}}}")
     {{/gson}}
+    {{#jackson}}
+    {{#isDateTime}}
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "dd-MM-yyyy hh:mm:ss")
+    {{/isDateTime}}
+    @JsonProperty("{{{vendorExtensions.x-base-name-literal}}}")
+    {{/jackson}}
     {{/multiplatform}}
     {{#multiplatform}}@SerialName(value = "{{{vendorExtensions.x-base-name-literal}}}") @Required {{/multiplatform}}{{>modelMutable}} {{{name}}}: {{#isEnum}}{{#isListContainer}}{{#isList}}kotlin.collections.List{{/isList}}{{^isList}}kotlin.Array{{/isList}}<{{classname}}.{{{nameInCamelCase}}}>{{/isListContainer}}{{^isListContainer}}{{classname}}.{{{nameInCamelCase}}}{{/isListContainer}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}{{#isNullable}}?{{/isNullable}}

--- a/modules/openapi-generator/src/main/resources/kotlin-client/jvm-common/infrastructure/Serializer.kt.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/jvm-common/infrastructure/Serializer.kt.mustache
@@ -24,6 +24,7 @@ import java.util.UUID
 {{/gson}}
 {{#jackson}}
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.annotation.JsonInclude
@@ -70,5 +71,6 @@ import java.util.Date
         .registerModule(Jdk8Module())
         .registerModule(JavaTimeModule())
         .setSerializationInclusion(JsonInclude.Include.NON_ABSENT)
+        .configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
 {{/jackson}}
 }

--- a/modules/openapi-generator/src/main/resources/kotlin-client/typeInfoAnnotation.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/typeInfoAnnotation.mustache
@@ -1,0 +1,6 @@
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "{{{discriminator.propertyBaseName}}}", visible = true)
+@JsonSubTypes(
+{{#discriminator.mappedModels}}
+    JsonSubTypes.Type(value = {{modelName}}::class, name = "{{^vendorExtensions.x-discriminator-value}}{{mappingName}}{{/vendorExtensions.x-discriminator-value}}{{#vendorExtensions.x-discriminator-value}}{{{vendorExtensions.x-discriminator-value}}}{{/vendorExtensions.x-discriminator-value}}"){{^-last}},{{/-last}}
+{{/discriminator.mappedModels}}
+)

--- a/samples/client/petstore/kotlin-gson/src/main/kotlin/org/openapitools/client/models/ApiResponse.kt
+++ b/samples/client/petstore/kotlin-gson/src/main/kotlin/org/openapitools/client/models/ApiResponse.kt
@@ -22,13 +22,10 @@ import com.google.gson.annotations.SerializedName
 
 data class ApiResponse (
     @SerializedName("code")
-    val code: kotlin.Int? = null
-,
+    val code: kotlin.Int? = null,
     @SerializedName("type")
-    val type: kotlin.String? = null
-,
+    val type: kotlin.String? = null,
     @SerializedName("message")
     val message: kotlin.String? = null
-
 )
 

--- a/samples/client/petstore/kotlin-gson/src/main/kotlin/org/openapitools/client/models/Category.kt
+++ b/samples/client/petstore/kotlin-gson/src/main/kotlin/org/openapitools/client/models/Category.kt
@@ -21,10 +21,8 @@ import com.google.gson.annotations.SerializedName
 
 data class Category (
     @SerializedName("id")
-    val id: kotlin.Long? = null
-,
+    val id: kotlin.Long? = null,
     @SerializedName("name")
     val name: kotlin.String? = null
-
 )
 

--- a/samples/client/petstore/kotlin-gson/src/main/kotlin/org/openapitools/client/models/Order.kt
+++ b/samples/client/petstore/kotlin-gson/src/main/kotlin/org/openapitools/client/models/Order.kt
@@ -25,24 +25,18 @@ import com.google.gson.annotations.SerializedName
 
 data class Order (
     @SerializedName("id")
-    val id: kotlin.Long? = null
-,
+    val id: kotlin.Long? = null,
     @SerializedName("petId")
-    val petId: kotlin.Long? = null
-,
+    val petId: kotlin.Long? = null,
     @SerializedName("quantity")
-    val quantity: kotlin.Int? = null
-,
+    val quantity: kotlin.Int? = null,
     @SerializedName("shipDate")
-    val shipDate: java.time.OffsetDateTime? = null
-,
+    val shipDate: java.time.OffsetDateTime? = null,
     /* Order Status */
     @SerializedName("status")
-    val status: Order.Status? = null
-,
+    val status: Order.Status? = null,
     @SerializedName("complete")
     val complete: kotlin.Boolean? = null
-
 ) {
 
     /**

--- a/samples/client/petstore/kotlin-gson/src/main/kotlin/org/openapitools/client/models/Order.kt
+++ b/samples/client/petstore/kotlin-gson/src/main/kotlin/org/openapitools/client/models/Order.kt
@@ -44,7 +44,6 @@ data class Order (
     * Values: placed,approved,delivered
     */
     
-    
     enum class Status(val value: kotlin.String){
         @SerializedName(value="placed")  placed("placed"),
         @SerializedName(value="approved")  approved("approved"),

--- a/samples/client/petstore/kotlin-gson/src/main/kotlin/org/openapitools/client/models/Pet.kt
+++ b/samples/client/petstore/kotlin-gson/src/main/kotlin/org/openapitools/client/models/Pet.kt
@@ -27,24 +27,18 @@ import com.google.gson.annotations.SerializedName
 
 data class Pet (
     @SerializedName("name")
-    val name: kotlin.String
-,
+    val name: kotlin.String,
     @SerializedName("photoUrls")
-    val photoUrls: kotlin.Array<kotlin.String>
-,
+    val photoUrls: kotlin.Array<kotlin.String>,
     @SerializedName("id")
-    val id: kotlin.Long? = null
-,
+    val id: kotlin.Long? = null,
     @SerializedName("category")
-    val category: Category? = null
-,
+    val category: Category? = null,
     @SerializedName("tags")
-    val tags: kotlin.Array<Tag>? = null
-,
+    val tags: kotlin.Array<Tag>? = null,
     /* pet status in the store */
     @SerializedName("status")
     val status: Pet.Status? = null
-
 ) {
 
     /**

--- a/samples/client/petstore/kotlin-gson/src/main/kotlin/org/openapitools/client/models/Pet.kt
+++ b/samples/client/petstore/kotlin-gson/src/main/kotlin/org/openapitools/client/models/Pet.kt
@@ -46,7 +46,6 @@ data class Pet (
     * Values: available,pending,sold
     */
     
-    
     enum class Status(val value: kotlin.String){
         @SerializedName(value="available")  available("available"),
         @SerializedName(value="pending")  pending("pending"),

--- a/samples/client/petstore/kotlin-gson/src/main/kotlin/org/openapitools/client/models/Tag.kt
+++ b/samples/client/petstore/kotlin-gson/src/main/kotlin/org/openapitools/client/models/Tag.kt
@@ -21,10 +21,8 @@ import com.google.gson.annotations.SerializedName
 
 data class Tag (
     @SerializedName("id")
-    val id: kotlin.Long? = null
-,
+    val id: kotlin.Long? = null,
     @SerializedName("name")
     val name: kotlin.String? = null
-
 )
 

--- a/samples/client/petstore/kotlin-gson/src/main/kotlin/org/openapitools/client/models/User.kt
+++ b/samples/client/petstore/kotlin-gson/src/main/kotlin/org/openapitools/client/models/User.kt
@@ -27,29 +27,21 @@ import com.google.gson.annotations.SerializedName
 
 data class User (
     @SerializedName("id")
-    val id: kotlin.Long? = null
-,
+    val id: kotlin.Long? = null,
     @SerializedName("username")
-    val username: kotlin.String? = null
-,
+    val username: kotlin.String? = null,
     @SerializedName("firstName")
-    val firstName: kotlin.String? = null
-,
+    val firstName: kotlin.String? = null,
     @SerializedName("lastName")
-    val lastName: kotlin.String? = null
-,
+    val lastName: kotlin.String? = null,
     @SerializedName("email")
-    val email: kotlin.String? = null
-,
+    val email: kotlin.String? = null,
     @SerializedName("password")
-    val password: kotlin.String? = null
-,
+    val password: kotlin.String? = null,
     @SerializedName("phone")
-    val phone: kotlin.String? = null
-,
+    val phone: kotlin.String? = null,
     /* User Status */
     @SerializedName("userStatus")
     val userStatus: kotlin.Int? = null
-
 )
 

--- a/samples/client/petstore/kotlin-jackson/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
+++ b/samples/client/petstore/kotlin-jackson/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
@@ -1,6 +1,7 @@
 package org.openapitools.client.infrastructure
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.annotation.JsonInclude
@@ -13,4 +14,5 @@ object Serializer {
         .registerModule(Jdk8Module())
         .registerModule(JavaTimeModule())
         .setSerializationInclusion(JsonInclude.Include.NON_ABSENT)
+        .configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
 }

--- a/samples/client/petstore/kotlin-jackson/src/main/kotlin/org/openapitools/client/models/ApiResponse.kt
+++ b/samples/client/petstore/kotlin-jackson/src/main/kotlin/org/openapitools/client/models/ApiResponse.kt
@@ -13,7 +13,6 @@ package org.openapitools.client.models
 
 
 import com.fasterxml.jackson.annotation.JsonProperty
-import com.fasterxml.jackson.annotation.JsonFormat
 /**
  * Describes the result of uploading an image resource
  * @param code 

--- a/samples/client/petstore/kotlin-jackson/src/main/kotlin/org/openapitools/client/models/ApiResponse.kt
+++ b/samples/client/petstore/kotlin-jackson/src/main/kotlin/org/openapitools/client/models/ApiResponse.kt
@@ -23,13 +23,10 @@ import com.fasterxml.jackson.annotation.JsonFormat
 
 data class ApiResponse (
     @JsonProperty("code")
-    val code: kotlin.Int? = null
-,
+    val code: kotlin.Int? = null,
     @JsonProperty("type")
-    val type: kotlin.String? = null
-,
+    val type: kotlin.String? = null,
     @JsonProperty("message")
     val message: kotlin.String? = null
-
 )
 

--- a/samples/client/petstore/kotlin-jackson/src/main/kotlin/org/openapitools/client/models/Category.kt
+++ b/samples/client/petstore/kotlin-jackson/src/main/kotlin/org/openapitools/client/models/Category.kt
@@ -22,10 +22,8 @@ import com.fasterxml.jackson.annotation.JsonFormat
 
 data class Category (
     @JsonProperty("id")
-    val id: kotlin.Long? = null
-,
+    val id: kotlin.Long? = null,
     @JsonProperty("name")
     val name: kotlin.String? = null
-
 )
 

--- a/samples/client/petstore/kotlin-jackson/src/main/kotlin/org/openapitools/client/models/Category.kt
+++ b/samples/client/petstore/kotlin-jackson/src/main/kotlin/org/openapitools/client/models/Category.kt
@@ -13,7 +13,6 @@ package org.openapitools.client.models
 
 
 import com.fasterxml.jackson.annotation.JsonProperty
-import com.fasterxml.jackson.annotation.JsonFormat
 /**
  * A category for a pet
  * @param id 

--- a/samples/client/petstore/kotlin-jackson/src/main/kotlin/org/openapitools/client/models/Order.kt
+++ b/samples/client/petstore/kotlin-jackson/src/main/kotlin/org/openapitools/client/models/Order.kt
@@ -13,7 +13,6 @@ package org.openapitools.client.models
 
 
 import com.fasterxml.jackson.annotation.JsonProperty
-import com.fasterxml.jackson.annotation.JsonFormat
 /**
  * An order for a pets from the pet store
  * @param id 
@@ -31,7 +30,6 @@ data class Order (
     val petId: kotlin.Long? = null,
     @JsonProperty("quantity")
     val quantity: kotlin.Int? = null,
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "dd-MM-yyyy hh:mm:ss")
     @JsonProperty("shipDate")
     val shipDate: java.time.OffsetDateTime? = null,
     /* Order Status */
@@ -46,7 +44,6 @@ data class Order (
     * Values: PLACED,APPROVED,DELIVERED
     */
     
-    @JsonFormat(shape = JsonFormat.Shape.NATURAL)
     enum class Status(val value: kotlin.String){
         @JsonProperty(value="placed") PLACED("placed"),
         @JsonProperty(value="approved") APPROVED("approved"),

--- a/samples/client/petstore/kotlin-jackson/src/main/kotlin/org/openapitools/client/models/Order.kt
+++ b/samples/client/petstore/kotlin-jackson/src/main/kotlin/org/openapitools/client/models/Order.kt
@@ -26,26 +26,19 @@ import com.fasterxml.jackson.annotation.JsonFormat
 
 data class Order (
     @JsonProperty("id")
-    val id: kotlin.Long? = null
-,
+    val id: kotlin.Long? = null,
     @JsonProperty("petId")
-    val petId: kotlin.Long? = null
-,
+    val petId: kotlin.Long? = null,
     @JsonProperty("quantity")
-    val quantity: kotlin.Int? = null
-,
-    @JsonFormat
-    (shape = JsonFormat.Shape.STRING, pattern = "dd-MM-yyyy hh:mm:ss")
+    val quantity: kotlin.Int? = null,
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "dd-MM-yyyy hh:mm:ss")
     @JsonProperty("shipDate")
-    val shipDate: java.time.OffsetDateTime? = null
-,
+    val shipDate: java.time.OffsetDateTime? = null,
     /* Order Status */
     @JsonProperty("status")
-    val status: Order.Status? = null
-,
+    val status: Order.Status? = null,
     @JsonProperty("complete")
     val complete: kotlin.Boolean? = null
-
 ) {
 
     /**

--- a/samples/client/petstore/kotlin-jackson/src/main/kotlin/org/openapitools/client/models/Pet.kt
+++ b/samples/client/petstore/kotlin-jackson/src/main/kotlin/org/openapitools/client/models/Pet.kt
@@ -28,24 +28,18 @@ import com.fasterxml.jackson.annotation.JsonFormat
 
 data class Pet (
     @JsonProperty("name")
-    val name: kotlin.String
-,
+    val name: kotlin.String,
     @JsonProperty("photoUrls")
-    val photoUrls: kotlin.Array<kotlin.String>
-,
+    val photoUrls: kotlin.Array<kotlin.String>,
     @JsonProperty("id")
-    val id: kotlin.Long? = null
-,
+    val id: kotlin.Long? = null,
     @JsonProperty("category")
-    val category: Category? = null
-,
+    val category: Category? = null,
     @JsonProperty("tags")
-    val tags: kotlin.Array<Tag>? = null
-,
+    val tags: kotlin.Array<Tag>? = null,
     /* pet status in the store */
     @JsonProperty("status")
     val status: Pet.Status? = null
-
 ) {
 
     /**

--- a/samples/client/petstore/kotlin-jackson/src/main/kotlin/org/openapitools/client/models/Pet.kt
+++ b/samples/client/petstore/kotlin-jackson/src/main/kotlin/org/openapitools/client/models/Pet.kt
@@ -15,7 +15,6 @@ import org.openapitools.client.models.Category
 import org.openapitools.client.models.Tag
 
 import com.fasterxml.jackson.annotation.JsonProperty
-import com.fasterxml.jackson.annotation.JsonFormat
 /**
  * A pet for sale in the pet store
  * @param name 
@@ -47,7 +46,6 @@ data class Pet (
     * Values: AVAILABLE,PENDING,SOLD
     */
     
-    @JsonFormat(shape = JsonFormat.Shape.NATURAL)
     enum class Status(val value: kotlin.String){
         @JsonProperty(value="available") AVAILABLE("available"),
         @JsonProperty(value="pending") PENDING("pending"),

--- a/samples/client/petstore/kotlin-jackson/src/main/kotlin/org/openapitools/client/models/Tag.kt
+++ b/samples/client/petstore/kotlin-jackson/src/main/kotlin/org/openapitools/client/models/Tag.kt
@@ -22,10 +22,8 @@ import com.fasterxml.jackson.annotation.JsonFormat
 
 data class Tag (
     @JsonProperty("id")
-    val id: kotlin.Long? = null
-,
+    val id: kotlin.Long? = null,
     @JsonProperty("name")
     val name: kotlin.String? = null
-
 )
 

--- a/samples/client/petstore/kotlin-jackson/src/main/kotlin/org/openapitools/client/models/Tag.kt
+++ b/samples/client/petstore/kotlin-jackson/src/main/kotlin/org/openapitools/client/models/Tag.kt
@@ -13,7 +13,6 @@ package org.openapitools.client.models
 
 
 import com.fasterxml.jackson.annotation.JsonProperty
-import com.fasterxml.jackson.annotation.JsonFormat
 /**
  * A tag for a pet
  * @param id 

--- a/samples/client/petstore/kotlin-jackson/src/main/kotlin/org/openapitools/client/models/User.kt
+++ b/samples/client/petstore/kotlin-jackson/src/main/kotlin/org/openapitools/client/models/User.kt
@@ -28,29 +28,21 @@ import com.fasterxml.jackson.annotation.JsonFormat
 
 data class User (
     @JsonProperty("id")
-    val id: kotlin.Long? = null
-,
+    val id: kotlin.Long? = null,
     @JsonProperty("username")
-    val username: kotlin.String? = null
-,
+    val username: kotlin.String? = null,
     @JsonProperty("firstName")
-    val firstName: kotlin.String? = null
-,
+    val firstName: kotlin.String? = null,
     @JsonProperty("lastName")
-    val lastName: kotlin.String? = null
-,
+    val lastName: kotlin.String? = null,
     @JsonProperty("email")
-    val email: kotlin.String? = null
-,
+    val email: kotlin.String? = null,
     @JsonProperty("password")
-    val password: kotlin.String? = null
-,
+    val password: kotlin.String? = null,
     @JsonProperty("phone")
-    val phone: kotlin.String? = null
-,
+    val phone: kotlin.String? = null,
     /* User Status */
     @JsonProperty("userStatus")
     val userStatus: kotlin.Int? = null
-
 )
 

--- a/samples/client/petstore/kotlin-jackson/src/main/kotlin/org/openapitools/client/models/User.kt
+++ b/samples/client/petstore/kotlin-jackson/src/main/kotlin/org/openapitools/client/models/User.kt
@@ -13,7 +13,6 @@ package org.openapitools.client.models
 
 
 import com.fasterxml.jackson.annotation.JsonProperty
-import com.fasterxml.jackson.annotation.JsonFormat
 /**
  * A User who is purchasing from the pet store
  * @param id 

--- a/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/models/ApiResponse.kt
+++ b/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/models/ApiResponse.kt
@@ -22,13 +22,10 @@ import com.squareup.moshi.Json
 
 data class ApiResponse (
     @Json(name = "code")
-    val code: kotlin.Int? = null
-,
+    val code: kotlin.Int? = null,
     @Json(name = "type")
-    val type: kotlin.String? = null
-,
+    val type: kotlin.String? = null,
     @Json(name = "message")
     val message: kotlin.String? = null
-
 )
 

--- a/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/models/Category.kt
+++ b/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/models/Category.kt
@@ -21,10 +21,8 @@ import com.squareup.moshi.Json
 
 data class Category (
     @Json(name = "id")
-    val id: kotlin.Long? = null
-,
+    val id: kotlin.Long? = null,
     @Json(name = "name")
     val name: kotlin.String? = null
-
 )
 

--- a/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/models/Order.kt
+++ b/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/models/Order.kt
@@ -25,24 +25,18 @@ import com.squareup.moshi.Json
 
 data class Order (
     @Json(name = "id")
-    val id: kotlin.Long? = null
-,
+    val id: kotlin.Long? = null,
     @Json(name = "petId")
-    val petId: kotlin.Long? = null
-,
+    val petId: kotlin.Long? = null,
     @Json(name = "quantity")
-    val quantity: kotlin.Int? = null
-,
+    val quantity: kotlin.Int? = null,
     @Json(name = "shipDate")
-    val shipDate: java.time.OffsetDateTime? = null
-,
+    val shipDate: java.time.OffsetDateTime? = null,
     /* Order Status */
     @Json(name = "status")
-    val status: Order.Status? = null
-,
+    val status: Order.Status? = null,
     @Json(name = "complete")
     val complete: kotlin.Boolean? = null
-
 ) {
 
     /**

--- a/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/models/Order.kt
+++ b/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/models/Order.kt
@@ -44,7 +44,6 @@ data class Order (
     * Values: placed,approved,delivered
     */
     
-    
     enum class Status(val value: kotlin.String){
         @Json(name = "placed") placed("placed"),
         @Json(name = "approved") approved("approved"),

--- a/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/models/Pet.kt
+++ b/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/models/Pet.kt
@@ -46,7 +46,6 @@ data class Pet (
     * Values: available,pending,sold
     */
     
-    
     enum class Status(val value: kotlin.String){
         @Json(name = "available") available("available"),
         @Json(name = "pending") pending("pending"),

--- a/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/models/Pet.kt
+++ b/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/models/Pet.kt
@@ -27,24 +27,18 @@ import com.squareup.moshi.Json
 
 data class Pet (
     @Json(name = "name")
-    val name: kotlin.String
-,
+    val name: kotlin.String,
     @Json(name = "photoUrls")
-    val photoUrls: kotlin.Array<kotlin.String>
-,
+    val photoUrls: kotlin.Array<kotlin.String>,
     @Json(name = "id")
-    val id: kotlin.Long? = null
-,
+    val id: kotlin.Long? = null,
     @Json(name = "category")
-    val category: Category? = null
-,
+    val category: Category? = null,
     @Json(name = "tags")
-    val tags: kotlin.Array<Tag>? = null
-,
+    val tags: kotlin.Array<Tag>? = null,
     /* pet status in the store */
     @Json(name = "status")
     val status: Pet.Status? = null
-
 ) {
 
     /**

--- a/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/models/Tag.kt
+++ b/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/models/Tag.kt
@@ -21,10 +21,8 @@ import com.squareup.moshi.Json
 
 data class Tag (
     @Json(name = "id")
-    val id: kotlin.Long? = null
-,
+    val id: kotlin.Long? = null,
     @Json(name = "name")
     val name: kotlin.String? = null
-
 )
 

--- a/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/models/User.kt
+++ b/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/models/User.kt
@@ -27,29 +27,21 @@ import com.squareup.moshi.Json
 
 data class User (
     @Json(name = "id")
-    val id: kotlin.Long? = null
-,
+    val id: kotlin.Long? = null,
     @Json(name = "username")
-    val username: kotlin.String? = null
-,
+    val username: kotlin.String? = null,
     @Json(name = "firstName")
-    val firstName: kotlin.String? = null
-,
+    val firstName: kotlin.String? = null,
     @Json(name = "lastName")
-    val lastName: kotlin.String? = null
-,
+    val lastName: kotlin.String? = null,
     @Json(name = "email")
-    val email: kotlin.String? = null
-,
+    val email: kotlin.String? = null,
     @Json(name = "password")
-    val password: kotlin.String? = null
-,
+    val password: kotlin.String? = null,
     @Json(name = "phone")
-    val phone: kotlin.String? = null
-,
+    val phone: kotlin.String? = null,
     /* User Status */
     @Json(name = "userStatus")
     val userStatus: kotlin.Int? = null
-
 )
 

--- a/samples/client/petstore/kotlin-moshi-codegen/src/main/kotlin/org/openapitools/client/models/ApiResponse.kt
+++ b/samples/client/petstore/kotlin-moshi-codegen/src/main/kotlin/org/openapitools/client/models/ApiResponse.kt
@@ -23,13 +23,10 @@ import com.squareup.moshi.JsonClass
 @JsonClass(generateAdapter = true)
 data class ApiResponse (
     @Json(name = "code")
-    val code: kotlin.Int? = null
-,
+    val code: kotlin.Int? = null,
     @Json(name = "type")
-    val type: kotlin.String? = null
-,
+    val type: kotlin.String? = null,
     @Json(name = "message")
     val message: kotlin.String? = null
-
 )
 

--- a/samples/client/petstore/kotlin-moshi-codegen/src/main/kotlin/org/openapitools/client/models/Category.kt
+++ b/samples/client/petstore/kotlin-moshi-codegen/src/main/kotlin/org/openapitools/client/models/Category.kt
@@ -22,10 +22,8 @@ import com.squareup.moshi.JsonClass
 @JsonClass(generateAdapter = true)
 data class Category (
     @Json(name = "id")
-    val id: kotlin.Long? = null
-,
+    val id: kotlin.Long? = null,
     @Json(name = "name")
     val name: kotlin.String? = null
-
 )
 

--- a/samples/client/petstore/kotlin-moshi-codegen/src/main/kotlin/org/openapitools/client/models/Order.kt
+++ b/samples/client/petstore/kotlin-moshi-codegen/src/main/kotlin/org/openapitools/client/models/Order.kt
@@ -45,7 +45,6 @@ data class Order (
     * Values: placed,approved,delivered
     */
     
-    
     enum class Status(val value: kotlin.String){
         @Json(name = "placed") placed("placed"),
         @Json(name = "approved") approved("approved"),

--- a/samples/client/petstore/kotlin-moshi-codegen/src/main/kotlin/org/openapitools/client/models/Order.kt
+++ b/samples/client/petstore/kotlin-moshi-codegen/src/main/kotlin/org/openapitools/client/models/Order.kt
@@ -26,24 +26,18 @@ import com.squareup.moshi.JsonClass
 @JsonClass(generateAdapter = true)
 data class Order (
     @Json(name = "id")
-    val id: kotlin.Long? = null
-,
+    val id: kotlin.Long? = null,
     @Json(name = "petId")
-    val petId: kotlin.Long? = null
-,
+    val petId: kotlin.Long? = null,
     @Json(name = "quantity")
-    val quantity: kotlin.Int? = null
-,
+    val quantity: kotlin.Int? = null,
     @Json(name = "shipDate")
-    val shipDate: java.time.OffsetDateTime? = null
-,
+    val shipDate: java.time.OffsetDateTime? = null,
     /* Order Status */
     @Json(name = "status")
-    val status: Order.Status? = null
-,
+    val status: Order.Status? = null,
     @Json(name = "complete")
     val complete: kotlin.Boolean? = null
-
 ) {
 
     /**

--- a/samples/client/petstore/kotlin-moshi-codegen/src/main/kotlin/org/openapitools/client/models/Pet.kt
+++ b/samples/client/petstore/kotlin-moshi-codegen/src/main/kotlin/org/openapitools/client/models/Pet.kt
@@ -47,7 +47,6 @@ data class Pet (
     * Values: available,pending,sold
     */
     
-    
     enum class Status(val value: kotlin.String){
         @Json(name = "available") available("available"),
         @Json(name = "pending") pending("pending"),

--- a/samples/client/petstore/kotlin-moshi-codegen/src/main/kotlin/org/openapitools/client/models/Pet.kt
+++ b/samples/client/petstore/kotlin-moshi-codegen/src/main/kotlin/org/openapitools/client/models/Pet.kt
@@ -28,24 +28,18 @@ import com.squareup.moshi.JsonClass
 @JsonClass(generateAdapter = true)
 data class Pet (
     @Json(name = "name")
-    val name: kotlin.String
-,
+    val name: kotlin.String,
     @Json(name = "photoUrls")
-    val photoUrls: kotlin.Array<kotlin.String>
-,
+    val photoUrls: kotlin.Array<kotlin.String>,
     @Json(name = "id")
-    val id: kotlin.Long? = null
-,
+    val id: kotlin.Long? = null,
     @Json(name = "category")
-    val category: Category? = null
-,
+    val category: Category? = null,
     @Json(name = "tags")
-    val tags: kotlin.Array<Tag>? = null
-,
+    val tags: kotlin.Array<Tag>? = null,
     /* pet status in the store */
     @Json(name = "status")
     val status: Pet.Status? = null
-
 ) {
 
     /**

--- a/samples/client/petstore/kotlin-moshi-codegen/src/main/kotlin/org/openapitools/client/models/Tag.kt
+++ b/samples/client/petstore/kotlin-moshi-codegen/src/main/kotlin/org/openapitools/client/models/Tag.kt
@@ -22,10 +22,8 @@ import com.squareup.moshi.JsonClass
 @JsonClass(generateAdapter = true)
 data class Tag (
     @Json(name = "id")
-    val id: kotlin.Long? = null
-,
+    val id: kotlin.Long? = null,
     @Json(name = "name")
     val name: kotlin.String? = null
-
 )
 

--- a/samples/client/petstore/kotlin-moshi-codegen/src/main/kotlin/org/openapitools/client/models/User.kt
+++ b/samples/client/petstore/kotlin-moshi-codegen/src/main/kotlin/org/openapitools/client/models/User.kt
@@ -28,29 +28,21 @@ import com.squareup.moshi.JsonClass
 @JsonClass(generateAdapter = true)
 data class User (
     @Json(name = "id")
-    val id: kotlin.Long? = null
-,
+    val id: kotlin.Long? = null,
     @Json(name = "username")
-    val username: kotlin.String? = null
-,
+    val username: kotlin.String? = null,
     @Json(name = "firstName")
-    val firstName: kotlin.String? = null
-,
+    val firstName: kotlin.String? = null,
     @Json(name = "lastName")
-    val lastName: kotlin.String? = null
-,
+    val lastName: kotlin.String? = null,
     @Json(name = "email")
-    val email: kotlin.String? = null
-,
+    val email: kotlin.String? = null,
     @Json(name = "password")
-    val password: kotlin.String? = null
-,
+    val password: kotlin.String? = null,
     @Json(name = "phone")
-    val phone: kotlin.String? = null
-,
+    val phone: kotlin.String? = null,
     /* User Status */
     @Json(name = "userStatus")
     val userStatus: kotlin.Int? = null
-
 )
 

--- a/samples/client/petstore/kotlin-multiplatform/src/commonMain/kotlin/org/openapitools/client/models/ApiResponse.kt
+++ b/samples/client/petstore/kotlin-multiplatform/src/commonMain/kotlin/org/openapitools/client/models/ApiResponse.kt
@@ -22,11 +22,8 @@ import kotlinx.serialization.internal.CommonEnumSerializer
  */
 @Serializable
 data class ApiResponse (
-    @SerialName(value = "code") val code: kotlin.Int? = null
-,
-    @SerialName(value = "type") val type: kotlin.String? = null
-,
+    @SerialName(value = "code") val code: kotlin.Int? = null,
+    @SerialName(value = "type") val type: kotlin.String? = null,
     @SerialName(value = "message") val message: kotlin.String? = null
-
 )
 

--- a/samples/client/petstore/kotlin-multiplatform/src/commonMain/kotlin/org/openapitools/client/models/Category.kt
+++ b/samples/client/petstore/kotlin-multiplatform/src/commonMain/kotlin/org/openapitools/client/models/Category.kt
@@ -21,9 +21,7 @@ import kotlinx.serialization.internal.CommonEnumSerializer
  */
 @Serializable
 data class Category (
-    @SerialName(value = "id") val id: kotlin.Long? = null
-,
+    @SerialName(value = "id") val id: kotlin.Long? = null,
     @SerialName(value = "name") val name: kotlin.String? = null
-
 )
 

--- a/samples/client/petstore/kotlin-multiplatform/src/commonMain/kotlin/org/openapitools/client/models/Order.kt
+++ b/samples/client/petstore/kotlin-multiplatform/src/commonMain/kotlin/org/openapitools/client/models/Order.kt
@@ -25,19 +25,13 @@ import kotlinx.serialization.internal.CommonEnumSerializer
  */
 @Serializable
 data class Order (
-    @SerialName(value = "id") val id: kotlin.Long? = null
-,
-    @SerialName(value = "petId") val petId: kotlin.Long? = null
-,
-    @SerialName(value = "quantity") val quantity: kotlin.Int? = null
-,
-    @SerialName(value = "shipDate") val shipDate: kotlin.String? = null
-,
+    @SerialName(value = "id") val id: kotlin.Long? = null,
+    @SerialName(value = "petId") val petId: kotlin.Long? = null,
+    @SerialName(value = "quantity") val quantity: kotlin.Int? = null,
+    @SerialName(value = "shipDate") val shipDate: kotlin.String? = null,
     /* Order Status */
-    @SerialName(value = "status") val status: Order.Status? = null
-,
+    @SerialName(value = "status") val status: Order.Status? = null,
     @SerialName(value = "complete") val complete: kotlin.Boolean? = null
-
 ) {
 
     /**

--- a/samples/client/petstore/kotlin-multiplatform/src/commonMain/kotlin/org/openapitools/client/models/Order.kt
+++ b/samples/client/petstore/kotlin-multiplatform/src/commonMain/kotlin/org/openapitools/client/models/Order.kt
@@ -39,7 +39,6 @@ data class Order (
     * Values: placed,approved,delivered
     */
     @Serializable(with = Status.Serializer::class)
-    
     enum class Status(val value: kotlin.String){
         placed("placed"),
         approved("approved"),

--- a/samples/client/petstore/kotlin-multiplatform/src/commonMain/kotlin/org/openapitools/client/models/Pet.kt
+++ b/samples/client/petstore/kotlin-multiplatform/src/commonMain/kotlin/org/openapitools/client/models/Pet.kt
@@ -41,7 +41,6 @@ data class Pet (
     * Values: available,pending,sold
     */
     @Serializable(with = Status.Serializer::class)
-    
     enum class Status(val value: kotlin.String){
         available("available"),
         pending("pending"),

--- a/samples/client/petstore/kotlin-multiplatform/src/commonMain/kotlin/org/openapitools/client/models/Pet.kt
+++ b/samples/client/petstore/kotlin-multiplatform/src/commonMain/kotlin/org/openapitools/client/models/Pet.kt
@@ -27,19 +27,13 @@ import kotlinx.serialization.internal.CommonEnumSerializer
  */
 @Serializable
 data class Pet (
-    @SerialName(value = "name") @Required val name: kotlin.String
-,
-    @SerialName(value = "photoUrls") @Required val photoUrls: kotlin.Array<kotlin.String>
-,
-    @SerialName(value = "id") val id: kotlin.Long? = null
-,
-    @SerialName(value = "category") val category: Category? = null
-,
-    @SerialName(value = "tags") val tags: kotlin.Array<Tag>? = null
-,
+    @SerialName(value = "name") @Required val name: kotlin.String,
+    @SerialName(value = "photoUrls") @Required val photoUrls: kotlin.Array<kotlin.String>,
+    @SerialName(value = "id") val id: kotlin.Long? = null,
+    @SerialName(value = "category") val category: Category? = null,
+    @SerialName(value = "tags") val tags: kotlin.Array<Tag>? = null,
     /* pet status in the store */
     @SerialName(value = "status") val status: Pet.Status? = null
-
 ) {
 
     /**

--- a/samples/client/petstore/kotlin-multiplatform/src/commonMain/kotlin/org/openapitools/client/models/Tag.kt
+++ b/samples/client/petstore/kotlin-multiplatform/src/commonMain/kotlin/org/openapitools/client/models/Tag.kt
@@ -21,9 +21,7 @@ import kotlinx.serialization.internal.CommonEnumSerializer
  */
 @Serializable
 data class Tag (
-    @SerialName(value = "id") val id: kotlin.Long? = null
-,
+    @SerialName(value = "id") val id: kotlin.Long? = null,
     @SerialName(value = "name") val name: kotlin.String? = null
-
 )
 

--- a/samples/client/petstore/kotlin-multiplatform/src/commonMain/kotlin/org/openapitools/client/models/User.kt
+++ b/samples/client/petstore/kotlin-multiplatform/src/commonMain/kotlin/org/openapitools/client/models/User.kt
@@ -27,22 +27,14 @@ import kotlinx.serialization.internal.CommonEnumSerializer
  */
 @Serializable
 data class User (
-    @SerialName(value = "id") val id: kotlin.Long? = null
-,
-    @SerialName(value = "username") val username: kotlin.String? = null
-,
-    @SerialName(value = "firstName") val firstName: kotlin.String? = null
-,
-    @SerialName(value = "lastName") val lastName: kotlin.String? = null
-,
-    @SerialName(value = "email") val email: kotlin.String? = null
-,
-    @SerialName(value = "password") val password: kotlin.String? = null
-,
-    @SerialName(value = "phone") val phone: kotlin.String? = null
-,
+    @SerialName(value = "id") val id: kotlin.Long? = null,
+    @SerialName(value = "username") val username: kotlin.String? = null,
+    @SerialName(value = "firstName") val firstName: kotlin.String? = null,
+    @SerialName(value = "lastName") val lastName: kotlin.String? = null,
+    @SerialName(value = "email") val email: kotlin.String? = null,
+    @SerialName(value = "password") val password: kotlin.String? = null,
+    @SerialName(value = "phone") val phone: kotlin.String? = null,
     /* User Status */
     @SerialName(value = "userStatus") val userStatus: kotlin.Int? = null
-
 )
 

--- a/samples/client/petstore/kotlin-nonpublic/src/main/kotlin/org/openapitools/client/models/ApiResponse.kt
+++ b/samples/client/petstore/kotlin-nonpublic/src/main/kotlin/org/openapitools/client/models/ApiResponse.kt
@@ -22,13 +22,10 @@ import com.squareup.moshi.Json
 
 internal data class ApiResponse (
     @Json(name = "code")
-    val code: kotlin.Int? = null
-,
+    val code: kotlin.Int? = null,
     @Json(name = "type")
-    val type: kotlin.String? = null
-,
+    val type: kotlin.String? = null,
     @Json(name = "message")
     val message: kotlin.String? = null
-
 )
 

--- a/samples/client/petstore/kotlin-nonpublic/src/main/kotlin/org/openapitools/client/models/Category.kt
+++ b/samples/client/petstore/kotlin-nonpublic/src/main/kotlin/org/openapitools/client/models/Category.kt
@@ -21,10 +21,8 @@ import com.squareup.moshi.Json
 
 internal data class Category (
     @Json(name = "id")
-    val id: kotlin.Long? = null
-,
+    val id: kotlin.Long? = null,
     @Json(name = "name")
     val name: kotlin.String? = null
-
 )
 

--- a/samples/client/petstore/kotlin-nonpublic/src/main/kotlin/org/openapitools/client/models/Order.kt
+++ b/samples/client/petstore/kotlin-nonpublic/src/main/kotlin/org/openapitools/client/models/Order.kt
@@ -25,24 +25,18 @@ import com.squareup.moshi.Json
 
 internal data class Order (
     @Json(name = "id")
-    val id: kotlin.Long? = null
-,
+    val id: kotlin.Long? = null,
     @Json(name = "petId")
-    val petId: kotlin.Long? = null
-,
+    val petId: kotlin.Long? = null,
     @Json(name = "quantity")
-    val quantity: kotlin.Int? = null
-,
+    val quantity: kotlin.Int? = null,
     @Json(name = "shipDate")
-    val shipDate: java.time.OffsetDateTime? = null
-,
+    val shipDate: java.time.OffsetDateTime? = null,
     /* Order Status */
     @Json(name = "status")
-    val status: Order.Status? = null
-,
+    val status: Order.Status? = null,
     @Json(name = "complete")
     val complete: kotlin.Boolean? = null
-
 ) {
 
     /**

--- a/samples/client/petstore/kotlin-nonpublic/src/main/kotlin/org/openapitools/client/models/Order.kt
+++ b/samples/client/petstore/kotlin-nonpublic/src/main/kotlin/org/openapitools/client/models/Order.kt
@@ -44,7 +44,6 @@ internal data class Order (
     * Values: placed,approved,delivered
     */
     
-    
     internal enum class Status(val value: kotlin.String){
         @Json(name = "placed") placed("placed"),
         @Json(name = "approved") approved("approved"),

--- a/samples/client/petstore/kotlin-nonpublic/src/main/kotlin/org/openapitools/client/models/Pet.kt
+++ b/samples/client/petstore/kotlin-nonpublic/src/main/kotlin/org/openapitools/client/models/Pet.kt
@@ -46,7 +46,6 @@ internal data class Pet (
     * Values: available,pending,sold
     */
     
-    
     internal enum class Status(val value: kotlin.String){
         @Json(name = "available") available("available"),
         @Json(name = "pending") pending("pending"),

--- a/samples/client/petstore/kotlin-nonpublic/src/main/kotlin/org/openapitools/client/models/Pet.kt
+++ b/samples/client/petstore/kotlin-nonpublic/src/main/kotlin/org/openapitools/client/models/Pet.kt
@@ -27,24 +27,18 @@ import com.squareup.moshi.Json
 
 internal data class Pet (
     @Json(name = "name")
-    val name: kotlin.String
-,
+    val name: kotlin.String,
     @Json(name = "photoUrls")
-    val photoUrls: kotlin.Array<kotlin.String>
-,
+    val photoUrls: kotlin.Array<kotlin.String>,
     @Json(name = "id")
-    val id: kotlin.Long? = null
-,
+    val id: kotlin.Long? = null,
     @Json(name = "category")
-    val category: Category? = null
-,
+    val category: Category? = null,
     @Json(name = "tags")
-    val tags: kotlin.Array<Tag>? = null
-,
+    val tags: kotlin.Array<Tag>? = null,
     /* pet status in the store */
     @Json(name = "status")
     val status: Pet.Status? = null
-
 ) {
 
     /**

--- a/samples/client/petstore/kotlin-nonpublic/src/main/kotlin/org/openapitools/client/models/Tag.kt
+++ b/samples/client/petstore/kotlin-nonpublic/src/main/kotlin/org/openapitools/client/models/Tag.kt
@@ -21,10 +21,8 @@ import com.squareup.moshi.Json
 
 internal data class Tag (
     @Json(name = "id")
-    val id: kotlin.Long? = null
-,
+    val id: kotlin.Long? = null,
     @Json(name = "name")
     val name: kotlin.String? = null
-
 )
 

--- a/samples/client/petstore/kotlin-nonpublic/src/main/kotlin/org/openapitools/client/models/User.kt
+++ b/samples/client/petstore/kotlin-nonpublic/src/main/kotlin/org/openapitools/client/models/User.kt
@@ -27,29 +27,21 @@ import com.squareup.moshi.Json
 
 internal data class User (
     @Json(name = "id")
-    val id: kotlin.Long? = null
-,
+    val id: kotlin.Long? = null,
     @Json(name = "username")
-    val username: kotlin.String? = null
-,
+    val username: kotlin.String? = null,
     @Json(name = "firstName")
-    val firstName: kotlin.String? = null
-,
+    val firstName: kotlin.String? = null,
     @Json(name = "lastName")
-    val lastName: kotlin.String? = null
-,
+    val lastName: kotlin.String? = null,
     @Json(name = "email")
-    val email: kotlin.String? = null
-,
+    val email: kotlin.String? = null,
     @Json(name = "password")
-    val password: kotlin.String? = null
-,
+    val password: kotlin.String? = null,
     @Json(name = "phone")
-    val phone: kotlin.String? = null
-,
+    val phone: kotlin.String? = null,
     /* User Status */
     @Json(name = "userStatus")
     val userStatus: kotlin.Int? = null
-
 )
 

--- a/samples/client/petstore/kotlin-nullable/src/main/kotlin/org/openapitools/client/models/ApiResponse.kt
+++ b/samples/client/petstore/kotlin-nullable/src/main/kotlin/org/openapitools/client/models/ApiResponse.kt
@@ -23,14 +23,11 @@ import java.io.Serializable
 
 data class ApiResponse (
     @Json(name = "code")
-    val code: kotlin.Int? = null
-,
+    val code: kotlin.Int? = null,
     @Json(name = "type")
-    val type: kotlin.String? = null
-,
+    val type: kotlin.String? = null,
     @Json(name = "message")
     val message: kotlin.String? = null
-
 ) : Serializable {
 	companion object {
 		private const val serialVersionUID: Long = 123

--- a/samples/client/petstore/kotlin-nullable/src/main/kotlin/org/openapitools/client/models/Category.kt
+++ b/samples/client/petstore/kotlin-nullable/src/main/kotlin/org/openapitools/client/models/Category.kt
@@ -22,11 +22,9 @@ import java.io.Serializable
 
 data class Category (
     @Json(name = "id")
-    val id: kotlin.Long? = null
-,
+    val id: kotlin.Long? = null,
     @Json(name = "name")
     val name: kotlin.String? = null
-
 ) : Serializable {
 	companion object {
 		private const val serialVersionUID: Long = 123

--- a/samples/client/petstore/kotlin-nullable/src/main/kotlin/org/openapitools/client/models/Order.kt
+++ b/samples/client/petstore/kotlin-nullable/src/main/kotlin/org/openapitools/client/models/Order.kt
@@ -48,7 +48,6 @@ data class Order (
     * Values: placed,approved,delivered
     */
     
-    
     enum class Status(val value: kotlin.String){
         @Json(name = "placed") placed("placed"),
         @Json(name = "approved") approved("approved"),

--- a/samples/client/petstore/kotlin-nullable/src/main/kotlin/org/openapitools/client/models/Order.kt
+++ b/samples/client/petstore/kotlin-nullable/src/main/kotlin/org/openapitools/client/models/Order.kt
@@ -26,24 +26,18 @@ import java.io.Serializable
 
 data class Order (
     @Json(name = "id")
-    val id: kotlin.Long? = null
-,
+    val id: kotlin.Long? = null,
     @Json(name = "petId")
-    val petId: kotlin.Long? = null
-,
+    val petId: kotlin.Long? = null,
     @Json(name = "quantity")
-    val quantity: kotlin.Int? = null
-,
+    val quantity: kotlin.Int? = null,
     @Json(name = "shipDate")
-    val shipDate: java.time.OffsetDateTime? = null
-,
+    val shipDate: java.time.OffsetDateTime? = null,
     /* Order Status */
     @Json(name = "status")
-    val status: Order.Status? = null
-,
+    val status: Order.Status? = null,
     @Json(name = "complete")
     val complete: kotlin.Boolean? = null
-
 ) : Serializable {
 	companion object {
 		private const val serialVersionUID: Long = 123

--- a/samples/client/petstore/kotlin-nullable/src/main/kotlin/org/openapitools/client/models/Pet.kt
+++ b/samples/client/petstore/kotlin-nullable/src/main/kotlin/org/openapitools/client/models/Pet.kt
@@ -50,7 +50,6 @@ data class Pet (
     * Values: available,pending,sold
     */
     
-    
     enum class Status(val value: kotlin.String){
         @Json(name = "available") available("available"),
         @Json(name = "pending") pending("pending"),

--- a/samples/client/petstore/kotlin-nullable/src/main/kotlin/org/openapitools/client/models/Pet.kt
+++ b/samples/client/petstore/kotlin-nullable/src/main/kotlin/org/openapitools/client/models/Pet.kt
@@ -28,24 +28,18 @@ import java.io.Serializable
 
 data class Pet (
     @Json(name = "name")
-    val name: kotlin.String
-,
+    val name: kotlin.String,
     @Json(name = "photoUrls")
-    val photoUrls: kotlin.Array<kotlin.String>
-,
+    val photoUrls: kotlin.Array<kotlin.String>,
     @Json(name = "id")
-    val id: kotlin.Long? = null
-,
+    val id: kotlin.Long? = null,
     @Json(name = "category")
-    val category: Category? = null
-,
+    val category: Category? = null,
     @Json(name = "tags")
-    val tags: kotlin.Array<Tag>? = null
-,
+    val tags: kotlin.Array<Tag>? = null,
     /* pet status in the store */
     @Json(name = "status")
     val status: Pet.Status? = null
-
 ) : Serializable {
 	companion object {
 		private const val serialVersionUID: Long = 123

--- a/samples/client/petstore/kotlin-nullable/src/main/kotlin/org/openapitools/client/models/Tag.kt
+++ b/samples/client/petstore/kotlin-nullable/src/main/kotlin/org/openapitools/client/models/Tag.kt
@@ -22,11 +22,9 @@ import java.io.Serializable
 
 data class Tag (
     @Json(name = "id")
-    val id: kotlin.Long? = null
-,
+    val id: kotlin.Long? = null,
     @Json(name = "name")
     val name: kotlin.String? = null
-
 ) : Serializable {
 	companion object {
 		private const val serialVersionUID: Long = 123

--- a/samples/client/petstore/kotlin-nullable/src/main/kotlin/org/openapitools/client/models/User.kt
+++ b/samples/client/petstore/kotlin-nullable/src/main/kotlin/org/openapitools/client/models/User.kt
@@ -28,30 +28,22 @@ import java.io.Serializable
 
 data class User (
     @Json(name = "id")
-    val id: kotlin.Long? = null
-,
+    val id: kotlin.Long? = null,
     @Json(name = "username")
-    val username: kotlin.String? = null
-,
+    val username: kotlin.String? = null,
     @Json(name = "firstName")
-    val firstName: kotlin.String? = null
-,
+    val firstName: kotlin.String? = null,
     @Json(name = "lastName")
-    val lastName: kotlin.String? = null
-,
+    val lastName: kotlin.String? = null,
     @Json(name = "email")
-    val email: kotlin.String? = null
-,
+    val email: kotlin.String? = null,
     @Json(name = "password")
-    val password: kotlin.String? = null
-,
+    val password: kotlin.String? = null,
     @Json(name = "phone")
-    val phone: kotlin.String? = null
-,
+    val phone: kotlin.String? = null,
     /* User Status */
     @Json(name = "userStatus")
     val userStatus: kotlin.Int? = null
-
 ) : Serializable {
 	companion object {
 		private const val serialVersionUID: Long = 123

--- a/samples/client/petstore/kotlin-okhttp3/src/main/kotlin/org/openapitools/client/models/ApiResponse.kt
+++ b/samples/client/petstore/kotlin-okhttp3/src/main/kotlin/org/openapitools/client/models/ApiResponse.kt
@@ -22,13 +22,10 @@ import com.squareup.moshi.Json
 
 data class ApiResponse (
     @Json(name = "code")
-    val code: kotlin.Int? = null
-,
+    val code: kotlin.Int? = null,
     @Json(name = "type")
-    val type: kotlin.String? = null
-,
+    val type: kotlin.String? = null,
     @Json(name = "message")
     val message: kotlin.String? = null
-
 )
 

--- a/samples/client/petstore/kotlin-okhttp3/src/main/kotlin/org/openapitools/client/models/Category.kt
+++ b/samples/client/petstore/kotlin-okhttp3/src/main/kotlin/org/openapitools/client/models/Category.kt
@@ -21,10 +21,8 @@ import com.squareup.moshi.Json
 
 data class Category (
     @Json(name = "id")
-    val id: kotlin.Long? = null
-,
+    val id: kotlin.Long? = null,
     @Json(name = "name")
     val name: kotlin.String? = null
-
 )
 

--- a/samples/client/petstore/kotlin-okhttp3/src/main/kotlin/org/openapitools/client/models/Order.kt
+++ b/samples/client/petstore/kotlin-okhttp3/src/main/kotlin/org/openapitools/client/models/Order.kt
@@ -25,24 +25,18 @@ import com.squareup.moshi.Json
 
 data class Order (
     @Json(name = "id")
-    val id: kotlin.Long? = null
-,
+    val id: kotlin.Long? = null,
     @Json(name = "petId")
-    val petId: kotlin.Long? = null
-,
+    val petId: kotlin.Long? = null,
     @Json(name = "quantity")
-    val quantity: kotlin.Int? = null
-,
+    val quantity: kotlin.Int? = null,
     @Json(name = "shipDate")
-    val shipDate: java.time.OffsetDateTime? = null
-,
+    val shipDate: java.time.OffsetDateTime? = null,
     /* Order Status */
     @Json(name = "status")
-    val status: Order.Status? = null
-,
+    val status: Order.Status? = null,
     @Json(name = "complete")
     val complete: kotlin.Boolean? = null
-
 ) {
 
     /**

--- a/samples/client/petstore/kotlin-okhttp3/src/main/kotlin/org/openapitools/client/models/Order.kt
+++ b/samples/client/petstore/kotlin-okhttp3/src/main/kotlin/org/openapitools/client/models/Order.kt
@@ -44,7 +44,6 @@ data class Order (
     * Values: placed,approved,delivered
     */
     
-    
     enum class Status(val value: kotlin.String){
         @Json(name = "placed") placed("placed"),
         @Json(name = "approved") approved("approved"),

--- a/samples/client/petstore/kotlin-okhttp3/src/main/kotlin/org/openapitools/client/models/Pet.kt
+++ b/samples/client/petstore/kotlin-okhttp3/src/main/kotlin/org/openapitools/client/models/Pet.kt
@@ -46,7 +46,6 @@ data class Pet (
     * Values: available,pending,sold
     */
     
-    
     enum class Status(val value: kotlin.String){
         @Json(name = "available") available("available"),
         @Json(name = "pending") pending("pending"),

--- a/samples/client/petstore/kotlin-okhttp3/src/main/kotlin/org/openapitools/client/models/Pet.kt
+++ b/samples/client/petstore/kotlin-okhttp3/src/main/kotlin/org/openapitools/client/models/Pet.kt
@@ -27,24 +27,18 @@ import com.squareup.moshi.Json
 
 data class Pet (
     @Json(name = "name")
-    val name: kotlin.String
-,
+    val name: kotlin.String,
     @Json(name = "photoUrls")
-    val photoUrls: kotlin.Array<kotlin.String>
-,
+    val photoUrls: kotlin.Array<kotlin.String>,
     @Json(name = "id")
-    val id: kotlin.Long? = null
-,
+    val id: kotlin.Long? = null,
     @Json(name = "category")
-    val category: Category? = null
-,
+    val category: Category? = null,
     @Json(name = "tags")
-    val tags: kotlin.Array<Tag>? = null
-,
+    val tags: kotlin.Array<Tag>? = null,
     /* pet status in the store */
     @Json(name = "status")
     val status: Pet.Status? = null
-
 ) {
 
     /**

--- a/samples/client/petstore/kotlin-okhttp3/src/main/kotlin/org/openapitools/client/models/Tag.kt
+++ b/samples/client/petstore/kotlin-okhttp3/src/main/kotlin/org/openapitools/client/models/Tag.kt
@@ -21,10 +21,8 @@ import com.squareup.moshi.Json
 
 data class Tag (
     @Json(name = "id")
-    val id: kotlin.Long? = null
-,
+    val id: kotlin.Long? = null,
     @Json(name = "name")
     val name: kotlin.String? = null
-
 )
 

--- a/samples/client/petstore/kotlin-okhttp3/src/main/kotlin/org/openapitools/client/models/User.kt
+++ b/samples/client/petstore/kotlin-okhttp3/src/main/kotlin/org/openapitools/client/models/User.kt
@@ -27,29 +27,21 @@ import com.squareup.moshi.Json
 
 data class User (
     @Json(name = "id")
-    val id: kotlin.Long? = null
-,
+    val id: kotlin.Long? = null,
     @Json(name = "username")
-    val username: kotlin.String? = null
-,
+    val username: kotlin.String? = null,
     @Json(name = "firstName")
-    val firstName: kotlin.String? = null
-,
+    val firstName: kotlin.String? = null,
     @Json(name = "lastName")
-    val lastName: kotlin.String? = null
-,
+    val lastName: kotlin.String? = null,
     @Json(name = "email")
-    val email: kotlin.String? = null
-,
+    val email: kotlin.String? = null,
     @Json(name = "password")
-    val password: kotlin.String? = null
-,
+    val password: kotlin.String? = null,
     @Json(name = "phone")
-    val phone: kotlin.String? = null
-,
+    val phone: kotlin.String? = null,
     /* User Status */
     @Json(name = "userStatus")
     val userStatus: kotlin.Int? = null
-
 )
 

--- a/samples/client/petstore/kotlin-retrofit2/src/main/kotlin/org/openapitools/client/models/ApiResponse.kt
+++ b/samples/client/petstore/kotlin-retrofit2/src/main/kotlin/org/openapitools/client/models/ApiResponse.kt
@@ -22,13 +22,10 @@ import com.squareup.moshi.Json
 
 data class ApiResponse (
     @Json(name = "code")
-    val code: kotlin.Int? = null
-,
+    val code: kotlin.Int? = null,
     @Json(name = "type")
-    val type: kotlin.String? = null
-,
+    val type: kotlin.String? = null,
     @Json(name = "message")
     val message: kotlin.String? = null
-
 )
 

--- a/samples/client/petstore/kotlin-retrofit2/src/main/kotlin/org/openapitools/client/models/Category.kt
+++ b/samples/client/petstore/kotlin-retrofit2/src/main/kotlin/org/openapitools/client/models/Category.kt
@@ -21,10 +21,8 @@ import com.squareup.moshi.Json
 
 data class Category (
     @Json(name = "id")
-    val id: kotlin.Long? = null
-,
+    val id: kotlin.Long? = null,
     @Json(name = "name")
     val name: kotlin.String? = null
-
 )
 

--- a/samples/client/petstore/kotlin-retrofit2/src/main/kotlin/org/openapitools/client/models/Order.kt
+++ b/samples/client/petstore/kotlin-retrofit2/src/main/kotlin/org/openapitools/client/models/Order.kt
@@ -25,24 +25,18 @@ import com.squareup.moshi.Json
 
 data class Order (
     @Json(name = "id")
-    val id: kotlin.Long? = null
-,
+    val id: kotlin.Long? = null,
     @Json(name = "petId")
-    val petId: kotlin.Long? = null
-,
+    val petId: kotlin.Long? = null,
     @Json(name = "quantity")
-    val quantity: kotlin.Int? = null
-,
+    val quantity: kotlin.Int? = null,
     @Json(name = "shipDate")
-    val shipDate: java.time.OffsetDateTime? = null
-,
+    val shipDate: java.time.OffsetDateTime? = null,
     /* Order Status */
     @Json(name = "status")
-    val status: Order.Status? = null
-,
+    val status: Order.Status? = null,
     @Json(name = "complete")
     val complete: kotlin.Boolean? = null
-
 ) {
 
     /**

--- a/samples/client/petstore/kotlin-retrofit2/src/main/kotlin/org/openapitools/client/models/Order.kt
+++ b/samples/client/petstore/kotlin-retrofit2/src/main/kotlin/org/openapitools/client/models/Order.kt
@@ -44,7 +44,6 @@ data class Order (
     * Values: placed,approved,delivered
     */
     
-    
     enum class Status(val value: kotlin.String){
         @Json(name = "placed") placed("placed"),
         @Json(name = "approved") approved("approved"),

--- a/samples/client/petstore/kotlin-retrofit2/src/main/kotlin/org/openapitools/client/models/Pet.kt
+++ b/samples/client/petstore/kotlin-retrofit2/src/main/kotlin/org/openapitools/client/models/Pet.kt
@@ -46,7 +46,6 @@ data class Pet (
     * Values: available,pending,sold
     */
     
-    
     enum class Status(val value: kotlin.String){
         @Json(name = "available") available("available"),
         @Json(name = "pending") pending("pending"),

--- a/samples/client/petstore/kotlin-retrofit2/src/main/kotlin/org/openapitools/client/models/Pet.kt
+++ b/samples/client/petstore/kotlin-retrofit2/src/main/kotlin/org/openapitools/client/models/Pet.kt
@@ -27,24 +27,18 @@ import com.squareup.moshi.Json
 
 data class Pet (
     @Json(name = "name")
-    val name: kotlin.String
-,
+    val name: kotlin.String,
     @Json(name = "photoUrls")
-    val photoUrls: kotlin.Array<kotlin.String>
-,
+    val photoUrls: kotlin.Array<kotlin.String>,
     @Json(name = "id")
-    val id: kotlin.Long? = null
-,
+    val id: kotlin.Long? = null,
     @Json(name = "category")
-    val category: Category? = null
-,
+    val category: Category? = null,
     @Json(name = "tags")
-    val tags: kotlin.Array<Tag>? = null
-,
+    val tags: kotlin.Array<Tag>? = null,
     /* pet status in the store */
     @Json(name = "status")
     val status: Pet.Status? = null
-
 ) {
 
     /**

--- a/samples/client/petstore/kotlin-retrofit2/src/main/kotlin/org/openapitools/client/models/Tag.kt
+++ b/samples/client/petstore/kotlin-retrofit2/src/main/kotlin/org/openapitools/client/models/Tag.kt
@@ -21,10 +21,8 @@ import com.squareup.moshi.Json
 
 data class Tag (
     @Json(name = "id")
-    val id: kotlin.Long? = null
-,
+    val id: kotlin.Long? = null,
     @Json(name = "name")
     val name: kotlin.String? = null
-
 )
 

--- a/samples/client/petstore/kotlin-retrofit2/src/main/kotlin/org/openapitools/client/models/User.kt
+++ b/samples/client/petstore/kotlin-retrofit2/src/main/kotlin/org/openapitools/client/models/User.kt
@@ -27,29 +27,21 @@ import com.squareup.moshi.Json
 
 data class User (
     @Json(name = "id")
-    val id: kotlin.Long? = null
-,
+    val id: kotlin.Long? = null,
     @Json(name = "username")
-    val username: kotlin.String? = null
-,
+    val username: kotlin.String? = null,
     @Json(name = "firstName")
-    val firstName: kotlin.String? = null
-,
+    val firstName: kotlin.String? = null,
     @Json(name = "lastName")
-    val lastName: kotlin.String? = null
-,
+    val lastName: kotlin.String? = null,
     @Json(name = "email")
-    val email: kotlin.String? = null
-,
+    val email: kotlin.String? = null,
     @Json(name = "password")
-    val password: kotlin.String? = null
-,
+    val password: kotlin.String? = null,
     @Json(name = "phone")
-    val phone: kotlin.String? = null
-,
+    val phone: kotlin.String? = null,
     /* User Status */
     @Json(name = "userStatus")
     val userStatus: kotlin.Int? = null
-
 )
 

--- a/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/models/ApiResponse.kt
+++ b/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/models/ApiResponse.kt
@@ -23,14 +23,11 @@ import java.io.Serializable
 
 data class ApiResponse (
     @Json(name = "code")
-    val code: kotlin.Int? = null
-,
+    val code: kotlin.Int? = null,
     @Json(name = "type")
-    val type: kotlin.String? = null
-,
+    val type: kotlin.String? = null,
     @Json(name = "message")
     val message: kotlin.String? = null
-
 ) : Serializable {
 	companion object {
 		private const val serialVersionUID: Long = 123

--- a/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/models/Category.kt
+++ b/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/models/Category.kt
@@ -22,11 +22,9 @@ import java.io.Serializable
 
 data class Category (
     @Json(name = "id")
-    val id: kotlin.Long? = null
-,
+    val id: kotlin.Long? = null,
     @Json(name = "name")
     val name: kotlin.String? = null
-
 ) : Serializable {
 	companion object {
 		private const val serialVersionUID: Long = 123

--- a/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/models/Order.kt
+++ b/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/models/Order.kt
@@ -48,7 +48,6 @@ data class Order (
     * Values: placed,approved,delivered
     */
     
-    
     enum class Status(val value: kotlin.String){
         @Json(name = "placed") placed("placed"),
         @Json(name = "approved") approved("approved"),

--- a/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/models/Order.kt
+++ b/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/models/Order.kt
@@ -26,24 +26,18 @@ import java.io.Serializable
 
 data class Order (
     @Json(name = "id")
-    val id: kotlin.Long? = null
-,
+    val id: kotlin.Long? = null,
     @Json(name = "petId")
-    val petId: kotlin.Long? = null
-,
+    val petId: kotlin.Long? = null,
     @Json(name = "quantity")
-    val quantity: kotlin.Int? = null
-,
+    val quantity: kotlin.Int? = null,
     @Json(name = "shipDate")
-    val shipDate: kotlin.String? = null
-,
+    val shipDate: kotlin.String? = null,
     /* Order Status */
     @Json(name = "status")
-    val status: Order.Status? = null
-,
+    val status: Order.Status? = null,
     @Json(name = "complete")
     val complete: kotlin.Boolean? = null
-
 ) : Serializable {
 	companion object {
 		private const val serialVersionUID: Long = 123

--- a/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/models/Pet.kt
+++ b/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/models/Pet.kt
@@ -28,24 +28,18 @@ import java.io.Serializable
 
 data class Pet (
     @Json(name = "id")
-    val id: kotlin.Long? = null
-,
+    val id: kotlin.Long? = null,
     @Json(name = "category")
-    val category: Category? = null
-,
+    val category: Category? = null,
     @Json(name = "name")
-    val name: kotlin.String
-,
+    val name: kotlin.String,
     @Json(name = "photoUrls")
-    val photoUrls: kotlin.Array<kotlin.String>
-,
+    val photoUrls: kotlin.Array<kotlin.String>,
     @Json(name = "tags")
-    val tags: kotlin.Array<Tag>? = null
-,
+    val tags: kotlin.Array<Tag>? = null,
     /* pet status in the store */
     @Json(name = "status")
     val status: Pet.Status? = null
-
 ) : Serializable {
 	companion object {
 		private const val serialVersionUID: Long = 123

--- a/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/models/Pet.kt
+++ b/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/models/Pet.kt
@@ -50,7 +50,6 @@ data class Pet (
     * Values: available,pending,sold
     */
     
-    
     enum class Status(val value: kotlin.String){
         @Json(name = "available") available("available"),
         @Json(name = "pending") pending("pending"),

--- a/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/models/Tag.kt
+++ b/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/models/Tag.kt
@@ -22,11 +22,9 @@ import java.io.Serializable
 
 data class Tag (
     @Json(name = "id")
-    val id: kotlin.Long? = null
-,
+    val id: kotlin.Long? = null,
     @Json(name = "name")
     val name: kotlin.String? = null
-
 ) : Serializable {
 	companion object {
 		private const val serialVersionUID: Long = 123

--- a/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/models/User.kt
+++ b/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/models/User.kt
@@ -28,30 +28,22 @@ import java.io.Serializable
 
 data class User (
     @Json(name = "id")
-    val id: kotlin.Long? = null
-,
+    val id: kotlin.Long? = null,
     @Json(name = "username")
-    val username: kotlin.String? = null
-,
+    val username: kotlin.String? = null,
     @Json(name = "firstName")
-    val firstName: kotlin.String? = null
-,
+    val firstName: kotlin.String? = null,
     @Json(name = "lastName")
-    val lastName: kotlin.String? = null
-,
+    val lastName: kotlin.String? = null,
     @Json(name = "email")
-    val email: kotlin.String? = null
-,
+    val email: kotlin.String? = null,
     @Json(name = "password")
-    val password: kotlin.String? = null
-,
+    val password: kotlin.String? = null,
     @Json(name = "phone")
-    val phone: kotlin.String? = null
-,
+    val phone: kotlin.String? = null,
     /* User Status */
     @Json(name = "userStatus")
     val userStatus: kotlin.Int? = null
-
 ) : Serializable {
 	companion object {
 		private const val serialVersionUID: Long = 123

--- a/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/models/ApiResponse.kt
+++ b/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/models/ApiResponse.kt
@@ -22,13 +22,10 @@ import com.squareup.moshi.Json
 
 data class ApiResponse (
     @Json(name = "code")
-    val code: kotlin.Int? = null
-,
+    val code: kotlin.Int? = null,
     @Json(name = "type")
-    val type: kotlin.String? = null
-,
+    val type: kotlin.String? = null,
     @Json(name = "message")
     val message: kotlin.String? = null
-
 )
 

--- a/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/models/Category.kt
+++ b/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/models/Category.kt
@@ -21,10 +21,8 @@ import com.squareup.moshi.Json
 
 data class Category (
     @Json(name = "id")
-    val id: kotlin.Long? = null
-,
+    val id: kotlin.Long? = null,
     @Json(name = "name")
     val name: kotlin.String? = null
-
 )
 

--- a/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/models/Order.kt
+++ b/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/models/Order.kt
@@ -25,24 +25,18 @@ import com.squareup.moshi.Json
 
 data class Order (
     @Json(name = "id")
-    val id: kotlin.Long? = null
-,
+    val id: kotlin.Long? = null,
     @Json(name = "petId")
-    val petId: kotlin.Long? = null
-,
+    val petId: kotlin.Long? = null,
     @Json(name = "quantity")
-    val quantity: kotlin.Int? = null
-,
+    val quantity: kotlin.Int? = null,
     @Json(name = "shipDate")
-    val shipDate: org.threeten.bp.OffsetDateTime? = null
-,
+    val shipDate: org.threeten.bp.OffsetDateTime? = null,
     /* Order Status */
     @Json(name = "status")
-    val status: Order.Status? = null
-,
+    val status: Order.Status? = null,
     @Json(name = "complete")
     val complete: kotlin.Boolean? = null
-
 ) {
 
     /**

--- a/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/models/Order.kt
+++ b/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/models/Order.kt
@@ -44,7 +44,6 @@ data class Order (
     * Values: placed,approved,delivered
     */
     
-    
     enum class Status(val value: kotlin.String){
         @Json(name = "placed") placed("placed"),
         @Json(name = "approved") approved("approved"),

--- a/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/models/Pet.kt
+++ b/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/models/Pet.kt
@@ -46,7 +46,6 @@ data class Pet (
     * Values: available,pending,sold
     */
     
-    
     enum class Status(val value: kotlin.String){
         @Json(name = "available") available("available"),
         @Json(name = "pending") pending("pending"),

--- a/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/models/Pet.kt
+++ b/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/models/Pet.kt
@@ -27,24 +27,18 @@ import com.squareup.moshi.Json
 
 data class Pet (
     @Json(name = "name")
-    val name: kotlin.String
-,
+    val name: kotlin.String,
     @Json(name = "photoUrls")
-    val photoUrls: kotlin.Array<kotlin.String>
-,
+    val photoUrls: kotlin.Array<kotlin.String>,
     @Json(name = "id")
-    val id: kotlin.Long? = null
-,
+    val id: kotlin.Long? = null,
     @Json(name = "category")
-    val category: Category? = null
-,
+    val category: Category? = null,
     @Json(name = "tags")
-    val tags: kotlin.Array<Tag>? = null
-,
+    val tags: kotlin.Array<Tag>? = null,
     /* pet status in the store */
     @Json(name = "status")
     val status: Pet.Status? = null
-
 ) {
 
     /**

--- a/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/models/Tag.kt
+++ b/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/models/Tag.kt
@@ -21,10 +21,8 @@ import com.squareup.moshi.Json
 
 data class Tag (
     @Json(name = "id")
-    val id: kotlin.Long? = null
-,
+    val id: kotlin.Long? = null,
     @Json(name = "name")
     val name: kotlin.String? = null
-
 )
 

--- a/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/models/User.kt
+++ b/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/models/User.kt
@@ -27,29 +27,21 @@ import com.squareup.moshi.Json
 
 data class User (
     @Json(name = "id")
-    val id: kotlin.Long? = null
-,
+    val id: kotlin.Long? = null,
     @Json(name = "username")
-    val username: kotlin.String? = null
-,
+    val username: kotlin.String? = null,
     @Json(name = "firstName")
-    val firstName: kotlin.String? = null
-,
+    val firstName: kotlin.String? = null,
     @Json(name = "lastName")
-    val lastName: kotlin.String? = null
-,
+    val lastName: kotlin.String? = null,
     @Json(name = "email")
-    val email: kotlin.String? = null
-,
+    val email: kotlin.String? = null,
     @Json(name = "password")
-    val password: kotlin.String? = null
-,
+    val password: kotlin.String? = null,
     @Json(name = "phone")
-    val phone: kotlin.String? = null
-,
+    val phone: kotlin.String? = null,
     /* User Status */
     @Json(name = "userStatus")
     val userStatus: kotlin.Int? = null
-
 )
 

--- a/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/models/ApiResponse.kt
+++ b/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/models/ApiResponse.kt
@@ -23,14 +23,11 @@ import java.io.Serializable
 
 data class ApiResponse (
     @Json(name = "code")
-    val code: kotlin.Int? = null
-,
+    val code: kotlin.Int? = null,
     @Json(name = "type")
-    val type: kotlin.String? = null
-,
+    val type: kotlin.String? = null,
     @Json(name = "message")
     val message: kotlin.String? = null
-
 ) : Serializable {
 	companion object {
 		private const val serialVersionUID: Long = 123

--- a/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/models/Category.kt
+++ b/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/models/Category.kt
@@ -22,11 +22,9 @@ import java.io.Serializable
 
 data class Category (
     @Json(name = "id")
-    val id: kotlin.Long? = null
-,
+    val id: kotlin.Long? = null,
     @Json(name = "name")
     val name: kotlin.String? = null
-
 ) : Serializable {
 	companion object {
 		private const val serialVersionUID: Long = 123

--- a/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/models/Order.kt
+++ b/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/models/Order.kt
@@ -48,7 +48,6 @@ data class Order (
     * Values: placed,approved,delivered
     */
     
-    
     enum class Status(val value: kotlin.String){
         @Json(name = "placed") placed("placed"),
         @Json(name = "approved") approved("approved"),

--- a/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/models/Order.kt
+++ b/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/models/Order.kt
@@ -26,24 +26,18 @@ import java.io.Serializable
 
 data class Order (
     @Json(name = "id")
-    val id: kotlin.Long? = null
-,
+    val id: kotlin.Long? = null,
     @Json(name = "petId")
-    val petId: kotlin.Long? = null
-,
+    val petId: kotlin.Long? = null,
     @Json(name = "quantity")
-    val quantity: kotlin.Int? = null
-,
+    val quantity: kotlin.Int? = null,
     @Json(name = "shipDate")
-    val shipDate: java.time.OffsetDateTime? = null
-,
+    val shipDate: java.time.OffsetDateTime? = null,
     /* Order Status */
     @Json(name = "status")
-    val status: Order.Status? = null
-,
+    val status: Order.Status? = null,
     @Json(name = "complete")
     val complete: kotlin.Boolean? = null
-
 ) : Serializable {
 	companion object {
 		private const val serialVersionUID: Long = 123

--- a/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/models/Pet.kt
+++ b/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/models/Pet.kt
@@ -50,7 +50,6 @@ data class Pet (
     * Values: available,pending,sold
     */
     
-    
     enum class Status(val value: kotlin.String){
         @Json(name = "available") available("available"),
         @Json(name = "pending") pending("pending"),

--- a/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/models/Pet.kt
+++ b/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/models/Pet.kt
@@ -28,24 +28,18 @@ import java.io.Serializable
 
 data class Pet (
     @Json(name = "name")
-    val name: kotlin.String
-,
+    val name: kotlin.String,
     @Json(name = "photoUrls")
-    val photoUrls: kotlin.Array<kotlin.String>
-,
+    val photoUrls: kotlin.Array<kotlin.String>,
     @Json(name = "id")
-    val id: kotlin.Long? = null
-,
+    val id: kotlin.Long? = null,
     @Json(name = "category")
-    val category: Category? = null
-,
+    val category: Category? = null,
     @Json(name = "tags")
-    val tags: kotlin.Array<Tag>? = null
-,
+    val tags: kotlin.Array<Tag>? = null,
     /* pet status in the store */
     @Json(name = "status")
     val status: Pet.Status? = null
-
 ) : Serializable {
 	companion object {
 		private const val serialVersionUID: Long = 123

--- a/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/models/Tag.kt
+++ b/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/models/Tag.kt
@@ -22,11 +22,9 @@ import java.io.Serializable
 
 data class Tag (
     @Json(name = "id")
-    val id: kotlin.Long? = null
-,
+    val id: kotlin.Long? = null,
     @Json(name = "name")
     val name: kotlin.String? = null
-
 ) : Serializable {
 	companion object {
 		private const val serialVersionUID: Long = 123

--- a/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/models/User.kt
+++ b/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/models/User.kt
@@ -28,30 +28,22 @@ import java.io.Serializable
 
 data class User (
     @Json(name = "id")
-    val id: kotlin.Long? = null
-,
+    val id: kotlin.Long? = null,
     @Json(name = "username")
-    val username: kotlin.String? = null
-,
+    val username: kotlin.String? = null,
     @Json(name = "firstName")
-    val firstName: kotlin.String? = null
-,
+    val firstName: kotlin.String? = null,
     @Json(name = "lastName")
-    val lastName: kotlin.String? = null
-,
+    val lastName: kotlin.String? = null,
     @Json(name = "email")
-    val email: kotlin.String? = null
-,
+    val email: kotlin.String? = null,
     @Json(name = "password")
-    val password: kotlin.String? = null
-,
+    val password: kotlin.String? = null,
     @Json(name = "phone")
-    val phone: kotlin.String? = null
-,
+    val phone: kotlin.String? = null,
     /* User Status */
     @Json(name = "userStatus")
     val userStatus: kotlin.Int? = null
-
 ) : Serializable {
 	companion object {
 		private const val serialVersionUID: Long = 123


### PR DESCRIPTION
Follow on to https://github.com/OpenAPITools/openapi-generator/pull/5236, this add Jackson annotations to interface variables as well. 

I also added the JsonFormat annotation to all of them for consistency and removed the extra line feeds from the data class var files to fix the output.

### PR checklist
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [X] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [X] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@jimschubert (2017/09) ❤️, @dr4ke616 (2018/08) @karismann (2019/03) @Zomzog (2019/04) @andrewemery (2019/10) @4brunu (2019/11)
