### PR TITLE
[C-libcurl] The name in API parameter should not be escaped

### DIFF
--- a/modules/openapi-generator/src/main/resources/C-libcurl/api-body.mustache
+++ b/modules/openapi-generator/src/main/resources/C-libcurl/api-body.mustache
@@ -120,7 +120,7 @@
     {{#isPrimitiveType}}{{#isNumber}}{{{dataType}}}{{/isNumber}}{{#isLong}}{{{dataType}}}{{/isLong}}{{#isInteger}}{{{dataType}}}{{/isInteger}}{{#isDouble}}{{{dataType}}}{{/isDouble}}{{#isFloat}}{{{dataType}}}{{/isFloat}}{{#isBoolean}}{{dataType}}{{/isBoolean}}{{#isEnum}}{{#isString}}{{{baseName}}}_e{{/isString}}{{/isEnum}}{{^isEnum}}{{#isString}}{{{dataType}}} *{{/isString}}{{/isEnum}}{{#isByteArray}}{{{dataType}}}{{/isByteArray}}{{#isDate}}{{{dataType}}}{{/isDate}}{{#isDateTime}}{{{dataType}}}{{/isDateTime}}{{#isFile}}{{{dataType}}}{{/isFile}}{{/isPrimitiveType}}{{^isPrimitiveType}}{{#isModel}}{{#isEnum}}{{datatypeWithEnum}}_e{{/isEnum}}{{^isEnum}}{{{dataType}}}_t *{{/isEnum}}{{/isModel}}{{^isModel}}{{#isEnum}}{{datatypeWithEnum}}_e{{/isEnum}}{{/isModel}}{{#isUuid}}{{dataType}} *{{/isUuid}}{{#isEmail}}{{dataType}}{{/isEmail}}{{/isPrimitiveType}} valueHeader_{{{paramName}}};
     keyValuePair_t *keyPairHeader_{{paramName}} = 0;
     if ({{paramName}}) {
-        keyHeader_{{{paramName}}} = strdup("{{{paramName}}}");
+        keyHeader_{{{paramName}}} = strdup("{{{baseName}}}");
         valueHeader_{{{paramName}}} = {{#isString}}{{^isEnum}}strdup({{/isEnum}}{{/isString}}({{{paramName}}}){{#isString}}{{^isEnum}}){{/isEnum}}{{/isString}};
         keyPairHeader_{{paramName}} = keyValuePair_create(keyHeader_{{{paramName}}}, {{#isEnum}}(void *){{/isEnum}}{{^isString}}&{{/isString}}valueHeader_{{{paramName}}});
         list_addElement(localVarHeaderParameters,keyPairHeader_{{paramName}});
@@ -164,13 +164,13 @@
     if ({{paramName}} != NULL)
     {
         {{#isFile}}
-        keyForm_{{paramName}} = strdup("{{{paramName}}}");
+        keyForm_{{paramName}} = strdup("{{{baseName}}}");
         valueForm_{{paramName}} = {{paramName}};
         keyPairForm_{{paramName}} = keyValuePair_create(keyForm_{{paramName}}, &valueForm_{{paramName}});
         list_addElement(localVarFormParameters,keyPairForm_{{paramName}}); //file adding
         {{/isFile}}
         {{^isFile}}
-        keyForm_{{paramName}} = strdup("{{{paramName}}}");
+        keyForm_{{paramName}} = strdup("{{{baseName}}}");
         valueForm_{{paramName}} = {{#isString}}{{^isEnum}}strdup({{/isEnum}}{{/isString}}({{{paramName}}}){{#isString}}{{^isEnum}}){{/isEnum}}{{/isString}};
         keyPairForm_{{paramName}} = keyValuePair_create(keyForm_{{paramName}},{{#isString}}{{#isEnum}}(void *){{/isEnum}}{{/isString}}{{^isString}}&{{/isString}}valueForm_{{paramName}});
         list_addElement(localVarFormParameters,keyPairForm_{{paramName}});


### PR DESCRIPTION
To fix the issue [#5101](https://github.com/OpenAPITools/openapi-generator/issues/5101)

The name "x-api-token" in API spec includes the c keyword "-",  and it is escaped:
```
if (x_api_token) {
    keyHeader_x_api_token = strdup("x_api_token");  <--should not be escaped here
    valueHeader_x_api_token = strdup((x_api_token));
```

Now the fix will not escape:
```
if (x_api_token) {
    keyHeader_x_api_token = strdup("x-api-token");  <--It is right now
    valueHeader_x_api_token = strdup((x_api_token));
```

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [X] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [X] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@wing328 @zhemant
