### PR TITLE
Scala-Akka: Add missing body to PATCH requests

### DIFF
--- a/modules/openapi-generator/src/main/resources/scala-akka-client/apiInvoker.mustache
+++ b/modules/openapi-generator/src/main/resources/scala-akka-client/apiInvoker.mustache
@@ -174,7 +174,7 @@ class ApiInvoker(formats: Formats)(implicit system: ActorSystem) extends CustomC
   private def createRequest(uri: Uri, request: ApiRequest[_]): HttpRequest = {
     val httpRequest = request.method.toAkkaHttpMethod match {
       case m@(HttpMethods.GET | HttpMethods.DELETE) => HttpRequest(m, uri)
-      case m@(HttpMethods.POST | HttpMethods.PUT) =>
+      case m@(HttpMethods.POST | HttpMethods.PUT | HttpMethods.PATCH) =>
         formDataContent(request) orElse bodyContent(request) match {
           case Some(c: FormData) =>
             HttpRequest(m, uri, entity = c.toEntity)

--- a/samples/client/petstore/scala-akka/src/main/scala/org/openapitools/client/core/ApiInvoker.scala
+++ b/samples/client/petstore/scala-akka/src/main/scala/org/openapitools/client/core/ApiInvoker.scala
@@ -184,7 +184,7 @@ class ApiInvoker(formats: Formats)(implicit system: ActorSystem) extends CustomC
   private def createRequest(uri: Uri, request: ApiRequest[_]): HttpRequest = {
     val httpRequest = request.method.toAkkaHttpMethod match {
       case m@(HttpMethods.GET | HttpMethods.DELETE) => HttpRequest(m, uri)
-      case m@(HttpMethods.POST | HttpMethods.PUT) =>
+      case m@(HttpMethods.POST | HttpMethods.PUT | HttpMethods.PATCH) =>
         formDataContent(request) orElse bodyContent(request) match {
           case Some(c: FormData) =>
             HttpRequest(m, uri, entity = c.toEntity)


### PR DESCRIPTION
Client code generated from scala-akka template does not attach specified body to PATCH requests.
This PR addresses the issue.

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@clasnake (2017/07), @jimschubert (2017/09) ❤️, @shijinkui (2018/01), @ramzimaalej (2018/03), @chameleon82 (2020/03)