### PR TITLE
[C#] [aspnetcore] Option to have files as IFormFile instead of Stream

### DIFF
--- a/bin/aspnetcore-binary-iformfile.sh
+++ b/bin/aspnetcore-binary-iformfile.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="generate -g aspnetcore -i modules/openapi-generator/src/test/resources/3_0/form-multipart-binary-array.yaml -t modules/openapi-generator/src/main/resources/aspnetcore/2.1/ -o samples/server/binary/aspnetcore --additional-properties packageGuid={3C799344-F285-4669-8FD5-7ED9B795D5C5} --additional-properties useIFormFileInsteadOfStream=true $@"
+ags="generate -g aspnetcore -i modules/openapi-generator/src/test/resources/3_0/form-multipart-binary-array.yaml -t modules/openapi-generator/src/main/resources/aspnetcore/2.1/ -o samples/server/binary/aspnetcore-iformfile --additional-properties packageGuid={3C799344-F285-4669-8FD5-7ED9B795D5C5} --additional-properties useIFormFileInsteadOfStream=true $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/aspnetcore-binary.sh
+++ b/bin/aspnetcore-binary.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+SCRIPT="$0"
+echo "# START SCRIPT: $SCRIPT"
+
+while [ -h "$SCRIPT" ] ; do
+  ls=`ls -ld "$SCRIPT"`
+  link=`expr "$ls" : '.*-> \(.*\)$'`
+  if expr "$link" : '/.*' > /dev/null; then
+    SCRIPT="$link"
+  else
+    SCRIPT=`dirname "$SCRIPT"`/"$link"
+  fi
+done
+
+if [ ! -d "${APP_DIR}" ]; then
+  APP_DIR=`dirname "$SCRIPT"`/..
+  APP_DIR=`cd "${APP_DIR}"; pwd`
+fi
+
+executable="./modules/openapi-generator-cli/target/openapi-generator-cli.jar"
+
+if [ ! -f "$executable" ]
+then
+  mvn -B clean package
+fi
+
+# if you've executed sbt assembly previously it will use that instead.
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
+ags="generate -g aspnetcore -i modules/openapi-generator/src/test/resources/3_0/form-multipart-binary-array.yaml -t modules/openapi-generator/src/main/resources/aspnetcore/2.1/ -o samples/server/binary/aspnetcore --additional-properties packageGuid={3C799344-F285-4669-8FD5-7ED9B795D5C5} --additional-properties useIFormFileInsteadOfStream=true $@"
+
+java $JAVA_OPTS -jar $executable $ags

--- a/docs/generators/aspnetcore.md
+++ b/docs/generators/aspnetcore.md
@@ -34,9 +34,9 @@ sidebar_label: aspnetcore
 |useDateTimeOffset|Use DateTimeOffset to model date-time properties| |false|
 |useDefaultRouting|Use default routing for the  ASP.NET Core version. For 3.0 turn off default because it is not yet supported.| |true|
 |useFrameworkReference|Use frameworkReference for ASP.NET Core 3.0+ and  PackageReference  ASP.NET Core 2.2 or earlier.| |false|
+|useIFormFileInsteadOfStream|Change so that File inputs are generated as IFormFile data types instead of Stream| |false|
 |useNewtonsoft|Uses the Newtonsoft JSON library.| |true|
 |useSwashbuckle|Uses the Swashbuckle.AspNetCore NuGet package for documentation.| |true|
-|useIFormFileInsteadOfStream|Uses IFormfile type for file transfers instead of Stream| |true|
 
 ## IMPORT MAPPING
 
@@ -71,6 +71,7 @@ sidebar_label: aspnetcore
 <li>Int32</li>
 <li>Int64</li>
 <li>List</li>
+<li>Microsoft.AspNetCore.Http.IFormFile</li>
 <li>Object</li>
 <li>String</li>
 <li>System.IO.Stream</li>

--- a/docs/generators/aspnetcore.md
+++ b/docs/generators/aspnetcore.md
@@ -36,6 +36,7 @@ sidebar_label: aspnetcore
 |useFrameworkReference|Use frameworkReference for ASP.NET Core 3.0+ and  PackageReference  ASP.NET Core 2.2 or earlier.| |false|
 |useNewtonsoft|Uses the Newtonsoft JSON library.| |true|
 |useSwashbuckle|Uses the Swashbuckle.AspNetCore NuGet package for documentation.| |true|
+|useIFormFileInsteadOfStream|Uses IFormfile type for file transfers instead of Stream| |true|
 
 ## IMPORT MAPPING
 

--- a/docs/generators/csharp-dotnet2.md
+++ b/docs/generators/csharp-dotnet2.md
@@ -42,6 +42,7 @@ sidebar_label: csharp-dotnet2
 <li>Int32</li>
 <li>Int64</li>
 <li>List</li>
+<li>Microsoft.AspNetCore.Http.IFormFile</li>
 <li>Object</li>
 <li>String</li>
 <li>System.IO.Stream</li>

--- a/docs/generators/csharp-nancyfx.md
+++ b/docs/generators/csharp-nancyfx.md
@@ -55,6 +55,7 @@ sidebar_label: csharp-nancyfx
 <li>List</li>
 <li>LocalDate?</li>
 <li>LocalTime?</li>
+<li>Microsoft.AspNetCore.Http.IFormFile</li>
 <li>Object</li>
 <li>String</li>
 <li>System.IO.Stream</li>

--- a/docs/generators/csharp-netcore.md
+++ b/docs/generators/csharp-netcore.md
@@ -63,6 +63,7 @@ sidebar_label: csharp-netcore
 <li>Int32</li>
 <li>Int64</li>
 <li>List</li>
+<li>Microsoft.AspNetCore.Http.IFormFile</li>
 <li>Object</li>
 <li>String</li>
 <li>System.IO.Stream</li>

--- a/docs/generators/csharp.md
+++ b/docs/generators/csharp.md
@@ -62,6 +62,7 @@ sidebar_label: csharp
 <li>Int32</li>
 <li>Int64</li>
 <li>List</li>
+<li>Microsoft.AspNetCore.Http.IFormFile</li>
 <li>Object</li>
 <li>String</li>
 <li>System.IO.Stream</li>

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractCSharpCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractCSharpCodegen.java
@@ -166,6 +166,7 @@ public abstract class AbstractCSharpCodegen extends DefaultCodegen implements Co
                         "Guid?",
                         "Guid",
                         "System.IO.Stream", // not really a primitive, we include it to avoid model import
+                        "Microsoft.AspNetCore.Http.IFormFile", // not really a primitive, we include it to avoid model import
                         "Object")
         );
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AspNetCoreServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AspNetCoreServerCodegen.java
@@ -58,6 +58,7 @@ public class AspNetCoreServerCodegen extends AbstractCSharpCodegen {
     public static final String USE_NEWTONSOFT = "useNewtonsoft";
     public static final String USE_DEFAULT_ROUTING = "useDefaultRouting";
     public static final String NEWTONSOFT_VERSION = "newtonsoftVersion";
+    public static final String USE_IFORMFILE_INSTEAD_OF_STREAM = "useIFormFileInsteadOfStream";
 
     private String packageGuid = "{" + randomUUID().toString().toUpperCase(Locale.ROOT) + "}";
 
@@ -84,6 +85,7 @@ public class AspNetCoreServerCodegen extends AbstractCSharpCodegen {
     private boolean useNewtonsoft = true;
     private boolean useDefaultRouting = true;
     private String newtonsoftVersion = "3.0.0-preview5-19227-01";
+    private boolean useIFormFileInsteadOfStream = false;
 
     public AspNetCoreServerCodegen() {
         super();
@@ -287,6 +289,9 @@ public class AspNetCoreServerCodegen extends AbstractCSharpCodegen {
         modelClassModifier.setOptValue(modelClassModifier.getDefault());
         addOption(modelClassModifier.getOpt(), modelClassModifier.getDescription(), modelClassModifier.getOptValue());
 
+        addSwitch(USE_IFORMFILE_INSTEAD_OF_STREAM,
+                "Change so that File inputs are generated as IFormFile data types instead of Stream",
+                useIFormFileInsteadOfStream);
     }
 
     @Override
@@ -335,7 +340,11 @@ public class AspNetCoreServerCodegen extends AbstractCSharpCodegen {
         setModelClassModifier();
         setUseSwashbuckle();
         setOperationIsAsync();
+        setIFormFileInsteadOfStream();
 
+        if (useIFormFileInsteadOfStream) {
+            typeMapping.put("file", "Microsoft.AspNetCore.Http.IFormFile");
+        }
         // CHeck for class modifier if not present set the default value.
         additionalProperties.put(PROJECT_SDK, projectSdk);
 
@@ -528,6 +537,12 @@ public class AspNetCoreServerCodegen extends AbstractCSharpCodegen {
             projectSdk = SDK_WEB;
         }
         additionalProperties.put(IS_LIBRARY, isLibrary);
+    }
+
+    private void setIFormFileInsteadOfStream() {
+        if (additionalProperties.containsKey(USE_IFORMFILE_INSTEAD_OF_STREAM)) {
+            useIFormFileInsteadOfStream = convertPropertyToBooleanAndWriteBack(USE_IFORMFILE_INSTEAD_OF_STREAM);
+        }
     }
 
     private void setAspnetCoreVersion(String packageFolder) {


### PR DESCRIPTION
Added option to aspnetcore generator to have it generate file data type as IFormFile instead of Stream

fix: #2398

<!-- Please check the completed items below -->
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [NA] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [X] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
Added new script bin/aspnetcore-binary.sh

- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [X] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

cc
@mandrean 
@jimschubert 
@frankyjuang 
@shibayan 

Question: Do I need to merge the sample output from the test script into the repo as well?