### PR TITLE
[rust][rust-server] Fix macOS Mojave+ builds by upgrading OpenSSL

### DIFF
--- a/modules/openapi-generator/src/main/resources/rust-server/Cargo.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/Cargo.mustache
@@ -17,7 +17,7 @@ conversion = ["frunk", "frunk_derives", "frunk_core", "frunk-enum-core", "frunk-
 # Common
 chrono = { version = "0.4", features = ["serde"] }
 futures = "0.1"
-swagger = "2.2"
+swagger = "4.4"
 lazy_static = "1.4"
 log = "0.3.0"
 mime = "0.2.6"
@@ -40,7 +40,7 @@ serde-xml-rs = {git = "git://github.com/Metaswitch/serde-xml-rs.git" , branch = 
 hyper = {version = "0.11", optional = true}
 hyper-tls = {version = "0.1.2", optional = true}
 native-tls = {version = "0.1.4", optional = true}
-openssl = {version = "0.9.14", optional = true}
+openssl = {version = "0.10.28", optional = true}
 serde_ignored = {version = "0.0.4", optional = true}
 tokio-core = {version = "0.1.6", optional = true}
 url = {version = "1.5", optional = true}

--- a/samples/server/petstore/rust-server/output/multipart-v3/Cargo.toml
+++ b/samples/server/petstore/rust-server/output/multipart-v3/Cargo.toml
@@ -15,7 +15,7 @@ conversion = ["frunk", "frunk_derives", "frunk_core", "frunk-enum-core", "frunk-
 # Common
 chrono = { version = "0.4", features = ["serde"] }
 futures = "0.1"
-swagger = "2.2"
+swagger = "4.4"
 lazy_static = "1.4"
 log = "0.3.0"
 mime = "0.2.6"
@@ -30,7 +30,7 @@ serde_json = "1.0"
 hyper = {version = "0.11", optional = true}
 hyper-tls = {version = "0.1.2", optional = true}
 native-tls = {version = "0.1.4", optional = true}
-openssl = {version = "0.9.14", optional = true}
+openssl = {version = "0.10.28", optional = true}
 serde_ignored = {version = "0.0.4", optional = true}
 tokio-core = {version = "0.1.6", optional = true}
 url = {version = "1.5", optional = true}

--- a/samples/server/petstore/rust-server/output/openapi-v3/Cargo.toml
+++ b/samples/server/petstore/rust-server/output/openapi-v3/Cargo.toml
@@ -15,7 +15,7 @@ conversion = ["frunk", "frunk_derives", "frunk_core", "frunk-enum-core", "frunk-
 # Common
 chrono = { version = "0.4", features = ["serde"] }
 futures = "0.1"
-swagger = "2.2"
+swagger = "4.4"
 lazy_static = "1.4"
 log = "0.3.0"
 mime = "0.2.6"
@@ -34,7 +34,7 @@ serde-xml-rs = {git = "git://github.com/Metaswitch/serde-xml-rs.git" , branch = 
 hyper = {version = "0.11", optional = true}
 hyper-tls = {version = "0.1.2", optional = true}
 native-tls = {version = "0.1.4", optional = true}
-openssl = {version = "0.9.14", optional = true}
+openssl = {version = "0.10.28", optional = true}
 serde_ignored = {version = "0.0.4", optional = true}
 tokio-core = {version = "0.1.6", optional = true}
 url = {version = "1.5", optional = true}

--- a/samples/server/petstore/rust-server/output/ops-v3/Cargo.toml
+++ b/samples/server/petstore/rust-server/output/ops-v3/Cargo.toml
@@ -15,7 +15,7 @@ conversion = ["frunk", "frunk_derives", "frunk_core", "frunk-enum-core", "frunk-
 # Common
 chrono = { version = "0.4", features = ["serde"] }
 futures = "0.1"
-swagger = "2.2"
+swagger = "4.4"
 lazy_static = "1.4"
 log = "0.3.0"
 mime = "0.2.6"
@@ -30,7 +30,7 @@ serde_json = "1.0"
 hyper = {version = "0.11", optional = true}
 hyper-tls = {version = "0.1.2", optional = true}
 native-tls = {version = "0.1.4", optional = true}
-openssl = {version = "0.9.14", optional = true}
+openssl = {version = "0.10.28", optional = true}
 serde_ignored = {version = "0.0.4", optional = true}
 tokio-core = {version = "0.1.6", optional = true}
 url = {version = "1.5", optional = true}

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/Cargo.toml
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/Cargo.toml
@@ -15,7 +15,7 @@ conversion = ["frunk", "frunk_derives", "frunk_core", "frunk-enum-core", "frunk-
 # Common
 chrono = { version = "0.4", features = ["serde"] }
 futures = "0.1"
-swagger = "2.2"
+swagger = "4.4"
 lazy_static = "1.4"
 log = "0.3.0"
 mime = "0.2.6"
@@ -34,7 +34,7 @@ serde-xml-rs = {git = "git://github.com/Metaswitch/serde-xml-rs.git" , branch = 
 hyper = {version = "0.11", optional = true}
 hyper-tls = {version = "0.1.2", optional = true}
 native-tls = {version = "0.1.4", optional = true}
-openssl = {version = "0.9.14", optional = true}
+openssl = {version = "0.10.28", optional = true}
 serde_ignored = {version = "0.0.4", optional = true}
 tokio-core = {version = "0.1.6", optional = true}
 url = {version = "1.5", optional = true}

--- a/samples/server/petstore/rust-server/output/rust-server-test/Cargo.toml
+++ b/samples/server/petstore/rust-server/output/rust-server-test/Cargo.toml
@@ -15,7 +15,7 @@ conversion = ["frunk", "frunk_derives", "frunk_core", "frunk-enum-core", "frunk-
 # Common
 chrono = { version = "0.4", features = ["serde"] }
 futures = "0.1"
-swagger = "2.2"
+swagger = "4.4"
 lazy_static = "1.4"
 log = "0.3.0"
 mime = "0.2.6"
@@ -30,7 +30,7 @@ serde_json = "1.0"
 hyper = {version = "0.11", optional = true}
 hyper-tls = {version = "0.1.2", optional = true}
 native-tls = {version = "0.1.4", optional = true}
-openssl = {version = "0.9.14", optional = true}
+openssl = {version = "0.10.28", optional = true}
 serde_ignored = {version = "0.0.4", optional = true}
 tokio-core = {version = "0.1.6", optional = true}
 url = {version = "1.5", optional = true}


### PR DESCRIPTION
Current builds fails on macOS because of a bug not yet fixed in the 0.9.28 openssl crate.
This PR upgrades the openssl crate, and the swagger crate that pulls in the openssl crate as well.

### PR checklist

- [x ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
