### PR TITLE
[powershell-experimental] Adds configuration option to skip certificate check

### DIFF
--- a/modules/openapi-generator/src/main/resources/powershell-experimental/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/powershell-experimental/api_client.mustache
@@ -34,14 +34,17 @@ function Invoke-{{{apiNamePrefix}}}ApiClient {
 
     $Configuration = Get-{{{apiNamePrefix}}}Configuration
     $RequestUri = $Configuration["BaseUrl"] + $Uri
+    $SkipCertificateCheck = $Configuration["SkipCertificateCheck"]
 
     # cookie parameters
-    foreach ($Parameter in $CookieParameters) {
-        if ($CookieParameters[$Parameter]) {
-            $HeaderParameters["Cookie"] = $CookieParameters[$Parameter]
+    foreach ($Parameter in $CookieParameters.GetEnumerator()) {
+        if ($Parameter.Name -eq "cookieAuth") {
+            $HeaderParameters["Cookie"] = $Parameter.Value
+        } else {
+            $HeaderParameters[$Parameter.Name] = $Parameter.Value
         }
     }
-    if ($CookieParametters -and $CookieParameters.Count -gt 1) {
+    if ($CookieParameters -and $CookieParameters.Count -gt 1) {
         Write-Warning "Multipe cookie parameters found. Curently only the first one is supported/used"
     }
 
@@ -80,11 +83,21 @@ function Invoke-{{{apiNamePrefix}}}ApiClient {
         $RequestBody = $Body
     }
 
-    $Response = Invoke-WebRequest -Uri $UriBuilder.Uri `
+    if ($SkipCertificateCheck -eq $true) {
+        $Response = Invoke-WebRequest -Uri $UriBuilder.Uri `
+                                  -Method $Method `
+                                  -Headers $HeaderParameters `
+                                  -Body $RequestBody `
+                                  -ErrorAction Stop `
+                                  -SkipCertificateCheck
+
+    } else {
+        $Response = Invoke-WebRequest -Uri $UriBuilder.Uri `
                                   -Method $Method `
                                   -Headers $HeaderParameters `
                                   -Body $RequestBody `
                                   -ErrorAction Stop
+    }
 
     return @{
         Response = DeserializeResponse -Response $Response -ReturnType $ReturnType

--- a/modules/openapi-generator/src/main/resources/powershell-experimental/configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/powershell-experimental/configuration.mustache
@@ -28,6 +28,10 @@ function Get-{{apiNamePrefix}}Configuration {
         $Configuration["ApiKeyPrefix"] = @{}
     }
 
+    if (!$Configuration.containsKey("SkipCertificateCheck")) {
+        $Configuration["SkipCertificateCheck"] = $false
+    }
+
     Return $Configuration
 
 }
@@ -48,6 +52,7 @@ function Set-{{{apiNamePrefix}}}Configuration {
         [AllowEmptyString()]
         [string]$AccessToken,
         [switch]$PassThru,
+        [bool]$SkipCertificateCheck,
         [switch]$Force
     )
 
@@ -79,6 +84,10 @@ function Set-{{{apiNamePrefix}}}Configuration {
 
         If ($AccessToken) {
             $Script:Configuration['AccessToken'] = $AccessToken
+        }
+
+        If ($SkipCertificateCheck) {
+            $Script:Configuration['SkipCertificateCheck'] = $SkipCertificateCheck
         }
     }
 }


### PR DESCRIPTION
This PR has the following changes,
1. Adds support for `SkipCertificateCheck` in Get/Set-Configuration. It is set to `$false` by default. It can be enabled to allow connection to a server with self-signed certificate.
2. Fixes an issue where cookie from configuration was not get consumed in ApiClient. 
3. Fix a minor typo.

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [ ] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

/cc @wing328 