### PR TITLE
[swift5] stop hiding network error

### DIFF
--- a/modules/openapi-generator/src/main/resources/swift5/Models.mustache
+++ b/modules/openapi-generator/src/main/resources/swift5/Models.mustache
@@ -25,7 +25,7 @@ protocol JSONEncodable {
 {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} enum DecodableRequestBuilderError: Error {
     case emptyDataResponse
     case nilHTTPResponse
-    case unsuccessfulHTTPStatusCode(Error?)
+    case unsuccessfulHTTPStatusCode
     case jsonDecoding(DecodingError)
     case generalError(Error)
 }

--- a/modules/openapi-generator/src/main/resources/swift5/libraries/urlsession/URLSessionImplementations.mustache
+++ b/modules/openapi-generator/src/main/resources/swift5/libraries/urlsession/URLSessionImplementations.mustache
@@ -182,18 +182,18 @@ private var urlSessionStore = SynchronizedDictionary<String, URLSession>()
     
     fileprivate func processRequestResponse(urlRequest: URLRequest, data: Data?, response: URLResponse?, error: Error?, completion: @escaping (_ result: Result<Response<T>, Error>) -> Void) {
 
+        if let error = error {
+            completion(.failure(ErrorResponse.error(-1, data, error)))
+            return
+        }
+
         guard let httpResponse = response as? HTTPURLResponse else {
             completion(.failure(ErrorResponse.error(-2, nil, DecodableRequestBuilderError.nilHTTPResponse)))
             return
         }
 
         guard httpResponse.isStatusCodeSuccessful else {
-            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, DecodableRequestBuilderError.unsuccessfulHTTPStatusCode(error))))
-            return
-        }
-
-        if let error = error {
-            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, error)))
+            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, DecodableRequestBuilderError.unsuccessfulHTTPStatusCode)))
             return
         }
 
@@ -314,18 +314,18 @@ private var urlSessionStore = SynchronizedDictionary<String, URLSession>()
 {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}open{{/nonPublicApi}} class URLSessionDecodableRequestBuilder<T:Decodable>: URLSessionRequestBuilder<T> {
     override fileprivate func processRequestResponse(urlRequest: URLRequest, data: Data?, response: URLResponse?, error: Error?, completion: @escaping (_ result: Result<Response<T>, Error>) -> Void) {
 
+        if let error = error {
+            completion(.failure(ErrorResponse.error(-1, data, error)))
+            return
+        }
+
         guard let httpResponse = response as? HTTPURLResponse else {
             completion(.failure(ErrorResponse.error(-2, nil, DecodableRequestBuilderError.nilHTTPResponse)))
             return
         }
 
         guard httpResponse.isStatusCodeSuccessful else {
-            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, DecodableRequestBuilderError.unsuccessfulHTTPStatusCode(error))))
-            return
-        }
-
-        if let error = error {
-            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, error)))
+            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, DecodableRequestBuilderError.unsuccessfulHTTPStatusCode)))
             return
         }
 

--- a/modules/openapi-generator/src/main/resources/swift5/libraries/urlsession/URLSessionImplementations.mustache
+++ b/modules/openapi-generator/src/main/resources/swift5/libraries/urlsession/URLSessionImplementations.mustache
@@ -188,7 +188,7 @@ private var urlSessionStore = SynchronizedDictionary<String, URLSession>()
         }
 
         guard let httpResponse = response as? HTTPURLResponse else {
-            completion(.failure(ErrorResponse.error(-2, nil, DecodableRequestBuilderError.nilHTTPResponse)))
+            completion(.failure(ErrorResponse.error(-2, data, DecodableRequestBuilderError.nilHTTPResponse)))
             return
         }
 
@@ -320,7 +320,7 @@ private var urlSessionStore = SynchronizedDictionary<String, URLSession>()
         }
 
         guard let httpResponse = response as? HTTPURLResponse else {
-            completion(.failure(ErrorResponse.error(-2, nil, DecodableRequestBuilderError.nilHTTPResponse)))
+            completion(.failure(ErrorResponse.error(-2, data, DecodableRequestBuilderError.nilHTTPResponse)))
             return
         }
 

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models.swift
@@ -25,7 +25,7 @@ public enum DownloadException: Error {
 public enum DecodableRequestBuilderError: Error {
     case emptyDataResponse
     case nilHTTPResponse
-    case unsuccessfulHTTPStatusCode(Error?)
+    case unsuccessfulHTTPStatusCode
     case jsonDecoding(DecodingError)
     case generalError(Error)
 }

--- a/samples/client/petstore/swift5/alamofireLibrary/SwaggerClientTests/SwaggerClientTests/FileUtils.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/SwaggerClientTests/SwaggerClientTests/FileUtils.swift
@@ -13,21 +13,21 @@ class FileUtils {
         guard let documentsDirectory = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first else {
             return nil
         }
-        
+
         let fileName = imageName
         let fileURL = documentsDirectory.appendingPathComponent(fileName)
         guard let data = image.jpegData(compressionQuality: 1) else { return nil }
-        
+
         //Checks if file exists, removes it if so.
         deleteFile(fileURL: fileURL)
-        
+
         do {
             try data.write(to: fileURL)
         } catch let error {
             print("error saving file with error", error)
             return nil
         }
-        
+
         return fileURL
     }
 
@@ -45,5 +45,5 @@ class FileUtils {
         }
         return false
     }
-    
+
 }

--- a/samples/client/petstore/swift5/alamofireLibrary/SwaggerClientTests/SwaggerClientTests/PetAPITests.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/SwaggerClientTests/SwaggerClientTests/PetAPITests.swift
@@ -61,7 +61,7 @@ class PetAPITests: XCTestCase {
 
         self.waitForExpectations(timeout: testTimeout, handler: nil)
     }
-    
+
     func test3UploadFile() {
         let expectation = self.expectation(description: "testUploadFile")
 
@@ -87,7 +87,6 @@ class PetAPITests: XCTestCase {
 
         self.waitForExpectations(timeout: testTimeout, handler: nil)
     }
-
 
     func test4DeletePet() {
         let expectation = self.expectation(description: "testDeletePet")

--- a/samples/client/petstore/swift5/alamofireLibrary/SwaggerClientTests/SwaggerClientTests/UIImage+Extras.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/SwaggerClientTests/SwaggerClientTests/UIImage+Extras.swift
@@ -16,8 +16,8 @@ extension UIImage {
         UIRectFill(rect)
         let image = UIGraphicsGetImageFromCurrentImageContext()
         UIGraphicsEndImageContext()
-        
+
         guard let cgImage = image?.cgImage else { return nil }
         self.init(cgImage: cgImage)
-    }    
+    }
 }

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models.swift
@@ -25,7 +25,7 @@ public enum DownloadException: Error {
 public enum DecodableRequestBuilderError: Error {
     case emptyDataResponse
     case nilHTTPResponse
-    case unsuccessfulHTTPStatusCode(Error?)
+    case unsuccessfulHTTPStatusCode
     case jsonDecoding(DecodingError)
     case generalError(Error)
 }

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
@@ -188,7 +188,7 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T> {
         }
 
         guard let httpResponse = response as? HTTPURLResponse else {
-            completion(.failure(ErrorResponse.error(-2, nil, DecodableRequestBuilderError.nilHTTPResponse)))
+            completion(.failure(ErrorResponse.error(-2, data, DecodableRequestBuilderError.nilHTTPResponse)))
             return
         }
 
@@ -320,7 +320,7 @@ open class URLSessionDecodableRequestBuilder<T: Decodable>: URLSessionRequestBui
         }
 
         guard let httpResponse = response as? HTTPURLResponse else {
-            completion(.failure(ErrorResponse.error(-2, nil, DecodableRequestBuilderError.nilHTTPResponse)))
+            completion(.failure(ErrorResponse.error(-2, data, DecodableRequestBuilderError.nilHTTPResponse)))
             return
         }
 

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
@@ -182,18 +182,18 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T> {
 
     fileprivate func processRequestResponse(urlRequest: URLRequest, data: Data?, response: URLResponse?, error: Error?, completion: @escaping (_ result: Result<Response<T>, Error>) -> Void) {
 
+        if let error = error {
+            completion(.failure(ErrorResponse.error(-1, data, error)))
+            return
+        }
+
         guard let httpResponse = response as? HTTPURLResponse else {
             completion(.failure(ErrorResponse.error(-2, nil, DecodableRequestBuilderError.nilHTTPResponse)))
             return
         }
 
         guard httpResponse.isStatusCodeSuccessful else {
-            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, DecodableRequestBuilderError.unsuccessfulHTTPStatusCode(error))))
-            return
-        }
-
-        if let error = error {
-            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, error)))
+            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, DecodableRequestBuilderError.unsuccessfulHTTPStatusCode)))
             return
         }
 
@@ -314,18 +314,18 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T> {
 open class URLSessionDecodableRequestBuilder<T: Decodable>: URLSessionRequestBuilder<T> {
     override fileprivate func processRequestResponse(urlRequest: URLRequest, data: Data?, response: URLResponse?, error: Error?, completion: @escaping (_ result: Result<Response<T>, Error>) -> Void) {
 
+        if let error = error {
+            completion(.failure(ErrorResponse.error(-1, data, error)))
+            return
+        }
+
         guard let httpResponse = response as? HTTPURLResponse else {
             completion(.failure(ErrorResponse.error(-2, nil, DecodableRequestBuilderError.nilHTTPResponse)))
             return
         }
 
         guard httpResponse.isStatusCodeSuccessful else {
-            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, DecodableRequestBuilderError.unsuccessfulHTTPStatusCode(error))))
-            return
-        }
-
-        if let error = error {
-            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, error)))
+            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, DecodableRequestBuilderError.unsuccessfulHTTPStatusCode)))
             return
         }
 

--- a/samples/client/petstore/swift5/combineLibrary/SwaggerClientTests/SwaggerClientTests/FileUtils.swift
+++ b/samples/client/petstore/swift5/combineLibrary/SwaggerClientTests/SwaggerClientTests/FileUtils.swift
@@ -13,21 +13,21 @@ class FileUtils {
         guard let documentsDirectory = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first else {
             return nil
         }
-        
+
         let fileName = imageName
         let fileURL = documentsDirectory.appendingPathComponent(fileName)
         guard let data = image.jpegData(compressionQuality: 1) else { return nil }
-        
+
         //Checks if file exists, removes it if so.
         deleteFile(fileURL: fileURL)
-        
+
         do {
             try data.write(to: fileURL)
         } catch let error {
             print("error saving file with error", error)
             return nil
         }
-        
+
         return fileURL
     }
 
@@ -45,5 +45,5 @@ class FileUtils {
         }
         return false
     }
-    
+
 }

--- a/samples/client/petstore/swift5/combineLibrary/SwaggerClientTests/SwaggerClientTests/UIImage+Extras.swift
+++ b/samples/client/petstore/swift5/combineLibrary/SwaggerClientTests/SwaggerClientTests/UIImage+Extras.swift
@@ -16,8 +16,8 @@ extension UIImage {
         UIRectFill(rect)
         let image = UIGraphicsGetImageFromCurrentImageContext()
         UIGraphicsEndImageContext()
-        
+
         guard let cgImage = image?.cgImage else { return nil }
         self.init(cgImage: cgImage)
-    }    
+    }
 }

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models.swift
@@ -25,7 +25,7 @@ public enum DownloadException: Error {
 public enum DecodableRequestBuilderError: Error {
     case emptyDataResponse
     case nilHTTPResponse
-    case unsuccessfulHTTPStatusCode(Error?)
+    case unsuccessfulHTTPStatusCode
     case jsonDecoding(DecodingError)
     case generalError(Error)
 }

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
@@ -188,7 +188,7 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T> {
         }
 
         guard let httpResponse = response as? HTTPURLResponse else {
-            completion(.failure(ErrorResponse.error(-2, nil, DecodableRequestBuilderError.nilHTTPResponse)))
+            completion(.failure(ErrorResponse.error(-2, data, DecodableRequestBuilderError.nilHTTPResponse)))
             return
         }
 
@@ -320,7 +320,7 @@ open class URLSessionDecodableRequestBuilder<T: Decodable>: URLSessionRequestBui
         }
 
         guard let httpResponse = response as? HTTPURLResponse else {
-            completion(.failure(ErrorResponse.error(-2, nil, DecodableRequestBuilderError.nilHTTPResponse)))
+            completion(.failure(ErrorResponse.error(-2, data, DecodableRequestBuilderError.nilHTTPResponse)))
             return
         }
 

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
@@ -182,18 +182,18 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T> {
 
     fileprivate func processRequestResponse(urlRequest: URLRequest, data: Data?, response: URLResponse?, error: Error?, completion: @escaping (_ result: Result<Response<T>, Error>) -> Void) {
 
+        if let error = error {
+            completion(.failure(ErrorResponse.error(-1, data, error)))
+            return
+        }
+
         guard let httpResponse = response as? HTTPURLResponse else {
             completion(.failure(ErrorResponse.error(-2, nil, DecodableRequestBuilderError.nilHTTPResponse)))
             return
         }
 
         guard httpResponse.isStatusCodeSuccessful else {
-            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, DecodableRequestBuilderError.unsuccessfulHTTPStatusCode(error))))
-            return
-        }
-
-        if let error = error {
-            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, error)))
+            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, DecodableRequestBuilderError.unsuccessfulHTTPStatusCode)))
             return
         }
 
@@ -314,18 +314,18 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T> {
 open class URLSessionDecodableRequestBuilder<T: Decodable>: URLSessionRequestBuilder<T> {
     override fileprivate func processRequestResponse(urlRequest: URLRequest, data: Data?, response: URLResponse?, error: Error?, completion: @escaping (_ result: Result<Response<T>, Error>) -> Void) {
 
+        if let error = error {
+            completion(.failure(ErrorResponse.error(-1, data, error)))
+            return
+        }
+
         guard let httpResponse = response as? HTTPURLResponse else {
             completion(.failure(ErrorResponse.error(-2, nil, DecodableRequestBuilderError.nilHTTPResponse)))
             return
         }
 
         guard httpResponse.isStatusCodeSuccessful else {
-            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, DecodableRequestBuilderError.unsuccessfulHTTPStatusCode(error))))
-            return
-        }
-
-        if let error = error {
-            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, error)))
+            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, DecodableRequestBuilderError.unsuccessfulHTTPStatusCode)))
             return
         }
 

--- a/samples/client/petstore/swift5/default/SwaggerClientTests/SwaggerClientTests/FileUtils.swift
+++ b/samples/client/petstore/swift5/default/SwaggerClientTests/SwaggerClientTests/FileUtils.swift
@@ -13,21 +13,21 @@ class FileUtils {
         guard let documentsDirectory = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first else {
             return nil
         }
-        
+
         let fileName = imageName
         let fileURL = documentsDirectory.appendingPathComponent(fileName)
         guard let data = image.jpegData(compressionQuality: 1) else { return nil }
-        
+
         //Checks if file exists, removes it if so.
         deleteFile(fileURL: fileURL)
-        
+
         do {
             try data.write(to: fileURL)
         } catch let error {
             print("error saving file with error", error)
             return nil
         }
-        
+
         return fileURL
     }
 
@@ -45,5 +45,5 @@ class FileUtils {
         }
         return false
     }
-    
+
 }

--- a/samples/client/petstore/swift5/default/SwaggerClientTests/SwaggerClientTests/UIImage+Extras.swift
+++ b/samples/client/petstore/swift5/default/SwaggerClientTests/SwaggerClientTests/UIImage+Extras.swift
@@ -16,8 +16,8 @@ extension UIImage {
         UIRectFill(rect)
         let image = UIGraphicsGetImageFromCurrentImageContext()
         UIGraphicsEndImageContext()
-        
+
         guard let cgImage = image?.cgImage else { return nil }
         self.init(cgImage: cgImage)
-    }    
+    }
 }

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models.swift
@@ -25,7 +25,7 @@ internal enum DownloadException: Error {
 internal enum DecodableRequestBuilderError: Error {
     case emptyDataResponse
     case nilHTTPResponse
-    case unsuccessfulHTTPStatusCode(Error?)
+    case unsuccessfulHTTPStatusCode
     case jsonDecoding(DecodingError)
     case generalError(Error)
 }

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
@@ -182,18 +182,18 @@ internal class URLSessionRequestBuilder<T>: RequestBuilder<T> {
 
     fileprivate func processRequestResponse(urlRequest: URLRequest, data: Data?, response: URLResponse?, error: Error?, completion: @escaping (_ result: Result<Response<T>, Error>) -> Void) {
 
+        if let error = error {
+            completion(.failure(ErrorResponse.error(-1, data, error)))
+            return
+        }
+
         guard let httpResponse = response as? HTTPURLResponse else {
             completion(.failure(ErrorResponse.error(-2, nil, DecodableRequestBuilderError.nilHTTPResponse)))
             return
         }
 
         guard httpResponse.isStatusCodeSuccessful else {
-            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, DecodableRequestBuilderError.unsuccessfulHTTPStatusCode(error))))
-            return
-        }
-
-        if let error = error {
-            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, error)))
+            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, DecodableRequestBuilderError.unsuccessfulHTTPStatusCode)))
             return
         }
 
@@ -314,18 +314,18 @@ internal class URLSessionRequestBuilder<T>: RequestBuilder<T> {
 internal class URLSessionDecodableRequestBuilder<T: Decodable>: URLSessionRequestBuilder<T> {
     override fileprivate func processRequestResponse(urlRequest: URLRequest, data: Data?, response: URLResponse?, error: Error?, completion: @escaping (_ result: Result<Response<T>, Error>) -> Void) {
 
+        if let error = error {
+            completion(.failure(ErrorResponse.error(-1, data, error)))
+            return
+        }
+
         guard let httpResponse = response as? HTTPURLResponse else {
             completion(.failure(ErrorResponse.error(-2, nil, DecodableRequestBuilderError.nilHTTPResponse)))
             return
         }
 
         guard httpResponse.isStatusCodeSuccessful else {
-            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, DecodableRequestBuilderError.unsuccessfulHTTPStatusCode(error))))
-            return
-        }
-
-        if let error = error {
-            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, error)))
+            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, DecodableRequestBuilderError.unsuccessfulHTTPStatusCode)))
             return
         }
 

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
@@ -188,7 +188,7 @@ internal class URLSessionRequestBuilder<T>: RequestBuilder<T> {
         }
 
         guard let httpResponse = response as? HTTPURLResponse else {
-            completion(.failure(ErrorResponse.error(-2, nil, DecodableRequestBuilderError.nilHTTPResponse)))
+            completion(.failure(ErrorResponse.error(-2, data, DecodableRequestBuilderError.nilHTTPResponse)))
             return
         }
 
@@ -320,7 +320,7 @@ internal class URLSessionDecodableRequestBuilder<T: Decodable>: URLSessionReques
         }
 
         guard let httpResponse = response as? HTTPURLResponse else {
-            completion(.failure(ErrorResponse.error(-2, nil, DecodableRequestBuilderError.nilHTTPResponse)))
+            completion(.failure(ErrorResponse.error(-2, data, DecodableRequestBuilderError.nilHTTPResponse)))
             return
         }
 

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models.swift
@@ -25,7 +25,7 @@ public enum DownloadException: Error {
 public enum DecodableRequestBuilderError: Error {
     case emptyDataResponse
     case nilHTTPResponse
-    case unsuccessfulHTTPStatusCode(Error?)
+    case unsuccessfulHTTPStatusCode
     case jsonDecoding(DecodingError)
     case generalError(Error)
 }

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
@@ -188,7 +188,7 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T> {
         }
 
         guard let httpResponse = response as? HTTPURLResponse else {
-            completion(.failure(ErrorResponse.error(-2, nil, DecodableRequestBuilderError.nilHTTPResponse)))
+            completion(.failure(ErrorResponse.error(-2, data, DecodableRequestBuilderError.nilHTTPResponse)))
             return
         }
 
@@ -320,7 +320,7 @@ open class URLSessionDecodableRequestBuilder<T: Decodable>: URLSessionRequestBui
         }
 
         guard let httpResponse = response as? HTTPURLResponse else {
-            completion(.failure(ErrorResponse.error(-2, nil, DecodableRequestBuilderError.nilHTTPResponse)))
+            completion(.failure(ErrorResponse.error(-2, data, DecodableRequestBuilderError.nilHTTPResponse)))
             return
         }
 

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
@@ -182,18 +182,18 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T> {
 
     fileprivate func processRequestResponse(urlRequest: URLRequest, data: Data?, response: URLResponse?, error: Error?, completion: @escaping (_ result: Result<Response<T>, Error>) -> Void) {
 
+        if let error = error {
+            completion(.failure(ErrorResponse.error(-1, data, error)))
+            return
+        }
+
         guard let httpResponse = response as? HTTPURLResponse else {
             completion(.failure(ErrorResponse.error(-2, nil, DecodableRequestBuilderError.nilHTTPResponse)))
             return
         }
 
         guard httpResponse.isStatusCodeSuccessful else {
-            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, DecodableRequestBuilderError.unsuccessfulHTTPStatusCode(error))))
-            return
-        }
-
-        if let error = error {
-            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, error)))
+            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, DecodableRequestBuilderError.unsuccessfulHTTPStatusCode)))
             return
         }
 
@@ -314,18 +314,18 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T> {
 open class URLSessionDecodableRequestBuilder<T: Decodable>: URLSessionRequestBuilder<T> {
     override fileprivate func processRequestResponse(urlRequest: URLRequest, data: Data?, response: URLResponse?, error: Error?, completion: @escaping (_ result: Result<Response<T>, Error>) -> Void) {
 
+        if let error = error {
+            completion(.failure(ErrorResponse.error(-1, data, error)))
+            return
+        }
+
         guard let httpResponse = response as? HTTPURLResponse else {
             completion(.failure(ErrorResponse.error(-2, nil, DecodableRequestBuilderError.nilHTTPResponse)))
             return
         }
 
         guard httpResponse.isStatusCodeSuccessful else {
-            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, DecodableRequestBuilderError.unsuccessfulHTTPStatusCode(error))))
-            return
-        }
-
-        if let error = error {
-            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, error)))
+            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, DecodableRequestBuilderError.unsuccessfulHTTPStatusCode)))
             return
         }
 

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models.swift
@@ -25,7 +25,7 @@ public enum DownloadException: Error {
 public enum DecodableRequestBuilderError: Error {
     case emptyDataResponse
     case nilHTTPResponse
-    case unsuccessfulHTTPStatusCode(Error?)
+    case unsuccessfulHTTPStatusCode
     case jsonDecoding(DecodingError)
     case generalError(Error)
 }

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
@@ -188,7 +188,7 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T> {
         }
 
         guard let httpResponse = response as? HTTPURLResponse else {
-            completion(.failure(ErrorResponse.error(-2, nil, DecodableRequestBuilderError.nilHTTPResponse)))
+            completion(.failure(ErrorResponse.error(-2, data, DecodableRequestBuilderError.nilHTTPResponse)))
             return
         }
 
@@ -320,7 +320,7 @@ open class URLSessionDecodableRequestBuilder<T: Decodable>: URLSessionRequestBui
         }
 
         guard let httpResponse = response as? HTTPURLResponse else {
-            completion(.failure(ErrorResponse.error(-2, nil, DecodableRequestBuilderError.nilHTTPResponse)))
+            completion(.failure(ErrorResponse.error(-2, data, DecodableRequestBuilderError.nilHTTPResponse)))
             return
         }
 

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
@@ -182,18 +182,18 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T> {
 
     fileprivate func processRequestResponse(urlRequest: URLRequest, data: Data?, response: URLResponse?, error: Error?, completion: @escaping (_ result: Result<Response<T>, Error>) -> Void) {
 
+        if let error = error {
+            completion(.failure(ErrorResponse.error(-1, data, error)))
+            return
+        }
+
         guard let httpResponse = response as? HTTPURLResponse else {
             completion(.failure(ErrorResponse.error(-2, nil, DecodableRequestBuilderError.nilHTTPResponse)))
             return
         }
 
         guard httpResponse.isStatusCodeSuccessful else {
-            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, DecodableRequestBuilderError.unsuccessfulHTTPStatusCode(error))))
-            return
-        }
-
-        if let error = error {
-            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, error)))
+            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, DecodableRequestBuilderError.unsuccessfulHTTPStatusCode)))
             return
         }
 
@@ -314,18 +314,18 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T> {
 open class URLSessionDecodableRequestBuilder<T: Decodable>: URLSessionRequestBuilder<T> {
     override fileprivate func processRequestResponse(urlRequest: URLRequest, data: Data?, response: URLResponse?, error: Error?, completion: @escaping (_ result: Result<Response<T>, Error>) -> Void) {
 
+        if let error = error {
+            completion(.failure(ErrorResponse.error(-1, data, error)))
+            return
+        }
+
         guard let httpResponse = response as? HTTPURLResponse else {
             completion(.failure(ErrorResponse.error(-2, nil, DecodableRequestBuilderError.nilHTTPResponse)))
             return
         }
 
         guard httpResponse.isStatusCodeSuccessful else {
-            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, DecodableRequestBuilderError.unsuccessfulHTTPStatusCode(error))))
-            return
-        }
-
-        if let error = error {
-            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, error)))
+            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, DecodableRequestBuilderError.unsuccessfulHTTPStatusCode)))
             return
         }
 

--- a/samples/client/petstore/swift5/promisekitLibrary/SwaggerClientTests/SwaggerClientTests/FileUtils.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/SwaggerClientTests/SwaggerClientTests/FileUtils.swift
@@ -13,21 +13,21 @@ class FileUtils {
         guard let documentsDirectory = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first else {
             return nil
         }
-        
+
         let fileName = imageName
         let fileURL = documentsDirectory.appendingPathComponent(fileName)
         guard let data = image.jpegData(compressionQuality: 1) else { return nil }
-        
+
         //Checks if file exists, removes it if so.
         deleteFile(fileURL: fileURL)
-        
+
         do {
             try data.write(to: fileURL)
         } catch let error {
             print("error saving file with error", error)
             return nil
         }
-        
+
         return fileURL
     }
 
@@ -45,5 +45,5 @@ class FileUtils {
         }
         return false
     }
-    
+
 }

--- a/samples/client/petstore/swift5/promisekitLibrary/SwaggerClientTests/SwaggerClientTests/PetAPITests.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/SwaggerClientTests/SwaggerClientTests/PetAPITests.swift
@@ -50,7 +50,7 @@ class PetAPITests: XCTestCase {
         }
         self.waitForExpectations(timeout: testTimeout, handler: nil)
     }
-    
+
     func test3UploadFile() {
         let expectation = self.expectation(description: "testUploadFile")
 
@@ -73,7 +73,6 @@ class PetAPITests: XCTestCase {
 
         self.waitForExpectations(timeout: testTimeout, handler: nil)
     }
-
 
     func test4DeletePet() {
         let expectation = self.expectation(description: "testDeletePet")

--- a/samples/client/petstore/swift5/promisekitLibrary/SwaggerClientTests/SwaggerClientTests/UIImage+Extras.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/SwaggerClientTests/SwaggerClientTests/UIImage+Extras.swift
@@ -16,8 +16,8 @@ extension UIImage {
         UIRectFill(rect)
         let image = UIGraphicsGetImageFromCurrentImageContext()
         UIGraphicsEndImageContext()
-        
+
         guard let cgImage = image?.cgImage else { return nil }
         self.init(cgImage: cgImage)
-    }    
+    }
 }

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models.swift
@@ -25,7 +25,7 @@ public enum DownloadException: Error {
 public enum DecodableRequestBuilderError: Error {
     case emptyDataResponse
     case nilHTTPResponse
-    case unsuccessfulHTTPStatusCode(Error?)
+    case unsuccessfulHTTPStatusCode
     case jsonDecoding(DecodingError)
     case generalError(Error)
 }

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
@@ -188,7 +188,7 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T> {
         }
 
         guard let httpResponse = response as? HTTPURLResponse else {
-            completion(.failure(ErrorResponse.error(-2, nil, DecodableRequestBuilderError.nilHTTPResponse)))
+            completion(.failure(ErrorResponse.error(-2, data, DecodableRequestBuilderError.nilHTTPResponse)))
             return
         }
 
@@ -320,7 +320,7 @@ open class URLSessionDecodableRequestBuilder<T: Decodable>: URLSessionRequestBui
         }
 
         guard let httpResponse = response as? HTTPURLResponse else {
-            completion(.failure(ErrorResponse.error(-2, nil, DecodableRequestBuilderError.nilHTTPResponse)))
+            completion(.failure(ErrorResponse.error(-2, data, DecodableRequestBuilderError.nilHTTPResponse)))
             return
         }
 

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
@@ -182,18 +182,18 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T> {
 
     fileprivate func processRequestResponse(urlRequest: URLRequest, data: Data?, response: URLResponse?, error: Error?, completion: @escaping (_ result: Result<Response<T>, Error>) -> Void) {
 
+        if let error = error {
+            completion(.failure(ErrorResponse.error(-1, data, error)))
+            return
+        }
+
         guard let httpResponse = response as? HTTPURLResponse else {
             completion(.failure(ErrorResponse.error(-2, nil, DecodableRequestBuilderError.nilHTTPResponse)))
             return
         }
 
         guard httpResponse.isStatusCodeSuccessful else {
-            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, DecodableRequestBuilderError.unsuccessfulHTTPStatusCode(error))))
-            return
-        }
-
-        if let error = error {
-            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, error)))
+            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, DecodableRequestBuilderError.unsuccessfulHTTPStatusCode)))
             return
         }
 
@@ -314,18 +314,18 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T> {
 open class URLSessionDecodableRequestBuilder<T: Decodable>: URLSessionRequestBuilder<T> {
     override fileprivate func processRequestResponse(urlRequest: URLRequest, data: Data?, response: URLResponse?, error: Error?, completion: @escaping (_ result: Result<Response<T>, Error>) -> Void) {
 
+        if let error = error {
+            completion(.failure(ErrorResponse.error(-1, data, error)))
+            return
+        }
+
         guard let httpResponse = response as? HTTPURLResponse else {
             completion(.failure(ErrorResponse.error(-2, nil, DecodableRequestBuilderError.nilHTTPResponse)))
             return
         }
 
         guard httpResponse.isStatusCodeSuccessful else {
-            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, DecodableRequestBuilderError.unsuccessfulHTTPStatusCode(error))))
-            return
-        }
-
-        if let error = error {
-            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, error)))
+            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, DecodableRequestBuilderError.unsuccessfulHTTPStatusCode)))
             return
         }
 

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models.swift
@@ -25,7 +25,7 @@ public enum DownloadException: Error {
 public enum DecodableRequestBuilderError: Error {
     case emptyDataResponse
     case nilHTTPResponse
-    case unsuccessfulHTTPStatusCode(Error?)
+    case unsuccessfulHTTPStatusCode
     case jsonDecoding(DecodingError)
     case generalError(Error)
 }

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
@@ -188,7 +188,7 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T> {
         }
 
         guard let httpResponse = response as? HTTPURLResponse else {
-            completion(.failure(ErrorResponse.error(-2, nil, DecodableRequestBuilderError.nilHTTPResponse)))
+            completion(.failure(ErrorResponse.error(-2, data, DecodableRequestBuilderError.nilHTTPResponse)))
             return
         }
 
@@ -320,7 +320,7 @@ open class URLSessionDecodableRequestBuilder<T: Decodable>: URLSessionRequestBui
         }
 
         guard let httpResponse = response as? HTTPURLResponse else {
-            completion(.failure(ErrorResponse.error(-2, nil, DecodableRequestBuilderError.nilHTTPResponse)))
+            completion(.failure(ErrorResponse.error(-2, data, DecodableRequestBuilderError.nilHTTPResponse)))
             return
         }
 

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
@@ -182,18 +182,18 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T> {
 
     fileprivate func processRequestResponse(urlRequest: URLRequest, data: Data?, response: URLResponse?, error: Error?, completion: @escaping (_ result: Result<Response<T>, Error>) -> Void) {
 
+        if let error = error {
+            completion(.failure(ErrorResponse.error(-1, data, error)))
+            return
+        }
+
         guard let httpResponse = response as? HTTPURLResponse else {
             completion(.failure(ErrorResponse.error(-2, nil, DecodableRequestBuilderError.nilHTTPResponse)))
             return
         }
 
         guard httpResponse.isStatusCodeSuccessful else {
-            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, DecodableRequestBuilderError.unsuccessfulHTTPStatusCode(error))))
-            return
-        }
-
-        if let error = error {
-            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, error)))
+            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, DecodableRequestBuilderError.unsuccessfulHTTPStatusCode)))
             return
         }
 
@@ -314,18 +314,18 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T> {
 open class URLSessionDecodableRequestBuilder<T: Decodable>: URLSessionRequestBuilder<T> {
     override fileprivate func processRequestResponse(urlRequest: URLRequest, data: Data?, response: URLResponse?, error: Error?, completion: @escaping (_ result: Result<Response<T>, Error>) -> Void) {
 
+        if let error = error {
+            completion(.failure(ErrorResponse.error(-1, data, error)))
+            return
+        }
+
         guard let httpResponse = response as? HTTPURLResponse else {
             completion(.failure(ErrorResponse.error(-2, nil, DecodableRequestBuilderError.nilHTTPResponse)))
             return
         }
 
         guard httpResponse.isStatusCodeSuccessful else {
-            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, DecodableRequestBuilderError.unsuccessfulHTTPStatusCode(error))))
-            return
-        }
-
-        if let error = error {
-            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, error)))
+            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, DecodableRequestBuilderError.unsuccessfulHTTPStatusCode)))
             return
         }
 

--- a/samples/client/petstore/swift5/rxswiftLibrary/SwaggerClientTests/SwaggerClientTests/FileUtils.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/SwaggerClientTests/SwaggerClientTests/FileUtils.swift
@@ -13,21 +13,21 @@ class FileUtils {
         guard let documentsDirectory = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first else {
             return nil
         }
-        
+
         let fileName = imageName
         let fileURL = documentsDirectory.appendingPathComponent(fileName)
         guard let data = image.jpegData(compressionQuality: 1) else { return nil }
-        
+
         //Checks if file exists, removes it if so.
         deleteFile(fileURL: fileURL)
-        
+
         do {
             try data.write(to: fileURL)
         } catch let error {
             print("error saving file with error", error)
             return nil
         }
-        
+
         return fileURL
     }
 
@@ -45,5 +45,5 @@ class FileUtils {
         }
         return false
     }
-    
+
 }

--- a/samples/client/petstore/swift5/rxswiftLibrary/SwaggerClientTests/SwaggerClientTests/PetAPITests.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/SwaggerClientTests/SwaggerClientTests/PetAPITests.swift
@@ -78,7 +78,7 @@ class PetAPITests: XCTestCase {
             fatalError()
         }
 
-        PetAPI.uploadFile(petId: 1000, additionalMetadata: "additionalMetadata", file: imageURL).subscribe(onNext: { pet in
+        PetAPI.uploadFile(petId: 1000, additionalMetadata: "additionalMetadata", file: imageURL).subscribe(onNext: { _ in
             FileUtils.deleteFile(fileURL: imageURL)
             expectation.fulfill()
         }, onError: { _ in

--- a/samples/client/petstore/swift5/rxswiftLibrary/SwaggerClientTests/SwaggerClientTests/UIImage+Extras.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/SwaggerClientTests/SwaggerClientTests/UIImage+Extras.swift
@@ -16,8 +16,8 @@ extension UIImage {
         UIRectFill(rect)
         let image = UIGraphicsGetImageFromCurrentImageContext()
         UIGraphicsEndImageContext()
-        
+
         guard let cgImage = image?.cgImage else { return nil }
         self.init(cgImage: cgImage)
-    }    
+    }
 }

--- a/samples/client/petstore/swift5/urlsessionLibrary/PetstoreClient/Classes/OpenAPIs/Models.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/PetstoreClient/Classes/OpenAPIs/Models.swift
@@ -25,7 +25,7 @@ public enum DownloadException: Error {
 public enum DecodableRequestBuilderError: Error {
     case emptyDataResponse
     case nilHTTPResponse
-    case unsuccessfulHTTPStatusCode(Error?)
+    case unsuccessfulHTTPStatusCode
     case jsonDecoding(DecodingError)
     case generalError(Error)
 }

--- a/samples/client/petstore/swift5/urlsessionLibrary/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
@@ -188,7 +188,7 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T> {
         }
 
         guard let httpResponse = response as? HTTPURLResponse else {
-            completion(.failure(ErrorResponse.error(-2, nil, DecodableRequestBuilderError.nilHTTPResponse)))
+            completion(.failure(ErrorResponse.error(-2, data, DecodableRequestBuilderError.nilHTTPResponse)))
             return
         }
 
@@ -320,7 +320,7 @@ open class URLSessionDecodableRequestBuilder<T: Decodable>: URLSessionRequestBui
         }
 
         guard let httpResponse = response as? HTTPURLResponse else {
-            completion(.failure(ErrorResponse.error(-2, nil, DecodableRequestBuilderError.nilHTTPResponse)))
+            completion(.failure(ErrorResponse.error(-2, data, DecodableRequestBuilderError.nilHTTPResponse)))
             return
         }
 

--- a/samples/client/petstore/swift5/urlsessionLibrary/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
@@ -182,18 +182,18 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T> {
 
     fileprivate func processRequestResponse(urlRequest: URLRequest, data: Data?, response: URLResponse?, error: Error?, completion: @escaping (_ result: Result<Response<T>, Error>) -> Void) {
 
+        if let error = error {
+            completion(.failure(ErrorResponse.error(-1, data, error)))
+            return
+        }
+
         guard let httpResponse = response as? HTTPURLResponse else {
             completion(.failure(ErrorResponse.error(-2, nil, DecodableRequestBuilderError.nilHTTPResponse)))
             return
         }
 
         guard httpResponse.isStatusCodeSuccessful else {
-            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, DecodableRequestBuilderError.unsuccessfulHTTPStatusCode(error))))
-            return
-        }
-
-        if let error = error {
-            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, error)))
+            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, DecodableRequestBuilderError.unsuccessfulHTTPStatusCode)))
             return
         }
 
@@ -314,18 +314,18 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T> {
 open class URLSessionDecodableRequestBuilder<T: Decodable>: URLSessionRequestBuilder<T> {
     override fileprivate func processRequestResponse(urlRequest: URLRequest, data: Data?, response: URLResponse?, error: Error?, completion: @escaping (_ result: Result<Response<T>, Error>) -> Void) {
 
+        if let error = error {
+            completion(.failure(ErrorResponse.error(-1, data, error)))
+            return
+        }
+
         guard let httpResponse = response as? HTTPURLResponse else {
             completion(.failure(ErrorResponse.error(-2, nil, DecodableRequestBuilderError.nilHTTPResponse)))
             return
         }
 
         guard httpResponse.isStatusCodeSuccessful else {
-            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, DecodableRequestBuilderError.unsuccessfulHTTPStatusCode(error))))
-            return
-        }
-
-        if let error = error {
-            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, error)))
+            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, DecodableRequestBuilderError.unsuccessfulHTTPStatusCode)))
             return
         }
 

--- a/samples/client/petstore/swift5/urlsessionLibrary/SwaggerClientTests/SwaggerClientTests/FileUtils.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/SwaggerClientTests/SwaggerClientTests/FileUtils.swift
@@ -13,21 +13,21 @@ class FileUtils {
         guard let documentsDirectory = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first else {
             return nil
         }
-        
+
         let fileName = imageName
         let fileURL = documentsDirectory.appendingPathComponent(fileName)
         guard let data = image.jpegData(compressionQuality: 1) else { return nil }
-        
+
         //Checks if file exists, removes it if so.
         deleteFile(fileURL: fileURL)
-        
+
         do {
             try data.write(to: fileURL)
         } catch let error {
             print("error saving file with error", error)
             return nil
         }
-        
+
         return fileURL
     }
 
@@ -45,5 +45,5 @@ class FileUtils {
         }
         return false
     }
-    
+
 }

--- a/samples/client/petstore/swift5/urlsessionLibrary/SwaggerClientTests/SwaggerClientTests/UIImage+Extras.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/SwaggerClientTests/SwaggerClientTests/UIImage+Extras.swift
@@ -16,8 +16,8 @@ extension UIImage {
         UIRectFill(rect)
         let image = UIGraphicsGetImageFromCurrentImageContext()
         UIGraphicsEndImageContext()
-        
+
         guard let cgImage = image?.cgImage else { return nil }
         self.init(cgImage: cgImage)
-    }    
+    }
 }

--- a/samples/client/test/swift5/default/TestClient/Classes/OpenAPIs/Models.swift
+++ b/samples/client/test/swift5/default/TestClient/Classes/OpenAPIs/Models.swift
@@ -25,7 +25,7 @@ public enum DownloadException: Error {
 public enum DecodableRequestBuilderError: Error {
     case emptyDataResponse
     case nilHTTPResponse
-    case unsuccessfulHTTPStatusCode(Error?)
+    case unsuccessfulHTTPStatusCode
     case jsonDecoding(DecodingError)
     case generalError(Error)
 }

--- a/samples/client/test/swift5/default/TestClient/Classes/OpenAPIs/URLSessionImplementations.swift
+++ b/samples/client/test/swift5/default/TestClient/Classes/OpenAPIs/URLSessionImplementations.swift
@@ -188,7 +188,7 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T> {
         }
 
         guard let httpResponse = response as? HTTPURLResponse else {
-            completion(.failure(ErrorResponse.error(-2, nil, DecodableRequestBuilderError.nilHTTPResponse)))
+            completion(.failure(ErrorResponse.error(-2, data, DecodableRequestBuilderError.nilHTTPResponse)))
             return
         }
 
@@ -320,7 +320,7 @@ open class URLSessionDecodableRequestBuilder<T: Decodable>: URLSessionRequestBui
         }
 
         guard let httpResponse = response as? HTTPURLResponse else {
-            completion(.failure(ErrorResponse.error(-2, nil, DecodableRequestBuilderError.nilHTTPResponse)))
+            completion(.failure(ErrorResponse.error(-2, data, DecodableRequestBuilderError.nilHTTPResponse)))
             return
         }
 

--- a/samples/client/test/swift5/default/TestClient/Classes/OpenAPIs/URLSessionImplementations.swift
+++ b/samples/client/test/swift5/default/TestClient/Classes/OpenAPIs/URLSessionImplementations.swift
@@ -182,18 +182,18 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T> {
 
     fileprivate func processRequestResponse(urlRequest: URLRequest, data: Data?, response: URLResponse?, error: Error?, completion: @escaping (_ result: Result<Response<T>, Error>) -> Void) {
 
+        if let error = error {
+            completion(.failure(ErrorResponse.error(-1, data, error)))
+            return
+        }
+
         guard let httpResponse = response as? HTTPURLResponse else {
             completion(.failure(ErrorResponse.error(-2, nil, DecodableRequestBuilderError.nilHTTPResponse)))
             return
         }
 
         guard httpResponse.isStatusCodeSuccessful else {
-            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, DecodableRequestBuilderError.unsuccessfulHTTPStatusCode(error))))
-            return
-        }
-
-        if let error = error {
-            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, error)))
+            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, DecodableRequestBuilderError.unsuccessfulHTTPStatusCode)))
             return
         }
 
@@ -314,18 +314,18 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T> {
 open class URLSessionDecodableRequestBuilder<T: Decodable>: URLSessionRequestBuilder<T> {
     override fileprivate func processRequestResponse(urlRequest: URLRequest, data: Data?, response: URLResponse?, error: Error?, completion: @escaping (_ result: Result<Response<T>, Error>) -> Void) {
 
+        if let error = error {
+            completion(.failure(ErrorResponse.error(-1, data, error)))
+            return
+        }
+
         guard let httpResponse = response as? HTTPURLResponse else {
             completion(.failure(ErrorResponse.error(-2, nil, DecodableRequestBuilderError.nilHTTPResponse)))
             return
         }
 
         guard httpResponse.isStatusCodeSuccessful else {
-            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, DecodableRequestBuilderError.unsuccessfulHTTPStatusCode(error))))
-            return
-        }
-
-        if let error = error {
-            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, error)))
+            completion(.failure(ErrorResponse.error(httpResponse.statusCode, data, DecodableRequestBuilderError.unsuccessfulHTTPStatusCode)))
             return
         }
 


### PR DESCRIPTION
Currently the Swift 5 generator that uses URLSession, is hiding the network error.

This is bad, because it doesn't allow the developer to check why the network connection has failed, timeout, no network connection, etc.

This PR fixes that.

### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [X] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [X] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@jgavris (2017/07) @ehyche (2017/08) @Edubits (2017/09) @jaz-ah (2017/09) @4brunu (2019/11)