### PR TITLE
Test Dart petstore client in CircleCI

### DIFF
--- a/CI/.drone.yml
+++ b/CI/.drone.yml
@@ -18,13 +18,14 @@ steps:
   image: haskell:8.6.5
   commands:
   - (cd samples/client/petstore/haskell-http-client/ && stack --install-ghc --no-haddock-deps haddock --fast && stack test --fast)
+# below dart tests moved to circle ci
 # test Dart 2.x petstore client
-- name: dart2x-test
-  image: google/dart
-  commands:
-  - (cd samples/client/petstore/dart-jaguar/openapi && pub get && pub run build_runner build --delete-conflicting-outputs)
-  - (cd samples/client/petstore/dart-jaguar/flutter_petstore/openapi && pub get && pub run build_runner build --delete-conflicting-outputs)
-  - (cd samples/client/petstore/dart2/petstore && pub get && pub run test)
+#- name: dart2x-test
+#  image: google/dart
+#  commands:
+#  - (cd samples/client/petstore/dart-jaguar/openapi && pub get && pub run build_runner build --delete-conflicting-outputs)
+#  - (cd samples/client/petstore/dart-jaguar/flutter_petstore/openapi && pub get && pub run build_runner build --delete-conflicting-outputs)
+#  - (cd samples/client/petstore/dart2/petstore && pub get && pub run test)
 # test Java 11 HTTP client
 - name: java11-test
   image: openjdk:11.0

--- a/CI/circle_parallel.sh
+++ b/CI/circle_parallel.sh
@@ -9,8 +9,16 @@ set -e
 
 if [ "$NODE_INDEX" = "1" ]; then
   echo "Running node $NODE_INDEX to test 'samples.circleci' defined in pom.xml ..."
-  #cp CI/pom.xml.circleci pom.xml
   java -version
+
+  # install dart2
+  sudo apt-get update
+  sudo apt-get install apt-transport-https
+  sudo sh -c 'wget -qO- https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -'
+  sudo sh -c 'wget -qO- https://storage.googleapis.com/download.dartlang.org/linux/debian/dart_stable.list > /etc/apt/sources.list.d/dart_stable.list'
+  sudo apt-get install dart
+  export PATH="$PATH:/usr/lib/dart/bin"
+
   mvn --quiet verify -Psamples.circleci -Dorg.slf4j.simpleLogger.defaultLogLevel=error
   mvn --quiet javadoc:javadoc -Psamples.circleci -Dorg.slf4j.simpleLogger.defaultLogLevel=error
 
@@ -46,13 +54,20 @@ elif [ "$NODE_INDEX" = "2" ]; then
   # install curl
   sudo apt-get -y build-dep libcurl4-gnutls-dev
   sudo apt-get -y install libcurl4-gnutls-dev
+
+  # install dart2
+  sudo apt-get install apt-transport-https
+  sudo sh -c 'wget -qO- https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -'
+  sudo sh -c 'wget -qO- https://storage.googleapis.com/download.dartlang.org/linux/debian/dart_stable.list > /etc/apt/sources.list.d/dart_stable.list'
+  sudo apt-get install dart
+  export PATH="$PATH:/usr/lib/dart/bin"
+
   # run integration tests
   mvn --quiet verify -Psamples.misc -Dorg.slf4j.simpleLogger.defaultLogLevel=error
 else
   echo "Running node $NODE_INDEX to test 'samples.circleci.jdk7' defined in pom.xml ..."
   sudo update-java-alternatives -s java-1.7.0-openjdk-amd64
   java -version
-  #cp CI/pom.xml.circleci.java7 pom.xml
   mvn --quiet verify -Psamples.circleci.jdk7 -Dorg.slf4j.simpleLogger.defaultLogLevel=error
 fi
 

--- a/CI/circle_parallel.sh
+++ b/CI/circle_parallel.sh
@@ -59,6 +59,7 @@ else
   sudo apt-get install apt-transport-https
   sudo sh -c 'wget -qO- https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -'
   sudo sh -c 'wget -qO- https://storage.googleapis.com/download.dartlang.org/linux/debian/dart_stable.list > /etc/apt/sources.list.d/dart_stable.list'
+  sudo apt-get update
   sudo apt-get install dart
   export PATH="$PATH:/usr/lib/dart/bin"
 

--- a/CI/circle_parallel.sh
+++ b/CI/circle_parallel.sh
@@ -55,6 +55,7 @@ else
   java -version
 
   # install dart2
+  sudo apt-get update
   sudo apt-get install apt-transport-https
   sudo sh -c 'wget -qO- https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -'
   sudo sh -c 'wget -qO- https://storage.googleapis.com/download.dartlang.org/linux/debian/dart_stable.list > /etc/apt/sources.list.d/dart_stable.list'

--- a/CI/circle_parallel.sh
+++ b/CI/circle_parallel.sh
@@ -11,14 +11,6 @@ if [ "$NODE_INDEX" = "1" ]; then
   echo "Running node $NODE_INDEX to test 'samples.circleci' defined in pom.xml ..."
   java -version
 
-  # install dart2
-  sudo apt-get update
-  sudo apt-get install apt-transport-https
-  sudo sh -c 'wget -qO- https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -'
-  sudo sh -c 'wget -qO- https://storage.googleapis.com/download.dartlang.org/linux/debian/dart_stable.list > /etc/apt/sources.list.d/dart_stable.list'
-  sudo apt-get install dart
-  export PATH="$PATH:/usr/lib/dart/bin"
-
   mvn --quiet verify -Psamples.circleci -Dorg.slf4j.simpleLogger.defaultLogLevel=error
   mvn --quiet javadoc:javadoc -Psamples.circleci -Dorg.slf4j.simpleLogger.defaultLogLevel=error
 
@@ -55,6 +47,13 @@ elif [ "$NODE_INDEX" = "2" ]; then
   sudo apt-get -y build-dep libcurl4-gnutls-dev
   sudo apt-get -y install libcurl4-gnutls-dev
 
+  # run integration tests
+  mvn --quiet verify -Psamples.misc -Dorg.slf4j.simpleLogger.defaultLogLevel=error
+else
+  echo "Running node $NODE_INDEX to test 'samples.circleci.jdk7' defined in pom.xml ..."
+  sudo update-java-alternatives -s java-1.7.0-openjdk-amd64
+  java -version
+
   # install dart2
   sudo apt-get install apt-transport-https
   sudo sh -c 'wget -qO- https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -'
@@ -62,12 +61,6 @@ elif [ "$NODE_INDEX" = "2" ]; then
   sudo apt-get install dart
   export PATH="$PATH:/usr/lib/dart/bin"
 
-  # run integration tests
-  mvn --quiet verify -Psamples.misc -Dorg.slf4j.simpleLogger.defaultLogLevel=error
-else
-  echo "Running node $NODE_INDEX to test 'samples.circleci.jdk7' defined in pom.xml ..."
-  sudo update-java-alternatives -s java-1.7.0-openjdk-amd64
-  java -version
   mvn --quiet verify -Psamples.circleci.jdk7 -Dorg.slf4j.simpleLogger.defaultLogLevel=error
 fi
 

--- a/pom.xml
+++ b/pom.xml
@@ -1384,6 +1384,9 @@
                 <module>samples/openapi3/client/petstore/ruby</module>
                 <!-- test java-related projects -->
                 <!--<module>samples/client/petstore/scala-akka</module>-->
+                <module>samples/client/petstore/dart2/petstore</module>
+                <module>samples/client/petstore/dart-jaguar/openapi</module>
+                <module>samples/client/petstore/dart-jaguar/flutter_petstore/openapi</module>
                 <module>samples/client/petstore/scala-httpclient</module>
                 <module>samples/client/petstore/scalaz</module>
                 <module>samples/client/petstore/java/feign</module>


### PR DESCRIPTION
Test dart petstore client in CircleCI instead (using local petstore server to avoid bad data in the public server)


<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

cc @ircecho (2017/07) @swipesight (2018/09) @jaumard (2018/09) @nickmeinhold (2019/09) @athornz (2019/12) @amondnet (2019/12)


