### PR TITLE
C-Libcurl client: fix enum model generation

### DIFF
--- a/modules/openapi-generator/src/main/resources/C-libcurl/model-body.mustache
+++ b/modules/openapi-generator/src/main/resources/C-libcurl/model-body.mustache
@@ -43,8 +43,8 @@ fail:
     return NULL;
 }
 
-{{classFilename}}_{{classname}}_e {{classFilename}}_{{classname}}_parseFromJSON(cJSON *{{classname}}JSON) {
-    {{classFilename}}_{{classname}}_e *{{classname}} = NULL;
+{{projectName}}_{{classVarName}}_{{enumName}}_e {{classFilename}}_{{classname}}_parseFromJSON(cJSON *{{classname}}JSON) {
+    {{projectName}}_{{classVarName}}_{{enumName}}_e *{{classname}} = NULL;
 {{#isEnum}}
 {{#isNumeric}}
     cJSON *{{{classname}}}Var = cJSON_GetObjectItemCaseSensitive({{classname}}JSON, "{{{classname}}}");
@@ -54,7 +54,7 @@ fail:
     }
 {{/isNumeric}}
 {{#isString}}
-    {{classFilename}}_{{{classname}}}_e {{classname}}Variable;
+    {{projectName}}_{{classVarName}}_{{enumName}}_e {{classname}}Variable;
     cJSON *{{{classname}}}Var = cJSON_GetObjectItemCaseSensitive({{classname}}JSON, "{{{classname}}}");
     if(!cJSON_IsString({{{classname}}}Var) || ({{{classname}}}Var->valuestring == NULL)){
         goto end;


### PR DESCRIPTION
Completes commit fc9d4584ca1144532c0b86db958d7f782098253d

The "..._parseFromJSON" template was buggy because the name of the _e type used was not the same than the generated.
See the first argument of "..._convertToJSON" to see that the _e type used there was not the same

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
About #5477 (#5091 and #4293)

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
