### PR TITLE
[BUG][scala][template] scala generate java.math.BigDecimal instead of scala type

### DIFF
--- a/docs/generators/scala-akka.md
+++ b/docs/generators/scala-akka.md
@@ -22,7 +22,6 @@ sidebar_label: scala-akka
 | ---------- | ------- |
 |Array|java.util.List|
 |ArrayList|java.util.ArrayList|
-|BigDecimal|java.math.BigDecimal|
 |Date|java.util.Date|
 |DateTime|org.joda.time.DateTime|
 |File|java.io.File|

--- a/docs/generators/scala-gatling.md
+++ b/docs/generators/scala-gatling.md
@@ -21,7 +21,6 @@ sidebar_label: scala-gatling
 | ---------- | ------- |
 |Array|java.util.List|
 |ArrayList|java.util.ArrayList|
-|BigDecimal|java.math.BigDecimal|
 |Date|java.util.Date|
 |DateTime|org.joda.time.*|
 |File|java.io.File|

--- a/docs/generators/scala-httpclient-deprecated.md
+++ b/docs/generators/scala-httpclient-deprecated.md
@@ -21,7 +21,6 @@ sidebar_label: scala-httpclient-deprecated
 | ---------- | ------- |
 |Array|java.util.List|
 |ArrayList|java.util.ArrayList|
-|BigDecimal|java.math.BigDecimal|
 |Date|java.util.Date|
 |DateTime|org.joda.time.*|
 |File|java.io.File|

--- a/docs/generators/scala-lagom-server.md
+++ b/docs/generators/scala-lagom-server.md
@@ -21,7 +21,6 @@ sidebar_label: scala-lagom-server
 | ---------- | ------- |
 |Array|java.util.List|
 |ArrayList|java.util.ArrayList|
-|BigDecimal|java.math.BigDecimal|
 |Date|java.util.Date|
 |DateTime|org.joda.time.DateTime|
 |File|java.io.File|

--- a/docs/generators/scala-play-server.md
+++ b/docs/generators/scala-play-server.md
@@ -31,13 +31,11 @@ sidebar_label: scala-play-server
 |DateTime|org.joda.time.*|
 |File|java.io.File|
 |HashMap|java.util.HashMap|
-|List|java.util.*|
 |ListBuffer|scala.collection.mutable.ListBuffer|
 |ListSet|scala.collection.immutable.ListSet|
 |LocalDate|java.time.LocalDate|
 |LocalDateTime|org.joda.time.*|
 |LocalTime|org.joda.time.*|
-|Map|java.util.Map|
 |OffsetDateTime|java.time.OffsetDateTime|
 |Seq|scala.collection.immutable.Seq|
 |Set|scala.collection.immutable.Set|

--- a/docs/generators/scala-sttp.md
+++ b/docs/generators/scala-sttp.md
@@ -22,7 +22,6 @@ sidebar_label: scala-sttp
 | ---------- | ------- |
 |Array|java.util.List|
 |ArrayList|java.util.ArrayList|
-|BigDecimal|java.math.BigDecimal|
 |Date|java.util.Date|
 |DateTime|org.joda.time.DateTime|
 |File|java.io.File|

--- a/docs/generators/scalaz.md
+++ b/docs/generators/scalaz.md
@@ -21,7 +21,6 @@ sidebar_label: scalaz
 | ---------- | ------- |
 |Array|java.util.List|
 |ArrayList|java.util.ArrayList|
-|BigDecimal|java.math.BigDecimal|
 |Date|java.util.Date|
 |DateTime|org.joda.time.DateTime|
 |File|java.io.File|

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractScalaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractScalaCodegen.java
@@ -29,10 +29,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
-import java.util.Arrays;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import static org.openapitools.codegen.utils.StringUtils.camelize;
 import static org.openapitools.codegen.utils.StringUtils.underscore;
@@ -105,11 +102,27 @@ public abstract class AbstractScalaCodegen extends DefaultCodegen {
                 "yield"
         ));
 
+        importMapping = new HashMap<String, String>();
         importMapping.put("ListBuffer", "scala.collection.mutable.ListBuffer");
         // although Seq is a predef, before Scala 2.13, it _could_ refer to a mutable Seq in some cases.
         importMapping.put("Seq", "scala.collection.immutable.Seq");
         importMapping.put("Set", "scala.collection.immutable.Set");
         importMapping.put("ListSet", "scala.collection.immutable.ListSet");
+        // fallback to java types
+        importMapping.put("UUID", "java.util.UUID");
+        importMapping.put("URI", "java.net.URI");
+        importMapping.put("File", "java.io.File");
+        importMapping.put("Timestamp", "java.sql.Timestamp");
+        importMapping.put("HashMap", "java.util.HashMap");
+        importMapping.put("Array", "java.util.List");
+        importMapping.put("ArrayList", "java.util.ArrayList");
+        // todo remove legacy date types
+        importMapping.put("Date", "java.util.Date");
+        importMapping.put("DateTime", "org.joda.time.*");
+        importMapping.put("LocalDateTime", "org.joda.time.*");
+        importMapping.put("LocalDate", "org.joda.time.*");
+        importMapping.put("LocalTime", "org.joda.time.*");
+
 
         instantiationTypes.put("set", "Set");
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/scala/AbstractScalaCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/scala/AbstractScalaCodegenTest.java
@@ -82,4 +82,17 @@ public class AbstractScalaCodegenTest {
         Assert.assertEquals(fakeScalaCodegen.toVarName("1AAaa"), "`1AAaa`");
     }
 
+    @Test
+    public void checkScalaTypeImportMapping() {
+        Assert.assertEquals(fakeScalaCodegen.importMapping().get("Seq"),
+                "scala.collection.immutable.Seq", "Seq is immutable collection");
+        Assert.assertEquals(fakeScalaCodegen.importMapping().get("Set"),
+                "scala.collection.immutable.Set", "Set is immutable collection");
+        Assert.assertFalse(fakeScalaCodegen.importMapping().containsKey("List"),
+                "List is a Scala type and must not be imported");
+        Assert.assertFalse(fakeScalaCodegen.importMapping().containsKey("BigDecimal"),
+                "BigDecimal is a Scala type and must not be imported");
+        Assert.assertFalse(fakeScalaCodegen.importMapping().containsKey("BigInt"),
+                "BigInt is a Scala type and must not be imported");
+    }
 }


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

With option `--type-mappings=number=BigDecimal` generators produce models with imported `java.math.BigDecimal` type instead of `scala.math.BigDecimal` which is not required any import as has public alias `BigDecimal` 

This PR is to replace import from DefaultCodegen with proper scala related types import

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@clasnake (2017/07), @jimschubert (2017/09) ❤️, @shijinkui (2018/01), @ramzimaalej (2018/03), @chameleon82 (2020/03)
