### PR TITLE
[core] Avoid overflow in CodegenModel#toString

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenModel.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenModel.java
@@ -18,9 +18,11 @@
 package org.openapitools.codegen;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.google.common.collect.ImmutableList;
 import io.swagger.v3.oas.models.ExternalDocumentation;
 
 import java.util.*;
+import java.util.stream.Collectors;
 
 @JsonIgnoreProperties({"parentModel", "interfaceModels"})
 public class CodegenModel implements IJsonSchemaValidationProperties {
@@ -616,9 +618,16 @@ public class CodegenModel implements IJsonSchemaValidationProperties {
         sb.append(", parentSchema='").append(parentSchema).append('\'');
         sb.append(", interfaces=").append(interfaces);
         sb.append(", allParents=").append(allParents);
-        sb.append(", parentModel=").append(parentModel);
+        // although unlikely, this will avoid stack overflow if parentModel refers to this instance.
+        sb.append(", parentModel=").append( !this.equals(parentModel) ? parentModel : null);
         sb.append(", interfaceModels=").append(interfaceModels);
-        sb.append(", children=").append(children);
+        if (children != null) {
+            // avoid stack overflow with back-referencing children
+            ImmutableList<CodegenModel> childModels = ImmutableList.copyOf(children.stream().filter(i -> !this.equals(i)).collect(Collectors.toList()));
+            sb.append(", children=").append(childModels);
+        } else {
+            sb.append(", children=").append(children);
+        }
         sb.append(", anyOf=").append(anyOf);
         sb.append(", oneOf=").append(oneOf);
         sb.append(", allOf=").append(allOf);


### PR DESCRIPTION
cc @sebastien-rosset I don't recall where I saw your comment, but you'd mentioned seeing stackoverflow on CodegenModel for complex schemas. Could you check this to see if it resolves your issue?

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

cc @OpenAPITools/generator-core-team 