### PR TITLE
Codegen v2 proposition

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/v2/AbstractCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/v2/AbstractCodegen.java
@@ -1,0 +1,66 @@
+package org.openapitools.codegen.v2;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import org.openapitools.codegen.v2.commons.CodegenCodeTags;
+import org.openapitools.codegen.v2.commons.StringCaseUtils;
+import org.openapitools.codegen.v2.outputs.CodegenOutputProcessor;
+import org.openapitools.codegen.v2.templates.CodegenTemplateProcessor;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Objects;
+
+public abstract class AbstractCodegen implements Codegen {
+
+    private static final CodegenTag OPTIONS = CodegenTag.of("codegen.options", CodegenOptions.class);
+    private static final CodegenTag TIMESTAMP = CodegenTag.of("codegen.timestamp", Instant.class);
+
+    private final CodegenTemplateProcessor templateProcessor;
+    private final CodegenOutputProcessor outputProcessor;
+
+    public AbstractCodegen(CodegenTemplateProcessor templateProcessor, CodegenOutputProcessor outputProcessor) {
+        this.templateProcessor = Objects.requireNonNull(templateProcessor);
+        this.outputProcessor = Objects.requireNonNull(outputProcessor);
+    }
+
+    @Override
+    public final void generate(OpenAPI openAPI, CodegenOptions options) {
+        onPreGenerate(openAPI, options);
+
+        CodegenSdk sdk = buildCodegenSdk(openAPI, options);
+        for (CodegenTagger tagger : getTaggers(options)) {
+            CodegenObjectVisitor visitor = tagger::tag;
+            visitor.visit(sdk);
+        }
+
+        templateProcessor.process(sdk);
+        outputProcessor.process(sdk);
+        onPostGenerate(openAPI, sdk, options);
+    }
+
+    protected void onPreGenerate(OpenAPI openAPI, CodegenOptions options) {
+        // virtual no-op
+    }
+
+    protected void onPostGenerate(OpenAPI openAPI, CodegenSdk sdk, CodegenOptions options) {
+        // virtual no-op
+    }
+
+    protected Collection<CodegenTagger> getTaggers(CodegenOptions options) {
+        // virtual no-op
+        return new ArrayList<>();
+    }
+
+    private CodegenSdk buildCodegenSdk(OpenAPI openAPI, CodegenOptions options) {
+        CodegenSdk sdk = new CodegenSdk(options.getProject());
+        sdk.setTag(OPTIONS, options);
+        sdk.setTag(TIMESTAMP, Instant.now());
+        sdk.setTag(CodegenCodeTags.GENERIC_TYPES, Arrays.asList("String", "Object"));
+
+        // TODO build graph from OpenAPI spec
+
+        return sdk;
+    }
+}

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/v2/AbstractCodegenTagger.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/v2/AbstractCodegenTagger.java
@@ -1,0 +1,48 @@
+package org.openapitools.codegen.v2;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.Method;
+import java.util.Objects;
+
+public abstract class AbstractCodegenTagger implements CodegenTagger {
+    private static final Logger LOGGER = LoggerFactory.getLogger(AbstractCodegenTagger.class);
+
+    @Override
+    public final void tag(CodegenObject object) {
+        Objects.requireNonNull(object);
+        try {
+            Class<? extends CodegenObject> objectClass = object.getClass();
+            Method tagMethod = getClass().getDeclaredMethod("tag", objectClass);
+            tagMethod.setAccessible(true);
+            tagMethod.invoke(this, objectClass.cast(object));
+        } catch (ReflectiveOperationException e) {
+            // no-op: no tag method for object
+        }
+    }
+
+    protected void tag(CodegenSdk sdk) {
+        // virtual no-op
+    }
+
+    protected void tag(CodegenApi api) {
+        // virtual no-op
+    }
+
+    protected void tag(CodegenModel model) {
+        // virtual no-op
+    }
+
+    protected void tag(CodegenProperty property) {
+        // virtual no-op
+    }
+
+    protected void tag(CodegenOperation operation) {
+        // virtual no-op
+    }
+
+    protected void tag(CodegenParameter parameter) {
+        // virtual no-op
+    }
+}

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/v2/Codegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/v2/Codegen.java
@@ -1,0 +1,7 @@
+package org.openapitools.codegen.v2;
+
+import io.swagger.v3.oas.models.OpenAPI;
+
+public interface Codegen {
+    void generate(OpenAPI openAPI, CodegenOptions options);
+}

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/v2/CodegenApi.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/v2/CodegenApi.java
@@ -1,0 +1,25 @@
+package org.openapitools.codegen.v2;
+
+import java.util.Collection;
+
+public class CodegenApi extends CodegenObject {
+    public CodegenApi(String id, CodegenSdk sdk) {
+        super(id, sdk);
+    }
+
+    public void addModel(CodegenModel model) {
+        addChild(model);
+    }
+
+    public void addOperation(CodegenOperation operation) {
+        addChild(operation);
+    }
+
+    public Collection<CodegenModel> getModels() {
+        return getChildrenOfType(CodegenModel.class);
+    }
+
+    public Collection<CodegenOperation> getOperations() {
+        return getChildrenOfType(CodegenOperation.class);
+    }
+}

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/v2/CodegenModel.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/v2/CodegenModel.java
@@ -1,0 +1,15 @@
+package org.openapitools.codegen.v2;
+
+public class CodegenModel extends CodegenObject {
+    public CodegenModel(String id, CodegenSdk sdk) {
+        super(id, sdk);
+    }
+
+    public void addProperty(CodegenProperty property) {
+        addChild(property);
+    }
+
+    public Iterable<CodegenProperty> getProperties() {
+        return getChildrenOfType(CodegenProperty.class);
+    }
+}

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/v2/CodegenObject.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/v2/CodegenObject.java
@@ -1,0 +1,75 @@
+package org.openapitools.codegen.v2;
+
+import org.yaml.snakeyaml.Yaml;
+
+import javax.annotation.Nonnull;
+import java.util.*;
+import java.util.stream.Collectors;
+
+public abstract class CodegenObject implements CodegenTaggable, Comparable<CodegenObject> {
+
+    private final String id;
+    private final CodegenObject parent;
+    private final Set<CodegenObject> children;
+    private final Map<CodegenTag, Object> tags;
+
+    protected CodegenObject(String id) {
+        this(id, null);
+    }
+
+    protected CodegenObject(String id, CodegenObject parent) {
+        this.id = Objects.requireNonNull(id);
+        this.parent = parent;
+        this.children = new TreeSet<>();
+        this.tags = new TreeMap<>();
+    }
+
+    @Override
+    public String toString() {
+        return new Yaml().dump(this);
+    }
+
+    @Override
+    public Map<CodegenTag, Object> getTags() {
+        return tags;
+    }
+
+    @Override
+    public int compareTo(@Nonnull CodegenObject object) {
+        return id.compareTo(object.getId());
+    }
+
+    @Override
+    public boolean equals(@Nonnull Object obj) {
+        if (obj instanceof CodegenObject) {
+            CodegenObject object = (CodegenObject) obj;
+            return Objects.equals(id, object.getId());
+        }
+        return false;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public CodegenObject getParent() {
+        return parent;
+    }
+
+    public Collection<CodegenObject> getChildren() {
+        return children;
+    }
+
+    public <TCodegenObject extends CodegenObject> Collection<TCodegenObject> getChildrenOfType(Class<TCodegenObject> objectClass) {
+        Objects.requireNonNull(objectClass);
+        return children.stream()
+                .filter(o -> getClass().isAssignableFrom(objectClass))
+                .map(objectClass::cast)
+                .collect(Collectors.toList());
+    }
+
+    protected void addChild(CodegenObject object) {
+        Objects.requireNonNull(object);
+        children.add(object);
+    }
+}

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/v2/CodegenObjectVisitor.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/v2/CodegenObjectVisitor.java
@@ -1,0 +1,31 @@
+package org.openapitools.codegen.v2;
+
+import java.util.Objects;
+
+@FunctionalInterface
+public interface CodegenObjectVisitor {
+    void visitOne(CodegenObject object);
+
+    default void visit(CodegenObject object) {
+        Objects.requireNonNull(object);
+        visitOne(object);
+        for (CodegenObject child : object.getChildren()) {
+            visit(object);
+        }
+    }
+
+    @FunctionalInterface
+    interface Of<TCodegenObject> {
+        void visitOne(TCodegenObject object);
+
+        default void visit(CodegenObject object, Class<TCodegenObject> objectClass) {
+            Objects.requireNonNull(object);
+            if (object.getClass().isAssignableFrom(objectClass)) {
+                visitOne(objectClass.cast(object));
+            }
+            for (CodegenObject child : object.getChildren()) {
+                visit(object, objectClass);
+            }
+        }
+    }
+}

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/v2/CodegenOperation.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/v2/CodegenOperation.java
@@ -1,0 +1,16 @@
+package org.openapitools.codegen.v2;
+
+public class CodegenOperation extends CodegenObject {
+
+    public CodegenOperation(String id, CodegenApi api) {
+        super(id, api);
+    }
+
+    public void addParameter(CodegenParameter parameter) {
+        addChild(parameter);
+    }
+
+    public Iterable<CodegenParameter> getParameters() {
+        return getChildrenOfType(CodegenParameter.class);
+    }
+}

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/v2/CodegenOptions.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/v2/CodegenOptions.java
@@ -1,0 +1,9 @@
+package org.openapitools.codegen.v2;
+
+import java.util.Map;
+
+public interface CodegenOptions {
+    String getProject();
+    String getVersion();
+    Map<String, Object> getAdditionalOptions();
+}

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/v2/CodegenParameter.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/v2/CodegenParameter.java
@@ -1,0 +1,7 @@
+package org.openapitools.codegen.v2;
+
+public class CodegenParameter extends CodegenObject {
+    public CodegenParameter(String id, CodegenOperation operation) {
+        super(id);
+    }
+}

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/v2/CodegenProperty.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/v2/CodegenProperty.java
@@ -1,0 +1,10 @@
+package org.openapitools.codegen.v2;
+
+public class CodegenProperty extends CodegenObject {
+
+
+
+    public CodegenProperty(String id) {
+        super(id);
+    }
+}

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/v2/CodegenSdk.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/v2/CodegenSdk.java
@@ -1,0 +1,19 @@
+package org.openapitools.codegen.v2;
+
+import java.util.Set;
+
+public class CodegenSdk extends CodegenObject {
+    private Set<CodegenApi> apis;
+
+    protected CodegenSdk(String id) {
+        super(id);
+    }
+
+    public Set<CodegenApi> getApis() {
+        return apis;
+    }
+
+    public void setApis(Set<CodegenApi> apis) {
+        this.apis = apis;
+    }
+}

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/v2/CodegenTag.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/v2/CodegenTag.java
@@ -1,0 +1,106 @@
+package org.openapitools.codegen.v2;
+
+import org.openapitools.codegen.v2.reflection.GenericClass;
+
+import javax.annotation.Nonnull;
+import java.util.Objects;
+
+public final class CodegenTag implements Comparable<CodegenTag> {
+
+    private final String name;
+    private final Class<?> valueClass;
+    private final GenericClass<?> valueGenericClass;
+
+    private CodegenTag(String name, GenericClass<?> valueGenericClass) {
+        this.name = name;
+        this.valueClass = null;
+        this.valueGenericClass = valueGenericClass;
+    }
+
+    private CodegenTag(String name, Class<?> valueClass) {
+        this.name = name;
+        this.valueClass = valueClass;
+        this.valueGenericClass = null;
+    }
+
+    @Override
+    public int compareTo(@Nonnull CodegenTag tag) {
+        return name.compareTo(tag.name);
+    }
+
+    @Override
+    public boolean equals(@Nonnull Object obj) {
+        if (obj instanceof CodegenTag) {
+            CodegenTag tag = (CodegenTag) obj;
+            return 0 == compareTo(tag);
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return name.hashCode();
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public Class<?> getValueClass() {
+        return valueGenericClass != null ? valueGenericClass.getGenericClass() : valueClass;
+    }
+
+    public GenericClass<?> getValueGenericClass() {
+        return valueGenericClass;
+    }
+
+    public <TValue> boolean acceptsValue(TValue value) {
+        Objects.requireNonNull(value);
+        return acceptsValueClass(value.getClass());
+    }
+
+    public <TValue> boolean acceptsValueGenericClass(GenericClass<TValue> valueGenericClass) {
+        Objects.requireNonNull(valueGenericClass);
+        return acceptsValueClass(valueGenericClass.getGenericClass());
+    }
+
+    public <TValue> boolean acceptsValueClass(Class<TValue> valueClass) {
+        Objects.requireNonNull(valueClass);
+        return getValueClass().isAssignableFrom(valueClass);
+    }
+
+    public <TValue> void ensureValueAccepted(TValue value) {
+        Objects.requireNonNull(value);
+        ensureValueClassAccepted(value.getClass());
+    }
+
+    public <TValue> void ensureValueAccepted(GenericClass<TValue> valueGenericClass) {
+        Objects.requireNonNull(valueGenericClass);
+        ensureValueClassAccepted(valueGenericClass.getGenericClass());
+    }
+
+    public <TValue> void ensureValueClassAccepted(Class<TValue> valueClass) {
+        Objects.requireNonNull(valueClass);
+        if (!acceptsValueClass(valueClass)) {
+            String message = String.format("Unexpected tag value of class '%s', expected '%s'", valueClass.getName(), getValueClass().getName());
+            throw new IllegalArgumentException(message);
+        }
+    }
+
+    public static CodegenTag of(String name) {
+        Objects.requireNonNull(name);
+        return of(name, Object.class);
+    }
+
+    public static <TValue> CodegenTag of(String name, Class<TValue> valueClass) {
+        Objects.requireNonNull(name);
+        Objects.requireNonNull(valueClass);
+        return new CodegenTag(name, valueClass);
+    }
+
+    public static <TValue> CodegenTag of(String name, GenericClass<TValue> valueGenericClass) {
+        Objects.requireNonNull(name);
+        Objects.requireNonNull(valueGenericClass);
+        return new CodegenTag(name, valueGenericClass);
+    }
+}

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/v2/CodegenTaggable.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/v2/CodegenTaggable.java
@@ -1,0 +1,71 @@
+package org.openapitools.codegen.v2;
+
+import org.openapitools.codegen.v2.reflection.GenericClass;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Supplier;
+
+public interface CodegenTaggable {
+    Map<CodegenTag, Object> getTags();
+
+    default void setTag(CodegenTag tag, Object value) {
+        Objects.requireNonNull(tag);
+        Objects.requireNonNull(value);
+        tag.ensureValueClassAccepted(value.getClass());
+        getTags().put(tag, value);
+    }
+
+    default void unsetTag(CodegenTag tag) {
+        Objects.requireNonNull(tag);
+        getTags().remove(tag);
+    }
+
+    default Object getTag(CodegenTag tag) {
+        Objects.requireNonNull(tag);
+        return getTags().getOrDefault(tag, null);
+    }
+
+    default <TValue> TValue getTag(CodegenTag tag, GenericClass<TValue> valueGenericClass) {
+        Objects.requireNonNull(tag);
+        Objects.requireNonNull(valueGenericClass);
+        return getTag(tag, valueGenericClass.getGenericClass());
+    }
+
+    default <TValue> TValue getTag(CodegenTag tag, Class<TValue> valueClass) {
+        Objects.requireNonNull(tag);
+        Objects.requireNonNull(valueClass);
+        Object value = getTag(tag);
+        return value != null && valueClass.isAssignableFrom(value.getClass()) ? valueClass.cast(value) : null;
+    }
+
+    default Object getTagOrDefault(CodegenTag tag, Supplier supplier) {
+        Objects.requireNonNull(tag);
+        Objects.requireNonNull(supplier);
+        Object value = getTag(tag);
+        if (value == null) {
+            value = supplier.get();
+            setTag(tag, value);
+        }
+        return value;
+    }
+
+    default <TValue> TValue getTagOrDefault(CodegenTag tag, GenericClass<TValue> valueGenericClass, Supplier<TValue> supplier) {
+        Objects.requireNonNull(tag);
+        Objects.requireNonNull(valueGenericClass);
+        Objects.requireNonNull(supplier);
+        return getTagOrDefault(tag, valueGenericClass.getGenericClass(), supplier);
+    }
+
+    default <TValue> TValue getTagOrDefault(CodegenTag tag, Class<TValue> valueClass, Supplier<TValue> supplier) {
+        Objects.requireNonNull(tag);
+        Objects.requireNonNull(valueClass);
+        Objects.requireNonNull(supplier);
+        Object value = getTagOrDefault(tag, supplier);
+        return value != null && valueClass.isAssignableFrom(value.getClass()) ? valueClass.cast(value) : null;
+    }
+
+    default boolean hasTag(CodegenTag tag) {
+        return getTags().containsKey(tag);
+    }
+}

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/v2/CodegenTagger.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/v2/CodegenTagger.java
@@ -1,0 +1,5 @@
+package org.openapitools.codegen.v2;
+
+public interface CodegenTagger {
+    void tag(CodegenObject object);
+}

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/v2/DefaultCodegenOptions.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/v2/DefaultCodegenOptions.java
@@ -1,0 +1,38 @@
+package org.openapitools.codegen.v2;
+
+import java.util.Map;
+import java.util.TreeMap;
+
+public class DefaultCodegenOptions implements CodegenOptions {
+
+    private String project;
+    private String version;
+    private final Map<String, Object> additionalOptions;
+
+    public DefaultCodegenOptions() {
+        this.additionalOptions = new TreeMap<>();
+    }
+
+    @Override
+    public String getProject() {
+        return project;
+    }
+
+    @Override
+    public String getVersion() {
+        return version;
+    }
+
+    @Override
+    public Map<String, Object> getAdditionalOptions() {
+        return additionalOptions;
+    }
+
+    public void setProject(String project) {
+        this.project = project;
+    }
+
+    public void setVersion(String version) {
+        this.version = version;
+    }
+}

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/v2/commons/CodegenCodeTags.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/v2/commons/CodegenCodeTags.java
@@ -1,0 +1,23 @@
+package org.openapitools.codegen.v2.commons;
+
+import org.openapitools.codegen.v2.CodegenTag;
+import org.openapitools.codegen.v2.reflection.GenericClass;
+
+import java.util.Collection;
+
+public class CodegenCodeTags {
+    private CodegenCodeTags() {}
+
+    public static final CodegenTag NAME = CodegenTag.of("code.name", String.class);
+    public static final CodegenTag NAMESPACE = CodegenTag.of("code.namespace", String.class);
+    public static final CodegenTag TYPE = CodegenTag.of("code.type", String.class);
+    public static final CodegenTag BASE_TYPE = CodegenTag.of("code.baseType", String.class);
+    public static final CodegenTag RETURN_TYPE = CodegenTag.of("code.returnType", String.class);
+    public static final CodegenTag GENERIC_TYPES = CodegenTag.of("code.genericTypes", new GenericClass<Collection<String>>() {});
+    public static final CodegenTag INTERFACES = CodegenTag.of("code.interfaces", new GenericClass<Collection<String>>() {});
+    public static final CodegenTag IMPORTS = CodegenTag.of("code.imports", new GenericClass<Collection<String>>() {});
+    public static final CodegenTag ENUMS = CodegenTag.of("code.enums", new GenericClass<Collection<String>>() {});
+    public static final CodegenTag ACCESSOR = CodegenTag.of("code.accessor", String.class);
+    public static final CodegenTag MUTATOR = CodegenTag.of("code.mutator", String.class);
+    public static final CodegenTag VISIBILITY = CodegenTag.of("code.visibility", String.class);
+}

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/v2/commons/CodegenDocTags.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/v2/commons/CodegenDocTags.java
@@ -1,0 +1,11 @@
+package org.openapitools.codegen.v2.commons;
+
+import org.openapitools.codegen.v2.CodegenTag;
+import org.openapitools.codegen.v2.reflection.GenericClass;
+
+public class CodegenDocTags {
+    private CodegenDocTags() {}
+    public static final CodegenTag AVAILABLE = CodegenTag.of("doc.available", Boolean.class);
+    public static final CodegenTag SUMMARY = CodegenTag.of("doc.summary", String.class);
+    public static final CodegenTag NOTE = CodegenTag.of("doc.note", String.class);
+}

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/v2/commons/CodegenSpecTags.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/v2/commons/CodegenSpecTags.java
@@ -1,0 +1,15 @@
+package org.openapitools.codegen.v2.commons;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.media.Schema;
+import org.openapitools.codegen.v2.CodegenTag;
+
+public class CodegenSpecTags {
+    private CodegenSpecTags() {}
+    public static final CodegenTag AVAILABLE = CodegenTag.of("spec.available", Boolean.class);
+    public static final CodegenTag OPEN_API = CodegenTag.of("spec.openAPI", OpenAPI.class);
+    public static final CodegenTag SCHEMA = CodegenTag.of("spec.schema", Schema.class);
+    public static final CodegenTag OPERATION = CodegenTag.of("spec.operation", Schema.class);
+    public static final CodegenTag PARAMETER = CodegenTag.of("spec.parameter", Schema.class);
+    public static final CodegenTag PROPERTY = CodegenTag.of("spec.property", Schema.class);
+}

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/v2/commons/StringCaseUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/v2/commons/StringCaseUtils.java
@@ -1,0 +1,177 @@
+package org.openapitools.codegen.v2.commons;
+
+import com.google.common.base.CharMatcher;
+
+import java.util.*;
+
+public final class StringCaseUtils {
+    private static final CharMatcher NON_ALPHA_MATCHER = CharMatcher
+            .inRange('a', 'z')
+            .or(CharMatcher.inRange('A', 'Z'))
+            .or(CharMatcher.inRange('0', '9'))
+            .negate()
+            .precomputed();
+
+//    private static final CharMatcher WORD_CASING_MATCHER = CharMatcher
+//            .inRange('A', 'Z')
+//            .precomputed();
+
+    private StringCaseUtils() { }
+
+    public static String camelCase(String string) {
+        Objects.requireNonNull(string);
+        boolean firstPass = true;
+        StringBuilder builder = new StringBuilder();
+        for (String word : splitWords(string)) {
+            word = word.toLowerCase();
+            builder.append(firstPass ? word.charAt(0) : Character.toUpperCase(word.charAt(0)));
+            builder.append(word, 1, word.length());
+            firstPass = false;
+        }
+        return builder.toString();
+    }
+
+    public static String upperCamelCase(String string) {
+        Objects.requireNonNull(string);
+        StringBuilder builder = new StringBuilder();
+        for (String word : splitWords(string)) {
+            word = word.toLowerCase();
+            builder.append(Character.toUpperCase(word.charAt(0)));
+            builder.append(word, 1, word.length());
+        }
+        return builder.toString();
+    }
+
+    public static String snakeCase(String string) {
+        Objects.requireNonNull(string);
+        StringBuilder builder = new StringBuilder();
+        for (String word : splitWords(string)) {
+            word = word.toLowerCase();
+            builder.append(word);
+            builder.append('_');
+        }
+        if (builder.length() > 1) {
+            builder.setLength(builder.length() - 1);
+        }
+        return builder.toString();
+    }
+
+    public static String upperSnakeCase(String string) {
+        Objects.requireNonNull(string);
+        StringBuilder builder = new StringBuilder();
+        for (String word : splitWords(string)) {
+            word = word.toUpperCase();
+            builder.append(word);
+            builder.append('_');
+        }
+        if (builder.length() > 1) {
+            builder.setLength(builder.length() - 1);
+        }
+        return builder.toString();
+    }
+
+    public static Set<String> splitUniqueWords(String string) {
+        return new TreeSet<>(splitWords(string));
+    }
+
+    public static List<String> splitWords(String string) {
+        Objects.requireNonNull(string);
+        String[] words = string.split("(?=[^a-z0-9])");
+        List<String> curatedWords = new ArrayList<>();
+        StringBuilder acronymBuilder = null;
+        for (String word : words) {
+            if (word.length() == 1 && Character.isUpperCase(word.charAt(0))) {
+                if (acronymBuilder == null) {
+                    acronymBuilder = new StringBuilder();
+                }
+                acronymBuilder.append(word);
+                continue;
+            }
+            if (acronymBuilder != null) {
+                curatedWords.add(acronymBuilder.toString());
+                acronymBuilder = null;
+            }
+            String curatedWord = NON_ALPHA_MATCHER.trimFrom(word);
+            if (!curatedWord.isEmpty()) {
+                curatedWords.add(curatedWord);
+            }
+        }
+        if (acronymBuilder != null) {
+            curatedWords.add(acronymBuilder.toString());
+        }
+        return curatedWords;
+//        int lastUpperIndex = -1;
+//        List<String> words = new ArrayList<>();
+//        StringBuilder stringBuilder = new StringBuilder();
+//        for (int i = 0; i < string.length(); i++) {
+//            char c = string.charAt(i);
+//            if (Character.isLetterOrDigit(c)) {
+//                if (Character.isUpperCase(c)) {
+//                    if (lastUpperIndex < 0) {
+//                        lastUpperIndex = i;
+//                    }
+//                } else {
+//                    if (lastUpperIndex >= 0) {
+//                        int diff = i - lastUpperIndex;
+//                        if (diff > 1) {
+//                            // someACRONYMId
+//                            stringBuilder.append(string, lastUpperIndex, i - 2);
+//                            words.add(stringBuilder.toString());
+//                            stringBuilder = new StringBuilder();
+//                            stringBuilder.append(c);
+//                        }
+//                    }
+//                    stringBuilder.append(c);
+//                }
+//            } else if (stringBuilder.length() > 0) {
+//                words.add(stringBuilder.toString());
+//            }
+//        }
+//        if (stringBuilder.length() > 0) {
+//            words.add(stringBuilder.toString());
+//        }
+//        return words;
+
+
+//        List<String> words = new ArrayList<>();
+//        Iterable<String> split = Splitter.on(WORD_MATCHER).omitEmptyStrings().split(string);
+//        Iterator<String> it = split.iterator();
+//
+//        while (it.hasNext()) {
+//            String word = it.next();
+//
+//
+//            if (Character.isUpperCase(word.charAt(0))) {
+//
+//
+//                StringBuilder stringBuilder = null;
+//                boolean acronym = false;
+//                while (word.length() == 1 && Character.isUpperCase(word.charAt(0))) {
+//                    if (stringBuilder == null) {
+//                        stringBuilder = new StringBuilder();
+//                    }
+//                    stringBuilder.append(word);
+//                    word = it.next();
+//                    acronym = true;
+//                }
+//                if (acronym) {
+//                    word = stringBuilder.toString();
+//                }
+//            }
+////            while (word.length() == 1 && Character.isUpperCase(word.charAt(0))) {
+////                if (stringBuilder == null) {
+////                    stringBuilder = new StringBuilder();
+////                }
+////                stringBuilder.append(word);
+////                word = it.next();
+////                acronym = true;
+////            }
+////            if (acronym) {
+////                word = stringBuilder.toString();
+////            }
+//            words.add(word);
+//        }
+
+//        return words;
+    }
+}

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/v2/commons/StringNormalizerCodegenTagger.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/v2/commons/StringNormalizerCodegenTagger.java
@@ -1,0 +1,46 @@
+package org.openapitools.codegen.v2.commons;
+
+import org.openapitools.codegen.v2.*;
+import org.openapitools.codegen.v2.reflection.GenericClass;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public final class StringNormalizerCodegenTagger implements CodegenTagger {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(StringNormalizerCodegenTagger.class);
+
+    private final Function<String, String> normalizeFunc;
+    private final Collection<CodegenTag> tags;
+
+    public StringNormalizerCodegenTagger(Function<String, String> standardizeFunc, CodegenTag... tags) {
+        this(standardizeFunc, Arrays.asList(tags));
+    }
+
+    public StringNormalizerCodegenTagger(Function<String, String> normalizeFunc, Collection<CodegenTag> tags) {
+        this.normalizeFunc = Objects.requireNonNull(normalizeFunc);
+        this.tags = Objects.requireNonNull(tags);
+    }
+
+    @Override
+    public void tag(CodegenObject object) {
+        for (CodegenTag tag : tags) {
+            if (tag.acceptsValueClass(String.class)) {
+                String value = object.getTag(tag, String.class);
+                if (value != null) {
+                    object.setTag(tag, normalizeFunc.apply(value));
+                }
+            } else if (tag.acceptsValueGenericClass(new GenericClass<Collection<String>>() {})) {
+                Collection<String> values = object.getTag(tag, new GenericClass<Collection<String>>() {});
+                if (values != null) {
+                    object.setTag(tag, values.stream().map(normalizeFunc).collect(Collectors.toList()));
+                }
+            }
+        }
+    }
+}

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/v2/http/CodegenHttpTags.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/v2/http/CodegenHttpTags.java
@@ -1,0 +1,13 @@
+package org.openapitools.codegen.v2.http;
+
+import org.openapitools.codegen.v2.CodegenTag;
+
+public class CodegenHttpTags {
+    private CodegenHttpTags() {}
+    public static final CodegenTag AVAILABLE = CodegenTag.of("http.available", Boolean.class);
+    public static final CodegenTag URL = CodegenTag.of("http.url", String.class);
+    public static final CodegenTag ROUTE = CodegenTag.of("http.route", String.class);
+    public static final CodegenTag METHOD = CodegenTag.of("http.method", String.class);
+    public static final CodegenTag CONSUMES = CodegenTag.of("http.consumes", String.class);
+    public static final CodegenTag PRODUCES = CodegenTag.of("http.produces", String.class);
+}

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/v2/outputs/CodegenOutput.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/v2/outputs/CodegenOutput.java
@@ -1,0 +1,21 @@
+package org.openapitools.codegen.v2.outputs;
+
+import java.util.Objects;
+
+public final class CodegenOutput {
+    private final Object location;
+    private final String content;
+
+    public CodegenOutput(Object location, String content) {
+        this.location = Objects.requireNonNull(location);
+        this.content = Objects.requireNonNull(content);
+    }
+
+    public Object getLocation() {
+        return location;
+    }
+
+    public String getContent() {
+        return content;
+    }
+}

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/v2/outputs/CodegenOutputProcessor.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/v2/outputs/CodegenOutputProcessor.java
@@ -1,0 +1,7 @@
+package org.openapitools.codegen.v2.outputs;
+
+import org.openapitools.codegen.v2.CodegenObject;
+
+public interface CodegenOutputProcessor {
+    void process(CodegenObject object);
+}

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/v2/outputs/CodegenOutputTags.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/v2/outputs/CodegenOutputTags.java
@@ -1,0 +1,12 @@
+package org.openapitools.codegen.v2.outputs;
+
+import org.openapitools.codegen.v2.CodegenTag;
+import org.openapitools.codegen.v2.reflection.GenericClass;
+
+import java.util.Collection;
+
+public final class CodegenOutputTags {
+    private CodegenOutputTags() { }
+    public static final CodegenTag AVAILABLE = CodegenTag.of("output.available", Boolean.class);
+    public static final CodegenTag OUTPUTS = CodegenTag.of("output.outputs", new GenericClass<Collection<CodegenOutput>>(){});
+}

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/v2/outputs/ConsoleCodegenOutputProcessor.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/v2/outputs/ConsoleCodegenOutputProcessor.java
@@ -1,0 +1,22 @@
+package org.openapitools.codegen.v2.outputs;
+
+import org.openapitools.codegen.v2.CodegenObject;
+import org.openapitools.codegen.v2.CodegenObjectVisitor;
+import org.openapitools.codegen.v2.reflection.GenericClass;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+public class ConsoleCodegenOutputProcessor implements CodegenOutputProcessor {
+    public void process(CodegenObject object) {
+        CodegenObjectVisitor visitor = o -> {
+            Collection<CodegenOutput> outputs = o.getTagOrDefault(
+                    CodegenOutputTags.OUTPUTS, new GenericClass<Collection<CodegenOutput>>() {}, ArrayList::new);
+            for (CodegenOutput output : outputs) {
+                System.out.printf("%s -> \n\n%s\n\n", output.getLocation(), output.getContent());
+            }
+        };
+
+        visitor.visit(object);
+    }
+}

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/v2/outputs/FileCodegenOutputProcessor.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/v2/outputs/FileCodegenOutputProcessor.java
@@ -1,0 +1,72 @@
+package org.openapitools.codegen.v2.outputs;
+
+import org.openapitools.codegen.v2.CodegenObject;
+import org.openapitools.codegen.v2.CodegenObjectVisitor;
+import org.openapitools.codegen.v2.reflection.GenericClass;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Objects;
+
+public final class FileCodegenOutputProcessor implements CodegenOutputProcessor {
+    private final Path basePath;
+    private final Charset charset;
+
+    public FileCodegenOutputProcessor() {
+        this(Paths.get("."), StandardCharsets.UTF_8);
+    }
+
+    public FileCodegenOutputProcessor(Path basePath, Charset charset) {
+        this.basePath = Objects.requireNonNull(basePath);
+        this.charset = Objects.requireNonNull(charset);
+    }
+
+    public void process(CodegenObject object) {
+        CodegenObjectVisitor visitor = o -> {
+            Collection<CodegenOutput> outputs = o.getTagOrDefault(
+                    CodegenOutputTags.OUTPUTS, new GenericClass<Collection<CodegenOutput>>() {}, ArrayList::new);
+            for (CodegenOutput output : outputs) {
+                try {
+                    Path outputPath = getPathFromLocation(output.getLocation());
+                    if (outputPath != null) {
+                        Path fullPath = basePath.resolve(outputPath).toAbsolutePath();
+                        Files.createDirectories(fullPath.getParent());
+                        Files.write(fullPath, output.getContent().getBytes(charset));
+                    }
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        };
+
+        visitor.visit(object);
+    }
+
+    private Path getPathFromLocation(Object location) {
+        if (location instanceof Path) {
+            return (Path) location;
+        }
+
+        if (location instanceof File) {
+            return ((File) location).toPath();
+        }
+
+        if (location instanceof String) {
+            return Paths.get((String) location);
+        }
+
+        if (location instanceof URI) {
+            return Paths.get((URI) location);
+        }
+
+        return null;
+    }
+}

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/v2/reflection/GenericClass.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/v2/reflection/GenericClass.java
@@ -1,0 +1,21 @@
+package org.openapitools.codegen.v2.reflection;
+
+import com.google.common.reflect.TypeToken;
+
+@SuppressWarnings("UnstableApiUsage")
+public abstract class GenericClass<T> {
+    private final TypeToken<T> typeToken;
+
+    public GenericClass() {
+        this.typeToken = new TypeToken<T>(getClass()) {};
+    }
+
+    @SuppressWarnings("unchecked")
+    public final Class<T> getGenericClass() {
+        return (Class<T>) typeToken.getRawType();
+    }
+
+//    public static <T> GenericClass<T> of() {
+//        return new GenericClass<T>() { };
+//    }
+}

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/v2/templates/CodegenTemplate.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/v2/templates/CodegenTemplate.java
@@ -1,0 +1,28 @@
+package org.openapitools.codegen.v2.templates;
+
+import java.util.Objects;
+
+public class CodegenTemplate {
+
+    private final CodegenTemplateEngine engine;
+    private final String templateFile;
+    private final String generatedName;
+
+    public CodegenTemplate(CodegenTemplateEngine engine, String templateFile, String generatedName) {
+        this.engine = Objects.requireNonNull(engine);
+        this.templateFile = Objects.requireNonNull(templateFile);
+        this.generatedName = Objects.requireNonNull(generatedName);
+    }
+
+    public CodegenTemplateEngine getEngine() {
+        return engine;
+    }
+
+    public String getTemplateFile() {
+        return templateFile;
+    }
+
+    public String getGeneratedName() {
+        return generatedName;
+    }
+}

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/v2/templates/CodegenTemplateEngine.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/v2/templates/CodegenTemplateEngine.java
@@ -1,0 +1,7 @@
+package org.openapitools.codegen.v2.templates;
+
+import org.openapitools.codegen.v2.CodegenObject;
+
+public interface CodegenTemplateEngine {
+    String process(CodegenObject object, CodegenTemplate template);
+}

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/v2/templates/CodegenTemplateProcessor.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/v2/templates/CodegenTemplateProcessor.java
@@ -1,0 +1,7 @@
+package org.openapitools.codegen.v2.templates;
+
+import org.openapitools.codegen.v2.CodegenObject;
+
+public interface CodegenTemplateProcessor {
+    void process(CodegenObject object);
+}

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/v2/templates/CodegenTemplateTagger.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/v2/templates/CodegenTemplateTagger.java
@@ -1,0 +1,97 @@
+package org.openapitools.codegen.v2.templates;
+
+import org.openapitools.codegen.v2.*;
+import org.openapitools.codegen.v2.reflection.GenericClass;
+import org.openapitools.codegen.v2.templates.mustache.MustacheCodegenTemplateEngine;
+
+import java.net.URISyntaxException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+public class CodegenTemplateTagger extends AbstractCodegenTagger {
+
+    public static class Builder {
+        private CodegenTemplateEngine engine;
+        private List<CodegenTemplate> sdkTemplates;
+        private List<CodegenTemplate> apiTemplates;
+        private List<CodegenTemplate> modelTemplates;
+
+        public Builder() {
+            try {
+                Path resourcePath = Paths.get(ClassLoader.getSystemResource("").toURI());
+                this.engine = new MustacheCodegenTemplateEngine(resourcePath);
+            } catch (URISyntaxException e) {
+                throw new RuntimeException(e);
+            }
+            this.sdkTemplates = new ArrayList<>();
+            this.apiTemplates = new ArrayList<>();
+            this.modelTemplates = new ArrayList<>();
+        }
+
+        public Builder withEngine(CodegenTemplateEngine engine) {
+            this.engine = Objects.requireNonNull(engine);
+            return this;
+        }
+
+        public Builder withSdkTemplate(String templateFile, String generatedName) {
+            sdkTemplates.add(new CodegenTemplate(engine, templateFile, generatedName));
+            return this;
+        }
+
+        public Builder withApiTemplate(String templateFile, String generatedName) {
+            apiTemplates.add(new CodegenTemplate(engine, templateFile, generatedName));
+            return this;
+        }
+
+        public Builder withModelTemplate(String templateFile, String generatedName) {
+            modelTemplates.add(new CodegenTemplate(engine, templateFile, generatedName));
+            return this;
+        }
+
+        public CodegenTagger build() {
+            CodegenTagger tagger = new CodegenTemplateTagger(sdkTemplates, apiTemplates, modelTemplates);
+            sdkTemplates = new ArrayList<>();
+            apiTemplates = new ArrayList<>();
+            modelTemplates = new ArrayList<>();
+            return tagger;
+        }
+    }
+
+    private final Collection<CodegenTemplate> sdkTemplates;
+    private final Collection<CodegenTemplate> apiTemplates;
+    private final Collection<CodegenTemplate> modelTemplates;
+
+    private CodegenTemplateTagger(Collection<CodegenTemplate> sdkTemplates, Collection<CodegenTemplate> apiTemplates, Collection<CodegenTemplate> modelTemplates) {
+        this.sdkTemplates = sdkTemplates;
+        this.apiTemplates = apiTemplates;
+        this.modelTemplates = modelTemplates;
+    }
+
+    @Override
+    protected void tag(CodegenSdk sdk) {
+        addTemplatesToObject(sdkTemplates, sdk);
+    }
+
+    @Override
+    protected void tag(CodegenApi api) {
+        addTemplatesToObject(apiTemplates, api);
+    }
+
+    @Override
+    protected void tag(CodegenModel model) {
+        addTemplatesToObject(modelTemplates, model);
+    }
+
+    private void addTemplatesToObject(Collection<CodegenTemplate> templates, CodegenObject object) {
+        Collection<CodegenTemplate> objectTemplates = object
+                .getTagOrDefault(CodegenTemplateTags.TEMPLATES, new GenericClass<Collection<CodegenTemplate>>() {}, ArrayList::new);
+        objectTemplates.addAll(templates.stream()
+                .map(x -> new CodegenTemplate(x.getEngine(), x.getTemplateFile(), object.getId() + x.getGeneratedName()))
+                .collect(Collectors.toList()));
+    }
+}

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/v2/templates/CodegenTemplateTags.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/v2/templates/CodegenTemplateTags.java
@@ -1,0 +1,12 @@
+package org.openapitools.codegen.v2.templates;
+
+import org.openapitools.codegen.v2.CodegenTag;
+import org.openapitools.codegen.v2.reflection.GenericClass;
+
+import java.util.Collection;
+
+public final class CodegenTemplateTags {
+    private CodegenTemplateTags() { }
+
+    public static final CodegenTag TEMPLATES = CodegenTag.of("template.templates", new GenericClass<Collection<CodegenTemplate>>() {});
+}

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/v2/templates/DefaultCodegenTemplateProcessor.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/v2/templates/DefaultCodegenTemplateProcessor.java
@@ -1,0 +1,36 @@
+package org.openapitools.codegen.v2.templates;
+
+import org.openapitools.codegen.v2.CodegenObject;
+import org.openapitools.codegen.v2.CodegenObjectVisitor;
+import org.openapitools.codegen.v2.outputs.CodegenOutput;
+import org.openapitools.codegen.v2.outputs.CodegenOutputTags;
+import org.openapitools.codegen.v2.reflection.GenericClass;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+public class DefaultCodegenTemplateProcessor implements CodegenTemplateProcessor {
+
+    public DefaultCodegenTemplateProcessor() {
+    }
+
+    @Override
+    public void process(CodegenObject object) {
+        CodegenObjectVisitor visitor = o -> {
+            Collection<CodegenOutput> outputs = o.getTagOrDefault(
+                    CodegenOutputTags.OUTPUTS, new GenericClass<Collection<CodegenOutput>>() {}, ArrayList::new);
+            Collection<CodegenTemplate> templates = object.getTagOrDefault(
+                    CodegenTemplateTags.TEMPLATES, new GenericClass<Collection<CodegenTemplate>>() {}, ArrayList::new);
+
+            for (CodegenTemplate template : templates) {
+                CodegenTemplateEngine engine = template.getEngine();
+                String name = template.getGeneratedName();
+                String content = engine.process(o, template);
+                outputs.add(new CodegenOutput(name, content));
+            }
+            o.setTag(CodegenOutputTags.AVAILABLE, true);
+        };
+
+        visitor.visit(object);
+    }
+}

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/v2/templates/mustache/MustacheCodegenCollector.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/v2/templates/mustache/MustacheCodegenCollector.java
@@ -1,0 +1,26 @@
+package org.openapitools.codegen.v2.templates.mustache;
+
+import com.samskivert.mustache.DefaultCollector;
+import com.samskivert.mustache.Mustache;
+import org.openapitools.codegen.v2.CodegenObject;
+import org.openapitools.codegen.v2.CodegenTag;
+
+public class MustacheCodegenCollector extends DefaultCollector {
+    @Override
+    public Mustache.VariableFetcher createFetcher(Object ctx, String name) {
+        Mustache.VariableFetcher fetcher = super.createFetcher(ctx, name);
+        if (fetcher != null) {
+            return fetcher;
+        } else {
+            if (ctx instanceof CodegenObject) {
+                CodegenObject object = (CodegenObject) ctx;
+                return (x, y) -> {
+                    CodegenTag tag = CodegenTag.of(name);
+                    return object.getTag(tag);
+                };
+            }
+
+            return null;
+        }
+    }
+}

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/v2/templates/mustache/MustacheCodegenTemplateEngine.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/v2/templates/mustache/MustacheCodegenTemplateEngine.java
@@ -1,0 +1,79 @@
+package org.openapitools.codegen.v2.templates.mustache;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.samskivert.mustache.Mustache;
+import com.samskivert.mustache.Template;
+import org.openapitools.codegen.v2.CodegenObject;
+import org.openapitools.codegen.v2.CodegenTag;
+import org.openapitools.codegen.v2.templates.CodegenTemplate;
+import org.openapitools.codegen.v2.templates.CodegenTemplateEngine;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.io.StringReader;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Map;
+
+public class MustacheCodegenTemplateEngine implements CodegenTemplateEngine {
+
+    private final Mustache.Compiler mustacheCompiler;
+    private final Path templateDirectory;
+
+    public MustacheCodegenTemplateEngine() {
+        this(null);
+    }
+
+    public MustacheCodegenTemplateEngine(Path templateDirectory) {
+        this.mustacheCompiler = Mustache.compiler();
+        this.templateDirectory = templateDirectory;
+    }
+
+    @Override
+    public String process(CodegenObject object, CodegenTemplate template) {
+        Template mustacheTemplate = mustacheCompiler
+                .withLoader(this::openTemplateFile)
+                .withCollector(new MustacheCodegenCollector())
+                .escapeHTML(false)
+                .defaultValue("")
+                .compile(openTemplateFile(template.getTemplateFile()));
+
+        return mustacheTemplate.execute(object);
+    }
+
+    private Reader openTemplateFile(String templateFile) {
+        try {
+            Path path = getTemplateFilePath(templateFile);
+            byte[] content = Files.readAllBytes(path);
+            return new StringReader(new String(content));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private Path getTemplateFilePath(String templateFile) {
+        if (templateDirectory != null) {
+            return templateDirectory.resolve(templateFile);
+        }
+
+        try {
+            return Paths.get(ClassLoader.getSystemResource(templateFile).toURI());
+        } catch (URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private Map<String, Object> buildContext(CodegenObject object) {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
+        Map<String, Object> context = mapper.convertValue(object, new TypeReference<Map<String, Object>>() {});
+        for (Map.Entry<CodegenTag, Object> entry : object.getTags().entrySet()) {
+            context.putIfAbsent(entry.getKey().getName(), entry.getValue());
+        }
+        return context;
+    }
+}


### PR DESCRIPTION
# OpenAPI generator v2
## Motivation
This project is awesome. I've used it to generate clients for unreal engine and unity and it works very well. However, I've hit many issues during development, mostly `NullPointerException` occurring from partially defined OpenAPI specifications and codegen models being mostly null. The inheritance model also hinder code re-use, with common methods only available for all codegens of a given language.

The main problem I've seen is that none of the objects used to generate code are closed; they cannot be extended unless PRs are submitted to the official project. This forces people to fork the project to have their own modifications, which is detrimental to the evolution of the code base.

Prior to using `openapi-generator`, I had created a C# project to generate clients, and I had created a fully dynamic api that could be adapated to any code generations, from REST services to AMQP messages. To achieve this level of genericity, I had a tagging system where a specification was only a graph (sometimes with circular dependencies) and taggers would traverse the graph and add tags (i.e. `string` tuple) to the specification objects. This allowed to develop small reusable tagger objects that could be composed in a pipeline to generate the metadata required for the SDK generation.

One issue I had is that string tags are not very flexible, and if you put an `object` value instead of a `string`, your whole code base is filled with type checks to prevent an invalid cast. Fast-forward a few months, I had to make modifications to the unreal client we were generating, and a lot of the code was unreadable string manipulation where it was not clear whether I had a schema type, a partially resolved type, a full c++ type and what not, and debugging was a bit of a nightmare. It's not easy to change the one template per api/model, in the sense that, types cannot be collected together to be outputted in one template. A bit of magic needs to be done (i.e. supporting file magic) for everything to work out.

## Proposition
This pull request proposes a v2 (not yet completed) of the codegen API. I've re-used my tagger idea, but the tags are not a `string` tuple anymore but a type-safe construct that disallows storing an unexpected value type. All codegen model objects are taggable and they're organized in a graph-like structure (i.e. with one parent and one-to-many children). This graph-like structure can be visited recursively, and taggers visit those codegen objects to add tags to them. For instance, there is tagger that adds template files to the relevant objects, and the templating engine now set output tags on the objects, which can be read by an output processor to output the content somewhere, on disk or in the console. Here is a description of the most important types:

- `CodegenTag`  
Immutable type that stores a name and a value class. Most instances are static and are used as type tokens, meant to be used as a key for maps.
- `CodegenTaggable`  
Interface that defines all methods to work with tags. It allows to get and set `CodegenTag` in a type-safe way. Most of its methods are default and use the `getTags()` to resolve tags.
- `CodegenObject`  
Abstract class that is the base class for all objects that are part of the codegen graph. All `CodegenObject` are `CodegenTaggable`, they also have a `getParent()` and `getChildren()` methods to traverse the graph and a `getId()` method to retrieve its unique name.
- `CodegenObjectVisitor`  
Functional interface to traverse a `CodegenObject` graph. `CodegenObjectVisitor.Of<T>` can be used to traverse the graph, but only visit `CodegenObject` of the given `T` type.
- `CodegenTagger`  
Interface that sets `CodegenTag` on a given `CodegenObject`.
- `AbstractCodegenTagger`  
Abstract `CodegenTagger` that invokes an overload of the `tag()` for a given `CodegenObject` type. Does nothing if no such method exists.
- `CodegenOutputProcessor`  
Interface for an object that consumes output tags to write a `CodegenObject` contents.
- `CodegenTemplateProcessor`  
Interface for an object that consumes template tags to process templates for the given `CodegenObject`. Generate output tags with the template's content.
- `Codegen`  
Interface for an object responsible of generating all code for the given OpenAPI specification.
- `AbstractCodegen`
Abstract class for specific `Codegen` configurations. Subclasses mostly setup their tagging pipeline through the `getTaggers()` method. Two additional virtual methods `onPreGenerate()` and `onPostGenerate()` can also be overriden to customize the codegen.

These are the most important types, but the proposition is a bit more complete. Currently, the v2 prototype supports mustache (`MustacheCodegenTemplateEngine`) and outputs both to file and console (`FileCodegenOutputProcessor` and `ConsoleCodegenOutputProcessor`). A custom codegen can be created as such:

```java
public class MyCodegen extends AbstractCodegen {
    public MyCodegen(CodegenTemplateProcessor templateProcessor, CodegenOutputProcessor outputProcessor) {
        super(templateProcessor, outputProcessor);
    }

    @Override
    protected Collection<CodegenTagger> getTaggers(CodegenOptions options) {
        return new ArrayList<CodegenTagger>() {{
            // Adds one template to objects of type CodegenApi
            // Adds one template to objects of type CodegenModel
            add(new CodegenTemplateTagger.Builder()
                    .withApiTemplate("myclient/api.mustache", ".java")
                    .withModelTemplate("myclient/model.mustache", ".java")
                    .build());
            // Normalizes names, getters and setters to camel case
            add(new StringNormalizerCodegenTagger(
                    StringCaseUtils::camelCase, 
                    CodegenCodeTags.NAME, CodegenCodeTags.ACCESSOR,
                    CodegenCodeTags.MUTATOR));
            // Normalizes all type names to upper camel case
            add(new StringNormalizerCodegenTagger(
                    StringCaseUtils::upperCamelCase, 
                    CodegenCodeTags.TYPE, CodegenCodeTags.BASE_TYPE, 
                    CodegenCodeTags.RETURN_TYPE, CodegenCodeTags.GENERIC_TYPES));
            // Normalizes enum values to upper snake case
            add(new StringNormalizerCodegenTagger(
                    StringCaseUtils::upperSnakeCase, CodegenCodeTags.ENUMS));
            // Add any additional taggers you may have
            // add(new MyCustomCodegenTagger());
        }};
    }
    
    @Override
    protected void onPreGenerate(OpenAPI openAPI, CodegenOptions options) {
        // Add any custom processing to do before generation
    }

    @Override
    protected void onPostGenerate(OpenAPI openAPI, CodegenSdk sdk, CodegenOptions options) {
        // Add any custom processing to do after generation
    }

    public static void main(String­[] args) {
         // [...] Retrieved from somewhere
        OpenAPI openAPI = null;

        // Create codegen from default template processor
        // that outputs generated content to System.out
        MyCodegen codegen = new MyCodegen(
                new DefaultCodegenTemplateProcessor(),
                new ConsoleCodegenOutputProcessor());
        
        // Builds codegen graph, tags all object, process
        // templates and outputs all content
        codegen.generate(openAPI, new DefaultCodegenOptions());
    }
}
```
