### PR TITLE
[Rust Server] Handle text/xml correctly

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustServerCodegen.java
@@ -69,6 +69,7 @@ public class RustServerCodegen extends DefaultCodegen implements CodegenConfig {
     private static final String bytesType = "swagger::ByteArray";
 
     private static final String xmlMimeType = "application/xml";
+    private static final String textXmlMimeType = "text/xml";
     private static final String octetMimeType = "application/octet-stream";
     private static final String plainMimeType = "text/plain";
     private static final String jsonMimeType = "application/json";
@@ -521,7 +522,8 @@ public class RustServerCodegen extends DefaultCodegen implements CodegenConfig {
     }
 
     private boolean isMimetypeXml(String mimetype) {
-        return mimetype.toLowerCase(Locale.ROOT).startsWith(xmlMimeType);
+        return mimetype.toLowerCase(Locale.ROOT).startsWith(xmlMimeType) ||
+               mimetype.toLowerCase(Locale.ROOT).startsWith(textXmlMimeType);
     }
 
     private boolean isMimetypePlainText(String mimetype) {

--- a/modules/openapi-generator/src/test/resources/3_0/rust-server/openapi-v3.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/rust-server/openapi-v3.yaml
@@ -99,12 +99,16 @@ paths:
     post:
       requestBody:
         content:
-          application/xml:
+          text/xml:
             schema:
               $ref: '#/components/schemas/anotherXmlObject'
       responses:
         '201':
           description: 'OK'
+          content:
+            text/xml:
+              schema:
+                $ref: "#/components/schemas/anotherXmlObject"
         '400':
           description: Bad Request
     put:

--- a/samples/server/petstore/rust-server/output/openapi-v3/api/openapi.yaml
+++ b/samples/server/petstore/rust-server/output/openapi-v3/api/openapi.yaml
@@ -81,11 +81,15 @@ paths:
     post:
       requestBody:
         content:
-          application/xml:
+          text/xml:
             schema:
               $ref: '#/components/schemas/anotherXmlObject'
       responses:
         "201":
+          content:
+            text/xml:
+              schema:
+                $ref: '#/components/schemas/anotherXmlObject'
           description: OK
         "400":
           description: Bad Request

--- a/samples/server/petstore/rust-server/output/openapi-v3/docs/default_api.md
+++ b/samples/server/petstore/rust-server/output/openapi-v3/docs/default_api.md
@@ -185,7 +185,7 @@ No authorization required
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # ****
-> (optional)
+> models::AnotherXmlObject (optional)
 
 
 ### Required Parameters
@@ -203,7 +203,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
- (empty response body)
+[**models::AnotherXmlObject**](anotherXmlObject.md)
 
 ### Authorization
 
@@ -211,8 +211,8 @@ No authorization required
 
 ### HTTP request headers
 
- - **Content-Type**: application/xml
- - **Accept**: Not defined
+ - **Content-Type**: text/xml
+ - **Accept**: text/xml, 
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 

--- a/samples/server/petstore/rust-server/output/openapi-v3/src/lib.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/src/lib.rs
@@ -137,6 +137,7 @@ pub enum XmlExtraPostResponse {
 pub enum XmlOtherPostResponse {
     /// OK
     OK
+    (models::AnotherXmlObject)
     ,
     /// Bad Request
     BadRequest

--- a/samples/server/petstore/rust-server/output/openapi-v3/src/mimetypes.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/src/mimetypes.rs
@@ -50,6 +50,11 @@ pub mod responses {
         pub static ref UUID_GET_DUPLICATE_RESPONSE_LONG_TEXT: Mime = "application/json".parse().unwrap();
     }
 
+    lazy_static! {
+        /// Create Mime objects for the response content types for XmlOtherPost
+        pub static ref XML_OTHER_POST_OK: Mime = "text/xml".parse().unwrap();
+    }
+
 }
 
 pub mod requests {
@@ -67,7 +72,7 @@ pub mod requests {
 
     lazy_static! {
         /// Create Mime objects for the request content types for XmlOtherPost
-        pub static ref XML_OTHER_POST: Mime = "application/xml".parse().unwrap();
+        pub static ref XML_OTHER_POST: Mime = "text/xml".parse().unwrap();
     }
 
     lazy_static! {

--- a/samples/server/petstore/rust-server/output/openapi-v3/src/server/mod.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/src/server/mod.rs
@@ -637,10 +637,19 @@ where
                                             Ok(rsp) => match rsp {
                                                 XmlOtherPostResponse::OK
 
+                                                    (body)
+
 
                                                 => {
                                                     response.set_status(StatusCode::try_from(201).unwrap());
 
+                                                    response.headers_mut().set(ContentType(mimetypes::responses::XML_OTHER_POST_OK.clone()));
+
+                                                    let mut namespaces = BTreeMap::new();
+                                                    // An empty string is used to indicate a global namespace in xmltree.
+                                                    namespaces.insert("".to_string(), models::AnotherXmlObject::NAMESPACE.to_string());
+                                                    let body = serde_xml_rs::to_string_with_namespaces(&body, namespaces).expect("impossible to fail to serialize");
+                                                    response.set_body(body);
                                                 },
                                                 XmlOtherPostResponse::BadRequest
 


### PR DESCRIPTION
Treat application/xml the same as text/xml as per RFC 7303 - https://tools.ietf.org/html/rfc7303

This fixes #5594 

### Rust Server Technical Committee

- @frol
- @farcaller 
- @bjgill

### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [X] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [X] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.