### PR TITLE
[python/asyncio] explicitly close client session and asynchronous context manager

### DIFF
--- a/modules/openapi-generator/src/main/resources/python/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/python/api_client.mustache
@@ -76,13 +76,25 @@ class ApiClient(object):
         self.user_agent = '{{#httpUserAgent}}{{{.}}}{{/httpUserAgent}}{{^httpUserAgent}}OpenAPI-Generator/{{{packageVersion}}}/python{{/httpUserAgent}}'
         self.client_side_validation = configuration.client_side_validation
 
+    {{#asyncio}}
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc_value, traceback):
+        await self.close()
+    {{/asyncio}}
+    {{^asyncio}}
     def __enter__(self):
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):
         self.close()
+    {{/asyncio}}
 
-    def close(self):
+    {{#asyncio}}async {{/asyncio}}def close(self):
+        {{#asyncio}}
+        await self.rest_client.close()
+        {{/asyncio}}
         if self._pool:
             self._pool.close()
             self._pool.join()

--- a/modules/openapi-generator/src/main/resources/python/asyncio/rest.mustache
+++ b/modules/openapi-generator/src/main/resources/python/asyncio/rest.mustache
@@ -10,7 +10,6 @@ import ssl
 
 import aiohttp
 import certifi
-import asyncio
 # python 2 and python 3 compatibility library
 from six.moves.urllib.parse import urlencode
 
@@ -77,8 +76,8 @@ class RESTClientObject(object):
                 connector=connector
             )
 
-    def __del__(self):
-        asyncio.ensure_future(self.pool_manager.close())
+    async def close(self):
+        await self.pool_manager.close()
 
     async def request(self, method, url, query_params=None, headers=None,
                       body=None, post_params=None, _preload_content=True,

--- a/samples/client/petstore/python-asyncio/petstore_api/api_client.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/api_client.py
@@ -81,13 +81,14 @@ class ApiClient(object):
         self.user_agent = 'OpenAPI-Generator/1.0.0/python'
         self.client_side_validation = configuration.client_side_validation
 
-    def __enter__(self):
+    async def __aenter__(self):
         return self
 
-    def __exit__(self, exc_type, exc_value, traceback):
-        self.close()
+    async def __aexit__(self, exc_type, exc_value, traceback):
+        await self.close()
 
-    def close(self):
+    async def close(self):
+        await self.rest_client.close()
         if self._pool:
             self._pool.close()
             self._pool.join()

--- a/samples/client/petstore/python-asyncio/petstore_api/rest.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/rest.py
@@ -18,7 +18,6 @@ import ssl
 
 import aiohttp
 import certifi
-import asyncio
 # python 2 and python 3 compatibility library
 from six.moves.urllib.parse import urlencode
 
@@ -85,8 +84,8 @@ class RESTClientObject(object):
                 connector=connector
             )
 
-    def __del__(self):
-        asyncio.ensure_future(self.pool_manager.close())
+    async def close(self):
+        await self.pool_manager.close()
 
     async def request(self, method, url, query_params=None, headers=None,
                       body=None, post_params=None, _preload_content=True,

--- a/samples/client/petstore/python-asyncio/tests/test_api_client.py
+++ b/samples/client/petstore/python-asyncio/tests/test_api_client.py
@@ -1,0 +1,27 @@
+# coding: utf-8
+
+# flake8: noqa
+
+import unittest
+import weakref
+
+from tests.util import async_test
+import petstore_api
+
+
+class TestApiClient(unittest.TestCase):
+
+    @async_test
+    async def test_context_manager_closes_client(self):
+
+        async with petstore_api.ApiClient() as client:
+            # thread pool
+            self.assertIsNotNone(client.pool)
+            pool_ref = weakref.ref(client._pool)
+            self.assertIsNotNone(pool_ref())
+            # pool_manager
+            self.assertFalse(client.rest_client.pool_manager.closed)
+            rest_pool_ref = client.rest_client.pool_manager
+
+        self.assertIsNone(pool_ref())
+        self.assertTrue(rest_pool_ref.closed)

--- a/samples/client/petstore/python-asyncio/tests/test_pet_api.py
+++ b/samples/client/petstore/python-asyncio/tests/test_pet_api.py
@@ -18,22 +18,13 @@ import petstore_api
 from petstore_api import Configuration
 from petstore_api.rest import ApiException
 
-from .util import id_gen
+from .util import id_gen, async_test
 
 import json
 
 import urllib3
 
 HOST = 'http://localhost:80/v2'
-
-
-def async_test(f):
-    def wrapper(*args, **kwargs):
-        coro = asyncio.coroutine(f)
-        future = coro(*args, **kwargs)
-        loop = asyncio.get_event_loop()
-        loop.run_until_complete(future)
-    return wrapper
 
 
 class TestPetApiTests(unittest.TestCase):

--- a/samples/client/petstore/python-asyncio/tests/util.py
+++ b/samples/client/petstore/python-asyncio/tests/util.py
@@ -1,5 +1,6 @@
 # flake8: noqa
 
+import asyncio
 import random
 
 
@@ -8,4 +9,10 @@ def id_gen(bits=32):
     return int(random.getrandbits(bits))
 
 
-
+def async_test(f):
+    def wrapper(*args, **kwargs):
+        coro = asyncio.coroutine(f)
+        future = coro(*args, **kwargs)
+        loop = asyncio.get_event_loop()
+        loop.run_until_complete(future)
+    return wrapper


### PR DESCRIPTION
From https://github.com/OpenAPITools/openapi-generator/pull/5094/ python clients expose api-client.close() method and the context manager. In this PR I added closing aiohttp.ClientSession there to allow users clean up objects in a more predictive way.

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

cc: @taxpon (2017/07) @frol (2017/07) @mbohlool (2017/07) @cbornet (2017/09) @kenjones-cisco (2017/11) @tomplus (2018/10) @Jyhess (2019/01) @slash-arun (2019/11) @spacether (2019/11)

Thank you reviewing and merging.