### PR TITLE
Added support for msvc builds in cpp-qt5-client generator

### DIFF
--- a/modules/openapi-generator/src/main/resources/cpp-qt5-client/CMakeLists.txt.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-client/CMakeLists.txt.mustache
@@ -5,7 +5,11 @@ set(CMAKE_VERBOSE_MAKEFILE ON)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_AUTOMOC ON)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -Wall -Wno-unused-variable")
+if (MSVC)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W4")
+else (MSVC)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -Wall -Wno-unused-variable")
+endif (MSVC)
 
 find_package(Qt5Core REQUIRED)
 find_package(Qt5Network REQUIRED){{#contentCompression}}

--- a/modules/openapi-generator/src/main/resources/cpp-qt5-client/CMakeLists.txt.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-client/CMakeLists.txt.mustache
@@ -7,9 +7,9 @@ set(CMAKE_AUTOMOC ON)
 
 if (MSVC)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W4")
-else (MSVC)
+else ()
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -Wall -Wno-unused-variable")
-endif (MSVC)
+endif ()
 
 find_package(Qt5Core REQUIRED)
 find_package(Qt5Network REQUIRED){{#contentCompression}}


### PR DESCRIPTION
Moved GCC-specific compile flags to non msvc builds, and added equivalent flags for msvc.

Copying the c++ technical committee @ravinikam @stkrwork @etherealjoy @martindelille @muttleyxd
