### PR TITLE
Exdend toDefaultValue for go codegen, resolve #5511

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractGoCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractGoCodegen.java
@@ -726,6 +726,10 @@ public abstract class AbstractGoCodegen extends DefaultCodegen implements Codege
         if (schema.getDefault() != null) {
             return schema.getDefault().toString();
         } else {
+            schema = ModelUtils.getReferencedSchema(this.openAPI, schema);
+            if (schema.getDefault() != null) {
+                return schema.getDefault().toString();
+            }
             return null;
         }
     }

--- a/samples/server/petstore/php-slim4/lib/Model/EnumClass.php
+++ b/samples/server/petstore/php-slim4/lib/Model/EnumClass.php
@@ -30,8 +30,8 @@ class EnumClass implements ModelInterface
     private const MODEL_SCHEMA = <<<'SCHEMA'
 {
   "type" : "string",
-  "default" : "-efg",
-  "enum" : [ "_abc", "-efg", "(xyz)" ]
+  "enum" : [ "_abc", "-efg", "(xyz)" ],
+  "default" : "-efg"
 }
 SCHEMA;
 


### PR DESCRIPTION
go-server codegen defaultValue is null

We have extended the go-server templates to generate our own specific code.
Here we also use the "{{defaultValue}}" in our templates. We found an issue in the file
org/openapitools/codegen/languages/AbstractGoCodegen.java
in the method toDefaultValue.