### PR TITLE
[java] Allow control of discriminator property in Spring (#5694)

### DIFF
--- a/docs/generators/spring.md
+++ b/docs/generators/spring.md
@@ -34,6 +34,7 @@ sidebar_label: spring
 |interfaceOnly|Whether to generate only API interface stubs without the server files.| |false|
 |invokerPackage|root package for generated code| |org.openapitools.api|
 |java8|Option. Use Java8 classes instead of third party equivalents|<dl><dt>**true**</dt><dd>Use Java 8 classes such as Base64. Use java8 default interface when a responseWrapper is used</dd><dt>**false**</dt><dd>Various third party libraries as needed</dd></dl>|false|
+|keepDiscriminatorProperty|if false the discriminator properties are deleted from model, even if they are defined - this option set `visible` into `@JsonTypeInfo`| |true|
 |library|library template (sub-template)|<dl><dt>**spring-boot**</dt><dd>Spring-boot Server application using the SpringFox integration.</dd><dt>**spring-mvc**</dt><dd>Spring-MVC Server application using the SpringFox integration.</dd><dt>**spring-cloud**</dt><dd>Spring-Cloud-Feign client with Spring-Boot auto-configured settings.</dd></dl>|spring-boot|
 |licenseName|The name of the license| |Unlicense|
 |licenseUrl|The URL of the license| |http://unlicense.org|

--- a/modules/openapi-generator/src/main/resources/JavaSpring/typeInfoAnnotation.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/typeInfoAnnotation.mustache
@@ -1,6 +1,6 @@
 {{#jackson}}
 
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXISTING_PROPERTY, property = "{{{discriminator.propertyBaseName}}}", visible = true)
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXISTING_PROPERTY, property = "{{{discriminator.propertyBaseName}}}", visible = {{{keepDiscriminatorProperty}}})
 @JsonSubTypes({
   {{#discriminator.mappedModels}}
   @JsonSubTypes.Type(value = {{modelName}}.class, name = "{{^vendorExtensions.x-discriminator-value}}{{mappingName}}{{/vendorExtensions.x-discriminator-value}}{{#vendorExtensions.x-discriminator-value}}{{{vendorExtensions.x-discriminator-value}}}{{/vendorExtensions.x-discriminator-value}}"),


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

Added new parameter to Spring generator which controls generating of the discriminator property.

Fixes issue #5694
Possibly fixes #3796


<!-- Please check the completed items below -->
### PR checklist

- [x] Read the contribution guidelines.
- [ ] If contributing template-only or documentation-only changes which will change sample output, build the project before.
- [x] Run the shell script(s) under ./bin/ (or Windows batch scripts under.\bin\windows) to update Petstore samples related to your fix. This is important, as CI jobs will verify all generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run ./bin/{LANG}-petstore.sh, ./bin/openapi3/{LANG}-petstore.sh if updating the code or mustache templates for a language ({LANG}) (e.g. php, ruby, python, etc).
- [x] File the PR against the correct branch: master, 4.3.x, 5.0.x. Default: master.
- [x] Copy the technical committee to review the pull request if your PR is targeting a particular programming language.

@bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04) @lwlee2608 (2019/10) @bkabrda (2020/01)