### PR TITLE
[powershell-experimental] Protects against stackoverflow when OAS spec has circular references

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PowerShellExperimentalClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PowerShellExperimentalClientCodegen.java
@@ -761,7 +761,7 @@ public class PowerShellExperimentalClientCodegen extends DefaultCodegen implemen
     private String constructExampleCode(CodegenModel codegenModel, HashMap<String, CodegenModel> modelMaps, HashMap<String, Boolean> processedModelMap) {
         String example;
 
-        // break recursion. In case a model is already processed in the current context, return.
+        // break infinite recursion. Return, in case a model is already processed in the current context.
         String model = codegenModel.name;
         if (processedModelMap.containsKey(model)) {
             return "";


### PR DESCRIPTION
fixes #5663 
The powershell-experimental generator runs into the below stackoverflow when the OAS spec has circular references. This happens while generating example strings.

```
[main] INFO  o.o.codegen.AbstractGenerator - writing file /home/vvb/sdk/powershell/src/PSOpenAPITools/Api/AaaApi.ps1
[main] INFO  o.o.codegen.AbstractGenerator - writing file /home/vvb/sdk/powershell/tests/AaaApi.Tests.ps1
[main] INFO  o.o.codegen.AbstractGenerator - writing file /home/vvb/sdk/powershell/docs/AaaApi.md
Exception in thread "main" java.lang.StackOverflowError
	at java.lang.StringBuilder.append(StringBuilder.java:136)
	at org.openapitools.codegen.languages.PowerShellExperimentalClientCodegen.constructExampleCode(PowerShellExperimentalClientCodegen.java:760)
	at org.openapitools.codegen.languages.PowerShellExperimentalClientCodegen.constructExampleCode(PowerShellExperimentalClientCodegen.java:750)
	at org.openapitools.codegen.languages.PowerShellExperimentalClientCodegen.constructExampleCode(PowerShellExperimentalClientCodegen.java:718)
	at org.openapitools.codegen.languages.PowerShellExperimentalClientCodegen.constructExampleCode(PowerShellExperimentalClientCodegen.java:763)
	at org.openapitools.codegen.languages.PowerShellExperimentalClientCodegen.constructExampleCode(PowerShellExperimentalClientCodegen.java:750)
	at org.openapitools.codegen.languages.PowerShellExperimentalClientCodegen.constructExampleCode(PowerShellExperimentalClientCodegen.java:763)
	at org.openapitools.codegen.languages.PowerShellExperimentalClientCodegen.constructExampleCode(PowerShellExperimentalClientCodegen.java:750)
	at org.openapitools.codegen.languages.PowerShellExperimentalClientCodegen.constructExampleCode(PowerShellExperimentalClientCodegen.java:718)
	at org.openapitools.codegen.languages.PowerShellExperimentalClientCodegen.constructExampleCode(PowerShellExperimentalClientCodegen.java:763)
	at org.openapitools.codegen.languages.PowerShellExperimentalClientCodegen.constructExampleCode(PowerShellExperimentalClientCodegen.java:750)
	at org.openapitools.codegen.languages.PowerShellExperimentalClientCodegen.constructExampleCode(PowerShellExperimentalClientCodegen.java:718)
	at org.openapitools.codegen.languages.PowerShellExperimentalClientCodegen.constructExampleCode(PowerShellExperimentalClientCodegen.java:763)
	at org.openapitools.codegen.languages.PowerShellExperimentalClientCodegen.constructExampleCode(PowerShellExperimentalClientCodegen.java:750)
	at org.openapitools.codegen.languages.PowerShellExperimentalClientCodegen.constructExampleCode(PowerShellExperimentalClientCodegen.java:718)
	at org.openapitools.codegen.languages.PowerShellExperimentalClientCodegen.constructExampleCode(PowerShellExperimentalClientCodegen.java:763)
	at org.openapitools.codegen.languages.PowerShellExperimentalClientCodegen.constructExampleCode(PowerShellExperimentalClientCodegen.java:750)
	at org.openapitools.codegen.languages.PowerShellExperimentalClientCodegen.constructExampleCode(PowerShellExperimentalClientCodegen.java:718)
	at org.openapitools.codegen.languages.PowerShellExperimentalClientCodegen.constructExampleCode(PowerShellExperimentalClientCodegen.java:763)
	at org.openapitools.codegen.languages.PowerShellExperimentalClientCodegen.constructExampleCode(PowerShellExperimentalClientCodegen.java:750)
	at org.openapitools.codegen.languages.PowerShellExperimentalClientCodegen.constructExampleCode(PowerShellExperimentalClientCodegen.java:718)
	at org.openapitools.codegen.languages.PowerShellExperimentalClientCodegen.constructExampleCode(PowerShellExperimentalClientCodegen.java:763)
	at org.openapitools.codegen.languages.PowerShellExperimentalClientCodegen.constructExampleCode(PowerShellExperimentalClientCodegen.java:750)
	at org.openapitools.codegen.languages.PowerShellExperimentalClientCodegen.constructExampleCode(PowerShellExperimentalClientCodegen.java:718)
	at org.openapitools.codegen.languages.PowerShellExperimentalClientCodegen.constructExampleCode(PowerShellExperimentalClientCodegen.java:763)
	at org.openapitools.codegen.languages.PowerShellExperimentalClientCodegen.constructExampleCode(PowerShellExperimentalClientCodegen.java:750)
	at org.openapitools.codegen.languages.PowerShellExperimentalClientCodegen.constructExampleCode(PowerShellExperimentalClientCodegen.java:718)
```

OAS Spec used for testing: https://gist.github.com/26be250f0b0e2518e35bd80916d62bb8
With reference to the above mentioned OAS spec, the current example generation logic breaks because of :  adapter.ConfigPolicy -> Mo.BaseMo -> ancestors -> mo.Optional.BaseMo -> Mo.BaseMo


<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
