### PR TITLE
[PHP] complete support for form style

### DIFF
--- a/modules/openapi-generator/src/main/resources/php/api.mustache
+++ b/modules/openapi-generator/src/main/resources/php/api.mustache
@@ -472,11 +472,22 @@ use {{invokerPackage}}\ObjectSerializer;
         $multipart = false;
 
         {{#queryParams}}
-
         // query params
         {{#isExplode}}
         if (${{paramName}} !== null) {
+        {{#style}}
+            if('form' === '{{style}}' && is_array(${{paramName}})) {
+                foreach(${{paramName}} as $key => $value) {
+                    $queryParams[$key] = $value;
+                }
+            }
+            else {
+                $queryParams['{{baseName}}'] = ${{paramName}};
+            }
+        {{/style}}
+        {{^style}}
             $queryParams['{{baseName}}'] = ${{paramName}};
+        {{/style}}
         }
         {{/isExplode}}
         {{^isExplode}}
@@ -487,7 +498,6 @@ use {{invokerPackage}}\ObjectSerializer;
             $queryParams['{{baseName}}'] = ${{paramName}};
         }
         {{/isExplode}}
-
         {{/queryParams}}
 
         {{#headerParams}}

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/FakeApi.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/FakeApi.php
@@ -1740,7 +1740,6 @@ class FakeApi
         $httpBody = '';
         $multipart = false;
 
-
         // query params
         if (is_array($query)) {
             $query = ObjectSerializer::serializeCollection($query, '', true);
@@ -1748,7 +1747,6 @@ class FakeApi
         if ($query !== null) {
             $queryParams['query'] = $query;
         }
-
 
 
 
@@ -2674,16 +2672,13 @@ class FakeApi
         $httpBody = '';
         $multipart = false;
 
-
         // query params
         if (is_array($enum_query_string_array)) {
-            $enum_query_string_array = ObjectSerializer::serializeCollection($enum_query_string_array, 'csv', true);
+            $enum_query_string_array = ObjectSerializer::serializeCollection($enum_query_string_array, 'form', true);
         }
         if ($enum_query_string_array !== null) {
             $queryParams['enum_query_string_array'] = $enum_query_string_array;
         }
-
-
         // query params
         if (is_array($enum_query_string)) {
             $enum_query_string = ObjectSerializer::serializeCollection($enum_query_string, '', true);
@@ -2691,8 +2686,6 @@ class FakeApi
         if ($enum_query_string !== null) {
             $queryParams['enum_query_string'] = $enum_query_string;
         }
-
-
         // query params
         if (is_array($enum_query_integer)) {
             $enum_query_integer = ObjectSerializer::serializeCollection($enum_query_integer, '', true);
@@ -2700,8 +2693,6 @@ class FakeApi
         if ($enum_query_integer !== null) {
             $queryParams['enum_query_integer'] = $enum_query_integer;
         }
-
-
         // query params
         if (is_array($enum_query_double)) {
             $enum_query_double = ObjectSerializer::serializeCollection($enum_query_double, '', true);
@@ -2709,7 +2700,6 @@ class FakeApi
         if ($enum_query_double !== null) {
             $queryParams['enum_query_double'] = $enum_query_double;
         }
-
 
         // header params
         if (is_array($enum_header_string_array)) {
@@ -3001,7 +2991,6 @@ class FakeApi
         $httpBody = '';
         $multipart = false;
 
-
         // query params
         if (is_array($required_string_group)) {
             $required_string_group = ObjectSerializer::serializeCollection($required_string_group, '', true);
@@ -3009,8 +2998,6 @@ class FakeApi
         if ($required_string_group !== null) {
             $queryParams['required_string_group'] = $required_string_group;
         }
-
-
         // query params
         if (is_array($required_int64_group)) {
             $required_int64_group = ObjectSerializer::serializeCollection($required_int64_group, '', true);
@@ -3018,8 +3005,6 @@ class FakeApi
         if ($required_int64_group !== null) {
             $queryParams['required_int64_group'] = $required_int64_group;
         }
-
-
         // query params
         if (is_array($string_group)) {
             $string_group = ObjectSerializer::serializeCollection($string_group, '', true);
@@ -3027,8 +3012,6 @@ class FakeApi
         if ($string_group !== null) {
             $queryParams['string_group'] = $string_group;
         }
-
-
         // query params
         if (is_array($int64_group)) {
             $int64_group = ObjectSerializer::serializeCollection($int64_group, '', true);
@@ -3036,7 +3019,6 @@ class FakeApi
         if ($int64_group !== null) {
             $queryParams['int64_group'] = $int64_group;
         }
-
 
         // header params
         if ($required_boolean_group !== null) {
@@ -3758,16 +3740,13 @@ class FakeApi
         $httpBody = '';
         $multipart = false;
 
-
         // query params
         if (is_array($pipe)) {
-            $pipe = ObjectSerializer::serializeCollection($pipe, 'csv', true);
+            $pipe = ObjectSerializer::serializeCollection($pipe, 'form', true);
         }
         if ($pipe !== null) {
             $queryParams['pipe'] = $pipe;
         }
-
-
         // query params
         if (is_array($ioutil)) {
             $ioutil = ObjectSerializer::serializeCollection($ioutil, 'csv', true);
@@ -3775,31 +3754,31 @@ class FakeApi
         if ($ioutil !== null) {
             $queryParams['ioutil'] = $ioutil;
         }
-
-
         // query params
         if (is_array($http)) {
-            $http = ObjectSerializer::serializeCollection($http, 'space', true);
+            $http = ObjectSerializer::serializeCollection($http, 'spaceDelimited', true);
         }
         if ($http !== null) {
             $queryParams['http'] = $http;
         }
-
-
         // query params
         if (is_array($url)) {
-            $url = ObjectSerializer::serializeCollection($url, 'csv', true);
+            $url = ObjectSerializer::serializeCollection($url, 'form', true);
         }
         if ($url !== null) {
             $queryParams['url'] = $url;
         }
-
-
         // query params
         if ($context !== null) {
-            $queryParams['context'] = $context;
+            if('form' === 'form' && is_array($context)) {
+                foreach($context as $key => $value) {
+                    $queryParams[$key] = $value;
+                }
+            }
+            else {
+                $queryParams['context'] = $context;
+            }
         }
-
 
 
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/PetApi.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/PetApi.php
@@ -775,15 +775,13 @@ class PetApi
         $httpBody = '';
         $multipart = false;
 
-
         // query params
         if (is_array($status)) {
-            $status = ObjectSerializer::serializeCollection($status, 'csv', true);
+            $status = ObjectSerializer::serializeCollection($status, 'form', true);
         }
         if ($status !== null) {
             $queryParams['status'] = $status;
         }
-
 
 
 
@@ -1053,15 +1051,13 @@ class PetApi
         $httpBody = '';
         $multipart = false;
 
-
         // query params
         if (is_array($tags)) {
-            $tags = ObjectSerializer::serializeCollection($tags, 'csv', true);
+            $tags = ObjectSerializer::serializeCollection($tags, 'form', true);
         }
         if ($tags !== null) {
             $queryParams['tags'] = $tags;
         }
-
 
 
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/UserApi.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/UserApi.php
@@ -1482,7 +1482,6 @@ class UserApi
         $httpBody = '';
         $multipart = false;
 
-
         // query params
         if (is_array($username)) {
             $username = ObjectSerializer::serializeCollection($username, '', true);
@@ -1490,8 +1489,6 @@ class UserApi
         if ($username !== null) {
             $queryParams['username'] = $username;
         }
-
-
         // query params
         if (is_array($password)) {
             $password = ObjectSerializer::serializeCollection($password, '', true);
@@ -1499,7 +1496,6 @@ class UserApi
         if ($password !== null) {
             $queryParams['password'] = $password;
         }
-
 
 
 

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Api/FakeApi.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Api/FakeApi.php
@@ -1774,12 +1774,17 @@ class FakeApi
         $httpBody = '';
         $multipart = false;
 
-
         // query params
         if ($query !== null) {
-            $queryParams['query'] = $query;
+            if('form' === 'form' && is_array($query)) {
+                foreach($query as $key => $value) {
+                    $queryParams[$key] = $value;
+                }
+            }
+            else {
+                $queryParams['query'] = $query;
+            }
         }
-
 
 
 
@@ -2705,30 +2710,50 @@ class FakeApi
         $httpBody = '';
         $multipart = false;
 
-
         // query params
         if ($enum_query_string_array !== null) {
-            $queryParams['enum_query_string_array'] = $enum_query_string_array;
+            if('form' === 'form' && is_array($enum_query_string_array)) {
+                foreach($enum_query_string_array as $key => $value) {
+                    $queryParams[$key] = $value;
+                }
+            }
+            else {
+                $queryParams['enum_query_string_array'] = $enum_query_string_array;
+            }
         }
-
-
         // query params
         if ($enum_query_string !== null) {
-            $queryParams['enum_query_string'] = $enum_query_string;
+            if('form' === 'form' && is_array($enum_query_string)) {
+                foreach($enum_query_string as $key => $value) {
+                    $queryParams[$key] = $value;
+                }
+            }
+            else {
+                $queryParams['enum_query_string'] = $enum_query_string;
+            }
         }
-
-
         // query params
         if ($enum_query_integer !== null) {
-            $queryParams['enum_query_integer'] = $enum_query_integer;
+            if('form' === 'form' && is_array($enum_query_integer)) {
+                foreach($enum_query_integer as $key => $value) {
+                    $queryParams[$key] = $value;
+                }
+            }
+            else {
+                $queryParams['enum_query_integer'] = $enum_query_integer;
+            }
         }
-
-
         // query params
         if ($enum_query_double !== null) {
-            $queryParams['enum_query_double'] = $enum_query_double;
+            if('form' === 'form' && is_array($enum_query_double)) {
+                foreach($enum_query_double as $key => $value) {
+                    $queryParams[$key] = $value;
+                }
+            }
+            else {
+                $queryParams['enum_query_double'] = $enum_query_double;
+            }
         }
-
 
         // header params
         if (is_array($enum_header_string_array)) {
@@ -3020,30 +3045,50 @@ class FakeApi
         $httpBody = '';
         $multipart = false;
 
-
         // query params
         if ($required_string_group !== null) {
-            $queryParams['required_string_group'] = $required_string_group;
+            if('form' === 'form' && is_array($required_string_group)) {
+                foreach($required_string_group as $key => $value) {
+                    $queryParams[$key] = $value;
+                }
+            }
+            else {
+                $queryParams['required_string_group'] = $required_string_group;
+            }
         }
-
-
         // query params
         if ($required_int64_group !== null) {
-            $queryParams['required_int64_group'] = $required_int64_group;
+            if('form' === 'form' && is_array($required_int64_group)) {
+                foreach($required_int64_group as $key => $value) {
+                    $queryParams[$key] = $value;
+                }
+            }
+            else {
+                $queryParams['required_int64_group'] = $required_int64_group;
+            }
         }
-
-
         // query params
         if ($string_group !== null) {
-            $queryParams['string_group'] = $string_group;
+            if('form' === 'form' && is_array($string_group)) {
+                foreach($string_group as $key => $value) {
+                    $queryParams[$key] = $value;
+                }
+            }
+            else {
+                $queryParams['string_group'] = $string_group;
+            }
         }
-
-
         // query params
         if ($int64_group !== null) {
-            $queryParams['int64_group'] = $int64_group;
+            if('form' === 'form' && is_array($int64_group)) {
+                foreach($int64_group as $key => $value) {
+                    $queryParams[$key] = $value;
+                }
+            }
+            else {
+                $queryParams['int64_group'] = $int64_group;
+            }
         }
-
 
         // header params
         if ($required_boolean_group !== null) {
@@ -3769,45 +3814,49 @@ class FakeApi
         $httpBody = '';
         $multipart = false;
 
-
         // query params
         if ($pipe !== null) {
-            $queryParams['pipe'] = $pipe;
+            if('form' === 'form' && is_array($pipe)) {
+                foreach($pipe as $key => $value) {
+                    $queryParams[$key] = $value;
+                }
+            }
+            else {
+                $queryParams['pipe'] = $pipe;
+            }
         }
-
-
         // query params
         if (is_array($ioutil)) {
-            $ioutil = ObjectSerializer::serializeCollection($ioutil, 'csv', true);
+            $ioutil = ObjectSerializer::serializeCollection($ioutil, 'form', true);
         }
         if ($ioutil !== null) {
             $queryParams['ioutil'] = $ioutil;
         }
-
-
         // query params
         if (is_array($http)) {
-            $http = ObjectSerializer::serializeCollection($http, 'space', true);
+            $http = ObjectSerializer::serializeCollection($http, 'spaceDelimited', true);
         }
         if ($http !== null) {
             $queryParams['http'] = $http;
         }
-
-
         // query params
         if (is_array($url)) {
-            $url = ObjectSerializer::serializeCollection($url, 'csv', true);
+            $url = ObjectSerializer::serializeCollection($url, 'form', true);
         }
         if ($url !== null) {
             $queryParams['url'] = $url;
         }
-
-
         // query params
         if ($context !== null) {
-            $queryParams['context'] = $context;
+            if('form' === 'form' && is_array($context)) {
+                foreach($context as $key => $value) {
+                    $queryParams[$key] = $value;
+                }
+            }
+            else {
+                $queryParams['context'] = $context;
+            }
         }
-
 
 
 

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Api/PetApi.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Api/PetApi.php
@@ -801,15 +801,13 @@ class PetApi
         $httpBody = '';
         $multipart = false;
 
-
         // query params
         if (is_array($status)) {
-            $status = ObjectSerializer::serializeCollection($status, 'csv', true);
+            $status = ObjectSerializer::serializeCollection($status, 'form', true);
         }
         if ($status !== null) {
             $queryParams['status'] = $status;
         }
-
 
 
 
@@ -1079,15 +1077,13 @@ class PetApi
         $httpBody = '';
         $multipart = false;
 
-
         // query params
         if (is_array($tags)) {
-            $tags = ObjectSerializer::serializeCollection($tags, 'csv', true);
+            $tags = ObjectSerializer::serializeCollection($tags, 'form', true);
         }
         if ($tags !== null) {
             $queryParams['tags'] = $tags;
         }
-
 
 
 

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Api/UserApi.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Api/UserApi.php
@@ -1482,18 +1482,28 @@ class UserApi
         $httpBody = '';
         $multipart = false;
 
-
         // query params
         if ($username !== null) {
-            $queryParams['username'] = $username;
+            if('form' === 'form' && is_array($username)) {
+                foreach($username as $key => $value) {
+                    $queryParams[$key] = $value;
+                }
+            }
+            else {
+                $queryParams['username'] = $username;
+            }
         }
-
-
         // query params
         if ($password !== null) {
-            $queryParams['password'] = $password;
+            if('form' === 'form' && is_array($password)) {
+                foreach($password as $key => $value) {
+                    $queryParams[$key] = $value;
+                }
+            }
+            else {
+                $queryParams['password'] = $password;
+            }
         }
-
 
 
 


### PR DESCRIPTION
Current code for the PHP generator doesn't properly support the 'form' style. If we look at other implementations (such as the Javascript one), when _explode_ is **true** and _style_ equals to **form**, the parameter should be expanded so that each key inside the parameter (which should then be an array) would result in a new query parameter. There is a very nice example of this in the accepted answer for [this thread at stackoverflow](https://stackoverflow.com/questions/49582559/how-to-document-dynamic-query-parameter-names-in-openapi-swagger).
So, to make this work, in my humble opinion this code might be changed to:
```
        if (${{paramName}} !== null) {
        {{#style}}
            if('form' === '{{style}}' && is_array(${{paramName}})) {
                foreach(${{paramName}} as $key => $value) {
                    $queryParams[$key] = $value;
                }
            }
            else {
                $queryParams['{{baseName}}'] = ${{paramName}};
            }
        {{/style}}
        {{^style}}
            $queryParams['{{baseName}}'] = ${{paramName}};
        {{/style}}
        }
```
This issue was presented as a comment to PR #3984, which has just being merged. This PR implements this change.

<!-- Please check the completed items below -->
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [X] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [X] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language: @jebentier (2017/07), @dkarlovi (2017/07), @mandrean (2017/08), @jfastnacht (2017/09), @ackintosh (2017/09) heart, @ybelenko (2018/07), @renepardon (2018/12), @wing328

I'm including a yaml file with an excerpt from the Webshipper API definition, which I'm using successfully after adding these changes to my own fork of openapi-generator.

[webshipper.yaml.gz](https://github.com/OpenAPITools/openapi-generator/files/4285969/webshipper.yaml.gz)

