### PR TITLE
[jaxrs-cxf-cdi] Support PATCH httpMethod

### DIFF
--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf-cdi/api.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf-cdi/api.mustache
@@ -14,6 +14,7 @@ import javax.inject.Inject;
 import io.swagger.annotations.*;
 import java.io.InputStream;
 
+import org.apache.cxf.jaxrs.ext.PATCH;
 import org.apache.cxf.jaxrs.ext.multipart.Attachment;
 import org.apache.cxf.jaxrs.ext.multipart.Multipart;
 

--- a/samples/server/petstore/jaxrs-cxf-cdi/pom.xml
+++ b/samples/server/petstore/jaxrs-cxf-cdi/pom.xml
@@ -58,8 +58,8 @@
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-frontend-jaxrs</artifactId>
             <!-- Version is just a guess -->
-            <!-- IBM WebSphere Application Server Liberty Core v8.5.5.6 uses v3.0.2, source https://www.ibm.com/support/knowledgecenter/SSD28V_8.5.5/com.ibm.websphere.wlp.core.doc/ae/rwlp_jaxrs_secure.html -->
-            <version>3.0.2</version>
+            <!-- Require at lease CXF 3.1.2 since HTTP PATCH support was added on this version -->
+            <version>3.1.2</version>
             <scope>provided</scope>
         </dependency>
 

--- a/samples/server/petstore/jaxrs-cxf-cdi/src/gen/java/org/openapitools/api/PetApi.java
+++ b/samples/server/petstore/jaxrs-cxf-cdi/src/gen/java/org/openapitools/api/PetApi.java
@@ -15,6 +15,7 @@ import javax.inject.Inject;
 import io.swagger.annotations.*;
 import java.io.InputStream;
 
+import org.apache.cxf.jaxrs.ext.PATCH;
 import org.apache.cxf.jaxrs.ext.multipart.Attachment;
 import org.apache.cxf.jaxrs.ext.multipart.Multipart;
 

--- a/samples/server/petstore/jaxrs-cxf-cdi/src/gen/java/org/openapitools/api/StoreApi.java
+++ b/samples/server/petstore/jaxrs-cxf-cdi/src/gen/java/org/openapitools/api/StoreApi.java
@@ -14,6 +14,7 @@ import javax.inject.Inject;
 import io.swagger.annotations.*;
 import java.io.InputStream;
 
+import org.apache.cxf.jaxrs.ext.PATCH;
 import org.apache.cxf.jaxrs.ext.multipart.Attachment;
 import org.apache.cxf.jaxrs.ext.multipart.Multipart;
 

--- a/samples/server/petstore/jaxrs-cxf-cdi/src/gen/java/org/openapitools/api/UserApi.java
+++ b/samples/server/petstore/jaxrs-cxf-cdi/src/gen/java/org/openapitools/api/UserApi.java
@@ -14,6 +14,7 @@ import javax.inject.Inject;
 import io.swagger.annotations.*;
 import java.io.InputStream;
 
+import org.apache.cxf.jaxrs.ext.PATCH;
 import org.apache.cxf.jaxrs.ext.multipart.Attachment;
 import org.apache.cxf.jaxrs.ext.multipart.Multipart;
 


### PR DESCRIPTION
Add the cxf PATCH annotation to the imports so that the generated code
when defining a PATCH api compiles.

When using "patch" as verb in an openapi specification and the jaxrs-cxf-cdi generator, the generated code do not compile, as it is missing the PATCH annotation that is provided by cxf.
I added the required import, and now the generated code compiles and works fine.

### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [X] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [X] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04) @lwlee2608 (2019/10) @bkabrda (2020/01)