### PR TITLE
[C] fix decode funtion

### DIFF
--- a/modules/openapi-generator/src/main/resources/C-libcurl/apiClient.c.mustache
+++ b/modules/openapi-generator/src/main/resources/C-libcurl/apiClient.c.mustache
@@ -597,7 +597,7 @@ char *base64encode (const void *b64_encode_this, int encode_this_many_bytes){
 #endif
 }
 
-char *base64decode (const void *b64_decode_this, int decode_this_many_bytes, int *decoded_byte_index){
+char *base64decode (const void *b64_decode_this, int decode_this_many_bytes, int *decoded_bytes){
 #ifdef OPENSSL
     BIO *b64_bio, *mem_bio;      //Declares two OpenSSL BIOs: a base64 filter and a memory BIO.
     char *base64_decoded = calloc( (decode_this_many_bytes*3)/4+1, sizeof(char) ); //+1 = null.
@@ -606,11 +606,12 @@ char *base64decode (const void *b64_decode_this, int decode_this_many_bytes, int
     BIO_write(mem_bio, b64_decode_this, decode_this_many_bytes); //Base64 data saved in source.
     BIO_push(b64_bio, mem_bio);          //Link the BIOs by creating a filter-source BIO chain.
     BIO_set_flags(b64_bio, BIO_FLAGS_BASE64_NO_NL);          //Don't require trailing newlines.
-    decoded_byte_index = 0;   //Index where the next base64_decoded byte should be written.
+    int decoded_byte_index = 0;   //Index where the next base64_decoded byte should be written.
     while ( 0 < BIO_read(b64_bio, base64_decoded+decoded_byte_index, 1) ){ //Read byte-by-byte.
         decoded_byte_index++; //Increment the index until read of BIO decoded data is complete.
     } //Once we're done reading decoded data, BIO_read returns -1 even though there's no error.
     BIO_free_all(b64_bio);  //Destroys all BIOs in chain, starting with b64 (i.e. the 1st one).
+    *decoded_bytes = decoded_byte_index;
     return base64_decoded;        //Returns base-64 decoded data with trailing null terminator.
 #endif
 }

--- a/modules/openapi-generator/src/main/resources/C-libcurl/apiClient.c.mustache
+++ b/modules/openapi-generator/src/main/resources/C-libcurl/apiClient.c.mustache
@@ -578,7 +578,7 @@ char *strReplace(char *orig, char *rep, char *with) {
     return result;
 }
 
-char *sbi_base64encode (const void *b64_encode_this, int encode_this_many_bytes){
+char *base64encode (const void *b64_encode_this, int encode_this_many_bytes){
 #ifdef OPENSSL
     BIO *b64_bio, *mem_bio;      //Declares two OpenSSL BIOs: a base64 filter and a memory BIO.
     BUF_MEM *mem_bio_mem_ptr;    //Pointer to a "memory BIO" structure holding our base64 data.
@@ -597,7 +597,7 @@ char *sbi_base64encode (const void *b64_encode_this, int encode_this_many_bytes)
 #endif
 }
 
-char *sbi_base64decode (const void *b64_decode_this, int decode_this_many_bytes){
+char *base64decode (const void *b64_decode_this, int decode_this_many_bytes, int *decoded_byte_index){
 #ifdef OPENSSL
     BIO *b64_bio, *mem_bio;      //Declares two OpenSSL BIOs: a base64 filter and a memory BIO.
     char *base64_decoded = calloc( (decode_this_many_bytes*3)/4+1, sizeof(char) ); //+1 = null.
@@ -606,7 +606,7 @@ char *sbi_base64decode (const void *b64_decode_this, int decode_this_many_bytes)
     BIO_write(mem_bio, b64_decode_this, decode_this_many_bytes); //Base64 data saved in source.
     BIO_push(b64_bio, mem_bio);          //Link the BIOs by creating a filter-source BIO chain.
     BIO_set_flags(b64_bio, BIO_FLAGS_BASE64_NO_NL);          //Don't require trailing newlines.
-    int decoded_byte_index = 0;   //Index where the next base64_decoded byte should be written.
+    decoded_byte_index = 0;   //Index where the next base64_decoded byte should be written.
     while ( 0 < BIO_read(b64_bio, base64_decoded+decoded_byte_index, 1) ){ //Read byte-by-byte.
         decoded_byte_index++; //Increment the index until read of BIO decoded data is complete.
     } //Once we're done reading decoded data, BIO_read returns -1 even though there's no error.

--- a/modules/openapi-generator/src/main/resources/C-libcurl/model-body.mustache
+++ b/modules/openapi-generator/src/main/resources/C-libcurl/model-body.mustache
@@ -520,13 +520,10 @@ fail:
     {
     goto end; //Binary
     }
-    char* decoded = base64decode({{{name}}}->valuestring, strlen({{{name}}}->valuestring));
-    decoded_str_{{{name}}}->data = malloc(strlen(decoded) - 1);
+    decoded_str_{{{name}}}->data = base64decode({{{name}}}->valuestring, strlen({{{name}}}->valuestring), &decoded_str_{{{name}}}->len);
     if (!decoded_str_{{{name}}}->data) {
         goto end;
     }
-    memcpy(decoded_str_{{{name}}}->data,decoded,(strlen(decoded)-1));
-    decoded_str_{{{name}}}->len = strlen(decoded) - 1;
     {{/isBinary}}
     {{#isDate}}
     {{^required}}if ({{{name}}}) { {{/required}}


### PR DESCRIPTION
This PR includes:
- correct the function names to correct one as defined in model-body
- reformat base64decode function to avoid unnecessary malloc and assigning of the wrong length.

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [ ] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
