### PR TITLE
[gradle] Include engine option for handlebars generation

### DIFF
--- a/modules/openapi-generator-gradle-plugin/README.adoc
+++ b/modules/openapi-generator-gradle-plugin/README.adoc
@@ -330,6 +330,10 @@ apply plugin: 'org.openapi.generator'
 |false
 |To generate alias (array, list, map) as model. When false, top-level objects defined as array, list, or map will result in those definitions generated as top-level Array-of-items, List-of-items, Map-of-items definitions. When true, A model representation either containing or extending the array,list,map (depending on specific generator implementation) will be generated.
 
+|engine
+|String
+|mustache
+|Templating engine: "mustache" (default) or "handlebars" (beta)
 |===
 
 [NOTE]

--- a/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/OpenApiGeneratorPlugin.kt
+++ b/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/OpenApiGeneratorPlugin.kt
@@ -138,6 +138,7 @@ class OpenApiGeneratorPlugin : Plugin<Project> {
                     enablePostProcessFile.set(generate.enablePostProcessFile)
                     skipValidateSpec.set(generate.skipValidateSpec)
                     generateAliasAsModel.set(generate.generateAliasAsModel)
+                    engine.set(generate.engine)
                 }
             }
         }

--- a/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/extensions/OpenApiGeneratorGenerateExtension.kt
+++ b/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/extensions/OpenApiGeneratorGenerateExtension.kt
@@ -307,6 +307,11 @@ open class OpenApiGeneratorGenerateExtension(project: Project) {
      */
     val configOptions = project.objects.mapProperty<String, String>()
 
+    /**
+     * Templating engine: "mustache" (default) or "handlebars" (beta)
+     */
+    val engine = project.objects.property<String?>()
+
     init {
         applyDefaults()
     }

--- a/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/tasks/GenerateTask.kt
+++ b/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/tasks/GenerateTask.kt
@@ -375,6 +375,12 @@ open class GenerateTask : DefaultTask() {
     @get:Internal
     val configOptions = project.objects.mapProperty<String, String>()
 
+    /**
+     * Templating engine: "mustache" (default) or "handlebars" (beta)
+     */
+    @get:Internal
+    val engine = project.objects.property<String?>()
+
     private fun <T : Any?> Property<T>.ifNotEmpty(block: Property<T>.(T) -> Unit) {
         if (isPresent) {
             val item: T? = get()
@@ -559,6 +565,12 @@ open class GenerateTask : DefaultTask() {
 
             generateAliasAsModel.ifNotEmpty { value ->
                 configurator.setGenerateAliasAsModel(value)
+            }
+
+            engine.ifNotEmpty { value ->
+                if ("handlebars".equals(value, ignoreCase = true)) {
+                    configurator.setTemplatingEngineName("handlebars")
+                }
             }
 
             if (systemProperties.isPresent) {

--- a/modules/openapi-generator-gradle-plugin/src/test/kotlin/GenerateTaskDslTest.kt
+++ b/modules/openapi-generator-gradle-plugin/src/test/kotlin/GenerateTaskDslTest.kt
@@ -126,4 +126,40 @@ class GenerateTaskDslTest : TestBase()  {
         assertEquals(TaskOutcome.SUCCESS, result.task(":openApiGenerate")?.outcome,
                 "Expected a successful run, but found ${result.task(":openApiGenerate")?.outcome}")
     }
+
+    @Test
+    fun `openapiGenerate should attempt to set handlebars when specified as engine`(){
+        // Arrange
+        val projectFiles = mapOf(
+            "spec.yaml" to javaClass.classLoader.getResourceAsStream("specs/petstore-v3.0.yaml")
+        )
+
+        withProject("""
+        plugins {
+          id 'org.openapi.generator'
+        }
+        openApiGenerate {
+            generatorName = "kotlin"
+            inputSpec = file("spec.yaml").absolutePath
+            outputDir = file("build/kotlin").absolutePath
+            apiPackage = "org.openapitools.example.api"
+            invokerPackage = "org.openapitools.example.invoker"
+            modelPackage = "org.openapitools.example.model"
+            engine = "handlebars"
+        }
+    """.trimIndent(), projectFiles)
+
+        // Act
+        val result = GradleRunner.create()
+            .withProjectDir(temp)
+            .withArguments("openApiGenerate")
+            .withPluginClasspath()
+            .buildAndFail()
+
+        // Assert
+        // rather than write out full handlebars generator templates, we'll just test that the configurator has set handlebars as the engine.
+        assertTrue(result.output.contains("kotlin-client/model.handlebars (No such file or directory)"), "Build should have attempted to use handlebars.")
+        assertEquals(TaskOutcome.FAILED, result.task(":openApiGenerate")?.outcome,
+            "Expected a failed run, but found ${result.task(":openApiGenerate")?.outcome}")
+    }
 }


### PR DESCRIPTION
Gradle Plugin was missing the option for the template engine to support handlebars. This adds the option and a unit test for validation.

Fixes #5685

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@OpenAPITools/generator-core-team 