### PR TITLE
[C++] [Qt5] CI Tests Handle negative response from the server

### DIFF
--- a/samples/client/petstore/cpp-qt5/PetStore/PetApiTests.cpp
+++ b/samples/client/petstore/cpp-qt5/PetStore/PetApiTests.cpp
@@ -24,6 +24,10 @@ void PetApiTests::findPetsByStatusTest() {
         }
         loop.quit();
     });
+    connect(&api, &PFXPetApi::findPetsByStatusSignalE, [&](QList<PFXPet>, QNetworkReply::NetworkError, QString error_str) {
+        qDebug() << "Error happened while issuing request : " << error_str;
+        loop.quit();
+    });
 
     api.findPetsByStatus({"available", "sold"});
     QTimer::singleShot(5000, &loop, &QEventLoop::quit);
@@ -41,6 +45,11 @@ void PetApiTests::createAndGetPetTest() {
         petCreated = true;
         loop.quit();
     });
+    connect(&api, &PFXPetApi::addPetSignalE, [&](QNetworkReply::NetworkError, QString error_str) {
+        qDebug() << "Error happened while issuing request : " << error_str;
+        loop.quit();
+    });
+
 
     PFXPet pet = createRandomPet();
     qint64 id = pet.getId();
@@ -55,10 +64,13 @@ void PetApiTests::createAndGetPetTest() {
     connect(&api, &PFXPetApi::getPetByIdSignal, [&](PFXPet pet) {
         QVERIFY(pet.getId() > 0);
         QVERIFY(pet.getStatus().compare("freaky") == 0);
-        loop.quit();
         petFetched = true;
+        loop.quit();
     });
-
+    connect(&api, &PFXPetApi::getPetByIdSignalE, [&](PFXPet, QNetworkReply::NetworkError, QString error_str) {
+        qDebug() << "Error happened while issuing request : " << error_str;
+        loop.quit();
+    });
     api.getPetById(id);
     QTimer::singleShot(14000, &loop, &QEventLoop::quit);
     loop.exec();
@@ -78,7 +90,10 @@ void PetApiTests::updatePetTest() {
         petAdded = true;
         loop.quit();
     });
-
+    connect(&api, &PFXPetApi::addPetSignalE, [&](QNetworkReply::NetworkError, QString error_str) {
+        qDebug() << "Error happened while issuing request : " << error_str;
+        loop.quit();
+    });
     // create pet
     api.addPet(pet);
     QTimer::singleShot(5000, &loop, &QEventLoop::quit);
@@ -93,7 +108,10 @@ void PetApiTests::updatePetTest() {
         petToCheck = pet;
         loop.quit();
     });
-
+    connect(&api, &PFXPetApi::getPetByIdSignalE, this, [&](PFXPet, QNetworkReply::NetworkError, QString error_str) {
+        qDebug() << "Error happened while issuing request : " << error_str;
+        loop.quit();
+    });
     // create pet
     api.getPetById(id);
     QTimer::singleShot(5000, &loop, &QEventLoop::quit);
@@ -104,6 +122,10 @@ void PetApiTests::updatePetTest() {
     bool petUpdated = false;
     connect(&api, &PFXPetApi::updatePetSignal, [&]() {
         petUpdated = true;
+        loop.quit();
+    });
+    connect(&api, &PFXPetApi::updatePetSignalE, [&](QNetworkReply::NetworkError, QString error_str) {
+        qDebug() << "Error happened while issuing request : " << error_str;
         loop.quit();
     });
 
@@ -120,6 +142,10 @@ void PetApiTests::updatePetTest() {
         petFetched2 = true;
         QVERIFY(pet.getId() == petToCheck.getId());
         QVERIFY(pet.getStatus().compare(petToCheck.getStatus()) == 0);
+        loop.quit();
+    });
+    connect(&api, &PFXPetApi::getPetByIdSignalE, [&](PFXPet, QNetworkReply::NetworkError, QString error_str) {
+        qDebug() << "Error happened while issuing request : " << error_str;
         loop.quit();
     });
     api.getPetById(id);
@@ -142,6 +168,10 @@ void PetApiTests::updatePetWithFormTest() {
         petAdded = true;
         loop.quit();
     });
+    connect(&api, &PFXPetApi::addPetSignalE, [&](QNetworkReply::NetworkError, QString error_str) {
+        qDebug() << "Error happened while issuing request : " << error_str;
+        loop.quit();
+    });
 
     api.addPet(pet);
     QTimer::singleShot(5000, &loop, &QEventLoop::quit);
@@ -153,6 +183,10 @@ void PetApiTests::updatePetWithFormTest() {
     connect(&api, &PFXPetApi::getPetByIdSignal, [&](PFXPet pet) {
         petFetched = true;
         petToCheck = pet;
+        loop.quit();
+    });
+    connect(&api, &PFXPetApi::getPetByIdSignalE, [&](PFXPet, QNetworkReply::NetworkError, QString error_str) {
+        qDebug() << "Error happened while issuing request : " << error_str;
         loop.quit();
     });
 
@@ -167,6 +201,10 @@ void PetApiTests::updatePetWithFormTest() {
         petUpdated = true;
         loop.quit();
     });
+    connect(&api, &PFXPetApi::updatePetWithFormSignalE, [&](QNetworkReply::NetworkError, QString error_str) {
+        qDebug() << "Error happened while issuing request : " << error_str;
+        loop.quit();
+    });
 
     QString name("gorilla");
     api.updatePetWithForm(id, name, nullptr);
@@ -179,6 +217,10 @@ void PetApiTests::updatePetWithFormTest() {
     connect(&api, &PFXPetApi::getPetByIdSignal, [&](PFXPet pet) {
         petUpdated2 = true;
         QVERIFY(pet.getName().compare(QString("gorilla")) == 0);
+        loop.quit();
+    });
+    connect(&api, &PFXPetApi::getPetByIdSignalE, [&](PFXPet, QNetworkReply::NetworkError, QString error_str) {
+        qDebug() << "Error happened while issuing request : " << error_str;
         loop.quit();
     });
 

--- a/samples/client/petstore/cpp-qt5/PetStore/StoreApiTests.cpp
+++ b/samples/client/petstore/cpp-qt5/PetStore/StoreApiTests.cpp
@@ -16,8 +16,8 @@ void StoreApiTests::placeOrderTest() {
         qDebug() << order.getShipDate();
         loop.quit();
     });
-    connect(&api, &PFXStoreApi::placeOrderSignalE, [&]() {
-        QFAIL("shouldn't trigger error");
+    connect(&api, &PFXStoreApi::placeOrderSignalE, [&](PFXOrder, QNetworkReply::NetworkError, QString error_str) {
+        qDebug() << "Error happened while issuing request : " << error_str;
         loop.quit();
     });
 
@@ -46,6 +46,10 @@ void StoreApiTests::getOrderByIdTest() {
         qDebug() << order.getShipDate();
         loop.quit();
     });
+    connect(&api, &PFXStoreApi::getOrderByIdSignalE, [&](PFXOrder, QNetworkReply::NetworkError, QString error_str) {
+        qDebug() << "Error happened while issuing request : " << error_str;
+        loop.quit();
+    });
 
     api.getOrderById(500);
     QTimer::singleShot(14000, &loop, &QEventLoop::quit);
@@ -63,6 +67,10 @@ void StoreApiTests::getInventoryTest() {
         for (const auto &key : status.keys()) {
             qDebug() << (key) << " Quantities " << status.value(key);
         }
+        loop.quit();
+    });
+    connect(&api, &PFXStoreApi::getInventorySignalE, [&](QMap<QString, qint32>, QNetworkReply::NetworkError, QString error_str) {
+        qDebug() << "Error happened while issuing request : " << error_str;
         loop.quit();
     });
 

--- a/samples/client/petstore/cpp-qt5/PetStore/UserApiTests.cpp
+++ b/samples/client/petstore/cpp-qt5/PetStore/UserApiTests.cpp
@@ -26,6 +26,10 @@ void UserApiTests::createUserTest() {
         userCreated = true;
         loop.quit();
     });
+    connect(&api, &PFXUserApi::createUserSignalE, [&](QNetworkReply::NetworkError, QString error_str) {
+        qDebug() << "Error happened while issuing request : " << error_str;
+        loop.quit();
+    });
 
     api.createUser(createRandomUser());
     QTimer::singleShot(14000, &loop, &QEventLoop::quit);
@@ -40,6 +44,10 @@ void UserApiTests::createUsersWithArrayInputTest() {
 
     connect(&api, &PFXUserApi::createUsersWithArrayInputSignal, [&]() {
         usersCreated = true;
+        loop.quit();
+    });
+    connect(&api, &PFXUserApi::createUsersWithArrayInputSignalE, [&](QNetworkReply::NetworkError, QString error_str) {
+        qDebug() << "Error happened while issuing request : " << error_str;
         loop.quit();
     });
 
@@ -60,6 +68,10 @@ void UserApiTests::createUsersWithListInputTest() {
 
     connect(&api, &PFXUserApi::createUsersWithListInputSignal, [&]() {
         usersCreated = true;
+        loop.quit();
+    });
+    connect(&api, &PFXUserApi::createUsersWithListInputSignalE, [&](QNetworkReply::NetworkError, QString error_str) {
+        qDebug() << "Error happened while issuing request : " << error_str;
         loop.quit();
     });
 
@@ -86,6 +98,11 @@ void UserApiTests::deleteUserTest() {
         userDeleted = true;
         loop.quit();
     });
+    connect(&api, &PFXUserApi::deleteUserSignalE, [&](QNetworkReply::NetworkError, QString error_str) {
+        userDeleted = true;
+        qDebug() << "Error happened while issuing request : " << error_str;
+        loop.quit();
+    });
 
     api.deleteUser("rambo");
     QTimer::singleShot(14000, &loop, &QEventLoop::quit);
@@ -102,6 +119,11 @@ void UserApiTests::getUserByNameTest() {
         userFetched = true;
         qDebug() << summary.getUsername();
         QVERIFY(summary.getUsername() == "johndoe");
+        loop.quit();
+    });
+    connect(&api, &PFXUserApi::getUserByNameSignalE, [&](PFXUser, QNetworkReply::NetworkError, QString error_str) {
+        userFetched = true;
+        qDebug() << "Error happened while issuing request : " << error_str;
         loop.quit();
     });
 
@@ -121,6 +143,11 @@ void UserApiTests::loginUserTest() {
         qDebug() << summary;
         loop.quit();
     });
+    connect(&api, &PFXUserApi::loginUserSignalE, [&](QString, QNetworkReply::NetworkError, QString error_str) {
+        userLogged = true;
+        qDebug() << "Error happened while issuing request : " << error_str;
+        loop.quit();
+    });
 
     api.loginUser("johndoe", "123456789");
     QTimer::singleShot(14000, &loop, &QEventLoop::quit);
@@ -137,6 +164,10 @@ void UserApiTests::logoutUserTest() {
         userLoggedOut = true;
         loop.quit();
     });
+    connect(&api, &PFXUserApi::logoutUserSignalE, [&](QNetworkReply::NetworkError, QString error_str) {
+        qDebug() << "Error happened while issuing request : " << error_str;
+        loop.quit();
+    });
 
     api.logoutUser();
     QTimer::singleShot(14000, &loop, &QEventLoop::quit);
@@ -151,6 +182,10 @@ void UserApiTests::updateUserTest() {
 
     connect(&api, &PFXUserApi::updateUserSignal, [&]() {
         userUpdated = true;
+        loop.quit();
+    });
+    connect(&api, &PFXUserApi::updateUserSignalE, [&](QNetworkReply::NetworkError, QString error_str) {
+        qDebug() << "Error happened while issuing request : " << error_str;
         loop.quit();
     });
 


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
Handle negative response from the server for the tests to avoid timeout errors

`cc`
@wing328 
@stkrwork @muttleyxd @MartinDelille @ravinikam 
<!-- Please check the completed items below -->
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [X] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [X] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
