### PR TITLE
[Ruby] Fix CVE-2020-8130

### DIFF
--- a/modules/openapi-generator/src/main/resources/ruby-client/Gemfile.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/Gemfile.mustache
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 gemspec
 
 group :development, :test do
-  gem 'rake', '~> 12.0.0'
+  gem 'rake', '~> 13.0.1'
   gem 'pry-byebug'
   gem 'rubocop', '~> 0.66.0'
 end

--- a/samples/client/petstore/ruby-faraday/Gemfile
+++ b/samples/client/petstore/ruby-faraday/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 gemspec
 
 group :development, :test do
-  gem 'rake', '~> 12.0.0'
+  gem 'rake', '~> 13.0.1'
   gem 'pry-byebug'
   gem 'rubocop', '~> 0.66.0'
 end

--- a/samples/client/petstore/ruby/Gemfile
+++ b/samples/client/petstore/ruby/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 gemspec
 
 group :development, :test do
-  gem 'rake', '~> 12.0.0'
+  gem 'rake', '~> 13.0.1'
   gem 'pry-byebug'
   gem 'rubocop', '~> 0.66.0'
 end

--- a/samples/openapi3/client/petstore/ruby-faraday/Gemfile
+++ b/samples/openapi3/client/petstore/ruby-faraday/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 gemspec
 
 group :development, :test do
-  gem 'rake', '~> 12.0.0'
+  gem 'rake', '~> 13.0.1'
   gem 'pry-byebug'
   gem 'rubocop', '~> 0.66.0'
 end

--- a/samples/openapi3/client/petstore/ruby/Gemfile
+++ b/samples/openapi3/client/petstore/ruby/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 gemspec
 
 group :development, :test do
-  gem 'rake', '~> 12.0.0'
+  gem 'rake', '~> 13.0.1'
   gem 'pry-byebug'
   gem 'rubocop', '~> 0.66.0'
 end


### PR DESCRIPTION
```
CVE-2020-8130
moderate severity
Vulnerable versions: <= 12.3.2
Patched version: 12.3.3
There is an OS command injection vulnerability in Ruby Rake before 12.3.3 in Rake::FileList when supplying a filename that begins with the pipe character |.
```

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

cc @cliffano (2017/07) @zlx (2017/09) @autopp (2019/02)


