### PR TITLE
[ruby] fix oneOf handling

### DIFF
--- a/bin/configs/ruby-faraday.yaml
+++ b/bin/configs/ruby-faraday.yaml
@@ -1,7 +1,7 @@
 generatorName: ruby
 outputDir: samples/client/petstore/ruby-faraday
 library: faraday
-inputSpec: modules/openapi-generator/src/test/resources/3_0/java/petstore-with-fake-endpoints-models-for-testing-with-http-signature.yaml
+inputSpec: modules/openapi-generator/src/test/resources/3_0/petstore-with-fake-endpoints-models-for-testing.yaml
 templateDir: modules/openapi-generator/src/main/resources/ruby-client
 additionalProperties:
   gemVersion: 1.0.0

--- a/bin/configs/ruby-faraday.yaml
+++ b/bin/configs/ruby-faraday.yaml
@@ -1,7 +1,7 @@
 generatorName: ruby
 outputDir: samples/client/petstore/ruby-faraday
 library: faraday
-inputSpec: modules/openapi-generator/src/test/resources/3_0/petstore-with-fake-endpoints-models-for-testing.yaml
+inputSpec: modules/openapi-generator/src/test/resources/3_0/java/petstore-with-fake-endpoints-models-for-testing-with-http-signature.yaml
 templateDir: modules/openapi-generator/src/main/resources/ruby-client
 additionalProperties:
   gemVersion: 1.0.0

--- a/bin/configs/ruby.yaml
+++ b/bin/configs/ruby.yaml
@@ -1,7 +1,7 @@
 generatorName: ruby
 outputDir: samples/client/petstore/ruby
 library: typhoeus
-inputSpec: modules/openapi-generator/src/test/resources/3_0/java/petstore-with-fake-endpoints-models-for-testing-with-http-signature.yaml
+inputSpec: modules/openapi-generator/src/test/resources/3_0/petstore-with-fake-endpoints-models-for-testing.yaml
 templateDir: modules/openapi-generator/src/main/resources/ruby-client
 additionalProperties:
   gemVersion: 1.0.0

--- a/bin/configs/ruby.yaml
+++ b/bin/configs/ruby.yaml
@@ -1,7 +1,7 @@
 generatorName: ruby
 outputDir: samples/client/petstore/ruby
 library: typhoeus
-inputSpec: modules/openapi-generator/src/test/resources/3_0/petstore-with-fake-endpoints-models-for-testing.yaml
+inputSpec: modules/openapi-generator/src/test/resources/3_0/java/petstore-with-fake-endpoints-models-for-testing-with-http-signature.yaml
 templateDir: modules/openapi-generator/src/main/resources/ruby-client
 additionalProperties:
   gemVersion: 1.0.0

--- a/modules/openapi-generator/src/main/resources/ruby-client/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/api_client.mustache
@@ -149,8 +149,9 @@ module {{moduleName}}
           data.each { |k, v| hash[k] = convert_to_type(v, sub_type) }
         end
       else
-        # models, e.g. Pet
-        {{moduleName}}.const_get(return_type).build_from_hash(data)
+        # models (e.g. Pet) or oneOf
+        klass = {{moduleName}}.const_get(return_type)
+        klass.respond_to?(:openapi_one_of) ? klass.build(data) : klass.build_from_hash(data)
       end
     end
 

--- a/modules/openapi-generator/src/main/resources/ruby-client/api_doc.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/api_doc.mustache
@@ -4,10 +4,13 @@
 
 All URIs are relative to *{{basePath}}*
 
-Method | HTTP request | Description
-------------- | ------------- | -------------
-{{#operations}}{{#operation}}[**{{operationId}}**]({{classname}}.md#{{operationId}}) | **{{httpMethod}}** {{path}} | {{#summary}}{{summary}}{{/summary}}
-{{/operation}}{{/operations}}
+| Method | HTTP request | Description |
+| ------ | ------------ | ----------- |
+{{#operations}}
+{{#operation}}
+| [**{{operationId}}**]({{classname}}.md#{{operationId}}) | **{{httpMethod}}** {{path}} | {{#summary}}{{summary}}{{/summary}} |
+{{/operation}}
+{{/operations}}
 
 {{#operations}}
 {{#operation}}
@@ -67,10 +70,15 @@ end
 
 ### Parameters
 
-{{^allParams}}This endpoint does not need any parameter.{{/allParams}}{{#allParams}}{{#-last}}
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------{{/-last}}{{/allParams}}
-{{#allParams}} **{{paramName}}** | {{#isPrimitiveType}}**{{dataType}}**{{/isPrimitiveType}}{{^isPrimitiveType}}{{#isFile}}**{{dataType}}**{{/isFile}}{{^isFile}}[**{{dataType}}**]({{baseType}}.md){{/isFile}}{{/isPrimitiveType}}| {{description}} | {{^required}}[optional] {{/required}}{{#defaultValue}}[default to {{defaultValue}}]{{/defaultValue}}
+{{^allParams}}
+This endpoint does not need any parameter.
+{{/allParams}}
+{{#allParams}}
+{{#-first}}
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+{{/-first}}
+| **{{paramName}}** | {{#isPrimitiveType}}**{{dataType}}**{{/isPrimitiveType}}{{^isPrimitiveType}}{{#isFile}}**{{dataType}}**{{/isFile}}{{^isFile}}[**{{dataType}}**]({{baseType}}.md){{/isFile}}{{/isPrimitiveType}} | {{description}} | {{^required}}[optional]{{/required}}{{#defaultValue}}[default to {{defaultValue}}]{{/defaultValue}} |
 {{/allParams}}
 
 ### Return type

--- a/modules/openapi-generator/src/main/resources/ruby-client/base_object.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/base_object.mustache
@@ -2,9 +2,7 @@
     # @param [Hash] attributes Model attributes in the form of hash
     # @return [Object] Returns the model itself
     def self.build_from_hash(attributes)
-      new(attributes).build_from_hash(attributes)
-    rescue ArgumentError
-      nil
+      new.build_from_hash(attributes)
     end
 
     # Builds the object from hash

--- a/modules/openapi-generator/src/main/resources/ruby-client/base_object.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/base_object.mustache
@@ -2,7 +2,9 @@
     # @param [Hash] attributes Model attributes in the form of hash
     # @return [Object] Returns the model itself
     def self.build_from_hash(attributes)
-      new.build_from_hash(attributes)
+      new(attributes).build_from_hash(attributes)
+    rescue ArgumentError
+      nil
     end
 
     # Builds the object from hash
@@ -93,7 +95,7 @@
           is_nullable = self.class.openapi_nullable.include?(attr)
           next if !is_nullable || (is_nullable && !instance_variable_defined?(:"@#{attr}"))
         end
-        
+
         hash[param] = _to_hash(value)
       end
       hash

--- a/modules/openapi-generator/src/main/resources/ruby-client/base_object.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/base_object.mustache
@@ -69,7 +69,9 @@
           end
         end
       else # model
-        {{moduleName}}.const_get(type).build_from_hash(value)
+        # models (e.g. Pet) or oneOf
+        klass = {{moduleName}}.const_get(type)
+        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/modules/openapi-generator/src/main/resources/ruby-client/model.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/model.mustache
@@ -12,7 +12,14 @@ module {{moduleName}}
 {{>partial_model_enum_class}}
 {{/isEnum}}
 {{^isEnum}}
+{{#oneOf}}
+{{#-first}}
+{{>partial_oneof_module}}
+{{/-first}}
+{{/oneOf}}
+{{^oneOf}}
 {{>partial_model_generic}}
+{{/oneOf}}
 {{/isEnum}}
 {{/model}}
 {{/models}}

--- a/modules/openapi-generator/src/main/resources/ruby-client/model_doc.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/model_doc.mustache
@@ -1,19 +1,12 @@
-{{#models}}{{#model}}# {{moduleName}}::{{classname}}
-
-## Properties
-
-Name | Type | Description | Notes
------------- | ------------- | ------------- | -------------
-{{#vars}}**{{name}}** | {{#isPrimitiveType}}**{{dataType}}**{{/isPrimitiveType}}{{^isPrimitiveType}}[**{{dataType}}**]({{complexType}}.md){{/isPrimitiveType}} | {{description}} | {{^required}}[optional] {{/required}}{{#isReadOnly}}[readonly] {{/isReadOnly}}{{#defaultValue}}[default to {{defaultValue}}]{{/defaultValue}}
-{{/vars}}
-
-## Code Sample
-
-```ruby
-require '{{moduleName}}'
-
-instance = {{moduleName}}::{{classname}}.new({{#vars}}{{name}}: {{example}}{{^-last}},
-                                 {{/-last}}{{/vars}})
-```
-
-{{/model}}{{/models}}
+{{#models}}
+{{#model}}
+{{#oneOf}}
+{{#-first}}
+{{>partial_oneof_module_doc}}
+{{/-first}}
+{{/oneOf}}
+{{^oneOf}}
+{{>partial_model_generic_doc}}
+{{/oneOf}}
+{{/model}}
+{{/models}}

--- a/modules/openapi-generator/src/main/resources/ruby-client/model_test.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/model_test.mustache
@@ -11,19 +11,13 @@ require 'date'
 # Please update as you see appropriate
 {{#models}}
 {{#model}}
-describe '{{classname}}' do
-  before do
-    # run before each test
-    @instance = {{moduleName}}::{{classname}}.new
-  end
-
-  after do
-    # run after each test
-  end
+describe {{moduleName}}::{{classname}} do
+{{^oneOf}}
+  let(:instance) { {{moduleName}}::{{classname}}.new }
 
   describe 'test an instance of {{classname}}' do
     it 'should create an instance of {{classname}}' do
-      expect(@instance).to be_instance_of({{moduleName}}::{{classname}})
+      expect(instance).to be_instance_of({{moduleName}}::{{classname}})
     end
   end
 {{#vars}}
@@ -33,7 +27,7 @@ describe '{{classname}}' do
       # assertion here. ref: https://www.relishapp.com/rspec/rspec-expectations/docs/built-in-matchers
       # validator = Petstore::EnumTest::EnumAttributeValidator.new('{{{dataType}}}', [{{#allowableValues}}{{#enumVars}}{{{value}}}{{^-last}}, {{/-last}}{{/enumVars}}{{/allowableValues}}])
       # validator.allowable_values.each do |value|
-      #   expect { @instance.{{name}} = value }.not_to raise_error
+      #   expect { instance.{{name}} = value }.not_to raise_error
       # end
       {{/isEnum}}
       {{^isEnum}}
@@ -43,6 +37,42 @@ describe '{{classname}}' do
   end
 
 {{/vars}}
+{{/oneOf}}
+{{#oneOf}}
+{{#-first}}
+  describe '.openapi_one_of' do
+    it 'lists the models referenced in the oneOf array' do
+      expect(described_class.openapi_one_of).to_not be_empty
+      described_class.openapi_one_of.each { |klass| expect { {{moduleName}}.const_get(klass) }.to_not raise_error }
+    end
+  end
+
+  {{#discriminator}}
+  {{#propertyName}}
+  describe '.openapi_discriminator_name' do
+    it 'returns the value of the "discriminator" property' do
+      expect(described_class.openapi_discriminator_name).to_not be_empty
+    end
+  end
+
+  {{/propertyName}}
+  {{#mappedModels}}
+  {{#-first}}
+  describe '.openapi_discriminator_mapping' do
+    it 'returns the key/values of the "mapping" property' do
+      expect(described_class.openapi_discriminator_mapping.values.sort).to eq(described_class.openapi_one_of.sort)
+    end
+  end
+
+  {{/-first}}
+  {{/mappedModels}}
+  {{/discriminator}}
+  describe '.build' do
+    it 'returns the correct model' do
+    end
+  end
+{{/-first}}
+{{/oneOf}}
 end
 {{/model}}
 {{/models}}

--- a/modules/openapi-generator/src/main/resources/ruby-client/partial_model_generic.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/partial_model_generic.mustache
@@ -42,6 +42,16 @@
       }
     end
 
+    # Returns all the JSON keys this model knows about{{#parent}}, including the ones defined in its parent(s){{/parent}}
+    def self.acceptable_attributes
+      {{^parent}}
+      attribute_map.values
+      {{/parent}}
+      {{#parent}}
+      attribute_map.values.concat(superclass.acceptable_attributes)
+      {{/parent}}
+    end
+
     # Attribute type mapping.
     def self.openapi_types
       {

--- a/modules/openapi-generator/src/main/resources/ruby-client/partial_model_generic.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/partial_model_generic.mustache
@@ -75,19 +75,6 @@
 
     {{/-last}}
     {{/anyOf}}
-    {{#oneOf}}
-    {{#-first}}
-    # List of class defined in oneOf (OpenAPI v3)
-    def self.openapi_one_of
-      [
-    {{/-first}}
-      :'{{{.}}}'{{^-last}},{{/-last}}
-    {{#-last}}
-      ]
-    end
-
-    {{/-last}}
-    {{/oneOf}}
     {{#allOf}}
     {{#-first}}
     # List of class defined in allOf (OpenAPI v3)
@@ -270,26 +257,6 @@
 
       {{/-first}}
       {{/anyOf}}
-      {{#oneOf}}
-      {{#-first}}
-      _one_of_found = false
-      self.class.openapi_one_of.each do |_class|
-        _one_of = {{moduleName}}.const_get(_class).build_from_hash(self.to_hash)
-        if _one_of.valid?
-          if _one_of_found
-            return false
-          else
-            _one_of_found = true
-          end
-        end
-      end
-
-      if !_one_of_found
-        return false
-      end
-
-      {{/-first}}
-      {{/oneOf}}
       true{{#parent}} && super{{/parent}}
     end
 

--- a/modules/openapi-generator/src/main/resources/ruby-client/partial_model_generic_doc.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/partial_model_generic_doc.mustache
@@ -1,0 +1,28 @@
+# {{moduleName}}::{{classname}}
+
+## Properties
+
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+{{#vars}}
+| **{{name}}** | {{#isPrimitiveType}}**{{dataType}}**{{/isPrimitiveType}}{{^isPrimitiveType}}[**{{dataType}}**]({{complexType}}.md){{/isPrimitiveType}} | {{description}} | {{^required}}[optional]{{/required}}{{#isReadOnly}}[readonly]{{/isReadOnly}}{{#defaultValue}}[default to {{defaultValue}}]{{/defaultValue}} |
+{{/vars}}
+
+## Code Sample
+
+```ruby
+require '{{{gemName}}}'
+
+{{^vars}}
+instance = {{moduleName}}::{{classname}}.new()
+{{/vars}}
+{{#vars}}
+{{#-first}}
+instance = {{moduleName}}::{{classname}}.new(
+{{/-first}}
+  {{name}}: {{example}}{{^-last}},{{/-last}}
+{{#-last}}
+)
+{{/-last}}
+{{/vars}}
+```

--- a/modules/openapi-generator/src/main/resources/ruby-client/partial_oneof_module.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/partial_oneof_module.mustache
@@ -1,0 +1,130 @@
+  {{#description}}
+  # {{{description}}}
+  {{/description}}
+  module {{classname}}
+    class << self
+      {{#oneOf}}
+      {{#-first}}
+      # List of class defined in oneOf (OpenAPI v3)
+      def openapi_one_of
+        [
+      {{/-first}}
+          :'{{{.}}}'{{^-last}},{{/-last}}
+      {{#-last}}
+        ]
+      end
+
+      {{/-last}}
+      {{/oneOf}}
+      {{#discriminator}}
+      {{#propertyName}}
+      # Discriminator's property name (OpenAPI v3)
+      def openapi_discriminator_name
+        :'{{{.}}}'
+      end
+
+      {{/propertyName}}
+      {{#mappedModels}}
+      {{#-first}}
+      # Discriminator's mapping (OpenAPI v3)
+      def openapi_discriminator_mapping
+        {
+      {{/-first}}
+          :'{{{mappingName}}}' => :'{{{modelName}}}'{{^-last}},{{/-last}}
+      {{#-last}}
+        }
+      end
+
+      {{/-last}}
+      {{/mappedModels}}
+      {{/discriminator}}
+      # Builds the object
+      # @param [Mixed] Data to be matched against the list of oneOf items
+      # @return [Object] Returns the model or the data itself
+      def build(data)
+      {{#discriminator}}
+        discriminator_value = data[openapi_discriminator_name]
+        return nil unless discriminator_value
+      {{#mappedModels}}
+      {{#-first}}
+
+        klass = openapi_discriminator_mapping[discriminator_value.to_sym]
+        return nil unless klass
+
+        {{moduleName}}.const_get(klass).build_from_hash(data)
+      {{/-first}}
+      {{/mappedModels}}
+      {{^mappedModels}}
+        {{moduleName}}.const_get(discriminator_value).build_from_hash(data)
+      {{/mappedModels}}
+      {{/discriminator}}
+      {{^discriminator}}
+        # Go through the list of oneOf items and attempt to identify the appropriate one.
+        # Note:
+        # - We do not attempt to check whether exactly one item matches.
+        # - No advanced validation of types in some cases (e.g. "x: { type: string }" will happily match { x: 123 })
+        #   due to the way the deserialization is made in the base_object template (it just casts without verifying).
+        # - TODO: scalar values are defacto behaving as if they were nullable.
+        # - TODO: logging when debugging is set.
+        openapi_one_of.each do |klass|
+          begin
+            next if klass == :AnyType # "nullable: true"
+            typed_data = find_and_cast_into_type(klass, data)
+            return typed_data if typed_data
+          rescue # rescue all errors so we keep iterating even if the current item lookup raises
+          end
+        end
+
+        openapi_one_of.include?(:AnyType) ? data : nil
+      {{/discriminator}}
+      end
+      {{^discriminator}}
+
+      private
+
+      SchemaMismatchError = Class.new(StandardError)
+
+      # Note: 'File' is missing here because in the regular case we get the data _after_ a call to JSON.parse.
+      def find_and_cast_into_type(klass, data)
+        return if data.nil?
+
+        case klass.to_s
+        when 'Boolean'
+          return data if data.instance_of?(TrueClass) || data.instance_of?(FalseClass)
+        when 'Float'
+          return data if data.instance_of?(Float)
+        when 'Integer'
+          return data if data.instance_of?(Integer)
+        when 'Time'
+          return Time.parse(data)
+        when 'Date'
+          return Date.parse(data)
+        when 'String'
+          return data if data.instance_of?(String)
+        when 'Object' # "type: object"
+          return data if data.instance_of?(Hash)
+        when /\AArray<(?<sub_type>.+)>\z/ # "type: array"
+          if data.instance_of?(Array)
+            sub_type = Regexp.last_match[:sub_type]
+            return data.map { |item| find_and_cast_into_type(sub_type, item) }
+          end
+        when /\AHash<String, (?<sub_type>.+)>\z/ # "type: object" with "additionalProperties: { ... }"
+          if data.instance_of?(Hash) && data.keys.all? { |k| k.instance_of?(Symbol) || k.instance_of?(String) }
+            sub_type = Regexp.last_match[:sub_type]
+            return data.each_with_object({}) { |(k, v), hsh| hsh[k] = find_and_cast_into_type(sub_type, v) }
+          end
+        else # model
+          const = {{moduleName}}.const_get(klass)
+          if const
+            model = const.build_from_hash(data)
+            return model if model && model.valid?
+          end
+        end
+
+        raise # if no match by now, raise
+      rescue
+        raise SchemaMismatchError, "#{data} doesn't match the #{klass} type"
+      end
+      {{/discriminator}}
+    end
+  end

--- a/modules/openapi-generator/src/main/resources/ruby-client/partial_oneof_module.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/partial_oneof_module.mustache
@@ -116,8 +116,15 @@
         else # model
           const = {{moduleName}}.const_get(klass)
           if const
-            model = const.build_from_hash(data)
-            return model if model && model.valid?
+            if const.respond_to?(:openapi_one_of) # nested oneOf model
+              model = const.build(data)
+              return model if model
+            else
+              # raise if data contains keys that are not known to the model
+              raise unless (data.keys - const.acceptable_attributes).empty?
+              model = const.build_from_hash(data)
+              return model if model && model.valid?
+            end
           end
         end
 

--- a/modules/openapi-generator/src/main/resources/ruby-client/partial_oneof_module_doc.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/partial_oneof_module_doc.mustache
@@ -1,0 +1,92 @@
+# {{moduleName}}::{{classname}}
+
+## Class instance methods
+
+### `openapi_one_of`
+
+Returns the list of classes defined in oneOf.
+
+#### Example
+
+```ruby
+require '{{{gemName}}}'
+
+{{moduleName}}::{{classname}}.openapi_one_of
+# =>
+{{#oneOf}}
+{{#-first}}
+# [
+{{/-first}}
+#   :'{{{.}}}'{{^-last}},{{/-last}}
+{{#-last}}
+# ]
+{{/-last}}
+{{/oneOf}}
+```
+{{#discriminator}}
+{{#propertyName}}
+
+### `openapi_discriminator_name`
+
+Returns the discriminator's property name.
+
+#### Example
+
+```ruby
+require '{{{gemName}}}'
+
+{{moduleName}}::{{classname}}.openapi_discriminator_name
+# => :'{{{.}}}'
+```
+{{/propertyName}}
+{{#mappedModels}}
+{{#-first}}
+
+### `openapi_discriminator_name`
+
+Returns the discriminator's mapping.
+
+#### Example
+
+```ruby
+require '{{{gemName}}}'
+
+{{moduleName}}::{{classname}}.openapi_discriminator_mapping
+# =>
+# {
+{{/-first}}
+#   :'{{{mappingName}}}' => :'{{{modelName}}}'{{^-last}},{{/-last}}
+{{#-last}}
+# }
+{{/-last}}
+{{/mappedModels}}
+{{/discriminator}}
+
+### build
+
+Find the appropriate object from the `openapi_one_of` list and casts the data into it.
+
+#### Example
+
+```ruby
+require '{{{gemName}}}'
+
+{{moduleName}}::{{classname}}.build(data)
+# => {{#oneOf}}{{#-first}}#<{{{.}}}:0x00007fdd4aab02a0>{{/-first}}{{/oneOf}}
+
+{{moduleName}}::{{classname}}.build(data_that_doesnt_match)
+# => nil
+```
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| **data** | **Mixed** | data to be matched against the list of oneOf items |
+
+#### Return type
+
+{{#oneOf}}
+- `{{{.}}}`
+{{/oneOf}}
+- `nil` (if no type matches)

--- a/modules/openapi-generator/src/test/resources/3_0/petstore-with-fake-endpoints-models-for-testing.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/petstore-with-fake-endpoints-models-for-testing.yaml
@@ -1100,16 +1100,16 @@ paths:
       summary: test http signature authentication
       operationId: fake-http-signature-test
       parameters:
-        - name: query_1 
+        - name: query_1
           in: query
           description: query parameter
-          required: optional 
+          required: optional
           schema:
             type: string
-        - name: header_1 
-          in: header 
+        - name: header_1
+          in: header
           description: header parameter
-          required: optional 
+          required: optional
           schema:
             type: string
       security:
@@ -1198,7 +1198,7 @@ components:
       bearerFormat: JWT
     http_signature_test:
       type: http
-      scheme: signature 
+      scheme: signature
   schemas:
     Foo:
       type: object

--- a/samples/client/petstore/ruby-faraday/docs/AdditionalPropertiesClass.md
+++ b/samples/client/petstore/ruby-faraday/docs/AdditionalPropertiesClass.md
@@ -2,18 +2,19 @@
 
 ## Properties
 
-Name | Type | Description | Notes
------------- | ------------- | ------------- | -------------
-**map_property** | **Hash&lt;String, String&gt;** |  | [optional] 
-**map_of_map_property** | **Hash&lt;String, Hash&lt;String, String&gt;&gt;** |  | [optional] 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **map_property** | **Hash&lt;String, String&gt;** |  | [optional] |
+| **map_of_map_property** | **Hash&lt;String, Hash&lt;String, String&gt;&gt;** |  | [optional] |
 
 ## Code Sample
 
 ```ruby
-require 'Petstore'
+require 'petstore'
 
-instance = Petstore::AdditionalPropertiesClass.new(map_property: null,
-                                 map_of_map_property: null)
+instance = Petstore::AdditionalPropertiesClass.new(
+  map_property: null,
+  map_of_map_property: null
+)
 ```
-
 

--- a/samples/client/petstore/ruby-faraday/docs/Animal.md
+++ b/samples/client/petstore/ruby-faraday/docs/Animal.md
@@ -2,18 +2,19 @@
 
 ## Properties
 
-Name | Type | Description | Notes
------------- | ------------- | ------------- | -------------
-**class_name** | **String** |  | 
-**color** | **String** |  | [optional] [default to &#39;red&#39;]
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **class_name** | **String** |  |  |
+| **color** | **String** |  | [optional][default to &#39;red&#39;] |
 
 ## Code Sample
 
 ```ruby
-require 'Petstore'
+require 'petstore'
 
-instance = Petstore::Animal.new(class_name: null,
-                                 color: null)
+instance = Petstore::Animal.new(
+  class_name: null,
+  color: null
+)
 ```
-
 

--- a/samples/client/petstore/ruby-faraday/docs/AnotherFakeApi.md
+++ b/samples/client/petstore/ruby-faraday/docs/AnotherFakeApi.md
@@ -2,10 +2,9 @@
 
 All URIs are relative to *http://petstore.swagger.io:80/v2*
 
-Method | HTTP request | Description
-------------- | ------------- | -------------
-[**call_123_test_special_tags**](AnotherFakeApi.md#call_123_test_special_tags) | **PATCH** /another-fake/dummy | To test special tags
-
+| Method | HTTP request | Description |
+| ------ | ------------ | ----------- |
+| [**call_123_test_special_tags**](AnotherFakeApi.md#call_123_test_special_tags) | **PATCH** /another-fake/dummy | To test special tags |
 
 
 ## call_123_test_special_tags
@@ -36,10 +35,9 @@ end
 
 ### Parameters
 
-
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **client** | [**Client**](Client.md)| client model | 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **client** | [**Client**](Client.md) | client model |  |
 
 ### Return type
 

--- a/samples/client/petstore/ruby-faraday/docs/ApiResponse.md
+++ b/samples/client/petstore/ruby-faraday/docs/ApiResponse.md
@@ -2,20 +2,21 @@
 
 ## Properties
 
-Name | Type | Description | Notes
------------- | ------------- | ------------- | -------------
-**code** | **Integer** |  | [optional] 
-**type** | **String** |  | [optional] 
-**message** | **String** |  | [optional] 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **code** | **Integer** |  | [optional] |
+| **type** | **String** |  | [optional] |
+| **message** | **String** |  | [optional] |
 
 ## Code Sample
 
 ```ruby
-require 'Petstore'
+require 'petstore'
 
-instance = Petstore::ApiResponse.new(code: null,
-                                 type: null,
-                                 message: null)
+instance = Petstore::ApiResponse.new(
+  code: null,
+  type: null,
+  message: null
+)
 ```
-
 

--- a/samples/client/petstore/ruby-faraday/docs/ArrayOfArrayOfNumberOnly.md
+++ b/samples/client/petstore/ruby-faraday/docs/ArrayOfArrayOfNumberOnly.md
@@ -2,16 +2,17 @@
 
 ## Properties
 
-Name | Type | Description | Notes
------------- | ------------- | ------------- | -------------
-**array_array_number** | **Array&lt;Array&lt;Float&gt;&gt;** |  | [optional] 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **array_array_number** | **Array&lt;Array&lt;Float&gt;&gt;** |  | [optional] |
 
 ## Code Sample
 
 ```ruby
-require 'Petstore'
+require 'petstore'
 
-instance = Petstore::ArrayOfArrayOfNumberOnly.new(array_array_number: null)
+instance = Petstore::ArrayOfArrayOfNumberOnly.new(
+  array_array_number: null
+)
 ```
-
 

--- a/samples/client/petstore/ruby-faraday/docs/ArrayOfNumberOnly.md
+++ b/samples/client/petstore/ruby-faraday/docs/ArrayOfNumberOnly.md
@@ -2,16 +2,17 @@
 
 ## Properties
 
-Name | Type | Description | Notes
------------- | ------------- | ------------- | -------------
-**array_number** | **Array&lt;Float&gt;** |  | [optional] 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **array_number** | **Array&lt;Float&gt;** |  | [optional] |
 
 ## Code Sample
 
 ```ruby
-require 'Petstore'
+require 'petstore'
 
-instance = Petstore::ArrayOfNumberOnly.new(array_number: null)
+instance = Petstore::ArrayOfNumberOnly.new(
+  array_number: null
+)
 ```
-
 

--- a/samples/client/petstore/ruby-faraday/docs/ArrayTest.md
+++ b/samples/client/petstore/ruby-faraday/docs/ArrayTest.md
@@ -2,20 +2,21 @@
 
 ## Properties
 
-Name | Type | Description | Notes
------------- | ------------- | ------------- | -------------
-**array_of_string** | **Array&lt;String&gt;** |  | [optional] 
-**array_array_of_integer** | **Array&lt;Array&lt;Integer&gt;&gt;** |  | [optional] 
-**array_array_of_model** | **Array&lt;Array&lt;ReadOnlyFirst&gt;&gt;** |  | [optional] 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **array_of_string** | **Array&lt;String&gt;** |  | [optional] |
+| **array_array_of_integer** | **Array&lt;Array&lt;Integer&gt;&gt;** |  | [optional] |
+| **array_array_of_model** | **Array&lt;Array&lt;ReadOnlyFirst&gt;&gt;** |  | [optional] |
 
 ## Code Sample
 
 ```ruby
-require 'Petstore'
+require 'petstore'
 
-instance = Petstore::ArrayTest.new(array_of_string: null,
-                                 array_array_of_integer: null,
-                                 array_array_of_model: null)
+instance = Petstore::ArrayTest.new(
+  array_of_string: null,
+  array_array_of_integer: null,
+  array_array_of_model: null
+)
 ```
-
 

--- a/samples/client/petstore/ruby-faraday/docs/Capitalization.md
+++ b/samples/client/petstore/ruby-faraday/docs/Capitalization.md
@@ -2,26 +2,27 @@
 
 ## Properties
 
-Name | Type | Description | Notes
------------- | ------------- | ------------- | -------------
-**small_camel** | **String** |  | [optional] 
-**capital_camel** | **String** |  | [optional] 
-**small_snake** | **String** |  | [optional] 
-**capital_snake** | **String** |  | [optional] 
-**sca_eth_flow_points** | **String** |  | [optional] 
-**att_name** | **String** | Name of the pet  | [optional] 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **small_camel** | **String** |  | [optional] |
+| **capital_camel** | **String** |  | [optional] |
+| **small_snake** | **String** |  | [optional] |
+| **capital_snake** | **String** |  | [optional] |
+| **sca_eth_flow_points** | **String** |  | [optional] |
+| **att_name** | **String** | Name of the pet  | [optional] |
 
 ## Code Sample
 
 ```ruby
-require 'Petstore'
+require 'petstore'
 
-instance = Petstore::Capitalization.new(small_camel: null,
-                                 capital_camel: null,
-                                 small_snake: null,
-                                 capital_snake: null,
-                                 sca_eth_flow_points: null,
-                                 att_name: null)
+instance = Petstore::Capitalization.new(
+  small_camel: null,
+  capital_camel: null,
+  small_snake: null,
+  capital_snake: null,
+  sca_eth_flow_points: null,
+  att_name: null
+)
 ```
-
 

--- a/samples/client/petstore/ruby-faraday/docs/Cat.md
+++ b/samples/client/petstore/ruby-faraday/docs/Cat.md
@@ -2,16 +2,17 @@
 
 ## Properties
 
-Name | Type | Description | Notes
------------- | ------------- | ------------- | -------------
-**declawed** | **Boolean** |  | [optional] 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **declawed** | **Boolean** |  | [optional] |
 
 ## Code Sample
 
 ```ruby
-require 'Petstore'
+require 'petstore'
 
-instance = Petstore::Cat.new(declawed: null)
+instance = Petstore::Cat.new(
+  declawed: null
+)
 ```
-
 

--- a/samples/client/petstore/ruby-faraday/docs/CatAllOf.md
+++ b/samples/client/petstore/ruby-faraday/docs/CatAllOf.md
@@ -2,16 +2,17 @@
 
 ## Properties
 
-Name | Type | Description | Notes
------------- | ------------- | ------------- | -------------
-**declawed** | **Boolean** |  | [optional] 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **declawed** | **Boolean** |  | [optional] |
 
 ## Code Sample
 
 ```ruby
-require 'Petstore'
+require 'petstore'
 
-instance = Petstore::CatAllOf.new(declawed: null)
+instance = Petstore::CatAllOf.new(
+  declawed: null
+)
 ```
-
 

--- a/samples/client/petstore/ruby-faraday/docs/Category.md
+++ b/samples/client/petstore/ruby-faraday/docs/Category.md
@@ -2,18 +2,19 @@
 
 ## Properties
 
-Name | Type | Description | Notes
------------- | ------------- | ------------- | -------------
-**id** | **Integer** |  | [optional] 
-**name** | **String** |  | [default to &#39;default-name&#39;]
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **id** | **Integer** |  | [optional] |
+| **name** | **String** |  | [default to &#39;default-name&#39;] |
 
 ## Code Sample
 
 ```ruby
-require 'Petstore'
+require 'petstore'
 
-instance = Petstore::Category.new(id: null,
-                                 name: null)
+instance = Petstore::Category.new(
+  id: null,
+  name: null
+)
 ```
-
 

--- a/samples/client/petstore/ruby-faraday/docs/ClassModel.md
+++ b/samples/client/petstore/ruby-faraday/docs/ClassModel.md
@@ -2,16 +2,17 @@
 
 ## Properties
 
-Name | Type | Description | Notes
------------- | ------------- | ------------- | -------------
-**_class** | **String** |  | [optional] 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **_class** | **String** |  | [optional] |
 
 ## Code Sample
 
 ```ruby
-require 'Petstore'
+require 'petstore'
 
-instance = Petstore::ClassModel.new(_class: null)
+instance = Petstore::ClassModel.new(
+  _class: null
+)
 ```
-
 

--- a/samples/client/petstore/ruby-faraday/docs/Client.md
+++ b/samples/client/petstore/ruby-faraday/docs/Client.md
@@ -2,16 +2,17 @@
 
 ## Properties
 
-Name | Type | Description | Notes
------------- | ------------- | ------------- | -------------
-**client** | **String** |  | [optional] 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **client** | **String** |  | [optional] |
 
 ## Code Sample
 
 ```ruby
-require 'Petstore'
+require 'petstore'
 
-instance = Petstore::Client.new(client: null)
+instance = Petstore::Client.new(
+  client: null
+)
 ```
-
 

--- a/samples/client/petstore/ruby-faraday/docs/DefaultApi.md
+++ b/samples/client/petstore/ruby-faraday/docs/DefaultApi.md
@@ -2,10 +2,9 @@
 
 All URIs are relative to *http://petstore.swagger.io:80/v2*
 
-Method | HTTP request | Description
-------------- | ------------- | -------------
-[**foo_get**](DefaultApi.md#foo_get) | **GET** /foo | 
-
+| Method | HTTP request | Description |
+| ------ | ------------ | ----------- |
+| [**foo_get**](DefaultApi.md#foo_get) | **GET** /foo |  |
 
 
 ## foo_get

--- a/samples/client/petstore/ruby-faraday/docs/Dog.md
+++ b/samples/client/petstore/ruby-faraday/docs/Dog.md
@@ -2,16 +2,17 @@
 
 ## Properties
 
-Name | Type | Description | Notes
------------- | ------------- | ------------- | -------------
-**breed** | **String** |  | [optional] 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **breed** | **String** |  | [optional] |
 
 ## Code Sample
 
 ```ruby
-require 'Petstore'
+require 'petstore'
 
-instance = Petstore::Dog.new(breed: null)
+instance = Petstore::Dog.new(
+  breed: null
+)
 ```
-
 

--- a/samples/client/petstore/ruby-faraday/docs/DogAllOf.md
+++ b/samples/client/petstore/ruby-faraday/docs/DogAllOf.md
@@ -2,16 +2,17 @@
 
 ## Properties
 
-Name | Type | Description | Notes
------------- | ------------- | ------------- | -------------
-**breed** | **String** |  | [optional] 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **breed** | **String** |  | [optional] |
 
 ## Code Sample
 
 ```ruby
-require 'Petstore'
+require 'petstore'
 
-instance = Petstore::DogAllOf.new(breed: null)
+instance = Petstore::DogAllOf.new(
+  breed: null
+)
 ```
-
 

--- a/samples/client/petstore/ruby-faraday/docs/EnumArrays.md
+++ b/samples/client/petstore/ruby-faraday/docs/EnumArrays.md
@@ -2,18 +2,19 @@
 
 ## Properties
 
-Name | Type | Description | Notes
------------- | ------------- | ------------- | -------------
-**just_symbol** | **String** |  | [optional] 
-**array_enum** | **Array&lt;String&gt;** |  | [optional] 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **just_symbol** | **String** |  | [optional] |
+| **array_enum** | **Array&lt;String&gt;** |  | [optional] |
 
 ## Code Sample
 
 ```ruby
-require 'Petstore'
+require 'petstore'
 
-instance = Petstore::EnumArrays.new(just_symbol: null,
-                                 array_enum: null)
+instance = Petstore::EnumArrays.new(
+  just_symbol: null,
+  array_enum: null
+)
 ```
-
 

--- a/samples/client/petstore/ruby-faraday/docs/EnumClass.md
+++ b/samples/client/petstore/ruby-faraday/docs/EnumClass.md
@@ -2,15 +2,14 @@
 
 ## Properties
 
-Name | Type | Description | Notes
------------- | ------------- | ------------- | -------------
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
 
 ## Code Sample
 
 ```ruby
-require 'Petstore'
+require 'petstore'
 
 instance = Petstore::EnumClass.new()
 ```
-
 

--- a/samples/client/petstore/ruby-faraday/docs/EnumTest.md
+++ b/samples/client/petstore/ruby-faraday/docs/EnumTest.md
@@ -2,30 +2,31 @@
 
 ## Properties
 
-Name | Type | Description | Notes
------------- | ------------- | ------------- | -------------
-**enum_string** | **String** |  | [optional] 
-**enum_string_required** | **String** |  | 
-**enum_integer** | **Integer** |  | [optional] 
-**enum_number** | **Float** |  | [optional] 
-**outer_enum** | [**OuterEnum**](OuterEnum.md) |  | [optional] 
-**outer_enum_integer** | [**OuterEnumInteger**](OuterEnumInteger.md) |  | [optional] 
-**outer_enum_default_value** | [**OuterEnumDefaultValue**](OuterEnumDefaultValue.md) |  | [optional] [default to &#39;placed&#39;]
-**outer_enum_integer_default_value** | [**OuterEnumIntegerDefaultValue**](OuterEnumIntegerDefaultValue.md) |  | [optional] [default to OuterEnumIntegerDefaultValue::N0]
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **enum_string** | **String** |  | [optional] |
+| **enum_string_required** | **String** |  |  |
+| **enum_integer** | **Integer** |  | [optional] |
+| **enum_number** | **Float** |  | [optional] |
+| **outer_enum** | [**OuterEnum**](OuterEnum.md) |  | [optional] |
+| **outer_enum_integer** | [**OuterEnumInteger**](OuterEnumInteger.md) |  | [optional] |
+| **outer_enum_default_value** | [**OuterEnumDefaultValue**](OuterEnumDefaultValue.md) |  | [optional][default to &#39;placed&#39;] |
+| **outer_enum_integer_default_value** | [**OuterEnumIntegerDefaultValue**](OuterEnumIntegerDefaultValue.md) |  | [optional][default to OuterEnumIntegerDefaultValue::N0] |
 
 ## Code Sample
 
 ```ruby
-require 'Petstore'
+require 'petstore'
 
-instance = Petstore::EnumTest.new(enum_string: null,
-                                 enum_string_required: null,
-                                 enum_integer: null,
-                                 enum_number: null,
-                                 outer_enum: null,
-                                 outer_enum_integer: null,
-                                 outer_enum_default_value: null,
-                                 outer_enum_integer_default_value: null)
+instance = Petstore::EnumTest.new(
+  enum_string: null,
+  enum_string_required: null,
+  enum_integer: null,
+  enum_number: null,
+  outer_enum: null,
+  outer_enum_integer: null,
+  outer_enum_default_value: null,
+  outer_enum_integer_default_value: null
+)
 ```
-
 

--- a/samples/client/petstore/ruby-faraday/docs/FakeApi.md
+++ b/samples/client/petstore/ruby-faraday/docs/FakeApi.md
@@ -2,24 +2,23 @@
 
 All URIs are relative to *http://petstore.swagger.io:80/v2*
 
-Method | HTTP request | Description
-------------- | ------------- | -------------
-[**fake_health_get**](FakeApi.md#fake_health_get) | **GET** /fake/health | Health check endpoint
-[**fake_http_signature_test**](FakeApi.md#fake_http_signature_test) | **GET** /fake/http-signature-test | test http signature authentication
-[**fake_outer_boolean_serialize**](FakeApi.md#fake_outer_boolean_serialize) | **POST** /fake/outer/boolean | 
-[**fake_outer_composite_serialize**](FakeApi.md#fake_outer_composite_serialize) | **POST** /fake/outer/composite | 
-[**fake_outer_number_serialize**](FakeApi.md#fake_outer_number_serialize) | **POST** /fake/outer/number | 
-[**fake_outer_string_serialize**](FakeApi.md#fake_outer_string_serialize) | **POST** /fake/outer/string | 
-[**test_body_with_file_schema**](FakeApi.md#test_body_with_file_schema) | **PUT** /fake/body-with-file-schema | 
-[**test_body_with_query_params**](FakeApi.md#test_body_with_query_params) | **PUT** /fake/body-with-query-params | 
-[**test_client_model**](FakeApi.md#test_client_model) | **PATCH** /fake | To test \&quot;client\&quot; model
-[**test_endpoint_parameters**](FakeApi.md#test_endpoint_parameters) | **POST** /fake | Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
-[**test_enum_parameters**](FakeApi.md#test_enum_parameters) | **GET** /fake | To test enum parameters
-[**test_group_parameters**](FakeApi.md#test_group_parameters) | **DELETE** /fake | Fake endpoint to test group parameters (optional)
-[**test_inline_additional_properties**](FakeApi.md#test_inline_additional_properties) | **POST** /fake/inline-additionalProperties | test inline additionalProperties
-[**test_json_form_data**](FakeApi.md#test_json_form_data) | **GET** /fake/jsonFormData | test json serialization of form data
-[**test_query_parameter_collection_format**](FakeApi.md#test_query_parameter_collection_format) | **PUT** /fake/test-query-paramters | 
-
+| Method | HTTP request | Description |
+| ------ | ------------ | ----------- |
+| [**fake_health_get**](FakeApi.md#fake_health_get) | **GET** /fake/health | Health check endpoint |
+| [**fake_http_signature_test**](FakeApi.md#fake_http_signature_test) | **GET** /fake/http-signature-test | test http signature authentication |
+| [**fake_outer_boolean_serialize**](FakeApi.md#fake_outer_boolean_serialize) | **POST** /fake/outer/boolean |  |
+| [**fake_outer_composite_serialize**](FakeApi.md#fake_outer_composite_serialize) | **POST** /fake/outer/composite |  |
+| [**fake_outer_number_serialize**](FakeApi.md#fake_outer_number_serialize) | **POST** /fake/outer/number |  |
+| [**fake_outer_string_serialize**](FakeApi.md#fake_outer_string_serialize) | **POST** /fake/outer/string |  |
+| [**test_body_with_file_schema**](FakeApi.md#test_body_with_file_schema) | **PUT** /fake/body-with-file-schema |  |
+| [**test_body_with_query_params**](FakeApi.md#test_body_with_query_params) | **PUT** /fake/body-with-query-params |  |
+| [**test_client_model**](FakeApi.md#test_client_model) | **PATCH** /fake | To test \&quot;client\&quot; model |
+| [**test_endpoint_parameters**](FakeApi.md#test_endpoint_parameters) | **POST** /fake | Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트  |
+| [**test_enum_parameters**](FakeApi.md#test_enum_parameters) | **GET** /fake | To test enum parameters |
+| [**test_group_parameters**](FakeApi.md#test_group_parameters) | **DELETE** /fake | Fake endpoint to test group parameters (optional) |
+| [**test_inline_additional_properties**](FakeApi.md#test_inline_additional_properties) | **POST** /fake/inline-additionalProperties | test inline additionalProperties |
+| [**test_json_form_data**](FakeApi.md#test_json_form_data) | **GET** /fake/jsonFormData | test json serialization of form data |
+| [**test_query_parameter_collection_format**](FakeApi.md#test_query_parameter_collection_format) | **PUT** /fake/test-query-paramters |  |
 
 
 ## fake_health_get
@@ -95,12 +94,11 @@ end
 
 ### Parameters
 
-
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **pet** | [**Pet**](Pet.md)| Pet object that needs to be added to the store | 
- **query_1** | **String**| query parameter | [optional] 
- **header_1** | **String**| header parameter | [optional] 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **pet** | [**Pet**](Pet.md) | Pet object that needs to be added to the store |  |
+| **query_1** | **String** | query parameter | [optional] |
+| **header_1** | **String** | header parameter | [optional] |
 
 ### Return type
 
@@ -145,10 +143,9 @@ end
 
 ### Parameters
 
-
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **body** | **Boolean**| Input boolean as post body | [optional] 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **body** | **Boolean** | Input boolean as post body | [optional] |
 
 ### Return type
 
@@ -193,10 +190,9 @@ end
 
 ### Parameters
 
-
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **outer_composite** | [**OuterComposite**](OuterComposite.md)| Input composite as post body | [optional] 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **outer_composite** | [**OuterComposite**](OuterComposite.md) | Input composite as post body | [optional] |
 
 ### Return type
 
@@ -241,10 +237,9 @@ end
 
 ### Parameters
 
-
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **body** | **Float**| Input number as post body | [optional] 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **body** | **Float** | Input number as post body | [optional] |
 
 ### Return type
 
@@ -289,10 +284,9 @@ end
 
 ### Parameters
 
-
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **body** | **String**| Input string as post body | [optional] 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **body** | **String** | Input string as post body | [optional] |
 
 ### Return type
 
@@ -334,10 +328,9 @@ end
 
 ### Parameters
 
-
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **file_schema_test_class** | [**FileSchemaTestClass**](FileSchemaTestClass.md)|  | 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **file_schema_test_class** | [**FileSchemaTestClass**](FileSchemaTestClass.md) |  |  |
 
 ### Return type
 
@@ -378,11 +371,10 @@ end
 
 ### Parameters
 
-
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **query** | **String**|  | 
- **user** | [**User**](User.md)|  | 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **query** | **String** |  |  |
+| **user** | [**User**](User.md) |  |  |
 
 ### Return type
 
@@ -426,10 +418,9 @@ end
 
 ### Parameters
 
-
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **client** | [**Client**](Client.md)| client model | 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **client** | [**Client**](Client.md) | client model |  |
 
 ### Return type
 
@@ -493,23 +484,22 @@ end
 
 ### Parameters
 
-
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **number** | **Float**| None | 
- **double** | **Float**| None | 
- **pattern_without_delimiter** | **String**| None | 
- **byte** | **String**| None | 
- **integer** | **Integer**| None | [optional] 
- **int32** | **Integer**| None | [optional] 
- **int64** | **Integer**| None | [optional] 
- **float** | **Float**| None | [optional] 
- **string** | **String**| None | [optional] 
- **binary** | **File**| None | [optional] 
- **date** | **Date**| None | [optional] 
- **date_time** | **Time**| None | [optional] 
- **password** | **String**| None | [optional] 
- **callback** | **String**| None | [optional] 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **number** | **Float** | None |  |
+| **double** | **Float** | None |  |
+| **pattern_without_delimiter** | **String** | None |  |
+| **byte** | **String** | None |  |
+| **integer** | **Integer** | None | [optional] |
+| **int32** | **Integer** | None | [optional] |
+| **int64** | **Integer** | None | [optional] |
+| **float** | **Float** | None | [optional] |
+| **string** | **String** | None | [optional] |
+| **binary** | **File** | None | [optional] |
+| **date** | **Date** | None | [optional] |
+| **date_time** | **Time** | None | [optional] |
+| **password** | **String** | None | [optional] |
+| **callback** | **String** | None | [optional] |
 
 ### Return type
 
@@ -561,17 +551,16 @@ end
 
 ### Parameters
 
-
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **enum_header_string_array** | [**Array&lt;String&gt;**](String.md)| Header parameter enum test (string array) | [optional] 
- **enum_header_string** | **String**| Header parameter enum test (string) | [optional] [default to &#39;-efg&#39;]
- **enum_query_string_array** | [**Array&lt;String&gt;**](String.md)| Query parameter enum test (string array) | [optional] 
- **enum_query_string** | **String**| Query parameter enum test (string) | [optional] [default to &#39;-efg&#39;]
- **enum_query_integer** | **Integer**| Query parameter enum test (double) | [optional] 
- **enum_query_double** | **Float**| Query parameter enum test (double) | [optional] 
- **enum_form_string_array** | [**Array&lt;String&gt;**](String.md)| Form parameter enum test (string array) | [optional] [default to &#39;$&#39;]
- **enum_form_string** | **String**| Form parameter enum test (string) | [optional] [default to &#39;-efg&#39;]
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **enum_header_string_array** | [**Array&lt;String&gt;**](String.md) | Header parameter enum test (string array) | [optional] |
+| **enum_header_string** | **String** | Header parameter enum test (string) | [optional][default to &#39;-efg&#39;] |
+| **enum_query_string_array** | [**Array&lt;String&gt;**](String.md) | Query parameter enum test (string array) | [optional] |
+| **enum_query_string** | **String** | Query parameter enum test (string) | [optional][default to &#39;-efg&#39;] |
+| **enum_query_integer** | **Integer** | Query parameter enum test (double) | [optional] |
+| **enum_query_double** | **Float** | Query parameter enum test (double) | [optional] |
+| **enum_form_string_array** | [**Array&lt;String&gt;**](String.md) | Form parameter enum test (string array) | [optional][default to &#39;$&#39;] |
+| **enum_form_string** | **String** | Form parameter enum test (string) | [optional][default to &#39;-efg&#39;] |
 
 ### Return type
 
@@ -626,15 +615,14 @@ end
 
 ### Parameters
 
-
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **required_string_group** | **Integer**| Required String in group parameters | 
- **required_boolean_group** | **Boolean**| Required Boolean in group parameters | 
- **required_int64_group** | **Integer**| Required Integer in group parameters | 
- **string_group** | **Integer**| String in group parameters | [optional] 
- **boolean_group** | **Boolean**| Boolean in group parameters | [optional] 
- **int64_group** | **Integer**| Integer in group parameters | [optional] 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **required_string_group** | **Integer** | Required String in group parameters |  |
+| **required_boolean_group** | **Boolean** | Required Boolean in group parameters |  |
+| **required_int64_group** | **Integer** | Required Integer in group parameters |  |
+| **string_group** | **Integer** | String in group parameters | [optional] |
+| **boolean_group** | **Boolean** | Boolean in group parameters | [optional] |
+| **int64_group** | **Integer** | Integer in group parameters | [optional] |
 
 ### Return type
 
@@ -675,10 +663,9 @@ end
 
 ### Parameters
 
-
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **request_body** | [**Hash&lt;String, String&gt;**](String.md)| request body | 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **request_body** | [**Hash&lt;String, String&gt;**](String.md) | request body |  |
 
 ### Return type
 
@@ -720,11 +707,10 @@ end
 
 ### Parameters
 
-
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **param** | **String**| field1 | 
- **param2** | **String**| field2 | 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **param** | **String** | field1 |  |
+| **param2** | **String** | field2 |  |
 
 ### Return type
 
@@ -770,14 +756,13 @@ end
 
 ### Parameters
 
-
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **pipe** | [**Array&lt;String&gt;**](String.md)|  | 
- **ioutil** | [**Array&lt;String&gt;**](String.md)|  | 
- **http** | [**Array&lt;String&gt;**](String.md)|  | 
- **url** | [**Array&lt;String&gt;**](String.md)|  | 
- **context** | [**Array&lt;String&gt;**](String.md)|  | 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **pipe** | [**Array&lt;String&gt;**](String.md) |  |  |
+| **ioutil** | [**Array&lt;String&gt;**](String.md) |  |  |
+| **http** | [**Array&lt;String&gt;**](String.md) |  |  |
+| **url** | [**Array&lt;String&gt;**](String.md) |  |  |
+| **context** | [**Array&lt;String&gt;**](String.md) |  |  |
 
 ### Return type
 

--- a/samples/client/petstore/ruby-faraday/docs/FakeClassnameTags123Api.md
+++ b/samples/client/petstore/ruby-faraday/docs/FakeClassnameTags123Api.md
@@ -2,10 +2,9 @@
 
 All URIs are relative to *http://petstore.swagger.io:80/v2*
 
-Method | HTTP request | Description
-------------- | ------------- | -------------
-[**test_classname**](FakeClassnameTags123Api.md#test_classname) | **PATCH** /fake_classname_test | To test class name in snake case
-
+| Method | HTTP request | Description |
+| ------ | ------------ | ----------- |
+| [**test_classname**](FakeClassnameTags123Api.md#test_classname) | **PATCH** /fake_classname_test | To test class name in snake case |
 
 
 ## test_classname
@@ -43,10 +42,9 @@ end
 
 ### Parameters
 
-
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **client** | [**Client**](Client.md)| client model | 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **client** | [**Client**](Client.md) | client model |  |
 
 ### Return type
 

--- a/samples/client/petstore/ruby-faraday/docs/File.md
+++ b/samples/client/petstore/ruby-faraday/docs/File.md
@@ -2,16 +2,17 @@
 
 ## Properties
 
-Name | Type | Description | Notes
------------- | ------------- | ------------- | -------------
-**source_uri** | **String** | Test capitalization | [optional] 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **source_uri** | **String** | Test capitalization | [optional] |
 
 ## Code Sample
 
 ```ruby
-require 'Petstore'
+require 'petstore'
 
-instance = Petstore::File.new(source_uri: null)
+instance = Petstore::File.new(
+  source_uri: null
+)
 ```
-
 

--- a/samples/client/petstore/ruby-faraday/docs/FileSchemaTestClass.md
+++ b/samples/client/petstore/ruby-faraday/docs/FileSchemaTestClass.md
@@ -2,18 +2,19 @@
 
 ## Properties
 
-Name | Type | Description | Notes
------------- | ------------- | ------------- | -------------
-**file** | **File** |  | [optional] 
-**files** | **Array&lt;File&gt;** |  | [optional] 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **file** | **File** |  | [optional] |
+| **files** | **Array&lt;File&gt;** |  | [optional] |
 
 ## Code Sample
 
 ```ruby
-require 'Petstore'
+require 'petstore'
 
-instance = Petstore::FileSchemaTestClass.new(file: null,
-                                 files: null)
+instance = Petstore::FileSchemaTestClass.new(
+  file: null,
+  files: null
+)
 ```
-
 

--- a/samples/client/petstore/ruby-faraday/docs/Foo.md
+++ b/samples/client/petstore/ruby-faraday/docs/Foo.md
@@ -2,16 +2,17 @@
 
 ## Properties
 
-Name | Type | Description | Notes
------------- | ------------- | ------------- | -------------
-**bar** | **String** |  | [optional] [default to &#39;bar&#39;]
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **bar** | **String** |  | [optional][default to &#39;bar&#39;] |
 
 ## Code Sample
 
 ```ruby
-require 'Petstore'
+require 'petstore'
 
-instance = Petstore::Foo.new(bar: null)
+instance = Petstore::Foo.new(
+  bar: null
+)
 ```
-
 

--- a/samples/client/petstore/ruby-faraday/docs/FormatTest.md
+++ b/samples/client/petstore/ruby-faraday/docs/FormatTest.md
@@ -2,46 +2,47 @@
 
 ## Properties
 
-Name | Type | Description | Notes
------------- | ------------- | ------------- | -------------
-**integer** | **Integer** |  | [optional] 
-**int32** | **Integer** |  | [optional] 
-**int64** | **Integer** |  | [optional] 
-**number** | **Float** |  | 
-**float** | **Float** |  | [optional] 
-**double** | **Float** |  | [optional] 
-**decimal** | [**Decimal**](Decimal.md) |  | [optional] 
-**string** | **String** |  | [optional] 
-**byte** | **String** |  | 
-**binary** | **File** |  | [optional] 
-**date** | **Date** |  | 
-**date_time** | **Time** |  | [optional] 
-**uuid** | **String** |  | [optional] 
-**password** | **String** |  | 
-**pattern_with_digits** | **String** | A string that is a 10 digit number. Can have leading zeros. | [optional] 
-**pattern_with_digits_and_delimiter** | **String** | A string starting with &#39;image_&#39; (case insensitive) and one to three digits following i.e. Image_01. | [optional] 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **integer** | **Integer** |  | [optional] |
+| **int32** | **Integer** |  | [optional] |
+| **int64** | **Integer** |  | [optional] |
+| **number** | **Float** |  |  |
+| **float** | **Float** |  | [optional] |
+| **double** | **Float** |  | [optional] |
+| **decimal** | [**Decimal**](Decimal.md) |  | [optional] |
+| **string** | **String** |  | [optional] |
+| **byte** | **String** |  |  |
+| **binary** | **File** |  | [optional] |
+| **date** | **Date** |  |  |
+| **date_time** | **Time** |  | [optional] |
+| **uuid** | **String** |  | [optional] |
+| **password** | **String** |  |  |
+| **pattern_with_digits** | **String** | A string that is a 10 digit number. Can have leading zeros. | [optional] |
+| **pattern_with_digits_and_delimiter** | **String** | A string starting with &#39;image_&#39; (case insensitive) and one to three digits following i.e. Image_01. | [optional] |
 
 ## Code Sample
 
 ```ruby
-require 'Petstore'
+require 'petstore'
 
-instance = Petstore::FormatTest.new(integer: null,
-                                 int32: null,
-                                 int64: null,
-                                 number: null,
-                                 float: null,
-                                 double: null,
-                                 decimal: null,
-                                 string: null,
-                                 byte: null,
-                                 binary: null,
-                                 date: null,
-                                 date_time: null,
-                                 uuid: 72f98069-206d-4f12-9f12-3d1e525a8e84,
-                                 password: null,
-                                 pattern_with_digits: null,
-                                 pattern_with_digits_and_delimiter: null)
+instance = Petstore::FormatTest.new(
+  integer: null,
+  int32: null,
+  int64: null,
+  number: null,
+  float: null,
+  double: null,
+  decimal: null,
+  string: null,
+  byte: null,
+  binary: null,
+  date: null,
+  date_time: null,
+  uuid: 72f98069-206d-4f12-9f12-3d1e525a8e84,
+  password: null,
+  pattern_with_digits: null,
+  pattern_with_digits_and_delimiter: null
+)
 ```
-
 

--- a/samples/client/petstore/ruby-faraday/docs/HasOnlyReadOnly.md
+++ b/samples/client/petstore/ruby-faraday/docs/HasOnlyReadOnly.md
@@ -2,18 +2,19 @@
 
 ## Properties
 
-Name | Type | Description | Notes
------------- | ------------- | ------------- | -------------
-**bar** | **String** |  | [optional] [readonly] 
-**foo** | **String** |  | [optional] [readonly] 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **bar** | **String** |  | [optional][readonly] |
+| **foo** | **String** |  | [optional][readonly] |
 
 ## Code Sample
 
 ```ruby
-require 'Petstore'
+require 'petstore'
 
-instance = Petstore::HasOnlyReadOnly.new(bar: null,
-                                 foo: null)
+instance = Petstore::HasOnlyReadOnly.new(
+  bar: null,
+  foo: null
+)
 ```
-
 

--- a/samples/client/petstore/ruby-faraday/docs/HealthCheckResult.md
+++ b/samples/client/petstore/ruby-faraday/docs/HealthCheckResult.md
@@ -2,16 +2,17 @@
 
 ## Properties
 
-Name | Type | Description | Notes
------------- | ------------- | ------------- | -------------
-**nullable_message** | **String** |  | [optional] 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **nullable_message** | **String** |  | [optional] |
 
 ## Code Sample
 
 ```ruby
-require 'Petstore'
+require 'petstore'
 
-instance = Petstore::HealthCheckResult.new(nullable_message: null)
+instance = Petstore::HealthCheckResult.new(
+  nullable_message: null
+)
 ```
-
 

--- a/samples/client/petstore/ruby-faraday/docs/InlineObject.md
+++ b/samples/client/petstore/ruby-faraday/docs/InlineObject.md
@@ -2,18 +2,19 @@
 
 ## Properties
 
-Name | Type | Description | Notes
------------- | ------------- | ------------- | -------------
-**name** | **String** | Updated name of the pet | [optional] 
-**status** | **String** | Updated status of the pet | [optional] 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **name** | **String** | Updated name of the pet | [optional] |
+| **status** | **String** | Updated status of the pet | [optional] |
 
 ## Code Sample
 
 ```ruby
-require 'Petstore'
+require 'petstore'
 
-instance = Petstore::InlineObject.new(name: null,
-                                 status: null)
+instance = Petstore::InlineObject.new(
+  name: null,
+  status: null
+)
 ```
-
 

--- a/samples/client/petstore/ruby-faraday/docs/InlineObject1.md
+++ b/samples/client/petstore/ruby-faraday/docs/InlineObject1.md
@@ -2,18 +2,19 @@
 
 ## Properties
 
-Name | Type | Description | Notes
------------- | ------------- | ------------- | -------------
-**additional_metadata** | **String** | Additional data to pass to server | [optional] 
-**file** | **File** | file to upload | [optional] 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **additional_metadata** | **String** | Additional data to pass to server | [optional] |
+| **file** | **File** | file to upload | [optional] |
 
 ## Code Sample
 
 ```ruby
-require 'Petstore'
+require 'petstore'
 
-instance = Petstore::InlineObject1.new(additional_metadata: null,
-                                 file: null)
+instance = Petstore::InlineObject1.new(
+  additional_metadata: null,
+  file: null
+)
 ```
-
 

--- a/samples/client/petstore/ruby-faraday/docs/InlineObject2.md
+++ b/samples/client/petstore/ruby-faraday/docs/InlineObject2.md
@@ -2,18 +2,19 @@
 
 ## Properties
 
-Name | Type | Description | Notes
------------- | ------------- | ------------- | -------------
-**enum_form_string_array** | **Array&lt;String&gt;** | Form parameter enum test (string array) | [optional] 
-**enum_form_string** | **String** | Form parameter enum test (string) | [optional] [default to &#39;-efg&#39;]
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **enum_form_string_array** | **Array&lt;String&gt;** | Form parameter enum test (string array) | [optional] |
+| **enum_form_string** | **String** | Form parameter enum test (string) | [optional][default to &#39;-efg&#39;] |
 
 ## Code Sample
 
 ```ruby
-require 'Petstore'
+require 'petstore'
 
-instance = Petstore::InlineObject2.new(enum_form_string_array: null,
-                                 enum_form_string: null)
+instance = Petstore::InlineObject2.new(
+  enum_form_string_array: null,
+  enum_form_string: null
+)
 ```
-
 

--- a/samples/client/petstore/ruby-faraday/docs/InlineObject3.md
+++ b/samples/client/petstore/ruby-faraday/docs/InlineObject3.md
@@ -2,42 +2,43 @@
 
 ## Properties
 
-Name | Type | Description | Notes
------------- | ------------- | ------------- | -------------
-**integer** | **Integer** | None | [optional] 
-**int32** | **Integer** | None | [optional] 
-**int64** | **Integer** | None | [optional] 
-**number** | **Float** | None | 
-**float** | **Float** | None | [optional] 
-**double** | **Float** | None | 
-**string** | **String** | None | [optional] 
-**pattern_without_delimiter** | **String** | None | 
-**byte** | **String** | None | 
-**binary** | **File** | None | [optional] 
-**date** | **Date** | None | [optional] 
-**date_time** | **Time** | None | [optional] 
-**password** | **String** | None | [optional] 
-**callback** | **String** | None | [optional] 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **integer** | **Integer** | None | [optional] |
+| **int32** | **Integer** | None | [optional] |
+| **int64** | **Integer** | None | [optional] |
+| **number** | **Float** | None |  |
+| **float** | **Float** | None | [optional] |
+| **double** | **Float** | None |  |
+| **string** | **String** | None | [optional] |
+| **pattern_without_delimiter** | **String** | None |  |
+| **byte** | **String** | None |  |
+| **binary** | **File** | None | [optional] |
+| **date** | **Date** | None | [optional] |
+| **date_time** | **Time** | None | [optional] |
+| **password** | **String** | None | [optional] |
+| **callback** | **String** | None | [optional] |
 
 ## Code Sample
 
 ```ruby
-require 'Petstore'
+require 'petstore'
 
-instance = Petstore::InlineObject3.new(integer: null,
-                                 int32: null,
-                                 int64: null,
-                                 number: null,
-                                 float: null,
-                                 double: null,
-                                 string: null,
-                                 pattern_without_delimiter: null,
-                                 byte: null,
-                                 binary: null,
-                                 date: null,
-                                 date_time: null,
-                                 password: null,
-                                 callback: null)
+instance = Petstore::InlineObject3.new(
+  integer: null,
+  int32: null,
+  int64: null,
+  number: null,
+  float: null,
+  double: null,
+  string: null,
+  pattern_without_delimiter: null,
+  byte: null,
+  binary: null,
+  date: null,
+  date_time: null,
+  password: null,
+  callback: null
+)
 ```
-
 

--- a/samples/client/petstore/ruby-faraday/docs/InlineObject4.md
+++ b/samples/client/petstore/ruby-faraday/docs/InlineObject4.md
@@ -2,18 +2,19 @@
 
 ## Properties
 
-Name | Type | Description | Notes
------------- | ------------- | ------------- | -------------
-**param** | **String** | field1 | 
-**param2** | **String** | field2 | 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **param** | **String** | field1 |  |
+| **param2** | **String** | field2 |  |
 
 ## Code Sample
 
 ```ruby
-require 'Petstore'
+require 'petstore'
 
-instance = Petstore::InlineObject4.new(param: null,
-                                 param2: null)
+instance = Petstore::InlineObject4.new(
+  param: null,
+  param2: null
+)
 ```
-
 

--- a/samples/client/petstore/ruby-faraday/docs/InlineObject5.md
+++ b/samples/client/petstore/ruby-faraday/docs/InlineObject5.md
@@ -2,18 +2,19 @@
 
 ## Properties
 
-Name | Type | Description | Notes
------------- | ------------- | ------------- | -------------
-**additional_metadata** | **String** | Additional data to pass to server | [optional] 
-**required_file** | **File** | file to upload | 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **additional_metadata** | **String** | Additional data to pass to server | [optional] |
+| **required_file** | **File** | file to upload |  |
 
 ## Code Sample
 
 ```ruby
-require 'Petstore'
+require 'petstore'
 
-instance = Petstore::InlineObject5.new(additional_metadata: null,
-                                 required_file: null)
+instance = Petstore::InlineObject5.new(
+  additional_metadata: null,
+  required_file: null
+)
 ```
-
 

--- a/samples/client/petstore/ruby-faraday/docs/InlineResponseDefault.md
+++ b/samples/client/petstore/ruby-faraday/docs/InlineResponseDefault.md
@@ -2,16 +2,17 @@
 
 ## Properties
 
-Name | Type | Description | Notes
------------- | ------------- | ------------- | -------------
-**string** | [**Foo**](Foo.md) |  | [optional] 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **string** | [**Foo**](Foo.md) |  | [optional] |
 
 ## Code Sample
 
 ```ruby
-require 'Petstore'
+require 'petstore'
 
-instance = Petstore::InlineResponseDefault.new(string: null)
+instance = Petstore::InlineResponseDefault.new(
+  string: null
+)
 ```
-
 

--- a/samples/client/petstore/ruby-faraday/docs/List.md
+++ b/samples/client/petstore/ruby-faraday/docs/List.md
@@ -2,16 +2,17 @@
 
 ## Properties
 
-Name | Type | Description | Notes
------------- | ------------- | ------------- | -------------
-**_123_list** | **String** |  | [optional] 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **_123_list** | **String** |  | [optional] |
 
 ## Code Sample
 
 ```ruby
-require 'Petstore'
+require 'petstore'
 
-instance = Petstore::List.new(_123_list: null)
+instance = Petstore::List.new(
+  _123_list: null
+)
 ```
-
 

--- a/samples/client/petstore/ruby-faraday/docs/MapTest.md
+++ b/samples/client/petstore/ruby-faraday/docs/MapTest.md
@@ -2,22 +2,23 @@
 
 ## Properties
 
-Name | Type | Description | Notes
------------- | ------------- | ------------- | -------------
-**map_map_of_string** | **Hash&lt;String, Hash&lt;String, String&gt;&gt;** |  | [optional] 
-**map_of_enum_string** | **Hash&lt;String, String&gt;** |  | [optional] 
-**direct_map** | **Hash&lt;String, Boolean&gt;** |  | [optional] 
-**indirect_map** | **Hash&lt;String, Boolean&gt;** |  | [optional] 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **map_map_of_string** | **Hash&lt;String, Hash&lt;String, String&gt;&gt;** |  | [optional] |
+| **map_of_enum_string** | **Hash&lt;String, String&gt;** |  | [optional] |
+| **direct_map** | **Hash&lt;String, Boolean&gt;** |  | [optional] |
+| **indirect_map** | **Hash&lt;String, Boolean&gt;** |  | [optional] |
 
 ## Code Sample
 
 ```ruby
-require 'Petstore'
+require 'petstore'
 
-instance = Petstore::MapTest.new(map_map_of_string: null,
-                                 map_of_enum_string: null,
-                                 direct_map: null,
-                                 indirect_map: null)
+instance = Petstore::MapTest.new(
+  map_map_of_string: null,
+  map_of_enum_string: null,
+  direct_map: null,
+  indirect_map: null
+)
 ```
-
 

--- a/samples/client/petstore/ruby-faraday/docs/MixedPropertiesAndAdditionalPropertiesClass.md
+++ b/samples/client/petstore/ruby-faraday/docs/MixedPropertiesAndAdditionalPropertiesClass.md
@@ -2,20 +2,21 @@
 
 ## Properties
 
-Name | Type | Description | Notes
------------- | ------------- | ------------- | -------------
-**uuid** | **String** |  | [optional] 
-**date_time** | **Time** |  | [optional] 
-**map** | [**Hash&lt;String, Animal&gt;**](Animal.md) |  | [optional] 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **uuid** | **String** |  | [optional] |
+| **date_time** | **Time** |  | [optional] |
+| **map** | [**Hash&lt;String, Animal&gt;**](Animal.md) |  | [optional] |
 
 ## Code Sample
 
 ```ruby
-require 'Petstore'
+require 'petstore'
 
-instance = Petstore::MixedPropertiesAndAdditionalPropertiesClass.new(uuid: null,
-                                 date_time: null,
-                                 map: null)
+instance = Petstore::MixedPropertiesAndAdditionalPropertiesClass.new(
+  uuid: null,
+  date_time: null,
+  map: null
+)
 ```
-
 

--- a/samples/client/petstore/ruby-faraday/docs/Model200Response.md
+++ b/samples/client/petstore/ruby-faraday/docs/Model200Response.md
@@ -2,18 +2,19 @@
 
 ## Properties
 
-Name | Type | Description | Notes
------------- | ------------- | ------------- | -------------
-**name** | **Integer** |  | [optional] 
-**_class** | **String** |  | [optional] 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **name** | **Integer** |  | [optional] |
+| **_class** | **String** |  | [optional] |
 
 ## Code Sample
 
 ```ruby
-require 'Petstore'
+require 'petstore'
 
-instance = Petstore::Model200Response.new(name: null,
-                                 _class: null)
+instance = Petstore::Model200Response.new(
+  name: null,
+  _class: null
+)
 ```
-
 

--- a/samples/client/petstore/ruby-faraday/docs/ModelReturn.md
+++ b/samples/client/petstore/ruby-faraday/docs/ModelReturn.md
@@ -2,16 +2,17 @@
 
 ## Properties
 
-Name | Type | Description | Notes
------------- | ------------- | ------------- | -------------
-**_return** | **Integer** |  | [optional] 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **_return** | **Integer** |  | [optional] |
 
 ## Code Sample
 
 ```ruby
-require 'Petstore'
+require 'petstore'
 
-instance = Petstore::ModelReturn.new(_return: null)
+instance = Petstore::ModelReturn.new(
+  _return: null
+)
 ```
-
 

--- a/samples/client/petstore/ruby-faraday/docs/Name.md
+++ b/samples/client/petstore/ruby-faraday/docs/Name.md
@@ -2,22 +2,23 @@
 
 ## Properties
 
-Name | Type | Description | Notes
------------- | ------------- | ------------- | -------------
-**name** | **Integer** |  | 
-**snake_case** | **Integer** |  | [optional] [readonly] 
-**property** | **String** |  | [optional] 
-**_123_number** | **Integer** |  | [optional] [readonly] 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **name** | **Integer** |  |  |
+| **snake_case** | **Integer** |  | [optional][readonly] |
+| **property** | **String** |  | [optional] |
+| **_123_number** | **Integer** |  | [optional][readonly] |
 
 ## Code Sample
 
 ```ruby
-require 'Petstore'
+require 'petstore'
 
-instance = Petstore::Name.new(name: null,
-                                 snake_case: null,
-                                 property: null,
-                                 _123_number: null)
+instance = Petstore::Name.new(
+  name: null,
+  snake_case: null,
+  property: null,
+  _123_number: null
+)
 ```
-
 

--- a/samples/client/petstore/ruby-faraday/docs/NullableClass.md
+++ b/samples/client/petstore/ruby-faraday/docs/NullableClass.md
@@ -2,38 +2,39 @@
 
 ## Properties
 
-Name | Type | Description | Notes
------------- | ------------- | ------------- | -------------
-**integer_prop** | **Integer** |  | [optional] 
-**number_prop** | **Float** |  | [optional] 
-**boolean_prop** | **Boolean** |  | [optional] 
-**string_prop** | **String** |  | [optional] 
-**date_prop** | **Date** |  | [optional] 
-**datetime_prop** | **Time** |  | [optional] 
-**array_nullable_prop** | **Array&lt;Object&gt;** |  | [optional] 
-**array_and_items_nullable_prop** | **Array&lt;Object&gt;** |  | [optional] 
-**array_items_nullable** | **Array&lt;Object&gt;** |  | [optional] 
-**object_nullable_prop** | **Hash&lt;String, Object&gt;** |  | [optional] 
-**object_and_items_nullable_prop** | **Hash&lt;String, Object&gt;** |  | [optional] 
-**object_items_nullable** | **Hash&lt;String, Object&gt;** |  | [optional] 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **integer_prop** | **Integer** |  | [optional] |
+| **number_prop** | **Float** |  | [optional] |
+| **boolean_prop** | **Boolean** |  | [optional] |
+| **string_prop** | **String** |  | [optional] |
+| **date_prop** | **Date** |  | [optional] |
+| **datetime_prop** | **Time** |  | [optional] |
+| **array_nullable_prop** | **Array&lt;Object&gt;** |  | [optional] |
+| **array_and_items_nullable_prop** | **Array&lt;Object&gt;** |  | [optional] |
+| **array_items_nullable** | **Array&lt;Object&gt;** |  | [optional] |
+| **object_nullable_prop** | **Hash&lt;String, Object&gt;** |  | [optional] |
+| **object_and_items_nullable_prop** | **Hash&lt;String, Object&gt;** |  | [optional] |
+| **object_items_nullable** | **Hash&lt;String, Object&gt;** |  | [optional] |
 
 ## Code Sample
 
 ```ruby
-require 'Petstore'
+require 'petstore'
 
-instance = Petstore::NullableClass.new(integer_prop: null,
-                                 number_prop: null,
-                                 boolean_prop: null,
-                                 string_prop: null,
-                                 date_prop: null,
-                                 datetime_prop: null,
-                                 array_nullable_prop: null,
-                                 array_and_items_nullable_prop: null,
-                                 array_items_nullable: null,
-                                 object_nullable_prop: null,
-                                 object_and_items_nullable_prop: null,
-                                 object_items_nullable: null)
+instance = Petstore::NullableClass.new(
+  integer_prop: null,
+  number_prop: null,
+  boolean_prop: null,
+  string_prop: null,
+  date_prop: null,
+  datetime_prop: null,
+  array_nullable_prop: null,
+  array_and_items_nullable_prop: null,
+  array_items_nullable: null,
+  object_nullable_prop: null,
+  object_and_items_nullable_prop: null,
+  object_items_nullable: null
+)
 ```
-
 

--- a/samples/client/petstore/ruby-faraday/docs/NumberOnly.md
+++ b/samples/client/petstore/ruby-faraday/docs/NumberOnly.md
@@ -2,16 +2,17 @@
 
 ## Properties
 
-Name | Type | Description | Notes
------------- | ------------- | ------------- | -------------
-**just_number** | **Float** |  | [optional] 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **just_number** | **Float** |  | [optional] |
 
 ## Code Sample
 
 ```ruby
-require 'Petstore'
+require 'petstore'
 
-instance = Petstore::NumberOnly.new(just_number: null)
+instance = Petstore::NumberOnly.new(
+  just_number: null
+)
 ```
-
 

--- a/samples/client/petstore/ruby-faraday/docs/Order.md
+++ b/samples/client/petstore/ruby-faraday/docs/Order.md
@@ -2,26 +2,27 @@
 
 ## Properties
 
-Name | Type | Description | Notes
------------- | ------------- | ------------- | -------------
-**id** | **Integer** |  | [optional] 
-**pet_id** | **Integer** |  | [optional] 
-**quantity** | **Integer** |  | [optional] 
-**ship_date** | **Time** |  | [optional] 
-**status** | **String** | Order Status | [optional] 
-**complete** | **Boolean** |  | [optional] [default to false]
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **id** | **Integer** |  | [optional] |
+| **pet_id** | **Integer** |  | [optional] |
+| **quantity** | **Integer** |  | [optional] |
+| **ship_date** | **Time** |  | [optional] |
+| **status** | **String** | Order Status | [optional] |
+| **complete** | **Boolean** |  | [optional][default to false] |
 
 ## Code Sample
 
 ```ruby
-require 'Petstore'
+require 'petstore'
 
-instance = Petstore::Order.new(id: null,
-                                 pet_id: null,
-                                 quantity: null,
-                                 ship_date: null,
-                                 status: null,
-                                 complete: null)
+instance = Petstore::Order.new(
+  id: null,
+  pet_id: null,
+  quantity: null,
+  ship_date: null,
+  status: null,
+  complete: null
+)
 ```
-
 

--- a/samples/client/petstore/ruby-faraday/docs/OuterComposite.md
+++ b/samples/client/petstore/ruby-faraday/docs/OuterComposite.md
@@ -2,20 +2,21 @@
 
 ## Properties
 
-Name | Type | Description | Notes
------------- | ------------- | ------------- | -------------
-**my_number** | **Float** |  | [optional] 
-**my_string** | **String** |  | [optional] 
-**my_boolean** | **Boolean** |  | [optional] 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **my_number** | **Float** |  | [optional] |
+| **my_string** | **String** |  | [optional] |
+| **my_boolean** | **Boolean** |  | [optional] |
 
 ## Code Sample
 
 ```ruby
-require 'Petstore'
+require 'petstore'
 
-instance = Petstore::OuterComposite.new(my_number: null,
-                                 my_string: null,
-                                 my_boolean: null)
+instance = Petstore::OuterComposite.new(
+  my_number: null,
+  my_string: null,
+  my_boolean: null
+)
 ```
-
 

--- a/samples/client/petstore/ruby-faraday/docs/OuterEnum.md
+++ b/samples/client/petstore/ruby-faraday/docs/OuterEnum.md
@@ -2,15 +2,14 @@
 
 ## Properties
 
-Name | Type | Description | Notes
------------- | ------------- | ------------- | -------------
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
 
 ## Code Sample
 
 ```ruby
-require 'Petstore'
+require 'petstore'
 
 instance = Petstore::OuterEnum.new()
 ```
-
 

--- a/samples/client/petstore/ruby-faraday/docs/OuterEnumDefaultValue.md
+++ b/samples/client/petstore/ruby-faraday/docs/OuterEnumDefaultValue.md
@@ -2,15 +2,14 @@
 
 ## Properties
 
-Name | Type | Description | Notes
------------- | ------------- | ------------- | -------------
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
 
 ## Code Sample
 
 ```ruby
-require 'Petstore'
+require 'petstore'
 
 instance = Petstore::OuterEnumDefaultValue.new()
 ```
-
 

--- a/samples/client/petstore/ruby-faraday/docs/OuterEnumInteger.md
+++ b/samples/client/petstore/ruby-faraday/docs/OuterEnumInteger.md
@@ -2,15 +2,14 @@
 
 ## Properties
 
-Name | Type | Description | Notes
------------- | ------------- | ------------- | -------------
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
 
 ## Code Sample
 
 ```ruby
-require 'Petstore'
+require 'petstore'
 
 instance = Petstore::OuterEnumInteger.new()
 ```
-
 

--- a/samples/client/petstore/ruby-faraday/docs/OuterEnumIntegerDefaultValue.md
+++ b/samples/client/petstore/ruby-faraday/docs/OuterEnumIntegerDefaultValue.md
@@ -2,15 +2,14 @@
 
 ## Properties
 
-Name | Type | Description | Notes
------------- | ------------- | ------------- | -------------
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
 
 ## Code Sample
 
 ```ruby
-require 'Petstore'
+require 'petstore'
 
 instance = Petstore::OuterEnumIntegerDefaultValue.new()
 ```
-
 

--- a/samples/client/petstore/ruby-faraday/docs/Pet.md
+++ b/samples/client/petstore/ruby-faraday/docs/Pet.md
@@ -2,26 +2,27 @@
 
 ## Properties
 
-Name | Type | Description | Notes
------------- | ------------- | ------------- | -------------
-**id** | **Integer** |  | [optional] 
-**category** | [**Category**](Category.md) |  | [optional] 
-**name** | **String** |  | 
-**photo_urls** | **Array&lt;String&gt;** |  | 
-**tags** | [**Array&lt;Tag&gt;**](Tag.md) |  | [optional] 
-**status** | **String** | pet status in the store | [optional] 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **id** | **Integer** |  | [optional] |
+| **category** | [**Category**](Category.md) |  | [optional] |
+| **name** | **String** |  |  |
+| **photo_urls** | **Array&lt;String&gt;** |  |  |
+| **tags** | [**Array&lt;Tag&gt;**](Tag.md) |  | [optional] |
+| **status** | **String** | pet status in the store | [optional] |
 
 ## Code Sample
 
 ```ruby
-require 'Petstore'
+require 'petstore'
 
-instance = Petstore::Pet.new(id: null,
-                                 category: null,
-                                 name: doggie,
-                                 photo_urls: null,
-                                 tags: null,
-                                 status: null)
+instance = Petstore::Pet.new(
+  id: null,
+  category: null,
+  name: doggie,
+  photo_urls: null,
+  tags: null,
+  status: null
+)
 ```
-
 

--- a/samples/client/petstore/ruby-faraday/docs/PetApi.md
+++ b/samples/client/petstore/ruby-faraday/docs/PetApi.md
@@ -2,18 +2,17 @@
 
 All URIs are relative to *http://petstore.swagger.io:80/v2*
 
-Method | HTTP request | Description
-------------- | ------------- | -------------
-[**add_pet**](PetApi.md#add_pet) | **POST** /pet | Add a new pet to the store
-[**delete_pet**](PetApi.md#delete_pet) | **DELETE** /pet/{petId} | Deletes a pet
-[**find_pets_by_status**](PetApi.md#find_pets_by_status) | **GET** /pet/findByStatus | Finds Pets by status
-[**find_pets_by_tags**](PetApi.md#find_pets_by_tags) | **GET** /pet/findByTags | Finds Pets by tags
-[**get_pet_by_id**](PetApi.md#get_pet_by_id) | **GET** /pet/{petId} | Find pet by ID
-[**update_pet**](PetApi.md#update_pet) | **PUT** /pet | Update an existing pet
-[**update_pet_with_form**](PetApi.md#update_pet_with_form) | **POST** /pet/{petId} | Updates a pet in the store with form data
-[**upload_file**](PetApi.md#upload_file) | **POST** /pet/{petId}/uploadImage | uploads an image
-[**upload_file_with_required_file**](PetApi.md#upload_file_with_required_file) | **POST** /fake/{petId}/uploadImageWithRequiredFile | uploads an image (required)
-
+| Method | HTTP request | Description |
+| ------ | ------------ | ----------- |
+| [**add_pet**](PetApi.md#add_pet) | **POST** /pet | Add a new pet to the store |
+| [**delete_pet**](PetApi.md#delete_pet) | **DELETE** /pet/{petId} | Deletes a pet |
+| [**find_pets_by_status**](PetApi.md#find_pets_by_status) | **GET** /pet/findByStatus | Finds Pets by status |
+| [**find_pets_by_tags**](PetApi.md#find_pets_by_tags) | **GET** /pet/findByTags | Finds Pets by tags |
+| [**get_pet_by_id**](PetApi.md#get_pet_by_id) | **GET** /pet/{petId} | Find pet by ID |
+| [**update_pet**](PetApi.md#update_pet) | **PUT** /pet | Update an existing pet |
+| [**update_pet_with_form**](PetApi.md#update_pet_with_form) | **POST** /pet/{petId} | Updates a pet in the store with form data |
+| [**upload_file**](PetApi.md#upload_file) | **POST** /pet/{petId}/uploadImage | uploads an image |
+| [**upload_file_with_required_file**](PetApi.md#upload_file_with_required_file) | **POST** /fake/{petId}/uploadImageWithRequiredFile | uploads an image (required) |
 
 
 ## add_pet
@@ -46,10 +45,9 @@ end
 
 ### Parameters
 
-
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **pet** | [**Pet**](Pet.md)| Pet object that needs to be added to the store | 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **pet** | [**Pet**](Pet.md) | Pet object that needs to be added to the store |  |
 
 ### Return type
 
@@ -98,11 +96,10 @@ end
 
 ### Parameters
 
-
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **pet_id** | **Integer**| Pet id to delete | 
- **api_key** | **String**|  | [optional] 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **pet_id** | **Integer** | Pet id to delete |  |
+| **api_key** | **String** |  | [optional] |
 
 ### Return type
 
@@ -151,10 +148,9 @@ end
 
 ### Parameters
 
-
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **status** | [**Array&lt;String&gt;**](String.md)| Status values that need to be considered for filter | 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **status** | [**Array&lt;String&gt;**](String.md) | Status values that need to be considered for filter |  |
 
 ### Return type
 
@@ -203,10 +199,9 @@ end
 
 ### Parameters
 
-
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **tags** | [**Array&lt;String&gt;**](String.md)| Tags to filter by | 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **tags** | [**Array&lt;String&gt;**](String.md) | Tags to filter by |  |
 
 ### Return type
 
@@ -257,10 +252,9 @@ end
 
 ### Parameters
 
-
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **pet_id** | **Integer**| ID of pet to return | 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **pet_id** | **Integer** | ID of pet to return |  |
 
 ### Return type
 
@@ -306,10 +300,9 @@ end
 
 ### Parameters
 
-
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **pet** | [**Pet**](Pet.md)| Pet object that needs to be added to the store | 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **pet** | [**Pet**](Pet.md) | Pet object that needs to be added to the store |  |
 
 ### Return type
 
@@ -359,12 +352,11 @@ end
 
 ### Parameters
 
-
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **pet_id** | **Integer**| ID of pet that needs to be updated | 
- **name** | **String**| Updated name of the pet | [optional] 
- **status** | **String**| Updated status of the pet | [optional] 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **pet_id** | **Integer** | ID of pet that needs to be updated |  |
+| **name** | **String** | Updated name of the pet | [optional] |
+| **status** | **String** | Updated status of the pet | [optional] |
 
 ### Return type
 
@@ -415,12 +407,11 @@ end
 
 ### Parameters
 
-
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **pet_id** | **Integer**| ID of pet to update | 
- **additional_metadata** | **String**| Additional data to pass to server | [optional] 
- **file** | **File**| file to upload | [optional] 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **pet_id** | **Integer** | ID of pet to update |  |
+| **additional_metadata** | **String** | Additional data to pass to server | [optional] |
+| **file** | **File** | file to upload | [optional] |
 
 ### Return type
 
@@ -471,12 +462,11 @@ end
 
 ### Parameters
 
-
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **pet_id** | **Integer**| ID of pet to update | 
- **required_file** | **File**| file to upload | 
- **additional_metadata** | **String**| Additional data to pass to server | [optional] 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **pet_id** | **Integer** | ID of pet to update |  |
+| **required_file** | **File** | file to upload |  |
+| **additional_metadata** | **String** | Additional data to pass to server | [optional] |
 
 ### Return type
 

--- a/samples/client/petstore/ruby-faraday/docs/ReadOnlyFirst.md
+++ b/samples/client/petstore/ruby-faraday/docs/ReadOnlyFirst.md
@@ -2,18 +2,19 @@
 
 ## Properties
 
-Name | Type | Description | Notes
------------- | ------------- | ------------- | -------------
-**bar** | **String** |  | [optional] [readonly] 
-**baz** | **String** |  | [optional] 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **bar** | **String** |  | [optional][readonly] |
+| **baz** | **String** |  | [optional] |
 
 ## Code Sample
 
 ```ruby
-require 'Petstore'
+require 'petstore'
 
-instance = Petstore::ReadOnlyFirst.new(bar: null,
-                                 baz: null)
+instance = Petstore::ReadOnlyFirst.new(
+  bar: null,
+  baz: null
+)
 ```
-
 

--- a/samples/client/petstore/ruby-faraday/docs/SpecialModelName.md
+++ b/samples/client/petstore/ruby-faraday/docs/SpecialModelName.md
@@ -2,16 +2,17 @@
 
 ## Properties
 
-Name | Type | Description | Notes
------------- | ------------- | ------------- | -------------
-**special_property_name** | **Integer** |  | [optional] 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **special_property_name** | **Integer** |  | [optional] |
 
 ## Code Sample
 
 ```ruby
-require 'Petstore'
+require 'petstore'
 
-instance = Petstore::SpecialModelName.new(special_property_name: null)
+instance = Petstore::SpecialModelName.new(
+  special_property_name: null
+)
 ```
-
 

--- a/samples/client/petstore/ruby-faraday/docs/StoreApi.md
+++ b/samples/client/petstore/ruby-faraday/docs/StoreApi.md
@@ -2,13 +2,12 @@
 
 All URIs are relative to *http://petstore.swagger.io:80/v2*
 
-Method | HTTP request | Description
-------------- | ------------- | -------------
-[**delete_order**](StoreApi.md#delete_order) | **DELETE** /store/order/{order_id} | Delete purchase order by ID
-[**get_inventory**](StoreApi.md#get_inventory) | **GET** /store/inventory | Returns pet inventories by status
-[**get_order_by_id**](StoreApi.md#get_order_by_id) | **GET** /store/order/{order_id} | Find purchase order by ID
-[**place_order**](StoreApi.md#place_order) | **POST** /store/order | Place an order for a pet
-
+| Method | HTTP request | Description |
+| ------ | ------------ | ----------- |
+| [**delete_order**](StoreApi.md#delete_order) | **DELETE** /store/order/{order_id} | Delete purchase order by ID |
+| [**get_inventory**](StoreApi.md#get_inventory) | **GET** /store/inventory | Returns pet inventories by status |
+| [**get_order_by_id**](StoreApi.md#get_order_by_id) | **GET** /store/order/{order_id} | Find purchase order by ID |
+| [**place_order**](StoreApi.md#place_order) | **POST** /store/order | Place an order for a pet |
 
 
 ## delete_order
@@ -38,10 +37,9 @@ end
 
 ### Parameters
 
-
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **order_id** | **String**| ID of the order that needs to be deleted | 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **order_id** | **String** | ID of the order that needs to be deleted |  |
 
 ### Return type
 
@@ -135,10 +133,9 @@ end
 
 ### Parameters
 
-
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **order_id** | **Integer**| ID of pet that needs to be fetched | 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **order_id** | **Integer** | ID of pet that needs to be fetched |  |
 
 ### Return type
 
@@ -180,10 +177,9 @@ end
 
 ### Parameters
 
-
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **order** | [**Order**](Order.md)| order placed for purchasing the pet | 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **order** | [**Order**](Order.md) | order placed for purchasing the pet |  |
 
 ### Return type
 

--- a/samples/client/petstore/ruby-faraday/docs/Tag.md
+++ b/samples/client/petstore/ruby-faraday/docs/Tag.md
@@ -2,18 +2,19 @@
 
 ## Properties
 
-Name | Type | Description | Notes
------------- | ------------- | ------------- | -------------
-**id** | **Integer** |  | [optional] 
-**name** | **String** |  | [optional] 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **id** | **Integer** |  | [optional] |
+| **name** | **String** |  | [optional] |
 
 ## Code Sample
 
 ```ruby
-require 'Petstore'
+require 'petstore'
 
-instance = Petstore::Tag.new(id: null,
-                                 name: null)
+instance = Petstore::Tag.new(
+  id: null,
+  name: null
+)
 ```
-
 

--- a/samples/client/petstore/ruby-faraday/docs/User.md
+++ b/samples/client/petstore/ruby-faraday/docs/User.md
@@ -2,30 +2,31 @@
 
 ## Properties
 
-Name | Type | Description | Notes
------------- | ------------- | ------------- | -------------
-**id** | **Integer** |  | [optional] 
-**username** | **String** |  | [optional] 
-**first_name** | **String** |  | [optional] 
-**last_name** | **String** |  | [optional] 
-**email** | **String** |  | [optional] 
-**password** | **String** |  | [optional] 
-**phone** | **String** |  | [optional] 
-**user_status** | **Integer** | User Status | [optional] 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **id** | **Integer** |  | [optional] |
+| **username** | **String** |  | [optional] |
+| **first_name** | **String** |  | [optional] |
+| **last_name** | **String** |  | [optional] |
+| **email** | **String** |  | [optional] |
+| **password** | **String** |  | [optional] |
+| **phone** | **String** |  | [optional] |
+| **user_status** | **Integer** | User Status | [optional] |
 
 ## Code Sample
 
 ```ruby
-require 'Petstore'
+require 'petstore'
 
-instance = Petstore::User.new(id: null,
-                                 username: null,
-                                 first_name: null,
-                                 last_name: null,
-                                 email: null,
-                                 password: null,
-                                 phone: null,
-                                 user_status: null)
+instance = Petstore::User.new(
+  id: null,
+  username: null,
+  first_name: null,
+  last_name: null,
+  email: null,
+  password: null,
+  phone: null,
+  user_status: null
+)
 ```
-
 

--- a/samples/client/petstore/ruby-faraday/docs/UserApi.md
+++ b/samples/client/petstore/ruby-faraday/docs/UserApi.md
@@ -2,17 +2,16 @@
 
 All URIs are relative to *http://petstore.swagger.io:80/v2*
 
-Method | HTTP request | Description
-------------- | ------------- | -------------
-[**create_user**](UserApi.md#create_user) | **POST** /user | Create user
-[**create_users_with_array_input**](UserApi.md#create_users_with_array_input) | **POST** /user/createWithArray | Creates list of users with given input array
-[**create_users_with_list_input**](UserApi.md#create_users_with_list_input) | **POST** /user/createWithList | Creates list of users with given input array
-[**delete_user**](UserApi.md#delete_user) | **DELETE** /user/{username} | Delete user
-[**get_user_by_name**](UserApi.md#get_user_by_name) | **GET** /user/{username} | Get user by user name
-[**login_user**](UserApi.md#login_user) | **GET** /user/login | Logs user into the system
-[**logout_user**](UserApi.md#logout_user) | **GET** /user/logout | Logs out current logged in user session
-[**update_user**](UserApi.md#update_user) | **PUT** /user/{username} | Updated user
-
+| Method | HTTP request | Description |
+| ------ | ------------ | ----------- |
+| [**create_user**](UserApi.md#create_user) | **POST** /user | Create user |
+| [**create_users_with_array_input**](UserApi.md#create_users_with_array_input) | **POST** /user/createWithArray | Creates list of users with given input array |
+| [**create_users_with_list_input**](UserApi.md#create_users_with_list_input) | **POST** /user/createWithList | Creates list of users with given input array |
+| [**delete_user**](UserApi.md#delete_user) | **DELETE** /user/{username} | Delete user |
+| [**get_user_by_name**](UserApi.md#get_user_by_name) | **GET** /user/{username} | Get user by user name |
+| [**login_user**](UserApi.md#login_user) | **GET** /user/login | Logs user into the system |
+| [**logout_user**](UserApi.md#logout_user) | **GET** /user/logout | Logs out current logged in user session |
+| [**update_user**](UserApi.md#update_user) | **PUT** /user/{username} | Updated user |
 
 
 ## create_user
@@ -42,10 +41,9 @@ end
 
 ### Parameters
 
-
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **user** | [**User**](User.md)| Created user object | 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **user** | [**User**](User.md) | Created user object |  |
 
 ### Return type
 
@@ -86,10 +84,9 @@ end
 
 ### Parameters
 
-
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **user** | [**Array&lt;User&gt;**](User.md)| List of user object | 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **user** | [**Array&lt;User&gt;**](User.md) | List of user object |  |
 
 ### Return type
 
@@ -130,10 +127,9 @@ end
 
 ### Parameters
 
-
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **user** | [**Array&lt;User&gt;**](User.md)| List of user object | 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **user** | [**Array&lt;User&gt;**](User.md) | List of user object |  |
 
 ### Return type
 
@@ -176,10 +172,9 @@ end
 
 ### Parameters
 
-
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **username** | **String**| The name that needs to be deleted | 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **username** | **String** | The name that needs to be deleted |  |
 
 ### Return type
 
@@ -221,10 +216,9 @@ end
 
 ### Parameters
 
-
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **username** | **String**| The name that needs to be fetched. Use user1 for testing. | 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **username** | **String** | The name that needs to be fetched. Use user1 for testing. |  |
 
 ### Return type
 
@@ -267,11 +261,10 @@ end
 
 ### Parameters
 
-
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **username** | **String**| The user name for login | 
- **password** | **String**| The password for login in clear text | 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **username** | **String** | The user name for login |  |
+| **password** | **String** | The password for login in clear text |  |
 
 ### Return type
 
@@ -355,11 +348,10 @@ end
 
 ### Parameters
 
-
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **username** | **String**| name that need to be deleted | 
- **user** | [**User**](User.md)| Updated user object | 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **username** | **String** | name that need to be deleted |  |
+| **user** | [**User**](User.md) | Updated user object |  |
 
 ### Return type
 

--- a/samples/client/petstore/ruby-faraday/lib/petstore/api_client.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/api_client.rb
@@ -280,8 +280,9 @@ module Petstore
           data.each { |k, v| hash[k] = convert_to_type(v, sub_type) }
         end
       else
-        # models, e.g. Pet
-        Petstore.const_get(return_type).build_from_hash(data)
+        # models (e.g. Pet) or oneOf
+        klass = Petstore.const_get(return_type)
+        klass.respond_to?(:openapi_one_of) ? klass.build(data) : klass.build_from_hash(data)
       end
     end
 

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/additional_properties_class.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/additional_properties_class.rb
@@ -169,7 +169,9 @@ module Petstore
           end
         end
       else # model
-        Petstore.const_get(type).build_from_hash(value)
+        # models (e.g. Pet) or oneOf
+        klass = Petstore.const_get(type)
+        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/additional_properties_class.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/additional_properties_class.rb
@@ -27,6 +27,11 @@ module Petstore
       }
     end
 
+    # Returns all the JSON keys this model knows about
+    def self.acceptable_attributes
+      attribute_map.values
+    end
+
     # Attribute type mapping.
     def self.openapi_types
       {
@@ -197,7 +202,7 @@ module Petstore
           is_nullable = self.class.openapi_nullable.include?(attr)
           next if !is_nullable || (is_nullable && !instance_variable_defined?(:"@#{attr}"))
         end
-        
+
         hash[param] = _to_hash(value)
       end
       hash
@@ -222,4 +227,5 @@ module Petstore
     end
 
   end
+
 end

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/animal.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/animal.rb
@@ -177,7 +177,9 @@ module Petstore
           end
         end
       else # model
-        Petstore.const_get(type).build_from_hash(value)
+        # models (e.g. Pet) or oneOf
+        klass = Petstore.const_get(type)
+        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/animal.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/animal.rb
@@ -27,6 +27,11 @@ module Petstore
       }
     end
 
+    # Returns all the JSON keys this model knows about
+    def self.acceptable_attributes
+      attribute_map.values
+    end
+
     # Attribute type mapping.
     def self.openapi_types
       {
@@ -205,7 +210,7 @@ module Petstore
           is_nullable = self.class.openapi_nullable.include?(attr)
           next if !is_nullable || (is_nullable && !instance_variable_defined?(:"@#{attr}"))
         end
-        
+
         hash[param] = _to_hash(value)
       end
       hash
@@ -230,4 +235,5 @@ module Petstore
     end
 
   end
+
 end

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/api_response.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/api_response.rb
@@ -174,7 +174,9 @@ module Petstore
           end
         end
       else # model
-        Petstore.const_get(type).build_from_hash(value)
+        # models (e.g. Pet) or oneOf
+        klass = Petstore.const_get(type)
+        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/api_response.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/api_response.rb
@@ -30,6 +30,11 @@ module Petstore
       }
     end
 
+    # Returns all the JSON keys this model knows about
+    def self.acceptable_attributes
+      attribute_map.values
+    end
+
     # Attribute type mapping.
     def self.openapi_types
       {
@@ -202,7 +207,7 @@ module Petstore
           is_nullable = self.class.openapi_nullable.include?(attr)
           next if !is_nullable || (is_nullable && !instance_variable_defined?(:"@#{attr}"))
         end
-        
+
         hash[param] = _to_hash(value)
       end
       hash
@@ -227,4 +232,5 @@ module Petstore
     end
 
   end
+
 end

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/array_of_array_of_number_only.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/array_of_array_of_number_only.rb
@@ -158,7 +158,9 @@ module Petstore
           end
         end
       else # model
-        Petstore.const_get(type).build_from_hash(value)
+        # models (e.g. Pet) or oneOf
+        klass = Petstore.const_get(type)
+        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/array_of_array_of_number_only.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/array_of_array_of_number_only.rb
@@ -24,6 +24,11 @@ module Petstore
       }
     end
 
+    # Returns all the JSON keys this model knows about
+    def self.acceptable_attributes
+      attribute_map.values
+    end
+
     # Attribute type mapping.
     def self.openapi_types
       {
@@ -186,7 +191,7 @@ module Petstore
           is_nullable = self.class.openapi_nullable.include?(attr)
           next if !is_nullable || (is_nullable && !instance_variable_defined?(:"@#{attr}"))
         end
-        
+
         hash[param] = _to_hash(value)
       end
       hash
@@ -211,4 +216,5 @@ module Petstore
     end
 
   end
+
 end

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/array_of_number_only.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/array_of_number_only.rb
@@ -158,7 +158,9 @@ module Petstore
           end
         end
       else # model
-        Petstore.const_get(type).build_from_hash(value)
+        # models (e.g. Pet) or oneOf
+        klass = Petstore.const_get(type)
+        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/array_of_number_only.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/array_of_number_only.rb
@@ -24,6 +24,11 @@ module Petstore
       }
     end
 
+    # Returns all the JSON keys this model knows about
+    def self.acceptable_attributes
+      attribute_map.values
+    end
+
     # Attribute type mapping.
     def self.openapi_types
       {
@@ -186,7 +191,7 @@ module Petstore
           is_nullable = self.class.openapi_nullable.include?(attr)
           next if !is_nullable || (is_nullable && !instance_variable_defined?(:"@#{attr}"))
         end
-        
+
         hash[param] = _to_hash(value)
       end
       hash
@@ -211,4 +216,5 @@ module Petstore
     end
 
   end
+
 end

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/array_test.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/array_test.rb
@@ -30,6 +30,11 @@ module Petstore
       }
     end
 
+    # Returns all the JSON keys this model knows about
+    def self.acceptable_attributes
+      attribute_map.values
+    end
+
     # Attribute type mapping.
     def self.openapi_types
       {
@@ -208,7 +213,7 @@ module Petstore
           is_nullable = self.class.openapi_nullable.include?(attr)
           next if !is_nullable || (is_nullable && !instance_variable_defined?(:"@#{attr}"))
         end
-        
+
         hash[param] = _to_hash(value)
       end
       hash
@@ -233,4 +238,5 @@ module Petstore
     end
 
   end
+
 end

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/array_test.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/array_test.rb
@@ -180,7 +180,9 @@ module Petstore
           end
         end
       else # model
-        Petstore.const_get(type).build_from_hash(value)
+        # models (e.g. Pet) or oneOf
+        klass = Petstore.const_get(type)
+        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/capitalization.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/capitalization.rb
@@ -40,6 +40,11 @@ module Petstore
       }
     end
 
+    # Returns all the JSON keys this model knows about
+    def self.acceptable_attributes
+      attribute_map.values
+    end
+
     # Attribute type mapping.
     def self.openapi_types
       {
@@ -230,7 +235,7 @@ module Petstore
           is_nullable = self.class.openapi_nullable.include?(attr)
           next if !is_nullable || (is_nullable && !instance_variable_defined?(:"@#{attr}"))
         end
-        
+
         hash[param] = _to_hash(value)
       end
       hash
@@ -255,4 +260,5 @@ module Petstore
     end
 
   end
+
 end

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/capitalization.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/capitalization.rb
@@ -202,7 +202,9 @@ module Petstore
           end
         end
       else # model
-        Petstore.const_get(type).build_from_hash(value)
+        # models (e.g. Pet) or oneOf
+        klass = Petstore.const_get(type)
+        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/cat.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/cat.rb
@@ -168,7 +168,9 @@ module Petstore
           end
         end
       else # model
-        Petstore.const_get(type).build_from_hash(value)
+        # models (e.g. Pet) or oneOf
+        klass = Petstore.const_get(type)
+        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/cat.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/cat.rb
@@ -24,6 +24,11 @@ module Petstore
       }
     end
 
+    # Returns all the JSON keys this model knows about, including the ones defined in its parent(s)
+    def self.acceptable_attributes
+      attribute_map.values.concat(superclass.acceptable_attributes)
+    end
+
     # Attribute type mapping.
     def self.openapi_types
       {
@@ -196,7 +201,7 @@ module Petstore
           is_nullable = self.class.openapi_nullable.include?(attr)
           next if !is_nullable || (is_nullable && !instance_variable_defined?(:"@#{attr}"))
         end
-        
+
         hash[param] = _to_hash(value)
       end
       hash
@@ -221,4 +226,5 @@ module Petstore
     end
 
   end
+
 end

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/cat_all_of.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/cat_all_of.rb
@@ -24,6 +24,11 @@ module Petstore
       }
     end
 
+    # Returns all the JSON keys this model knows about
+    def self.acceptable_attributes
+      attribute_map.values
+    end
+
     # Attribute type mapping.
     def self.openapi_types
       {
@@ -184,7 +189,7 @@ module Petstore
           is_nullable = self.class.openapi_nullable.include?(attr)
           next if !is_nullable || (is_nullable && !instance_variable_defined?(:"@#{attr}"))
         end
-        
+
         hash[param] = _to_hash(value)
       end
       hash
@@ -209,4 +214,5 @@ module Petstore
     end
 
   end
+
 end

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/cat_all_of.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/cat_all_of.rb
@@ -156,7 +156,9 @@ module Petstore
           end
         end
       else # model
-        Petstore.const_get(type).build_from_hash(value)
+        # models (e.g. Pet) or oneOf
+        klass = Petstore.const_get(type)
+        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/category.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/category.rb
@@ -27,6 +27,11 @@ module Petstore
       }
     end
 
+    # Returns all the JSON keys this model knows about
+    def self.acceptable_attributes
+      attribute_map.values
+    end
+
     # Attribute type mapping.
     def self.openapi_types
       {
@@ -200,7 +205,7 @@ module Petstore
           is_nullable = self.class.openapi_nullable.include?(attr)
           next if !is_nullable || (is_nullable && !instance_variable_defined?(:"@#{attr}"))
         end
-        
+
         hash[param] = _to_hash(value)
       end
       hash
@@ -225,4 +230,5 @@ module Petstore
     end
 
   end
+
 end

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/category.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/category.rb
@@ -172,7 +172,9 @@ module Petstore
           end
         end
       else # model
-        Petstore.const_get(type).build_from_hash(value)
+        # models (e.g. Pet) or oneOf
+        klass = Petstore.const_get(type)
+        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/class_model.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/class_model.rb
@@ -25,6 +25,11 @@ module Petstore
       }
     end
 
+    # Returns all the JSON keys this model knows about
+    def self.acceptable_attributes
+      attribute_map.values
+    end
+
     # Attribute type mapping.
     def self.openapi_types
       {
@@ -185,7 +190,7 @@ module Petstore
           is_nullable = self.class.openapi_nullable.include?(attr)
           next if !is_nullable || (is_nullable && !instance_variable_defined?(:"@#{attr}"))
         end
-        
+
         hash[param] = _to_hash(value)
       end
       hash
@@ -210,4 +215,5 @@ module Petstore
     end
 
   end
+
 end

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/class_model.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/class_model.rb
@@ -157,7 +157,9 @@ module Petstore
           end
         end
       else # model
-        Petstore.const_get(type).build_from_hash(value)
+        # models (e.g. Pet) or oneOf
+        klass = Petstore.const_get(type)
+        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/client.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/client.rb
@@ -24,6 +24,11 @@ module Petstore
       }
     end
 
+    # Returns all the JSON keys this model knows about
+    def self.acceptable_attributes
+      attribute_map.values
+    end
+
     # Attribute type mapping.
     def self.openapi_types
       {
@@ -184,7 +189,7 @@ module Petstore
           is_nullable = self.class.openapi_nullable.include?(attr)
           next if !is_nullable || (is_nullable && !instance_variable_defined?(:"@#{attr}"))
         end
-        
+
         hash[param] = _to_hash(value)
       end
       hash
@@ -209,4 +214,5 @@ module Petstore
     end
 
   end
+
 end

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/client.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/client.rb
@@ -156,7 +156,9 @@ module Petstore
           end
         end
       else # model
-        Petstore.const_get(type).build_from_hash(value)
+        # models (e.g. Pet) or oneOf
+        klass = Petstore.const_get(type)
+        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/dog.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/dog.rb
@@ -168,7 +168,9 @@ module Petstore
           end
         end
       else # model
-        Petstore.const_get(type).build_from_hash(value)
+        # models (e.g. Pet) or oneOf
+        klass = Petstore.const_get(type)
+        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/dog.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/dog.rb
@@ -24,6 +24,11 @@ module Petstore
       }
     end
 
+    # Returns all the JSON keys this model knows about, including the ones defined in its parent(s)
+    def self.acceptable_attributes
+      attribute_map.values.concat(superclass.acceptable_attributes)
+    end
+
     # Attribute type mapping.
     def self.openapi_types
       {
@@ -196,7 +201,7 @@ module Petstore
           is_nullable = self.class.openapi_nullable.include?(attr)
           next if !is_nullable || (is_nullable && !instance_variable_defined?(:"@#{attr}"))
         end
-        
+
         hash[param] = _to_hash(value)
       end
       hash
@@ -221,4 +226,5 @@ module Petstore
     end
 
   end
+
 end

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/dog_all_of.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/dog_all_of.rb
@@ -24,6 +24,11 @@ module Petstore
       }
     end
 
+    # Returns all the JSON keys this model knows about
+    def self.acceptable_attributes
+      attribute_map.values
+    end
+
     # Attribute type mapping.
     def self.openapi_types
       {
@@ -184,7 +189,7 @@ module Petstore
           is_nullable = self.class.openapi_nullable.include?(attr)
           next if !is_nullable || (is_nullable && !instance_variable_defined?(:"@#{attr}"))
         end
-        
+
         hash[param] = _to_hash(value)
       end
       hash
@@ -209,4 +214,5 @@ module Petstore
     end
 
   end
+
 end

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/dog_all_of.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/dog_all_of.rb
@@ -156,7 +156,9 @@ module Petstore
           end
         end
       else # model
-        Petstore.const_get(type).build_from_hash(value)
+        # models (e.g. Pet) or oneOf
+        klass = Petstore.const_get(type)
+        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/enum_arrays.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/enum_arrays.rb
@@ -201,7 +201,9 @@ module Petstore
           end
         end
       else # model
-        Petstore.const_get(type).build_from_hash(value)
+        # models (e.g. Pet) or oneOf
+        klass = Petstore.const_get(type)
+        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/enum_arrays.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/enum_arrays.rb
@@ -49,6 +49,11 @@ module Petstore
       }
     end
 
+    # Returns all the JSON keys this model knows about
+    def self.acceptable_attributes
+      attribute_map.values
+    end
+
     # Attribute type mapping.
     def self.openapi_types
       {
@@ -229,7 +234,7 @@ module Petstore
           is_nullable = self.class.openapi_nullable.include?(attr)
           next if !is_nullable || (is_nullable && !instance_variable_defined?(:"@#{attr}"))
         end
-        
+
         hash[param] = _to_hash(value)
       end
       hash
@@ -254,4 +259,5 @@ module Petstore
     end
 
   end
+
 end

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/enum_test.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/enum_test.rb
@@ -67,6 +67,11 @@ module Petstore
       }
     end
 
+    # Returns all the JSON keys this model knows about
+    def self.acceptable_attributes
+      attribute_map.values
+    end
+
     # Attribute type mapping.
     def self.openapi_types
       {
@@ -327,7 +332,7 @@ module Petstore
           is_nullable = self.class.openapi_nullable.include?(attr)
           next if !is_nullable || (is_nullable && !instance_variable_defined?(:"@#{attr}"))
         end
-        
+
         hash[param] = _to_hash(value)
       end
       hash
@@ -352,4 +357,5 @@ module Petstore
     end
 
   end
+
 end

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/enum_test.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/enum_test.rb
@@ -299,7 +299,9 @@ module Petstore
           end
         end
       else # model
-        Petstore.const_get(type).build_from_hash(value)
+        # models (e.g. Pet) or oneOf
+        klass = Petstore.const_get(type)
+        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/file.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/file.rb
@@ -158,7 +158,9 @@ module Petstore
           end
         end
       else # model
-        Petstore.const_get(type).build_from_hash(value)
+        # models (e.g. Pet) or oneOf
+        klass = Petstore.const_get(type)
+        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/file.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/file.rb
@@ -26,6 +26,11 @@ module Petstore
       }
     end
 
+    # Returns all the JSON keys this model knows about
+    def self.acceptable_attributes
+      attribute_map.values
+    end
+
     # Attribute type mapping.
     def self.openapi_types
       {
@@ -186,7 +191,7 @@ module Petstore
           is_nullable = self.class.openapi_nullable.include?(attr)
           next if !is_nullable || (is_nullable && !instance_variable_defined?(:"@#{attr}"))
         end
-        
+
         hash[param] = _to_hash(value)
       end
       hash
@@ -211,4 +216,5 @@ module Petstore
     end
 
   end
+
 end

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/file_schema_test_class.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/file_schema_test_class.rb
@@ -167,7 +167,9 @@ module Petstore
           end
         end
       else # model
-        Petstore.const_get(type).build_from_hash(value)
+        # models (e.g. Pet) or oneOf
+        klass = Petstore.const_get(type)
+        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/file_schema_test_class.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/file_schema_test_class.rb
@@ -27,6 +27,11 @@ module Petstore
       }
     end
 
+    # Returns all the JSON keys this model knows about
+    def self.acceptable_attributes
+      attribute_map.values
+    end
+
     # Attribute type mapping.
     def self.openapi_types
       {
@@ -195,7 +200,7 @@ module Petstore
           is_nullable = self.class.openapi_nullable.include?(attr)
           next if !is_nullable || (is_nullable && !instance_variable_defined?(:"@#{attr}"))
         end
-        
+
         hash[param] = _to_hash(value)
       end
       hash
@@ -220,4 +225,5 @@ module Petstore
     end
 
   end
+
 end

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/foo.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/foo.rb
@@ -158,7 +158,9 @@ module Petstore
           end
         end
       else # model
-        Petstore.const_get(type).build_from_hash(value)
+        # models (e.g. Pet) or oneOf
+        klass = Petstore.const_get(type)
+        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/foo.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/foo.rb
@@ -24,6 +24,11 @@ module Petstore
       }
     end
 
+    # Returns all the JSON keys this model knows about
+    def self.acceptable_attributes
+      attribute_map.values
+    end
+
     # Attribute type mapping.
     def self.openapi_types
       {
@@ -186,7 +191,7 @@ module Petstore
           is_nullable = self.class.openapi_nullable.include?(attr)
           next if !is_nullable || (is_nullable && !instance_variable_defined?(:"@#{attr}"))
         end
-        
+
         hash[param] = _to_hash(value)
       end
       hash
@@ -211,4 +216,5 @@ module Petstore
     end
 
   end
+
 end

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/format_test.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/format_test.rb
@@ -516,7 +516,9 @@ module Petstore
           end
         end
       else # model
-        Petstore.const_get(type).build_from_hash(value)
+        # models (e.g. Pet) or oneOf
+        klass = Petstore.const_get(type)
+        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/format_test.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/format_test.rb
@@ -71,6 +71,11 @@ module Petstore
       }
     end
 
+    # Returns all the JSON keys this model knows about
+    def self.acceptable_attributes
+      attribute_map.values
+    end
+
     # Attribute type mapping.
     def self.openapi_types
       {
@@ -544,7 +549,7 @@ module Petstore
           is_nullable = self.class.openapi_nullable.include?(attr)
           next if !is_nullable || (is_nullable && !instance_variable_defined?(:"@#{attr}"))
         end
-        
+
         hash[param] = _to_hash(value)
       end
       hash
@@ -569,4 +574,5 @@ module Petstore
     end
 
   end
+
 end

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/has_only_read_only.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/has_only_read_only.rb
@@ -165,7 +165,9 @@ module Petstore
           end
         end
       else # model
-        Petstore.const_get(type).build_from_hash(value)
+        # models (e.g. Pet) or oneOf
+        klass = Petstore.const_get(type)
+        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/has_only_read_only.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/has_only_read_only.rb
@@ -27,6 +27,11 @@ module Petstore
       }
     end
 
+    # Returns all the JSON keys this model knows about
+    def self.acceptable_attributes
+      attribute_map.values
+    end
+
     # Attribute type mapping.
     def self.openapi_types
       {
@@ -193,7 +198,7 @@ module Petstore
           is_nullable = self.class.openapi_nullable.include?(attr)
           next if !is_nullable || (is_nullable && !instance_variable_defined?(:"@#{attr}"))
         end
-        
+
         hash[param] = _to_hash(value)
       end
       hash
@@ -218,4 +223,5 @@ module Petstore
     end
 
   end
+
 end

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/health_check_result.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/health_check_result.rb
@@ -25,6 +25,11 @@ module Petstore
       }
     end
 
+    # Returns all the JSON keys this model knows about
+    def self.acceptable_attributes
+      attribute_map.values
+    end
+
     # Attribute type mapping.
     def self.openapi_types
       {
@@ -186,7 +191,7 @@ module Petstore
           is_nullable = self.class.openapi_nullable.include?(attr)
           next if !is_nullable || (is_nullable && !instance_variable_defined?(:"@#{attr}"))
         end
-        
+
         hash[param] = _to_hash(value)
       end
       hash
@@ -211,4 +216,5 @@ module Petstore
     end
 
   end
+
 end

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/health_check_result.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/health_check_result.rb
@@ -158,7 +158,9 @@ module Petstore
           end
         end
       else # model
-        Petstore.const_get(type).build_from_hash(value)
+        # models (e.g. Pet) or oneOf
+        klass = Petstore.const_get(type)
+        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/inline_object.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/inline_object.rb
@@ -29,6 +29,11 @@ module Petstore
       }
     end
 
+    # Returns all the JSON keys this model knows about
+    def self.acceptable_attributes
+      attribute_map.values
+    end
+
     # Attribute type mapping.
     def self.openapi_types
       {
@@ -195,7 +200,7 @@ module Petstore
           is_nullable = self.class.openapi_nullable.include?(attr)
           next if !is_nullable || (is_nullable && !instance_variable_defined?(:"@#{attr}"))
         end
-        
+
         hash[param] = _to_hash(value)
       end
       hash
@@ -220,4 +225,5 @@ module Petstore
     end
 
   end
+
 end

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/inline_object.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/inline_object.rb
@@ -167,7 +167,9 @@ module Petstore
           end
         end
       else # model
-        Petstore.const_get(type).build_from_hash(value)
+        # models (e.g. Pet) or oneOf
+        klass = Petstore.const_get(type)
+        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/inline_object1.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/inline_object1.rb
@@ -29,6 +29,11 @@ module Petstore
       }
     end
 
+    # Returns all the JSON keys this model knows about
+    def self.acceptable_attributes
+      attribute_map.values
+    end
+
     # Attribute type mapping.
     def self.openapi_types
       {
@@ -195,7 +200,7 @@ module Petstore
           is_nullable = self.class.openapi_nullable.include?(attr)
           next if !is_nullable || (is_nullable && !instance_variable_defined?(:"@#{attr}"))
         end
-        
+
         hash[param] = _to_hash(value)
       end
       hash
@@ -220,4 +225,5 @@ module Petstore
     end
 
   end
+
 end

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/inline_object1.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/inline_object1.rb
@@ -167,7 +167,9 @@ module Petstore
           end
         end
       else # model
-        Petstore.const_get(type).build_from_hash(value)
+        # models (e.g. Pet) or oneOf
+        klass = Petstore.const_get(type)
+        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/inline_object2.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/inline_object2.rb
@@ -205,7 +205,9 @@ module Petstore
           end
         end
       else # model
-        Petstore.const_get(type).build_from_hash(value)
+        # models (e.g. Pet) or oneOf
+        klass = Petstore.const_get(type)
+        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/inline_object2.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/inline_object2.rb
@@ -51,6 +51,11 @@ module Petstore
       }
     end
 
+    # Returns all the JSON keys this model knows about
+    def self.acceptable_attributes
+      attribute_map.values
+    end
+
     # Attribute type mapping.
     def self.openapi_types
       {
@@ -233,7 +238,7 @@ module Petstore
           is_nullable = self.class.openapi_nullable.include?(attr)
           next if !is_nullable || (is_nullable && !instance_variable_defined?(:"@#{attr}"))
         end
-        
+
         hash[param] = _to_hash(value)
       end
       hash
@@ -258,4 +263,5 @@ module Petstore
     end
 
   end
+
 end

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/inline_object3.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/inline_object3.rb
@@ -488,7 +488,9 @@ module Petstore
           end
         end
       else # model
-        Petstore.const_get(type).build_from_hash(value)
+        # models (e.g. Pet) or oneOf
+        klass = Petstore.const_get(type)
+        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/inline_object3.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/inline_object3.rb
@@ -77,6 +77,11 @@ module Petstore
       }
     end
 
+    # Returns all the JSON keys this model knows about
+    def self.acceptable_attributes
+      attribute_map.values
+    end
+
     # Attribute type mapping.
     def self.openapi_types
       {
@@ -516,7 +521,7 @@ module Petstore
           is_nullable = self.class.openapi_nullable.include?(attr)
           next if !is_nullable || (is_nullable && !instance_variable_defined?(:"@#{attr}"))
         end
-        
+
         hash[param] = _to_hash(value)
       end
       hash
@@ -541,4 +546,5 @@ module Petstore
     end
 
   end
+
 end

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/inline_object4.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/inline_object4.rb
@@ -177,7 +177,9 @@ module Petstore
           end
         end
       else # model
-        Petstore.const_get(type).build_from_hash(value)
+        # models (e.g. Pet) or oneOf
+        klass = Petstore.const_get(type)
+        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/inline_object4.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/inline_object4.rb
@@ -29,6 +29,11 @@ module Petstore
       }
     end
 
+    # Returns all the JSON keys this model knows about
+    def self.acceptable_attributes
+      attribute_map.values
+    end
+
     # Attribute type mapping.
     def self.openapi_types
       {
@@ -205,7 +210,7 @@ module Petstore
           is_nullable = self.class.openapi_nullable.include?(attr)
           next if !is_nullable || (is_nullable && !instance_variable_defined?(:"@#{attr}"))
         end
-        
+
         hash[param] = _to_hash(value)
       end
       hash
@@ -230,4 +235,5 @@ module Petstore
     end
 
   end
+
 end

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/inline_object5.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/inline_object5.rb
@@ -29,6 +29,11 @@ module Petstore
       }
     end
 
+    # Returns all the JSON keys this model knows about
+    def self.acceptable_attributes
+      attribute_map.values
+    end
+
     # Attribute type mapping.
     def self.openapi_types
       {
@@ -200,7 +205,7 @@ module Petstore
           is_nullable = self.class.openapi_nullable.include?(attr)
           next if !is_nullable || (is_nullable && !instance_variable_defined?(:"@#{attr}"))
         end
-        
+
         hash[param] = _to_hash(value)
       end
       hash
@@ -225,4 +230,5 @@ module Petstore
     end
 
   end
+
 end

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/inline_object5.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/inline_object5.rb
@@ -172,7 +172,9 @@ module Petstore
           end
         end
       else # model
-        Petstore.const_get(type).build_from_hash(value)
+        # models (e.g. Pet) or oneOf
+        klass = Petstore.const_get(type)
+        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/inline_response_default.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/inline_response_default.rb
@@ -24,6 +24,11 @@ module Petstore
       }
     end
 
+    # Returns all the JSON keys this model knows about
+    def self.acceptable_attributes
+      attribute_map.values
+    end
+
     # Attribute type mapping.
     def self.openapi_types
       {
@@ -184,7 +189,7 @@ module Petstore
           is_nullable = self.class.openapi_nullable.include?(attr)
           next if !is_nullable || (is_nullable && !instance_variable_defined?(:"@#{attr}"))
         end
-        
+
         hash[param] = _to_hash(value)
       end
       hash
@@ -209,4 +214,5 @@ module Petstore
     end
 
   end
+
 end

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/inline_response_default.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/inline_response_default.rb
@@ -156,7 +156,9 @@ module Petstore
           end
         end
       else # model
-        Petstore.const_get(type).build_from_hash(value)
+        # models (e.g. Pet) or oneOf
+        klass = Petstore.const_get(type)
+        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/list.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/list.rb
@@ -24,6 +24,11 @@ module Petstore
       }
     end
 
+    # Returns all the JSON keys this model knows about
+    def self.acceptable_attributes
+      attribute_map.values
+    end
+
     # Attribute type mapping.
     def self.openapi_types
       {
@@ -184,7 +189,7 @@ module Petstore
           is_nullable = self.class.openapi_nullable.include?(attr)
           next if !is_nullable || (is_nullable && !instance_variable_defined?(:"@#{attr}"))
         end
-        
+
         hash[param] = _to_hash(value)
       end
       hash
@@ -209,4 +214,5 @@ module Petstore
     end
 
   end
+
 end

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/list.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/list.rb
@@ -156,7 +156,9 @@ module Petstore
           end
         end
       else # model
-        Petstore.const_get(type).build_from_hash(value)
+        # models (e.g. Pet) or oneOf
+        klass = Petstore.const_get(type)
+        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/map_test.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/map_test.rb
@@ -55,6 +55,11 @@ module Petstore
       }
     end
 
+    # Returns all the JSON keys this model knows about
+    def self.acceptable_attributes
+      attribute_map.values
+    end
+
     # Attribute type mapping.
     def self.openapi_types
       {
@@ -241,7 +246,7 @@ module Petstore
           is_nullable = self.class.openapi_nullable.include?(attr)
           next if !is_nullable || (is_nullable && !instance_variable_defined?(:"@#{attr}"))
         end
-        
+
         hash[param] = _to_hash(value)
       end
       hash
@@ -266,4 +271,5 @@ module Petstore
     end
 
   end
+
 end

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/map_test.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/map_test.rb
@@ -213,7 +213,9 @@ module Petstore
           end
         end
       else # model
-        Petstore.const_get(type).build_from_hash(value)
+        # models (e.g. Pet) or oneOf
+        klass = Petstore.const_get(type)
+        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/mixed_properties_and_additional_properties_class.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/mixed_properties_and_additional_properties_class.rb
@@ -176,7 +176,9 @@ module Petstore
           end
         end
       else # model
-        Petstore.const_get(type).build_from_hash(value)
+        # models (e.g. Pet) or oneOf
+        klass = Petstore.const_get(type)
+        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/mixed_properties_and_additional_properties_class.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/mixed_properties_and_additional_properties_class.rb
@@ -30,6 +30,11 @@ module Petstore
       }
     end
 
+    # Returns all the JSON keys this model knows about
+    def self.acceptable_attributes
+      attribute_map.values
+    end
+
     # Attribute type mapping.
     def self.openapi_types
       {
@@ -204,7 +209,7 @@ module Petstore
           is_nullable = self.class.openapi_nullable.include?(attr)
           next if !is_nullable || (is_nullable && !instance_variable_defined?(:"@#{attr}"))
         end
-        
+
         hash[param] = _to_hash(value)
       end
       hash
@@ -229,4 +234,5 @@ module Petstore
     end
 
   end
+
 end

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/model200_response.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/model200_response.rb
@@ -28,6 +28,11 @@ module Petstore
       }
     end
 
+    # Returns all the JSON keys this model knows about
+    def self.acceptable_attributes
+      attribute_map.values
+    end
+
     # Attribute type mapping.
     def self.openapi_types
       {
@@ -194,7 +199,7 @@ module Petstore
           is_nullable = self.class.openapi_nullable.include?(attr)
           next if !is_nullable || (is_nullable && !instance_variable_defined?(:"@#{attr}"))
         end
-        
+
         hash[param] = _to_hash(value)
       end
       hash
@@ -219,4 +224,5 @@ module Petstore
     end
 
   end
+
 end

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/model200_response.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/model200_response.rb
@@ -166,7 +166,9 @@ module Petstore
           end
         end
       else # model
-        Petstore.const_get(type).build_from_hash(value)
+        # models (e.g. Pet) or oneOf
+        klass = Petstore.const_get(type)
+        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/model_return.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/model_return.rb
@@ -25,6 +25,11 @@ module Petstore
       }
     end
 
+    # Returns all the JSON keys this model knows about
+    def self.acceptable_attributes
+      attribute_map.values
+    end
+
     # Attribute type mapping.
     def self.openapi_types
       {
@@ -185,7 +190,7 @@ module Petstore
           is_nullable = self.class.openapi_nullable.include?(attr)
           next if !is_nullable || (is_nullable && !instance_variable_defined?(:"@#{attr}"))
         end
-        
+
         hash[param] = _to_hash(value)
       end
       hash
@@ -210,4 +215,5 @@ module Petstore
     end
 
   end
+
 end

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/model_return.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/model_return.rb
@@ -157,7 +157,9 @@ module Petstore
           end
         end
       else # model
-        Petstore.const_get(type).build_from_hash(value)
+        # models (e.g. Pet) or oneOf
+        klass = Petstore.const_get(type)
+        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/name.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/name.rb
@@ -189,7 +189,9 @@ module Petstore
           end
         end
       else # model
-        Petstore.const_get(type).build_from_hash(value)
+        # models (e.g. Pet) or oneOf
+        klass = Petstore.const_get(type)
+        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/name.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/name.rb
@@ -34,6 +34,11 @@ module Petstore
       }
     end
 
+    # Returns all the JSON keys this model knows about
+    def self.acceptable_attributes
+      attribute_map.values
+    end
+
     # Attribute type mapping.
     def self.openapi_types
       {
@@ -217,7 +222,7 @@ module Petstore
           is_nullable = self.class.openapi_nullable.include?(attr)
           next if !is_nullable || (is_nullable && !instance_variable_defined?(:"@#{attr}"))
         end
-        
+
         hash[param] = _to_hash(value)
       end
       hash
@@ -242,4 +247,5 @@ module Petstore
     end
 
   end
+
 end

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/nullable_class.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/nullable_class.rb
@@ -57,6 +57,11 @@ module Petstore
       }
     end
 
+    # Returns all the JSON keys this model knows about
+    def self.acceptable_attributes
+      attribute_map.values
+    end
+
     # Attribute type mapping.
     def self.openapi_types
       {
@@ -305,7 +310,7 @@ module Petstore
           is_nullable = self.class.openapi_nullable.include?(attr)
           next if !is_nullable || (is_nullable && !instance_variable_defined?(:"@#{attr}"))
         end
-        
+
         hash[param] = _to_hash(value)
       end
       hash
@@ -330,4 +335,5 @@ module Petstore
     end
 
   end
+
 end

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/nullable_class.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/nullable_class.rb
@@ -277,7 +277,9 @@ module Petstore
           end
         end
       else # model
-        Petstore.const_get(type).build_from_hash(value)
+        # models (e.g. Pet) or oneOf
+        klass = Petstore.const_get(type)
+        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/number_only.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/number_only.rb
@@ -24,6 +24,11 @@ module Petstore
       }
     end
 
+    # Returns all the JSON keys this model knows about
+    def self.acceptable_attributes
+      attribute_map.values
+    end
+
     # Attribute type mapping.
     def self.openapi_types
       {
@@ -184,7 +189,7 @@ module Petstore
           is_nullable = self.class.openapi_nullable.include?(attr)
           next if !is_nullable || (is_nullable && !instance_variable_defined?(:"@#{attr}"))
         end
-        
+
         hash[param] = _to_hash(value)
       end
       hash
@@ -209,4 +214,5 @@ module Petstore
     end
 
   end
+
 end

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/number_only.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/number_only.rb
@@ -156,7 +156,9 @@ module Petstore
           end
         end
       else # model
-        Petstore.const_get(type).build_from_hash(value)
+        # models (e.g. Pet) or oneOf
+        klass = Petstore.const_get(type)
+        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/order.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/order.rb
@@ -238,7 +238,9 @@ module Petstore
           end
         end
       else # model
-        Petstore.const_get(type).build_from_hash(value)
+        # models (e.g. Pet) or oneOf
+        klass = Petstore.const_get(type)
+        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/order.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/order.rb
@@ -62,6 +62,11 @@ module Petstore
       }
     end
 
+    # Returns all the JSON keys this model knows about
+    def self.acceptable_attributes
+      attribute_map.values
+    end
+
     # Attribute type mapping.
     def self.openapi_types
       {
@@ -266,7 +271,7 @@ module Petstore
           is_nullable = self.class.openapi_nullable.include?(attr)
           next if !is_nullable || (is_nullable && !instance_variable_defined?(:"@#{attr}"))
         end
-        
+
         hash[param] = _to_hash(value)
       end
       hash
@@ -291,4 +296,5 @@ module Petstore
     end
 
   end
+
 end

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/outer_composite.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/outer_composite.rb
@@ -174,7 +174,9 @@ module Petstore
           end
         end
       else # model
-        Petstore.const_get(type).build_from_hash(value)
+        # models (e.g. Pet) or oneOf
+        klass = Petstore.const_get(type)
+        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/outer_composite.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/outer_composite.rb
@@ -30,6 +30,11 @@ module Petstore
       }
     end
 
+    # Returns all the JSON keys this model knows about
+    def self.acceptable_attributes
+      attribute_map.values
+    end
+
     # Attribute type mapping.
     def self.openapi_types
       {
@@ -202,7 +207,7 @@ module Petstore
           is_nullable = self.class.openapi_nullable.include?(attr)
           next if !is_nullable || (is_nullable && !instance_variable_defined?(:"@#{attr}"))
         end
-        
+
         hash[param] = _to_hash(value)
       end
       hash
@@ -227,4 +232,5 @@ module Petstore
     end
 
   end
+
 end

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/pet.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/pet.rb
@@ -62,6 +62,11 @@ module Petstore
       }
     end
 
+    # Returns all the JSON keys this model knows about
+    def self.acceptable_attributes
+      attribute_map.values
+    end
+
     # Attribute type mapping.
     def self.openapi_types
       {
@@ -278,7 +283,7 @@ module Petstore
           is_nullable = self.class.openapi_nullable.include?(attr)
           next if !is_nullable || (is_nullable && !instance_variable_defined?(:"@#{attr}"))
         end
-        
+
         hash[param] = _to_hash(value)
       end
       hash
@@ -303,4 +308,5 @@ module Petstore
     end
 
   end
+
 end

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/pet.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/pet.rb
@@ -250,7 +250,9 @@ module Petstore
           end
         end
       else # model
-        Petstore.const_get(type).build_from_hash(value)
+        # models (e.g. Pet) or oneOf
+        klass = Petstore.const_get(type)
+        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/read_only_first.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/read_only_first.rb
@@ -165,7 +165,9 @@ module Petstore
           end
         end
       else # model
-        Petstore.const_get(type).build_from_hash(value)
+        # models (e.g. Pet) or oneOf
+        klass = Petstore.const_get(type)
+        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/read_only_first.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/read_only_first.rb
@@ -27,6 +27,11 @@ module Petstore
       }
     end
 
+    # Returns all the JSON keys this model knows about
+    def self.acceptable_attributes
+      attribute_map.values
+    end
+
     # Attribute type mapping.
     def self.openapi_types
       {
@@ -193,7 +198,7 @@ module Petstore
           is_nullable = self.class.openapi_nullable.include?(attr)
           next if !is_nullable || (is_nullable && !instance_variable_defined?(:"@#{attr}"))
         end
-        
+
         hash[param] = _to_hash(value)
       end
       hash
@@ -218,4 +223,5 @@ module Petstore
     end
 
   end
+
 end

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/special_model_name.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/special_model_name.rb
@@ -24,6 +24,11 @@ module Petstore
       }
     end
 
+    # Returns all the JSON keys this model knows about
+    def self.acceptable_attributes
+      attribute_map.values
+    end
+
     # Attribute type mapping.
     def self.openapi_types
       {
@@ -184,7 +189,7 @@ module Petstore
           is_nullable = self.class.openapi_nullable.include?(attr)
           next if !is_nullable || (is_nullable && !instance_variable_defined?(:"@#{attr}"))
         end
-        
+
         hash[param] = _to_hash(value)
       end
       hash
@@ -209,4 +214,5 @@ module Petstore
     end
 
   end
+
 end

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/special_model_name.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/special_model_name.rb
@@ -156,7 +156,9 @@ module Petstore
           end
         end
       else # model
-        Petstore.const_get(type).build_from_hash(value)
+        # models (e.g. Pet) or oneOf
+        klass = Petstore.const_get(type)
+        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/tag.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/tag.rb
@@ -165,7 +165,9 @@ module Petstore
           end
         end
       else # model
-        Petstore.const_get(type).build_from_hash(value)
+        # models (e.g. Pet) or oneOf
+        klass = Petstore.const_get(type)
+        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/tag.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/tag.rb
@@ -27,6 +27,11 @@ module Petstore
       }
     end
 
+    # Returns all the JSON keys this model knows about
+    def self.acceptable_attributes
+      attribute_map.values
+    end
+
     # Attribute type mapping.
     def self.openapi_types
       {
@@ -193,7 +198,7 @@ module Petstore
           is_nullable = self.class.openapi_nullable.include?(attr)
           next if !is_nullable || (is_nullable && !instance_variable_defined?(:"@#{attr}"))
         end
-        
+
         hash[param] = _to_hash(value)
       end
       hash
@@ -218,4 +223,5 @@ module Petstore
     end
 
   end
+
 end

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/user.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/user.rb
@@ -46,6 +46,11 @@ module Petstore
       }
     end
 
+    # Returns all the JSON keys this model knows about
+    def self.acceptable_attributes
+      attribute_map.values
+    end
+
     # Attribute type mapping.
     def self.openapi_types
       {
@@ -248,7 +253,7 @@ module Petstore
           is_nullable = self.class.openapi_nullable.include?(attr)
           next if !is_nullable || (is_nullable && !instance_variable_defined?(:"@#{attr}"))
         end
-        
+
         hash[param] = _to_hash(value)
       end
       hash
@@ -273,4 +278,5 @@ module Petstore
     end
 
   end
+
 end

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/user.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/user.rb
@@ -220,7 +220,9 @@ module Petstore
           end
         end
       else # model
-        Petstore.const_get(type).build_from_hash(value)
+        # models (e.g. Pet) or oneOf
+        klass = Petstore.const_get(type)
+        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby/docs/AdditionalPropertiesClass.md
+++ b/samples/client/petstore/ruby/docs/AdditionalPropertiesClass.md
@@ -2,18 +2,19 @@
 
 ## Properties
 
-Name | Type | Description | Notes
------------- | ------------- | ------------- | -------------
-**map_property** | **Hash&lt;String, String&gt;** |  | [optional] 
-**map_of_map_property** | **Hash&lt;String, Hash&lt;String, String&gt;&gt;** |  | [optional] 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **map_property** | **Hash&lt;String, String&gt;** |  | [optional] |
+| **map_of_map_property** | **Hash&lt;String, Hash&lt;String, String&gt;&gt;** |  | [optional] |
 
 ## Code Sample
 
 ```ruby
-require 'Petstore'
+require 'petstore'
 
-instance = Petstore::AdditionalPropertiesClass.new(map_property: null,
-                                 map_of_map_property: null)
+instance = Petstore::AdditionalPropertiesClass.new(
+  map_property: null,
+  map_of_map_property: null
+)
 ```
-
 

--- a/samples/client/petstore/ruby/docs/Animal.md
+++ b/samples/client/petstore/ruby/docs/Animal.md
@@ -2,18 +2,19 @@
 
 ## Properties
 
-Name | Type | Description | Notes
------------- | ------------- | ------------- | -------------
-**class_name** | **String** |  | 
-**color** | **String** |  | [optional] [default to &#39;red&#39;]
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **class_name** | **String** |  |  |
+| **color** | **String** |  | [optional][default to &#39;red&#39;] |
 
 ## Code Sample
 
 ```ruby
-require 'Petstore'
+require 'petstore'
 
-instance = Petstore::Animal.new(class_name: null,
-                                 color: null)
+instance = Petstore::Animal.new(
+  class_name: null,
+  color: null
+)
 ```
-
 

--- a/samples/client/petstore/ruby/docs/AnotherFakeApi.md
+++ b/samples/client/petstore/ruby/docs/AnotherFakeApi.md
@@ -2,10 +2,9 @@
 
 All URIs are relative to *http://petstore.swagger.io:80/v2*
 
-Method | HTTP request | Description
-------------- | ------------- | -------------
-[**call_123_test_special_tags**](AnotherFakeApi.md#call_123_test_special_tags) | **PATCH** /another-fake/dummy | To test special tags
-
+| Method | HTTP request | Description |
+| ------ | ------------ | ----------- |
+| [**call_123_test_special_tags**](AnotherFakeApi.md#call_123_test_special_tags) | **PATCH** /another-fake/dummy | To test special tags |
 
 
 ## call_123_test_special_tags
@@ -36,10 +35,9 @@ end
 
 ### Parameters
 
-
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **client** | [**Client**](Client.md)| client model | 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **client** | [**Client**](Client.md) | client model |  |
 
 ### Return type
 

--- a/samples/client/petstore/ruby/docs/ApiResponse.md
+++ b/samples/client/petstore/ruby/docs/ApiResponse.md
@@ -2,20 +2,21 @@
 
 ## Properties
 
-Name | Type | Description | Notes
------------- | ------------- | ------------- | -------------
-**code** | **Integer** |  | [optional] 
-**type** | **String** |  | [optional] 
-**message** | **String** |  | [optional] 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **code** | **Integer** |  | [optional] |
+| **type** | **String** |  | [optional] |
+| **message** | **String** |  | [optional] |
 
 ## Code Sample
 
 ```ruby
-require 'Petstore'
+require 'petstore'
 
-instance = Petstore::ApiResponse.new(code: null,
-                                 type: null,
-                                 message: null)
+instance = Petstore::ApiResponse.new(
+  code: null,
+  type: null,
+  message: null
+)
 ```
-
 

--- a/samples/client/petstore/ruby/docs/ArrayOfArrayOfNumberOnly.md
+++ b/samples/client/petstore/ruby/docs/ArrayOfArrayOfNumberOnly.md
@@ -2,16 +2,17 @@
 
 ## Properties
 
-Name | Type | Description | Notes
------------- | ------------- | ------------- | -------------
-**array_array_number** | **Array&lt;Array&lt;Float&gt;&gt;** |  | [optional] 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **array_array_number** | **Array&lt;Array&lt;Float&gt;&gt;** |  | [optional] |
 
 ## Code Sample
 
 ```ruby
-require 'Petstore'
+require 'petstore'
 
-instance = Petstore::ArrayOfArrayOfNumberOnly.new(array_array_number: null)
+instance = Petstore::ArrayOfArrayOfNumberOnly.new(
+  array_array_number: null
+)
 ```
-
 

--- a/samples/client/petstore/ruby/docs/ArrayOfNumberOnly.md
+++ b/samples/client/petstore/ruby/docs/ArrayOfNumberOnly.md
@@ -2,16 +2,17 @@
 
 ## Properties
 
-Name | Type | Description | Notes
------------- | ------------- | ------------- | -------------
-**array_number** | **Array&lt;Float&gt;** |  | [optional] 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **array_number** | **Array&lt;Float&gt;** |  | [optional] |
 
 ## Code Sample
 
 ```ruby
-require 'Petstore'
+require 'petstore'
 
-instance = Petstore::ArrayOfNumberOnly.new(array_number: null)
+instance = Petstore::ArrayOfNumberOnly.new(
+  array_number: null
+)
 ```
-
 

--- a/samples/client/petstore/ruby/docs/ArrayTest.md
+++ b/samples/client/petstore/ruby/docs/ArrayTest.md
@@ -2,20 +2,21 @@
 
 ## Properties
 
-Name | Type | Description | Notes
------------- | ------------- | ------------- | -------------
-**array_of_string** | **Array&lt;String&gt;** |  | [optional] 
-**array_array_of_integer** | **Array&lt;Array&lt;Integer&gt;&gt;** |  | [optional] 
-**array_array_of_model** | **Array&lt;Array&lt;ReadOnlyFirst&gt;&gt;** |  | [optional] 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **array_of_string** | **Array&lt;String&gt;** |  | [optional] |
+| **array_array_of_integer** | **Array&lt;Array&lt;Integer&gt;&gt;** |  | [optional] |
+| **array_array_of_model** | **Array&lt;Array&lt;ReadOnlyFirst&gt;&gt;** |  | [optional] |
 
 ## Code Sample
 
 ```ruby
-require 'Petstore'
+require 'petstore'
 
-instance = Petstore::ArrayTest.new(array_of_string: null,
-                                 array_array_of_integer: null,
-                                 array_array_of_model: null)
+instance = Petstore::ArrayTest.new(
+  array_of_string: null,
+  array_array_of_integer: null,
+  array_array_of_model: null
+)
 ```
-
 

--- a/samples/client/petstore/ruby/docs/Capitalization.md
+++ b/samples/client/petstore/ruby/docs/Capitalization.md
@@ -2,26 +2,27 @@
 
 ## Properties
 
-Name | Type | Description | Notes
------------- | ------------- | ------------- | -------------
-**small_camel** | **String** |  | [optional] 
-**capital_camel** | **String** |  | [optional] 
-**small_snake** | **String** |  | [optional] 
-**capital_snake** | **String** |  | [optional] 
-**sca_eth_flow_points** | **String** |  | [optional] 
-**att_name** | **String** | Name of the pet  | [optional] 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **small_camel** | **String** |  | [optional] |
+| **capital_camel** | **String** |  | [optional] |
+| **small_snake** | **String** |  | [optional] |
+| **capital_snake** | **String** |  | [optional] |
+| **sca_eth_flow_points** | **String** |  | [optional] |
+| **att_name** | **String** | Name of the pet  | [optional] |
 
 ## Code Sample
 
 ```ruby
-require 'Petstore'
+require 'petstore'
 
-instance = Petstore::Capitalization.new(small_camel: null,
-                                 capital_camel: null,
-                                 small_snake: null,
-                                 capital_snake: null,
-                                 sca_eth_flow_points: null,
-                                 att_name: null)
+instance = Petstore::Capitalization.new(
+  small_camel: null,
+  capital_camel: null,
+  small_snake: null,
+  capital_snake: null,
+  sca_eth_flow_points: null,
+  att_name: null
+)
 ```
-
 

--- a/samples/client/petstore/ruby/docs/Cat.md
+++ b/samples/client/petstore/ruby/docs/Cat.md
@@ -2,16 +2,17 @@
 
 ## Properties
 
-Name | Type | Description | Notes
------------- | ------------- | ------------- | -------------
-**declawed** | **Boolean** |  | [optional] 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **declawed** | **Boolean** |  | [optional] |
 
 ## Code Sample
 
 ```ruby
-require 'Petstore'
+require 'petstore'
 
-instance = Petstore::Cat.new(declawed: null)
+instance = Petstore::Cat.new(
+  declawed: null
+)
 ```
-
 

--- a/samples/client/petstore/ruby/docs/CatAllOf.md
+++ b/samples/client/petstore/ruby/docs/CatAllOf.md
@@ -2,16 +2,17 @@
 
 ## Properties
 
-Name | Type | Description | Notes
------------- | ------------- | ------------- | -------------
-**declawed** | **Boolean** |  | [optional] 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **declawed** | **Boolean** |  | [optional] |
 
 ## Code Sample
 
 ```ruby
-require 'Petstore'
+require 'petstore'
 
-instance = Petstore::CatAllOf.new(declawed: null)
+instance = Petstore::CatAllOf.new(
+  declawed: null
+)
 ```
-
 

--- a/samples/client/petstore/ruby/docs/Category.md
+++ b/samples/client/petstore/ruby/docs/Category.md
@@ -2,18 +2,19 @@
 
 ## Properties
 
-Name | Type | Description | Notes
------------- | ------------- | ------------- | -------------
-**id** | **Integer** |  | [optional] 
-**name** | **String** |  | [default to &#39;default-name&#39;]
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **id** | **Integer** |  | [optional] |
+| **name** | **String** |  | [default to &#39;default-name&#39;] |
 
 ## Code Sample
 
 ```ruby
-require 'Petstore'
+require 'petstore'
 
-instance = Petstore::Category.new(id: null,
-                                 name: null)
+instance = Petstore::Category.new(
+  id: null,
+  name: null
+)
 ```
-
 

--- a/samples/client/petstore/ruby/docs/ClassModel.md
+++ b/samples/client/petstore/ruby/docs/ClassModel.md
@@ -2,16 +2,17 @@
 
 ## Properties
 
-Name | Type | Description | Notes
------------- | ------------- | ------------- | -------------
-**_class** | **String** |  | [optional] 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **_class** | **String** |  | [optional] |
 
 ## Code Sample
 
 ```ruby
-require 'Petstore'
+require 'petstore'
 
-instance = Petstore::ClassModel.new(_class: null)
+instance = Petstore::ClassModel.new(
+  _class: null
+)
 ```
-
 

--- a/samples/client/petstore/ruby/docs/Client.md
+++ b/samples/client/petstore/ruby/docs/Client.md
@@ -2,16 +2,17 @@
 
 ## Properties
 
-Name | Type | Description | Notes
------------- | ------------- | ------------- | -------------
-**client** | **String** |  | [optional] 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **client** | **String** |  | [optional] |
 
 ## Code Sample
 
 ```ruby
-require 'Petstore'
+require 'petstore'
 
-instance = Petstore::Client.new(client: null)
+instance = Petstore::Client.new(
+  client: null
+)
 ```
-
 

--- a/samples/client/petstore/ruby/docs/DefaultApi.md
+++ b/samples/client/petstore/ruby/docs/DefaultApi.md
@@ -2,10 +2,9 @@
 
 All URIs are relative to *http://petstore.swagger.io:80/v2*
 
-Method | HTTP request | Description
-------------- | ------------- | -------------
-[**foo_get**](DefaultApi.md#foo_get) | **GET** /foo | 
-
+| Method | HTTP request | Description |
+| ------ | ------------ | ----------- |
+| [**foo_get**](DefaultApi.md#foo_get) | **GET** /foo |  |
 
 
 ## foo_get

--- a/samples/client/petstore/ruby/docs/Dog.md
+++ b/samples/client/petstore/ruby/docs/Dog.md
@@ -2,16 +2,17 @@
 
 ## Properties
 
-Name | Type | Description | Notes
------------- | ------------- | ------------- | -------------
-**breed** | **String** |  | [optional] 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **breed** | **String** |  | [optional] |
 
 ## Code Sample
 
 ```ruby
-require 'Petstore'
+require 'petstore'
 
-instance = Petstore::Dog.new(breed: null)
+instance = Petstore::Dog.new(
+  breed: null
+)
 ```
-
 

--- a/samples/client/petstore/ruby/docs/DogAllOf.md
+++ b/samples/client/petstore/ruby/docs/DogAllOf.md
@@ -2,16 +2,17 @@
 
 ## Properties
 
-Name | Type | Description | Notes
------------- | ------------- | ------------- | -------------
-**breed** | **String** |  | [optional] 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **breed** | **String** |  | [optional] |
 
 ## Code Sample
 
 ```ruby
-require 'Petstore'
+require 'petstore'
 
-instance = Petstore::DogAllOf.new(breed: null)
+instance = Petstore::DogAllOf.new(
+  breed: null
+)
 ```
-
 

--- a/samples/client/petstore/ruby/docs/EnumArrays.md
+++ b/samples/client/petstore/ruby/docs/EnumArrays.md
@@ -2,18 +2,19 @@
 
 ## Properties
 
-Name | Type | Description | Notes
------------- | ------------- | ------------- | -------------
-**just_symbol** | **String** |  | [optional] 
-**array_enum** | **Array&lt;String&gt;** |  | [optional] 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **just_symbol** | **String** |  | [optional] |
+| **array_enum** | **Array&lt;String&gt;** |  | [optional] |
 
 ## Code Sample
 
 ```ruby
-require 'Petstore'
+require 'petstore'
 
-instance = Petstore::EnumArrays.new(just_symbol: null,
-                                 array_enum: null)
+instance = Petstore::EnumArrays.new(
+  just_symbol: null,
+  array_enum: null
+)
 ```
-
 

--- a/samples/client/petstore/ruby/docs/EnumClass.md
+++ b/samples/client/petstore/ruby/docs/EnumClass.md
@@ -2,15 +2,14 @@
 
 ## Properties
 
-Name | Type | Description | Notes
------------- | ------------- | ------------- | -------------
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
 
 ## Code Sample
 
 ```ruby
-require 'Petstore'
+require 'petstore'
 
 instance = Petstore::EnumClass.new()
 ```
-
 

--- a/samples/client/petstore/ruby/docs/EnumTest.md
+++ b/samples/client/petstore/ruby/docs/EnumTest.md
@@ -2,30 +2,31 @@
 
 ## Properties
 
-Name | Type | Description | Notes
------------- | ------------- | ------------- | -------------
-**enum_string** | **String** |  | [optional] 
-**enum_string_required** | **String** |  | 
-**enum_integer** | **Integer** |  | [optional] 
-**enum_number** | **Float** |  | [optional] 
-**outer_enum** | [**OuterEnum**](OuterEnum.md) |  | [optional] 
-**outer_enum_integer** | [**OuterEnumInteger**](OuterEnumInteger.md) |  | [optional] 
-**outer_enum_default_value** | [**OuterEnumDefaultValue**](OuterEnumDefaultValue.md) |  | [optional] [default to &#39;placed&#39;]
-**outer_enum_integer_default_value** | [**OuterEnumIntegerDefaultValue**](OuterEnumIntegerDefaultValue.md) |  | [optional] [default to OuterEnumIntegerDefaultValue::N0]
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **enum_string** | **String** |  | [optional] |
+| **enum_string_required** | **String** |  |  |
+| **enum_integer** | **Integer** |  | [optional] |
+| **enum_number** | **Float** |  | [optional] |
+| **outer_enum** | [**OuterEnum**](OuterEnum.md) |  | [optional] |
+| **outer_enum_integer** | [**OuterEnumInteger**](OuterEnumInteger.md) |  | [optional] |
+| **outer_enum_default_value** | [**OuterEnumDefaultValue**](OuterEnumDefaultValue.md) |  | [optional][default to &#39;placed&#39;] |
+| **outer_enum_integer_default_value** | [**OuterEnumIntegerDefaultValue**](OuterEnumIntegerDefaultValue.md) |  | [optional][default to OuterEnumIntegerDefaultValue::N0] |
 
 ## Code Sample
 
 ```ruby
-require 'Petstore'
+require 'petstore'
 
-instance = Petstore::EnumTest.new(enum_string: null,
-                                 enum_string_required: null,
-                                 enum_integer: null,
-                                 enum_number: null,
-                                 outer_enum: null,
-                                 outer_enum_integer: null,
-                                 outer_enum_default_value: null,
-                                 outer_enum_integer_default_value: null)
+instance = Petstore::EnumTest.new(
+  enum_string: null,
+  enum_string_required: null,
+  enum_integer: null,
+  enum_number: null,
+  outer_enum: null,
+  outer_enum_integer: null,
+  outer_enum_default_value: null,
+  outer_enum_integer_default_value: null
+)
 ```
-
 

--- a/samples/client/petstore/ruby/docs/FakeApi.md
+++ b/samples/client/petstore/ruby/docs/FakeApi.md
@@ -2,24 +2,23 @@
 
 All URIs are relative to *http://petstore.swagger.io:80/v2*
 
-Method | HTTP request | Description
-------------- | ------------- | -------------
-[**fake_health_get**](FakeApi.md#fake_health_get) | **GET** /fake/health | Health check endpoint
-[**fake_http_signature_test**](FakeApi.md#fake_http_signature_test) | **GET** /fake/http-signature-test | test http signature authentication
-[**fake_outer_boolean_serialize**](FakeApi.md#fake_outer_boolean_serialize) | **POST** /fake/outer/boolean | 
-[**fake_outer_composite_serialize**](FakeApi.md#fake_outer_composite_serialize) | **POST** /fake/outer/composite | 
-[**fake_outer_number_serialize**](FakeApi.md#fake_outer_number_serialize) | **POST** /fake/outer/number | 
-[**fake_outer_string_serialize**](FakeApi.md#fake_outer_string_serialize) | **POST** /fake/outer/string | 
-[**test_body_with_file_schema**](FakeApi.md#test_body_with_file_schema) | **PUT** /fake/body-with-file-schema | 
-[**test_body_with_query_params**](FakeApi.md#test_body_with_query_params) | **PUT** /fake/body-with-query-params | 
-[**test_client_model**](FakeApi.md#test_client_model) | **PATCH** /fake | To test \&quot;client\&quot; model
-[**test_endpoint_parameters**](FakeApi.md#test_endpoint_parameters) | **POST** /fake | Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
-[**test_enum_parameters**](FakeApi.md#test_enum_parameters) | **GET** /fake | To test enum parameters
-[**test_group_parameters**](FakeApi.md#test_group_parameters) | **DELETE** /fake | Fake endpoint to test group parameters (optional)
-[**test_inline_additional_properties**](FakeApi.md#test_inline_additional_properties) | **POST** /fake/inline-additionalProperties | test inline additionalProperties
-[**test_json_form_data**](FakeApi.md#test_json_form_data) | **GET** /fake/jsonFormData | test json serialization of form data
-[**test_query_parameter_collection_format**](FakeApi.md#test_query_parameter_collection_format) | **PUT** /fake/test-query-paramters | 
-
+| Method | HTTP request | Description |
+| ------ | ------------ | ----------- |
+| [**fake_health_get**](FakeApi.md#fake_health_get) | **GET** /fake/health | Health check endpoint |
+| [**fake_http_signature_test**](FakeApi.md#fake_http_signature_test) | **GET** /fake/http-signature-test | test http signature authentication |
+| [**fake_outer_boolean_serialize**](FakeApi.md#fake_outer_boolean_serialize) | **POST** /fake/outer/boolean |  |
+| [**fake_outer_composite_serialize**](FakeApi.md#fake_outer_composite_serialize) | **POST** /fake/outer/composite |  |
+| [**fake_outer_number_serialize**](FakeApi.md#fake_outer_number_serialize) | **POST** /fake/outer/number |  |
+| [**fake_outer_string_serialize**](FakeApi.md#fake_outer_string_serialize) | **POST** /fake/outer/string |  |
+| [**test_body_with_file_schema**](FakeApi.md#test_body_with_file_schema) | **PUT** /fake/body-with-file-schema |  |
+| [**test_body_with_query_params**](FakeApi.md#test_body_with_query_params) | **PUT** /fake/body-with-query-params |  |
+| [**test_client_model**](FakeApi.md#test_client_model) | **PATCH** /fake | To test \&quot;client\&quot; model |
+| [**test_endpoint_parameters**](FakeApi.md#test_endpoint_parameters) | **POST** /fake | Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트  |
+| [**test_enum_parameters**](FakeApi.md#test_enum_parameters) | **GET** /fake | To test enum parameters |
+| [**test_group_parameters**](FakeApi.md#test_group_parameters) | **DELETE** /fake | Fake endpoint to test group parameters (optional) |
+| [**test_inline_additional_properties**](FakeApi.md#test_inline_additional_properties) | **POST** /fake/inline-additionalProperties | test inline additionalProperties |
+| [**test_json_form_data**](FakeApi.md#test_json_form_data) | **GET** /fake/jsonFormData | test json serialization of form data |
+| [**test_query_parameter_collection_format**](FakeApi.md#test_query_parameter_collection_format) | **PUT** /fake/test-query-paramters |  |
 
 
 ## fake_health_get
@@ -95,12 +94,11 @@ end
 
 ### Parameters
 
-
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **pet** | [**Pet**](Pet.md)| Pet object that needs to be added to the store | 
- **query_1** | **String**| query parameter | [optional] 
- **header_1** | **String**| header parameter | [optional] 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **pet** | [**Pet**](Pet.md) | Pet object that needs to be added to the store |  |
+| **query_1** | **String** | query parameter | [optional] |
+| **header_1** | **String** | header parameter | [optional] |
 
 ### Return type
 
@@ -145,10 +143,9 @@ end
 
 ### Parameters
 
-
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **body** | **Boolean**| Input boolean as post body | [optional] 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **body** | **Boolean** | Input boolean as post body | [optional] |
 
 ### Return type
 
@@ -193,10 +190,9 @@ end
 
 ### Parameters
 
-
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **outer_composite** | [**OuterComposite**](OuterComposite.md)| Input composite as post body | [optional] 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **outer_composite** | [**OuterComposite**](OuterComposite.md) | Input composite as post body | [optional] |
 
 ### Return type
 
@@ -241,10 +237,9 @@ end
 
 ### Parameters
 
-
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **body** | **Float**| Input number as post body | [optional] 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **body** | **Float** | Input number as post body | [optional] |
 
 ### Return type
 
@@ -289,10 +284,9 @@ end
 
 ### Parameters
 
-
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **body** | **String**| Input string as post body | [optional] 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **body** | **String** | Input string as post body | [optional] |
 
 ### Return type
 
@@ -334,10 +328,9 @@ end
 
 ### Parameters
 
-
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **file_schema_test_class** | [**FileSchemaTestClass**](FileSchemaTestClass.md)|  | 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **file_schema_test_class** | [**FileSchemaTestClass**](FileSchemaTestClass.md) |  |  |
 
 ### Return type
 
@@ -378,11 +371,10 @@ end
 
 ### Parameters
 
-
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **query** | **String**|  | 
- **user** | [**User**](User.md)|  | 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **query** | **String** |  |  |
+| **user** | [**User**](User.md) |  |  |
 
 ### Return type
 
@@ -426,10 +418,9 @@ end
 
 ### Parameters
 
-
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **client** | [**Client**](Client.md)| client model | 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **client** | [**Client**](Client.md) | client model |  |
 
 ### Return type
 
@@ -493,23 +484,22 @@ end
 
 ### Parameters
 
-
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **number** | **Float**| None | 
- **double** | **Float**| None | 
- **pattern_without_delimiter** | **String**| None | 
- **byte** | **String**| None | 
- **integer** | **Integer**| None | [optional] 
- **int32** | **Integer**| None | [optional] 
- **int64** | **Integer**| None | [optional] 
- **float** | **Float**| None | [optional] 
- **string** | **String**| None | [optional] 
- **binary** | **File**| None | [optional] 
- **date** | **Date**| None | [optional] 
- **date_time** | **Time**| None | [optional] 
- **password** | **String**| None | [optional] 
- **callback** | **String**| None | [optional] 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **number** | **Float** | None |  |
+| **double** | **Float** | None |  |
+| **pattern_without_delimiter** | **String** | None |  |
+| **byte** | **String** | None |  |
+| **integer** | **Integer** | None | [optional] |
+| **int32** | **Integer** | None | [optional] |
+| **int64** | **Integer** | None | [optional] |
+| **float** | **Float** | None | [optional] |
+| **string** | **String** | None | [optional] |
+| **binary** | **File** | None | [optional] |
+| **date** | **Date** | None | [optional] |
+| **date_time** | **Time** | None | [optional] |
+| **password** | **String** | None | [optional] |
+| **callback** | **String** | None | [optional] |
 
 ### Return type
 
@@ -561,17 +551,16 @@ end
 
 ### Parameters
 
-
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **enum_header_string_array** | [**Array&lt;String&gt;**](String.md)| Header parameter enum test (string array) | [optional] 
- **enum_header_string** | **String**| Header parameter enum test (string) | [optional] [default to &#39;-efg&#39;]
- **enum_query_string_array** | [**Array&lt;String&gt;**](String.md)| Query parameter enum test (string array) | [optional] 
- **enum_query_string** | **String**| Query parameter enum test (string) | [optional] [default to &#39;-efg&#39;]
- **enum_query_integer** | **Integer**| Query parameter enum test (double) | [optional] 
- **enum_query_double** | **Float**| Query parameter enum test (double) | [optional] 
- **enum_form_string_array** | [**Array&lt;String&gt;**](String.md)| Form parameter enum test (string array) | [optional] [default to &#39;$&#39;]
- **enum_form_string** | **String**| Form parameter enum test (string) | [optional] [default to &#39;-efg&#39;]
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **enum_header_string_array** | [**Array&lt;String&gt;**](String.md) | Header parameter enum test (string array) | [optional] |
+| **enum_header_string** | **String** | Header parameter enum test (string) | [optional][default to &#39;-efg&#39;] |
+| **enum_query_string_array** | [**Array&lt;String&gt;**](String.md) | Query parameter enum test (string array) | [optional] |
+| **enum_query_string** | **String** | Query parameter enum test (string) | [optional][default to &#39;-efg&#39;] |
+| **enum_query_integer** | **Integer** | Query parameter enum test (double) | [optional] |
+| **enum_query_double** | **Float** | Query parameter enum test (double) | [optional] |
+| **enum_form_string_array** | [**Array&lt;String&gt;**](String.md) | Form parameter enum test (string array) | [optional][default to &#39;$&#39;] |
+| **enum_form_string** | **String** | Form parameter enum test (string) | [optional][default to &#39;-efg&#39;] |
 
 ### Return type
 
@@ -626,15 +615,14 @@ end
 
 ### Parameters
 
-
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **required_string_group** | **Integer**| Required String in group parameters | 
- **required_boolean_group** | **Boolean**| Required Boolean in group parameters | 
- **required_int64_group** | **Integer**| Required Integer in group parameters | 
- **string_group** | **Integer**| String in group parameters | [optional] 
- **boolean_group** | **Boolean**| Boolean in group parameters | [optional] 
- **int64_group** | **Integer**| Integer in group parameters | [optional] 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **required_string_group** | **Integer** | Required String in group parameters |  |
+| **required_boolean_group** | **Boolean** | Required Boolean in group parameters |  |
+| **required_int64_group** | **Integer** | Required Integer in group parameters |  |
+| **string_group** | **Integer** | String in group parameters | [optional] |
+| **boolean_group** | **Boolean** | Boolean in group parameters | [optional] |
+| **int64_group** | **Integer** | Integer in group parameters | [optional] |
 
 ### Return type
 
@@ -675,10 +663,9 @@ end
 
 ### Parameters
 
-
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **request_body** | [**Hash&lt;String, String&gt;**](String.md)| request body | 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **request_body** | [**Hash&lt;String, String&gt;**](String.md) | request body |  |
 
 ### Return type
 
@@ -720,11 +707,10 @@ end
 
 ### Parameters
 
-
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **param** | **String**| field1 | 
- **param2** | **String**| field2 | 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **param** | **String** | field1 |  |
+| **param2** | **String** | field2 |  |
 
 ### Return type
 
@@ -770,14 +756,13 @@ end
 
 ### Parameters
 
-
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **pipe** | [**Array&lt;String&gt;**](String.md)|  | 
- **ioutil** | [**Array&lt;String&gt;**](String.md)|  | 
- **http** | [**Array&lt;String&gt;**](String.md)|  | 
- **url** | [**Array&lt;String&gt;**](String.md)|  | 
- **context** | [**Array&lt;String&gt;**](String.md)|  | 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **pipe** | [**Array&lt;String&gt;**](String.md) |  |  |
+| **ioutil** | [**Array&lt;String&gt;**](String.md) |  |  |
+| **http** | [**Array&lt;String&gt;**](String.md) |  |  |
+| **url** | [**Array&lt;String&gt;**](String.md) |  |  |
+| **context** | [**Array&lt;String&gt;**](String.md) |  |  |
 
 ### Return type
 

--- a/samples/client/petstore/ruby/docs/FakeClassnameTags123Api.md
+++ b/samples/client/petstore/ruby/docs/FakeClassnameTags123Api.md
@@ -2,10 +2,9 @@
 
 All URIs are relative to *http://petstore.swagger.io:80/v2*
 
-Method | HTTP request | Description
-------------- | ------------- | -------------
-[**test_classname**](FakeClassnameTags123Api.md#test_classname) | **PATCH** /fake_classname_test | To test class name in snake case
-
+| Method | HTTP request | Description |
+| ------ | ------------ | ----------- |
+| [**test_classname**](FakeClassnameTags123Api.md#test_classname) | **PATCH** /fake_classname_test | To test class name in snake case |
 
 
 ## test_classname
@@ -43,10 +42,9 @@ end
 
 ### Parameters
 
-
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **client** | [**Client**](Client.md)| client model | 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **client** | [**Client**](Client.md) | client model |  |
 
 ### Return type
 

--- a/samples/client/petstore/ruby/docs/File.md
+++ b/samples/client/petstore/ruby/docs/File.md
@@ -2,16 +2,17 @@
 
 ## Properties
 
-Name | Type | Description | Notes
------------- | ------------- | ------------- | -------------
-**source_uri** | **String** | Test capitalization | [optional] 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **source_uri** | **String** | Test capitalization | [optional] |
 
 ## Code Sample
 
 ```ruby
-require 'Petstore'
+require 'petstore'
 
-instance = Petstore::File.new(source_uri: null)
+instance = Petstore::File.new(
+  source_uri: null
+)
 ```
-
 

--- a/samples/client/petstore/ruby/docs/FileSchemaTestClass.md
+++ b/samples/client/petstore/ruby/docs/FileSchemaTestClass.md
@@ -2,18 +2,19 @@
 
 ## Properties
 
-Name | Type | Description | Notes
------------- | ------------- | ------------- | -------------
-**file** | **File** |  | [optional] 
-**files** | **Array&lt;File&gt;** |  | [optional] 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **file** | **File** |  | [optional] |
+| **files** | **Array&lt;File&gt;** |  | [optional] |
 
 ## Code Sample
 
 ```ruby
-require 'Petstore'
+require 'petstore'
 
-instance = Petstore::FileSchemaTestClass.new(file: null,
-                                 files: null)
+instance = Petstore::FileSchemaTestClass.new(
+  file: null,
+  files: null
+)
 ```
-
 

--- a/samples/client/petstore/ruby/docs/Foo.md
+++ b/samples/client/petstore/ruby/docs/Foo.md
@@ -2,16 +2,17 @@
 
 ## Properties
 
-Name | Type | Description | Notes
------------- | ------------- | ------------- | -------------
-**bar** | **String** |  | [optional] [default to &#39;bar&#39;]
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **bar** | **String** |  | [optional][default to &#39;bar&#39;] |
 
 ## Code Sample
 
 ```ruby
-require 'Petstore'
+require 'petstore'
 
-instance = Petstore::Foo.new(bar: null)
+instance = Petstore::Foo.new(
+  bar: null
+)
 ```
-
 

--- a/samples/client/petstore/ruby/docs/FormatTest.md
+++ b/samples/client/petstore/ruby/docs/FormatTest.md
@@ -2,46 +2,47 @@
 
 ## Properties
 
-Name | Type | Description | Notes
------------- | ------------- | ------------- | -------------
-**integer** | **Integer** |  | [optional] 
-**int32** | **Integer** |  | [optional] 
-**int64** | **Integer** |  | [optional] 
-**number** | **Float** |  | 
-**float** | **Float** |  | [optional] 
-**double** | **Float** |  | [optional] 
-**decimal** | [**Decimal**](Decimal.md) |  | [optional] 
-**string** | **String** |  | [optional] 
-**byte** | **String** |  | 
-**binary** | **File** |  | [optional] 
-**date** | **Date** |  | 
-**date_time** | **Time** |  | [optional] 
-**uuid** | **String** |  | [optional] 
-**password** | **String** |  | 
-**pattern_with_digits** | **String** | A string that is a 10 digit number. Can have leading zeros. | [optional] 
-**pattern_with_digits_and_delimiter** | **String** | A string starting with &#39;image_&#39; (case insensitive) and one to three digits following i.e. Image_01. | [optional] 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **integer** | **Integer** |  | [optional] |
+| **int32** | **Integer** |  | [optional] |
+| **int64** | **Integer** |  | [optional] |
+| **number** | **Float** |  |  |
+| **float** | **Float** |  | [optional] |
+| **double** | **Float** |  | [optional] |
+| **decimal** | [**Decimal**](Decimal.md) |  | [optional] |
+| **string** | **String** |  | [optional] |
+| **byte** | **String** |  |  |
+| **binary** | **File** |  | [optional] |
+| **date** | **Date** |  |  |
+| **date_time** | **Time** |  | [optional] |
+| **uuid** | **String** |  | [optional] |
+| **password** | **String** |  |  |
+| **pattern_with_digits** | **String** | A string that is a 10 digit number. Can have leading zeros. | [optional] |
+| **pattern_with_digits_and_delimiter** | **String** | A string starting with &#39;image_&#39; (case insensitive) and one to three digits following i.e. Image_01. | [optional] |
 
 ## Code Sample
 
 ```ruby
-require 'Petstore'
+require 'petstore'
 
-instance = Petstore::FormatTest.new(integer: null,
-                                 int32: null,
-                                 int64: null,
-                                 number: null,
-                                 float: null,
-                                 double: null,
-                                 decimal: null,
-                                 string: null,
-                                 byte: null,
-                                 binary: null,
-                                 date: null,
-                                 date_time: null,
-                                 uuid: 72f98069-206d-4f12-9f12-3d1e525a8e84,
-                                 password: null,
-                                 pattern_with_digits: null,
-                                 pattern_with_digits_and_delimiter: null)
+instance = Petstore::FormatTest.new(
+  integer: null,
+  int32: null,
+  int64: null,
+  number: null,
+  float: null,
+  double: null,
+  decimal: null,
+  string: null,
+  byte: null,
+  binary: null,
+  date: null,
+  date_time: null,
+  uuid: 72f98069-206d-4f12-9f12-3d1e525a8e84,
+  password: null,
+  pattern_with_digits: null,
+  pattern_with_digits_and_delimiter: null
+)
 ```
-
 

--- a/samples/client/petstore/ruby/docs/HasOnlyReadOnly.md
+++ b/samples/client/petstore/ruby/docs/HasOnlyReadOnly.md
@@ -2,18 +2,19 @@
 
 ## Properties
 
-Name | Type | Description | Notes
------------- | ------------- | ------------- | -------------
-**bar** | **String** |  | [optional] [readonly] 
-**foo** | **String** |  | [optional] [readonly] 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **bar** | **String** |  | [optional][readonly] |
+| **foo** | **String** |  | [optional][readonly] |
 
 ## Code Sample
 
 ```ruby
-require 'Petstore'
+require 'petstore'
 
-instance = Petstore::HasOnlyReadOnly.new(bar: null,
-                                 foo: null)
+instance = Petstore::HasOnlyReadOnly.new(
+  bar: null,
+  foo: null
+)
 ```
-
 

--- a/samples/client/petstore/ruby/docs/HealthCheckResult.md
+++ b/samples/client/petstore/ruby/docs/HealthCheckResult.md
@@ -2,16 +2,17 @@
 
 ## Properties
 
-Name | Type | Description | Notes
------------- | ------------- | ------------- | -------------
-**nullable_message** | **String** |  | [optional] 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **nullable_message** | **String** |  | [optional] |
 
 ## Code Sample
 
 ```ruby
-require 'Petstore'
+require 'petstore'
 
-instance = Petstore::HealthCheckResult.new(nullable_message: null)
+instance = Petstore::HealthCheckResult.new(
+  nullable_message: null
+)
 ```
-
 

--- a/samples/client/petstore/ruby/docs/InlineObject.md
+++ b/samples/client/petstore/ruby/docs/InlineObject.md
@@ -2,18 +2,19 @@
 
 ## Properties
 
-Name | Type | Description | Notes
------------- | ------------- | ------------- | -------------
-**name** | **String** | Updated name of the pet | [optional] 
-**status** | **String** | Updated status of the pet | [optional] 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **name** | **String** | Updated name of the pet | [optional] |
+| **status** | **String** | Updated status of the pet | [optional] |
 
 ## Code Sample
 
 ```ruby
-require 'Petstore'
+require 'petstore'
 
-instance = Petstore::InlineObject.new(name: null,
-                                 status: null)
+instance = Petstore::InlineObject.new(
+  name: null,
+  status: null
+)
 ```
-
 

--- a/samples/client/petstore/ruby/docs/InlineObject1.md
+++ b/samples/client/petstore/ruby/docs/InlineObject1.md
@@ -2,18 +2,19 @@
 
 ## Properties
 
-Name | Type | Description | Notes
------------- | ------------- | ------------- | -------------
-**additional_metadata** | **String** | Additional data to pass to server | [optional] 
-**file** | **File** | file to upload | [optional] 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **additional_metadata** | **String** | Additional data to pass to server | [optional] |
+| **file** | **File** | file to upload | [optional] |
 
 ## Code Sample
 
 ```ruby
-require 'Petstore'
+require 'petstore'
 
-instance = Petstore::InlineObject1.new(additional_metadata: null,
-                                 file: null)
+instance = Petstore::InlineObject1.new(
+  additional_metadata: null,
+  file: null
+)
 ```
-
 

--- a/samples/client/petstore/ruby/docs/InlineObject2.md
+++ b/samples/client/petstore/ruby/docs/InlineObject2.md
@@ -2,18 +2,19 @@
 
 ## Properties
 
-Name | Type | Description | Notes
------------- | ------------- | ------------- | -------------
-**enum_form_string_array** | **Array&lt;String&gt;** | Form parameter enum test (string array) | [optional] 
-**enum_form_string** | **String** | Form parameter enum test (string) | [optional] [default to &#39;-efg&#39;]
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **enum_form_string_array** | **Array&lt;String&gt;** | Form parameter enum test (string array) | [optional] |
+| **enum_form_string** | **String** | Form parameter enum test (string) | [optional][default to &#39;-efg&#39;] |
 
 ## Code Sample
 
 ```ruby
-require 'Petstore'
+require 'petstore'
 
-instance = Petstore::InlineObject2.new(enum_form_string_array: null,
-                                 enum_form_string: null)
+instance = Petstore::InlineObject2.new(
+  enum_form_string_array: null,
+  enum_form_string: null
+)
 ```
-
 

--- a/samples/client/petstore/ruby/docs/InlineObject3.md
+++ b/samples/client/petstore/ruby/docs/InlineObject3.md
@@ -2,42 +2,43 @@
 
 ## Properties
 
-Name | Type | Description | Notes
------------- | ------------- | ------------- | -------------
-**integer** | **Integer** | None | [optional] 
-**int32** | **Integer** | None | [optional] 
-**int64** | **Integer** | None | [optional] 
-**number** | **Float** | None | 
-**float** | **Float** | None | [optional] 
-**double** | **Float** | None | 
-**string** | **String** | None | [optional] 
-**pattern_without_delimiter** | **String** | None | 
-**byte** | **String** | None | 
-**binary** | **File** | None | [optional] 
-**date** | **Date** | None | [optional] 
-**date_time** | **Time** | None | [optional] 
-**password** | **String** | None | [optional] 
-**callback** | **String** | None | [optional] 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **integer** | **Integer** | None | [optional] |
+| **int32** | **Integer** | None | [optional] |
+| **int64** | **Integer** | None | [optional] |
+| **number** | **Float** | None |  |
+| **float** | **Float** | None | [optional] |
+| **double** | **Float** | None |  |
+| **string** | **String** | None | [optional] |
+| **pattern_without_delimiter** | **String** | None |  |
+| **byte** | **String** | None |  |
+| **binary** | **File** | None | [optional] |
+| **date** | **Date** | None | [optional] |
+| **date_time** | **Time** | None | [optional] |
+| **password** | **String** | None | [optional] |
+| **callback** | **String** | None | [optional] |
 
 ## Code Sample
 
 ```ruby
-require 'Petstore'
+require 'petstore'
 
-instance = Petstore::InlineObject3.new(integer: null,
-                                 int32: null,
-                                 int64: null,
-                                 number: null,
-                                 float: null,
-                                 double: null,
-                                 string: null,
-                                 pattern_without_delimiter: null,
-                                 byte: null,
-                                 binary: null,
-                                 date: null,
-                                 date_time: null,
-                                 password: null,
-                                 callback: null)
+instance = Petstore::InlineObject3.new(
+  integer: null,
+  int32: null,
+  int64: null,
+  number: null,
+  float: null,
+  double: null,
+  string: null,
+  pattern_without_delimiter: null,
+  byte: null,
+  binary: null,
+  date: null,
+  date_time: null,
+  password: null,
+  callback: null
+)
 ```
-
 

--- a/samples/client/petstore/ruby/docs/InlineObject4.md
+++ b/samples/client/petstore/ruby/docs/InlineObject4.md
@@ -2,18 +2,19 @@
 
 ## Properties
 
-Name | Type | Description | Notes
------------- | ------------- | ------------- | -------------
-**param** | **String** | field1 | 
-**param2** | **String** | field2 | 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **param** | **String** | field1 |  |
+| **param2** | **String** | field2 |  |
 
 ## Code Sample
 
 ```ruby
-require 'Petstore'
+require 'petstore'
 
-instance = Petstore::InlineObject4.new(param: null,
-                                 param2: null)
+instance = Petstore::InlineObject4.new(
+  param: null,
+  param2: null
+)
 ```
-
 

--- a/samples/client/petstore/ruby/docs/InlineObject5.md
+++ b/samples/client/petstore/ruby/docs/InlineObject5.md
@@ -2,18 +2,19 @@
 
 ## Properties
 
-Name | Type | Description | Notes
------------- | ------------- | ------------- | -------------
-**additional_metadata** | **String** | Additional data to pass to server | [optional] 
-**required_file** | **File** | file to upload | 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **additional_metadata** | **String** | Additional data to pass to server | [optional] |
+| **required_file** | **File** | file to upload |  |
 
 ## Code Sample
 
 ```ruby
-require 'Petstore'
+require 'petstore'
 
-instance = Petstore::InlineObject5.new(additional_metadata: null,
-                                 required_file: null)
+instance = Petstore::InlineObject5.new(
+  additional_metadata: null,
+  required_file: null
+)
 ```
-
 

--- a/samples/client/petstore/ruby/docs/InlineResponseDefault.md
+++ b/samples/client/petstore/ruby/docs/InlineResponseDefault.md
@@ -2,16 +2,17 @@
 
 ## Properties
 
-Name | Type | Description | Notes
------------- | ------------- | ------------- | -------------
-**string** | [**Foo**](Foo.md) |  | [optional] 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **string** | [**Foo**](Foo.md) |  | [optional] |
 
 ## Code Sample
 
 ```ruby
-require 'Petstore'
+require 'petstore'
 
-instance = Petstore::InlineResponseDefault.new(string: null)
+instance = Petstore::InlineResponseDefault.new(
+  string: null
+)
 ```
-
 

--- a/samples/client/petstore/ruby/docs/List.md
+++ b/samples/client/petstore/ruby/docs/List.md
@@ -2,16 +2,17 @@
 
 ## Properties
 
-Name | Type | Description | Notes
------------- | ------------- | ------------- | -------------
-**_123_list** | **String** |  | [optional] 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **_123_list** | **String** |  | [optional] |
 
 ## Code Sample
 
 ```ruby
-require 'Petstore'
+require 'petstore'
 
-instance = Petstore::List.new(_123_list: null)
+instance = Petstore::List.new(
+  _123_list: null
+)
 ```
-
 

--- a/samples/client/petstore/ruby/docs/MapTest.md
+++ b/samples/client/petstore/ruby/docs/MapTest.md
@@ -2,22 +2,23 @@
 
 ## Properties
 
-Name | Type | Description | Notes
------------- | ------------- | ------------- | -------------
-**map_map_of_string** | **Hash&lt;String, Hash&lt;String, String&gt;&gt;** |  | [optional] 
-**map_of_enum_string** | **Hash&lt;String, String&gt;** |  | [optional] 
-**direct_map** | **Hash&lt;String, Boolean&gt;** |  | [optional] 
-**indirect_map** | **Hash&lt;String, Boolean&gt;** |  | [optional] 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **map_map_of_string** | **Hash&lt;String, Hash&lt;String, String&gt;&gt;** |  | [optional] |
+| **map_of_enum_string** | **Hash&lt;String, String&gt;** |  | [optional] |
+| **direct_map** | **Hash&lt;String, Boolean&gt;** |  | [optional] |
+| **indirect_map** | **Hash&lt;String, Boolean&gt;** |  | [optional] |
 
 ## Code Sample
 
 ```ruby
-require 'Petstore'
+require 'petstore'
 
-instance = Petstore::MapTest.new(map_map_of_string: null,
-                                 map_of_enum_string: null,
-                                 direct_map: null,
-                                 indirect_map: null)
+instance = Petstore::MapTest.new(
+  map_map_of_string: null,
+  map_of_enum_string: null,
+  direct_map: null,
+  indirect_map: null
+)
 ```
-
 

--- a/samples/client/petstore/ruby/docs/MixedPropertiesAndAdditionalPropertiesClass.md
+++ b/samples/client/petstore/ruby/docs/MixedPropertiesAndAdditionalPropertiesClass.md
@@ -2,20 +2,21 @@
 
 ## Properties
 
-Name | Type | Description | Notes
------------- | ------------- | ------------- | -------------
-**uuid** | **String** |  | [optional] 
-**date_time** | **Time** |  | [optional] 
-**map** | [**Hash&lt;String, Animal&gt;**](Animal.md) |  | [optional] 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **uuid** | **String** |  | [optional] |
+| **date_time** | **Time** |  | [optional] |
+| **map** | [**Hash&lt;String, Animal&gt;**](Animal.md) |  | [optional] |
 
 ## Code Sample
 
 ```ruby
-require 'Petstore'
+require 'petstore'
 
-instance = Petstore::MixedPropertiesAndAdditionalPropertiesClass.new(uuid: null,
-                                 date_time: null,
-                                 map: null)
+instance = Petstore::MixedPropertiesAndAdditionalPropertiesClass.new(
+  uuid: null,
+  date_time: null,
+  map: null
+)
 ```
-
 

--- a/samples/client/petstore/ruby/docs/Model200Response.md
+++ b/samples/client/petstore/ruby/docs/Model200Response.md
@@ -2,18 +2,19 @@
 
 ## Properties
 
-Name | Type | Description | Notes
------------- | ------------- | ------------- | -------------
-**name** | **Integer** |  | [optional] 
-**_class** | **String** |  | [optional] 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **name** | **Integer** |  | [optional] |
+| **_class** | **String** |  | [optional] |
 
 ## Code Sample
 
 ```ruby
-require 'Petstore'
+require 'petstore'
 
-instance = Petstore::Model200Response.new(name: null,
-                                 _class: null)
+instance = Petstore::Model200Response.new(
+  name: null,
+  _class: null
+)
 ```
-
 

--- a/samples/client/petstore/ruby/docs/ModelReturn.md
+++ b/samples/client/petstore/ruby/docs/ModelReturn.md
@@ -2,16 +2,17 @@
 
 ## Properties
 
-Name | Type | Description | Notes
------------- | ------------- | ------------- | -------------
-**_return** | **Integer** |  | [optional] 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **_return** | **Integer** |  | [optional] |
 
 ## Code Sample
 
 ```ruby
-require 'Petstore'
+require 'petstore'
 
-instance = Petstore::ModelReturn.new(_return: null)
+instance = Petstore::ModelReturn.new(
+  _return: null
+)
 ```
-
 

--- a/samples/client/petstore/ruby/docs/Name.md
+++ b/samples/client/petstore/ruby/docs/Name.md
@@ -2,22 +2,23 @@
 
 ## Properties
 
-Name | Type | Description | Notes
------------- | ------------- | ------------- | -------------
-**name** | **Integer** |  | 
-**snake_case** | **Integer** |  | [optional] [readonly] 
-**property** | **String** |  | [optional] 
-**_123_number** | **Integer** |  | [optional] [readonly] 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **name** | **Integer** |  |  |
+| **snake_case** | **Integer** |  | [optional][readonly] |
+| **property** | **String** |  | [optional] |
+| **_123_number** | **Integer** |  | [optional][readonly] |
 
 ## Code Sample
 
 ```ruby
-require 'Petstore'
+require 'petstore'
 
-instance = Petstore::Name.new(name: null,
-                                 snake_case: null,
-                                 property: null,
-                                 _123_number: null)
+instance = Petstore::Name.new(
+  name: null,
+  snake_case: null,
+  property: null,
+  _123_number: null
+)
 ```
-
 

--- a/samples/client/petstore/ruby/docs/NullableClass.md
+++ b/samples/client/petstore/ruby/docs/NullableClass.md
@@ -2,38 +2,39 @@
 
 ## Properties
 
-Name | Type | Description | Notes
------------- | ------------- | ------------- | -------------
-**integer_prop** | **Integer** |  | [optional] 
-**number_prop** | **Float** |  | [optional] 
-**boolean_prop** | **Boolean** |  | [optional] 
-**string_prop** | **String** |  | [optional] 
-**date_prop** | **Date** |  | [optional] 
-**datetime_prop** | **Time** |  | [optional] 
-**array_nullable_prop** | **Array&lt;Object&gt;** |  | [optional] 
-**array_and_items_nullable_prop** | **Array&lt;Object&gt;** |  | [optional] 
-**array_items_nullable** | **Array&lt;Object&gt;** |  | [optional] 
-**object_nullable_prop** | **Hash&lt;String, Object&gt;** |  | [optional] 
-**object_and_items_nullable_prop** | **Hash&lt;String, Object&gt;** |  | [optional] 
-**object_items_nullable** | **Hash&lt;String, Object&gt;** |  | [optional] 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **integer_prop** | **Integer** |  | [optional] |
+| **number_prop** | **Float** |  | [optional] |
+| **boolean_prop** | **Boolean** |  | [optional] |
+| **string_prop** | **String** |  | [optional] |
+| **date_prop** | **Date** |  | [optional] |
+| **datetime_prop** | **Time** |  | [optional] |
+| **array_nullable_prop** | **Array&lt;Object&gt;** |  | [optional] |
+| **array_and_items_nullable_prop** | **Array&lt;Object&gt;** |  | [optional] |
+| **array_items_nullable** | **Array&lt;Object&gt;** |  | [optional] |
+| **object_nullable_prop** | **Hash&lt;String, Object&gt;** |  | [optional] |
+| **object_and_items_nullable_prop** | **Hash&lt;String, Object&gt;** |  | [optional] |
+| **object_items_nullable** | **Hash&lt;String, Object&gt;** |  | [optional] |
 
 ## Code Sample
 
 ```ruby
-require 'Petstore'
+require 'petstore'
 
-instance = Petstore::NullableClass.new(integer_prop: null,
-                                 number_prop: null,
-                                 boolean_prop: null,
-                                 string_prop: null,
-                                 date_prop: null,
-                                 datetime_prop: null,
-                                 array_nullable_prop: null,
-                                 array_and_items_nullable_prop: null,
-                                 array_items_nullable: null,
-                                 object_nullable_prop: null,
-                                 object_and_items_nullable_prop: null,
-                                 object_items_nullable: null)
+instance = Petstore::NullableClass.new(
+  integer_prop: null,
+  number_prop: null,
+  boolean_prop: null,
+  string_prop: null,
+  date_prop: null,
+  datetime_prop: null,
+  array_nullable_prop: null,
+  array_and_items_nullable_prop: null,
+  array_items_nullable: null,
+  object_nullable_prop: null,
+  object_and_items_nullable_prop: null,
+  object_items_nullable: null
+)
 ```
-
 

--- a/samples/client/petstore/ruby/docs/NumberOnly.md
+++ b/samples/client/petstore/ruby/docs/NumberOnly.md
@@ -2,16 +2,17 @@
 
 ## Properties
 
-Name | Type | Description | Notes
------------- | ------------- | ------------- | -------------
-**just_number** | **Float** |  | [optional] 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **just_number** | **Float** |  | [optional] |
 
 ## Code Sample
 
 ```ruby
-require 'Petstore'
+require 'petstore'
 
-instance = Petstore::NumberOnly.new(just_number: null)
+instance = Petstore::NumberOnly.new(
+  just_number: null
+)
 ```
-
 

--- a/samples/client/petstore/ruby/docs/Order.md
+++ b/samples/client/petstore/ruby/docs/Order.md
@@ -2,26 +2,27 @@
 
 ## Properties
 
-Name | Type | Description | Notes
------------- | ------------- | ------------- | -------------
-**id** | **Integer** |  | [optional] 
-**pet_id** | **Integer** |  | [optional] 
-**quantity** | **Integer** |  | [optional] 
-**ship_date** | **Time** |  | [optional] 
-**status** | **String** | Order Status | [optional] 
-**complete** | **Boolean** |  | [optional] [default to false]
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **id** | **Integer** |  | [optional] |
+| **pet_id** | **Integer** |  | [optional] |
+| **quantity** | **Integer** |  | [optional] |
+| **ship_date** | **Time** |  | [optional] |
+| **status** | **String** | Order Status | [optional] |
+| **complete** | **Boolean** |  | [optional][default to false] |
 
 ## Code Sample
 
 ```ruby
-require 'Petstore'
+require 'petstore'
 
-instance = Petstore::Order.new(id: null,
-                                 pet_id: null,
-                                 quantity: null,
-                                 ship_date: null,
-                                 status: null,
-                                 complete: null)
+instance = Petstore::Order.new(
+  id: null,
+  pet_id: null,
+  quantity: null,
+  ship_date: null,
+  status: null,
+  complete: null
+)
 ```
-
 

--- a/samples/client/petstore/ruby/docs/OuterComposite.md
+++ b/samples/client/petstore/ruby/docs/OuterComposite.md
@@ -2,20 +2,21 @@
 
 ## Properties
 
-Name | Type | Description | Notes
------------- | ------------- | ------------- | -------------
-**my_number** | **Float** |  | [optional] 
-**my_string** | **String** |  | [optional] 
-**my_boolean** | **Boolean** |  | [optional] 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **my_number** | **Float** |  | [optional] |
+| **my_string** | **String** |  | [optional] |
+| **my_boolean** | **Boolean** |  | [optional] |
 
 ## Code Sample
 
 ```ruby
-require 'Petstore'
+require 'petstore'
 
-instance = Petstore::OuterComposite.new(my_number: null,
-                                 my_string: null,
-                                 my_boolean: null)
+instance = Petstore::OuterComposite.new(
+  my_number: null,
+  my_string: null,
+  my_boolean: null
+)
 ```
-
 

--- a/samples/client/petstore/ruby/docs/OuterEnum.md
+++ b/samples/client/petstore/ruby/docs/OuterEnum.md
@@ -2,15 +2,14 @@
 
 ## Properties
 
-Name | Type | Description | Notes
------------- | ------------- | ------------- | -------------
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
 
 ## Code Sample
 
 ```ruby
-require 'Petstore'
+require 'petstore'
 
 instance = Petstore::OuterEnum.new()
 ```
-
 

--- a/samples/client/petstore/ruby/docs/OuterEnumDefaultValue.md
+++ b/samples/client/petstore/ruby/docs/OuterEnumDefaultValue.md
@@ -2,15 +2,14 @@
 
 ## Properties
 
-Name | Type | Description | Notes
------------- | ------------- | ------------- | -------------
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
 
 ## Code Sample
 
 ```ruby
-require 'Petstore'
+require 'petstore'
 
 instance = Petstore::OuterEnumDefaultValue.new()
 ```
-
 

--- a/samples/client/petstore/ruby/docs/OuterEnumInteger.md
+++ b/samples/client/petstore/ruby/docs/OuterEnumInteger.md
@@ -2,15 +2,14 @@
 
 ## Properties
 
-Name | Type | Description | Notes
------------- | ------------- | ------------- | -------------
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
 
 ## Code Sample
 
 ```ruby
-require 'Petstore'
+require 'petstore'
 
 instance = Petstore::OuterEnumInteger.new()
 ```
-
 

--- a/samples/client/petstore/ruby/docs/OuterEnumIntegerDefaultValue.md
+++ b/samples/client/petstore/ruby/docs/OuterEnumIntegerDefaultValue.md
@@ -2,15 +2,14 @@
 
 ## Properties
 
-Name | Type | Description | Notes
------------- | ------------- | ------------- | -------------
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
 
 ## Code Sample
 
 ```ruby
-require 'Petstore'
+require 'petstore'
 
 instance = Petstore::OuterEnumIntegerDefaultValue.new()
 ```
-
 

--- a/samples/client/petstore/ruby/docs/Pet.md
+++ b/samples/client/petstore/ruby/docs/Pet.md
@@ -2,26 +2,27 @@
 
 ## Properties
 
-Name | Type | Description | Notes
------------- | ------------- | ------------- | -------------
-**id** | **Integer** |  | [optional] 
-**category** | [**Category**](Category.md) |  | [optional] 
-**name** | **String** |  | 
-**photo_urls** | **Array&lt;String&gt;** |  | 
-**tags** | [**Array&lt;Tag&gt;**](Tag.md) |  | [optional] 
-**status** | **String** | pet status in the store | [optional] 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **id** | **Integer** |  | [optional] |
+| **category** | [**Category**](Category.md) |  | [optional] |
+| **name** | **String** |  |  |
+| **photo_urls** | **Array&lt;String&gt;** |  |  |
+| **tags** | [**Array&lt;Tag&gt;**](Tag.md) |  | [optional] |
+| **status** | **String** | pet status in the store | [optional] |
 
 ## Code Sample
 
 ```ruby
-require 'Petstore'
+require 'petstore'
 
-instance = Petstore::Pet.new(id: null,
-                                 category: null,
-                                 name: doggie,
-                                 photo_urls: null,
-                                 tags: null,
-                                 status: null)
+instance = Petstore::Pet.new(
+  id: null,
+  category: null,
+  name: doggie,
+  photo_urls: null,
+  tags: null,
+  status: null
+)
 ```
-
 

--- a/samples/client/petstore/ruby/docs/PetApi.md
+++ b/samples/client/petstore/ruby/docs/PetApi.md
@@ -2,18 +2,17 @@
 
 All URIs are relative to *http://petstore.swagger.io:80/v2*
 
-Method | HTTP request | Description
-------------- | ------------- | -------------
-[**add_pet**](PetApi.md#add_pet) | **POST** /pet | Add a new pet to the store
-[**delete_pet**](PetApi.md#delete_pet) | **DELETE** /pet/{petId} | Deletes a pet
-[**find_pets_by_status**](PetApi.md#find_pets_by_status) | **GET** /pet/findByStatus | Finds Pets by status
-[**find_pets_by_tags**](PetApi.md#find_pets_by_tags) | **GET** /pet/findByTags | Finds Pets by tags
-[**get_pet_by_id**](PetApi.md#get_pet_by_id) | **GET** /pet/{petId} | Find pet by ID
-[**update_pet**](PetApi.md#update_pet) | **PUT** /pet | Update an existing pet
-[**update_pet_with_form**](PetApi.md#update_pet_with_form) | **POST** /pet/{petId} | Updates a pet in the store with form data
-[**upload_file**](PetApi.md#upload_file) | **POST** /pet/{petId}/uploadImage | uploads an image
-[**upload_file_with_required_file**](PetApi.md#upload_file_with_required_file) | **POST** /fake/{petId}/uploadImageWithRequiredFile | uploads an image (required)
-
+| Method | HTTP request | Description |
+| ------ | ------------ | ----------- |
+| [**add_pet**](PetApi.md#add_pet) | **POST** /pet | Add a new pet to the store |
+| [**delete_pet**](PetApi.md#delete_pet) | **DELETE** /pet/{petId} | Deletes a pet |
+| [**find_pets_by_status**](PetApi.md#find_pets_by_status) | **GET** /pet/findByStatus | Finds Pets by status |
+| [**find_pets_by_tags**](PetApi.md#find_pets_by_tags) | **GET** /pet/findByTags | Finds Pets by tags |
+| [**get_pet_by_id**](PetApi.md#get_pet_by_id) | **GET** /pet/{petId} | Find pet by ID |
+| [**update_pet**](PetApi.md#update_pet) | **PUT** /pet | Update an existing pet |
+| [**update_pet_with_form**](PetApi.md#update_pet_with_form) | **POST** /pet/{petId} | Updates a pet in the store with form data |
+| [**upload_file**](PetApi.md#upload_file) | **POST** /pet/{petId}/uploadImage | uploads an image |
+| [**upload_file_with_required_file**](PetApi.md#upload_file_with_required_file) | **POST** /fake/{petId}/uploadImageWithRequiredFile | uploads an image (required) |
 
 
 ## add_pet
@@ -46,10 +45,9 @@ end
 
 ### Parameters
 
-
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **pet** | [**Pet**](Pet.md)| Pet object that needs to be added to the store | 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **pet** | [**Pet**](Pet.md) | Pet object that needs to be added to the store |  |
 
 ### Return type
 
@@ -98,11 +96,10 @@ end
 
 ### Parameters
 
-
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **pet_id** | **Integer**| Pet id to delete | 
- **api_key** | **String**|  | [optional] 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **pet_id** | **Integer** | Pet id to delete |  |
+| **api_key** | **String** |  | [optional] |
 
 ### Return type
 
@@ -151,10 +148,9 @@ end
 
 ### Parameters
 
-
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **status** | [**Array&lt;String&gt;**](String.md)| Status values that need to be considered for filter | 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **status** | [**Array&lt;String&gt;**](String.md) | Status values that need to be considered for filter |  |
 
 ### Return type
 
@@ -203,10 +199,9 @@ end
 
 ### Parameters
 
-
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **tags** | [**Array&lt;String&gt;**](String.md)| Tags to filter by | 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **tags** | [**Array&lt;String&gt;**](String.md) | Tags to filter by |  |
 
 ### Return type
 
@@ -257,10 +252,9 @@ end
 
 ### Parameters
 
-
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **pet_id** | **Integer**| ID of pet to return | 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **pet_id** | **Integer** | ID of pet to return |  |
 
 ### Return type
 
@@ -306,10 +300,9 @@ end
 
 ### Parameters
 
-
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **pet** | [**Pet**](Pet.md)| Pet object that needs to be added to the store | 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **pet** | [**Pet**](Pet.md) | Pet object that needs to be added to the store |  |
 
 ### Return type
 
@@ -359,12 +352,11 @@ end
 
 ### Parameters
 
-
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **pet_id** | **Integer**| ID of pet that needs to be updated | 
- **name** | **String**| Updated name of the pet | [optional] 
- **status** | **String**| Updated status of the pet | [optional] 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **pet_id** | **Integer** | ID of pet that needs to be updated |  |
+| **name** | **String** | Updated name of the pet | [optional] |
+| **status** | **String** | Updated status of the pet | [optional] |
 
 ### Return type
 
@@ -415,12 +407,11 @@ end
 
 ### Parameters
 
-
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **pet_id** | **Integer**| ID of pet to update | 
- **additional_metadata** | **String**| Additional data to pass to server | [optional] 
- **file** | **File**| file to upload | [optional] 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **pet_id** | **Integer** | ID of pet to update |  |
+| **additional_metadata** | **String** | Additional data to pass to server | [optional] |
+| **file** | **File** | file to upload | [optional] |
 
 ### Return type
 
@@ -471,12 +462,11 @@ end
 
 ### Parameters
 
-
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **pet_id** | **Integer**| ID of pet to update | 
- **required_file** | **File**| file to upload | 
- **additional_metadata** | **String**| Additional data to pass to server | [optional] 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **pet_id** | **Integer** | ID of pet to update |  |
+| **required_file** | **File** | file to upload |  |
+| **additional_metadata** | **String** | Additional data to pass to server | [optional] |
 
 ### Return type
 

--- a/samples/client/petstore/ruby/docs/ReadOnlyFirst.md
+++ b/samples/client/petstore/ruby/docs/ReadOnlyFirst.md
@@ -2,18 +2,19 @@
 
 ## Properties
 
-Name | Type | Description | Notes
------------- | ------------- | ------------- | -------------
-**bar** | **String** |  | [optional] [readonly] 
-**baz** | **String** |  | [optional] 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **bar** | **String** |  | [optional][readonly] |
+| **baz** | **String** |  | [optional] |
 
 ## Code Sample
 
 ```ruby
-require 'Petstore'
+require 'petstore'
 
-instance = Petstore::ReadOnlyFirst.new(bar: null,
-                                 baz: null)
+instance = Petstore::ReadOnlyFirst.new(
+  bar: null,
+  baz: null
+)
 ```
-
 

--- a/samples/client/petstore/ruby/docs/SpecialModelName.md
+++ b/samples/client/petstore/ruby/docs/SpecialModelName.md
@@ -2,16 +2,17 @@
 
 ## Properties
 
-Name | Type | Description | Notes
------------- | ------------- | ------------- | -------------
-**special_property_name** | **Integer** |  | [optional] 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **special_property_name** | **Integer** |  | [optional] |
 
 ## Code Sample
 
 ```ruby
-require 'Petstore'
+require 'petstore'
 
-instance = Petstore::SpecialModelName.new(special_property_name: null)
+instance = Petstore::SpecialModelName.new(
+  special_property_name: null
+)
 ```
-
 

--- a/samples/client/petstore/ruby/docs/StoreApi.md
+++ b/samples/client/petstore/ruby/docs/StoreApi.md
@@ -2,13 +2,12 @@
 
 All URIs are relative to *http://petstore.swagger.io:80/v2*
 
-Method | HTTP request | Description
-------------- | ------------- | -------------
-[**delete_order**](StoreApi.md#delete_order) | **DELETE** /store/order/{order_id} | Delete purchase order by ID
-[**get_inventory**](StoreApi.md#get_inventory) | **GET** /store/inventory | Returns pet inventories by status
-[**get_order_by_id**](StoreApi.md#get_order_by_id) | **GET** /store/order/{order_id} | Find purchase order by ID
-[**place_order**](StoreApi.md#place_order) | **POST** /store/order | Place an order for a pet
-
+| Method | HTTP request | Description |
+| ------ | ------------ | ----------- |
+| [**delete_order**](StoreApi.md#delete_order) | **DELETE** /store/order/{order_id} | Delete purchase order by ID |
+| [**get_inventory**](StoreApi.md#get_inventory) | **GET** /store/inventory | Returns pet inventories by status |
+| [**get_order_by_id**](StoreApi.md#get_order_by_id) | **GET** /store/order/{order_id} | Find purchase order by ID |
+| [**place_order**](StoreApi.md#place_order) | **POST** /store/order | Place an order for a pet |
 
 
 ## delete_order
@@ -38,10 +37,9 @@ end
 
 ### Parameters
 
-
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **order_id** | **String**| ID of the order that needs to be deleted | 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **order_id** | **String** | ID of the order that needs to be deleted |  |
 
 ### Return type
 
@@ -135,10 +133,9 @@ end
 
 ### Parameters
 
-
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **order_id** | **Integer**| ID of pet that needs to be fetched | 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **order_id** | **Integer** | ID of pet that needs to be fetched |  |
 
 ### Return type
 
@@ -180,10 +177,9 @@ end
 
 ### Parameters
 
-
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **order** | [**Order**](Order.md)| order placed for purchasing the pet | 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **order** | [**Order**](Order.md) | order placed for purchasing the pet |  |
 
 ### Return type
 

--- a/samples/client/petstore/ruby/docs/Tag.md
+++ b/samples/client/petstore/ruby/docs/Tag.md
@@ -2,18 +2,19 @@
 
 ## Properties
 
-Name | Type | Description | Notes
------------- | ------------- | ------------- | -------------
-**id** | **Integer** |  | [optional] 
-**name** | **String** |  | [optional] 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **id** | **Integer** |  | [optional] |
+| **name** | **String** |  | [optional] |
 
 ## Code Sample
 
 ```ruby
-require 'Petstore'
+require 'petstore'
 
-instance = Petstore::Tag.new(id: null,
-                                 name: null)
+instance = Petstore::Tag.new(
+  id: null,
+  name: null
+)
 ```
-
 

--- a/samples/client/petstore/ruby/docs/User.md
+++ b/samples/client/petstore/ruby/docs/User.md
@@ -2,30 +2,31 @@
 
 ## Properties
 
-Name | Type | Description | Notes
------------- | ------------- | ------------- | -------------
-**id** | **Integer** |  | [optional] 
-**username** | **String** |  | [optional] 
-**first_name** | **String** |  | [optional] 
-**last_name** | **String** |  | [optional] 
-**email** | **String** |  | [optional] 
-**password** | **String** |  | [optional] 
-**phone** | **String** |  | [optional] 
-**user_status** | **Integer** | User Status | [optional] 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **id** | **Integer** |  | [optional] |
+| **username** | **String** |  | [optional] |
+| **first_name** | **String** |  | [optional] |
+| **last_name** | **String** |  | [optional] |
+| **email** | **String** |  | [optional] |
+| **password** | **String** |  | [optional] |
+| **phone** | **String** |  | [optional] |
+| **user_status** | **Integer** | User Status | [optional] |
 
 ## Code Sample
 
 ```ruby
-require 'Petstore'
+require 'petstore'
 
-instance = Petstore::User.new(id: null,
-                                 username: null,
-                                 first_name: null,
-                                 last_name: null,
-                                 email: null,
-                                 password: null,
-                                 phone: null,
-                                 user_status: null)
+instance = Petstore::User.new(
+  id: null,
+  username: null,
+  first_name: null,
+  last_name: null,
+  email: null,
+  password: null,
+  phone: null,
+  user_status: null
+)
 ```
-
 

--- a/samples/client/petstore/ruby/docs/UserApi.md
+++ b/samples/client/petstore/ruby/docs/UserApi.md
@@ -2,17 +2,16 @@
 
 All URIs are relative to *http://petstore.swagger.io:80/v2*
 
-Method | HTTP request | Description
-------------- | ------------- | -------------
-[**create_user**](UserApi.md#create_user) | **POST** /user | Create user
-[**create_users_with_array_input**](UserApi.md#create_users_with_array_input) | **POST** /user/createWithArray | Creates list of users with given input array
-[**create_users_with_list_input**](UserApi.md#create_users_with_list_input) | **POST** /user/createWithList | Creates list of users with given input array
-[**delete_user**](UserApi.md#delete_user) | **DELETE** /user/{username} | Delete user
-[**get_user_by_name**](UserApi.md#get_user_by_name) | **GET** /user/{username} | Get user by user name
-[**login_user**](UserApi.md#login_user) | **GET** /user/login | Logs user into the system
-[**logout_user**](UserApi.md#logout_user) | **GET** /user/logout | Logs out current logged in user session
-[**update_user**](UserApi.md#update_user) | **PUT** /user/{username} | Updated user
-
+| Method | HTTP request | Description |
+| ------ | ------------ | ----------- |
+| [**create_user**](UserApi.md#create_user) | **POST** /user | Create user |
+| [**create_users_with_array_input**](UserApi.md#create_users_with_array_input) | **POST** /user/createWithArray | Creates list of users with given input array |
+| [**create_users_with_list_input**](UserApi.md#create_users_with_list_input) | **POST** /user/createWithList | Creates list of users with given input array |
+| [**delete_user**](UserApi.md#delete_user) | **DELETE** /user/{username} | Delete user |
+| [**get_user_by_name**](UserApi.md#get_user_by_name) | **GET** /user/{username} | Get user by user name |
+| [**login_user**](UserApi.md#login_user) | **GET** /user/login | Logs user into the system |
+| [**logout_user**](UserApi.md#logout_user) | **GET** /user/logout | Logs out current logged in user session |
+| [**update_user**](UserApi.md#update_user) | **PUT** /user/{username} | Updated user |
 
 
 ## create_user
@@ -42,10 +41,9 @@ end
 
 ### Parameters
 
-
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **user** | [**User**](User.md)| Created user object | 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **user** | [**User**](User.md) | Created user object |  |
 
 ### Return type
 
@@ -86,10 +84,9 @@ end
 
 ### Parameters
 
-
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **user** | [**Array&lt;User&gt;**](User.md)| List of user object | 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **user** | [**Array&lt;User&gt;**](User.md) | List of user object |  |
 
 ### Return type
 
@@ -130,10 +127,9 @@ end
 
 ### Parameters
 
-
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **user** | [**Array&lt;User&gt;**](User.md)| List of user object | 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **user** | [**Array&lt;User&gt;**](User.md) | List of user object |  |
 
 ### Return type
 
@@ -176,10 +172,9 @@ end
 
 ### Parameters
 
-
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **username** | **String**| The name that needs to be deleted | 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **username** | **String** | The name that needs to be deleted |  |
 
 ### Return type
 
@@ -221,10 +216,9 @@ end
 
 ### Parameters
 
-
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **username** | **String**| The name that needs to be fetched. Use user1 for testing. | 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **username** | **String** | The name that needs to be fetched. Use user1 for testing. |  |
 
 ### Return type
 
@@ -267,11 +261,10 @@ end
 
 ### Parameters
 
-
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **username** | **String**| The user name for login | 
- **password** | **String**| The password for login in clear text | 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **username** | **String** | The user name for login |  |
+| **password** | **String** | The password for login in clear text |  |
 
 ### Return type
 
@@ -355,11 +348,10 @@ end
 
 ### Parameters
 
-
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **username** | **String**| name that need to be deleted | 
- **user** | [**User**](User.md)| Updated user object | 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **username** | **String** | name that need to be deleted |  |
+| **user** | [**User**](User.md) | Updated user object |  |
 
 ### Return type
 

--- a/samples/client/petstore/ruby/lib/petstore/api_client.rb
+++ b/samples/client/petstore/ruby/lib/petstore/api_client.rb
@@ -275,8 +275,9 @@ module Petstore
           data.each { |k, v| hash[k] = convert_to_type(v, sub_type) }
         end
       else
-        # models, e.g. Pet
-        Petstore.const_get(return_type).build_from_hash(data)
+        # models (e.g. Pet) or oneOf
+        klass = Petstore.const_get(return_type)
+        klass.respond_to?(:openapi_one_of) ? klass.build(data) : klass.build_from_hash(data)
       end
     end
 

--- a/samples/client/petstore/ruby/lib/petstore/models/additional_properties_class.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/additional_properties_class.rb
@@ -169,7 +169,9 @@ module Petstore
           end
         end
       else # model
-        Petstore.const_get(type).build_from_hash(value)
+        # models (e.g. Pet) or oneOf
+        klass = Petstore.const_get(type)
+        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby/lib/petstore/models/additional_properties_class.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/additional_properties_class.rb
@@ -27,6 +27,11 @@ module Petstore
       }
     end
 
+    # Returns all the JSON keys this model knows about
+    def self.acceptable_attributes
+      attribute_map.values
+    end
+
     # Attribute type mapping.
     def self.openapi_types
       {
@@ -197,7 +202,7 @@ module Petstore
           is_nullable = self.class.openapi_nullable.include?(attr)
           next if !is_nullable || (is_nullable && !instance_variable_defined?(:"@#{attr}"))
         end
-        
+
         hash[param] = _to_hash(value)
       end
       hash
@@ -222,4 +227,5 @@ module Petstore
     end
 
   end
+
 end

--- a/samples/client/petstore/ruby/lib/petstore/models/animal.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/animal.rb
@@ -177,7 +177,9 @@ module Petstore
           end
         end
       else # model
-        Petstore.const_get(type).build_from_hash(value)
+        # models (e.g. Pet) or oneOf
+        klass = Petstore.const_get(type)
+        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby/lib/petstore/models/animal.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/animal.rb
@@ -27,6 +27,11 @@ module Petstore
       }
     end
 
+    # Returns all the JSON keys this model knows about
+    def self.acceptable_attributes
+      attribute_map.values
+    end
+
     # Attribute type mapping.
     def self.openapi_types
       {
@@ -205,7 +210,7 @@ module Petstore
           is_nullable = self.class.openapi_nullable.include?(attr)
           next if !is_nullable || (is_nullable && !instance_variable_defined?(:"@#{attr}"))
         end
-        
+
         hash[param] = _to_hash(value)
       end
       hash
@@ -230,4 +235,5 @@ module Petstore
     end
 
   end
+
 end

--- a/samples/client/petstore/ruby/lib/petstore/models/api_response.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/api_response.rb
@@ -174,7 +174,9 @@ module Petstore
           end
         end
       else # model
-        Petstore.const_get(type).build_from_hash(value)
+        # models (e.g. Pet) or oneOf
+        klass = Petstore.const_get(type)
+        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby/lib/petstore/models/api_response.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/api_response.rb
@@ -30,6 +30,11 @@ module Petstore
       }
     end
 
+    # Returns all the JSON keys this model knows about
+    def self.acceptable_attributes
+      attribute_map.values
+    end
+
     # Attribute type mapping.
     def self.openapi_types
       {
@@ -202,7 +207,7 @@ module Petstore
           is_nullable = self.class.openapi_nullable.include?(attr)
           next if !is_nullable || (is_nullable && !instance_variable_defined?(:"@#{attr}"))
         end
-        
+
         hash[param] = _to_hash(value)
       end
       hash
@@ -227,4 +232,5 @@ module Petstore
     end
 
   end
+
 end

--- a/samples/client/petstore/ruby/lib/petstore/models/array_of_array_of_number_only.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/array_of_array_of_number_only.rb
@@ -158,7 +158,9 @@ module Petstore
           end
         end
       else # model
-        Petstore.const_get(type).build_from_hash(value)
+        # models (e.g. Pet) or oneOf
+        klass = Petstore.const_get(type)
+        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby/lib/petstore/models/array_of_array_of_number_only.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/array_of_array_of_number_only.rb
@@ -24,6 +24,11 @@ module Petstore
       }
     end
 
+    # Returns all the JSON keys this model knows about
+    def self.acceptable_attributes
+      attribute_map.values
+    end
+
     # Attribute type mapping.
     def self.openapi_types
       {
@@ -186,7 +191,7 @@ module Petstore
           is_nullable = self.class.openapi_nullable.include?(attr)
           next if !is_nullable || (is_nullable && !instance_variable_defined?(:"@#{attr}"))
         end
-        
+
         hash[param] = _to_hash(value)
       end
       hash
@@ -211,4 +216,5 @@ module Petstore
     end
 
   end
+
 end

--- a/samples/client/petstore/ruby/lib/petstore/models/array_of_number_only.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/array_of_number_only.rb
@@ -158,7 +158,9 @@ module Petstore
           end
         end
       else # model
-        Petstore.const_get(type).build_from_hash(value)
+        # models (e.g. Pet) or oneOf
+        klass = Petstore.const_get(type)
+        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby/lib/petstore/models/array_of_number_only.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/array_of_number_only.rb
@@ -24,6 +24,11 @@ module Petstore
       }
     end
 
+    # Returns all the JSON keys this model knows about
+    def self.acceptable_attributes
+      attribute_map.values
+    end
+
     # Attribute type mapping.
     def self.openapi_types
       {
@@ -186,7 +191,7 @@ module Petstore
           is_nullable = self.class.openapi_nullable.include?(attr)
           next if !is_nullable || (is_nullable && !instance_variable_defined?(:"@#{attr}"))
         end
-        
+
         hash[param] = _to_hash(value)
       end
       hash
@@ -211,4 +216,5 @@ module Petstore
     end
 
   end
+
 end

--- a/samples/client/petstore/ruby/lib/petstore/models/array_test.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/array_test.rb
@@ -30,6 +30,11 @@ module Petstore
       }
     end
 
+    # Returns all the JSON keys this model knows about
+    def self.acceptable_attributes
+      attribute_map.values
+    end
+
     # Attribute type mapping.
     def self.openapi_types
       {
@@ -208,7 +213,7 @@ module Petstore
           is_nullable = self.class.openapi_nullable.include?(attr)
           next if !is_nullable || (is_nullable && !instance_variable_defined?(:"@#{attr}"))
         end
-        
+
         hash[param] = _to_hash(value)
       end
       hash
@@ -233,4 +238,5 @@ module Petstore
     end
 
   end
+
 end

--- a/samples/client/petstore/ruby/lib/petstore/models/array_test.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/array_test.rb
@@ -180,7 +180,9 @@ module Petstore
           end
         end
       else # model
-        Petstore.const_get(type).build_from_hash(value)
+        # models (e.g. Pet) or oneOf
+        klass = Petstore.const_get(type)
+        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby/lib/petstore/models/capitalization.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/capitalization.rb
@@ -40,6 +40,11 @@ module Petstore
       }
     end
 
+    # Returns all the JSON keys this model knows about
+    def self.acceptable_attributes
+      attribute_map.values
+    end
+
     # Attribute type mapping.
     def self.openapi_types
       {
@@ -230,7 +235,7 @@ module Petstore
           is_nullable = self.class.openapi_nullable.include?(attr)
           next if !is_nullable || (is_nullable && !instance_variable_defined?(:"@#{attr}"))
         end
-        
+
         hash[param] = _to_hash(value)
       end
       hash
@@ -255,4 +260,5 @@ module Petstore
     end
 
   end
+
 end

--- a/samples/client/petstore/ruby/lib/petstore/models/capitalization.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/capitalization.rb
@@ -202,7 +202,9 @@ module Petstore
           end
         end
       else # model
-        Petstore.const_get(type).build_from_hash(value)
+        # models (e.g. Pet) or oneOf
+        klass = Petstore.const_get(type)
+        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby/lib/petstore/models/cat.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/cat.rb
@@ -168,7 +168,9 @@ module Petstore
           end
         end
       else # model
-        Petstore.const_get(type).build_from_hash(value)
+        # models (e.g. Pet) or oneOf
+        klass = Petstore.const_get(type)
+        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby/lib/petstore/models/cat.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/cat.rb
@@ -24,6 +24,11 @@ module Petstore
       }
     end
 
+    # Returns all the JSON keys this model knows about, including the ones defined in its parent(s)
+    def self.acceptable_attributes
+      attribute_map.values.concat(superclass.acceptable_attributes)
+    end
+
     # Attribute type mapping.
     def self.openapi_types
       {
@@ -196,7 +201,7 @@ module Petstore
           is_nullable = self.class.openapi_nullable.include?(attr)
           next if !is_nullable || (is_nullable && !instance_variable_defined?(:"@#{attr}"))
         end
-        
+
         hash[param] = _to_hash(value)
       end
       hash
@@ -221,4 +226,5 @@ module Petstore
     end
 
   end
+
 end

--- a/samples/client/petstore/ruby/lib/petstore/models/cat_all_of.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/cat_all_of.rb
@@ -24,6 +24,11 @@ module Petstore
       }
     end
 
+    # Returns all the JSON keys this model knows about
+    def self.acceptable_attributes
+      attribute_map.values
+    end
+
     # Attribute type mapping.
     def self.openapi_types
       {
@@ -184,7 +189,7 @@ module Petstore
           is_nullable = self.class.openapi_nullable.include?(attr)
           next if !is_nullable || (is_nullable && !instance_variable_defined?(:"@#{attr}"))
         end
-        
+
         hash[param] = _to_hash(value)
       end
       hash
@@ -209,4 +214,5 @@ module Petstore
     end
 
   end
+
 end

--- a/samples/client/petstore/ruby/lib/petstore/models/cat_all_of.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/cat_all_of.rb
@@ -156,7 +156,9 @@ module Petstore
           end
         end
       else # model
-        Petstore.const_get(type).build_from_hash(value)
+        # models (e.g. Pet) or oneOf
+        klass = Petstore.const_get(type)
+        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby/lib/petstore/models/category.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/category.rb
@@ -27,6 +27,11 @@ module Petstore
       }
     end
 
+    # Returns all the JSON keys this model knows about
+    def self.acceptable_attributes
+      attribute_map.values
+    end
+
     # Attribute type mapping.
     def self.openapi_types
       {
@@ -200,7 +205,7 @@ module Petstore
           is_nullable = self.class.openapi_nullable.include?(attr)
           next if !is_nullable || (is_nullable && !instance_variable_defined?(:"@#{attr}"))
         end
-        
+
         hash[param] = _to_hash(value)
       end
       hash
@@ -225,4 +230,5 @@ module Petstore
     end
 
   end
+
 end

--- a/samples/client/petstore/ruby/lib/petstore/models/category.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/category.rb
@@ -172,7 +172,9 @@ module Petstore
           end
         end
       else # model
-        Petstore.const_get(type).build_from_hash(value)
+        # models (e.g. Pet) or oneOf
+        klass = Petstore.const_get(type)
+        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby/lib/petstore/models/class_model.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/class_model.rb
@@ -25,6 +25,11 @@ module Petstore
       }
     end
 
+    # Returns all the JSON keys this model knows about
+    def self.acceptable_attributes
+      attribute_map.values
+    end
+
     # Attribute type mapping.
     def self.openapi_types
       {
@@ -185,7 +190,7 @@ module Petstore
           is_nullable = self.class.openapi_nullable.include?(attr)
           next if !is_nullable || (is_nullable && !instance_variable_defined?(:"@#{attr}"))
         end
-        
+
         hash[param] = _to_hash(value)
       end
       hash
@@ -210,4 +215,5 @@ module Petstore
     end
 
   end
+
 end

--- a/samples/client/petstore/ruby/lib/petstore/models/class_model.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/class_model.rb
@@ -157,7 +157,9 @@ module Petstore
           end
         end
       else # model
-        Petstore.const_get(type).build_from_hash(value)
+        # models (e.g. Pet) or oneOf
+        klass = Petstore.const_get(type)
+        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby/lib/petstore/models/client.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/client.rb
@@ -24,6 +24,11 @@ module Petstore
       }
     end
 
+    # Returns all the JSON keys this model knows about
+    def self.acceptable_attributes
+      attribute_map.values
+    end
+
     # Attribute type mapping.
     def self.openapi_types
       {
@@ -184,7 +189,7 @@ module Petstore
           is_nullable = self.class.openapi_nullable.include?(attr)
           next if !is_nullable || (is_nullable && !instance_variable_defined?(:"@#{attr}"))
         end
-        
+
         hash[param] = _to_hash(value)
       end
       hash
@@ -209,4 +214,5 @@ module Petstore
     end
 
   end
+
 end

--- a/samples/client/petstore/ruby/lib/petstore/models/client.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/client.rb
@@ -156,7 +156,9 @@ module Petstore
           end
         end
       else # model
-        Petstore.const_get(type).build_from_hash(value)
+        # models (e.g. Pet) or oneOf
+        klass = Petstore.const_get(type)
+        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby/lib/petstore/models/dog.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/dog.rb
@@ -168,7 +168,9 @@ module Petstore
           end
         end
       else # model
-        Petstore.const_get(type).build_from_hash(value)
+        # models (e.g. Pet) or oneOf
+        klass = Petstore.const_get(type)
+        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby/lib/petstore/models/dog.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/dog.rb
@@ -24,6 +24,11 @@ module Petstore
       }
     end
 
+    # Returns all the JSON keys this model knows about, including the ones defined in its parent(s)
+    def self.acceptable_attributes
+      attribute_map.values.concat(superclass.acceptable_attributes)
+    end
+
     # Attribute type mapping.
     def self.openapi_types
       {
@@ -196,7 +201,7 @@ module Petstore
           is_nullable = self.class.openapi_nullable.include?(attr)
           next if !is_nullable || (is_nullable && !instance_variable_defined?(:"@#{attr}"))
         end
-        
+
         hash[param] = _to_hash(value)
       end
       hash
@@ -221,4 +226,5 @@ module Petstore
     end
 
   end
+
 end

--- a/samples/client/petstore/ruby/lib/petstore/models/dog_all_of.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/dog_all_of.rb
@@ -24,6 +24,11 @@ module Petstore
       }
     end
 
+    # Returns all the JSON keys this model knows about
+    def self.acceptable_attributes
+      attribute_map.values
+    end
+
     # Attribute type mapping.
     def self.openapi_types
       {
@@ -184,7 +189,7 @@ module Petstore
           is_nullable = self.class.openapi_nullable.include?(attr)
           next if !is_nullable || (is_nullable && !instance_variable_defined?(:"@#{attr}"))
         end
-        
+
         hash[param] = _to_hash(value)
       end
       hash
@@ -209,4 +214,5 @@ module Petstore
     end
 
   end
+
 end

--- a/samples/client/petstore/ruby/lib/petstore/models/dog_all_of.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/dog_all_of.rb
@@ -156,7 +156,9 @@ module Petstore
           end
         end
       else # model
-        Petstore.const_get(type).build_from_hash(value)
+        # models (e.g. Pet) or oneOf
+        klass = Petstore.const_get(type)
+        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby/lib/petstore/models/enum_arrays.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/enum_arrays.rb
@@ -201,7 +201,9 @@ module Petstore
           end
         end
       else # model
-        Petstore.const_get(type).build_from_hash(value)
+        # models (e.g. Pet) or oneOf
+        klass = Petstore.const_get(type)
+        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby/lib/petstore/models/enum_arrays.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/enum_arrays.rb
@@ -49,6 +49,11 @@ module Petstore
       }
     end
 
+    # Returns all the JSON keys this model knows about
+    def self.acceptable_attributes
+      attribute_map.values
+    end
+
     # Attribute type mapping.
     def self.openapi_types
       {
@@ -229,7 +234,7 @@ module Petstore
           is_nullable = self.class.openapi_nullable.include?(attr)
           next if !is_nullable || (is_nullable && !instance_variable_defined?(:"@#{attr}"))
         end
-        
+
         hash[param] = _to_hash(value)
       end
       hash
@@ -254,4 +259,5 @@ module Petstore
     end
 
   end
+
 end

--- a/samples/client/petstore/ruby/lib/petstore/models/enum_test.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/enum_test.rb
@@ -67,6 +67,11 @@ module Petstore
       }
     end
 
+    # Returns all the JSON keys this model knows about
+    def self.acceptable_attributes
+      attribute_map.values
+    end
+
     # Attribute type mapping.
     def self.openapi_types
       {
@@ -327,7 +332,7 @@ module Petstore
           is_nullable = self.class.openapi_nullable.include?(attr)
           next if !is_nullable || (is_nullable && !instance_variable_defined?(:"@#{attr}"))
         end
-        
+
         hash[param] = _to_hash(value)
       end
       hash
@@ -352,4 +357,5 @@ module Petstore
     end
 
   end
+
 end

--- a/samples/client/petstore/ruby/lib/petstore/models/enum_test.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/enum_test.rb
@@ -299,7 +299,9 @@ module Petstore
           end
         end
       else # model
-        Petstore.const_get(type).build_from_hash(value)
+        # models (e.g. Pet) or oneOf
+        klass = Petstore.const_get(type)
+        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby/lib/petstore/models/file.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/file.rb
@@ -158,7 +158,9 @@ module Petstore
           end
         end
       else # model
-        Petstore.const_get(type).build_from_hash(value)
+        # models (e.g. Pet) or oneOf
+        klass = Petstore.const_get(type)
+        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby/lib/petstore/models/file.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/file.rb
@@ -26,6 +26,11 @@ module Petstore
       }
     end
 
+    # Returns all the JSON keys this model knows about
+    def self.acceptable_attributes
+      attribute_map.values
+    end
+
     # Attribute type mapping.
     def self.openapi_types
       {
@@ -186,7 +191,7 @@ module Petstore
           is_nullable = self.class.openapi_nullable.include?(attr)
           next if !is_nullable || (is_nullable && !instance_variable_defined?(:"@#{attr}"))
         end
-        
+
         hash[param] = _to_hash(value)
       end
       hash
@@ -211,4 +216,5 @@ module Petstore
     end
 
   end
+
 end

--- a/samples/client/petstore/ruby/lib/petstore/models/file_schema_test_class.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/file_schema_test_class.rb
@@ -167,7 +167,9 @@ module Petstore
           end
         end
       else # model
-        Petstore.const_get(type).build_from_hash(value)
+        # models (e.g. Pet) or oneOf
+        klass = Petstore.const_get(type)
+        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby/lib/petstore/models/file_schema_test_class.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/file_schema_test_class.rb
@@ -27,6 +27,11 @@ module Petstore
       }
     end
 
+    # Returns all the JSON keys this model knows about
+    def self.acceptable_attributes
+      attribute_map.values
+    end
+
     # Attribute type mapping.
     def self.openapi_types
       {
@@ -195,7 +200,7 @@ module Petstore
           is_nullable = self.class.openapi_nullable.include?(attr)
           next if !is_nullable || (is_nullable && !instance_variable_defined?(:"@#{attr}"))
         end
-        
+
         hash[param] = _to_hash(value)
       end
       hash
@@ -220,4 +225,5 @@ module Petstore
     end
 
   end
+
 end

--- a/samples/client/petstore/ruby/lib/petstore/models/foo.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/foo.rb
@@ -158,7 +158,9 @@ module Petstore
           end
         end
       else # model
-        Petstore.const_get(type).build_from_hash(value)
+        # models (e.g. Pet) or oneOf
+        klass = Petstore.const_get(type)
+        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby/lib/petstore/models/foo.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/foo.rb
@@ -24,6 +24,11 @@ module Petstore
       }
     end
 
+    # Returns all the JSON keys this model knows about
+    def self.acceptable_attributes
+      attribute_map.values
+    end
+
     # Attribute type mapping.
     def self.openapi_types
       {
@@ -186,7 +191,7 @@ module Petstore
           is_nullable = self.class.openapi_nullable.include?(attr)
           next if !is_nullable || (is_nullable && !instance_variable_defined?(:"@#{attr}"))
         end
-        
+
         hash[param] = _to_hash(value)
       end
       hash
@@ -211,4 +216,5 @@ module Petstore
     end
 
   end
+
 end

--- a/samples/client/petstore/ruby/lib/petstore/models/format_test.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/format_test.rb
@@ -516,7 +516,9 @@ module Petstore
           end
         end
       else # model
-        Petstore.const_get(type).build_from_hash(value)
+        # models (e.g. Pet) or oneOf
+        klass = Petstore.const_get(type)
+        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby/lib/petstore/models/format_test.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/format_test.rb
@@ -71,6 +71,11 @@ module Petstore
       }
     end
 
+    # Returns all the JSON keys this model knows about
+    def self.acceptable_attributes
+      attribute_map.values
+    end
+
     # Attribute type mapping.
     def self.openapi_types
       {
@@ -544,7 +549,7 @@ module Petstore
           is_nullable = self.class.openapi_nullable.include?(attr)
           next if !is_nullable || (is_nullable && !instance_variable_defined?(:"@#{attr}"))
         end
-        
+
         hash[param] = _to_hash(value)
       end
       hash
@@ -569,4 +574,5 @@ module Petstore
     end
 
   end
+
 end

--- a/samples/client/petstore/ruby/lib/petstore/models/has_only_read_only.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/has_only_read_only.rb
@@ -165,7 +165,9 @@ module Petstore
           end
         end
       else # model
-        Petstore.const_get(type).build_from_hash(value)
+        # models (e.g. Pet) or oneOf
+        klass = Petstore.const_get(type)
+        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby/lib/petstore/models/has_only_read_only.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/has_only_read_only.rb
@@ -27,6 +27,11 @@ module Petstore
       }
     end
 
+    # Returns all the JSON keys this model knows about
+    def self.acceptable_attributes
+      attribute_map.values
+    end
+
     # Attribute type mapping.
     def self.openapi_types
       {
@@ -193,7 +198,7 @@ module Petstore
           is_nullable = self.class.openapi_nullable.include?(attr)
           next if !is_nullable || (is_nullable && !instance_variable_defined?(:"@#{attr}"))
         end
-        
+
         hash[param] = _to_hash(value)
       end
       hash
@@ -218,4 +223,5 @@ module Petstore
     end
 
   end
+
 end

--- a/samples/client/petstore/ruby/lib/petstore/models/health_check_result.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/health_check_result.rb
@@ -25,6 +25,11 @@ module Petstore
       }
     end
 
+    # Returns all the JSON keys this model knows about
+    def self.acceptable_attributes
+      attribute_map.values
+    end
+
     # Attribute type mapping.
     def self.openapi_types
       {
@@ -186,7 +191,7 @@ module Petstore
           is_nullable = self.class.openapi_nullable.include?(attr)
           next if !is_nullable || (is_nullable && !instance_variable_defined?(:"@#{attr}"))
         end
-        
+
         hash[param] = _to_hash(value)
       end
       hash
@@ -211,4 +216,5 @@ module Petstore
     end
 
   end
+
 end

--- a/samples/client/petstore/ruby/lib/petstore/models/health_check_result.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/health_check_result.rb
@@ -158,7 +158,9 @@ module Petstore
           end
         end
       else # model
-        Petstore.const_get(type).build_from_hash(value)
+        # models (e.g. Pet) or oneOf
+        klass = Petstore.const_get(type)
+        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby/lib/petstore/models/inline_object.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/inline_object.rb
@@ -29,6 +29,11 @@ module Petstore
       }
     end
 
+    # Returns all the JSON keys this model knows about
+    def self.acceptable_attributes
+      attribute_map.values
+    end
+
     # Attribute type mapping.
     def self.openapi_types
       {
@@ -195,7 +200,7 @@ module Petstore
           is_nullable = self.class.openapi_nullable.include?(attr)
           next if !is_nullable || (is_nullable && !instance_variable_defined?(:"@#{attr}"))
         end
-        
+
         hash[param] = _to_hash(value)
       end
       hash
@@ -220,4 +225,5 @@ module Petstore
     end
 
   end
+
 end

--- a/samples/client/petstore/ruby/lib/petstore/models/inline_object.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/inline_object.rb
@@ -167,7 +167,9 @@ module Petstore
           end
         end
       else # model
-        Petstore.const_get(type).build_from_hash(value)
+        # models (e.g. Pet) or oneOf
+        klass = Petstore.const_get(type)
+        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby/lib/petstore/models/inline_object1.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/inline_object1.rb
@@ -29,6 +29,11 @@ module Petstore
       }
     end
 
+    # Returns all the JSON keys this model knows about
+    def self.acceptable_attributes
+      attribute_map.values
+    end
+
     # Attribute type mapping.
     def self.openapi_types
       {
@@ -195,7 +200,7 @@ module Petstore
           is_nullable = self.class.openapi_nullable.include?(attr)
           next if !is_nullable || (is_nullable && !instance_variable_defined?(:"@#{attr}"))
         end
-        
+
         hash[param] = _to_hash(value)
       end
       hash
@@ -220,4 +225,5 @@ module Petstore
     end
 
   end
+
 end

--- a/samples/client/petstore/ruby/lib/petstore/models/inline_object1.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/inline_object1.rb
@@ -167,7 +167,9 @@ module Petstore
           end
         end
       else # model
-        Petstore.const_get(type).build_from_hash(value)
+        # models (e.g. Pet) or oneOf
+        klass = Petstore.const_get(type)
+        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby/lib/petstore/models/inline_object2.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/inline_object2.rb
@@ -205,7 +205,9 @@ module Petstore
           end
         end
       else # model
-        Petstore.const_get(type).build_from_hash(value)
+        # models (e.g. Pet) or oneOf
+        klass = Petstore.const_get(type)
+        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby/lib/petstore/models/inline_object2.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/inline_object2.rb
@@ -51,6 +51,11 @@ module Petstore
       }
     end
 
+    # Returns all the JSON keys this model knows about
+    def self.acceptable_attributes
+      attribute_map.values
+    end
+
     # Attribute type mapping.
     def self.openapi_types
       {
@@ -233,7 +238,7 @@ module Petstore
           is_nullable = self.class.openapi_nullable.include?(attr)
           next if !is_nullable || (is_nullable && !instance_variable_defined?(:"@#{attr}"))
         end
-        
+
         hash[param] = _to_hash(value)
       end
       hash
@@ -258,4 +263,5 @@ module Petstore
     end
 
   end
+
 end

--- a/samples/client/petstore/ruby/lib/petstore/models/inline_object3.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/inline_object3.rb
@@ -488,7 +488,9 @@ module Petstore
           end
         end
       else # model
-        Petstore.const_get(type).build_from_hash(value)
+        # models (e.g. Pet) or oneOf
+        klass = Petstore.const_get(type)
+        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby/lib/petstore/models/inline_object3.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/inline_object3.rb
@@ -77,6 +77,11 @@ module Petstore
       }
     end
 
+    # Returns all the JSON keys this model knows about
+    def self.acceptable_attributes
+      attribute_map.values
+    end
+
     # Attribute type mapping.
     def self.openapi_types
       {
@@ -516,7 +521,7 @@ module Petstore
           is_nullable = self.class.openapi_nullable.include?(attr)
           next if !is_nullable || (is_nullable && !instance_variable_defined?(:"@#{attr}"))
         end
-        
+
         hash[param] = _to_hash(value)
       end
       hash
@@ -541,4 +546,5 @@ module Petstore
     end
 
   end
+
 end

--- a/samples/client/petstore/ruby/lib/petstore/models/inline_object4.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/inline_object4.rb
@@ -177,7 +177,9 @@ module Petstore
           end
         end
       else # model
-        Petstore.const_get(type).build_from_hash(value)
+        # models (e.g. Pet) or oneOf
+        klass = Petstore.const_get(type)
+        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby/lib/petstore/models/inline_object4.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/inline_object4.rb
@@ -29,6 +29,11 @@ module Petstore
       }
     end
 
+    # Returns all the JSON keys this model knows about
+    def self.acceptable_attributes
+      attribute_map.values
+    end
+
     # Attribute type mapping.
     def self.openapi_types
       {
@@ -205,7 +210,7 @@ module Petstore
           is_nullable = self.class.openapi_nullable.include?(attr)
           next if !is_nullable || (is_nullable && !instance_variable_defined?(:"@#{attr}"))
         end
-        
+
         hash[param] = _to_hash(value)
       end
       hash
@@ -230,4 +235,5 @@ module Petstore
     end
 
   end
+
 end

--- a/samples/client/petstore/ruby/lib/petstore/models/inline_object5.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/inline_object5.rb
@@ -29,6 +29,11 @@ module Petstore
       }
     end
 
+    # Returns all the JSON keys this model knows about
+    def self.acceptable_attributes
+      attribute_map.values
+    end
+
     # Attribute type mapping.
     def self.openapi_types
       {
@@ -200,7 +205,7 @@ module Petstore
           is_nullable = self.class.openapi_nullable.include?(attr)
           next if !is_nullable || (is_nullable && !instance_variable_defined?(:"@#{attr}"))
         end
-        
+
         hash[param] = _to_hash(value)
       end
       hash
@@ -225,4 +230,5 @@ module Petstore
     end
 
   end
+
 end

--- a/samples/client/petstore/ruby/lib/petstore/models/inline_object5.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/inline_object5.rb
@@ -172,7 +172,9 @@ module Petstore
           end
         end
       else # model
-        Petstore.const_get(type).build_from_hash(value)
+        # models (e.g. Pet) or oneOf
+        klass = Petstore.const_get(type)
+        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby/lib/petstore/models/inline_response_default.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/inline_response_default.rb
@@ -24,6 +24,11 @@ module Petstore
       }
     end
 
+    # Returns all the JSON keys this model knows about
+    def self.acceptable_attributes
+      attribute_map.values
+    end
+
     # Attribute type mapping.
     def self.openapi_types
       {
@@ -184,7 +189,7 @@ module Petstore
           is_nullable = self.class.openapi_nullable.include?(attr)
           next if !is_nullable || (is_nullable && !instance_variable_defined?(:"@#{attr}"))
         end
-        
+
         hash[param] = _to_hash(value)
       end
       hash
@@ -209,4 +214,5 @@ module Petstore
     end
 
   end
+
 end

--- a/samples/client/petstore/ruby/lib/petstore/models/inline_response_default.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/inline_response_default.rb
@@ -156,7 +156,9 @@ module Petstore
           end
         end
       else # model
-        Petstore.const_get(type).build_from_hash(value)
+        # models (e.g. Pet) or oneOf
+        klass = Petstore.const_get(type)
+        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby/lib/petstore/models/list.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/list.rb
@@ -24,6 +24,11 @@ module Petstore
       }
     end
 
+    # Returns all the JSON keys this model knows about
+    def self.acceptable_attributes
+      attribute_map.values
+    end
+
     # Attribute type mapping.
     def self.openapi_types
       {
@@ -184,7 +189,7 @@ module Petstore
           is_nullable = self.class.openapi_nullable.include?(attr)
           next if !is_nullable || (is_nullable && !instance_variable_defined?(:"@#{attr}"))
         end
-        
+
         hash[param] = _to_hash(value)
       end
       hash
@@ -209,4 +214,5 @@ module Petstore
     end
 
   end
+
 end

--- a/samples/client/petstore/ruby/lib/petstore/models/list.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/list.rb
@@ -156,7 +156,9 @@ module Petstore
           end
         end
       else # model
-        Petstore.const_get(type).build_from_hash(value)
+        # models (e.g. Pet) or oneOf
+        klass = Petstore.const_get(type)
+        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby/lib/petstore/models/map_test.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/map_test.rb
@@ -55,6 +55,11 @@ module Petstore
       }
     end
 
+    # Returns all the JSON keys this model knows about
+    def self.acceptable_attributes
+      attribute_map.values
+    end
+
     # Attribute type mapping.
     def self.openapi_types
       {
@@ -241,7 +246,7 @@ module Petstore
           is_nullable = self.class.openapi_nullable.include?(attr)
           next if !is_nullable || (is_nullable && !instance_variable_defined?(:"@#{attr}"))
         end
-        
+
         hash[param] = _to_hash(value)
       end
       hash
@@ -266,4 +271,5 @@ module Petstore
     end
 
   end
+
 end

--- a/samples/client/petstore/ruby/lib/petstore/models/map_test.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/map_test.rb
@@ -213,7 +213,9 @@ module Petstore
           end
         end
       else # model
-        Petstore.const_get(type).build_from_hash(value)
+        # models (e.g. Pet) or oneOf
+        klass = Petstore.const_get(type)
+        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby/lib/petstore/models/mixed_properties_and_additional_properties_class.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/mixed_properties_and_additional_properties_class.rb
@@ -176,7 +176,9 @@ module Petstore
           end
         end
       else # model
-        Petstore.const_get(type).build_from_hash(value)
+        # models (e.g. Pet) or oneOf
+        klass = Petstore.const_get(type)
+        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby/lib/petstore/models/mixed_properties_and_additional_properties_class.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/mixed_properties_and_additional_properties_class.rb
@@ -30,6 +30,11 @@ module Petstore
       }
     end
 
+    # Returns all the JSON keys this model knows about
+    def self.acceptable_attributes
+      attribute_map.values
+    end
+
     # Attribute type mapping.
     def self.openapi_types
       {
@@ -204,7 +209,7 @@ module Petstore
           is_nullable = self.class.openapi_nullable.include?(attr)
           next if !is_nullable || (is_nullable && !instance_variable_defined?(:"@#{attr}"))
         end
-        
+
         hash[param] = _to_hash(value)
       end
       hash
@@ -229,4 +234,5 @@ module Petstore
     end
 
   end
+
 end

--- a/samples/client/petstore/ruby/lib/petstore/models/model200_response.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/model200_response.rb
@@ -28,6 +28,11 @@ module Petstore
       }
     end
 
+    # Returns all the JSON keys this model knows about
+    def self.acceptable_attributes
+      attribute_map.values
+    end
+
     # Attribute type mapping.
     def self.openapi_types
       {
@@ -194,7 +199,7 @@ module Petstore
           is_nullable = self.class.openapi_nullable.include?(attr)
           next if !is_nullable || (is_nullable && !instance_variable_defined?(:"@#{attr}"))
         end
-        
+
         hash[param] = _to_hash(value)
       end
       hash
@@ -219,4 +224,5 @@ module Petstore
     end
 
   end
+
 end

--- a/samples/client/petstore/ruby/lib/petstore/models/model200_response.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/model200_response.rb
@@ -166,7 +166,9 @@ module Petstore
           end
         end
       else # model
-        Petstore.const_get(type).build_from_hash(value)
+        # models (e.g. Pet) or oneOf
+        klass = Petstore.const_get(type)
+        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby/lib/petstore/models/model_return.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/model_return.rb
@@ -25,6 +25,11 @@ module Petstore
       }
     end
 
+    # Returns all the JSON keys this model knows about
+    def self.acceptable_attributes
+      attribute_map.values
+    end
+
     # Attribute type mapping.
     def self.openapi_types
       {
@@ -185,7 +190,7 @@ module Petstore
           is_nullable = self.class.openapi_nullable.include?(attr)
           next if !is_nullable || (is_nullable && !instance_variable_defined?(:"@#{attr}"))
         end
-        
+
         hash[param] = _to_hash(value)
       end
       hash
@@ -210,4 +215,5 @@ module Petstore
     end
 
   end
+
 end

--- a/samples/client/petstore/ruby/lib/petstore/models/model_return.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/model_return.rb
@@ -157,7 +157,9 @@ module Petstore
           end
         end
       else # model
-        Petstore.const_get(type).build_from_hash(value)
+        # models (e.g. Pet) or oneOf
+        klass = Petstore.const_get(type)
+        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby/lib/petstore/models/name.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/name.rb
@@ -189,7 +189,9 @@ module Petstore
           end
         end
       else # model
-        Petstore.const_get(type).build_from_hash(value)
+        # models (e.g. Pet) or oneOf
+        klass = Petstore.const_get(type)
+        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby/lib/petstore/models/name.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/name.rb
@@ -34,6 +34,11 @@ module Petstore
       }
     end
 
+    # Returns all the JSON keys this model knows about
+    def self.acceptable_attributes
+      attribute_map.values
+    end
+
     # Attribute type mapping.
     def self.openapi_types
       {
@@ -217,7 +222,7 @@ module Petstore
           is_nullable = self.class.openapi_nullable.include?(attr)
           next if !is_nullable || (is_nullable && !instance_variable_defined?(:"@#{attr}"))
         end
-        
+
         hash[param] = _to_hash(value)
       end
       hash
@@ -242,4 +247,5 @@ module Petstore
     end
 
   end
+
 end

--- a/samples/client/petstore/ruby/lib/petstore/models/nullable_class.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/nullable_class.rb
@@ -57,6 +57,11 @@ module Petstore
       }
     end
 
+    # Returns all the JSON keys this model knows about
+    def self.acceptable_attributes
+      attribute_map.values
+    end
+
     # Attribute type mapping.
     def self.openapi_types
       {
@@ -305,7 +310,7 @@ module Petstore
           is_nullable = self.class.openapi_nullable.include?(attr)
           next if !is_nullable || (is_nullable && !instance_variable_defined?(:"@#{attr}"))
         end
-        
+
         hash[param] = _to_hash(value)
       end
       hash
@@ -330,4 +335,5 @@ module Petstore
     end
 
   end
+
 end

--- a/samples/client/petstore/ruby/lib/petstore/models/nullable_class.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/nullable_class.rb
@@ -277,7 +277,9 @@ module Petstore
           end
         end
       else # model
-        Petstore.const_get(type).build_from_hash(value)
+        # models (e.g. Pet) or oneOf
+        klass = Petstore.const_get(type)
+        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby/lib/petstore/models/number_only.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/number_only.rb
@@ -24,6 +24,11 @@ module Petstore
       }
     end
 
+    # Returns all the JSON keys this model knows about
+    def self.acceptable_attributes
+      attribute_map.values
+    end
+
     # Attribute type mapping.
     def self.openapi_types
       {
@@ -184,7 +189,7 @@ module Petstore
           is_nullable = self.class.openapi_nullable.include?(attr)
           next if !is_nullable || (is_nullable && !instance_variable_defined?(:"@#{attr}"))
         end
-        
+
         hash[param] = _to_hash(value)
       end
       hash
@@ -209,4 +214,5 @@ module Petstore
     end
 
   end
+
 end

--- a/samples/client/petstore/ruby/lib/petstore/models/number_only.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/number_only.rb
@@ -156,7 +156,9 @@ module Petstore
           end
         end
       else # model
-        Petstore.const_get(type).build_from_hash(value)
+        # models (e.g. Pet) or oneOf
+        klass = Petstore.const_get(type)
+        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby/lib/petstore/models/order.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/order.rb
@@ -238,7 +238,9 @@ module Petstore
           end
         end
       else # model
-        Petstore.const_get(type).build_from_hash(value)
+        # models (e.g. Pet) or oneOf
+        klass = Petstore.const_get(type)
+        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby/lib/petstore/models/order.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/order.rb
@@ -62,6 +62,11 @@ module Petstore
       }
     end
 
+    # Returns all the JSON keys this model knows about
+    def self.acceptable_attributes
+      attribute_map.values
+    end
+
     # Attribute type mapping.
     def self.openapi_types
       {
@@ -266,7 +271,7 @@ module Petstore
           is_nullable = self.class.openapi_nullable.include?(attr)
           next if !is_nullable || (is_nullable && !instance_variable_defined?(:"@#{attr}"))
         end
-        
+
         hash[param] = _to_hash(value)
       end
       hash
@@ -291,4 +296,5 @@ module Petstore
     end
 
   end
+
 end

--- a/samples/client/petstore/ruby/lib/petstore/models/outer_composite.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/outer_composite.rb
@@ -174,7 +174,9 @@ module Petstore
           end
         end
       else # model
-        Petstore.const_get(type).build_from_hash(value)
+        # models (e.g. Pet) or oneOf
+        klass = Petstore.const_get(type)
+        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby/lib/petstore/models/outer_composite.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/outer_composite.rb
@@ -30,6 +30,11 @@ module Petstore
       }
     end
 
+    # Returns all the JSON keys this model knows about
+    def self.acceptable_attributes
+      attribute_map.values
+    end
+
     # Attribute type mapping.
     def self.openapi_types
       {
@@ -202,7 +207,7 @@ module Petstore
           is_nullable = self.class.openapi_nullable.include?(attr)
           next if !is_nullable || (is_nullable && !instance_variable_defined?(:"@#{attr}"))
         end
-        
+
         hash[param] = _to_hash(value)
       end
       hash
@@ -227,4 +232,5 @@ module Petstore
     end
 
   end
+
 end

--- a/samples/client/petstore/ruby/lib/petstore/models/pet.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/pet.rb
@@ -62,6 +62,11 @@ module Petstore
       }
     end
 
+    # Returns all the JSON keys this model knows about
+    def self.acceptable_attributes
+      attribute_map.values
+    end
+
     # Attribute type mapping.
     def self.openapi_types
       {
@@ -278,7 +283,7 @@ module Petstore
           is_nullable = self.class.openapi_nullable.include?(attr)
           next if !is_nullable || (is_nullable && !instance_variable_defined?(:"@#{attr}"))
         end
-        
+
         hash[param] = _to_hash(value)
       end
       hash
@@ -303,4 +308,5 @@ module Petstore
     end
 
   end
+
 end

--- a/samples/client/petstore/ruby/lib/petstore/models/pet.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/pet.rb
@@ -250,7 +250,9 @@ module Petstore
           end
         end
       else # model
-        Petstore.const_get(type).build_from_hash(value)
+        # models (e.g. Pet) or oneOf
+        klass = Petstore.const_get(type)
+        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby/lib/petstore/models/read_only_first.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/read_only_first.rb
@@ -165,7 +165,9 @@ module Petstore
           end
         end
       else # model
-        Petstore.const_get(type).build_from_hash(value)
+        # models (e.g. Pet) or oneOf
+        klass = Petstore.const_get(type)
+        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby/lib/petstore/models/read_only_first.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/read_only_first.rb
@@ -27,6 +27,11 @@ module Petstore
       }
     end
 
+    # Returns all the JSON keys this model knows about
+    def self.acceptable_attributes
+      attribute_map.values
+    end
+
     # Attribute type mapping.
     def self.openapi_types
       {
@@ -193,7 +198,7 @@ module Petstore
           is_nullable = self.class.openapi_nullable.include?(attr)
           next if !is_nullable || (is_nullable && !instance_variable_defined?(:"@#{attr}"))
         end
-        
+
         hash[param] = _to_hash(value)
       end
       hash
@@ -218,4 +223,5 @@ module Petstore
     end
 
   end
+
 end

--- a/samples/client/petstore/ruby/lib/petstore/models/special_model_name.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/special_model_name.rb
@@ -24,6 +24,11 @@ module Petstore
       }
     end
 
+    # Returns all the JSON keys this model knows about
+    def self.acceptable_attributes
+      attribute_map.values
+    end
+
     # Attribute type mapping.
     def self.openapi_types
       {
@@ -184,7 +189,7 @@ module Petstore
           is_nullable = self.class.openapi_nullable.include?(attr)
           next if !is_nullable || (is_nullable && !instance_variable_defined?(:"@#{attr}"))
         end
-        
+
         hash[param] = _to_hash(value)
       end
       hash
@@ -209,4 +214,5 @@ module Petstore
     end
 
   end
+
 end

--- a/samples/client/petstore/ruby/lib/petstore/models/special_model_name.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/special_model_name.rb
@@ -156,7 +156,9 @@ module Petstore
           end
         end
       else # model
-        Petstore.const_get(type).build_from_hash(value)
+        # models (e.g. Pet) or oneOf
+        klass = Petstore.const_get(type)
+        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby/lib/petstore/models/tag.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/tag.rb
@@ -165,7 +165,9 @@ module Petstore
           end
         end
       else # model
-        Petstore.const_get(type).build_from_hash(value)
+        # models (e.g. Pet) or oneOf
+        klass = Petstore.const_get(type)
+        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby/lib/petstore/models/tag.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/tag.rb
@@ -27,6 +27,11 @@ module Petstore
       }
     end
 
+    # Returns all the JSON keys this model knows about
+    def self.acceptable_attributes
+      attribute_map.values
+    end
+
     # Attribute type mapping.
     def self.openapi_types
       {
@@ -193,7 +198,7 @@ module Petstore
           is_nullable = self.class.openapi_nullable.include?(attr)
           next if !is_nullable || (is_nullable && !instance_variable_defined?(:"@#{attr}"))
         end
-        
+
         hash[param] = _to_hash(value)
       end
       hash
@@ -218,4 +223,5 @@ module Petstore
     end
 
   end
+
 end

--- a/samples/client/petstore/ruby/lib/petstore/models/user.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/user.rb
@@ -46,6 +46,11 @@ module Petstore
       }
     end
 
+    # Returns all the JSON keys this model knows about
+    def self.acceptable_attributes
+      attribute_map.values
+    end
+
     # Attribute type mapping.
     def self.openapi_types
       {
@@ -248,7 +253,7 @@ module Petstore
           is_nullable = self.class.openapi_nullable.include?(attr)
           next if !is_nullable || (is_nullable && !instance_variable_defined?(:"@#{attr}"))
         end
-        
+
         hash[param] = _to_hash(value)
       end
       hash
@@ -273,4 +278,5 @@ module Petstore
     end
 
   end
+
 end

--- a/samples/client/petstore/ruby/lib/petstore/models/user.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/user.rb
@@ -220,7 +220,9 @@ module Petstore
           end
         end
       else # model
-        Petstore.const_get(type).build_from_hash(value)
+        # models (e.g. Pet) or oneOf
+        klass = Petstore.const_get(type)
+        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/openapi3/client/features/dynamic-servers/ruby/docs/UsageApi.md
+++ b/samples/openapi3/client/features/dynamic-servers/ruby/docs/UsageApi.md
@@ -2,11 +2,10 @@
 
 All URIs are relative to *http://petstore.swagger.io:80/v2*
 
-Method | HTTP request | Description
-------------- | ------------- | -------------
-[**custom_server**](UsageApi.md#custom_server) | **GET** /custom | Use custom server
-[**default_server**](UsageApi.md#default_server) | **GET** /default | Use default server
-
+| Method | HTTP request | Description |
+| ------ | ------------ | ----------- |
+| [**custom_server**](UsageApi.md#custom_server) | **GET** /custom | Use custom server |
+| [**default_server**](UsageApi.md#default_server) | **GET** /default | Use default server |
 
 
 ## custom_server

--- a/samples/openapi3/client/features/dynamic-servers/ruby/lib/dynamic_servers/api_client.rb
+++ b/samples/openapi3/client/features/dynamic-servers/ruby/lib/dynamic_servers/api_client.rb
@@ -274,8 +274,9 @@ module DynamicServers
           data.each { |k, v| hash[k] = convert_to_type(v, sub_type) }
         end
       else
-        # models, e.g. Pet
-        DynamicServers.const_get(return_type).build_from_hash(data)
+        # models (e.g. Pet) or oneOf
+        klass = DynamicServers.const_get(return_type)
+        klass.respond_to?(:openapi_one_of) ? klass.build(data) : klass.build_from_hash(data)
       end
     end
 

--- a/samples/openapi3/client/features/generate-alias-as-model/ruby-client/docs/ArrayAlias.md
+++ b/samples/openapi3/client/features/generate-alias-as-model/ruby-client/docs/ArrayAlias.md
@@ -2,15 +2,14 @@
 
 ## Properties
 
-Name | Type | Description | Notes
------------- | ------------- | ------------- | -------------
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
 
 ## Code Sample
 
 ```ruby
-require 'Petstore'
+require 'petstore'
 
 instance = Petstore::ArrayAlias.new()
 ```
-
 

--- a/samples/openapi3/client/features/generate-alias-as-model/ruby-client/docs/MapAlias.md
+++ b/samples/openapi3/client/features/generate-alias-as-model/ruby-client/docs/MapAlias.md
@@ -2,15 +2,14 @@
 
 ## Properties
 
-Name | Type | Description | Notes
------------- | ------------- | ------------- | -------------
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
 
 ## Code Sample
 
 ```ruby
-require 'Petstore'
+require 'petstore'
 
 instance = Petstore::MapAlias.new()
 ```
-
 

--- a/samples/openapi3/client/features/generate-alias-as-model/ruby-client/docs/UsageApi.md
+++ b/samples/openapi3/client/features/generate-alias-as-model/ruby-client/docs/UsageApi.md
@@ -2,11 +2,10 @@
 
 All URIs are relative to *http://petstore.swagger.io/v2*
 
-Method | HTTP request | Description
-------------- | ------------- | -------------
-[**array**](UsageApi.md#array) | **GET** /array | Use alias to array
-[**map**](UsageApi.md#map) | **GET** /map | Use alias to map
-
+| Method | HTTP request | Description |
+| ------ | ------------ | ----------- |
+| [**array**](UsageApi.md#array) | **GET** /array | Use alias to array |
+| [**map**](UsageApi.md#map) | **GET** /map | Use alias to map |
 
 
 ## array
@@ -39,10 +38,9 @@ end
 
 ### Parameters
 
-
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **array_alias** | [**ArrayAlias**](ArrayAlias.md)|  | [optional] 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **array_alias** | [**ArrayAlias**](ArrayAlias.md) |  | [optional] |
 
 ### Return type
 
@@ -88,10 +86,9 @@ end
 
 ### Parameters
 
-
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **map_alias** | [**MapAlias**](MapAlias.md)|  | [optional] 
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **map_alias** | [**MapAlias**](MapAlias.md) |  | [optional] |
 
 ### Return type
 

--- a/samples/openapi3/client/features/generate-alias-as-model/ruby-client/lib/petstore/api_client.rb
+++ b/samples/openapi3/client/features/generate-alias-as-model/ruby-client/lib/petstore/api_client.rb
@@ -274,8 +274,9 @@ module Petstore
           data.each { |k, v| hash[k] = convert_to_type(v, sub_type) }
         end
       else
-        # models, e.g. Pet
-        Petstore.const_get(return_type).build_from_hash(data)
+        # models (e.g. Pet) or oneOf
+        klass = Petstore.const_get(return_type)
+        klass.respond_to?(:openapi_one_of) ? klass.build(data) : klass.build_from_hash(data)
       end
     end
 

--- a/samples/openapi3/client/features/generate-alias-as-model/ruby-client/lib/petstore/models/array_alias.rb
+++ b/samples/openapi3/client/features/generate-alias-as-model/ruby-client/lib/petstore/models/array_alias.rb
@@ -151,7 +151,9 @@ module Petstore
           end
         end
       else # model
-        Petstore.const_get(type).build_from_hash(value)
+        # models (e.g. Pet) or oneOf
+        klass = Petstore.const_get(type)
+        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/openapi3/client/features/generate-alias-as-model/ruby-client/lib/petstore/models/array_alias.rb
+++ b/samples/openapi3/client/features/generate-alias-as-model/ruby-client/lib/petstore/models/array_alias.rb
@@ -21,6 +21,11 @@ module Petstore
       }
     end
 
+    # Returns all the JSON keys this model knows about, including the ones defined in its parent(s)
+    def self.acceptable_attributes
+      attribute_map.values.concat(superclass.acceptable_attributes)
+    end
+
     # Attribute type mapping.
     def self.openapi_types
       {
@@ -179,7 +184,7 @@ module Petstore
           is_nullable = self.class.openapi_nullable.include?(attr)
           next if !is_nullable || (is_nullable && !instance_variable_defined?(:"@#{attr}"))
         end
-        
+
         hash[param] = _to_hash(value)
       end
       hash
@@ -204,4 +209,5 @@ module Petstore
     end
 
   end
+
 end

--- a/samples/openapi3/client/features/generate-alias-as-model/ruby-client/lib/petstore/models/map_alias.rb
+++ b/samples/openapi3/client/features/generate-alias-as-model/ruby-client/lib/petstore/models/map_alias.rb
@@ -21,6 +21,11 @@ module Petstore
       }
     end
 
+    # Returns all the JSON keys this model knows about
+    def self.acceptable_attributes
+      attribute_map.values
+    end
+
     # Attribute type mapping.
     def self.openapi_types
       {
@@ -175,7 +180,7 @@ module Petstore
           is_nullable = self.class.openapi_nullable.include?(attr)
           next if !is_nullable || (is_nullable && !instance_variable_defined?(:"@#{attr}"))
         end
-        
+
         hash[param] = _to_hash(value)
       end
       hash
@@ -200,4 +205,5 @@ module Petstore
     end
 
   end
+
 end

--- a/samples/openapi3/client/features/generate-alias-as-model/ruby-client/lib/petstore/models/map_alias.rb
+++ b/samples/openapi3/client/features/generate-alias-as-model/ruby-client/lib/petstore/models/map_alias.rb
@@ -147,7 +147,9 @@ module Petstore
           end
         end
       else # model
-        Petstore.const_get(type).build_from_hash(value)
+        # models (e.g. Pet) or oneOf
+        klass = Petstore.const_get(type)
+        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 


### PR DESCRIPTION
Fixes #3630.

~I have yet to update the documentation related templates and update the samples but opening now to gather initial feedback on the direction.~ 👌 

~Basically, this builds up on the work from @bkabrda on the java and go experimental clients.
I didn't go "ruby-experiemental" because the support of oneOf in the current ruby client is broken anyway.~ _not doing this in the end._

How it works is, in the spirit of the "oneof as interfaces" this creates a **module**, not a class, for oneOf models and provides a set of class methods related to the functionality.
The core method is `build_from_hash` whose job in this case is to find the relevant oneOf item and transparently building and returning the correct model.
It does so by using the discriminator if present, mapping if present and "falls back" to the existing validation-based look up.

~I changed some test yaml files to include more oneOf examples.~ _no need in the end._

If I try to do a before/after using the modified `composed-one.yaml` file, it goes like (some parts trimmed for brevity):

`openapi-generator generate -i composed-oneof.yaml -g ruby --library faraday -o ./out/ruby_oneof`

### model files
```sh
# current master
custom_one_of_schema.rb
obj_a.rb
obj_b.rb
obj_c.rb
obj_d.rb

# this branch
custom_one_of_array_schema_one_of.rb
custom_one_of_schema.rb
obj_a.rb
obj_b.rb
obj_c.rb
obj_c_data_one_of.rb
obj_d.rb
```

### custom_one_of_schema.rb
```ruby
# current master
module OpenapiClient
  class CustomOneOfSchema
    attr_accessor :realtype

    attr_accessor :message

    attr_accessor :description

    attr_accessor :code

    # Attribute mapping from ruby-style variable name to JSON key.
    def self.attribute_map
      {
        :'realtype' => :'realtype',
        :'message' => :'message',
        :'description' => :'description',
        :'code' => :'code'
      }
    end

    # Attribute type mapping.
    def self.openapi_types
      {
        :'realtype' => :'String',
        :'message' => :'String',
        :'description' => :'String',
        :'code' => :'Integer'
      }
    end

    # List of attributes with nullable: true
    def self.openapi_nullable
      Set.new([
      ])
    end

    # List of class defined in oneOf (OpenAPI v3)
    def self.openapi_one_of
      [
      :'ObjA',
      :'ObjB'
      ]
    end

    # discriminator's property name in OpenAPI v3
    def self.openapi_discriminator_name
      :'realtype'
    end

    # Initializes the object
    # @param [Hash] attributes Model attributes in the form of hash
    def initialize(attributes = {})

# another 200 lines of model code...
```

```ruby
# this branch
module OpenapiClient
  module CustomOneOfSchema
    # List of class defined in oneOf (OpenAPI v3)
    def self.openapi_one_of
      [
        :'ObjA',
        :'ObjB'
      ]
    end

    # discriminator's property name in OpenAPI v3
    def self.openapi_discriminator_name
      :'realtype'
    end

    # discriminator's mapping in OpenAPI v3
    def self.openapi_discriminator_mapping
      {
        :'a-type' => :'ObjA',
        :'b-type' => :'ObjB'
      }
    end

    # Builds the object from hash
    # @param [Hash] attributes Model attributes in the form of hash
    # @return [Object] Returns the model itself
    def self.build_from_hash(attributes)
      discriminator_value = attributes[openapi_discriminator_name]
      return nil unless discriminator_value

      _class = openapi_discriminator_mapping[discriminator_value.to_sym]
      return nil unless _class

      OpenapiClient.const_get(_class).build_from_hash(attributes)
    end
  end

end
```

Noteworthy is in the obj_c.rb the nested oneOf property has its model generated, albeit with a sligthly different name:

```ruby
# current master
    def self.openapi_types
      {
        :'realtype' => :'String',
        :'data' => :'OneOfObjAObjB'  # <==== model not generated!
      }
    end

# this branch
    def self.openapi_types
      {
        :'realtype' => :'String',
        :'data' => :'ObjCDataOneOf'  # <==== "interface" module generated
      }
    end
```

### Limitations / bugs / food for thought

- Interestingly, a `custom_one_of_array_schema_one_of.rb` "interface" module is now generated but the oneOf is taking place inside the `items`. I'm not sure this solution is going to work here. In this case maybe a regular model should be generated alongside some `custom_one_of_array_schema_one_of_items.rb` "interface" module?
  @bkabrda how do the java and experimental go clients fare in this case?
- In java the interface pattern used in this PR makes the models referenced in a oneOf carry the "dynamic" props illustrated in ObjD. https://github.com/OpenAPITools/openapi-generator/pull/4695 sort of discourages that pattern but I guess if the tool can do it, why not. What could be improved in the case of ruby though is to make some "dynamicProps" module in the interface module and dynamically include the props at runtime upon deserializing. Performance may not be stellar so it's trade off between "pureness" of the models and speed I guess.


### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@cliffano (2017/07) @zlx (2017/09) @autopp (2019/02)