### PR TITLE
[markdown] Fix broken links when generating markdown

### DIFF
--- a/modules/openapi-generator/src/main/resources/markdown-documentation/README.mustache
+++ b/modules/openapi-generator/src/main/resources/markdown-documentation/README.mustache
@@ -17,7 +17,7 @@ Class | Method | HTTP request | Description
 ## Documentation for Models
 
 {{#modelPackage}}
-{{#models}}{{#model}} - [{{{modelPackage}}}.{{{classname}}}](Models/{{modelDocPath}}{{{classname}}}.md)
+{{#models}}{{#model}} - [{{{classname}}}](./{{{modelPackage}}}/{{modelDocPath}}{{{classname}}}.md)
 {{/model}}{{/models}}
 {{/modelPackage}}
 {{^modelPackage}}

--- a/modules/openapi-generator/src/main/resources/markdown-documentation/api.mustache
+++ b/modules/openapi-generator/src/main/resources/markdown-documentation/api.mustache
@@ -22,12 +22,12 @@ Method | HTTP request | Description
 {{^allParams}}This endpoint does not need any parameter.{{/allParams}}{{#allParams}}{{#-last}}
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------{{/-last}}{{/allParams}}
-{{#allParams}} **{{paramName}}** | {{#isPrimitiveType}}**{{dataType}}**{{/isPrimitiveType}}{{^isPrimitiveType}}{{#isFile}}**{{dataType}}**{{/isFile}}{{^isFile}}{{#generateModelDocs}}[**{{dataType}}**]({{modelPackage}}/{{baseType}}.md){{/generateModelDocs}}{{^generateModelDocs}}**{{dataType}}**{{/generateModelDocs}}{{/isFile}}{{/isPrimitiveType}}| {{description}} |{{^required}} [optional]{{/required}}{{#defaultValue}} [default to {{defaultValue}}]{{/defaultValue}}{{#allowableValues}} [enum: {{#values}}{{{.}}}{{^-last}}, {{/-last}}{{/values}}]{{/allowableValues}}
+{{#allParams}} **{{paramName}}** | {{#isPrimitiveType}}**{{dataType}}**{{/isPrimitiveType}}{{^isPrimitiveType}}{{#isFile}}**{{dataType}}**{{/isFile}}{{^isFile}}{{#generateModelDocs}}[**{{dataType}}**](../{{modelPackage}}/{{baseType}}.md){{/generateModelDocs}}{{^generateModelDocs}}**{{dataType}}**{{/generateModelDocs}}{{/isFile}}{{/isPrimitiveType}}| {{description}} |{{^required}} [optional]{{/required}}{{#defaultValue}} [default to {{defaultValue}}]{{/defaultValue}}{{#allowableValues}} [enum: {{#values}}{{{.}}}{{^-last}}, {{/-last}}{{/values}}]{{/allowableValues}}
 {{/allParams}}
 
 ### Return type
 
-{{#returnType}}{{#returnTypeIsPrimitive}}**{{returnType}}**{{/returnTypeIsPrimitive}}{{^returnTypeIsPrimitive}}{{#generateModelDocs}}[**{{returnType}}**]({{modelPackage}}/{{returnBaseType}}.md){{/generateModelDocs}}{{^generateModelDocs}}**{{returnType}}**{{/generateModelDocs}}{{/returnTypeIsPrimitive}}{{/returnType}}{{^returnType}}null (empty response body){{/returnType}}
+{{#returnType}}{{#returnTypeIsPrimitive}}**{{returnType}}**{{/returnTypeIsPrimitive}}{{^returnTypeIsPrimitive}}{{#generateModelDocs}}[**{{returnType}}**](../{{modelPackage}}/{{returnBaseType}}.md){{/generateModelDocs}}{{^generateModelDocs}}**{{returnType}}**{{/generateModelDocs}}{{/returnTypeIsPrimitive}}{{/returnType}}{{^returnType}}null (empty response body){{/returnType}}
 
 ### Authorization
 

--- a/modules/openapi-generator/src/main/resources/markdown-documentation/model.mustache
+++ b/modules/openapi-generator/src/main/resources/markdown-documentation/model.mustache
@@ -1,6 +1,6 @@
 {{#models}}
 {{#model}}
-# {{{packageName}}}.{{modelPackage}}.{{{classname}}}
+# {{{classname}}}
 ## Properties
 
 Name | Type | Description | Notes

--- a/samples/documentation/markdown/Apis/PetApi.md
+++ b/samples/documentation/markdown/Apis/PetApi.md
@@ -24,7 +24,7 @@ Add a new pet to the store
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **body** | [**Pet**](/Models/Pet.md)| Pet object that needs to be added to the store |
+ **body** | [**Pet**](..//Models/Pet.md)| Pet object that needs to be added to the store |
 
 ### Return type
 
@@ -77,11 +77,11 @@ Finds Pets by status
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **status** | [**List**](/Models/String.md)| Status values that need to be considered for filter | [default to null] [enum: available, pending, sold]
+ **status** | [**List**](..//Models/String.md)| Status values that need to be considered for filter | [default to null] [enum: available, pending, sold]
 
 ### Return type
 
-[**List**](/Models/Pet.md)
+[**List**](..//Models/Pet.md)
 
 ### Authorization
 
@@ -104,11 +104,11 @@ Finds Pets by tags
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **tags** | [**List**](/Models/String.md)| Tags to filter by | [default to null]
+ **tags** | [**List**](..//Models/String.md)| Tags to filter by | [default to null]
 
 ### Return type
 
-[**List**](/Models/Pet.md)
+[**List**](..//Models/Pet.md)
 
 ### Authorization
 
@@ -135,7 +135,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-[**Pet**](/Models/Pet.md)
+[**Pet**](..//Models/Pet.md)
 
 ### Authorization
 
@@ -156,7 +156,7 @@ Update an existing pet
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **body** | [**Pet**](/Models/Pet.md)| Pet object that needs to be added to the store |
+ **body** | [**Pet**](..//Models/Pet.md)| Pet object that needs to be added to the store |
 
 ### Return type
 
@@ -214,7 +214,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-[**ApiResponse**](/Models/ApiResponse.md)
+[**ApiResponse**](..//Models/ApiResponse.md)
 
 ### Authorization
 

--- a/samples/documentation/markdown/Models/ApiResponse.md
+++ b/samples/documentation/markdown/Models/ApiResponse.md
@@ -1,4 +1,4 @@
-# ./Models.ApiResponse
+# ApiResponse
 ## Properties
 
 Name | Type | Description | Notes

--- a/samples/documentation/markdown/Models/Category.md
+++ b/samples/documentation/markdown/Models/Category.md
@@ -1,4 +1,4 @@
-# ./Models.Category
+# Category
 ## Properties
 
 Name | Type | Description | Notes

--- a/samples/documentation/markdown/Models/Order.md
+++ b/samples/documentation/markdown/Models/Order.md
@@ -1,4 +1,4 @@
-# ./Models.Order
+# Order
 ## Properties
 
 Name | Type | Description | Notes

--- a/samples/documentation/markdown/Models/Pet.md
+++ b/samples/documentation/markdown/Models/Pet.md
@@ -1,4 +1,4 @@
-# ./Models.Pet
+# Pet
 ## Properties
 
 Name | Type | Description | Notes

--- a/samples/documentation/markdown/Models/Tag.md
+++ b/samples/documentation/markdown/Models/Tag.md
@@ -1,4 +1,4 @@
-# ./Models.Tag
+# Tag
 ## Properties
 
 Name | Type | Description | Notes

--- a/samples/documentation/markdown/Models/User.md
+++ b/samples/documentation/markdown/Models/User.md
@@ -1,4 +1,4 @@
-# ./Models.User
+# User
 ## Properties
 
 Name | Type | Description | Notes

--- a/samples/documentation/markdown/README.md
+++ b/samples/documentation/markdown/README.md
@@ -32,12 +32,12 @@ Class | Method | HTTP request | Description
 <a name="documentation-for-models"></a>
 ## Documentation for Models
 
- - [/Models.ApiResponse](Models/ApiResponse.md)
- - [/Models.Category](Models/Category.md)
- - [/Models.Order](Models/Order.md)
- - [/Models.Pet](Models/Pet.md)
- - [/Models.Tag](Models/Tag.md)
- - [/Models.User](Models/User.md)
+ - [ApiResponse](.//Models/ApiResponse.md)
+ - [Category](.//Models/Category.md)
+ - [Order](.//Models/Order.md)
+ - [Pet](.//Models/Pet.md)
+ - [Tag](.//Models/Tag.md)
+ - [User](.//Models/User.md)
 
 
 <a name="documentation-for-authorization"></a>


### PR DESCRIPTION
The `api.mustache` file generates links to the markdown model files.
These links were previously brokeen.

Additionally, the defaultPackage for markdown is "/Models", so this
looked pretty in the heading for model files. So this prefix has been
stripped from the header in `model.mustache`.

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
