### PR TITLE
Adding Response Interceptor

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/native/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/native/ApiClient.mustache
@@ -46,6 +46,7 @@ public class ApiClient {
   private int port;
   private String basePath;
   private Consumer<HttpRequest.Builder> interceptor;
+  private Consumer<HttpResponse<InputStream>> responseInterceptor;
   private Duration readTimeout;
 
   private static String valueToString(Object value) {
@@ -161,6 +162,7 @@ public class ApiClient {
     basePath = baseURI.getRawPath();
     interceptor = null;
     readTimeout = null;
+    responseInterceptor = null;
   }
 
   /**
@@ -293,6 +295,29 @@ public class ApiClient {
   }
 
   /**
+   * Set a custom response interceptor.
+   *
+   * <p>This is useful for logging, monitoring or extraction of header variables</p>
+   *
+   * @param interceptor A function invoked before creating each request. A value
+   *                    of null resets the interceptor to a no-op.
+   * @return This object.
+   */
+  public ApiClient setResponseInterceptor(Consumer<HttpResponse<InputStream>> interceptor) {
+    this.responseInterceptor = interceptor;
+    return this;
+  }
+
+ /**
+   * Get the custom response interceptor.
+   *
+   * @return The custom interceptor that was set, or null if there isn't any.
+   */
+  public Consumer<HttpResponse<InputStream>> getRequestInterceptor() {
+    return responseInterceptor;
+  }
+
+  /**
    * Set the read timeout for the http client.
    *
    * <p>This is the value used by default for each request, though it can be
@@ -307,7 +332,7 @@ public class ApiClient {
     this.readTimeout = readTimeout;
     return this;
   }
-
+  
   /**
    * Get the read timeout that was set.
    *

--- a/modules/openapi-generator/src/main/resources/Java/libraries/native/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/native/ApiClient.mustache
@@ -8,10 +8,12 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.openapitools.jackson.nullable.JsonNullableModule;
 
+import java.io.InputStream;
 import java.net.URI;
 import java.net.URLEncoder;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
 import java.nio.charset.Charset;
 import java.time.Duration;
 import java.util.Collection;
@@ -313,7 +315,7 @@ public class ApiClient {
    *
    * @return The custom interceptor that was set, or null if there isn't any.
    */
-  public Consumer<HttpResponse<InputStream>> getRequestInterceptor() {
+  public Consumer<HttpResponse<InputStream>> getResponseInterceptor() {
     return responseInterceptor;
   }
 

--- a/modules/openapi-generator/src/main/resources/Java/libraries/native/api.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/native/api.mustache
@@ -36,7 +36,8 @@ public class {{classname}} {
   private final String memberVarBaseUri;
   private final Consumer<HttpRequest.Builder> memberVarInterceptor;
   private final Duration memberVarReadTimeout;
-
+  private final Consumer<HttpResponse<InputStream>> memberVarResponseInterceptor;
+  
   public {{classname}}() {
     this(new ApiClient());
   }
@@ -47,6 +48,7 @@ public class {{classname}} {
     memberVarBaseUri = apiClient.getBaseUri();
     memberVarInterceptor = apiClient.getRequestInterceptor();
     memberVarReadTimeout = apiClient.getReadTimeout();
+    memberVarResponseInterceptor = apiClient.getResponseInterceptor();
   }
 
   {{#operation}}
@@ -138,6 +140,9 @@ public class {{classname}} {
       HttpResponse<InputStream> localVarResponse = memberVarHttpClient.send(
           localVarRequestBuilder.build(),
           HttpResponse.BodyHandlers.ofInputStream());
+      if (memberVarResponseInterceptor != null) {
+        memberVarResponseInterceptor.accept(localVarResponse);
+      }          
       if (localVarResponse.statusCode()/ 100 != 2) {
         throw new ApiException(localVarResponse.statusCode(),
             "{{operationId}} call received non-success response",

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/ApiClient.java
@@ -19,10 +19,12 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.openapitools.jackson.nullable.JsonNullableModule;
 
+import java.io.InputStream;
 import java.net.URI;
 import java.net.URLEncoder;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
 import java.nio.charset.Charset;
 import java.time.Duration;
 import java.util.Collection;
@@ -324,7 +326,7 @@ public class ApiClient {
    *
    * @return The custom interceptor that was set, or null if there isn't any.
    */
-  public Consumer<HttpResponse<InputStream>> getRequestInterceptor() {
+  public Consumer<HttpResponse<InputStream>> getResponseInterceptor() {
     return responseInterceptor;
   }
 

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/ApiClient.java
@@ -57,6 +57,7 @@ public class ApiClient {
   private int port;
   private String basePath;
   private Consumer<HttpRequest.Builder> interceptor;
+  private Consumer<HttpResponse<InputStream>> responseInterceptor;
   private Duration readTimeout;
 
   private static String valueToString(Object value) {
@@ -172,6 +173,7 @@ public class ApiClient {
     basePath = baseURI.getRawPath();
     interceptor = null;
     readTimeout = null;
+    responseInterceptor = null;
   }
 
   /**
@@ -304,6 +306,29 @@ public class ApiClient {
   }
 
   /**
+   * Set a custom response interceptor.
+   *
+   * <p>This is useful for logging, monitoring or extraction of header variables</p>
+   *
+   * @param interceptor A function invoked before creating each request. A value
+   *                    of null resets the interceptor to a no-op.
+   * @return This object.
+   */
+  public ApiClient setResponseInterceptor(Consumer<HttpResponse<InputStream>> interceptor) {
+    this.responseInterceptor = interceptor;
+    return this;
+  }
+
+ /**
+   * Get the custom response interceptor.
+   *
+   * @return The custom interceptor that was set, or null if there isn't any.
+   */
+  public Consumer<HttpResponse<InputStream>> getRequestInterceptor() {
+    return responseInterceptor;
+  }
+
+  /**
    * Set the read timeout for the http client.
    *
    * <p>This is the value used by default for each request, though it can be
@@ -318,7 +343,7 @@ public class ApiClient {
     this.readTimeout = readTimeout;
     return this;
   }
-
+  
   /**
    * Get the read timeout that was set.
    *

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
@@ -42,7 +42,8 @@ public class AnotherFakeApi {
   private final String memberVarBaseUri;
   private final Consumer<HttpRequest.Builder> memberVarInterceptor;
   private final Duration memberVarReadTimeout;
-
+  private final Consumer<HttpResponse<InputStream>> memberVarResponseInterceptor;
+  
   public AnotherFakeApi() {
     this(new ApiClient());
   }
@@ -53,6 +54,7 @@ public class AnotherFakeApi {
     memberVarBaseUri = apiClient.getBaseUri();
     memberVarInterceptor = apiClient.getRequestInterceptor();
     memberVarReadTimeout = apiClient.getReadTimeout();
+    memberVarResponseInterceptor = apiClient.getResponseInterceptor();
   }
 
   /**
@@ -90,6 +92,9 @@ public class AnotherFakeApi {
       HttpResponse<InputStream> localVarResponse = memberVarHttpClient.send(
           localVarRequestBuilder.build(),
           HttpResponse.BodyHandlers.ofInputStream());
+      if (memberVarResponseInterceptor != null) {
+        memberVarResponseInterceptor.accept(localVarResponse);
+      }          
       if (localVarResponse.statusCode()/ 100 != 2) {
         throw new ApiException(localVarResponse.statusCode(),
             "call123testSpecialTags call received non-success response",

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -50,7 +50,8 @@ public class FakeApi {
   private final String memberVarBaseUri;
   private final Consumer<HttpRequest.Builder> memberVarInterceptor;
   private final Duration memberVarReadTimeout;
-
+  private final Consumer<HttpResponse<InputStream>> memberVarResponseInterceptor;
+  
   public FakeApi() {
     this(new ApiClient());
   }
@@ -61,6 +62,7 @@ public class FakeApi {
     memberVarBaseUri = apiClient.getBaseUri();
     memberVarInterceptor = apiClient.getRequestInterceptor();
     memberVarReadTimeout = apiClient.getReadTimeout();
+    memberVarResponseInterceptor = apiClient.getResponseInterceptor();
   }
 
   /**
@@ -97,6 +99,9 @@ public class FakeApi {
       HttpResponse<InputStream> localVarResponse = memberVarHttpClient.send(
           localVarRequestBuilder.build(),
           HttpResponse.BodyHandlers.ofInputStream());
+      if (memberVarResponseInterceptor != null) {
+        memberVarResponseInterceptor.accept(localVarResponse);
+      }          
       if (localVarResponse.statusCode()/ 100 != 2) {
         throw new ApiException(localVarResponse.statusCode(),
             "createXmlItem call received non-success response",
@@ -142,6 +147,9 @@ public class FakeApi {
       HttpResponse<InputStream> localVarResponse = memberVarHttpClient.send(
           localVarRequestBuilder.build(),
           HttpResponse.BodyHandlers.ofInputStream());
+      if (memberVarResponseInterceptor != null) {
+        memberVarResponseInterceptor.accept(localVarResponse);
+      }          
       if (localVarResponse.statusCode()/ 100 != 2) {
         throw new ApiException(localVarResponse.statusCode(),
             "fakeOuterBooleanSerialize call received non-success response",
@@ -188,6 +196,9 @@ public class FakeApi {
       HttpResponse<InputStream> localVarResponse = memberVarHttpClient.send(
           localVarRequestBuilder.build(),
           HttpResponse.BodyHandlers.ofInputStream());
+      if (memberVarResponseInterceptor != null) {
+        memberVarResponseInterceptor.accept(localVarResponse);
+      }          
       if (localVarResponse.statusCode()/ 100 != 2) {
         throw new ApiException(localVarResponse.statusCode(),
             "fakeOuterCompositeSerialize call received non-success response",
@@ -234,6 +245,9 @@ public class FakeApi {
       HttpResponse<InputStream> localVarResponse = memberVarHttpClient.send(
           localVarRequestBuilder.build(),
           HttpResponse.BodyHandlers.ofInputStream());
+      if (memberVarResponseInterceptor != null) {
+        memberVarResponseInterceptor.accept(localVarResponse);
+      }          
       if (localVarResponse.statusCode()/ 100 != 2) {
         throw new ApiException(localVarResponse.statusCode(),
             "fakeOuterNumberSerialize call received non-success response",
@@ -280,6 +294,9 @@ public class FakeApi {
       HttpResponse<InputStream> localVarResponse = memberVarHttpClient.send(
           localVarRequestBuilder.build(),
           HttpResponse.BodyHandlers.ofInputStream());
+      if (memberVarResponseInterceptor != null) {
+        memberVarResponseInterceptor.accept(localVarResponse);
+      }          
       if (localVarResponse.statusCode()/ 100 != 2) {
         throw new ApiException(localVarResponse.statusCode(),
             "fakeOuterStringSerialize call received non-success response",
@@ -329,6 +346,9 @@ public class FakeApi {
       HttpResponse<InputStream> localVarResponse = memberVarHttpClient.send(
           localVarRequestBuilder.build(),
           HttpResponse.BodyHandlers.ofInputStream());
+      if (memberVarResponseInterceptor != null) {
+        memberVarResponseInterceptor.accept(localVarResponse);
+      }          
       if (localVarResponse.statusCode()/ 100 != 2) {
         throw new ApiException(localVarResponse.statusCode(),
             "testBodyWithFileSchema call received non-success response",
@@ -391,6 +411,9 @@ public class FakeApi {
       HttpResponse<InputStream> localVarResponse = memberVarHttpClient.send(
           localVarRequestBuilder.build(),
           HttpResponse.BodyHandlers.ofInputStream());
+      if (memberVarResponseInterceptor != null) {
+        memberVarResponseInterceptor.accept(localVarResponse);
+      }          
       if (localVarResponse.statusCode()/ 100 != 2) {
         throw new ApiException(localVarResponse.statusCode(),
             "testBodyWithQueryParams call received non-success response",
@@ -440,6 +463,9 @@ public class FakeApi {
       HttpResponse<InputStream> localVarResponse = memberVarHttpClient.send(
           localVarRequestBuilder.build(),
           HttpResponse.BodyHandlers.ofInputStream());
+      if (memberVarResponseInterceptor != null) {
+        memberVarResponseInterceptor.accept(localVarResponse);
+      }          
       if (localVarResponse.statusCode()/ 100 != 2) {
         throw new ApiException(localVarResponse.statusCode(),
             "testClientModel call received non-success response",
@@ -512,6 +538,9 @@ public class FakeApi {
       HttpResponse<InputStream> localVarResponse = memberVarHttpClient.send(
           localVarRequestBuilder.build(),
           HttpResponse.BodyHandlers.ofInputStream());
+      if (memberVarResponseInterceptor != null) {
+        memberVarResponseInterceptor.accept(localVarResponse);
+      }          
       if (localVarResponse.statusCode()/ 100 != 2) {
         throw new ApiException(localVarResponse.statusCode(),
             "testEndpointParameters call received non-success response",
@@ -579,6 +608,9 @@ public class FakeApi {
       HttpResponse<InputStream> localVarResponse = memberVarHttpClient.send(
           localVarRequestBuilder.build(),
           HttpResponse.BodyHandlers.ofInputStream());
+      if (memberVarResponseInterceptor != null) {
+        memberVarResponseInterceptor.accept(localVarResponse);
+      }          
       if (localVarResponse.statusCode()/ 100 != 2) {
         throw new ApiException(localVarResponse.statusCode(),
             "testEnumParameters call received non-success response",
@@ -656,6 +688,9 @@ public class FakeApi {
       HttpResponse<InputStream> localVarResponse = memberVarHttpClient.send(
           localVarRequestBuilder.build(),
           HttpResponse.BodyHandlers.ofInputStream());
+      if (memberVarResponseInterceptor != null) {
+        memberVarResponseInterceptor.accept(localVarResponse);
+      }          
       if (localVarResponse.statusCode()/ 100 != 2) {
         throw new ApiException(localVarResponse.statusCode(),
             "testGroupParameters call received non-success response",
@@ -704,6 +739,9 @@ public class FakeApi {
       HttpResponse<InputStream> localVarResponse = memberVarHttpClient.send(
           localVarRequestBuilder.build(),
           HttpResponse.BodyHandlers.ofInputStream());
+      if (memberVarResponseInterceptor != null) {
+        memberVarResponseInterceptor.accept(localVarResponse);
+      }          
       if (localVarResponse.statusCode()/ 100 != 2) {
         throw new ApiException(localVarResponse.statusCode(),
             "testInlineAdditionalProperties call received non-success response",
@@ -755,6 +793,9 @@ public class FakeApi {
       HttpResponse<InputStream> localVarResponse = memberVarHttpClient.send(
           localVarRequestBuilder.build(),
           HttpResponse.BodyHandlers.ofInputStream());
+      if (memberVarResponseInterceptor != null) {
+        memberVarResponseInterceptor.accept(localVarResponse);
+      }          
       if (localVarResponse.statusCode()/ 100 != 2) {
         throw new ApiException(localVarResponse.statusCode(),
             "testJsonFormData call received non-success response",
@@ -834,6 +875,9 @@ public class FakeApi {
       HttpResponse<InputStream> localVarResponse = memberVarHttpClient.send(
           localVarRequestBuilder.build(),
           HttpResponse.BodyHandlers.ofInputStream());
+      if (memberVarResponseInterceptor != null) {
+        memberVarResponseInterceptor.accept(localVarResponse);
+      }          
       if (localVarResponse.statusCode()/ 100 != 2) {
         throw new ApiException(localVarResponse.statusCode(),
             "testQueryParameterCollectionFormat call received non-success response",

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
@@ -42,7 +42,8 @@ public class FakeClassnameTags123Api {
   private final String memberVarBaseUri;
   private final Consumer<HttpRequest.Builder> memberVarInterceptor;
   private final Duration memberVarReadTimeout;
-
+  private final Consumer<HttpResponse<InputStream>> memberVarResponseInterceptor;
+  
   public FakeClassnameTags123Api() {
     this(new ApiClient());
   }
@@ -53,6 +54,7 @@ public class FakeClassnameTags123Api {
     memberVarBaseUri = apiClient.getBaseUri();
     memberVarInterceptor = apiClient.getRequestInterceptor();
     memberVarReadTimeout = apiClient.getReadTimeout();
+    memberVarResponseInterceptor = apiClient.getResponseInterceptor();
   }
 
   /**
@@ -90,6 +92,9 @@ public class FakeClassnameTags123Api {
       HttpResponse<InputStream> localVarResponse = memberVarHttpClient.send(
           localVarRequestBuilder.build(),
           HttpResponse.BodyHandlers.ofInputStream());
+      if (memberVarResponseInterceptor != null) {
+        memberVarResponseInterceptor.accept(localVarResponse);
+      }          
       if (localVarResponse.statusCode()/ 100 != 2) {
         throw new ApiException(localVarResponse.statusCode(),
             "testClassname call received non-success response",

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/api/PetApi.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/api/PetApi.java
@@ -44,7 +44,8 @@ public class PetApi {
   private final String memberVarBaseUri;
   private final Consumer<HttpRequest.Builder> memberVarInterceptor;
   private final Duration memberVarReadTimeout;
-
+  private final Consumer<HttpResponse<InputStream>> memberVarResponseInterceptor;
+  
   public PetApi() {
     this(new ApiClient());
   }
@@ -55,6 +56,7 @@ public class PetApi {
     memberVarBaseUri = apiClient.getBaseUri();
     memberVarInterceptor = apiClient.getRequestInterceptor();
     memberVarReadTimeout = apiClient.getReadTimeout();
+    memberVarResponseInterceptor = apiClient.getResponseInterceptor();
   }
 
   /**
@@ -91,6 +93,9 @@ public class PetApi {
       HttpResponse<InputStream> localVarResponse = memberVarHttpClient.send(
           localVarRequestBuilder.build(),
           HttpResponse.BodyHandlers.ofInputStream());
+      if (memberVarResponseInterceptor != null) {
+        memberVarResponseInterceptor.accept(localVarResponse);
+      }          
       if (localVarResponse.statusCode()/ 100 != 2) {
         throw new ApiException(localVarResponse.statusCode(),
             "addPet call received non-success response",
@@ -142,6 +147,9 @@ public class PetApi {
       HttpResponse<InputStream> localVarResponse = memberVarHttpClient.send(
           localVarRequestBuilder.build(),
           HttpResponse.BodyHandlers.ofInputStream());
+      if (memberVarResponseInterceptor != null) {
+        memberVarResponseInterceptor.accept(localVarResponse);
+      }          
       if (localVarResponse.statusCode()/ 100 != 2) {
         throw new ApiException(localVarResponse.statusCode(),
             "deletePet call received non-success response",
@@ -198,6 +206,9 @@ public class PetApi {
       HttpResponse<InputStream> localVarResponse = memberVarHttpClient.send(
           localVarRequestBuilder.build(),
           HttpResponse.BodyHandlers.ofInputStream());
+      if (memberVarResponseInterceptor != null) {
+        memberVarResponseInterceptor.accept(localVarResponse);
+      }          
       if (localVarResponse.statusCode()/ 100 != 2) {
         throw new ApiException(localVarResponse.statusCode(),
             "findPetsByStatus call received non-success response",
@@ -257,6 +268,9 @@ public class PetApi {
       HttpResponse<InputStream> localVarResponse = memberVarHttpClient.send(
           localVarRequestBuilder.build(),
           HttpResponse.BodyHandlers.ofInputStream());
+      if (memberVarResponseInterceptor != null) {
+        memberVarResponseInterceptor.accept(localVarResponse);
+      }          
       if (localVarResponse.statusCode()/ 100 != 2) {
         throw new ApiException(localVarResponse.statusCode(),
             "findPetsByTags call received non-success response",
@@ -306,6 +320,9 @@ public class PetApi {
       HttpResponse<InputStream> localVarResponse = memberVarHttpClient.send(
           localVarRequestBuilder.build(),
           HttpResponse.BodyHandlers.ofInputStream());
+      if (memberVarResponseInterceptor != null) {
+        memberVarResponseInterceptor.accept(localVarResponse);
+      }          
       if (localVarResponse.statusCode()/ 100 != 2) {
         throw new ApiException(localVarResponse.statusCode(),
             "getPetById call received non-success response",
@@ -355,6 +372,9 @@ public class PetApi {
       HttpResponse<InputStream> localVarResponse = memberVarHttpClient.send(
           localVarRequestBuilder.build(),
           HttpResponse.BodyHandlers.ofInputStream());
+      if (memberVarResponseInterceptor != null) {
+        memberVarResponseInterceptor.accept(localVarResponse);
+      }          
       if (localVarResponse.statusCode()/ 100 != 2) {
         throw new ApiException(localVarResponse.statusCode(),
             "updatePet call received non-success response",
@@ -404,6 +424,9 @@ public class PetApi {
       HttpResponse<InputStream> localVarResponse = memberVarHttpClient.send(
           localVarRequestBuilder.build(),
           HttpResponse.BodyHandlers.ofInputStream());
+      if (memberVarResponseInterceptor != null) {
+        memberVarResponseInterceptor.accept(localVarResponse);
+      }          
       if (localVarResponse.statusCode()/ 100 != 2) {
         throw new ApiException(localVarResponse.statusCode(),
             "updatePetWithForm call received non-success response",
@@ -454,6 +477,9 @@ public class PetApi {
       HttpResponse<InputStream> localVarResponse = memberVarHttpClient.send(
           localVarRequestBuilder.build(),
           HttpResponse.BodyHandlers.ofInputStream());
+      if (memberVarResponseInterceptor != null) {
+        memberVarResponseInterceptor.accept(localVarResponse);
+      }          
       if (localVarResponse.statusCode()/ 100 != 2) {
         throw new ApiException(localVarResponse.statusCode(),
             "uploadFile call received non-success response",
@@ -509,6 +535,9 @@ public class PetApi {
       HttpResponse<InputStream> localVarResponse = memberVarHttpClient.send(
           localVarRequestBuilder.build(),
           HttpResponse.BodyHandlers.ofInputStream());
+      if (memberVarResponseInterceptor != null) {
+        memberVarResponseInterceptor.accept(localVarResponse);
+      }          
       if (localVarResponse.statusCode()/ 100 != 2) {
         throw new ApiException(localVarResponse.statusCode(),
             "uploadFileWithRequiredFile call received non-success response",

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/api/StoreApi.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/api/StoreApi.java
@@ -42,7 +42,8 @@ public class StoreApi {
   private final String memberVarBaseUri;
   private final Consumer<HttpRequest.Builder> memberVarInterceptor;
   private final Duration memberVarReadTimeout;
-
+  private final Consumer<HttpResponse<InputStream>> memberVarResponseInterceptor;
+  
   public StoreApi() {
     this(new ApiClient());
   }
@@ -53,6 +54,7 @@ public class StoreApi {
     memberVarBaseUri = apiClient.getBaseUri();
     memberVarInterceptor = apiClient.getRequestInterceptor();
     memberVarReadTimeout = apiClient.getReadTimeout();
+    memberVarResponseInterceptor = apiClient.getResponseInterceptor();
   }
 
   /**
@@ -88,6 +90,9 @@ public class StoreApi {
       HttpResponse<InputStream> localVarResponse = memberVarHttpClient.send(
           localVarRequestBuilder.build(),
           HttpResponse.BodyHandlers.ofInputStream());
+      if (memberVarResponseInterceptor != null) {
+        memberVarResponseInterceptor.accept(localVarResponse);
+      }          
       if (localVarResponse.statusCode()/ 100 != 2) {
         throw new ApiException(localVarResponse.statusCode(),
             "deleteOrder call received non-success response",
@@ -130,6 +135,9 @@ public class StoreApi {
       HttpResponse<InputStream> localVarResponse = memberVarHttpClient.send(
           localVarRequestBuilder.build(),
           HttpResponse.BodyHandlers.ofInputStream());
+      if (memberVarResponseInterceptor != null) {
+        memberVarResponseInterceptor.accept(localVarResponse);
+      }          
       if (localVarResponse.statusCode()/ 100 != 2) {
         throw new ApiException(localVarResponse.statusCode(),
             "getInventory call received non-success response",
@@ -179,6 +187,9 @@ public class StoreApi {
       HttpResponse<InputStream> localVarResponse = memberVarHttpClient.send(
           localVarRequestBuilder.build(),
           HttpResponse.BodyHandlers.ofInputStream());
+      if (memberVarResponseInterceptor != null) {
+        memberVarResponseInterceptor.accept(localVarResponse);
+      }          
       if (localVarResponse.statusCode()/ 100 != 2) {
         throw new ApiException(localVarResponse.statusCode(),
             "getOrderById call received non-success response",
@@ -229,6 +240,9 @@ public class StoreApi {
       HttpResponse<InputStream> localVarResponse = memberVarHttpClient.send(
           localVarRequestBuilder.build(),
           HttpResponse.BodyHandlers.ofInputStream());
+      if (memberVarResponseInterceptor != null) {
+        memberVarResponseInterceptor.accept(localVarResponse);
+      }          
       if (localVarResponse.statusCode()/ 100 != 2) {
         throw new ApiException(localVarResponse.statusCode(),
             "placeOrder call received non-success response",

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/api/UserApi.java
@@ -42,7 +42,8 @@ public class UserApi {
   private final String memberVarBaseUri;
   private final Consumer<HttpRequest.Builder> memberVarInterceptor;
   private final Duration memberVarReadTimeout;
-
+  private final Consumer<HttpResponse<InputStream>> memberVarResponseInterceptor;
+  
   public UserApi() {
     this(new ApiClient());
   }
@@ -53,6 +54,7 @@ public class UserApi {
     memberVarBaseUri = apiClient.getBaseUri();
     memberVarInterceptor = apiClient.getRequestInterceptor();
     memberVarReadTimeout = apiClient.getReadTimeout();
+    memberVarResponseInterceptor = apiClient.getResponseInterceptor();
   }
 
   /**
@@ -89,6 +91,9 @@ public class UserApi {
       HttpResponse<InputStream> localVarResponse = memberVarHttpClient.send(
           localVarRequestBuilder.build(),
           HttpResponse.BodyHandlers.ofInputStream());
+      if (memberVarResponseInterceptor != null) {
+        memberVarResponseInterceptor.accept(localVarResponse);
+      }          
       if (localVarResponse.statusCode()/ 100 != 2) {
         throw new ApiException(localVarResponse.statusCode(),
             "createUser call received non-success response",
@@ -137,6 +142,9 @@ public class UserApi {
       HttpResponse<InputStream> localVarResponse = memberVarHttpClient.send(
           localVarRequestBuilder.build(),
           HttpResponse.BodyHandlers.ofInputStream());
+      if (memberVarResponseInterceptor != null) {
+        memberVarResponseInterceptor.accept(localVarResponse);
+      }          
       if (localVarResponse.statusCode()/ 100 != 2) {
         throw new ApiException(localVarResponse.statusCode(),
             "createUsersWithArrayInput call received non-success response",
@@ -185,6 +193,9 @@ public class UserApi {
       HttpResponse<InputStream> localVarResponse = memberVarHttpClient.send(
           localVarRequestBuilder.build(),
           HttpResponse.BodyHandlers.ofInputStream());
+      if (memberVarResponseInterceptor != null) {
+        memberVarResponseInterceptor.accept(localVarResponse);
+      }          
       if (localVarResponse.statusCode()/ 100 != 2) {
         throw new ApiException(localVarResponse.statusCode(),
             "createUsersWithListInput call received non-success response",
@@ -232,6 +243,9 @@ public class UserApi {
       HttpResponse<InputStream> localVarResponse = memberVarHttpClient.send(
           localVarRequestBuilder.build(),
           HttpResponse.BodyHandlers.ofInputStream());
+      if (memberVarResponseInterceptor != null) {
+        memberVarResponseInterceptor.accept(localVarResponse);
+      }          
       if (localVarResponse.statusCode()/ 100 != 2) {
         throw new ApiException(localVarResponse.statusCode(),
             "deleteUser call received non-success response",
@@ -280,6 +294,9 @@ public class UserApi {
       HttpResponse<InputStream> localVarResponse = memberVarHttpClient.send(
           localVarRequestBuilder.build(),
           HttpResponse.BodyHandlers.ofInputStream());
+      if (memberVarResponseInterceptor != null) {
+        memberVarResponseInterceptor.accept(localVarResponse);
+      }          
       if (localVarResponse.statusCode()/ 100 != 2) {
         throw new ApiException(localVarResponse.statusCode(),
             "getUserByName call received non-success response",
@@ -343,6 +360,9 @@ public class UserApi {
       HttpResponse<InputStream> localVarResponse = memberVarHttpClient.send(
           localVarRequestBuilder.build(),
           HttpResponse.BodyHandlers.ofInputStream());
+      if (memberVarResponseInterceptor != null) {
+        memberVarResponseInterceptor.accept(localVarResponse);
+      }          
       if (localVarResponse.statusCode()/ 100 != 2) {
         throw new ApiException(localVarResponse.statusCode(),
             "loginUser call received non-success response",
@@ -385,6 +405,9 @@ public class UserApi {
       HttpResponse<InputStream> localVarResponse = memberVarHttpClient.send(
           localVarRequestBuilder.build(),
           HttpResponse.BodyHandlers.ofInputStream());
+      if (memberVarResponseInterceptor != null) {
+        memberVarResponseInterceptor.accept(localVarResponse);
+      }          
       if (localVarResponse.statusCode()/ 100 != 2) {
         throw new ApiException(localVarResponse.statusCode(),
             "logoutUser call received non-success response",
@@ -439,6 +462,9 @@ public class UserApi {
       HttpResponse<InputStream> localVarResponse = memberVarHttpClient.send(
           localVarRequestBuilder.build(),
           HttpResponse.BodyHandlers.ofInputStream());
+      if (memberVarResponseInterceptor != null) {
+        memberVarResponseInterceptor.accept(localVarResponse);
+      }          
       if (localVarResponse.statusCode()/ 100 != 2) {
         throw new ApiException(localVarResponse.statusCode(),
             "updateUser call received non-success response",


### PR DESCRIPTION
Added Response interceptor for various reasons:
 - logging
 - extraction of header variables

to close #5501 
<!-- Please check the completed items below -->
### PR checklist

- [ x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [ x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [ x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [ x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04) @lwlee2608 (2019/10) @bkabrda (2020/01