### PR TITLE
[cli][gradle] Validate now uses parseOptions w/setResolve

### DIFF
--- a/modules/openapi-generator-cli/src/main/java/org/openapitools/codegen/cmd/Validate.java
+++ b/modules/openapi-generator-cli/src/main/java/org/openapitools/codegen/cmd/Validate.java
@@ -22,6 +22,7 @@ import io.airlift.airline.Option;
 
 import io.swagger.parser.OpenAPIParser;
 import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.parser.core.models.ParseOptions;
 import io.swagger.v3.parser.core.models.SwaggerParseResult;
 import org.apache.commons.lang3.text.WordUtils;
 import org.openapitools.codegen.validation.ValidationResult;
@@ -45,8 +46,9 @@ public class Validate implements Runnable {
     @Override
     public void run() {
         System.out.println("Validating spec (" + spec + ")");
-
-        SwaggerParseResult result = new OpenAPIParser().readLocation(spec, null, null);
+        ParseOptions options = new ParseOptions();
+        options.setResolve(true);
+        SwaggerParseResult result = new OpenAPIParser().readLocation(spec, null, options);
         List<String> messageList = result.getMessages();
         Set<String> errors = new HashSet<>(messageList);
         Set<String> warnings = new HashSet<>();

--- a/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/tasks/ValidateTask.kt
+++ b/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/tasks/ValidateTask.kt
@@ -19,12 +19,13 @@
 package org.openapitools.generator.gradle.plugin.tasks
 
 import io.swagger.parser.OpenAPIParser
+import io.swagger.v3.parser.core.models.ParseOptions
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
+import org.gradle.api.logging.Logging
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.options.Option
-import org.gradle.api.logging.Logging
 import org.gradle.internal.logging.text.StyledTextOutput
 import org.gradle.internal.logging.text.StyledTextOutputFactory
 import org.gradle.kotlin.dsl.property
@@ -71,7 +72,11 @@ open class ValidateTask : DefaultTask() {
         val recommendations = recommend.get()
 
         logger.quiet("Validating spec $spec")
-        val result = OpenAPIParser().readLocation(spec, null, null)
+
+        val options = ParseOptions()
+        options.isResolve = true
+        
+        val result = OpenAPIParser().readLocation(spec, null, options)
         val messages = result.messages.toSet()
         val out = services.get(StyledTextOutputFactory::class.java).create("openapi")
 


### PR DESCRIPTION
The validate command now uses ParseOptions#setResolve(true) to match how
we parse in CodegenConfigurator and online's Generate. Without this
option, the OpenAPI 3 parser skips the "resolve" block, which made lead
to validations in the command not matching validations during
generation.

I found this difference while stepping through #5413 

This will now match: https://github.com/OpenAPITools/openapi-generator/blob/b0b46d57e07696932038122aec569905c5ed5a22/modules/openapi-generator/src/main/java/org/openapitools/codegen/config/CodegenConfigurator.java#L453-L455

and:

https://github.com/OpenAPITools/openapi-generator/blob/b0b46d57e07696932038122aec569905c5ed5a22/modules/openapi-generator-online/src/main/java/org/openapitools/codegen/online/service/Generator.java#L95-L105

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

cc @OpenAPITools/generator-core-team 