### PR TITLE
[Go][Experimental] Rename extensions from x-basetype to x-go-base-type

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/GoClientExperimentalCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/GoClientExperimentalCodegen.java
@@ -153,7 +153,7 @@ public class GoClientExperimentalCodegen extends GoClientCodegen {
     public Map<String, Object> postProcessModels(Map<String, Object> objs) {
         // The superclass determines the list of required golang imports. The actual list of imports
         // depends on which types are used, some of which are changed in the code below (but then preserved
-        // and used through x-basetype in templates). So super.postProcessModels
+        // and used through x-go-base-type in templates). So super.postProcessModels
         // must be invoked at the beginning of this method.
         objs = super.postProcessModels(objs);
 
@@ -167,7 +167,7 @@ public class GoClientExperimentalCodegen extends GoClientCodegen {
                 }
 
                 for (CodegenProperty param : model.vars) {
-                    param.vendorExtensions.put("x-basetype", param.dataType);
+                    param.vendorExtensions.put("x-go-base-type", param.dataType);
                     if (!param.isNullable || param.isMapContainer || param.isListContainer) {
                         continue;
                     }

--- a/modules/openapi-generator/src/main/resources/go-experimental/model.mustache
+++ b/modules/openapi-generator/src/main/resources/go-experimental/model.mustache
@@ -112,11 +112,11 @@ func New{{classname}}WithDefaults() *{{classname}} {
 {{#required}}
 // Get{{name}} returns the {{name}} field value
 {{#isNullable}}
-// If the value is explicit nil, the zero value for {{vendorExtensions.x-basetype}} will be returned
+// If the value is explicit nil, the zero value for {{vendorExtensions.x-go-base-type}} will be returned
 {{/isNullable}}
-func (o *{{classname}}) Get{{name}}() {{vendorExtensions.x-basetype}} {
+func (o *{{classname}}) Get{{name}}() {{vendorExtensions.x-go-base-type}} {
 	if o == nil {{#isNullable}}{{^isContainer}}|| o.{{name}}.Get() == nil{{/isContainer}}{{/isNullable}} {
-		var ret {{vendorExtensions.x-basetype}}
+		var ret {{vendorExtensions.x-go-base-type}}
 		return ret
 	}
 
@@ -138,7 +138,7 @@ func (o *{{classname}}) Get{{name}}() {{vendorExtensions.x-basetype}} {
 {{#isNullable}}
 // NOTE: If the value is an explicit nil, `nil, true` will be returned
 {{/isNullable}}
-func (o *{{classname}}) Get{{name}}Ok() (*{{vendorExtensions.x-basetype}}, bool) {
+func (o *{{classname}}) Get{{name}}Ok() (*{{vendorExtensions.x-go-base-type}}, bool) {
 	if o == nil {{#isNullable}}{{#isContainer}}|| o.{{name}} == nil{{/isContainer}}{{/isNullable}} {
 		return nil, false
 	}
@@ -156,7 +156,7 @@ func (o *{{classname}}) Get{{name}}Ok() (*{{vendorExtensions.x-basetype}}, bool)
 }
 
 // Set{{name}} sets field value
-func (o *{{classname}}) Set{{name}}(v {{vendorExtensions.x-basetype}}) {
+func (o *{{classname}}) Set{{name}}(v {{vendorExtensions.x-go-base-type}}) {
 {{#isNullable}}
 {{#isContainer}}
 	o.{{name}} = v
@@ -173,9 +173,9 @@ func (o *{{classname}}) Set{{name}}(v {{vendorExtensions.x-basetype}}) {
 {{/required}}
 {{^required}}
 // Get{{name}} returns the {{name}} field value if set, zero value otherwise{{#isNullable}} (both if not set or set to explicit null){{/isNullable}}.
-func (o *{{classname}}) Get{{name}}() {{vendorExtensions.x-basetype}} {
+func (o *{{classname}}) Get{{name}}() {{vendorExtensions.x-go-base-type}} {
 	if o == nil {{^isNullable}}|| o.{{name}} == nil{{/isNullable}}{{#isNullable}}{{^isContainer}}|| o.{{name}}.Get() == nil{{/isContainer}}{{/isNullable}} {
-		var ret {{vendorExtensions.x-basetype}}
+		var ret {{vendorExtensions.x-go-base-type}}
 		return ret
 	}
 {{#isNullable}}
@@ -196,7 +196,7 @@ func (o *{{classname}}) Get{{name}}() {{vendorExtensions.x-basetype}} {
 {{#isNullable}}
 // NOTE: If the value is an explicit nil, `nil, true` will be returned
 {{/isNullable}}
-func (o *{{classname}}) Get{{name}}Ok() (*{{vendorExtensions.x-basetype}}, bool) {
+func (o *{{classname}}) Get{{name}}Ok() (*{{vendorExtensions.x-go-base-type}}, bool) {
 	if o == nil {{^isNullable}}|| o.{{name}} == nil{{/isNullable}}{{#isNullable}}{{#isContainer}}|| o.{{name}} == nil{{/isContainer}}{{/isNullable}} {
 		return nil, false
 	}
@@ -223,7 +223,7 @@ func (o *{{classname}}) Has{{name}}() bool {
 }
 
 // Set{{name}} gets a reference to the given {{dataType}} and assigns it to the {{name}} field.
-func (o *{{classname}}) Set{{name}}(v {{vendorExtensions.x-basetype}}) {
+func (o *{{classname}}) Set{{name}}(v {{vendorExtensions.x-go-base-type}}) {
 {{#isNullable}}
 {{#isContainer}}
 	o.{{name}} = v

--- a/modules/openapi-generator/src/main/resources/go-experimental/model_doc.mustache
+++ b/modules/openapi-generator/src/main/resources/go-experimental/model_doc.mustache
@@ -36,20 +36,20 @@ but it doesn't guarantee that properties required by API are set
 {{#vars}}
 ### Get{{name}}
 
-`func (o *{{classname}}) Get{{name}}() {{vendorExtensions.x-basetype}}`
+`func (o *{{classname}}) Get{{name}}() {{vendorExtensions.x-go-base-type}}`
 
 Get{{name}} returns the {{name}} field if non-nil, zero value otherwise.
 
 ### Get{{name}}Ok
 
-`func (o *{{classname}}) Get{{name}}Ok() (*{{vendorExtensions.x-basetype}}, bool)`
+`func (o *{{classname}}) Get{{name}}Ok() (*{{vendorExtensions.x-go-base-type}}, bool)`
 
 Get{{name}}Ok returns a tuple with the {{name}} field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### Set{{name}}
 
-`func (o *{{classname}}) Set{{name}}(v {{vendorExtensions.x-basetype}})`
+`func (o *{{classname}}) Set{{name}}(v {{vendorExtensions.x-go-base-type}})`
 
 Set{{name}} sets {{name}} field to given value.
 

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/Apple.md
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/Apple.md
@@ -34,22 +34,22 @@ GetCultivar returns the Cultivar field if non-nil, zero value otherwise.
 
 ### GetCultivarOk
 
-`func (o *Apple) GetCultivarOk() (string, bool)`
+`func (o *Apple) GetCultivarOk() (*string, bool)`
 
 GetCultivarOk returns a tuple with the Cultivar field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
+
+### SetCultivar
+
+`func (o *Apple) SetCultivar(v string)`
+
+SetCultivar sets Cultivar field to given value.
 
 ### HasCultivar
 
 `func (o *Apple) HasCultivar() bool`
 
 HasCultivar returns a boolean if a field has been set.
-
-### SetCultivar
-
-`func (o *Apple) SetCultivar(v string)`
-
-SetCultivar gets a reference to the given string and assigns it to the Cultivar field.
 
 ### GetColor
 
@@ -59,22 +59,22 @@ GetColor returns the Color field if non-nil, zero value otherwise.
 
 ### GetColorOk
 
-`func (o *Apple) GetColorOk() (string, bool)`
+`func (o *Apple) GetColorOk() (*string, bool)`
 
 GetColorOk returns a tuple with the Color field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
+
+### SetColor
+
+`func (o *Apple) SetColor(v string)`
+
+SetColor sets Color field to given value.
 
 ### HasColor
 
 `func (o *Apple) HasColor() bool`
 
 HasColor returns a boolean if a field has been set.
-
-### SetColor
-
-`func (o *Apple) SetColor(v string)`
-
-SetColor gets a reference to the given string and assigns it to the Color field.
 
 
 ### AsFruit

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/AppleReq.md
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/AppleReq.md
@@ -34,22 +34,17 @@ GetCultivar returns the Cultivar field if non-nil, zero value otherwise.
 
 ### GetCultivarOk
 
-`func (o *AppleReq) GetCultivarOk() (string, bool)`
+`func (o *AppleReq) GetCultivarOk() (*string, bool)`
 
 GetCultivarOk returns a tuple with the Cultivar field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasCultivar
-
-`func (o *AppleReq) HasCultivar() bool`
-
-HasCultivar returns a boolean if a field has been set.
 
 ### SetCultivar
 
 `func (o *AppleReq) SetCultivar(v string)`
 
-SetCultivar gets a reference to the given string and assigns it to the Cultivar field.
+SetCultivar sets Cultivar field to given value.
+
 
 ### GetMealy
 
@@ -59,22 +54,22 @@ GetMealy returns the Mealy field if non-nil, zero value otherwise.
 
 ### GetMealyOk
 
-`func (o *AppleReq) GetMealyOk() (bool, bool)`
+`func (o *AppleReq) GetMealyOk() (*bool, bool)`
 
 GetMealyOk returns a tuple with the Mealy field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
+
+### SetMealy
+
+`func (o *AppleReq) SetMealy(v bool)`
+
+SetMealy sets Mealy field to given value.
 
 ### HasMealy
 
 `func (o *AppleReq) HasMealy() bool`
 
 HasMealy returns a boolean if a field has been set.
-
-### SetMealy
-
-`func (o *AppleReq) SetMealy(v bool)`
-
-SetMealy gets a reference to the given bool and assigns it to the Mealy field.
 
 
 ### AsFruitReq

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/Banana.md
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/Banana.md
@@ -34,22 +34,22 @@ GetLengthCm returns the LengthCm field if non-nil, zero value otherwise.
 
 ### GetLengthCmOk
 
-`func (o *Banana) GetLengthCmOk() (float32, bool)`
+`func (o *Banana) GetLengthCmOk() (*float32, bool)`
 
 GetLengthCmOk returns a tuple with the LengthCm field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
+
+### SetLengthCm
+
+`func (o *Banana) SetLengthCm(v float32)`
+
+SetLengthCm sets LengthCm field to given value.
 
 ### HasLengthCm
 
 `func (o *Banana) HasLengthCm() bool`
 
 HasLengthCm returns a boolean if a field has been set.
-
-### SetLengthCm
-
-`func (o *Banana) SetLengthCm(v float32)`
-
-SetLengthCm gets a reference to the given float32 and assigns it to the LengthCm field.
 
 ### GetColor
 
@@ -59,22 +59,22 @@ GetColor returns the Color field if non-nil, zero value otherwise.
 
 ### GetColorOk
 
-`func (o *Banana) GetColorOk() (string, bool)`
+`func (o *Banana) GetColorOk() (*string, bool)`
 
 GetColorOk returns a tuple with the Color field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
+
+### SetColor
+
+`func (o *Banana) SetColor(v string)`
+
+SetColor sets Color field to given value.
 
 ### HasColor
 
 `func (o *Banana) HasColor() bool`
 
 HasColor returns a boolean if a field has been set.
-
-### SetColor
-
-`func (o *Banana) SetColor(v string)`
-
-SetColor gets a reference to the given string and assigns it to the Color field.
 
 
 ### AsFruit

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/BananaReq.md
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/BananaReq.md
@@ -34,22 +34,17 @@ GetLengthCm returns the LengthCm field if non-nil, zero value otherwise.
 
 ### GetLengthCmOk
 
-`func (o *BananaReq) GetLengthCmOk() (float32, bool)`
+`func (o *BananaReq) GetLengthCmOk() (*float32, bool)`
 
 GetLengthCmOk returns a tuple with the LengthCm field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasLengthCm
-
-`func (o *BananaReq) HasLengthCm() bool`
-
-HasLengthCm returns a boolean if a field has been set.
 
 ### SetLengthCm
 
 `func (o *BananaReq) SetLengthCm(v float32)`
 
-SetLengthCm gets a reference to the given float32 and assigns it to the LengthCm field.
+SetLengthCm sets LengthCm field to given value.
+
 
 ### GetSweet
 
@@ -59,22 +54,22 @@ GetSweet returns the Sweet field if non-nil, zero value otherwise.
 
 ### GetSweetOk
 
-`func (o *BananaReq) GetSweetOk() (bool, bool)`
+`func (o *BananaReq) GetSweetOk() (*bool, bool)`
 
 GetSweetOk returns a tuple with the Sweet field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
+
+### SetSweet
+
+`func (o *BananaReq) SetSweet(v bool)`
+
+SetSweet sets Sweet field to given value.
 
 ### HasSweet
 
 `func (o *BananaReq) HasSweet() bool`
 
 HasSweet returns a boolean if a field has been set.
-
-### SetSweet
-
-`func (o *BananaReq) SetSweet(v bool)`
-
-SetSweet gets a reference to the given bool and assigns it to the Sweet field.
 
 
 ### AsFruitReq

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/GmFruit.md
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/GmFruit.md
@@ -35,22 +35,22 @@ GetColor returns the Color field if non-nil, zero value otherwise.
 
 ### GetColorOk
 
-`func (o *GmFruit) GetColorOk() (string, bool)`
+`func (o *GmFruit) GetColorOk() (*string, bool)`
 
 GetColorOk returns a tuple with the Color field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
+
+### SetColor
+
+`func (o *GmFruit) SetColor(v string)`
+
+SetColor sets Color field to given value.
 
 ### HasColor
 
 `func (o *GmFruit) HasColor() bool`
 
 HasColor returns a boolean if a field has been set.
-
-### SetColor
-
-`func (o *GmFruit) SetColor(v string)`
-
-SetColor gets a reference to the given string and assigns it to the Color field.
 
 ### GetCultivar
 
@@ -60,22 +60,22 @@ GetCultivar returns the Cultivar field if non-nil, zero value otherwise.
 
 ### GetCultivarOk
 
-`func (o *GmFruit) GetCultivarOk() (string, bool)`
+`func (o *GmFruit) GetCultivarOk() (*string, bool)`
 
 GetCultivarOk returns a tuple with the Cultivar field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
+
+### SetCultivar
+
+`func (o *GmFruit) SetCultivar(v string)`
+
+SetCultivar sets Cultivar field to given value.
 
 ### HasCultivar
 
 `func (o *GmFruit) HasCultivar() bool`
 
 HasCultivar returns a boolean if a field has been set.
-
-### SetCultivar
-
-`func (o *GmFruit) SetCultivar(v string)`
-
-SetCultivar gets a reference to the given string and assigns it to the Cultivar field.
 
 ### GetLengthCm
 
@@ -85,22 +85,22 @@ GetLengthCm returns the LengthCm field if non-nil, zero value otherwise.
 
 ### GetLengthCmOk
 
-`func (o *GmFruit) GetLengthCmOk() (float32, bool)`
+`func (o *GmFruit) GetLengthCmOk() (*float32, bool)`
 
 GetLengthCmOk returns a tuple with the LengthCm field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
+
+### SetLengthCm
+
+`func (o *GmFruit) SetLengthCm(v float32)`
+
+SetLengthCm sets LengthCm field to given value.
 
 ### HasLengthCm
 
 `func (o *GmFruit) HasLengthCm() bool`
 
 HasLengthCm returns a boolean if a field has been set.
-
-### SetLengthCm
-
-`func (o *GmFruit) SetLengthCm(v float32)`
-
-SetLengthCm gets a reference to the given float32 and assigns it to the LengthCm field.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/Whale.md
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/Whale.md
@@ -35,22 +35,22 @@ GetHasBaleen returns the HasBaleen field if non-nil, zero value otherwise.
 
 ### GetHasBaleenOk
 
-`func (o *Whale) GetHasBaleenOk() (bool, bool)`
+`func (o *Whale) GetHasBaleenOk() (*bool, bool)`
 
 GetHasBaleenOk returns a tuple with the HasBaleen field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
+
+### SetHasBaleen
+
+`func (o *Whale) SetHasBaleen(v bool)`
+
+SetHasBaleen sets HasBaleen field to given value.
 
 ### HasHasBaleen
 
 `func (o *Whale) HasHasBaleen() bool`
 
 HasHasBaleen returns a boolean if a field has been set.
-
-### SetHasBaleen
-
-`func (o *Whale) SetHasBaleen(v bool)`
-
-SetHasBaleen gets a reference to the given bool and assigns it to the HasBaleen field.
 
 ### GetHasTeeth
 
@@ -60,22 +60,22 @@ GetHasTeeth returns the HasTeeth field if non-nil, zero value otherwise.
 
 ### GetHasTeethOk
 
-`func (o *Whale) GetHasTeethOk() (bool, bool)`
+`func (o *Whale) GetHasTeethOk() (*bool, bool)`
 
 GetHasTeethOk returns a tuple with the HasTeeth field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
+
+### SetHasTeeth
+
+`func (o *Whale) SetHasTeeth(v bool)`
+
+SetHasTeeth sets HasTeeth field to given value.
 
 ### HasHasTeeth
 
 `func (o *Whale) HasHasTeeth() bool`
 
 HasHasTeeth returns a boolean if a field has been set.
-
-### SetHasTeeth
-
-`func (o *Whale) SetHasTeeth(v bool)`
-
-SetHasTeeth gets a reference to the given bool and assigns it to the HasTeeth field.
 
 ### GetClassName
 
@@ -85,22 +85,17 @@ GetClassName returns the ClassName field if non-nil, zero value otherwise.
 
 ### GetClassNameOk
 
-`func (o *Whale) GetClassNameOk() (string, bool)`
+`func (o *Whale) GetClassNameOk() (*string, bool)`
 
 GetClassNameOk returns a tuple with the ClassName field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasClassName
-
-`func (o *Whale) HasClassName() bool`
-
-HasClassName returns a boolean if a field has been set.
 
 ### SetClassName
 
 `func (o *Whale) SetClassName(v string)`
 
-SetClassName gets a reference to the given string and assigns it to the ClassName field.
+SetClassName sets ClassName field to given value.
+
 
 
 ### AsMammal

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/Zebra.md
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/Zebra.md
@@ -34,22 +34,22 @@ GetType returns the Type field if non-nil, zero value otherwise.
 
 ### GetTypeOk
 
-`func (o *Zebra) GetTypeOk() (string, bool)`
+`func (o *Zebra) GetTypeOk() (*string, bool)`
 
 GetTypeOk returns a tuple with the Type field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
+
+### SetType
+
+`func (o *Zebra) SetType(v string)`
+
+SetType sets Type field to given value.
 
 ### HasType
 
 `func (o *Zebra) HasType() bool`
 
 HasType returns a boolean if a field has been set.
-
-### SetType
-
-`func (o *Zebra) SetType(v string)`
-
-SetType gets a reference to the given string and assigns it to the Type field.
 
 ### GetClassName
 
@@ -59,22 +59,17 @@ GetClassName returns the ClassName field if non-nil, zero value otherwise.
 
 ### GetClassNameOk
 
-`func (o *Zebra) GetClassNameOk() (string, bool)`
+`func (o *Zebra) GetClassNameOk() (*string, bool)`
 
 GetClassNameOk returns a tuple with the ClassName field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
-
-### HasClassName
-
-`func (o *Zebra) HasClassName() bool`
-
-HasClassName returns a boolean if a field has been set.
 
 ### SetClassName
 
 `func (o *Zebra) SetClassName(v string)`
 
-SetClassName gets a reference to the given string and assigns it to the ClassName field.
+SetClassName sets ClassName field to given value.
+
 
 
 ### AsMammal

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_apple.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_apple.go
@@ -10,7 +10,6 @@
 package petstore
 
 import (
-	"bytes"
 	"encoding/json"
 )
 
@@ -25,16 +24,16 @@ type Apple struct {
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
 func NewApple() *Apple {
-    this := Apple{}
-    return &this
+	this := Apple{}
+	return &this
 }
 
 // NewAppleWithDefaults instantiates a new Apple object
 // This constructor will only assign default values to properties that have it defined,
 // but it doesn't guarantee that properties required by API are set
 func NewAppleWithDefaults() *Apple {
-    this := Apple{}
-    return &this
+	this := Apple{}
+	return &this
 }
 
 // GetCultivar returns the Cultivar field value if set, zero value otherwise.
@@ -46,14 +45,13 @@ func (o *Apple) GetCultivar() string {
 	return *o.Cultivar
 }
 
-// GetCultivarOk returns a tuple with the Cultivar field value if set, zero value otherwise
+// GetCultivarOk returns a tuple with the Cultivar field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *Apple) GetCultivarOk() (string, bool) {
+func (o *Apple) GetCultivarOk() (*string, bool) {
 	if o == nil || o.Cultivar == nil {
-		var ret string
-		return ret, false
+		return nil, false
 	}
-	return *o.Cultivar, true
+	return o.Cultivar, true
 }
 
 // HasCultivar returns a boolean if a field has been set.
@@ -79,14 +77,13 @@ func (o *Apple) GetColor() string {
 	return *o.Color
 }
 
-// GetColorOk returns a tuple with the Color field value if set, zero value otherwise
+// GetColorOk returns a tuple with the Color field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *Apple) GetColorOk() (string, bool) {
+func (o *Apple) GetColorOk() (*string, bool) {
 	if o == nil || o.Color == nil {
-		var ret string
-		return ret, false
+		return nil, false
 	}
-	return *o.Color, true
+	return o.Color, true
 }
 
 // HasColor returns a boolean if a field has been set.
@@ -103,29 +100,53 @@ func (o *Apple) SetColor(v string) {
 	o.Color = &v
 }
 
+func (o Apple) MarshalJSON() ([]byte, error) {
+	toSerialize := map[string]interface{}{}
+	if o.Cultivar != nil {
+		toSerialize["cultivar"] = o.Cultivar
+	}
+	if o.Color != nil {
+		toSerialize["color"] = o.Color
+	}
+	return json.Marshal(toSerialize)
+}
+
 // AsFruit wraps this instance of Apple in Fruit
 func (s *Apple) AsFruit() Fruit {
-    return Fruit{ FruitInterface: s }
+	return Fruit{ FruitInterface: s }
 }
 type NullableApple struct {
-	Value Apple
-	ExplicitNull bool
+	value *Apple
+	isSet bool
+}
+
+func (v NullableApple) Get() *Apple {
+	return v.value
+}
+
+func (v *NullableApple) Set(val *Apple) {
+	v.value = val
+	v.isSet = true
+}
+
+func (v NullableApple) IsSet() bool {
+	return v.isSet
+}
+
+func (v *NullableApple) Unset() {
+	v.value = nil
+	v.isSet = false
+}
+
+func NewNullableApple(val *Apple) *NullableApple {
+	return &NullableApple{value: val, isSet: true}
 }
 
 func (v NullableApple) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-		return json.Marshal(v.Value)
-	}
+	return json.Marshal(v.value)
 }
 
 func (v *NullableApple) UnmarshalJSON(src []byte) error {
-	if bytes.Equal(src, []byte("null")) {
-		v.ExplicitNull = true
-		return nil
-	}
-
-	return json.Unmarshal(src, &v.Value)
+	v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_apple_req.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_apple_req.go
@@ -10,7 +10,6 @@
 package petstore
 
 import (
-	"bytes"
 	"encoding/json"
 )
 
@@ -25,27 +24,36 @@ type AppleReq struct {
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
 func NewAppleReq(cultivar string, ) *AppleReq {
-    this := AppleReq{}
-    this.Cultivar = cultivar
-    return &this
+	this := AppleReq{}
+	this.Cultivar = cultivar
+	return &this
 }
 
 // NewAppleReqWithDefaults instantiates a new AppleReq object
 // This constructor will only assign default values to properties that have it defined,
 // but it doesn't guarantee that properties required by API are set
 func NewAppleReqWithDefaults() *AppleReq {
-    this := AppleReq{}
-    return &this
+	this := AppleReq{}
+	return &this
 }
 
 // GetCultivar returns the Cultivar field value
 func (o *AppleReq) GetCultivar() string {
-	if o == nil {
+	if o == nil  {
 		var ret string
 		return ret
 	}
 
 	return o.Cultivar
+}
+
+// GetCultivarOk returns a tuple with the Cultivar field value
+// and a boolean to check if the value has been set.
+func (o *AppleReq) GetCultivarOk() (*string, bool) {
+	if o == nil  {
+		return nil, false
+	}
+	return &o.Cultivar, true
 }
 
 // SetCultivar sets field value
@@ -62,14 +70,13 @@ func (o *AppleReq) GetMealy() bool {
 	return *o.Mealy
 }
 
-// GetMealyOk returns a tuple with the Mealy field value if set, zero value otherwise
+// GetMealyOk returns a tuple with the Mealy field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *AppleReq) GetMealyOk() (bool, bool) {
+func (o *AppleReq) GetMealyOk() (*bool, bool) {
 	if o == nil || o.Mealy == nil {
-		var ret bool
-		return ret, false
+		return nil, false
 	}
-	return *o.Mealy, true
+	return o.Mealy, true
 }
 
 // HasMealy returns a boolean if a field has been set.
@@ -86,29 +93,53 @@ func (o *AppleReq) SetMealy(v bool) {
 	o.Mealy = &v
 }
 
+func (o AppleReq) MarshalJSON() ([]byte, error) {
+	toSerialize := map[string]interface{}{}
+	if true {
+		toSerialize["cultivar"] = o.Cultivar
+	}
+	if o.Mealy != nil {
+		toSerialize["mealy"] = o.Mealy
+	}
+	return json.Marshal(toSerialize)
+}
+
 // AsFruitReq wraps this instance of AppleReq in FruitReq
 func (s *AppleReq) AsFruitReq() FruitReq {
-    return FruitReq{ FruitReqInterface: s }
+	return FruitReq{ FruitReqInterface: s }
 }
 type NullableAppleReq struct {
-	Value AppleReq
-	ExplicitNull bool
+	value *AppleReq
+	isSet bool
+}
+
+func (v NullableAppleReq) Get() *AppleReq {
+	return v.value
+}
+
+func (v *NullableAppleReq) Set(val *AppleReq) {
+	v.value = val
+	v.isSet = true
+}
+
+func (v NullableAppleReq) IsSet() bool {
+	return v.isSet
+}
+
+func (v *NullableAppleReq) Unset() {
+	v.value = nil
+	v.isSet = false
+}
+
+func NewNullableAppleReq(val *AppleReq) *NullableAppleReq {
+	return &NullableAppleReq{value: val, isSet: true}
 }
 
 func (v NullableAppleReq) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-		return json.Marshal(v.Value)
-	}
+	return json.Marshal(v.value)
 }
 
 func (v *NullableAppleReq) UnmarshalJSON(src []byte) error {
-	if bytes.Equal(src, []byte("null")) {
-		v.ExplicitNull = true
-		return nil
-	}
-
-	return json.Unmarshal(src, &v.Value)
+	v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_banana.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_banana.go
@@ -10,7 +10,6 @@
 package petstore
 
 import (
-	"bytes"
 	"encoding/json"
 )
 
@@ -25,16 +24,16 @@ type Banana struct {
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
 func NewBanana() *Banana {
-    this := Banana{}
-    return &this
+	this := Banana{}
+	return &this
 }
 
 // NewBananaWithDefaults instantiates a new Banana object
 // This constructor will only assign default values to properties that have it defined,
 // but it doesn't guarantee that properties required by API are set
 func NewBananaWithDefaults() *Banana {
-    this := Banana{}
-    return &this
+	this := Banana{}
+	return &this
 }
 
 // GetLengthCm returns the LengthCm field value if set, zero value otherwise.
@@ -46,14 +45,13 @@ func (o *Banana) GetLengthCm() float32 {
 	return *o.LengthCm
 }
 
-// GetLengthCmOk returns a tuple with the LengthCm field value if set, zero value otherwise
+// GetLengthCmOk returns a tuple with the LengthCm field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *Banana) GetLengthCmOk() (float32, bool) {
+func (o *Banana) GetLengthCmOk() (*float32, bool) {
 	if o == nil || o.LengthCm == nil {
-		var ret float32
-		return ret, false
+		return nil, false
 	}
-	return *o.LengthCm, true
+	return o.LengthCm, true
 }
 
 // HasLengthCm returns a boolean if a field has been set.
@@ -79,14 +77,13 @@ func (o *Banana) GetColor() string {
 	return *o.Color
 }
 
-// GetColorOk returns a tuple with the Color field value if set, zero value otherwise
+// GetColorOk returns a tuple with the Color field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *Banana) GetColorOk() (string, bool) {
+func (o *Banana) GetColorOk() (*string, bool) {
 	if o == nil || o.Color == nil {
-		var ret string
-		return ret, false
+		return nil, false
 	}
-	return *o.Color, true
+	return o.Color, true
 }
 
 // HasColor returns a boolean if a field has been set.
@@ -103,29 +100,53 @@ func (o *Banana) SetColor(v string) {
 	o.Color = &v
 }
 
+func (o Banana) MarshalJSON() ([]byte, error) {
+	toSerialize := map[string]interface{}{}
+	if o.LengthCm != nil {
+		toSerialize["lengthCm"] = o.LengthCm
+	}
+	if o.Color != nil {
+		toSerialize["color"] = o.Color
+	}
+	return json.Marshal(toSerialize)
+}
+
 // AsFruit wraps this instance of Banana in Fruit
 func (s *Banana) AsFruit() Fruit {
-    return Fruit{ FruitInterface: s }
+	return Fruit{ FruitInterface: s }
 }
 type NullableBanana struct {
-	Value Banana
-	ExplicitNull bool
+	value *Banana
+	isSet bool
+}
+
+func (v NullableBanana) Get() *Banana {
+	return v.value
+}
+
+func (v *NullableBanana) Set(val *Banana) {
+	v.value = val
+	v.isSet = true
+}
+
+func (v NullableBanana) IsSet() bool {
+	return v.isSet
+}
+
+func (v *NullableBanana) Unset() {
+	v.value = nil
+	v.isSet = false
+}
+
+func NewNullableBanana(val *Banana) *NullableBanana {
+	return &NullableBanana{value: val, isSet: true}
 }
 
 func (v NullableBanana) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-		return json.Marshal(v.Value)
-	}
+	return json.Marshal(v.value)
 }
 
 func (v *NullableBanana) UnmarshalJSON(src []byte) error {
-	if bytes.Equal(src, []byte("null")) {
-		v.ExplicitNull = true
-		return nil
-	}
-
-	return json.Unmarshal(src, &v.Value)
+	v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_banana_req.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_banana_req.go
@@ -10,7 +10,6 @@
 package petstore
 
 import (
-	"bytes"
 	"encoding/json"
 )
 
@@ -25,27 +24,36 @@ type BananaReq struct {
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
 func NewBananaReq(lengthCm float32, ) *BananaReq {
-    this := BananaReq{}
-    this.LengthCm = lengthCm
-    return &this
+	this := BananaReq{}
+	this.LengthCm = lengthCm
+	return &this
 }
 
 // NewBananaReqWithDefaults instantiates a new BananaReq object
 // This constructor will only assign default values to properties that have it defined,
 // but it doesn't guarantee that properties required by API are set
 func NewBananaReqWithDefaults() *BananaReq {
-    this := BananaReq{}
-    return &this
+	this := BananaReq{}
+	return &this
 }
 
 // GetLengthCm returns the LengthCm field value
 func (o *BananaReq) GetLengthCm() float32 {
-	if o == nil {
+	if o == nil  {
 		var ret float32
 		return ret
 	}
 
 	return o.LengthCm
+}
+
+// GetLengthCmOk returns a tuple with the LengthCm field value
+// and a boolean to check if the value has been set.
+func (o *BananaReq) GetLengthCmOk() (*float32, bool) {
+	if o == nil  {
+		return nil, false
+	}
+	return &o.LengthCm, true
 }
 
 // SetLengthCm sets field value
@@ -62,14 +70,13 @@ func (o *BananaReq) GetSweet() bool {
 	return *o.Sweet
 }
 
-// GetSweetOk returns a tuple with the Sweet field value if set, zero value otherwise
+// GetSweetOk returns a tuple with the Sweet field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *BananaReq) GetSweetOk() (bool, bool) {
+func (o *BananaReq) GetSweetOk() (*bool, bool) {
 	if o == nil || o.Sweet == nil {
-		var ret bool
-		return ret, false
+		return nil, false
 	}
-	return *o.Sweet, true
+	return o.Sweet, true
 }
 
 // HasSweet returns a boolean if a field has been set.
@@ -86,29 +93,53 @@ func (o *BananaReq) SetSweet(v bool) {
 	o.Sweet = &v
 }
 
+func (o BananaReq) MarshalJSON() ([]byte, error) {
+	toSerialize := map[string]interface{}{}
+	if true {
+		toSerialize["lengthCm"] = o.LengthCm
+	}
+	if o.Sweet != nil {
+		toSerialize["sweet"] = o.Sweet
+	}
+	return json.Marshal(toSerialize)
+}
+
 // AsFruitReq wraps this instance of BananaReq in FruitReq
 func (s *BananaReq) AsFruitReq() FruitReq {
-    return FruitReq{ FruitReqInterface: s }
+	return FruitReq{ FruitReqInterface: s }
 }
 type NullableBananaReq struct {
-	Value BananaReq
-	ExplicitNull bool
+	value *BananaReq
+	isSet bool
+}
+
+func (v NullableBananaReq) Get() *BananaReq {
+	return v.value
+}
+
+func (v *NullableBananaReq) Set(val *BananaReq) {
+	v.value = val
+	v.isSet = true
+}
+
+func (v NullableBananaReq) IsSet() bool {
+	return v.isSet
+}
+
+func (v *NullableBananaReq) Unset() {
+	v.value = nil
+	v.isSet = false
+}
+
+func NewNullableBananaReq(val *BananaReq) *NullableBananaReq {
+	return &NullableBananaReq{value: val, isSet: true}
 }
 
 func (v NullableBananaReq) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-		return json.Marshal(v.Value)
-	}
+	return json.Marshal(v.value)
 }
 
 func (v *NullableBananaReq) UnmarshalJSON(src []byte) error {
-	if bytes.Equal(src, []byte("null")) {
-		v.ExplicitNull = true
-		return nil
-	}
-
-	return json.Unmarshal(src, &v.Value)
+	v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_fruit.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_fruit.go
@@ -10,55 +10,67 @@
 package petstore
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 )
 
 // Fruit struct for Fruit
 type Fruit struct {
-    FruitInterface interface {  }
+	FruitInterface interface {  }
 }
 
-func (s *Fruit) MarshalJSON() ([]byte, error) {
-    return json.Marshal(s.FruitInterface)
+func (s Fruit) MarshalJSON() ([]byte, error) {
+	return json.Marshal(s.FruitInterface)
 }
 
 func (s *Fruit) UnmarshalJSON(src []byte) error {
-    var err error
-    var unmarshaledApple *Apple = &Apple{}
-    err = json.Unmarshal(src, unmarshaledApple)
-    if err == nil {
-        s.FruitInterface = unmarshaledApple
-        return nil
-    }
-    var unmarshaledBanana *Banana = &Banana{}
-    err = json.Unmarshal(src, unmarshaledBanana)
-    if err == nil {
-        s.FruitInterface = unmarshaledBanana
-        return nil
-    }
-    return fmt.Errorf("No oneOf model could be deserialized from payload: %s", string(src))
+	var err error
+	var unmarshaledApple *Apple = &Apple{}
+	err = json.Unmarshal(src, unmarshaledApple)
+	if err == nil {
+		s.FruitInterface = unmarshaledApple
+		return nil
+	}
+	var unmarshaledBanana *Banana = &Banana{}
+	err = json.Unmarshal(src, unmarshaledBanana)
+	if err == nil {
+		s.FruitInterface = unmarshaledBanana
+		return nil
+	}
+	return fmt.Errorf("No oneOf model could be deserialized from payload: %s", string(src))
 }
 type NullableFruit struct {
-	Value Fruit
-	ExplicitNull bool
+	value *Fruit
+	isSet bool
+}
+
+func (v NullableFruit) Get() *Fruit {
+	return v.value
+}
+
+func (v *NullableFruit) Set(val *Fruit) {
+	v.value = val
+	v.isSet = true
+}
+
+func (v NullableFruit) IsSet() bool {
+	return v.isSet
+}
+
+func (v *NullableFruit) Unset() {
+	v.value = nil
+	v.isSet = false
+}
+
+func NewNullableFruit(val *Fruit) *NullableFruit {
+	return &NullableFruit{value: val, isSet: true}
 }
 
 func (v NullableFruit) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-		return json.Marshal(v.Value)
-	}
+	return json.Marshal(v.value)
 }
 
 func (v *NullableFruit) UnmarshalJSON(src []byte) error {
-	if bytes.Equal(src, []byte("null")) {
-		v.ExplicitNull = true
-		return nil
-	}
-
-	return json.Unmarshal(src, &v.Value)
+	v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_fruit_req.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_fruit_req.go
@@ -10,55 +10,67 @@
 package petstore
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 )
 
 // FruitReq struct for FruitReq
 type FruitReq struct {
-    FruitReqInterface interface {  }
+	FruitReqInterface interface {  }
 }
 
-func (s *FruitReq) MarshalJSON() ([]byte, error) {
-    return json.Marshal(s.FruitReqInterface)
+func (s FruitReq) MarshalJSON() ([]byte, error) {
+	return json.Marshal(s.FruitReqInterface)
 }
 
 func (s *FruitReq) UnmarshalJSON(src []byte) error {
-    var err error
-    var unmarshaledAppleReq *AppleReq = &AppleReq{}
-    err = json.Unmarshal(src, unmarshaledAppleReq)
-    if err == nil {
-        s.FruitReqInterface = unmarshaledAppleReq
-        return nil
-    }
-    var unmarshaledBananaReq *BananaReq = &BananaReq{}
-    err = json.Unmarshal(src, unmarshaledBananaReq)
-    if err == nil {
-        s.FruitReqInterface = unmarshaledBananaReq
-        return nil
-    }
-    return fmt.Errorf("No oneOf model could be deserialized from payload: %s", string(src))
+	var err error
+	var unmarshaledAppleReq *AppleReq = &AppleReq{}
+	err = json.Unmarshal(src, unmarshaledAppleReq)
+	if err == nil {
+		s.FruitReqInterface = unmarshaledAppleReq
+		return nil
+	}
+	var unmarshaledBananaReq *BananaReq = &BananaReq{}
+	err = json.Unmarshal(src, unmarshaledBananaReq)
+	if err == nil {
+		s.FruitReqInterface = unmarshaledBananaReq
+		return nil
+	}
+	return fmt.Errorf("No oneOf model could be deserialized from payload: %s", string(src))
 }
 type NullableFruitReq struct {
-	Value FruitReq
-	ExplicitNull bool
+	value *FruitReq
+	isSet bool
+}
+
+func (v NullableFruitReq) Get() *FruitReq {
+	return v.value
+}
+
+func (v *NullableFruitReq) Set(val *FruitReq) {
+	v.value = val
+	v.isSet = true
+}
+
+func (v NullableFruitReq) IsSet() bool {
+	return v.isSet
+}
+
+func (v *NullableFruitReq) Unset() {
+	v.value = nil
+	v.isSet = false
+}
+
+func NewNullableFruitReq(val *FruitReq) *NullableFruitReq {
+	return &NullableFruitReq{value: val, isSet: true}
 }
 
 func (v NullableFruitReq) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-		return json.Marshal(v.Value)
-	}
+	return json.Marshal(v.value)
 }
 
 func (v *NullableFruitReq) UnmarshalJSON(src []byte) error {
-	if bytes.Equal(src, []byte("null")) {
-		v.ExplicitNull = true
-		return nil
-	}
-
-	return json.Unmarshal(src, &v.Value)
+	v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_gm_fruit.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_gm_fruit.go
@@ -10,7 +10,6 @@
 package petstore
 
 import (
-	"bytes"
 	"encoding/json"
 )
 
@@ -26,16 +25,16 @@ type GmFruit struct {
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
 func NewGmFruit() *GmFruit {
-    this := GmFruit{}
-    return &this
+	this := GmFruit{}
+	return &this
 }
 
 // NewGmFruitWithDefaults instantiates a new GmFruit object
 // This constructor will only assign default values to properties that have it defined,
 // but it doesn't guarantee that properties required by API are set
 func NewGmFruitWithDefaults() *GmFruit {
-    this := GmFruit{}
-    return &this
+	this := GmFruit{}
+	return &this
 }
 
 // GetColor returns the Color field value if set, zero value otherwise.
@@ -47,14 +46,13 @@ func (o *GmFruit) GetColor() string {
 	return *o.Color
 }
 
-// GetColorOk returns a tuple with the Color field value if set, zero value otherwise
+// GetColorOk returns a tuple with the Color field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *GmFruit) GetColorOk() (string, bool) {
+func (o *GmFruit) GetColorOk() (*string, bool) {
 	if o == nil || o.Color == nil {
-		var ret string
-		return ret, false
+		return nil, false
 	}
-	return *o.Color, true
+	return o.Color, true
 }
 
 // HasColor returns a boolean if a field has been set.
@@ -80,14 +78,13 @@ func (o *GmFruit) GetCultivar() string {
 	return *o.Cultivar
 }
 
-// GetCultivarOk returns a tuple with the Cultivar field value if set, zero value otherwise
+// GetCultivarOk returns a tuple with the Cultivar field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *GmFruit) GetCultivarOk() (string, bool) {
+func (o *GmFruit) GetCultivarOk() (*string, bool) {
 	if o == nil || o.Cultivar == nil {
-		var ret string
-		return ret, false
+		return nil, false
 	}
-	return *o.Cultivar, true
+	return o.Cultivar, true
 }
 
 // HasCultivar returns a boolean if a field has been set.
@@ -113,14 +110,13 @@ func (o *GmFruit) GetLengthCm() float32 {
 	return *o.LengthCm
 }
 
-// GetLengthCmOk returns a tuple with the LengthCm field value if set, zero value otherwise
+// GetLengthCmOk returns a tuple with the LengthCm field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *GmFruit) GetLengthCmOk() (float32, bool) {
+func (o *GmFruit) GetLengthCmOk() (*float32, bool) {
 	if o == nil || o.LengthCm == nil {
-		var ret float32
-		return ret, false
+		return nil, false
 	}
-	return *o.LengthCm, true
+	return o.LengthCm, true
 }
 
 // HasLengthCm returns a boolean if a field has been set.
@@ -137,25 +133,52 @@ func (o *GmFruit) SetLengthCm(v float32) {
 	o.LengthCm = &v
 }
 
+func (o GmFruit) MarshalJSON() ([]byte, error) {
+	toSerialize := map[string]interface{}{}
+	if o.Color != nil {
+		toSerialize["color"] = o.Color
+	}
+	if o.Cultivar != nil {
+		toSerialize["cultivar"] = o.Cultivar
+	}
+	if o.LengthCm != nil {
+		toSerialize["lengthCm"] = o.LengthCm
+	}
+	return json.Marshal(toSerialize)
+}
+
 type NullableGmFruit struct {
-	Value GmFruit
-	ExplicitNull bool
+	value *GmFruit
+	isSet bool
+}
+
+func (v NullableGmFruit) Get() *GmFruit {
+	return v.value
+}
+
+func (v *NullableGmFruit) Set(val *GmFruit) {
+	v.value = val
+	v.isSet = true
+}
+
+func (v NullableGmFruit) IsSet() bool {
+	return v.isSet
+}
+
+func (v *NullableGmFruit) Unset() {
+	v.value = nil
+	v.isSet = false
+}
+
+func NewNullableGmFruit(val *GmFruit) *NullableGmFruit {
+	return &NullableGmFruit{value: val, isSet: true}
 }
 
 func (v NullableGmFruit) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-		return json.Marshal(v.Value)
-	}
+	return json.Marshal(v.value)
 }
 
 func (v *NullableGmFruit) UnmarshalJSON(src []byte) error {
-	if bytes.Equal(src, []byte("null")) {
-		v.ExplicitNull = true
-		return nil
-	}
-
-	return json.Unmarshal(src, &v.Value)
+	v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_mammal.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_mammal.go
@@ -10,71 +10,83 @@
 package petstore
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 )
 
 // Mammal struct for Mammal
 type Mammal struct {
-    MammalInterface interface { GetClassName() string }
+	MammalInterface interface { GetClassName() string }
 }
 
-func (s *Mammal) MarshalJSON() ([]byte, error) {
-    return json.Marshal(s.MammalInterface)
+func (s Mammal) MarshalJSON() ([]byte, error) {
+	return json.Marshal(s.MammalInterface)
 }
 
 func (s *Mammal) UnmarshalJSON(src []byte) error {
-    var err error
-    var unmarshaled map[string]interface{}
-    err = json.Unmarshal(src, &unmarshaled)
-    if err != nil {
-        return err
-    }
-    if v, ok := unmarshaled["className"]; ok {
-        switch v {
-            case "whale":
-                var result *Whale = &Whale{}
-                err = json.Unmarshal(src, result)
-                if err != nil {
-                    return err
-                }
-                s.MammalInterface = result
-                return nil
-            case "zebra":
-                var result *Zebra = &Zebra{}
-                err = json.Unmarshal(src, result)
-                if err != nil {
-                    return err
-                }
-                s.MammalInterface = result
-                return nil
-            default:
-                return fmt.Errorf("No oneOf model has 'className' equal to %s", v)
-        }
-    } else {
-        return fmt.Errorf("Discriminator property 'className' not found in unmarshaled payload: %+v", unmarshaled)
-    }
+	var err error
+	var unmarshaled map[string]interface{}
+	err = json.Unmarshal(src, &unmarshaled)
+	if err != nil {
+		return err
+	}
+	if v, ok := unmarshaled["className"]; ok {
+		switch v {
+			case "whale":
+				var result *Whale = &Whale{}
+				err = json.Unmarshal(src, result)
+				if err != nil {
+					return err
+				}
+				s.MammalInterface = result
+				return nil
+			case "zebra":
+				var result *Zebra = &Zebra{}
+				err = json.Unmarshal(src, result)
+				if err != nil {
+					return err
+				}
+				s.MammalInterface = result
+				return nil
+			default:
+				return fmt.Errorf("No oneOf model has 'className' equal to %s", v)
+		}
+	} else {
+		return fmt.Errorf("Discriminator property 'className' not found in unmarshaled payload: %+v", unmarshaled)
+	}
 }
 type NullableMammal struct {
-	Value Mammal
-	ExplicitNull bool
+	value *Mammal
+	isSet bool
+}
+
+func (v NullableMammal) Get() *Mammal {
+	return v.value
+}
+
+func (v *NullableMammal) Set(val *Mammal) {
+	v.value = val
+	v.isSet = true
+}
+
+func (v NullableMammal) IsSet() bool {
+	return v.isSet
+}
+
+func (v *NullableMammal) Unset() {
+	v.value = nil
+	v.isSet = false
+}
+
+func NewNullableMammal(val *Mammal) *NullableMammal {
+	return &NullableMammal{value: val, isSet: true}
 }
 
 func (v NullableMammal) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-		return json.Marshal(v.Value)
-	}
+	return json.Marshal(v.value)
 }
 
 func (v *NullableMammal) UnmarshalJSON(src []byte) error {
-	if bytes.Equal(src, []byte("null")) {
-		v.ExplicitNull = true
-		return nil
-	}
-
-	return json.Unmarshal(src, &v.Value)
+	v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_whale.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_whale.go
@@ -10,7 +10,6 @@
 package petstore
 
 import (
-	"bytes"
 	"encoding/json"
 )
 
@@ -26,17 +25,17 @@ type Whale struct {
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
 func NewWhale(className string, ) *Whale {
-    this := Whale{}
-    this.ClassName = className
-    return &this
+	this := Whale{}
+	this.ClassName = className
+	return &this
 }
 
 // NewWhaleWithDefaults instantiates a new Whale object
 // This constructor will only assign default values to properties that have it defined,
 // but it doesn't guarantee that properties required by API are set
 func NewWhaleWithDefaults() *Whale {
-    this := Whale{}
-    return &this
+	this := Whale{}
+	return &this
 }
 
 // GetHasBaleen returns the HasBaleen field value if set, zero value otherwise.
@@ -48,14 +47,13 @@ func (o *Whale) GetHasBaleen() bool {
 	return *o.HasBaleen
 }
 
-// GetHasBaleenOk returns a tuple with the HasBaleen field value if set, zero value otherwise
+// GetHasBaleenOk returns a tuple with the HasBaleen field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *Whale) GetHasBaleenOk() (bool, bool) {
+func (o *Whale) GetHasBaleenOk() (*bool, bool) {
 	if o == nil || o.HasBaleen == nil {
-		var ret bool
-		return ret, false
+		return nil, false
 	}
-	return *o.HasBaleen, true
+	return o.HasBaleen, true
 }
 
 // HasHasBaleen returns a boolean if a field has been set.
@@ -81,14 +79,13 @@ func (o *Whale) GetHasTeeth() bool {
 	return *o.HasTeeth
 }
 
-// GetHasTeethOk returns a tuple with the HasTeeth field value if set, zero value otherwise
+// GetHasTeethOk returns a tuple with the HasTeeth field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *Whale) GetHasTeethOk() (bool, bool) {
+func (o *Whale) GetHasTeethOk() (*bool, bool) {
 	if o == nil || o.HasTeeth == nil {
-		var ret bool
-		return ret, false
+		return nil, false
 	}
-	return *o.HasTeeth, true
+	return o.HasTeeth, true
 }
 
 // HasHasTeeth returns a boolean if a field has been set.
@@ -107,7 +104,7 @@ func (o *Whale) SetHasTeeth(v bool) {
 
 // GetClassName returns the ClassName field value
 func (o *Whale) GetClassName() string {
-	if o == nil {
+	if o == nil  {
 		var ret string
 		return ret
 	}
@@ -115,34 +112,70 @@ func (o *Whale) GetClassName() string {
 	return o.ClassName
 }
 
+// GetClassNameOk returns a tuple with the ClassName field value
+// and a boolean to check if the value has been set.
+func (o *Whale) GetClassNameOk() (*string, bool) {
+	if o == nil  {
+		return nil, false
+	}
+	return &o.ClassName, true
+}
+
 // SetClassName sets field value
 func (o *Whale) SetClassName(v string) {
 	o.ClassName = v
 }
 
+func (o Whale) MarshalJSON() ([]byte, error) {
+	toSerialize := map[string]interface{}{}
+	if o.HasBaleen != nil {
+		toSerialize["hasBaleen"] = o.HasBaleen
+	}
+	if o.HasTeeth != nil {
+		toSerialize["hasTeeth"] = o.HasTeeth
+	}
+	if true {
+		toSerialize["className"] = o.ClassName
+	}
+	return json.Marshal(toSerialize)
+}
+
 // AsMammal wraps this instance of Whale in Mammal
 func (s *Whale) AsMammal() Mammal {
-    return Mammal{ MammalInterface: s }
+	return Mammal{ MammalInterface: s }
 }
 type NullableWhale struct {
-	Value Whale
-	ExplicitNull bool
+	value *Whale
+	isSet bool
+}
+
+func (v NullableWhale) Get() *Whale {
+	return v.value
+}
+
+func (v *NullableWhale) Set(val *Whale) {
+	v.value = val
+	v.isSet = true
+}
+
+func (v NullableWhale) IsSet() bool {
+	return v.isSet
+}
+
+func (v *NullableWhale) Unset() {
+	v.value = nil
+	v.isSet = false
+}
+
+func NewNullableWhale(val *Whale) *NullableWhale {
+	return &NullableWhale{value: val, isSet: true}
 }
 
 func (v NullableWhale) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-		return json.Marshal(v.Value)
-	}
+	return json.Marshal(v.value)
 }
 
 func (v *NullableWhale) UnmarshalJSON(src []byte) error {
-	if bytes.Equal(src, []byte("null")) {
-		v.ExplicitNull = true
-		return nil
-	}
-
-	return json.Unmarshal(src, &v.Value)
+	v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_zebra.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_zebra.go
@@ -10,7 +10,6 @@
 package petstore
 
 import (
-	"bytes"
 	"encoding/json"
 )
 
@@ -25,17 +24,17 @@ type Zebra struct {
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
 func NewZebra(className string, ) *Zebra {
-    this := Zebra{}
-    this.ClassName = className
-    return &this
+	this := Zebra{}
+	this.ClassName = className
+	return &this
 }
 
 // NewZebraWithDefaults instantiates a new Zebra object
 // This constructor will only assign default values to properties that have it defined,
 // but it doesn't guarantee that properties required by API are set
 func NewZebraWithDefaults() *Zebra {
-    this := Zebra{}
-    return &this
+	this := Zebra{}
+	return &this
 }
 
 // GetType returns the Type field value if set, zero value otherwise.
@@ -47,14 +46,13 @@ func (o *Zebra) GetType() string {
 	return *o.Type
 }
 
-// GetTypeOk returns a tuple with the Type field value if set, zero value otherwise
+// GetTypeOk returns a tuple with the Type field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *Zebra) GetTypeOk() (string, bool) {
+func (o *Zebra) GetTypeOk() (*string, bool) {
 	if o == nil || o.Type == nil {
-		var ret string
-		return ret, false
+		return nil, false
 	}
-	return *o.Type, true
+	return o.Type, true
 }
 
 // HasType returns a boolean if a field has been set.
@@ -73,7 +71,7 @@ func (o *Zebra) SetType(v string) {
 
 // GetClassName returns the ClassName field value
 func (o *Zebra) GetClassName() string {
-	if o == nil {
+	if o == nil  {
 		var ret string
 		return ret
 	}
@@ -81,34 +79,67 @@ func (o *Zebra) GetClassName() string {
 	return o.ClassName
 }
 
+// GetClassNameOk returns a tuple with the ClassName field value
+// and a boolean to check if the value has been set.
+func (o *Zebra) GetClassNameOk() (*string, bool) {
+	if o == nil  {
+		return nil, false
+	}
+	return &o.ClassName, true
+}
+
 // SetClassName sets field value
 func (o *Zebra) SetClassName(v string) {
 	o.ClassName = v
 }
 
+func (o Zebra) MarshalJSON() ([]byte, error) {
+	toSerialize := map[string]interface{}{}
+	if o.Type != nil {
+		toSerialize["type"] = o.Type
+	}
+	if true {
+		toSerialize["className"] = o.ClassName
+	}
+	return json.Marshal(toSerialize)
+}
+
 // AsMammal wraps this instance of Zebra in Mammal
 func (s *Zebra) AsMammal() Mammal {
-    return Mammal{ MammalInterface: s }
+	return Mammal{ MammalInterface: s }
 }
 type NullableZebra struct {
-	Value Zebra
-	ExplicitNull bool
+	value *Zebra
+	isSet bool
+}
+
+func (v NullableZebra) Get() *Zebra {
+	return v.value
+}
+
+func (v *NullableZebra) Set(val *Zebra) {
+	v.value = val
+	v.isSet = true
+}
+
+func (v NullableZebra) IsSet() bool {
+	return v.isSet
+}
+
+func (v *NullableZebra) Unset() {
+	v.value = nil
+	v.isSet = false
+}
+
+func NewNullableZebra(val *Zebra) *NullableZebra {
+	return &NullableZebra{value: val, isSet: true}
 }
 
 func (v NullableZebra) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-		return json.Marshal(v.Value)
-	}
+	return json.Marshal(v.value)
 }
 
 func (v *NullableZebra) UnmarshalJSON(src []byte) error {
-	if bytes.Equal(src, []byte("null")) {
-		v.ExplicitNull = true
-		return nil
-	}
-
-	return json.Unmarshal(src, &v.Value)
+	v.isSet = true
+	return json.Unmarshal(src, &v.value)
 }


### PR DESCRIPTION
Rename from `x-basetype` to `x-go-base-type`

Also update Go (experimental) petstore samples (OAS3) 

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

cc @antihax (2017/11) @bvwells (2017/12) @grokify (2018/07) @kemokemo (2018/09) @bkabrda (2019/07)


