### PR TITLE
added named params to typescript-axios

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-axios/apiInner.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-axios/apiInner.mustache
@@ -317,8 +317,8 @@ export class {{classname}} extends BaseAPI {
      * @throws {RequiredError}
      * @memberof {{classname}}
      */
-    public {{nickname}}({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/allParams}}options?: any) {
-        return {{classname}}Fp(this.configuration).{{nickname}}({{#allParams}}{{paramName}}, {{/allParams}}options)(this.axios, this.basePath);
+    public {{nickname}}(params:{ {{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/allParams}}options?: any}) {
+        return {{classname}}Fp(this.configuration).{{nickname}}({{#allParams}}params.{{paramName}}, {{/allParams}}params.options)(this.axios, this.basePath);
     }
 
     {{/operation}}


### PR DESCRIPTION
This enables the use of an object as a parameter thus avoiding getting the parameters scrambled during a re-generation of the client.

Ref: https://github.com/OpenAPITools/openapi-generator/issues/5385

@TiFu @taxpon @sebastianhaas @kenisteward @Vrolijkx @macjohnny @nicokoenig @topce  @akehir @petejohansonxo  @amakhrov
