### PR TITLE
[k6] bugfixes to improve the output script

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/K6ClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/K6ClientCodegen.java
@@ -497,6 +497,14 @@ public class K6ClientCodegen extends DefaultCodegen implements CodegenConfig {
         return name;
     }
 
+    @Override
+    public String escapeReservedWord(String name) {
+        if (this.reservedWordsMappings().containsKey(name)) {
+            return this.reservedWordsMappings().get(name);
+        }
+        return "_" + name;
+    }
+
     private String getTemplateString(String input) {
         return "`" + getTemplateVariable(input) + "`";
     }

--- a/modules/openapi-generator/src/main/resources/k6/licenseInfo.mustache
+++ b/modules/openapi-generator/src/main/resources/k6/licenseInfo.mustache
@@ -1,6 +1,6 @@
 /*
  * {{appName}}
- * {{appDescription}}
+ * {{& appDescription}}
  *
  {{#version}}
  * OpenAPI spec version: {{version}}

--- a/samples/client/petstore/k6/script.js
+++ b/samples/client/petstore/k6/script.js
@@ -1,6 +1,6 @@
 /*
  * OpenAPI Petstore
- * This is a sample server Petstore server. For this sample, you can use the api key &#x60;special-key&#x60; to test the authorization filters.
+ * This is a sample server Petstore server.  For this sample, you can use the api key \"special-key\" to test the authorization filters
  *
  * OpenAPI spec version: 1.0.0
  *
@@ -19,7 +19,7 @@ const BASE_URL = "http://petstore.swagger.io/v2";
 // You might want to edit the value of this variable or remove calls to the sleep function on the script.
 const SLEEP_DURATION = 0.1;
 // Global variables should be initialized.
-let api_key = "TODO_EDIT_THE_API_KEY";
+let apiKey = "TODO_EDIT_THE_API_KEY";
 
 export default function() {
     group("/pet", () => {
@@ -76,7 +76,7 @@ export default function() {
         sleep(SLEEP_DURATION);
 
         // Request No. 3
-        params = {headers: {"api_key": `${api_key}`}};
+        params = {headers: {"api_key": `${apiKey}`}};
         request = http.delete(url, params);
         sleep(SLEEP_DURATION);
     });


### PR DESCRIPTION
A strange case appeared while testing the generator (when writing the blog post #5608) in variable conversion, so here's the fix.

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [ ] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
