### PR TITLE
Adds parseFlattenSpec

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
@@ -1134,8 +1134,8 @@ public class ModelUtils {
                     } else {
                         // not a parent since discriminator.propertyName is not set
                         hasAmbiguousParents = true;
-                        Boolean isNotExtractedInlineSchmea = !parentName.equals(schemaName+"_allOf");
-                        if (isNotExtractedInlineSchmea) {
+                        Boolean isNotExtractedInlineSchema = !parentName.equals(schemaName+"_allOf");
+                        if (isNotExtractedInlineSchema) {
                             refedWithoutDiscriminator.add(parentName);
                         }
                     }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
@@ -269,10 +269,10 @@ public class ModelUtils {
 
     /**
      * Invoke the specified visitor function for every schema that matches mimeType in the OpenAPI document.
-     * 
+     *
      * To avoid infinite recursion, referenced schemas are visited only once. When a referenced schema is visited,
      * it is added to visitedSchemas.
-     * 
+     *
      * @param openAPI the OpenAPI document that contains schema objects.
      * @param schema the root schema object to be visited.
      * @param mimeType the mime type. TODO: does not seem to be used in a meaningful way.
@@ -355,14 +355,14 @@ public class ModelUtils {
 
     /**
      * Return true if the specified schema is an object with a fixed number of properties.
-     * 
+     *
      * A ObjectSchema differs from an MapSchema in the following way:
      * - An ObjectSchema is not extensible, i.e. it has a fixed number of properties.
      * - A MapSchema is an object that can be extended with an arbitrary set of properties.
      *   The payload may include dynamic properties.
-     * 
+     *
      * For example, an OpenAPI schema is considered an ObjectSchema in the following scenarios:
-     * 
+     *
      *   type: object
      *   additionalProperties: false
      *   properties:
@@ -370,7 +370,7 @@ public class ModelUtils {
      *       type: string
      *     address:
      *       type: string
-     * 
+     *
      * @param schema the OAS schema
      * @return true if the specified schema is an Object schema.
      */
@@ -394,7 +394,7 @@ public class ModelUtils {
     /**
      * Return true if the specified schema is composed, i.e. if it uses
      * 'oneOf', 'anyOf' or 'allOf'.
-     * 
+     *
      * @param schema the OAS schema
      * @return true if the specified schema is a Composed schema.
      */
@@ -659,7 +659,7 @@ public class ModelUtils {
 
     /**
      * Check to see if the schema is a free form object.
-     * 
+     *
      * A free form object is an object (i.e. 'type: object' in a OAS document) that:
      * 1) Does not define properties, and
      * 2) Is not a composed schema (no anyOf, oneOf, allOf), and
@@ -737,7 +737,7 @@ public class ModelUtils {
      * Return a Map of the schemas defined under /components/schemas in the OAS document.
      * The returned Map only includes the direct children of /components/schemas in the OAS document; the Map
      * does not include inlined schemas.
-     * 
+     *
      * @param openAPI the OpenAPI document.
      * @return a map of schemas in the OAS document.
      */
@@ -767,7 +767,7 @@ public class ModelUtils {
         });
         return allSchemas;
     }
-    
+
     /**
      * If a RequestBody contains a reference to an other RequestBody with '$ref', returns the referenced RequestBody if it is found or the actual RequestBody in the other cases.
      *
@@ -906,10 +906,10 @@ public class ModelUtils {
 
     /**
      * Return the first Schema from a specified OAS 'content' section.
-     * 
+     *
      * For example, given the following OAS, this method returns the schema
      * for the 'application/json' content type because it is listed first in the OAS.
-     * 
+     *
      * responses:
      *   '200':
      *     content:
@@ -918,8 +918,8 @@ public class ModelUtils {
      *           $ref: '#/components/schemas/XYZ'
      *       application/xml:
      *          ...
-     *   
-     * @param content a 'content' section in the OAS specification. 
+     *
+     * @param content a 'content' section in the OAS specification.
      * @return the Schema.
      */
     private static Schema getSchemaFromContent(Content content) {
@@ -1110,6 +1110,14 @@ public class ModelUtils {
         int nullSchemaChildrenCount = 0;
         boolean hasAmbiguousParents = false;
         List<String> refedWithoutDiscriminator = new ArrayList<>();
+        String schemaName = "";
+        for (String thisSchemaName : allSchemas.keySet()) {
+            Schema sc = allSchemas.get(thisSchemaName);
+            if (isComposedSchema(sc) && (ComposedSchema) sc == composedSchema) {
+                schemaName = thisSchemaName;
+                break;
+            }
+        }
 
         if (interfaces != null && !interfaces.isEmpty()) {
             for (Schema schema : interfaces) {
@@ -1126,7 +1134,10 @@ public class ModelUtils {
                     } else {
                         // not a parent since discriminator.propertyName is not set
                         hasAmbiguousParents = true;
-                        refedWithoutDiscriminator.add(parentName);
+                        Boolean isNotExtractedInlineSchmea = !parentName.equals(schemaName+"_allOf");
+                        if (isNotExtractedInlineSchmea) {
+                            refedWithoutDiscriminator.add(parentName);
+                        }
                     }
                 } else {
                     // not a ref, doing nothing, except counting the number of times the 'null' type
@@ -1235,19 +1246,19 @@ public class ModelUtils {
     /**
      * Return true if the 'nullable' attribute is set to true in the schema, i.e. if the value
      * of the property can be the null value.
-     * 
+     *
      * In addition, if the OAS document is 3.1 or above, isNullable returns true if the input
      * schema is a 'oneOf' composed document with at most two children, and one of the children
      * is the 'null' type.
-     * 
+     *
      * The caller is responsible for resolving schema references before invoking isNullable.
      * If the input schema is a $ref and the referenced schema has 'nullable: true', this method
      * returns false (because the nullable attribute is defined in the referenced schema).
-     * 
+     *
      * The 'nullable' attribute was introduced in OAS 3.0.
      * The 'nullable' attribute is deprecated in OAS 3.1. In a OAS 3.1 document, the preferred way
      * to specify nullable properties is to use the 'null' type.
-     * 
+     *
      * @param schema the OAS schema.
      * @return true if the schema is nullable.
      */
@@ -1273,7 +1284,7 @@ public class ModelUtils {
     /**
      * Return true if the specified composed schema is 'oneOf', contains one or two elements,
      * and at least one of the elements is the 'null' type.
-     * 
+     *
      * The 'null' type is supported in OAS 3.1 and above.
      * In the example below, the 'OptionalOrder' can have the null value because the 'null'
      * type is one of the elements under 'oneOf'.
@@ -1282,7 +1293,7 @@ public class ModelUtils {
      *   oneOf:
      *     - type: 'null'
      *     - $ref: '#/components/schemas/Order'
-     * 
+     *
      * @param schema the OAS composed schema.
      * @return true if the composed schema is nullable.
      */
@@ -1296,22 +1307,22 @@ public class ModelUtils {
             }
         }
         return false;
-    }    
+    }
 
     /**
      * isNullType returns true if the input schema is the 'null' type.
-     * 
+     *
      * The 'null' type is supported in OAS 3.1 and above. It is not supported
      * in OAS 2.0 and OAS 3.0.x.
-     * 
+     *
      * For example, the "null" type could be used to specify that a value must
      * either be null or a specified type:
-     * 
+     *
      * OptionalOrder:
      *   oneOf:
      *     - type: 'null'
      *     - $ref: '#/components/schemas/Order'
-     * 
+     *
      * @param schema the OpenAPI schema
      * @return true if the schema is the 'null' type
      */

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
@@ -1134,7 +1134,7 @@ public class ModelUtils {
                     } else {
                         // not a parent since discriminator.propertyName is not set
                         hasAmbiguousParents = true;
-                        Boolean isNotExtractedInlineSchema = !parentName.equals(schemaName+"_allOf");
+                        boolean isNotExtractedInlineSchema = !parentName.equals(schemaName+"_allOf");
                         if (isNotExtractedInlineSchema) {
                             refedWithoutDiscriminator.add(parentName);
                         }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
@@ -138,7 +138,7 @@ public class DefaultCodegenTest {
 
     @Test
     public void testGetProducesInfo() throws Exception {
-        final OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/produces.yaml");
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/produces.yaml");
         final DefaultCodegen codegen = new DefaultCodegen();
         codegen.setOpenAPI(openAPI);
 
@@ -210,7 +210,7 @@ public class DefaultCodegenTest {
 
     @Test
     public void testFormParameterHasDefaultValue() {
-        final OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml");
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml");
         final DefaultCodegen codegen = new DefaultCodegen();
         codegen.setOpenAPI(openAPI);
 
@@ -222,7 +222,7 @@ public class DefaultCodegenTest {
 
     @Test
     public void testEnsureNoDuplicateProduces() {
-        final OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/two-responses.yaml");
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/two-responses.yaml");
         final DefaultCodegen codegen = new DefaultCodegen();
         codegen.setOpenAPI(openAPI);
 
@@ -257,7 +257,7 @@ public class DefaultCodegenTest {
 
     @Test
     public void testGetSchemaTypeWithComposedSchemaWithOneOf() {
-        final OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/composed-oneof.yaml");
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/composed-oneof.yaml");
         final DefaultCodegen codegen = new DefaultCodegen();
 
         Operation operation = openAPI.getPaths().get("/state").getPost();
@@ -270,7 +270,7 @@ public class DefaultCodegenTest {
 
     @Test
     public void testComposedSchemaOneOfWithProperties() {
-        final OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/oneOf.yaml");
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/oneOf.yaml");
         final DefaultCodegen codegen = new DefaultCodegen();
 
         final Schema schema = openAPI.getComponents().getSchemas().get("fruit");
@@ -483,7 +483,7 @@ public class DefaultCodegenTest {
 
     @Test
     public void testExample1() {
-        final OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/examples.yaml");
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/examples.yaml");
         final DefaultCodegen codegen = new DefaultCodegen();
 
         Operation operation = openAPI.getPaths().get("/example1/singular").getGet();
@@ -501,7 +501,7 @@ public class DefaultCodegenTest {
 
     @Test
     public void testExample2() {
-        final OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/examples.yaml");
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/examples.yaml");
         final DefaultCodegen codegen = new DefaultCodegen();
 
         Operation operation = openAPI.getPaths().get("/example2/singular").getGet();
@@ -513,7 +513,7 @@ public class DefaultCodegenTest {
 
     @Test
     public void testExample3() {
-        final OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/examples.yaml");
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/examples.yaml");
         final DefaultCodegen codegen = new DefaultCodegen();
 
         Operation operation = openAPI.getPaths().get("/example3/singular").getGet();
@@ -531,7 +531,7 @@ public class DefaultCodegenTest {
 
     @Test
     public void testExample4() {
-        final OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/examples.yaml");
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/examples.yaml");
         final DefaultCodegen codegen = new DefaultCodegen();
 
         Operation operation = openAPI.getPaths().get("/example4/singular").getPost();
@@ -549,7 +549,7 @@ public class DefaultCodegenTest {
 
     @Test
     public void testDiscriminator() {
-        final OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml");
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml");
         DefaultCodegen codegen = new DefaultCodegen();
 
         Schema animal = openAPI.getComponents().getSchemas().get("Animal");
@@ -567,7 +567,7 @@ public class DefaultCodegenTest {
 
     @Test
     public void testDiscriminatorWithCustomMapping() {
-        final OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/allOf.yaml");
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/allOf.yaml");
         DefaultCodegen codegen = new DefaultCodegen();
         codegen.setOpenAPI(openAPI);
 
@@ -584,7 +584,7 @@ public class DefaultCodegenTest {
 
     @Test
     public void testParentName() {
-        final OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/allOf.yaml");
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/allOf.yaml");
         DefaultCodegen codegen = new DefaultCodegen();
 
         Schema child = openAPI.getComponents().getSchemas().get("Child");
@@ -595,7 +595,7 @@ public class DefaultCodegenTest {
 
     @Test
     public void testAllOfRequired() {
-        final OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/allOf-required.yaml");
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/allOf-required.yaml");
         DefaultCodegen codegen = new DefaultCodegen();
 
         Schema child = openAPI.getComponents().getSchemas().get("clubForCreation");
@@ -606,7 +606,7 @@ public class DefaultCodegenTest {
 
     @Test
     public void testAllOfSingleRefNoOwnProps() {
-        final OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/2_0/composed-allof.yaml");
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/2_0/composed-allof.yaml");
         final DefaultCodegen codegen = new CodegenWithMultipleInheritance();
 
         Schema schema = openAPI.getComponents().getSchemas().get("NewMessageEventCoreNoOwnProps");
@@ -628,7 +628,7 @@ public class DefaultCodegenTest {
 
     @Test
     public void testAllOfParent() {
-        final OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/allOf-required-parent.yaml");
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/allOf-required-parent.yaml");
         DefaultCodegen codegen = new DefaultCodegen();
         codegen.setOpenAPI(openAPI);
 
@@ -656,7 +656,7 @@ public class DefaultCodegenTest {
 
     @Test
     public void testCallbacks() {
-        final OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/callbacks.yaml");
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/callbacks.yaml");
         final CodegenConfig codegen = new DefaultCodegen();
         codegen.setOpenAPI(openAPI);
 
@@ -764,7 +764,7 @@ public class DefaultCodegenTest {
 
     @Test
     public void testNullableProperty() {
-        final OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/examples.yaml");
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/examples.yaml");
         new InlineModelResolver().flatten(openAPI);
         final DefaultCodegen codegen = new DefaultCodegen();
         codegen.setOpenAPI(openAPI);
@@ -776,7 +776,7 @@ public class DefaultCodegenTest {
 
     @Test
     public void testDeprecatedProperty() {
-        final OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/property-deplicated.yaml");
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/property-deplicated.yaml");
         new InlineModelResolver().flatten(openAPI);
         final DefaultCodegen codegen = new DefaultCodegen();
         codegen.setOpenAPI(openAPI);
@@ -952,7 +952,7 @@ public class DefaultCodegenTest {
 
     @Test
     public void testAlias() {
-        final OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/type_alias.yaml");
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/type_alias.yaml");
         new InlineModelResolver().flatten(openAPI);
 
         final DefaultCodegen codegen = new DefaultCodegen();
@@ -1052,7 +1052,7 @@ public class DefaultCodegenTest {
 
     @Test
     public void objectQueryParamIdentifyAsObject() {
-        final OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/objectQueryParam.yaml");
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/objectQueryParam.yaml");
         new InlineModelResolver().flatten(openAPI);
         final DefaultCodegen codegen = new DefaultCodegen();
         codegen.setOpenAPI(openAPI);
@@ -1060,6 +1060,7 @@ public class DefaultCodegenTest {
         Set<String> imports = new HashSet<>();
         CodegenParameter parameter = codegen.fromParameter(openAPI.getPaths().get("/pony").getGet().getParameters().get(0), imports);
 
+        // TODO: This must be updated to work with flattened inline models
         Assert.assertEquals(parameter.dataType, "PageQuery");
         Assert.assertEquals(imports.size(), 1);
         Assert.assertEquals(imports.iterator().next(), "PageQuery");
@@ -1067,7 +1068,7 @@ public class DefaultCodegenTest {
 
     @Test
     public void mapParamImportInnerObject() {
-        final OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/2_0/mapArgs.yaml");
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/2_0/mapArgs.yaml");
         final DefaultCodegen codegen = new DefaultCodegen();
         codegen.setOpenAPI(openAPI);
 
@@ -1142,7 +1143,7 @@ public class DefaultCodegenTest {
 
     @Test
     public void arrayInnerReferencedSchemaMarkedAsModel_20() {
-        final OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/2_0/arrayRefBody.yaml");
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/2_0/arrayRefBody.yaml");
         final DefaultCodegen codegen = new DefaultCodegen();
         codegen.setOpenAPI(openAPI);
 
@@ -1159,7 +1160,7 @@ public class DefaultCodegenTest {
 
     @Test
     public void arrayInnerReferencedSchemaMarkedAsModel_30() {
-        final OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/arrayRefBody.yaml");
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/arrayRefBody.yaml");
         new InlineModelResolver().flatten(openAPI);
         final DefaultCodegen codegen = new DefaultCodegen();
         codegen.setOpenAPI(openAPI);
@@ -1213,7 +1214,7 @@ public class DefaultCodegenTest {
 
     public static class FromParameter {
         private CodegenParameter codegenParameter(String path) {
-            final OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/fromParameter.yaml");
+            final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/fromParameter.yaml");
             new InlineModelResolver().flatten(openAPI);
             final DefaultCodegen codegen = new DefaultCodegen();
             codegen.setOpenAPI(openAPI);
@@ -1341,7 +1342,7 @@ public class DefaultCodegenTest {
 
     @Test
     public void testUseOneOfInterfaces() {
-        final OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/composed-oneof.yaml");
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/composed-oneof.yaml");
         final DefaultCodegen cg = new DefaultCodegen();
         cg.setUseOneOfInterfaces(true);
         cg.preprocessOpenAPI(openAPI);

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
@@ -1061,9 +1061,9 @@ public class DefaultCodegenTest {
         CodegenParameter parameter = codegen.fromParameter(openAPI.getPaths().get("/pony").getGet().getParameters().get(0), imports);
 
         // TODO: This must be updated to work with flattened inline models
-        Assert.assertEquals(parameter.dataType, "PageQuery");
+        Assert.assertEquals(parameter.dataType, "PageQuery1");
         Assert.assertEquals(imports.size(), 1);
-        Assert.assertEquals(imports.iterator().next(), "PageQuery");
+        Assert.assertEquals(imports.iterator().next(), "PageQuery1");
     }
 
     @Test

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultGeneratorTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultGeneratorTest.java
@@ -82,7 +82,7 @@ public class DefaultGeneratorTest {
 
     @Test
     public void testRefModelValidationProperties(){
-        OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/2_0/refAliasedPrimitiveWithValidation.yml");
+        OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/2_0/refAliasedPrimitiveWithValidation.yml");
         ClientOptInput opts = new ClientOptInput();
         opts.setOpenAPI(openAPI);
         DefaultCodegen config = new DefaultCodegen();

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/ExampleGeneratorTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/ExampleGeneratorTest.java
@@ -12,7 +12,7 @@ import static org.testng.AssertJUnit.assertNull;
 public class ExampleGeneratorTest {
     @Test
     public void generateFromResponseSchemaWithPrimitiveType() {
-        OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/example_generator_test.yaml");
+        OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/example_generator_test.yaml");
 
         new InlineModelResolver().flatten(openAPI);
 
@@ -41,7 +41,7 @@ public class ExampleGeneratorTest {
 
     @Test
     public void generateFromResponseSchemaWithNoExample() {
-        OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/example_generator_test.yaml");
+        OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/example_generator_test.yaml");
 
         new InlineModelResolver().flatten(openAPI);
 
@@ -67,7 +67,7 @@ public class ExampleGeneratorTest {
 
     @Test
     public void generateFromResponseSchemaWithArrayOfModel() {
-        OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/example_generator_test.yaml");
+        OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/example_generator_test.yaml");
 
         new InlineModelResolver().flatten(openAPI);
 
@@ -96,7 +96,7 @@ public class ExampleGeneratorTest {
 
     @Test
     public void generateFromResponseSchemaWithArrayOfPrimitiveTypes() {
-        OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/example_generator_test.yaml");
+        OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/example_generator_test.yaml");
 
         new InlineModelResolver().flatten(openAPI);
 
@@ -125,7 +125,7 @@ public class ExampleGeneratorTest {
 
     @Test
     public void generateFromResponseSchemaWithModel() {
-        OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/example_generator_test.yaml");
+        OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/example_generator_test.yaml");
 
         new InlineModelResolver().flatten(openAPI);
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/InlineModelResolverTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/InlineModelResolverTest.java
@@ -313,7 +313,7 @@ public class InlineModelResolverTest {
         assertNotNull(openAPI.getComponents());
         assertNotNull(openAPI.getComponents().getRequestBodies());
     }
-    
+
     @Test
     public void resolveInlineArraySchemaWithTitle() {
         OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/inline_model_resolver.yaml");
@@ -329,7 +329,7 @@ public class InlineModelResolverTest {
         assertTrue(user.getProperties().get("street") instanceof StringSchema);
         assertTrue(user.getProperties().get("city") instanceof StringSchema);
     }
-    
+
     @Test
     public void resolveInlineRequestBody() {
         OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/inline_model_resolver.yaml");

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/TestUtils.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/TestUtils.java
@@ -36,7 +36,6 @@ public class TestUtils {
      */
     public static OpenAPI parseFlattenSpec(String specFilePath) {
         OpenAPI openAPI = parseSpec(specFilePath);
-        // resolve inline models
         InlineModelResolver inlineModelResolver = new InlineModelResolver();
         inlineModelResolver.flatten(openAPI);
         return openAPI;

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/TestUtils.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/TestUtils.java
@@ -35,7 +35,7 @@ public class TestUtils {
      * @return A processed OpenAPI document
      */
     public static OpenAPI parseFlattenSpec(String specFilePath) {
-        OpenAPI openAPI = new OpenAPIParser().readLocation(specFilePath, null, new ParseOptions()).getOpenAPI();
+        OpenAPI openAPI = parseSpec(specFilePath);
         // resolve inline models
         InlineModelResolver inlineModelResolver = new InlineModelResolver();
         inlineModelResolver.flatten(openAPI);

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/TestUtils.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/TestUtils.java
@@ -28,6 +28,30 @@ import java.util.stream.Collectors;
 
 public class TestUtils {
 
+    /**
+     * Helper method for parsing specs as a generator would be presented at runtime (inline models resolved, flattened).
+     *
+     * @param specFilePath The path to the specification file
+     * @return A processed OpenAPI document
+     */
+    public static OpenAPI parseFlattenSpec(String specFilePath) {
+        OpenAPI openAPI = new OpenAPIParser().readLocation(specFilePath, null, new ParseOptions()).getOpenAPI();
+        // resolve inline models
+        InlineModelResolver inlineModelResolver = new InlineModelResolver();
+        inlineModelResolver.flatten(openAPI);
+        return openAPI;
+    }
+
+    /**
+     * Helper method for parsing specs into an intermediary OpenAPI structure for pre-processing.
+     *
+     * Use this method only for tests targeting processing helpers such as {@link org.openapitools.codegen.utils.ModelUtils}
+     * or {@link InlineModelResolver}. Using this for testing generators will mean you're not testing the OpenAPI document
+     * in a state the generator will be presented at runtime.
+     *
+     * @param specFilePath The path to the specification file
+     * @return A "raw" OpenAPI document
+     */
     public static OpenAPI parseSpec(String specFilePath) {
         return new OpenAPIParser().readLocation(specFilePath, null, new ParseOptions()).getOpenAPI();
     }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/asciidoc/AsciidocGeneratorTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/asciidoc/AsciidocGeneratorTest.java
@@ -29,7 +29,7 @@ public class AsciidocGeneratorTest {
 
     @Test
     public void testPingSpecTitle() throws Exception {
-        final OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/ping.yaml");
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/ping.yaml");
 
         AsciidocDocumentationCodegen codeGen = new AsciidocDocumentationCodegen();
         codeGen.preprocessOpenAPI(openAPI);
@@ -61,7 +61,7 @@ public class AsciidocGeneratorTest {
         output.mkdirs();
         output.deleteOnExit();
 
-        final OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/ping.yaml");
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/ping.yaml");
         CodegenConfig codegenConfig = new AsciidocDocumentationCodegen();
         codegenConfig.setOutputDir(output.getAbsolutePath());
         ClientOptInput clientOptInput = new ClientOptInput().openAPI(openAPI).config(codegenConfig);

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/bash/BashTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/bash/BashTest.java
@@ -34,7 +34,7 @@ public class BashTest {
     public void petstoreOperationTest() {
 
         final OpenAPI openAPI
-            = TestUtils.parseSpec("src/test/resources/2_0/petstore-bash.json");
+            = TestUtils.parseFlattenSpec("src/test/resources/2_0/petstore-bash.json");
         final DefaultCodegen codegen = new BashClientCodegen();
         codegen.setOpenAPI(openAPI);
         final Operation findPetsByStatusOperation
@@ -63,7 +63,7 @@ public class BashTest {
     public void petstoreParameterExampleTest() {
 
         final OpenAPI openAPI
-            = TestUtils.parseSpec("src/test/resources/2_0/petstore-bash.json");
+            = TestUtils.parseFlattenSpec("src/test/resources/2_0/petstore-bash.json");
         final DefaultCodegen codegen = new BashClientCodegen();
         codegen.setOpenAPI(openAPI);
         final Operation addPetOperation

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/csharp/CsharpModelEnumTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/csharp/CsharpModelEnumTest.java
@@ -99,7 +99,7 @@ public class CsharpModelEnumTest {
         codegen.setEnumNameSuffix("EnumName");
         codegen.setEnumValueSuffix("EnumValue");
 
-        OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/petstore.yaml");
+        OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/petstore.yaml");
         codegen.setOpenAPI(openAPI);
 
         final Schema petSchema = openAPI.getComponents().getSchemas().get("Pet");
@@ -116,7 +116,7 @@ public class CsharpModelEnumTest {
     public void useDefaultEnumSuffixes() {
         final AspNetCoreServerCodegen codegen = new AspNetCoreServerCodegen();
 
-        OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/petstore.yaml");
+        OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/petstore.yaml");
         codegen.setOpenAPI(openAPI);
 
         final Schema petSchema = openAPI.getComponents().getSchemas().get("Pet");
@@ -135,7 +135,7 @@ public class CsharpModelEnumTest {
         codegen.setEnumNameSuffix("");
         codegen.setEnumValueSuffix("");
 
-        OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/petstore.yaml");
+        OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/petstore.yaml");
         codegen.setOpenAPI(openAPI);
 
         final Schema petSchema = openAPI.getComponents().getSchemas().get("Pet");

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/dart/DartModelTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/dart/DartModelTest.java
@@ -309,7 +309,7 @@ public class DartModelTest {
     // datetime (or primitive type) not yet supported in HTTP request body
     @Test(description = "returns DateTime when using `--model-name-prefix`")
     public void dateTest() {
-        final OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/2_0/datePropertyTest.json");
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/2_0/datePropertyTest.json");
         final DefaultCodegen codegen = new DartClientCodegen();
         codegen.setModelNamePrefix("foo");
         codegen.setOpenAPI(openAPI);

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/dartdio/DartDioModelTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/dartdio/DartDioModelTest.java
@@ -397,7 +397,7 @@ public class DartDioModelTest {
     // datetime (or primitive type) not yet supported in HTTP request body
     @Test(description = "returns DateTime when using `--model-name-prefix`")
     public void dateTest() {
-        final OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/2_0/datePropertyTest.json");
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/2_0/datePropertyTest.json");
         final DefaultCodegen codegen = new DartDioClientCodegen();
         codegen.setModelNamePrefix("foo");
         codegen.setOpenAPI(openAPI);

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/go/GoClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/go/GoClientCodegenTest.java
@@ -60,7 +60,7 @@ public class GoClientCodegenTest {
 
     @Test(description = "test example value for body parameter")
     public void bodyParameterTest() {
-        final OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml");
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml");
         final GoClientCodegen codegen = new GoClientCodegen();
         codegen.setOpenAPI(openAPI);
         final String path = "/fake";

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/html/StaticHtmlGeneratorTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/html/StaticHtmlGeneratorTest.java
@@ -48,7 +48,7 @@ public class StaticHtmlGeneratorTest {
 
     @Test
     public void testSpecWithoutSchema() throws Exception {
-        final OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/ping.yaml");
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/ping.yaml");
 
         final StaticHtmlGenerator codegen = new StaticHtmlGenerator();
         codegen.preprocessOpenAPI(openAPI);

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/AbstractJavaCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/AbstractJavaCodegenTest.java
@@ -66,7 +66,7 @@ public class AbstractJavaCodegenTest {
 
     @Test
     public void testPreprocessOpenAPI() throws Exception {
-        final OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/petstore.yaml");
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/petstore.yaml");
         final P_AbstractJavaCodegen codegen = new P_AbstractJavaCodegen();
 
         codegen.preprocessOpenAPI(openAPI);
@@ -77,7 +77,7 @@ public class AbstractJavaCodegenTest {
 
     @Test
     public void testPreprocessOpenAPINumVersion() throws Exception {
-        final OpenAPI openAPIOtherNumVersion = TestUtils.parseSpec("src/test/resources/2_0/duplicateOperationIds.yaml");
+        final OpenAPI openAPIOtherNumVersion = TestUtils.parseFlattenSpec("src/test/resources/2_0/duplicateOperationIds.yaml");
         final P_AbstractJavaCodegen codegen = new P_AbstractJavaCodegen();
 
         codegen.preprocessOpenAPI(openAPIOtherNumVersion);
@@ -461,7 +461,7 @@ public class AbstractJavaCodegenTest {
     @Test
     public void processOptsBooleanTrueFromString() {
         final P_AbstractJavaCodegen codegen = new P_AbstractJavaCodegen();
-        final OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/petstore.yaml");
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/petstore.yaml");
         codegen.additionalProperties().put(CodegenConstants.SNAPSHOT_VERSION, "true");
         codegen.preprocessOpenAPI(openAPI);
         Assert.assertTrue((boolean) codegen.additionalProperties().get(CodegenConstants.SNAPSHOT_VERSION));
@@ -470,7 +470,7 @@ public class AbstractJavaCodegenTest {
     @Test
     public void processOptsBooleanTrueFromBoolean() {
         final P_AbstractJavaCodegen codegen = new P_AbstractJavaCodegen();
-        final OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/petstore.yaml");
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/petstore.yaml");
         codegen.additionalProperties().put(CodegenConstants.SNAPSHOT_VERSION, true);
         codegen.preprocessOpenAPI(openAPI);
         Assert.assertTrue((boolean) codegen.additionalProperties().get(CodegenConstants.SNAPSHOT_VERSION));
@@ -479,7 +479,7 @@ public class AbstractJavaCodegenTest {
     @Test
     public void processOptsBooleanFalseFromString() {
         final P_AbstractJavaCodegen codegen = new P_AbstractJavaCodegen();
-        final OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/petstore.yaml");
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/petstore.yaml");
         codegen.additionalProperties().put(CodegenConstants.SNAPSHOT_VERSION, "false");
         codegen.preprocessOpenAPI(openAPI);
         Assert.assertFalse((boolean) codegen.additionalProperties().get(CodegenConstants.SNAPSHOT_VERSION));
@@ -488,7 +488,7 @@ public class AbstractJavaCodegenTest {
     @Test
     public void processOptsBooleanFalseFromBoolean() {
         final P_AbstractJavaCodegen codegen = new P_AbstractJavaCodegen();
-        final OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/petstore.yaml");
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/petstore.yaml");
         codegen.additionalProperties().put(CodegenConstants.SNAPSHOT_VERSION, false);
         codegen.preprocessOpenAPI(openAPI);
         Assert.assertFalse((boolean) codegen.additionalProperties().get(CodegenConstants.SNAPSHOT_VERSION));
@@ -497,7 +497,7 @@ public class AbstractJavaCodegenTest {
     @Test
     public void processOptsBooleanFalseFromGarbage() {
         final P_AbstractJavaCodegen codegen = new P_AbstractJavaCodegen();
-        final OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/petstore.yaml");
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/petstore.yaml");
         codegen.additionalProperties().put(CodegenConstants.SNAPSHOT_VERSION, "blibb");
         codegen.preprocessOpenAPI(openAPI);
         Assert.assertFalse((boolean) codegen.additionalProperties().get(CodegenConstants.SNAPSHOT_VERSION));
@@ -506,7 +506,7 @@ public class AbstractJavaCodegenTest {
     @Test
     public void processOptsBooleanFalseFromNumeric() {
         final P_AbstractJavaCodegen codegen = new P_AbstractJavaCodegen();
-        final OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/petstore.yaml");
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/petstore.yaml");
         codegen.additionalProperties().put(CodegenConstants.SNAPSHOT_VERSION, 42L);
         codegen.preprocessOpenAPI(openAPI);
         Assert.assertFalse((boolean) codegen.additionalProperties().get(CodegenConstants.SNAPSHOT_VERSION));

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
@@ -207,7 +207,7 @@ public class JavaClientCodegenTest {
 
     @Test
     public void testGetSchemaTypeWithComposedSchemaWithAllOf() {
-        final OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/2_0/composed-allof.yaml");
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/2_0/composed-allof.yaml");
         final JavaClientCodegen codegen = new JavaClientCodegen();
 
         Operation operation = openAPI.getPaths().get("/ping").getPost();
@@ -433,7 +433,7 @@ public class JavaClientCodegenTest {
 
     @Test
     public void testReferencedHeader() {
-        final OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/issue855.yaml");
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/issue855.yaml");
         JavaClientCodegen codegen = new JavaClientCodegen();
         codegen.setOpenAPI(openAPI);
 
@@ -448,7 +448,7 @@ public class JavaClientCodegenTest {
 
     @Test
     public void testAuthorizationScopeValues_Issue392() {
-        final OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/issue392.yaml");
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/issue392.yaml");
 
         final DefaultGenerator defaultGenerator = new DefaultGenerator();
 
@@ -476,7 +476,7 @@ public class JavaClientCodegenTest {
 
     @Test
     public void testAuthorizationsHasMoreWhenFiltered() {
-        final OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/issue4584.yaml");
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/issue4584.yaml");
 
         final DefaultGenerator defaultGenerator = new DefaultGenerator();
 
@@ -496,7 +496,7 @@ public class JavaClientCodegenTest {
 
     @Test
     public void testFreeFormObjects() {
-        final OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/issue796.yaml");
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/issue796.yaml");
         JavaClientCodegen codegen = new JavaClientCodegen();
 
         Schema test1 = openAPI.getComponents().getSchemas().get("MapTest1");
@@ -578,7 +578,7 @@ public class JavaClientCodegenTest {
 
     @Test
     public void testBearerAuth() {
-        final OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/pingBearerAuth.yaml");
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/pingBearerAuth.yaml");
         JavaClientCodegen codegen = new JavaClientCodegen();
 
         List<CodegenSecurity> security = codegen.fromSecurity(openAPI.getComponents().getSecuritySchemes());

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaModelEnumTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaModelEnumTest.java
@@ -167,7 +167,7 @@ public class JavaModelEnumTest {
 
     @Test
     public void testEnumTestSchema() {
-        final OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/petstore-with-fake-endpoints-models-for-testing.yaml");
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/petstore-with-fake-endpoints-models-for-testing.yaml");
         JavaClientCodegen codegen = new JavaClientCodegen();
         codegen.setOpenAPI(openAPI);
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaModelTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaModelTest.java
@@ -1275,7 +1275,7 @@ public class JavaModelTest {
         config.setHideGenerationTimestamp(true);
         config.setOutputDir(output.getAbsolutePath());
 
-        final OpenAPI openAPI = TestUtils.parseSpec(inputSpec);
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec(inputSpec);
 
         final ClientOptInput opts = new ClientOptInput();
         opts.setConfig(config);

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/jaxrs/JavaJerseyServerCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/jaxrs/JavaJerseyServerCodegenTest.java
@@ -92,7 +92,7 @@ public class JavaJerseyServerCodegenTest extends JavaJaxrsBaseTest {
         File output = Files.createTempDirectory("test").toFile();
         output.deleteOnExit();
 
-        OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/tags.yaml");
+        OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/tags.yaml");
         ((JavaJerseyServerCodegen) codegen).setUseTags(false);
         codegen.setOutputDir(output.getAbsolutePath());
 
@@ -169,7 +169,7 @@ public class JavaJerseyServerCodegenTest extends JavaJaxrsBaseTest {
         File output = Files.createTempDirectory("test").toFile();
         output.deleteOnExit();
 
-        OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/tags.yaml");
+        OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/tags.yaml");
         ((JavaJerseyServerCodegen) codegen).setUseTags(true);
         codegen.setOutputDir(output.getAbsolutePath());
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
@@ -485,7 +485,7 @@ public class SpringCodegenTest {
         // we had an issue where int64, float, and double values were having single character string suffixes
         // included in their defaultValues
         // This test verifies that those characters are no longer present
-        final OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/2_0/issue1226.yaml");
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/2_0/issue1226.yaml");
         final SpringCodegen codegen = new SpringCodegen();
         codegen.setOpenAPI(openAPI);
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/javascript/JavascriptClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/javascript/JavascriptClientCodegenTest.java
@@ -66,7 +66,7 @@ public class JavascriptClientCodegenTest {
 
     @Test(description = "test defaultValueWithParam for model's properties")
     public void bodyParameterTest() {
-        final OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/2_0/petstore.yaml");
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/2_0/petstore.yaml");
         final JavascriptClientCodegen codegen = new JavascriptClientCodegen();
         final Schema pet = openAPI.getComponents().getSchemas().get("Pet");
         codegen.setOpenAPI(openAPI);

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/KotlinReservedWordsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/KotlinReservedWordsTest.java
@@ -16,7 +16,7 @@ import static org.testng.Assert.assertEquals;
 
 @SuppressWarnings("rawtypes")
 public class KotlinReservedWordsTest {
-    final OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/kotlin/reserved_words.yaml");
+    final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/kotlin/reserved_words.yaml");
 
     @DataProvider(name = "reservedWords")
     static Object[][] reservedWords() {

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/spring/KotlinSpringServerCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/spring/KotlinSpringServerCodegenTest.java
@@ -28,7 +28,7 @@ public class KotlinSpringServerCodegenTest {
     public void embeddedEnumArrayTest() throws Exception {
         String baseModelPackage = "zz";
         File output = Files.createTempDirectory("test").toFile().getCanonicalFile(); //may be move to /build
-        OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/issue______kotlinArrayEnumEmbedded.yaml");
+        OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/issue______kotlinArrayEnumEmbedded.yaml");
         KotlinSpringServerCodegen codegen = new KotlinSpringServerCodegen();
         codegen.setOutputDir(output.getAbsolutePath());
         codegen.additionalProperties().put(CodegenConstants.MODEL_PACKAGE, baseModelPackage + ".yyyy.model.xxxx");

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/objc/ObjcModelTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/objc/ObjcModelTest.java
@@ -302,7 +302,7 @@ public class ObjcModelTest {
 
     @Test(description = "test udid")
     public void udidAndPasswordDataModelTest() {
-        final OpenAPI openAPI =  TestUtils.parseSpec("src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml");
+        final OpenAPI openAPI =  TestUtils.parseFlattenSpec("src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml");
         final DefaultCodegen codegen = new ObjcClientCodegen();
         codegen.setOpenAPI(openAPI);
         final Schema definition = openAPI.getComponents().getSchemas().get("format_test");
@@ -317,7 +317,7 @@ public class ObjcModelTest {
 
     @Test(description = "test mixedProperties")
     public void mixedPropertiesDataModelTest() {
-        final OpenAPI openAPI =  TestUtils.parseSpec("src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml");
+        final OpenAPI openAPI =  TestUtils.parseFlattenSpec("src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml");
         final DefaultCodegen codegen = new ObjcClientCodegen();
         codegen.setOpenAPI(openAPI);
         final Schema definition = openAPI.getComponents().getSchemas().get("MixedPropertiesAndAdditionalPropertiesClass");
@@ -329,7 +329,7 @@ public class ObjcModelTest {
 
     @Test(description = "test isArrayModel")
     public void isArrayModelModelTest() {
-        final OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml");
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml");
         final DefaultCodegen codegen = new ObjcClientCodegen();
         final Schema definition = openAPI.getComponents().getSchemas().get("AnimalFarm");
         codegen.setOpenAPI(openAPI);
@@ -342,7 +342,7 @@ public class ObjcModelTest {
 
     @Test(description = "test binary data")
     public void binaryDataModelTest() {
-        final OpenAPI openAPI =  TestUtils.parseSpec("src/test/resources/2_0/binaryDataTest.json");
+        final OpenAPI openAPI =  TestUtils.parseFlattenSpec("src/test/resources/2_0/binaryDataTest.json");
         final DefaultCodegen codegen = new ObjcClientCodegen();
         final String path = "/tests/binaryResponse";
         final Operation p = openAPI.getPaths().get(path).getPost();
@@ -357,7 +357,7 @@ public class ObjcModelTest {
 
     @Test(description = "create proper imports per #316")
     public void issue316Test() {
-        final OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/2_0/postBodyTest.json");
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/2_0/postBodyTest.json");
         final DefaultCodegen codegen = new ObjcClientCodegen();
         codegen.setOpenAPI(openAPI);
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/perl/PerlClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/perl/PerlClientCodegenTest.java
@@ -59,7 +59,7 @@ public class PerlClientCodegenTest {
 
     @Test
     public void testIssue677() {
-        final OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/issue677.yaml");
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/issue677.yaml");
         final PerlClientCodegen codegen = new PerlClientCodegen();
         codegen.setOpenAPI(openAPI);
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/php/PhpModelTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/php/PhpModelTest.java
@@ -302,7 +302,7 @@ public class PhpModelTest {
 
     @Test(description = "test enum array model")
     public void enumArrayModelTest() {
-        final OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml");
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml");
         final DefaultCodegen codegen = new PhpClientCodegen();
         codegen.setOpenAPI(openAPI);
         final Map<String, Schema> schemas = openAPI.getComponents().getSchemas();
@@ -337,7 +337,7 @@ public class PhpModelTest {
 
     @Test(description = "test enum model for values (numeric, string, etc)")
     public void enumMdoelValueTest() {
-        final OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml");
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml");
         final DefaultCodegen codegen = new PhpClientCodegen();
         codegen.setOpenAPI(openAPI);
         final Schema definition = openAPI.getComponents().getSchemas().get("Enum_Test");
@@ -376,7 +376,7 @@ public class PhpModelTest {
     // datetime (or primitive type) not yet supported in HTTP request body
     @Test(description = "returns DateTime when using `--model-name-prefix`")
     public void dateTest() {
-        final OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/2_0/datePropertyTest.json");
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/2_0/datePropertyTest.json");
         final DefaultCodegen codegen = new PhpClientCodegen();
         codegen.setModelNamePrefix("foo");
         codegen.setOpenAPI(openAPI);

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/python/PythonClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/python/PythonClientCodegenTest.java
@@ -63,7 +63,7 @@ public class PythonClientCodegenTest {
 
     @Test(description = "test enum null/nullable patterns")
     public void testEnumNull() {
-        final OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/issue_1997.yaml");
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/issue_1997.yaml");
 
         StringSchema prop = (StringSchema) openAPI.getComponents().getSchemas().get("Type").getProperties().get("prop");
         ArrayList<Object> expected = new ArrayList<>(Arrays.asList("A", "B", "C"));
@@ -73,7 +73,7 @@ public class PythonClientCodegenTest {
 
     @Test(description = "test regex patterns")
     public void testRegularExpressionOpenAPISchemaVersion3() {
-        final OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/issue_1517.yaml");
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/issue_1517.yaml");
         final PythonClientCodegen codegen = new PythonClientCodegen();
         codegen.setOpenAPI(openAPI);
         final String path = "/ping";

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/python/PythonClientExperimentalTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/python/PythonClientExperimentalTest.java
@@ -31,7 +31,7 @@ public class PythonClientExperimentalTest {
 
     @Test(description = "convert a python model with dots")
     public void modelTest() {
-        final OpenAPI openAPI= TestUtils.parseSpec("src/test/resources/2_0/v1beta3.json");
+        final OpenAPI openAPI= TestUtils.parseFlattenSpec("src/test/resources/2_0/v1beta3.json");
         final DefaultCodegen codegen = new PythonClientExperimentalCodegen();
         codegen.setOpenAPI(openAPI);
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/python/PythonTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/python/PythonTest.java
@@ -32,7 +32,7 @@ public class PythonTest {
 
     @Test(description = "convert a python model with dots")
     public void modelTest() {
-        final OpenAPI openAPI= TestUtils.parseSpec("src/test/resources/2_0/v1beta3.json");
+        final OpenAPI openAPI= TestUtils.parseFlattenSpec("src/test/resources/2_0/v1beta3.json");
         final DefaultCodegen codegen = new PythonClientCodegen();
         codegen.setOpenAPI(openAPI);
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/ruby/RubyClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/ruby/RubyClientCodegenTest.java
@@ -33,6 +33,7 @@ import java.util.Arrays;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.TreeSet;
 
 import static org.testng.Assert.assertTrue;
@@ -419,9 +420,11 @@ public class RubyClientCodegenTest {
         Assert.assertNotNull(child);
 
         // to test allVars (without parent's properties)
-        Assert.assertEquals(child.getAllVars().size(), 7);
-
-        List<String> allVars = Arrays.asList(
+        List<String> allVars  =
+                child.getAllVars().stream()
+                        .map(CodegenProperty::getName)
+                        .collect(Collectors.toList());
+        List<String> allVarsExpected = Arrays.asList(
                 "age",
                 "first_name",
                 "_type",
@@ -430,31 +433,32 @@ public class RubyClientCodegenTest {
                 "duplicated_required",
                 "person_required"
         );
-        Integer i = 0;
-        for (String varName: allVars) {
-            CodegenProperty cp = child.getAllVars().get(i);
-            Assert.assertEquals(cp.name, varName);
-            i ++;
-        }
+        Assert.assertEquals(allVars.size(), allVarsExpected.size());
+        Assert.assertTrue(allVars.containsAll(allVarsExpected));
 
         // to test vars (without parent's properties)
-        Assert.assertEquals(child.getVars().size(), 2);
-
-        CodegenProperty cp0 = child.getVars().get(0);
-        Assert.assertEquals(cp0.name, "age");
-
-        CodegenProperty cp1 = child.getVars().get(1);
-        Assert.assertEquals(cp1.name, "first_name");
+        List<String> vars  =
+                child.getVars().stream()
+                        .map(CodegenProperty::getName)
+                        .collect(Collectors.toList());
+        List<String> varsExpected = Arrays.asList(
+                "age",
+                "first_name"
+        );
+        Assert.assertEquals(vars.size(), varsExpected.size());
+        Assert.assertTrue(vars.containsAll(varsExpected));
 
         // to test requiredVars
-        Assert.assertEquals(child.getRequiredVars().size(), 2);
-
-        cp0 = child.getRequiredVars().get(0);
-        Assert.assertEquals(cp0.name, "duplicated_required");
-
-        cp1 = child.getRequiredVars().get(1);
-        Assert.assertEquals(cp1.name, "person_required");
-
+        List<String> requiredVars  =
+                child.getRequiredVars().stream()
+                        .map(CodegenProperty::getName)
+                        .collect(Collectors.toList());
+        List<String> requiredVarsExpected = Arrays.asList(
+                "duplicated_required",
+                "person_required"
+                );
+        Assert.assertEquals(vars.size(), requiredVarsExpected.size());
+        Assert.assertTrue(requiredVars.containsAll(requiredVarsExpected));
     }
 
     @Test(description = "test allOf with discriminator and duplicated properties(OAS3) for Adult model")

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/ruby/RubyClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/ruby/RubyClientCodegenTest.java
@@ -29,6 +29,7 @@ import org.testng.annotations.Test;
 import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.util.Arrays;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
@@ -420,34 +421,29 @@ public class RubyClientCodegenTest {
         // to test allVars (without parent's properties)
         Assert.assertEquals(child.getAllVars().size(), 7);
 
-        CodegenProperty cp0 = child.getAllVars().get(0);
-        Assert.assertEquals(cp0.name, "_type");
-
-        CodegenProperty cp1 = child.getAllVars().get(1);
-        Assert.assertEquals(cp1.name, "last_name");
-
-        CodegenProperty cp2 = child.getAllVars().get(2);
-        Assert.assertEquals(cp2.name, "first_name");
-
-        CodegenProperty cp3 = child.getAllVars().get(3);
-        Assert.assertEquals(cp3.name, "duplicated_optional");
-
-        CodegenProperty cp4 = child.getAllVars().get(4);
-        Assert.assertEquals(cp4.name, "duplicated_required");
-
-        CodegenProperty cp5 = child.getAllVars().get(5);
-        Assert.assertEquals(cp5.name, "person_required");
-
-        CodegenProperty cp6 = child.getAllVars().get(6);
-        Assert.assertEquals(cp6.name, "age");
+        List<String> allVars = Arrays.asList(
+                "age",
+                "first_name",
+                "_type",
+                "last_name",
+                "duplicated_optional",
+                "duplicated_required",
+                "person_required"
+        );
+        Integer i = 0;
+        for (String varName: allVars) {
+            CodegenProperty cp = child.getAllVars().get(i);
+            Assert.assertEquals(cp.name, varName);
+            i ++;
+        }
 
         // to test vars (without parent's properties)
         Assert.assertEquals(child.getVars().size(), 2);
 
-        cp0 = child.getVars().get(0);
+        CodegenProperty cp0 = child.getVars().get(0);
         Assert.assertEquals(cp0.name, "age");
 
-        cp1 = child.getVars().get(1);
+        CodegenProperty cp1 = child.getVars().get(1);
         Assert.assertEquals(cp1.name, "first_name");
 
         // to test requiredVars

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/ruby/RubyClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/ruby/RubyClientCodegenTest.java
@@ -49,7 +49,7 @@ public class RubyClientCodegenTest {
         output.mkdirs();
         output.deleteOnExit();
 
-        final OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/2_0/pathWithHtmlEntity.yaml");
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/2_0/pathWithHtmlEntity.yaml");
         CodegenConfig codegenConfig = new RubyClientCodegen();
         codegenConfig.setOutputDir(output.getAbsolutePath());
 
@@ -113,7 +113,7 @@ public class RubyClientCodegenTest {
         output.mkdirs();
         output.deleteOnExit();
 
-        final OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/2_0/npe1.yaml");
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/2_0/npe1.yaml");
         CodegenConfig codegenConfig = new RubyClientCodegen();
         codegenConfig.setOutputDir(output.getAbsolutePath());
 
@@ -136,7 +136,7 @@ public class RubyClientCodegenTest {
 
     @Test(description = "verify enum parameters (query, form, header)")
     public void enumParameterTest() {
-        final OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml");
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml");
         final DefaultCodegen codegen = new RubyClientCodegen();
         codegen.setOpenAPI(openAPI);
         final String path = "/fake";
@@ -151,7 +151,7 @@ public class RubyClientCodegenTest {
 
     @Test(description = "test example value for body parameter")
     public void bodyParameterTest() {
-        final OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml");
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml");
         final RubyClientCodegen codegen = new RubyClientCodegen();
         codegen.setModuleName("OnlinePetstore");
         codegen.setOpenAPI(openAPI);
@@ -166,7 +166,7 @@ public class RubyClientCodegenTest {
 
     @Test(description = "test nullable for properties")
     public void nullablePropertyTest() {
-        final OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/petstore_oas3_test.yaml");
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/petstore_oas3_test.yaml");
         final RubyClientCodegen codegen = new RubyClientCodegen();
         codegen.setModuleName("OnlinePetstore");
         final String path = "/pet";
@@ -195,7 +195,7 @@ public class RubyClientCodegenTest {
 
     @Test(description = "test properties without nullable")
     public void propertiesWithoutNullableTest() {
-        final OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/petstore_oas3_test.yaml");
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/petstore_oas3_test.yaml");
         final RubyClientCodegen codegen = new RubyClientCodegen();
         codegen.setModuleName("OnlinePetstore");
         final String path = "/pet";
@@ -281,7 +281,7 @@ public class RubyClientCodegenTest {
 
     @Test(description = "test nullable for parameters (OAS3)")
     public void nullableParameterOAS3Test() {
-        final OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/petstore_oas3_test.yaml");
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/petstore_oas3_test.yaml");
         final RubyClientCodegen codegen = new RubyClientCodegen();
         codegen.setModuleName("OnlinePetstore");
         codegen.setOpenAPI(openAPI);
@@ -303,7 +303,7 @@ public class RubyClientCodegenTest {
 
     @Test(description = "test nullable for parameters (OAS2)")
     public void nullableParameterOAS2Test() {
-        final OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/2_0/petstore-nullable.yaml");
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/2_0/petstore-nullable.yaml");
         final RubyClientCodegen codegen = new RubyClientCodegen();
         codegen.setModuleName("OnlinePetstore");
         codegen.setOpenAPI(openAPI);
@@ -327,7 +327,7 @@ public class RubyClientCodegenTest {
 
     @Test(description = "test anyOf (OAS3)")
     public void anyOfTest() {
-        final OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/anyOf.yaml");
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/anyOf.yaml");
         final RubyClientCodegen codegen = new RubyClientCodegen();
         codegen.setModuleName("OnlinePetstore");
 
@@ -343,7 +343,7 @@ public class RubyClientCodegenTest {
 
     @Test(description = "test oneOf (OAS3)")
     public void oneOfTest() {
-        final OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/oneOf.yaml");
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/oneOf.yaml");
         final RubyClientCodegen codegen = new RubyClientCodegen();
         codegen.setModuleName("OnlinePetstore");
 
@@ -359,7 +359,7 @@ public class RubyClientCodegenTest {
 
     @Test(description = "test allOf (OAS3)")
     public void allOfTest() {
-        final OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/allOf.yaml");
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/allOf.yaml");
         final RubyClientCodegen codegen = new RubyClientCodegen();
         codegen.setModuleName("OnlinePetstore");
 
@@ -379,7 +379,7 @@ public class RubyClientCodegenTest {
 
     @Test(description = "test allOf with only allOf and duplicated properties(OAS3)")
     public void allOfDuplicatedPropertiesTest() {
-        final OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/allOfDuplicatedProperties.yaml");
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/allOfDuplicatedProperties.yaml");
         final RubyClientCodegen codegen = new RubyClientCodegen();
         codegen.setModuleName("OnlinePetstore");
 
@@ -408,7 +408,7 @@ public class RubyClientCodegenTest {
 
     @Test(description = "test allOf with discriminator and duplicated properties(OAS3) for Child model")
     public void allOfMappingDuplicatedPropertiesTestForChild() {
-        final OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/allOfMappingDuplicatedProperties.yaml");
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/allOfMappingDuplicatedProperties.yaml");
         final RubyClientCodegen codegen = new RubyClientCodegen();
         codegen.setModuleName("OnlinePetstore");
 
@@ -463,7 +463,7 @@ public class RubyClientCodegenTest {
 
     @Test(description = "test allOf with discriminator and duplicated properties(OAS3) for Adult model")
     public void allOfMappingDuplicatedPropertiesTestForAdult() {
-        final OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/allOfMappingDuplicatedProperties.yaml");
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/allOfMappingDuplicatedProperties.yaml");
         final RubyClientCodegen codegen = new RubyClientCodegen();
         codegen.setModuleName("OnlinePetstore");
 
@@ -523,7 +523,7 @@ public class RubyClientCodegenTest {
 
     @Test(description = "test allOf composition")
     public void allOfCompositionTest() {
-        final OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/allOf_composition.yaml");
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/allOf_composition.yaml");
         final RubyClientCodegen codegen = new RubyClientCodegen();
         codegen.setModuleName("OnlinePetstore");
 
@@ -591,7 +591,7 @@ public class RubyClientCodegenTest {
 
     @Test(description = "test example string imported from x-example parameterr (OAS2)")
     public void exampleStringFromExampleParameterOAS2Test() {
-        final OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/2_0/petstore-nullable.yaml");
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/2_0/petstore-nullable.yaml");
         final RubyClientCodegen codegen = new RubyClientCodegen();
         codegen.setModuleName("OnlinePetstore");
         codegen.setOpenAPI(openAPI);
@@ -606,7 +606,7 @@ public class RubyClientCodegenTest {
 
     @Test(description = "test example string imported from example in schema (OAS3)")
     public void exampleStringFromXExampleParameterOAS3Test() {
-        final OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/petstore_oas3_test.yaml");
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/petstore_oas3_test.yaml");
         final RubyClientCodegen codegen = new RubyClientCodegen();
         codegen.setModuleName("OnlinePetstore");
         codegen.setOpenAPI(openAPI);
@@ -627,7 +627,7 @@ public class RubyClientCodegenTest {
      */
     @Test(description = "test regex patterns")
     public void exampleRegexParameterValidationOAS3Test() {
-        final OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/test_regex.yaml");
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/test_regex.yaml");
         final RubyClientCodegen codegen = new RubyClientCodegen();
         codegen.setOpenAPI(openAPI);
         final String path = "/ping";

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/swift3/Swift3CodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/swift3/Swift3CodegenTest.java
@@ -89,7 +89,7 @@ public class Swift3CodegenTest {
 
     @Test(description = "returns NSData when response format is binary", enabled = false)
     public void binaryDataTest() {
-        final OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/2_0/binaryDataTest.json");
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/2_0/binaryDataTest.json");
         final DefaultCodegen codegen = new Swift3Codegen();
         codegen.setOpenAPI(openAPI);
         final String path = "/tests/binaryResponse";
@@ -104,7 +104,7 @@ public class Swift3CodegenTest {
 
     @Test(description = "returns ISOFullDate when response format is date", enabled = false)
     public void dateTest() {
-        final OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/2_0/datePropertyTest.json");
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/2_0/datePropertyTest.json");
         final DefaultCodegen codegen = new Swift3Codegen();
         codegen.setOpenAPI(openAPI);
         final String path = "/tests/dateResponse";

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/swift4/Swift4CodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/swift4/Swift4CodegenTest.java
@@ -92,7 +92,7 @@ public class Swift4CodegenTest {
     public void binaryDataTest() {
         // TODO update json file
 
-        final OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/2_0/binaryDataTest.json");
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/2_0/binaryDataTest.json");
         final DefaultCodegen codegen = new Swift4Codegen();
         codegen.setOpenAPI(openAPI);
         final String path = "/tests/binaryResponse";
@@ -107,7 +107,7 @@ public class Swift4CodegenTest {
 
     @Test(description = "returns Date when response format is date", enabled = true)
     public void dateTest() {
-        final OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/2_0/datePropertyTest.json");
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/2_0/datePropertyTest.json");
         final DefaultCodegen codegen = new Swift4Codegen();
         codegen.setOpenAPI(openAPI);
         final String path = "/tests/dateResponse";

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/swift5/Swift5ClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/swift5/Swift5ClientCodegenTest.java
@@ -92,7 +92,7 @@ public class Swift5ClientCodegenTest {
     public void binaryDataTest() {
         // TODO update json file
 
-        final OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/2_0/binaryDataTest.json");
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/2_0/binaryDataTest.json");
         final DefaultCodegen codegen = new Swift5ClientCodegen();
         codegen.setOpenAPI(openAPI);
         final String path = "/tests/binaryResponse";
@@ -107,7 +107,7 @@ public class Swift5ClientCodegenTest {
 
     @Test(description = "returns Date when response format is date", enabled = true)
     public void dateTest() {
-        final OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/2_0/datePropertyTest.json");
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/2_0/datePropertyTest.json");
         final DefaultCodegen codegen = new Swift5ClientCodegen();
         codegen.setOpenAPI(openAPI);
         final String path = "/tests/dateResponse";

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/fetch/TypeScriptFetchModelTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/fetch/TypeScriptFetchModelTest.java
@@ -225,7 +225,7 @@ public class TypeScriptFetchModelTest {
     @Test(description = "test enum array model")
     public void enumArrayMdoelTest() {
         // TODO: update yaml file.
-        final OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml");
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml");
         final DefaultCodegen codegen = new TypeScriptFetchClientCodegen();
         codegen.processOpts();
         codegen.setOpenAPI(openAPI);
@@ -263,7 +263,7 @@ public class TypeScriptFetchModelTest {
 
     @Test(description = "test enum model for values (numeric, string, etc)")
     public void enumMdoelValueTest() {
-        final OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml");
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml");
         final DefaultCodegen codegen = new TypeScriptFetchClientCodegen();
         codegen.processOpts();
         codegen.setOpenAPI(openAPI);

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/typescriptnode/TypeScriptNodeModelTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/typescriptnode/TypeScriptNodeModelTest.java
@@ -258,7 +258,7 @@ public class TypeScriptNodeModelTest {
 
     @Test(description = "prepend imports with ./ by default")
     public void defaultFromModelTest() {
-        final OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/petstore.yaml");
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/petstore.yaml");
         final DefaultCodegen codegen = new TypeScriptNodeClientCodegen();
         codegen.setOpenAPI(openAPI);
         final Schema categorySchema = openAPI.getComponents().getSchemas().get("ApiResponse");
@@ -270,7 +270,7 @@ public class TypeScriptNodeModelTest {
 
     @Test(description = "use mapped imports for type")
     public void mappedFromModelTest() {
-        final OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/petstore.yaml");
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/petstore.yaml");
         final DefaultCodegen codegen = new TypeScriptNodeClientCodegen();
         final String mappedName = "@namespace/dir/response";
         codegen.importMapping().put("ApiResponse", mappedName);

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/utils/ModelUtilsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/utils/ModelUtilsTest.java
@@ -26,86 +26,84 @@ import org.openapitools.codegen.TestUtils;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 public class ModelUtilsTest {
 
     @Test
     public void testGetAllUsedSchemas() {
-        final OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/unusedSchemas.yaml");
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/unusedSchemas.yaml");
         List<String> allUsedSchemas = ModelUtils.getAllUsedSchemas(openAPI);
-        Assert.assertEquals(allUsedSchemas.size(), 41);
-
-        Assert.assertTrue(allUsedSchemas.contains("SomeObjShared"), "contains 'SomeObjShared'");
-        Assert.assertTrue(allUsedSchemas.contains("SomeObj1"), "contains 'UnusedObj1'");
-        Assert.assertTrue(allUsedSchemas.contains("SomeObj2"), "contains 'SomeObj2'");
-        Assert.assertTrue(allUsedSchemas.contains("SomeObj3"), "contains 'SomeObj3'");
-        Assert.assertTrue(allUsedSchemas.contains("SomeObj6"), "contains 'SomeObj6'");
-        Assert.assertTrue(allUsedSchemas.contains("SomeObj7"), "contains 'SomeObj7'");
-        Assert.assertTrue(allUsedSchemas.contains("SomeObj8"), "contains 'SomeObj8'");
-        Assert.assertTrue(allUsedSchemas.contains("SomeObj9A"), "contains 'SomeObj9A'");
-        Assert.assertTrue(allUsedSchemas.contains("SomeObj9B"), "contains 'SomeObj9B'");
-        Assert.assertTrue(allUsedSchemas.contains("SomeObj10A"), "contains 'SomeObj10A'");
-        Assert.assertTrue(allUsedSchemas.contains("SomeObj10B"), "contains 'SomeObj10B'");
-        Assert.assertTrue(allUsedSchemas.contains("SomeObj11"), "contains 'SomeObj11'");
-        Assert.assertTrue(allUsedSchemas.contains("SomeArrayObj12"), "contains 'SomeArrayObj12'");
-        Assert.assertTrue(allUsedSchemas.contains("ArrayItem12"), "contains 'ArrayItem12'");
-        Assert.assertTrue(allUsedSchemas.contains("SomeArrayObj13"), "contains 'SomeArrayObj13'");
-        Assert.assertTrue(allUsedSchemas.contains("ArrayItem13"), "contains 'ArrayItem13'");
-        Assert.assertTrue(allUsedSchemas.contains("SomeObj14"), "contains 'SomeObj14'");
-        Assert.assertTrue(allUsedSchemas.contains("PropertyObj14"), "contains 'PropertyObj14'");
-        Assert.assertTrue(allUsedSchemas.contains("SomeObj15"), "contains 'SomeObj15'");
-        Assert.assertTrue(allUsedSchemas.contains("SomeMapObj16"), "contains 'SomeMapObj16'");
-        Assert.assertTrue(allUsedSchemas.contains("MapItem16"), "contains 'MapItem16'");
-        Assert.assertTrue(allUsedSchemas.contains("SomeObj17"), "contains 'SomeObj17'");
-        Assert.assertTrue(allUsedSchemas.contains("SomeObj18"), "contains 'SomeObj18'");
-        Assert.assertTrue(allUsedSchemas.contains("Common18"), "contains 'Common18'");
-        Assert.assertTrue(allUsedSchemas.contains("Obj19ByAge"), "contains 'Obj19ByAge'");
-        Assert.assertTrue(allUsedSchemas.contains("Obj19ByType"), "contains 'Obj19ByType'");
-        Assert.assertTrue(allUsedSchemas.contains("SomeObj20"), "contains 'SomeObj20'");
-        Assert.assertTrue(allUsedSchemas.contains("OtherObj20"), "contains 'OtherObj20'");
-        Assert.assertTrue(allUsedSchemas.contains("PingDataInput21"), "contains 'PingDataInput21'");
-        Assert.assertTrue(allUsedSchemas.contains("PingDataOutput21"), "contains 'PingDataOutput21'");
-        Assert.assertTrue(allUsedSchemas.contains("SInput22"), "contains 'SInput22'");
-        Assert.assertTrue(allUsedSchemas.contains("SOutput22"), "contains 'SInput22'");
-        Assert.assertTrue(allUsedSchemas.contains("SomeHeader23"), "contains 'SomeHeader23'");
-        Assert.assertTrue(allUsedSchemas.contains("SomeHeader24"), "contains 'SomeHeader24'");
-        Assert.assertTrue(allUsedSchemas.contains("SomeObj25"), "contains 'SomeObj25'");
-        Assert.assertTrue(allUsedSchemas.contains("SomeObj26"), "contains 'SomeObj26'");
-        Assert.assertTrue(allUsedSchemas.contains("Param27"), "contains 'Param27'");
-        Assert.assertTrue(allUsedSchemas.contains("Param28"), "contains 'Param28'");
-        Assert.assertTrue(allUsedSchemas.contains("Parent30"), "contains 'Parent30'");
-        Assert.assertTrue(allUsedSchemas.contains("AChild30"), "contains 'AChild30'");
-        Assert.assertTrue(allUsedSchemas.contains("BChild30"), "contains 'BChild30'");
+        Assert.assertEquals(allUsedSchemas.size(), 42);
+        List<String> expectedallUsedSchemas = Arrays.asList(
+                "SomeObj1",
+                "SomeObj2",
+                "SomeObj3",
+                "SomeObjShared",
+                "SomeObj6",
+                "SomeObj7",
+                "SomeObj8",
+                "SomeObj9A",
+                "SomeObj9B",
+                "SomeObj10A",
+                "SomeObj10B",
+                "SomeObj11",
+                "SomeArrayObj12",
+                "ArrayItem12",
+                "SomeArrayObj13",
+                "ArrayItem13",
+                "SomeObj14",
+                "PropertyObj14",
+                "SomeObj15",
+                "SomeMapObj16",
+                "MapItem16",
+                "SomeObj17",
+                "SomeObj18",
+                "Common18",
+                "SomeObj18_allOf",
+                "Obj19ByAge",
+                "Obj19ByType",
+                "SomeObj20",
+                "OtherObj20",
+                "PingDataInput21",
+                "PingDataOutput21",
+                "SInput22",
+                "SOutput22",
+                "SomeHeader23",
+                "SomeHeader24",
+                "SomeObj25",
+                "SomeObj26",
+                "Param27",
+                "Param28",
+                "Parent30",
+                "AChild30",
+                "BChild30"
+        );
+        Assert.assertEquals(allUsedSchemas, expectedallUsedSchemas);
     }
 
     @Test
     public void testGetUnusedSchemas() {
-        final OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/unusedSchemas.yaml");
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/unusedSchemas.yaml");
         List<String> unusedSchemas = ModelUtils.getUnusedSchemas(openAPI);
-        Assert.assertEquals(unusedSchemas.size(), 7);
-        //UnusedObj1 is not used at all:
-        Assert.assertTrue(unusedSchemas.contains("UnusedObj1"), "contains 'UnusedObj1'");
-        //UnusedObj2 is used in a request body that is not used.
-        Assert.assertTrue(unusedSchemas.contains("UnusedObj2"), "contains 'UnusedObj2'");
-        //UnusedObj3 is used in a response that is not used.
-        Assert.assertTrue(unusedSchemas.contains("UnusedObj3"), "contains 'UnusedObj3'");
-        //UnusedObj4 is used in a parameter that is not used.
-        Assert.assertTrue(unusedSchemas.contains("UnusedObj4"), "contains 'UnusedObj4'");
-        //Parent29 is not used at all (only unused children AChild29 and BChild29 are referencing him):
-        Assert.assertTrue(unusedSchemas.contains("Parent29"), "contains 'Parent29'");
-        //AChild29 is not used at all:
-        Assert.assertTrue(unusedSchemas.contains("AChild29"), "contains 'AChild29'");
-        //BChild29 is not used at all:
-        Assert.assertTrue(unusedSchemas.contains("BChild29"), "contains 'BChild29'");
+        Assert.assertEquals(unusedSchemas.size(), 9);
+        List<String> expectedUnusedSchemas = Arrays.asList(
+                "UnusedObj1",
+                "UnusedObj2",
+                "UnusedObj3",
+                "UnusedObj4",
+                "Parent29",
+                "AChild29",
+                "BChild29",
+                "AChild29_allOf",
+                "BChild29_allOf"
+        );
+        Assert.assertEquals(unusedSchemas, expectedUnusedSchemas);
     }
 
     @Test
     public void testSchemasUsedOnlyInFormParam() {
-        final OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/unusedSchemas.yaml");
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/unusedSchemas.yaml");
         List<String> unusedSchemas = ModelUtils.getSchemasUsedOnlyInFormParam(openAPI);
         Assert.assertEquals(unusedSchemas.size(), 3);
         //SomeObj2 is only used in an 'application/x-www-form-urlencoded' request
@@ -118,14 +116,14 @@ public class ModelUtilsTest {
 
     @Test
     public void testNoComponentsSection() {
-        final OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/ping.yaml");
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/ping.yaml");
         List<String> unusedSchemas = ModelUtils.getSchemasUsedOnlyInFormParam(openAPI);
         Assert.assertEquals(unusedSchemas.size(), 0);
     }
 
     @Test
     public void testGlobalProducesConsumes() {
-        final OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/2_0/globalProducesConsumesTest.yaml");
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/2_0/globalProducesConsumesTest.yaml");
         List<String> unusedSchemas = ModelUtils.getSchemasUsedOnlyInFormParam(openAPI);
         Assert.assertEquals(unusedSchemas.size(), 0);
     }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/utils/ModelUtilsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/utils/ModelUtilsTest.java
@@ -79,7 +79,7 @@ public class ModelUtilsTest {
                 "AChild30",
                 "BChild30"
         );
-        Assert.assertEquals(allUsedSchemas, expectedallUsedSchemas);
+        Assert.assertTrue(allUsedSchemas.containsAll(expectedallUsedSchemas));
     }
 
     @Test

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/utils/ModelUtilsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/utils/ModelUtilsTest.java
@@ -86,7 +86,6 @@ public class ModelUtilsTest {
     public void testGetUnusedSchemas() {
         final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/unusedSchemas.yaml");
         List<String> unusedSchemas = ModelUtils.getUnusedSchemas(openAPI);
-        Assert.assertEquals(unusedSchemas.size(), 9);
         List<String> expectedUnusedSchemas = Arrays.asList(
                 "UnusedObj1",
                 "UnusedObj2",
@@ -98,7 +97,8 @@ public class ModelUtilsTest {
                 "AChild29_allOf",
                 "BChild29_allOf"
         );
-        Assert.assertEquals(unusedSchemas, expectedUnusedSchemas);
+        Assert.assertEquals(unusedSchemas.size(), expectedUnusedSchemas.size());
+        Assert.assertTrue(unusedSchemas.containsAll(expectedUnusedSchemas));
     }
 
     @Test

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/utils/ModelUtilsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/utils/ModelUtilsTest.java
@@ -34,7 +34,6 @@ public class ModelUtilsTest {
     public void testGetAllUsedSchemas() {
         final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/unusedSchemas.yaml");
         List<String> allUsedSchemas = ModelUtils.getAllUsedSchemas(openAPI);
-        Assert.assertEquals(allUsedSchemas.size(), 42);
         List<String> expectedallUsedSchemas = Arrays.asList(
                 "SomeObj1",
                 "SomeObj2",
@@ -79,6 +78,7 @@ public class ModelUtilsTest {
                 "AChild30",
                 "BChild30"
         );
+        Assert.assertEquals(allUsedSchemas.size(), expectedallUsedSchemas.size());
         Assert.assertTrue(allUsedSchemas.containsAll(expectedallUsedSchemas));
     }
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/validations/oas/OpenApiSchemaTypeTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/validations/oas/OpenApiSchemaTypeTest.java
@@ -37,7 +37,7 @@ public class OpenApiSchemaTypeTest {
     @DataProvider(name = "oas31RecommendationExpectations")
     public Object[][] oas31RecommendationExpectations() {
         return new Object[][]{
-            {TestUtils.parseSpec("src/test/resources/3_1/null-types.yaml"), true}
+            {TestUtils.parseFlattenSpec("src/test/resources/3_1/null-types.yaml"), true}
         };
     }
 }

--- a/samples/client/petstore/python-experimental/docs/Child.md
+++ b/samples/client/petstore/python-experimental/docs/Child.md
@@ -3,9 +3,9 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
+**inter_net** | **bool** |  | [optional] 
 **radio_waves** | **bool** |  | [optional] 
 **tele_vision** | **bool** |  | [optional] 
-**inter_net** | **bool** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/python-experimental/docs/Parent.md
+++ b/samples/client/petstore/python-experimental/docs/Parent.md
@@ -3,8 +3,8 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**radio_waves** | **bool** |  | [optional] 
 **tele_vision** | **bool** |  | [optional] 
+**radio_waves** | **bool** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/python-experimental/petstore_api/models/child.py
+++ b/samples/client/petstore/python-experimental/petstore_api/models/child.py
@@ -84,9 +84,9 @@ class Child(ModelComposed):
                 and the value is attribute type.
         """
         return {
+            'inter_net': (bool,),  # noqa: E501
             'radio_waves': (bool,),  # noqa: E501
             'tele_vision': (bool,),  # noqa: E501
-            'inter_net': (bool,),  # noqa: E501
         }
 
     @staticmethod
@@ -94,9 +94,9 @@ class Child(ModelComposed):
         return None
 
     attribute_map = {
+        'inter_net': 'interNet',  # noqa: E501
         'radio_waves': 'radioWaves',  # noqa: E501
         'tele_vision': 'teleVision',  # noqa: E501
-        'inter_net': 'interNet',  # noqa: E501
     }
 
     required_properties = set([
@@ -127,9 +127,9 @@ class Child(ModelComposed):
                                 deserializing a file_type parameter.
                                 If passed, type conversion is attempted
                                 If omitted no type conversion is done.
+            inter_net (bool): [optional]  # noqa: E501
             radio_waves (bool): [optional]  # noqa: E501
             tele_vision (bool): [optional]  # noqa: E501
-            inter_net (bool): [optional]  # noqa: E501
         """
 
         self._data_store = {}

--- a/samples/client/petstore/python-experimental/petstore_api/models/parent.py
+++ b/samples/client/petstore/python-experimental/petstore_api/models/parent.py
@@ -84,8 +84,8 @@ class Parent(ModelComposed):
                 and the value is attribute type.
         """
         return {
-            'radio_waves': (bool,),  # noqa: E501
             'tele_vision': (bool,),  # noqa: E501
+            'radio_waves': (bool,),  # noqa: E501
         }
 
     @staticmethod
@@ -93,8 +93,8 @@ class Parent(ModelComposed):
         return None
 
     attribute_map = {
-        'radio_waves': 'radioWaves',  # noqa: E501
         'tele_vision': 'teleVision',  # noqa: E501
+        'radio_waves': 'radioWaves',  # noqa: E501
     }
 
     required_properties = set([
@@ -125,8 +125,8 @@ class Parent(ModelComposed):
                                 deserializing a file_type parameter.
                                 If passed, type conversion is attempted
                                 If omitted no type conversion is done.
-            radio_waves (bool): [optional]  # noqa: E501
             tele_vision (bool): [optional]  # noqa: E501
+            radio_waves (bool): [optional]  # noqa: E501
         """
 
         self._data_store = {}


### PR DESCRIPTION
We automatically flatten inline models in specs in allOf and other composed schemas into new different Schemas. All of our testing was not including that flattening.
This PR adds the function parseFlattenSpec which includes the flattening and uses it in all tests except for the inline model resolver tests.

This PR was extracted from work in: https://github.com/OpenAPITools/openapi-generator/pull/4906/files and is blocking that PR

### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [ ] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [X] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

Core Team Members
@wing328 (2015/07) 
@jimschubert (2016/05) 
@cbornet (2016/05)
@ackintosh (2018/02) 
@jmini (2018/04) 
@etherealjoy (2019/06)