### PR TITLE
[Ruby] Fix obsolete configuration of Rubocop and Rubocop's warns (#5417)

### DIFF
--- a/modules/openapi-generator/src/main/resources/ruby-client/api_client_spec.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/api_client_spec.mustache
@@ -150,7 +150,7 @@ describe {{moduleName}}::ApiClient do
     end
 
     it 'fails for invalid collection format' do
-      expect{api_client.build_collection_param(param, :INVALID)}.to raise_error(RuntimeError, 'unknown collection format: :INVALID')
+      expect { api_client.build_collection_param(param, :INVALID) }.to raise_error(RuntimeError, 'unknown collection format: :INVALID')
     end
   end
 

--- a/modules/openapi-generator/src/main/resources/ruby-client/rubocop.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/rubocop.mustache
@@ -14,12 +14,6 @@ AllCops:
 Style/AndOr:
   Enabled: true
 
-# Do not use braces for hash literals when they are the last argument of a
-# method call.
-Style/BracesAroundHashParameters:
-  Enabled: true
-  EnforcedStyle: context_dependent
-
 # Align `when` with `case`.
 Layout/CaseIndentation:
   Enabled: true
@@ -46,7 +40,7 @@ Layout/EmptyLinesAroundMethodBody:
 Layout/EmptyLinesAroundModuleBody:
   Enabled: true
 
-Layout/IndentFirstArgument:
+Layout/FirstArgumentIndentation:
   Enabled: true
 
 # Use Ruby >= 1.9 syntax for hashes. Prefer { a: :b } over { :a => :b }.
@@ -57,7 +51,7 @@ Style/HashSyntax:
 # extra level of indentation.
 Layout/IndentationConsistency:
   Enabled: true
-  EnforcedStyle: rails
+  EnforcedStyle: indented_internal_methods
 
 # Two spaces, no tabs (for indentation).
 Layout/IndentationWidth:
@@ -123,7 +117,7 @@ Layout/Tab:
   Enabled: true
 
 # Blank lines should not have any spaces.
-Layout/TrailingBlankLines:
+Layout/TrailingEmptyLines:
   Enabled: true
 
 # No trailing whitespace.
@@ -131,7 +125,7 @@ Layout/TrailingWhitespace:
   Enabled: false
 
 # Use quotes for string literals when they are enough.
-Style/UnneededPercentQ:
+Style/RedundantPercentQ:
   Enabled: true
 
 # Align `end` with the matching keyword or starting expression except for

--- a/samples/client/petstore/ruby-faraday/.rubocop.yml
+++ b/samples/client/petstore/ruby-faraday/.rubocop.yml
@@ -14,12 +14,6 @@ AllCops:
 Style/AndOr:
   Enabled: true
 
-# Do not use braces for hash literals when they are the last argument of a
-# method call.
-Style/BracesAroundHashParameters:
-  Enabled: true
-  EnforcedStyle: context_dependent
-
 # Align `when` with `case`.
 Layout/CaseIndentation:
   Enabled: true
@@ -46,7 +40,7 @@ Layout/EmptyLinesAroundMethodBody:
 Layout/EmptyLinesAroundModuleBody:
   Enabled: true
 
-Layout/IndentFirstArgument:
+Layout/FirstArgumentIndentation:
   Enabled: true
 
 # Use Ruby >= 1.9 syntax for hashes. Prefer { a: :b } over { :a => :b }.
@@ -57,7 +51,7 @@ Style/HashSyntax:
 # extra level of indentation.
 Layout/IndentationConsistency:
   Enabled: true
-  EnforcedStyle: rails
+  EnforcedStyle: indented_internal_methods
 
 # Two spaces, no tabs (for indentation).
 Layout/IndentationWidth:
@@ -123,7 +117,7 @@ Layout/Tab:
   Enabled: true
 
 # Blank lines should not have any spaces.
-Layout/TrailingBlankLines:
+Layout/TrailingEmptyLines:
   Enabled: true
 
 # No trailing whitespace.
@@ -131,7 +125,7 @@ Layout/TrailingWhitespace:
   Enabled: false
 
 # Use quotes for string literals when they are enough.
-Style/UnneededPercentQ:
+Style/RedundantPercentQ:
   Enabled: true
 
 # Align `end` with the matching keyword or starting expression except for

--- a/samples/client/petstore/ruby/.rubocop.yml
+++ b/samples/client/petstore/ruby/.rubocop.yml
@@ -14,12 +14,6 @@ AllCops:
 Style/AndOr:
   Enabled: true
 
-# Do not use braces for hash literals when they are the last argument of a
-# method call.
-Style/BracesAroundHashParameters:
-  Enabled: true
-  EnforcedStyle: context_dependent
-
 # Align `when` with `case`.
 Layout/CaseIndentation:
   Enabled: true
@@ -46,7 +40,7 @@ Layout/EmptyLinesAroundMethodBody:
 Layout/EmptyLinesAroundModuleBody:
   Enabled: true
 
-Layout/IndentFirstArgument:
+Layout/FirstArgumentIndentation:
   Enabled: true
 
 # Use Ruby >= 1.9 syntax for hashes. Prefer { a: :b } over { :a => :b }.
@@ -57,7 +51,7 @@ Style/HashSyntax:
 # extra level of indentation.
 Layout/IndentationConsistency:
   Enabled: true
-  EnforcedStyle: rails
+  EnforcedStyle: indented_internal_methods
 
 # Two spaces, no tabs (for indentation).
 Layout/IndentationWidth:
@@ -123,7 +117,7 @@ Layout/Tab:
   Enabled: true
 
 # Blank lines should not have any spaces.
-Layout/TrailingBlankLines:
+Layout/TrailingEmptyLines:
   Enabled: true
 
 # No trailing whitespace.
@@ -131,7 +125,7 @@ Layout/TrailingWhitespace:
   Enabled: false
 
 # Use quotes for string literals when they are enough.
-Style/UnneededPercentQ:
+Style/RedundantPercentQ:
   Enabled: true
 
 # Align `end` with the matching keyword or starting expression except for

--- a/samples/client/petstore/ruby/spec/api_client_spec.rb
+++ b/samples/client/petstore/ruby/spec/api_client_spec.rb
@@ -156,7 +156,7 @@ describe Petstore::ApiClient do
     end
 
     it 'fails for invalid collection format' do
-      expect{api_client.build_collection_param(param, :INVALID)}.to raise_error(RuntimeError, 'unknown collection format: :INVALID')
+      expect { api_client.build_collection_param(param, :INVALID) }.to raise_error(RuntimeError, 'unknown collection format: :INVALID')
     end
   end
 

--- a/samples/openapi3/client/petstore/ruby-faraday/.rubocop.yml
+++ b/samples/openapi3/client/petstore/ruby-faraday/.rubocop.yml
@@ -14,12 +14,6 @@ AllCops:
 Style/AndOr:
   Enabled: true
 
-# Do not use braces for hash literals when they are the last argument of a
-# method call.
-Style/BracesAroundHashParameters:
-  Enabled: true
-  EnforcedStyle: context_dependent
-
 # Align `when` with `case`.
 Layout/CaseIndentation:
   Enabled: true
@@ -46,7 +40,7 @@ Layout/EmptyLinesAroundMethodBody:
 Layout/EmptyLinesAroundModuleBody:
   Enabled: true
 
-Layout/IndentFirstArgument:
+Layout/FirstArgumentIndentation:
   Enabled: true
 
 # Use Ruby >= 1.9 syntax for hashes. Prefer { a: :b } over { :a => :b }.
@@ -57,7 +51,7 @@ Style/HashSyntax:
 # extra level of indentation.
 Layout/IndentationConsistency:
   Enabled: true
-  EnforcedStyle: rails
+  EnforcedStyle: indented_internal_methods
 
 # Two spaces, no tabs (for indentation).
 Layout/IndentationWidth:
@@ -123,7 +117,7 @@ Layout/Tab:
   Enabled: true
 
 # Blank lines should not have any spaces.
-Layout/TrailingBlankLines:
+Layout/TrailingEmptyLines:
   Enabled: true
 
 # No trailing whitespace.
@@ -131,7 +125,7 @@ Layout/TrailingWhitespace:
   Enabled: false
 
 # Use quotes for string literals when they are enough.
-Style/UnneededPercentQ:
+Style/RedundantPercentQ:
   Enabled: true
 
 # Align `end` with the matching keyword or starting expression except for

--- a/samples/openapi3/client/petstore/ruby-faraday/spec/api_client_spec.rb
+++ b/samples/openapi3/client/petstore/ruby-faraday/spec/api_client_spec.rb
@@ -118,7 +118,7 @@ describe Petstore::ApiClient do
     end
 
     it 'fails for invalid collection format' do
-      expect{api_client.build_collection_param(param, :INVALID)}.to raise_error(RuntimeError, 'unknown collection format: :INVALID')
+      expect { api_client.build_collection_param(param, :INVALID) }.to raise_error(RuntimeError, 'unknown collection format: :INVALID')
     end
   end
 

--- a/samples/openapi3/client/petstore/ruby/.rubocop.yml
+++ b/samples/openapi3/client/petstore/ruby/.rubocop.yml
@@ -14,12 +14,6 @@ AllCops:
 Style/AndOr:
   Enabled: true
 
-# Do not use braces for hash literals when they are the last argument of a
-# method call.
-Style/BracesAroundHashParameters:
-  Enabled: true
-  EnforcedStyle: context_dependent
-
 # Align `when` with `case`.
 Layout/CaseIndentation:
   Enabled: true
@@ -46,7 +40,7 @@ Layout/EmptyLinesAroundMethodBody:
 Layout/EmptyLinesAroundModuleBody:
   Enabled: true
 
-Layout/IndentFirstArgument:
+Layout/FirstArgumentIndentation:
   Enabled: true
 
 # Use Ruby >= 1.9 syntax for hashes. Prefer { a: :b } over { :a => :b }.
@@ -57,7 +51,7 @@ Style/HashSyntax:
 # extra level of indentation.
 Layout/IndentationConsistency:
   Enabled: true
-  EnforcedStyle: rails
+  EnforcedStyle: indented_internal_methods
 
 # Two spaces, no tabs (for indentation).
 Layout/IndentationWidth:
@@ -123,7 +117,7 @@ Layout/Tab:
   Enabled: true
 
 # Blank lines should not have any spaces.
-Layout/TrailingBlankLines:
+Layout/TrailingEmptyLines:
   Enabled: true
 
 # No trailing whitespace.
@@ -131,7 +125,7 @@ Layout/TrailingWhitespace:
   Enabled: false
 
 # Use quotes for string literals when they are enough.
-Style/UnneededPercentQ:
+Style/RedundantPercentQ:
   Enabled: true
 
 # Align `end` with the matching keyword or starting expression except for

--- a/samples/openapi3/client/petstore/ruby/spec/api_client_spec.rb
+++ b/samples/openapi3/client/petstore/ruby/spec/api_client_spec.rb
@@ -156,7 +156,7 @@ describe Petstore::ApiClient do
     end
 
     it 'fails for invalid collection format' do
-      expect{api_client.build_collection_param(param, :INVALID)}.to raise_error(RuntimeError, 'unknown collection format: :INVALID')
+      expect { api_client.build_collection_param(param, :INVALID) }.to raise_error(RuntimeError, 'unknown collection format: :INVALID')
     end
   end
 


### PR DESCRIPTION
Fix #5417

- Fix renamed Cop and its settings in generated `.rubocop.yml`
- Remove obsolete cop `Style/BracesAroundHashParameters` from generated `.rubocop.yml` (this has been removed from Rubocop v0.80.0)
- Fix rubocop's warns in generated Ruby client code

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language. @cliffano @zlx @autopp
