### PR TITLE
Fix rubocop warnings in Ruby client's custom spec

### DIFF
--- a/samples/openapi3/client/petstore/ruby/spec/custom/pet_spec.rb
+++ b/samples/openapi3/client/petstore/ruby/spec/custom/pet_spec.rb
@@ -23,7 +23,7 @@ describe "Pet" do
       tag1 = Petstore::Tag.new('id' => 1, 'name' => 'tag1')
       tag2 = Petstore::Tag.new('id' => 2, 'name' => 'tag2')
       category1 = Petstore::Category.new(:id => 1, :name => 'category unknown')
-      # initalize using both string and symbol key
+      # initialize using both string and symbol key
       pet_hash = {
         :id => @pet_id,
         :name => "RUBY UNIT TESTING",
@@ -79,7 +79,7 @@ describe "Pet" do
       rescue Petstore::ApiError => e
         expect(e.code).to eq(404)
         # skip the check as the response contains a timestamp that changes on every reponse
-        #expect(e.message).to eq("Error message: the server returns an error\nHTTP status code: 404\nResponse headers: {\"Date\"=>\"Tue, 26 Feb 2019 04:35:40 GMT\", \"Access-Control-Allow-Origin\"=>\"*\", \"Access-Control-Allow-Methods\"=>\"GET, POST, DELETE, PUT\", \"Access-Control-Allow-Headers\"=>\"Content-Type, api_key, Authorization\", \"Content-Type\"=>\"application/json\", \"Connection\"=>\"close\", \"Server\"=>\"Jetty(9.2.9.v20150224)\"}\nResponse body: {\"code\":1,\"type\":\"error\",\"message\":\"Pet not found\"}")
+        # expect(e.message).to eq("Error message: the server returns an error\nHTTP status code: 404\nResponse headers: {\"Date\"=>\"Tue, 26 Feb 2019 04:35:40 GMT\", \"Access-Control-Allow-Origin\"=>\"*\", \"Access-Control-Allow-Methods\"=>\"GET, POST, DELETE, PUT\", \"Access-Control-Allow-Headers\"=>\"Content-Type, api_key, Authorization\", \"Content-Type\"=>\"application/json\", \"Connection\"=>\"close\", \"Server\"=>\"Jetty(9.2.9.v20150224)\"}\nResponse body: {\"code\":1,\"type\":\"error\",\"message\":\"Pet not found\"}")
         expect(e.response_body).to eq('{"code":1,"type":"error","message":"Pet not found"}')
         expect(e.response_headers).to include('Content-Type')
         expect(e.response_headers['Content-Type']).to eq('application/json')

--- a/samples/openapi3/client/petstore/ruby/spec/petstore_helper.rb
+++ b/samples/openapi3/client/petstore/ruby/spec/petstore_helper.rb
@@ -48,5 +48,3 @@ def deserialize_json(s, type)
   response = double('response', headers: headers, body: s)
   API_CLIENT.deserialize(response, type)
 end
-
-


### PR DESCRIPTION
This PR fixes Rubocop warnings in `samples/openapi3/client/petstore/ruby`.

Before:
```
$ (cd samples/openapi3/client/petstore/ruby && rubocop -c .rubocop.yml)
Inspecting 129 files
............................................................................C..................................................C.

Offenses:

spec/custom/pet_spec.rb:82:9: C: Layout/LeadingCommentSpace: Missing space after #.
        #expect(e.message).to eq("Error message: the server returns an error\nHTTP status code: 404\nResponse headers: {\"Date\"=>\"Tue, 26 Feb 2019 04:35:40 GMT\", \"Access-Control-Allow-Origin\"=>\"*\", \"Access-Control-Allow-Methods\"=>\"GET, POST, DELETE, PUT\", \"Access-Control-Allow-Headers\"=>\"Content-Type, api_key, Authorization\", \"Content-Type\"=>\"application/json\", \"Connection\"=>\"close\", \"Server\"=>\"Jetty(9.2.9.v20150224)\"}\nResponse body: {\"code\":1,\"type\":\"error\",\"message\":\"Pet not found\"}")
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/petstore_helper.rb:51:1: C: Layout/TrailingEmptyLines: 2 trailing blank lines detected.

129 files inspected, 2 offenses detected
```

After:
```
$ (cd samples/openapi3/client/petstore/ruby && rubocop -c .rubocop.yml)
Inspecting 129 files
.................................................................................................................................

129 files inspected, no offenses detected
```

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language. @cliffano (2017/07) @zlx (2017/09) @autopp (2019/02)
