### PR TITLE
[Java][client] deserialize error bodies into defined models for Jersey2

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/ApiClient.mustache
@@ -808,6 +808,30 @@ public class ApiClient {
    * @throws ApiException API exception
    */
   public <T> ApiResponse<T> invokeAPI(String operation, String path, String method, List<Pair> queryParams, Object body, Map<String, String> headerParams, Map<String, String> cookieParams, Map<String, Object> formParams, String accept, String contentType, String[] authNames, GenericType<T> returnType) throws ApiException {
+    return invokeAPI(operation, path, method, queryParams, body, headerParams, cookieParams, formParams, accept, contentType, authNames, returnType, null);
+  }
+
+  /**
+   * Invoke API by sending HTTP request with the given options.
+   *
+   * @param <T> Type
+   * @param operation The qualified name of the operation
+   * @param path The sub-path of the HTTP URL
+   * @param method The request method, one of "GET", "POST", "PUT", "HEAD" and "DELETE"
+   * @param queryParams The query parameters
+   * @param body The request body object
+   * @param headerParams The header parameters
+   * @param cookieParams The cookie parameters
+   * @param formParams The form parameters
+   * @param accept The request's Accept header
+   * @param contentType The request's Content-Type header
+   * @param authNames The authentications to apply
+   * @param returnType The return type into which to deserialize the response
+   * @param errorTypes Mapping of error codes to types into which to deserialize the response
+   * @return The response body in type of string
+   * @throws ApiException API exception
+   */
+  public <T> ApiResponse<T> invokeAPI(String operation, String path, String method, List<Pair> queryParams, Object body, Map<String, String> headerParams, Map<String, String> cookieParams, Map<String, Object> formParams, String accept, String contentType, String[] authNames, GenericType<T> returnType, Map<String, GenericType> errorTypes) throws ApiException {
     updateParamsForAuth(authNames, queryParams, headerParams, cookieParams);
 
     // Not using `.target(targetURL).path(path)` below,
@@ -919,6 +943,8 @@ public class ApiClient {
         String respBody = null;
         if (response.hasEntity()) {
           try {
+            // call bufferEntity, so that a subsequent call to `readEntity` in `deserialize` doesn't fail
+            response.bufferEntity();
             respBody = String.valueOf(response.readEntity(String.class));
             message = respBody;
           } catch (RuntimeException e) {
@@ -929,7 +955,8 @@ public class ApiClient {
           response.getStatus(),
           message,
           buildResponseHeaders(response),
-          respBody);
+          respBody,
+          deserializeErrorEntity(errorTypes, response));
       }
     } finally {
       try {
@@ -937,6 +964,21 @@ public class ApiClient {
       } catch (Exception e) {
         // it's not critical, since the response object is local in method invokeAPI; that's fine, just continue
       }
+    }
+  }
+
+  private Object deserializeErrorEntity(Map<String, GenericType> errorTypes, Response response) {
+    if (errorTypes == null) {
+      return null;
+    }
+    GenericType errorType = errorTypes.get(String.valueOf(response.getStatus()));
+    if (errorType == null) {
+        errorType = errorTypes.get("0"); // "0" is the "default" response
+    }
+    try {
+      return deserialize(response, errorType);
+    } catch (Exception e) {
+      return String.format("Failed deserializing error entity: %s", e.toString());
     }
   }
 

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/api.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/api.mustache
@@ -150,8 +150,17 @@ public class {{classname}} {
 
     String[] localVarAuthNames = new String[] { {{#authMethods}}"{{name}}"{{#hasMore}}, {{/hasMore}}{{/authMethods}} };
 
+    final Map<String, GenericType> localVarErrorTypes = new HashMap<String, GenericType>();
+    {{#responses}}
+    {{^-first}}
+    {{#dataType}}
+    localVarErrorTypes.put("{{code}}", new GenericType<{{{dataType}}}>() {});
+    {{/dataType}}
+    {{/-first}}
+    {{/responses}}
+
     {{#returnType}}GenericType<{{{returnType}}}> localVarReturnType = new GenericType<{{{returnType}}}>() {};{{/returnType}}
-    return apiClient.invokeAPI("{{classname}}.{{operationId}}", localVarPath, "{{httpMethod}}", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, {{#returnType}}localVarReturnType{{/returnType}}{{^returnType}}null{{/returnType}});
+    return apiClient.invokeAPI("{{classname}}.{{operationId}}", localVarPath, "{{httpMethod}}", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, {{#returnType}}localVarReturnType{{/returnType}}{{^returnType}}null{{/returnType}}, localVarErrorTypes);
   }
   {{#vendorExtensions.x-group-parameters}}
 

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/apiException.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/apiException.mustache
@@ -14,6 +14,7 @@ public class ApiException extends{{#useRuntimeException}} RuntimeException {{/us
     private int code = 0;
     private Map<String, List<String>> responseHeaders = null;
     private String responseBody = null;
+    private Object errorEntity = null;
 
     public ApiException() {}
 
@@ -67,6 +68,11 @@ public class ApiException extends{{#useRuntimeException}} RuntimeException {{/us
         this.responseBody = responseBody;
     }
 
+    public ApiException(int code, String message, Map<String, List<String>> responseHeaders, String responseBody, Object errorEntity) {
+        this(code, message, responseHeaders, responseBody);
+        this.errorEntity = errorEntity;
+    }
+
     /**
      * Get the HTTP status code.
      *
@@ -92,5 +98,14 @@ public class ApiException extends{{#useRuntimeException}} RuntimeException {{/us
      */
     public String getResponseBody() {
         return responseBody;
+    }
+
+    /**
+     * Get the deserialized error entity (or null if this error doesn't have a model associated).
+     *
+     * @return Deserialized error entity
+     */
+    public Object getErrorEntity() {
+        return errorEntity;
     }
 }

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/ApiException.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/ApiException.java
@@ -21,6 +21,7 @@ public class ApiException extends Exception {
     private int code = 0;
     private Map<String, List<String>> responseHeaders = null;
     private String responseBody = null;
+    private Object errorEntity = null;
 
     public ApiException() {}
 
@@ -62,6 +63,11 @@ public class ApiException extends Exception {
         this.responseBody = responseBody;
     }
 
+    public ApiException(int code, String message, Map<String, List<String>> responseHeaders, String responseBody, Object errorEntity) {
+        this(code, message, responseHeaders, responseBody);
+        this.errorEntity = errorEntity;
+    }
+
     /**
      * Get the HTTP status code.
      *
@@ -87,5 +93,14 @@ public class ApiException extends Exception {
      */
     public String getResponseBody() {
         return responseBody;
+    }
+
+    /**
+     * Get the deserialized error entity (or null if this error doesn't have a model associated).
+     *
+     * @return Deserialized error entity
+     */
+    public Object getErrorEntity() {
+        return errorEntity;
     }
 }

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
@@ -95,7 +95,9 @@ public class AnotherFakeApi {
 
     String[] localVarAuthNames = new String[] {  };
 
+    final Map<String, GenericType> localVarErrorTypes = new HashMap<String, GenericType>();
+
     GenericType<Client> localVarReturnType = new GenericType<Client>() {};
-    return apiClient.invokeAPI("AnotherFakeApi.call123testSpecialTags", localVarPath, "PATCH", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType);
+    return apiClient.invokeAPI("AnotherFakeApi.call123testSpecialTags", localVarPath, "PATCH", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType, localVarErrorTypes);
   }
 }

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -102,8 +102,10 @@ public class FakeApi {
 
     String[] localVarAuthNames = new String[] {  };
 
+    final Map<String, GenericType> localVarErrorTypes = new HashMap<String, GenericType>();
+
     
-    return apiClient.invokeAPI("FakeApi.createXmlItem", localVarPath, "POST", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null);
+    return apiClient.invokeAPI("FakeApi.createXmlItem", localVarPath, "POST", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null, localVarErrorTypes);
   }
   /**
    * 
@@ -161,8 +163,10 @@ public class FakeApi {
 
     String[] localVarAuthNames = new String[] {  };
 
+    final Map<String, GenericType> localVarErrorTypes = new HashMap<String, GenericType>();
+
     GenericType<Boolean> localVarReturnType = new GenericType<Boolean>() {};
-    return apiClient.invokeAPI("FakeApi.fakeOuterBooleanSerialize", localVarPath, "POST", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType);
+    return apiClient.invokeAPI("FakeApi.fakeOuterBooleanSerialize", localVarPath, "POST", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType, localVarErrorTypes);
   }
   /**
    * 
@@ -220,8 +224,10 @@ public class FakeApi {
 
     String[] localVarAuthNames = new String[] {  };
 
+    final Map<String, GenericType> localVarErrorTypes = new HashMap<String, GenericType>();
+
     GenericType<OuterComposite> localVarReturnType = new GenericType<OuterComposite>() {};
-    return apiClient.invokeAPI("FakeApi.fakeOuterCompositeSerialize", localVarPath, "POST", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType);
+    return apiClient.invokeAPI("FakeApi.fakeOuterCompositeSerialize", localVarPath, "POST", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType, localVarErrorTypes);
   }
   /**
    * 
@@ -279,8 +285,10 @@ public class FakeApi {
 
     String[] localVarAuthNames = new String[] {  };
 
+    final Map<String, GenericType> localVarErrorTypes = new HashMap<String, GenericType>();
+
     GenericType<BigDecimal> localVarReturnType = new GenericType<BigDecimal>() {};
-    return apiClient.invokeAPI("FakeApi.fakeOuterNumberSerialize", localVarPath, "POST", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType);
+    return apiClient.invokeAPI("FakeApi.fakeOuterNumberSerialize", localVarPath, "POST", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType, localVarErrorTypes);
   }
   /**
    * 
@@ -338,8 +346,10 @@ public class FakeApi {
 
     String[] localVarAuthNames = new String[] {  };
 
+    final Map<String, GenericType> localVarErrorTypes = new HashMap<String, GenericType>();
+
     GenericType<String> localVarReturnType = new GenericType<String>() {};
-    return apiClient.invokeAPI("FakeApi.fakeOuterStringSerialize", localVarPath, "POST", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType);
+    return apiClient.invokeAPI("FakeApi.fakeOuterStringSerialize", localVarPath, "POST", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType, localVarErrorTypes);
   }
   /**
    * 
@@ -401,8 +411,10 @@ public class FakeApi {
 
     String[] localVarAuthNames = new String[] {  };
 
+    final Map<String, GenericType> localVarErrorTypes = new HashMap<String, GenericType>();
+
     
-    return apiClient.invokeAPI("FakeApi.testBodyWithFileSchema", localVarPath, "PUT", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null);
+    return apiClient.invokeAPI("FakeApi.testBodyWithFileSchema", localVarPath, "PUT", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null, localVarErrorTypes);
   }
   /**
    * 
@@ -472,8 +484,10 @@ public class FakeApi {
 
     String[] localVarAuthNames = new String[] {  };
 
+    final Map<String, GenericType> localVarErrorTypes = new HashMap<String, GenericType>();
+
     
-    return apiClient.invokeAPI("FakeApi.testBodyWithQueryParams", localVarPath, "PUT", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null);
+    return apiClient.invokeAPI("FakeApi.testBodyWithQueryParams", localVarPath, "PUT", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null, localVarErrorTypes);
   }
   /**
    * To test \&quot;client\&quot; model
@@ -536,8 +550,10 @@ public class FakeApi {
 
     String[] localVarAuthNames = new String[] {  };
 
+    final Map<String, GenericType> localVarErrorTypes = new HashMap<String, GenericType>();
+
     GenericType<Client> localVarReturnType = new GenericType<Client>() {};
-    return apiClient.invokeAPI("FakeApi.testClientModel", localVarPath, "PATCH", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType);
+    return apiClient.invokeAPI("FakeApi.testClientModel", localVarPath, "PATCH", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType, localVarErrorTypes);
   }
   /**
    * Fake endpoint for testing various parameters  假端點  偽のエンドポイント  가짜 엔드 포인트
@@ -670,8 +686,10 @@ if (paramCallback != null)
 
     String[] localVarAuthNames = new String[] { "http_basic_test" };
 
+    final Map<String, GenericType> localVarErrorTypes = new HashMap<String, GenericType>();
+
     
-    return apiClient.invokeAPI("FakeApi.testEndpointParameters", localVarPath, "POST", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null);
+    return apiClient.invokeAPI("FakeApi.testEndpointParameters", localVarPath, "POST", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null, localVarErrorTypes);
   }
   /**
    * To test enum parameters
@@ -756,8 +774,10 @@ if (enumFormString != null)
 
     String[] localVarAuthNames = new String[] {  };
 
+    final Map<String, GenericType> localVarErrorTypes = new HashMap<String, GenericType>();
+
     
-    return apiClient.invokeAPI("FakeApi.testEnumParameters", localVarPath, "GET", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null);
+    return apiClient.invokeAPI("FakeApi.testEnumParameters", localVarPath, "GET", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null, localVarErrorTypes);
   }
 
 private ApiResponse<Void> testGroupParametersWithHttpInfo(Integer requiredStringGroup, Boolean requiredBooleanGroup, Long requiredInt64Group, Integer stringGroup, Boolean booleanGroup, Long int64Group) throws ApiException {
@@ -811,8 +831,10 @@ if (booleanGroup != null)
 
     String[] localVarAuthNames = new String[] {  };
 
+    final Map<String, GenericType> localVarErrorTypes = new HashMap<String, GenericType>();
+
     
-    return apiClient.invokeAPI("FakeApi.testGroupParameters", localVarPath, "DELETE", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null);
+    return apiClient.invokeAPI("FakeApi.testGroupParameters", localVarPath, "DELETE", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null, localVarErrorTypes);
   }
 
   public class APItestGroupParametersRequest {
@@ -998,8 +1020,10 @@ if (booleanGroup != null)
 
     String[] localVarAuthNames = new String[] {  };
 
+    final Map<String, GenericType> localVarErrorTypes = new HashMap<String, GenericType>();
+
     
-    return apiClient.invokeAPI("FakeApi.testInlineAdditionalProperties", localVarPath, "POST", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null);
+    return apiClient.invokeAPI("FakeApi.testInlineAdditionalProperties", localVarPath, "POST", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null, localVarErrorTypes);
   }
   /**
    * test json serialization of form data
@@ -1072,8 +1096,10 @@ if (param2 != null)
 
     String[] localVarAuthNames = new String[] {  };
 
+    final Map<String, GenericType> localVarErrorTypes = new HashMap<String, GenericType>();
+
     
-    return apiClient.invokeAPI("FakeApi.testJsonFormData", localVarPath, "GET", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null);
+    return apiClient.invokeAPI("FakeApi.testJsonFormData", localVarPath, "GET", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null, localVarErrorTypes);
   }
   /**
    * 
@@ -1168,7 +1194,9 @@ if (param2 != null)
 
     String[] localVarAuthNames = new String[] {  };
 
+    final Map<String, GenericType> localVarErrorTypes = new HashMap<String, GenericType>();
+
     
-    return apiClient.invokeAPI("FakeApi.testQueryParameterCollectionFormat", localVarPath, "PUT", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null);
+    return apiClient.invokeAPI("FakeApi.testQueryParameterCollectionFormat", localVarPath, "PUT", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null, localVarErrorTypes);
   }
 }

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
@@ -95,7 +95,9 @@ public class FakeClassnameTags123Api {
 
     String[] localVarAuthNames = new String[] { "api_key_query" };
 
+    final Map<String, GenericType> localVarErrorTypes = new HashMap<String, GenericType>();
+
     GenericType<Client> localVarReturnType = new GenericType<Client>() {};
-    return apiClient.invokeAPI("FakeClassnameTags123Api.testClassname", localVarPath, "PATCH", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType);
+    return apiClient.invokeAPI("FakeClassnameTags123Api.testClassname", localVarPath, "PATCH", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType, localVarErrorTypes);
   }
 }

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/api/PetApi.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/api/PetApi.java
@@ -98,8 +98,10 @@ public class PetApi {
 
     String[] localVarAuthNames = new String[] { "petstore_auth" };
 
+    final Map<String, GenericType> localVarErrorTypes = new HashMap<String, GenericType>();
+
     
-    return apiClient.invokeAPI("PetApi.addPet", localVarPath, "POST", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null);
+    return apiClient.invokeAPI("PetApi.addPet", localVarPath, "POST", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null, localVarErrorTypes);
   }
   /**
    * Deletes a pet
@@ -168,8 +170,10 @@ public class PetApi {
 
     String[] localVarAuthNames = new String[] { "petstore_auth" };
 
+    final Map<String, GenericType> localVarErrorTypes = new HashMap<String, GenericType>();
+
     
-    return apiClient.invokeAPI("PetApi.deletePet", localVarPath, "DELETE", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null);
+    return apiClient.invokeAPI("PetApi.deletePet", localVarPath, "DELETE", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null, localVarErrorTypes);
   }
   /**
    * Finds Pets by status
@@ -235,8 +239,10 @@ public class PetApi {
 
     String[] localVarAuthNames = new String[] { "petstore_auth" };
 
+    final Map<String, GenericType> localVarErrorTypes = new HashMap<String, GenericType>();
+
     GenericType<List<Pet>> localVarReturnType = new GenericType<List<Pet>>() {};
-    return apiClient.invokeAPI("PetApi.findPetsByStatus", localVarPath, "GET", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType);
+    return apiClient.invokeAPI("PetApi.findPetsByStatus", localVarPath, "GET", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType, localVarErrorTypes);
   }
   /**
    * Finds Pets by tags
@@ -306,8 +312,10 @@ public class PetApi {
 
     String[] localVarAuthNames = new String[] { "petstore_auth" };
 
+    final Map<String, GenericType> localVarErrorTypes = new HashMap<String, GenericType>();
+
     GenericType<List<Pet>> localVarReturnType = new GenericType<List<Pet>>() {};
-    return apiClient.invokeAPI("PetApi.findPetsByTags", localVarPath, "GET", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType);
+    return apiClient.invokeAPI("PetApi.findPetsByTags", localVarPath, "GET", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType, localVarErrorTypes);
   }
   /**
    * Find pet by ID
@@ -375,8 +383,10 @@ public class PetApi {
 
     String[] localVarAuthNames = new String[] { "api_key" };
 
+    final Map<String, GenericType> localVarErrorTypes = new HashMap<String, GenericType>();
+
     GenericType<Pet> localVarReturnType = new GenericType<Pet>() {};
-    return apiClient.invokeAPI("PetApi.getPetById", localVarPath, "GET", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType);
+    return apiClient.invokeAPI("PetApi.getPetById", localVarPath, "GET", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType, localVarErrorTypes);
   }
   /**
    * Update an existing pet
@@ -444,8 +454,10 @@ public class PetApi {
 
     String[] localVarAuthNames = new String[] { "petstore_auth" };
 
+    final Map<String, GenericType> localVarErrorTypes = new HashMap<String, GenericType>();
+
     
-    return apiClient.invokeAPI("PetApi.updatePet", localVarPath, "PUT", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null);
+    return apiClient.invokeAPI("PetApi.updatePet", localVarPath, "PUT", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null, localVarErrorTypes);
   }
   /**
    * Updates a pet in the store with form data
@@ -516,8 +528,10 @@ if (status != null)
 
     String[] localVarAuthNames = new String[] { "petstore_auth" };
 
+    final Map<String, GenericType> localVarErrorTypes = new HashMap<String, GenericType>();
+
     
-    return apiClient.invokeAPI("PetApi.updatePetWithForm", localVarPath, "POST", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null);
+    return apiClient.invokeAPI("PetApi.updatePetWithForm", localVarPath, "POST", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null, localVarErrorTypes);
   }
   /**
    * uploads an image
@@ -589,8 +603,10 @@ if (file != null)
 
     String[] localVarAuthNames = new String[] { "petstore_auth" };
 
+    final Map<String, GenericType> localVarErrorTypes = new HashMap<String, GenericType>();
+
     GenericType<ModelApiResponse> localVarReturnType = new GenericType<ModelApiResponse>() {};
-    return apiClient.invokeAPI("PetApi.uploadFile", localVarPath, "POST", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType);
+    return apiClient.invokeAPI("PetApi.uploadFile", localVarPath, "POST", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType, localVarErrorTypes);
   }
   /**
    * uploads an image (required)
@@ -667,7 +683,9 @@ if (requiredFile != null)
 
     String[] localVarAuthNames = new String[] { "petstore_auth" };
 
+    final Map<String, GenericType> localVarErrorTypes = new HashMap<String, GenericType>();
+
     GenericType<ModelApiResponse> localVarReturnType = new GenericType<ModelApiResponse>() {};
-    return apiClient.invokeAPI("PetApi.uploadFileWithRequiredFile", localVarPath, "POST", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType);
+    return apiClient.invokeAPI("PetApi.uploadFileWithRequiredFile", localVarPath, "POST", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType, localVarErrorTypes);
   }
 }

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/api/StoreApi.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/api/StoreApi.java
@@ -97,8 +97,10 @@ public class StoreApi {
 
     String[] localVarAuthNames = new String[] {  };
 
+    final Map<String, GenericType> localVarErrorTypes = new HashMap<String, GenericType>();
+
     
-    return apiClient.invokeAPI("StoreApi.deleteOrder", localVarPath, "DELETE", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null);
+    return apiClient.invokeAPI("StoreApi.deleteOrder", localVarPath, "DELETE", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null, localVarErrorTypes);
   }
   /**
    * Returns pet inventories by status
@@ -154,8 +156,10 @@ public class StoreApi {
 
     String[] localVarAuthNames = new String[] { "api_key" };
 
+    final Map<String, GenericType> localVarErrorTypes = new HashMap<String, GenericType>();
+
     GenericType<Map<String, Integer>> localVarReturnType = new GenericType<Map<String, Integer>>() {};
-    return apiClient.invokeAPI("StoreApi.getInventory", localVarPath, "GET", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType);
+    return apiClient.invokeAPI("StoreApi.getInventory", localVarPath, "GET", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType, localVarErrorTypes);
   }
   /**
    * Find purchase order by ID
@@ -223,8 +227,10 @@ public class StoreApi {
 
     String[] localVarAuthNames = new String[] {  };
 
+    final Map<String, GenericType> localVarErrorTypes = new HashMap<String, GenericType>();
+
     GenericType<Order> localVarReturnType = new GenericType<Order>() {};
-    return apiClient.invokeAPI("StoreApi.getOrderById", localVarPath, "GET", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType);
+    return apiClient.invokeAPI("StoreApi.getOrderById", localVarPath, "GET", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType, localVarErrorTypes);
   }
   /**
    * Place an order for a pet
@@ -289,7 +295,9 @@ public class StoreApi {
 
     String[] localVarAuthNames = new String[] {  };
 
+    final Map<String, GenericType> localVarErrorTypes = new HashMap<String, GenericType>();
+
     GenericType<Order> localVarReturnType = new GenericType<Order>() {};
-    return apiClient.invokeAPI("StoreApi.placeOrder", localVarPath, "POST", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType);
+    return apiClient.invokeAPI("StoreApi.placeOrder", localVarPath, "POST", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType, localVarErrorTypes);
   }
 }

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/api/UserApi.java
@@ -94,8 +94,10 @@ public class UserApi {
 
     String[] localVarAuthNames = new String[] {  };
 
+    final Map<String, GenericType> localVarErrorTypes = new HashMap<String, GenericType>();
+
     
-    return apiClient.invokeAPI("UserApi.createUser", localVarPath, "POST", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null);
+    return apiClient.invokeAPI("UserApi.createUser", localVarPath, "POST", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null, localVarErrorTypes);
   }
   /**
    * Creates list of users with given input array
@@ -157,8 +159,10 @@ public class UserApi {
 
     String[] localVarAuthNames = new String[] {  };
 
+    final Map<String, GenericType> localVarErrorTypes = new HashMap<String, GenericType>();
+
     
-    return apiClient.invokeAPI("UserApi.createUsersWithArrayInput", localVarPath, "POST", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null);
+    return apiClient.invokeAPI("UserApi.createUsersWithArrayInput", localVarPath, "POST", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null, localVarErrorTypes);
   }
   /**
    * Creates list of users with given input array
@@ -220,8 +224,10 @@ public class UserApi {
 
     String[] localVarAuthNames = new String[] {  };
 
+    final Map<String, GenericType> localVarErrorTypes = new HashMap<String, GenericType>();
+
     
-    return apiClient.invokeAPI("UserApi.createUsersWithListInput", localVarPath, "POST", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null);
+    return apiClient.invokeAPI("UserApi.createUsersWithListInput", localVarPath, "POST", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null, localVarErrorTypes);
   }
   /**
    * Delete user
@@ -286,8 +292,10 @@ public class UserApi {
 
     String[] localVarAuthNames = new String[] {  };
 
+    final Map<String, GenericType> localVarErrorTypes = new HashMap<String, GenericType>();
+
     
-    return apiClient.invokeAPI("UserApi.deleteUser", localVarPath, "DELETE", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null);
+    return apiClient.invokeAPI("UserApi.deleteUser", localVarPath, "DELETE", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null, localVarErrorTypes);
   }
   /**
    * Get user by user name
@@ -355,8 +363,10 @@ public class UserApi {
 
     String[] localVarAuthNames = new String[] {  };
 
+    final Map<String, GenericType> localVarErrorTypes = new HashMap<String, GenericType>();
+
     GenericType<User> localVarReturnType = new GenericType<User>() {};
-    return apiClient.invokeAPI("UserApi.getUserByName", localVarPath, "GET", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType);
+    return apiClient.invokeAPI("UserApi.getUserByName", localVarPath, "GET", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType, localVarErrorTypes);
   }
   /**
    * Logs user into the system
@@ -430,8 +440,10 @@ public class UserApi {
 
     String[] localVarAuthNames = new String[] {  };
 
+    final Map<String, GenericType> localVarErrorTypes = new HashMap<String, GenericType>();
+
     GenericType<String> localVarReturnType = new GenericType<String>() {};
-    return apiClient.invokeAPI("UserApi.loginUser", localVarPath, "GET", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType);
+    return apiClient.invokeAPI("UserApi.loginUser", localVarPath, "GET", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType, localVarErrorTypes);
   }
   /**
    * Logs out current logged in user session
@@ -486,8 +498,10 @@ public class UserApi {
 
     String[] localVarAuthNames = new String[] {  };
 
+    final Map<String, GenericType> localVarErrorTypes = new HashMap<String, GenericType>();
+
     
-    return apiClient.invokeAPI("UserApi.logoutUser", localVarPath, "GET", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null);
+    return apiClient.invokeAPI("UserApi.logoutUser", localVarPath, "GET", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null, localVarErrorTypes);
   }
   /**
    * Updated user
@@ -559,7 +573,9 @@ public class UserApi {
 
     String[] localVarAuthNames = new String[] {  };
 
+    final Map<String, GenericType> localVarErrorTypes = new HashMap<String, GenericType>();
+
     
-    return apiClient.invokeAPI("UserApi.updateUser", localVarPath, "PUT", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null);
+    return apiClient.invokeAPI("UserApi.updateUser", localVarPath, "PUT", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null, localVarErrorTypes);
   }
 }

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/ApiException.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/ApiException.java
@@ -21,6 +21,7 @@ public class ApiException extends Exception {
     private int code = 0;
     private Map<String, List<String>> responseHeaders = null;
     private String responseBody = null;
+    private Object errorEntity = null;
 
     public ApiException() {}
 
@@ -62,6 +63,11 @@ public class ApiException extends Exception {
         this.responseBody = responseBody;
     }
 
+    public ApiException(int code, String message, Map<String, List<String>> responseHeaders, String responseBody, Object errorEntity) {
+        this(code, message, responseHeaders, responseBody);
+        this.errorEntity = errorEntity;
+    }
+
     /**
      * Get the HTTP status code.
      *
@@ -87,5 +93,14 @@ public class ApiException extends Exception {
      */
     public String getResponseBody() {
         return responseBody;
+    }
+
+    /**
+     * Get the deserialized error entity (or null if this error doesn't have a model associated).
+     *
+     * @return Deserialized error entity
+     */
+    public Object getErrorEntity() {
+        return errorEntity;
     }
 }

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
@@ -95,7 +95,9 @@ public class AnotherFakeApi {
 
     String[] localVarAuthNames = new String[] {  };
 
+    final Map<String, GenericType> localVarErrorTypes = new HashMap<String, GenericType>();
+
     GenericType<Client> localVarReturnType = new GenericType<Client>() {};
-    return apiClient.invokeAPI("AnotherFakeApi.call123testSpecialTags", localVarPath, "PATCH", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType);
+    return apiClient.invokeAPI("AnotherFakeApi.call123testSpecialTags", localVarPath, "PATCH", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType, localVarErrorTypes);
   }
 }

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -102,8 +102,10 @@ public class FakeApi {
 
     String[] localVarAuthNames = new String[] {  };
 
+    final Map<String, GenericType> localVarErrorTypes = new HashMap<String, GenericType>();
+
     
-    return apiClient.invokeAPI("FakeApi.createXmlItem", localVarPath, "POST", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null);
+    return apiClient.invokeAPI("FakeApi.createXmlItem", localVarPath, "POST", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null, localVarErrorTypes);
   }
   /**
    * 
@@ -161,8 +163,10 @@ public class FakeApi {
 
     String[] localVarAuthNames = new String[] {  };
 
+    final Map<String, GenericType> localVarErrorTypes = new HashMap<String, GenericType>();
+
     GenericType<Boolean> localVarReturnType = new GenericType<Boolean>() {};
-    return apiClient.invokeAPI("FakeApi.fakeOuterBooleanSerialize", localVarPath, "POST", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType);
+    return apiClient.invokeAPI("FakeApi.fakeOuterBooleanSerialize", localVarPath, "POST", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType, localVarErrorTypes);
   }
   /**
    * 
@@ -220,8 +224,10 @@ public class FakeApi {
 
     String[] localVarAuthNames = new String[] {  };
 
+    final Map<String, GenericType> localVarErrorTypes = new HashMap<String, GenericType>();
+
     GenericType<OuterComposite> localVarReturnType = new GenericType<OuterComposite>() {};
-    return apiClient.invokeAPI("FakeApi.fakeOuterCompositeSerialize", localVarPath, "POST", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType);
+    return apiClient.invokeAPI("FakeApi.fakeOuterCompositeSerialize", localVarPath, "POST", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType, localVarErrorTypes);
   }
   /**
    * 
@@ -279,8 +285,10 @@ public class FakeApi {
 
     String[] localVarAuthNames = new String[] {  };
 
+    final Map<String, GenericType> localVarErrorTypes = new HashMap<String, GenericType>();
+
     GenericType<BigDecimal> localVarReturnType = new GenericType<BigDecimal>() {};
-    return apiClient.invokeAPI("FakeApi.fakeOuterNumberSerialize", localVarPath, "POST", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType);
+    return apiClient.invokeAPI("FakeApi.fakeOuterNumberSerialize", localVarPath, "POST", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType, localVarErrorTypes);
   }
   /**
    * 
@@ -338,8 +346,10 @@ public class FakeApi {
 
     String[] localVarAuthNames = new String[] {  };
 
+    final Map<String, GenericType> localVarErrorTypes = new HashMap<String, GenericType>();
+
     GenericType<String> localVarReturnType = new GenericType<String>() {};
-    return apiClient.invokeAPI("FakeApi.fakeOuterStringSerialize", localVarPath, "POST", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType);
+    return apiClient.invokeAPI("FakeApi.fakeOuterStringSerialize", localVarPath, "POST", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType, localVarErrorTypes);
   }
   /**
    * 
@@ -401,8 +411,10 @@ public class FakeApi {
 
     String[] localVarAuthNames = new String[] {  };
 
+    final Map<String, GenericType> localVarErrorTypes = new HashMap<String, GenericType>();
+
     
-    return apiClient.invokeAPI("FakeApi.testBodyWithFileSchema", localVarPath, "PUT", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null);
+    return apiClient.invokeAPI("FakeApi.testBodyWithFileSchema", localVarPath, "PUT", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null, localVarErrorTypes);
   }
   /**
    * 
@@ -472,8 +484,10 @@ public class FakeApi {
 
     String[] localVarAuthNames = new String[] {  };
 
+    final Map<String, GenericType> localVarErrorTypes = new HashMap<String, GenericType>();
+
     
-    return apiClient.invokeAPI("FakeApi.testBodyWithQueryParams", localVarPath, "PUT", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null);
+    return apiClient.invokeAPI("FakeApi.testBodyWithQueryParams", localVarPath, "PUT", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null, localVarErrorTypes);
   }
   /**
    * To test \&quot;client\&quot; model
@@ -536,8 +550,10 @@ public class FakeApi {
 
     String[] localVarAuthNames = new String[] {  };
 
+    final Map<String, GenericType> localVarErrorTypes = new HashMap<String, GenericType>();
+
     GenericType<Client> localVarReturnType = new GenericType<Client>() {};
-    return apiClient.invokeAPI("FakeApi.testClientModel", localVarPath, "PATCH", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType);
+    return apiClient.invokeAPI("FakeApi.testClientModel", localVarPath, "PATCH", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType, localVarErrorTypes);
   }
   /**
    * Fake endpoint for testing various parameters  假端點  偽のエンドポイント  가짜 엔드 포인트
@@ -670,8 +686,10 @@ if (paramCallback != null)
 
     String[] localVarAuthNames = new String[] { "http_basic_test" };
 
+    final Map<String, GenericType> localVarErrorTypes = new HashMap<String, GenericType>();
+
     
-    return apiClient.invokeAPI("FakeApi.testEndpointParameters", localVarPath, "POST", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null);
+    return apiClient.invokeAPI("FakeApi.testEndpointParameters", localVarPath, "POST", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null, localVarErrorTypes);
   }
   /**
    * To test enum parameters
@@ -756,8 +774,10 @@ if (enumFormString != null)
 
     String[] localVarAuthNames = new String[] {  };
 
+    final Map<String, GenericType> localVarErrorTypes = new HashMap<String, GenericType>();
+
     
-    return apiClient.invokeAPI("FakeApi.testEnumParameters", localVarPath, "GET", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null);
+    return apiClient.invokeAPI("FakeApi.testEnumParameters", localVarPath, "GET", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null, localVarErrorTypes);
   }
 
 private ApiResponse<Void> testGroupParametersWithHttpInfo(Integer requiredStringGroup, Boolean requiredBooleanGroup, Long requiredInt64Group, Integer stringGroup, Boolean booleanGroup, Long int64Group) throws ApiException {
@@ -811,8 +831,10 @@ if (booleanGroup != null)
 
     String[] localVarAuthNames = new String[] {  };
 
+    final Map<String, GenericType> localVarErrorTypes = new HashMap<String, GenericType>();
+
     
-    return apiClient.invokeAPI("FakeApi.testGroupParameters", localVarPath, "DELETE", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null);
+    return apiClient.invokeAPI("FakeApi.testGroupParameters", localVarPath, "DELETE", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null, localVarErrorTypes);
   }
 
   public class APItestGroupParametersRequest {
@@ -998,8 +1020,10 @@ if (booleanGroup != null)
 
     String[] localVarAuthNames = new String[] {  };
 
+    final Map<String, GenericType> localVarErrorTypes = new HashMap<String, GenericType>();
+
     
-    return apiClient.invokeAPI("FakeApi.testInlineAdditionalProperties", localVarPath, "POST", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null);
+    return apiClient.invokeAPI("FakeApi.testInlineAdditionalProperties", localVarPath, "POST", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null, localVarErrorTypes);
   }
   /**
    * test json serialization of form data
@@ -1072,8 +1096,10 @@ if (param2 != null)
 
     String[] localVarAuthNames = new String[] {  };
 
+    final Map<String, GenericType> localVarErrorTypes = new HashMap<String, GenericType>();
+
     
-    return apiClient.invokeAPI("FakeApi.testJsonFormData", localVarPath, "GET", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null);
+    return apiClient.invokeAPI("FakeApi.testJsonFormData", localVarPath, "GET", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null, localVarErrorTypes);
   }
   /**
    * 
@@ -1168,7 +1194,9 @@ if (param2 != null)
 
     String[] localVarAuthNames = new String[] {  };
 
+    final Map<String, GenericType> localVarErrorTypes = new HashMap<String, GenericType>();
+
     
-    return apiClient.invokeAPI("FakeApi.testQueryParameterCollectionFormat", localVarPath, "PUT", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null);
+    return apiClient.invokeAPI("FakeApi.testQueryParameterCollectionFormat", localVarPath, "PUT", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null, localVarErrorTypes);
   }
 }

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
@@ -95,7 +95,9 @@ public class FakeClassnameTags123Api {
 
     String[] localVarAuthNames = new String[] { "api_key_query" };
 
+    final Map<String, GenericType> localVarErrorTypes = new HashMap<String, GenericType>();
+
     GenericType<Client> localVarReturnType = new GenericType<Client>() {};
-    return apiClient.invokeAPI("FakeClassnameTags123Api.testClassname", localVarPath, "PATCH", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType);
+    return apiClient.invokeAPI("FakeClassnameTags123Api.testClassname", localVarPath, "PATCH", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType, localVarErrorTypes);
   }
 }

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/PetApi.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/PetApi.java
@@ -98,8 +98,10 @@ public class PetApi {
 
     String[] localVarAuthNames = new String[] { "petstore_auth" };
 
+    final Map<String, GenericType> localVarErrorTypes = new HashMap<String, GenericType>();
+
     
-    return apiClient.invokeAPI("PetApi.addPet", localVarPath, "POST", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null);
+    return apiClient.invokeAPI("PetApi.addPet", localVarPath, "POST", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null, localVarErrorTypes);
   }
   /**
    * Deletes a pet
@@ -168,8 +170,10 @@ public class PetApi {
 
     String[] localVarAuthNames = new String[] { "petstore_auth" };
 
+    final Map<String, GenericType> localVarErrorTypes = new HashMap<String, GenericType>();
+
     
-    return apiClient.invokeAPI("PetApi.deletePet", localVarPath, "DELETE", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null);
+    return apiClient.invokeAPI("PetApi.deletePet", localVarPath, "DELETE", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null, localVarErrorTypes);
   }
   /**
    * Finds Pets by status
@@ -235,8 +239,10 @@ public class PetApi {
 
     String[] localVarAuthNames = new String[] { "petstore_auth" };
 
+    final Map<String, GenericType> localVarErrorTypes = new HashMap<String, GenericType>();
+
     GenericType<List<Pet>> localVarReturnType = new GenericType<List<Pet>>() {};
-    return apiClient.invokeAPI("PetApi.findPetsByStatus", localVarPath, "GET", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType);
+    return apiClient.invokeAPI("PetApi.findPetsByStatus", localVarPath, "GET", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType, localVarErrorTypes);
   }
   /**
    * Finds Pets by tags
@@ -306,8 +312,10 @@ public class PetApi {
 
     String[] localVarAuthNames = new String[] { "petstore_auth" };
 
+    final Map<String, GenericType> localVarErrorTypes = new HashMap<String, GenericType>();
+
     GenericType<List<Pet>> localVarReturnType = new GenericType<List<Pet>>() {};
-    return apiClient.invokeAPI("PetApi.findPetsByTags", localVarPath, "GET", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType);
+    return apiClient.invokeAPI("PetApi.findPetsByTags", localVarPath, "GET", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType, localVarErrorTypes);
   }
   /**
    * Find pet by ID
@@ -375,8 +383,10 @@ public class PetApi {
 
     String[] localVarAuthNames = new String[] { "api_key" };
 
+    final Map<String, GenericType> localVarErrorTypes = new HashMap<String, GenericType>();
+
     GenericType<Pet> localVarReturnType = new GenericType<Pet>() {};
-    return apiClient.invokeAPI("PetApi.getPetById", localVarPath, "GET", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType);
+    return apiClient.invokeAPI("PetApi.getPetById", localVarPath, "GET", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType, localVarErrorTypes);
   }
   /**
    * Update an existing pet
@@ -444,8 +454,10 @@ public class PetApi {
 
     String[] localVarAuthNames = new String[] { "petstore_auth" };
 
+    final Map<String, GenericType> localVarErrorTypes = new HashMap<String, GenericType>();
+
     
-    return apiClient.invokeAPI("PetApi.updatePet", localVarPath, "PUT", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null);
+    return apiClient.invokeAPI("PetApi.updatePet", localVarPath, "PUT", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null, localVarErrorTypes);
   }
   /**
    * Updates a pet in the store with form data
@@ -516,8 +528,10 @@ if (status != null)
 
     String[] localVarAuthNames = new String[] { "petstore_auth" };
 
+    final Map<String, GenericType> localVarErrorTypes = new HashMap<String, GenericType>();
+
     
-    return apiClient.invokeAPI("PetApi.updatePetWithForm", localVarPath, "POST", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null);
+    return apiClient.invokeAPI("PetApi.updatePetWithForm", localVarPath, "POST", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null, localVarErrorTypes);
   }
   /**
    * uploads an image
@@ -589,8 +603,10 @@ if (file != null)
 
     String[] localVarAuthNames = new String[] { "petstore_auth" };
 
+    final Map<String, GenericType> localVarErrorTypes = new HashMap<String, GenericType>();
+
     GenericType<ModelApiResponse> localVarReturnType = new GenericType<ModelApiResponse>() {};
-    return apiClient.invokeAPI("PetApi.uploadFile", localVarPath, "POST", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType);
+    return apiClient.invokeAPI("PetApi.uploadFile", localVarPath, "POST", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType, localVarErrorTypes);
   }
   /**
    * uploads an image (required)
@@ -667,7 +683,9 @@ if (requiredFile != null)
 
     String[] localVarAuthNames = new String[] { "petstore_auth" };
 
+    final Map<String, GenericType> localVarErrorTypes = new HashMap<String, GenericType>();
+
     GenericType<ModelApiResponse> localVarReturnType = new GenericType<ModelApiResponse>() {};
-    return apiClient.invokeAPI("PetApi.uploadFileWithRequiredFile", localVarPath, "POST", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType);
+    return apiClient.invokeAPI("PetApi.uploadFileWithRequiredFile", localVarPath, "POST", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType, localVarErrorTypes);
   }
 }

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/StoreApi.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/StoreApi.java
@@ -97,8 +97,10 @@ public class StoreApi {
 
     String[] localVarAuthNames = new String[] {  };
 
+    final Map<String, GenericType> localVarErrorTypes = new HashMap<String, GenericType>();
+
     
-    return apiClient.invokeAPI("StoreApi.deleteOrder", localVarPath, "DELETE", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null);
+    return apiClient.invokeAPI("StoreApi.deleteOrder", localVarPath, "DELETE", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null, localVarErrorTypes);
   }
   /**
    * Returns pet inventories by status
@@ -154,8 +156,10 @@ public class StoreApi {
 
     String[] localVarAuthNames = new String[] { "api_key" };
 
+    final Map<String, GenericType> localVarErrorTypes = new HashMap<String, GenericType>();
+
     GenericType<Map<String, Integer>> localVarReturnType = new GenericType<Map<String, Integer>>() {};
-    return apiClient.invokeAPI("StoreApi.getInventory", localVarPath, "GET", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType);
+    return apiClient.invokeAPI("StoreApi.getInventory", localVarPath, "GET", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType, localVarErrorTypes);
   }
   /**
    * Find purchase order by ID
@@ -223,8 +227,10 @@ public class StoreApi {
 
     String[] localVarAuthNames = new String[] {  };
 
+    final Map<String, GenericType> localVarErrorTypes = new HashMap<String, GenericType>();
+
     GenericType<Order> localVarReturnType = new GenericType<Order>() {};
-    return apiClient.invokeAPI("StoreApi.getOrderById", localVarPath, "GET", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType);
+    return apiClient.invokeAPI("StoreApi.getOrderById", localVarPath, "GET", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType, localVarErrorTypes);
   }
   /**
    * Place an order for a pet
@@ -289,7 +295,9 @@ public class StoreApi {
 
     String[] localVarAuthNames = new String[] {  };
 
+    final Map<String, GenericType> localVarErrorTypes = new HashMap<String, GenericType>();
+
     GenericType<Order> localVarReturnType = new GenericType<Order>() {};
-    return apiClient.invokeAPI("StoreApi.placeOrder", localVarPath, "POST", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType);
+    return apiClient.invokeAPI("StoreApi.placeOrder", localVarPath, "POST", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType, localVarErrorTypes);
   }
 }

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/UserApi.java
@@ -94,8 +94,10 @@ public class UserApi {
 
     String[] localVarAuthNames = new String[] {  };
 
+    final Map<String, GenericType> localVarErrorTypes = new HashMap<String, GenericType>();
+
     
-    return apiClient.invokeAPI("UserApi.createUser", localVarPath, "POST", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null);
+    return apiClient.invokeAPI("UserApi.createUser", localVarPath, "POST", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null, localVarErrorTypes);
   }
   /**
    * Creates list of users with given input array
@@ -157,8 +159,10 @@ public class UserApi {
 
     String[] localVarAuthNames = new String[] {  };
 
+    final Map<String, GenericType> localVarErrorTypes = new HashMap<String, GenericType>();
+
     
-    return apiClient.invokeAPI("UserApi.createUsersWithArrayInput", localVarPath, "POST", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null);
+    return apiClient.invokeAPI("UserApi.createUsersWithArrayInput", localVarPath, "POST", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null, localVarErrorTypes);
   }
   /**
    * Creates list of users with given input array
@@ -220,8 +224,10 @@ public class UserApi {
 
     String[] localVarAuthNames = new String[] {  };
 
+    final Map<String, GenericType> localVarErrorTypes = new HashMap<String, GenericType>();
+
     
-    return apiClient.invokeAPI("UserApi.createUsersWithListInput", localVarPath, "POST", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null);
+    return apiClient.invokeAPI("UserApi.createUsersWithListInput", localVarPath, "POST", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null, localVarErrorTypes);
   }
   /**
    * Delete user
@@ -286,8 +292,10 @@ public class UserApi {
 
     String[] localVarAuthNames = new String[] {  };
 
+    final Map<String, GenericType> localVarErrorTypes = new HashMap<String, GenericType>();
+
     
-    return apiClient.invokeAPI("UserApi.deleteUser", localVarPath, "DELETE", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null);
+    return apiClient.invokeAPI("UserApi.deleteUser", localVarPath, "DELETE", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null, localVarErrorTypes);
   }
   /**
    * Get user by user name
@@ -355,8 +363,10 @@ public class UserApi {
 
     String[] localVarAuthNames = new String[] {  };
 
+    final Map<String, GenericType> localVarErrorTypes = new HashMap<String, GenericType>();
+
     GenericType<User> localVarReturnType = new GenericType<User>() {};
-    return apiClient.invokeAPI("UserApi.getUserByName", localVarPath, "GET", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType);
+    return apiClient.invokeAPI("UserApi.getUserByName", localVarPath, "GET", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType, localVarErrorTypes);
   }
   /**
    * Logs user into the system
@@ -430,8 +440,10 @@ public class UserApi {
 
     String[] localVarAuthNames = new String[] {  };
 
+    final Map<String, GenericType> localVarErrorTypes = new HashMap<String, GenericType>();
+
     GenericType<String> localVarReturnType = new GenericType<String>() {};
-    return apiClient.invokeAPI("UserApi.loginUser", localVarPath, "GET", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType);
+    return apiClient.invokeAPI("UserApi.loginUser", localVarPath, "GET", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType, localVarErrorTypes);
   }
   /**
    * Logs out current logged in user session
@@ -486,8 +498,10 @@ public class UserApi {
 
     String[] localVarAuthNames = new String[] {  };
 
+    final Map<String, GenericType> localVarErrorTypes = new HashMap<String, GenericType>();
+
     
-    return apiClient.invokeAPI("UserApi.logoutUser", localVarPath, "GET", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null);
+    return apiClient.invokeAPI("UserApi.logoutUser", localVarPath, "GET", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null, localVarErrorTypes);
   }
   /**
    * Updated user
@@ -559,7 +573,9 @@ public class UserApi {
 
     String[] localVarAuthNames = new String[] {  };
 
+    final Map<String, GenericType> localVarErrorTypes = new HashMap<String, GenericType>();
+
     
-    return apiClient.invokeAPI("UserApi.updateUser", localVarPath, "PUT", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null);
+    return apiClient.invokeAPI("UserApi.updateUser", localVarPath, "PUT", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null, localVarErrorTypes);
   }
 }

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/ApiException.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/ApiException.java
@@ -21,6 +21,7 @@ public class ApiException extends Exception {
     private int code = 0;
     private Map<String, List<String>> responseHeaders = null;
     private String responseBody = null;
+    private Object errorEntity = null;
 
     public ApiException() {}
 
@@ -62,6 +63,11 @@ public class ApiException extends Exception {
         this.responseBody = responseBody;
     }
 
+    public ApiException(int code, String message, Map<String, List<String>> responseHeaders, String responseBody, Object errorEntity) {
+        this(code, message, responseHeaders, responseBody);
+        this.errorEntity = errorEntity;
+    }
+
     /**
      * Get the HTTP status code.
      *
@@ -87,5 +93,14 @@ public class ApiException extends Exception {
      */
     public String getResponseBody() {
         return responseBody;
+    }
+
+    /**
+     * Get the deserialized error entity (or null if this error doesn't have a model associated).
+     *
+     * @return Deserialized error entity
+     */
+    public Object getErrorEntity() {
+        return errorEntity;
     }
 }

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
@@ -95,7 +95,9 @@ public class AnotherFakeApi {
 
     String[] localVarAuthNames = new String[] {  };
 
+    final Map<String, GenericType> localVarErrorTypes = new HashMap<String, GenericType>();
+
     GenericType<Client> localVarReturnType = new GenericType<Client>() {};
-    return apiClient.invokeAPI("AnotherFakeApi.call123testSpecialTags", localVarPath, "PATCH", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType);
+    return apiClient.invokeAPI("AnotherFakeApi.call123testSpecialTags", localVarPath, "PATCH", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType, localVarErrorTypes);
   }
 }

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -102,8 +102,10 @@ public class FakeApi {
 
     String[] localVarAuthNames = new String[] {  };
 
+    final Map<String, GenericType> localVarErrorTypes = new HashMap<String, GenericType>();
+
     
-    return apiClient.invokeAPI("FakeApi.createXmlItem", localVarPath, "POST", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null);
+    return apiClient.invokeAPI("FakeApi.createXmlItem", localVarPath, "POST", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null, localVarErrorTypes);
   }
   /**
    * 
@@ -161,8 +163,10 @@ public class FakeApi {
 
     String[] localVarAuthNames = new String[] {  };
 
+    final Map<String, GenericType> localVarErrorTypes = new HashMap<String, GenericType>();
+
     GenericType<Boolean> localVarReturnType = new GenericType<Boolean>() {};
-    return apiClient.invokeAPI("FakeApi.fakeOuterBooleanSerialize", localVarPath, "POST", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType);
+    return apiClient.invokeAPI("FakeApi.fakeOuterBooleanSerialize", localVarPath, "POST", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType, localVarErrorTypes);
   }
   /**
    * 
@@ -220,8 +224,10 @@ public class FakeApi {
 
     String[] localVarAuthNames = new String[] {  };
 
+    final Map<String, GenericType> localVarErrorTypes = new HashMap<String, GenericType>();
+
     GenericType<OuterComposite> localVarReturnType = new GenericType<OuterComposite>() {};
-    return apiClient.invokeAPI("FakeApi.fakeOuterCompositeSerialize", localVarPath, "POST", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType);
+    return apiClient.invokeAPI("FakeApi.fakeOuterCompositeSerialize", localVarPath, "POST", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType, localVarErrorTypes);
   }
   /**
    * 
@@ -279,8 +285,10 @@ public class FakeApi {
 
     String[] localVarAuthNames = new String[] {  };
 
+    final Map<String, GenericType> localVarErrorTypes = new HashMap<String, GenericType>();
+
     GenericType<BigDecimal> localVarReturnType = new GenericType<BigDecimal>() {};
-    return apiClient.invokeAPI("FakeApi.fakeOuterNumberSerialize", localVarPath, "POST", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType);
+    return apiClient.invokeAPI("FakeApi.fakeOuterNumberSerialize", localVarPath, "POST", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType, localVarErrorTypes);
   }
   /**
    * 
@@ -338,8 +346,10 @@ public class FakeApi {
 
     String[] localVarAuthNames = new String[] {  };
 
+    final Map<String, GenericType> localVarErrorTypes = new HashMap<String, GenericType>();
+
     GenericType<String> localVarReturnType = new GenericType<String>() {};
-    return apiClient.invokeAPI("FakeApi.fakeOuterStringSerialize", localVarPath, "POST", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType);
+    return apiClient.invokeAPI("FakeApi.fakeOuterStringSerialize", localVarPath, "POST", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType, localVarErrorTypes);
   }
   /**
    * 
@@ -401,8 +411,10 @@ public class FakeApi {
 
     String[] localVarAuthNames = new String[] {  };
 
+    final Map<String, GenericType> localVarErrorTypes = new HashMap<String, GenericType>();
+
     
-    return apiClient.invokeAPI("FakeApi.testBodyWithFileSchema", localVarPath, "PUT", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null);
+    return apiClient.invokeAPI("FakeApi.testBodyWithFileSchema", localVarPath, "PUT", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null, localVarErrorTypes);
   }
   /**
    * 
@@ -472,8 +484,10 @@ public class FakeApi {
 
     String[] localVarAuthNames = new String[] {  };
 
+    final Map<String, GenericType> localVarErrorTypes = new HashMap<String, GenericType>();
+
     
-    return apiClient.invokeAPI("FakeApi.testBodyWithQueryParams", localVarPath, "PUT", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null);
+    return apiClient.invokeAPI("FakeApi.testBodyWithQueryParams", localVarPath, "PUT", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null, localVarErrorTypes);
   }
   /**
    * To test \&quot;client\&quot; model
@@ -536,8 +550,10 @@ public class FakeApi {
 
     String[] localVarAuthNames = new String[] {  };
 
+    final Map<String, GenericType> localVarErrorTypes = new HashMap<String, GenericType>();
+
     GenericType<Client> localVarReturnType = new GenericType<Client>() {};
-    return apiClient.invokeAPI("FakeApi.testClientModel", localVarPath, "PATCH", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType);
+    return apiClient.invokeAPI("FakeApi.testClientModel", localVarPath, "PATCH", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType, localVarErrorTypes);
   }
   /**
    * Fake endpoint for testing various parameters  假端點  偽のエンドポイント  가짜 엔드 포인트
@@ -670,8 +686,10 @@ if (paramCallback != null)
 
     String[] localVarAuthNames = new String[] { "http_basic_test" };
 
+    final Map<String, GenericType> localVarErrorTypes = new HashMap<String, GenericType>();
+
     
-    return apiClient.invokeAPI("FakeApi.testEndpointParameters", localVarPath, "POST", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null);
+    return apiClient.invokeAPI("FakeApi.testEndpointParameters", localVarPath, "POST", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null, localVarErrorTypes);
   }
   /**
    * To test enum parameters
@@ -756,8 +774,10 @@ if (enumFormString != null)
 
     String[] localVarAuthNames = new String[] {  };
 
+    final Map<String, GenericType> localVarErrorTypes = new HashMap<String, GenericType>();
+
     
-    return apiClient.invokeAPI("FakeApi.testEnumParameters", localVarPath, "GET", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null);
+    return apiClient.invokeAPI("FakeApi.testEnumParameters", localVarPath, "GET", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null, localVarErrorTypes);
   }
 
 private ApiResponse<Void> testGroupParametersWithHttpInfo(Integer requiredStringGroup, Boolean requiredBooleanGroup, Long requiredInt64Group, Integer stringGroup, Boolean booleanGroup, Long int64Group) throws ApiException {
@@ -811,8 +831,10 @@ if (booleanGroup != null)
 
     String[] localVarAuthNames = new String[] {  };
 
+    final Map<String, GenericType> localVarErrorTypes = new HashMap<String, GenericType>();
+
     
-    return apiClient.invokeAPI("FakeApi.testGroupParameters", localVarPath, "DELETE", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null);
+    return apiClient.invokeAPI("FakeApi.testGroupParameters", localVarPath, "DELETE", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null, localVarErrorTypes);
   }
 
   public class APItestGroupParametersRequest {
@@ -998,8 +1020,10 @@ if (booleanGroup != null)
 
     String[] localVarAuthNames = new String[] {  };
 
+    final Map<String, GenericType> localVarErrorTypes = new HashMap<String, GenericType>();
+
     
-    return apiClient.invokeAPI("FakeApi.testInlineAdditionalProperties", localVarPath, "POST", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null);
+    return apiClient.invokeAPI("FakeApi.testInlineAdditionalProperties", localVarPath, "POST", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null, localVarErrorTypes);
   }
   /**
    * test json serialization of form data
@@ -1072,8 +1096,10 @@ if (param2 != null)
 
     String[] localVarAuthNames = new String[] {  };
 
+    final Map<String, GenericType> localVarErrorTypes = new HashMap<String, GenericType>();
+
     
-    return apiClient.invokeAPI("FakeApi.testJsonFormData", localVarPath, "GET", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null);
+    return apiClient.invokeAPI("FakeApi.testJsonFormData", localVarPath, "GET", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null, localVarErrorTypes);
   }
   /**
    * 
@@ -1168,7 +1194,9 @@ if (param2 != null)
 
     String[] localVarAuthNames = new String[] {  };
 
+    final Map<String, GenericType> localVarErrorTypes = new HashMap<String, GenericType>();
+
     
-    return apiClient.invokeAPI("FakeApi.testQueryParameterCollectionFormat", localVarPath, "PUT", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null);
+    return apiClient.invokeAPI("FakeApi.testQueryParameterCollectionFormat", localVarPath, "PUT", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null, localVarErrorTypes);
   }
 }

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
@@ -95,7 +95,9 @@ public class FakeClassnameTags123Api {
 
     String[] localVarAuthNames = new String[] { "api_key_query" };
 
+    final Map<String, GenericType> localVarErrorTypes = new HashMap<String, GenericType>();
+
     GenericType<Client> localVarReturnType = new GenericType<Client>() {};
-    return apiClient.invokeAPI("FakeClassnameTags123Api.testClassname", localVarPath, "PATCH", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType);
+    return apiClient.invokeAPI("FakeClassnameTags123Api.testClassname", localVarPath, "PATCH", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType, localVarErrorTypes);
   }
 }

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/api/PetApi.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/api/PetApi.java
@@ -98,8 +98,10 @@ public class PetApi {
 
     String[] localVarAuthNames = new String[] { "petstore_auth" };
 
+    final Map<String, GenericType> localVarErrorTypes = new HashMap<String, GenericType>();
+
     
-    return apiClient.invokeAPI("PetApi.addPet", localVarPath, "POST", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null);
+    return apiClient.invokeAPI("PetApi.addPet", localVarPath, "POST", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null, localVarErrorTypes);
   }
   /**
    * Deletes a pet
@@ -168,8 +170,10 @@ public class PetApi {
 
     String[] localVarAuthNames = new String[] { "petstore_auth" };
 
+    final Map<String, GenericType> localVarErrorTypes = new HashMap<String, GenericType>();
+
     
-    return apiClient.invokeAPI("PetApi.deletePet", localVarPath, "DELETE", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null);
+    return apiClient.invokeAPI("PetApi.deletePet", localVarPath, "DELETE", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null, localVarErrorTypes);
   }
   /**
    * Finds Pets by status
@@ -235,8 +239,10 @@ public class PetApi {
 
     String[] localVarAuthNames = new String[] { "petstore_auth" };
 
+    final Map<String, GenericType> localVarErrorTypes = new HashMap<String, GenericType>();
+
     GenericType<List<Pet>> localVarReturnType = new GenericType<List<Pet>>() {};
-    return apiClient.invokeAPI("PetApi.findPetsByStatus", localVarPath, "GET", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType);
+    return apiClient.invokeAPI("PetApi.findPetsByStatus", localVarPath, "GET", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType, localVarErrorTypes);
   }
   /**
    * Finds Pets by tags
@@ -306,8 +312,10 @@ public class PetApi {
 
     String[] localVarAuthNames = new String[] { "petstore_auth" };
 
+    final Map<String, GenericType> localVarErrorTypes = new HashMap<String, GenericType>();
+
     GenericType<List<Pet>> localVarReturnType = new GenericType<List<Pet>>() {};
-    return apiClient.invokeAPI("PetApi.findPetsByTags", localVarPath, "GET", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType);
+    return apiClient.invokeAPI("PetApi.findPetsByTags", localVarPath, "GET", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType, localVarErrorTypes);
   }
   /**
    * Find pet by ID
@@ -375,8 +383,10 @@ public class PetApi {
 
     String[] localVarAuthNames = new String[] { "api_key" };
 
+    final Map<String, GenericType> localVarErrorTypes = new HashMap<String, GenericType>();
+
     GenericType<Pet> localVarReturnType = new GenericType<Pet>() {};
-    return apiClient.invokeAPI("PetApi.getPetById", localVarPath, "GET", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType);
+    return apiClient.invokeAPI("PetApi.getPetById", localVarPath, "GET", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType, localVarErrorTypes);
   }
   /**
    * Update an existing pet
@@ -444,8 +454,10 @@ public class PetApi {
 
     String[] localVarAuthNames = new String[] { "petstore_auth" };
 
+    final Map<String, GenericType> localVarErrorTypes = new HashMap<String, GenericType>();
+
     
-    return apiClient.invokeAPI("PetApi.updatePet", localVarPath, "PUT", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null);
+    return apiClient.invokeAPI("PetApi.updatePet", localVarPath, "PUT", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null, localVarErrorTypes);
   }
   /**
    * Updates a pet in the store with form data
@@ -516,8 +528,10 @@ if (status != null)
 
     String[] localVarAuthNames = new String[] { "petstore_auth" };
 
+    final Map<String, GenericType> localVarErrorTypes = new HashMap<String, GenericType>();
+
     
-    return apiClient.invokeAPI("PetApi.updatePetWithForm", localVarPath, "POST", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null);
+    return apiClient.invokeAPI("PetApi.updatePetWithForm", localVarPath, "POST", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null, localVarErrorTypes);
   }
   /**
    * uploads an image
@@ -589,8 +603,10 @@ if (file != null)
 
     String[] localVarAuthNames = new String[] { "petstore_auth" };
 
+    final Map<String, GenericType> localVarErrorTypes = new HashMap<String, GenericType>();
+
     GenericType<ModelApiResponse> localVarReturnType = new GenericType<ModelApiResponse>() {};
-    return apiClient.invokeAPI("PetApi.uploadFile", localVarPath, "POST", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType);
+    return apiClient.invokeAPI("PetApi.uploadFile", localVarPath, "POST", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType, localVarErrorTypes);
   }
   /**
    * uploads an image (required)
@@ -667,7 +683,9 @@ if (requiredFile != null)
 
     String[] localVarAuthNames = new String[] { "petstore_auth" };
 
+    final Map<String, GenericType> localVarErrorTypes = new HashMap<String, GenericType>();
+
     GenericType<ModelApiResponse> localVarReturnType = new GenericType<ModelApiResponse>() {};
-    return apiClient.invokeAPI("PetApi.uploadFileWithRequiredFile", localVarPath, "POST", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType);
+    return apiClient.invokeAPI("PetApi.uploadFileWithRequiredFile", localVarPath, "POST", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType, localVarErrorTypes);
   }
 }

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/api/StoreApi.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/api/StoreApi.java
@@ -97,8 +97,10 @@ public class StoreApi {
 
     String[] localVarAuthNames = new String[] {  };
 
+    final Map<String, GenericType> localVarErrorTypes = new HashMap<String, GenericType>();
+
     
-    return apiClient.invokeAPI("StoreApi.deleteOrder", localVarPath, "DELETE", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null);
+    return apiClient.invokeAPI("StoreApi.deleteOrder", localVarPath, "DELETE", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null, localVarErrorTypes);
   }
   /**
    * Returns pet inventories by status
@@ -154,8 +156,10 @@ public class StoreApi {
 
     String[] localVarAuthNames = new String[] { "api_key" };
 
+    final Map<String, GenericType> localVarErrorTypes = new HashMap<String, GenericType>();
+
     GenericType<Map<String, Integer>> localVarReturnType = new GenericType<Map<String, Integer>>() {};
-    return apiClient.invokeAPI("StoreApi.getInventory", localVarPath, "GET", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType);
+    return apiClient.invokeAPI("StoreApi.getInventory", localVarPath, "GET", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType, localVarErrorTypes);
   }
   /**
    * Find purchase order by ID
@@ -223,8 +227,10 @@ public class StoreApi {
 
     String[] localVarAuthNames = new String[] {  };
 
+    final Map<String, GenericType> localVarErrorTypes = new HashMap<String, GenericType>();
+
     GenericType<Order> localVarReturnType = new GenericType<Order>() {};
-    return apiClient.invokeAPI("StoreApi.getOrderById", localVarPath, "GET", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType);
+    return apiClient.invokeAPI("StoreApi.getOrderById", localVarPath, "GET", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType, localVarErrorTypes);
   }
   /**
    * Place an order for a pet
@@ -289,7 +295,9 @@ public class StoreApi {
 
     String[] localVarAuthNames = new String[] {  };
 
+    final Map<String, GenericType> localVarErrorTypes = new HashMap<String, GenericType>();
+
     GenericType<Order> localVarReturnType = new GenericType<Order>() {};
-    return apiClient.invokeAPI("StoreApi.placeOrder", localVarPath, "POST", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType);
+    return apiClient.invokeAPI("StoreApi.placeOrder", localVarPath, "POST", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType, localVarErrorTypes);
   }
 }

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/api/UserApi.java
@@ -94,8 +94,10 @@ public class UserApi {
 
     String[] localVarAuthNames = new String[] {  };
 
+    final Map<String, GenericType> localVarErrorTypes = new HashMap<String, GenericType>();
+
     
-    return apiClient.invokeAPI("UserApi.createUser", localVarPath, "POST", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null);
+    return apiClient.invokeAPI("UserApi.createUser", localVarPath, "POST", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null, localVarErrorTypes);
   }
   /**
    * Creates list of users with given input array
@@ -157,8 +159,10 @@ public class UserApi {
 
     String[] localVarAuthNames = new String[] {  };
 
+    final Map<String, GenericType> localVarErrorTypes = new HashMap<String, GenericType>();
+
     
-    return apiClient.invokeAPI("UserApi.createUsersWithArrayInput", localVarPath, "POST", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null);
+    return apiClient.invokeAPI("UserApi.createUsersWithArrayInput", localVarPath, "POST", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null, localVarErrorTypes);
   }
   /**
    * Creates list of users with given input array
@@ -220,8 +224,10 @@ public class UserApi {
 
     String[] localVarAuthNames = new String[] {  };
 
+    final Map<String, GenericType> localVarErrorTypes = new HashMap<String, GenericType>();
+
     
-    return apiClient.invokeAPI("UserApi.createUsersWithListInput", localVarPath, "POST", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null);
+    return apiClient.invokeAPI("UserApi.createUsersWithListInput", localVarPath, "POST", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null, localVarErrorTypes);
   }
   /**
    * Delete user
@@ -286,8 +292,10 @@ public class UserApi {
 
     String[] localVarAuthNames = new String[] {  };
 
+    final Map<String, GenericType> localVarErrorTypes = new HashMap<String, GenericType>();
+
     
-    return apiClient.invokeAPI("UserApi.deleteUser", localVarPath, "DELETE", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null);
+    return apiClient.invokeAPI("UserApi.deleteUser", localVarPath, "DELETE", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null, localVarErrorTypes);
   }
   /**
    * Get user by user name
@@ -355,8 +363,10 @@ public class UserApi {
 
     String[] localVarAuthNames = new String[] {  };
 
+    final Map<String, GenericType> localVarErrorTypes = new HashMap<String, GenericType>();
+
     GenericType<User> localVarReturnType = new GenericType<User>() {};
-    return apiClient.invokeAPI("UserApi.getUserByName", localVarPath, "GET", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType);
+    return apiClient.invokeAPI("UserApi.getUserByName", localVarPath, "GET", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType, localVarErrorTypes);
   }
   /**
    * Logs user into the system
@@ -430,8 +440,10 @@ public class UserApi {
 
     String[] localVarAuthNames = new String[] {  };
 
+    final Map<String, GenericType> localVarErrorTypes = new HashMap<String, GenericType>();
+
     GenericType<String> localVarReturnType = new GenericType<String>() {};
-    return apiClient.invokeAPI("UserApi.loginUser", localVarPath, "GET", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType);
+    return apiClient.invokeAPI("UserApi.loginUser", localVarPath, "GET", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType, localVarErrorTypes);
   }
   /**
    * Logs out current logged in user session
@@ -486,8 +498,10 @@ public class UserApi {
 
     String[] localVarAuthNames = new String[] {  };
 
+    final Map<String, GenericType> localVarErrorTypes = new HashMap<String, GenericType>();
+
     
-    return apiClient.invokeAPI("UserApi.logoutUser", localVarPath, "GET", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null);
+    return apiClient.invokeAPI("UserApi.logoutUser", localVarPath, "GET", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null, localVarErrorTypes);
   }
   /**
    * Updated user
@@ -559,7 +573,9 @@ public class UserApi {
 
     String[] localVarAuthNames = new String[] {  };
 
+    final Map<String, GenericType> localVarErrorTypes = new HashMap<String, GenericType>();
+
     
-    return apiClient.invokeAPI("UserApi.updateUser", localVarPath, "PUT", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null);
+    return apiClient.invokeAPI("UserApi.updateUser", localVarPath, "PUT", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null, localVarErrorTypes);
   }
 }


### PR DESCRIPTION
This PR implements deserialization of models for error responses (== responses that are represented by thrown `ApiException`). For now this is only done for Jersey2 client.

The `ApiException` class got a new method `getErrorEntity` that returns the deserialized error model when the given error code has an error model defined and the deserialization of the error payload is successful.

Attempts to solve https://github.com/OpenAPITools/openapi-generator/issues/4777 for Jersey2.

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

CC @bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04) @lwlee2608 (2019/10) @bkabrda (2020/01)