### PR TITLE
[C][Client] Support SSL client authentication for the c client

### DIFF
--- a/modules/openapi-generator/src/main/resources/C-libcurl/apiClient.c.mustache
+++ b/modules/openapi-generator/src/main/resources/C-libcurl/apiClient.c.mustache
@@ -13,7 +13,7 @@ apiClient_t *apiClient_create() {
     curl_global_init(CURL_GLOBAL_ALL);
     apiClient_t *apiClient = malloc(sizeof(apiClient_t));
     apiClient->basePath = strdup("{{{basePath}}}");
-    apiClient->caPath = NULL;
+    apiClient->sslConfig = NULL;
     apiClient->dataReceived = NULL;
     apiClient->response_code = 0;
     {{#hasAuthMethods}}
@@ -35,7 +35,7 @@ apiClient_t *apiClient_create() {
 }
 
 apiClient_t *apiClient_create_with_base_path(const char *basePath
-, const char *caPath
+, sslConfig_t *sslConfig
 {{#hasAuthMethods}}
 {{#authMethods}}
 {{#isApiKey}}
@@ -52,10 +52,10 @@ apiClient_t *apiClient_create_with_base_path(const char *basePath
         apiClient->basePath = strdup("{{{basePath}}}");
     }
 
-    if(caPath){
-        apiClient->caPath = strdup(caPath);
+    if(sslConfig){
+        apiClient->sslConfig = sslConfig;
     }else{
-        apiClient->caPath = NULL;
+        apiClient->sslConfig = NULL;
     }
 
     apiClient->dataReceived = NULL;
@@ -92,9 +92,6 @@ void apiClient_free(apiClient_t *apiClient) {
     if(apiClient->basePath) {
         free(apiClient->basePath);
     }
-    if(apiClient->caPath) {
-        free(apiClient->caPath);
-    }
     {{#hasAuthMethods}}
     {{#authMethods}}
     {{#isBasic}}
@@ -130,6 +127,33 @@ void apiClient_free(apiClient_t *apiClient) {
     {{/hasAuthMethods}}
     free(apiClient);
     curl_global_cleanup();
+}
+
+sslConfig_t *sslConfig_create(const char *clientCertFile, const char *clientKeyFile, const char *CACertFile, int insecureSkipTlsVerify) {
+    sslConfig_t *sslConfig = calloc(1, sizeof(sslConfig_t));
+    if ( clientCertFile ) {
+        sslConfig->clientCertFile = strdup(clientCertFile);
+    }
+    if ( clientKeyFile ) {
+        sslConfig->clientKeyFile = strdup(clientKeyFile);
+    }
+    if ( CACertFile ) {
+        sslConfig->CACertFile = strdup(CACertFile);
+    }
+    sslConfig->insecureSkipTlsVerify = insecureSkipTlsVerify;
+}
+
+void sslConfig_free(sslConfig_t *sslConfig) {
+    if ( sslConfig->clientCertFile ) {
+        free(sslConfig->clientCertFile);
+    }
+    if ( sslConfig->clientKeyFile ) {
+        free(sslConfig->clientKeyFile);
+    }
+    if ( sslConfig->CACertFile ){
+        free(sslConfig->CACertFile);
+    }
+    free(sslConfig);
 }
 
 void replaceSpaceWithPlus(char *stringToProcess) {
@@ -388,13 +412,27 @@ void apiClient_invoke(apiClient_t    *apiClient,
             }
         }
 
-        if( strstr(apiClient->basePath, "https") != NULL ){
-            if (apiClient->caPath) {
-                curl_easy_setopt(handle, CURLOPT_SSL_VERIFYPEER, true);
-                curl_easy_setopt(handle, CURLOPT_CAINFO, apiClient->caPath);
+        if ( strstr(apiClient->basePath, "https") != NULL ) {
+            if ( apiClient->sslConfig ) {
+                if( apiClient->sslConfig->clientCertFile ) {
+                    curl_easy_setopt(handle, CURLOPT_SSLCERT, apiClient->sslConfig->clientCertFile);
+                }
+                if( apiClient->sslConfig->clientKeyFile ) {
+                    curl_easy_setopt(handle, CURLOPT_SSLKEY, apiClient->sslConfig->clientKeyFile);
+                }
+                if( apiClient->sslConfig->CACertFile ) {
+                    curl_easy_setopt(handle, CURLOPT_CAINFO, apiClient->sslConfig->CACertFile);
+                }
+                if ( 1 == apiClient->sslConfig->insecureSkipTlsVerify ) {
+                    curl_easy_setopt(handle, CURLOPT_SSL_VERIFYPEER, 0L);
+                    curl_easy_setopt(handle, CURLOPT_SSL_VERIFYHOST, 0L);
+                } else {
+                    curl_easy_setopt(handle, CURLOPT_SSL_VERIFYPEER, 1L);
+                    curl_easy_setopt(handle, CURLOPT_SSL_VERIFYHOST, 2L);
+                }
             } else {
-                curl_easy_setopt(handle, CURLOPT_SSL_VERIFYPEER, false);
-                curl_easy_setopt(handle, CURLOPT_SSL_VERIFYHOST, false);
+                curl_easy_setopt(handle, CURLOPT_SSL_VERIFYPEER, 0L);
+                curl_easy_setopt(handle, CURLOPT_SSL_VERIFYHOST, 0L);
             }
         }
 

--- a/modules/openapi-generator/src/main/resources/C-libcurl/apiClient.h.mustache
+++ b/modules/openapi-generator/src/main/resources/C-libcurl/apiClient.h.mustache
@@ -9,9 +9,17 @@
 #include "../include/list.h"
 #include "../include/keyValuePair.h"
 
+typedef struct sslConfig_t {
+    char *clientCertFile;         /* client certificate */
+    char *clientKeyFile;          /* client private key */
+    char *CACertFile;             /* CA certificate */
+    int  insecureSkipTlsVerify ;  /* 0 -- verify server certificate */
+                                  /* 1 -- skip ssl verify for server certificate */
+} sslConfig_t;
+
 typedef struct apiClient_t {
     char *basePath;
-    char *caPath;
+    sslConfig_t *sslConfig;
     void *dataReceived;
     long response_code;
     {{#hasAuthMethods}}
@@ -39,7 +47,7 @@ typedef struct binary_t
 apiClient_t* apiClient_create();
 
 apiClient_t* apiClient_create_with_base_path(const char *basePath
-, const char *caPath
+, sslConfig_t *sslConfig
 {{#hasAuthMethods}}
 {{#authMethods}}
 {{#isApiKey}}
@@ -52,6 +60,10 @@ apiClient_t* apiClient_create_with_base_path(const char *basePath
 void apiClient_free(apiClient_t *apiClient);
 
 void apiClient_invoke(apiClient_t *apiClient,char* operationParameter, list_t *queryParameters, list_t *headerParameters, list_t *formParameters,list_t *headerType,list_t *contentType, char *bodyParameters, char *requestType);
+
+sslConfig_t *sslConfig_create(const char *clientCertFile, const char *clientKeyFile, const char *CACertFile, int insecureSkipTlsVerify);
+
+void sslConfig_free(sslConfig_t *sslConfig);
 
 char *strReplace(char *orig, char *rep, char *with);
 

--- a/samples/client/petstore/c/include/apiClient.h
+++ b/samples/client/petstore/c/include/apiClient.h
@@ -9,9 +9,17 @@
 #include "../include/list.h"
 #include "../include/keyValuePair.h"
 
+typedef struct sslConfig_t {
+    char *clientCertFile;         /* client certificate */
+    char *clientKeyFile;          /* client private key */
+    char *CACertFile;             /* CA certificate */
+    int  insecureSkipTlsVerify ;  /* 0 -- verify server certificate */
+                                  /* 1 -- skip ssl verify for server certificate */
+} sslConfig_t;
+
 typedef struct apiClient_t {
     char *basePath;
-    char *caPath;
+    sslConfig_t *sslConfig;
     void *dataReceived;
     long response_code;
     list_t *apiKeys;
@@ -27,13 +35,17 @@ typedef struct binary_t
 apiClient_t* apiClient_create();
 
 apiClient_t* apiClient_create_with_base_path(const char *basePath
-, const char *caPath
+, sslConfig_t *sslConfig
 , list_t *apiKeys
 );
 
 void apiClient_free(apiClient_t *apiClient);
 
 void apiClient_invoke(apiClient_t *apiClient,char* operationParameter, list_t *queryParameters, list_t *headerParameters, list_t *formParameters,list_t *headerType,list_t *contentType, char *bodyParameters, char *requestType);
+
+sslConfig_t *sslConfig_create(const char *clientCertFile, const char *clientKeyFile, const char *CACertFile, int insecureSkipTlsVerify);
+
+void sslConfig_free(sslConfig_t *sslConfig);
 
 char *strReplace(char *orig, char *rep, char *with);
 

--- a/samples/client/petstore/c/src/apiClient.c
+++ b/samples/client/petstore/c/src/apiClient.c
@@ -13,7 +13,7 @@ apiClient_t *apiClient_create() {
     curl_global_init(CURL_GLOBAL_ALL);
     apiClient_t *apiClient = malloc(sizeof(apiClient_t));
     apiClient->basePath = strdup("http://petstore.swagger.io/v2");
-    apiClient->caPath = NULL;
+    apiClient->sslConfig = NULL;
     apiClient->dataReceived = NULL;
     apiClient->response_code = 0;
     apiClient->apiKeys = NULL;
@@ -23,7 +23,7 @@ apiClient_t *apiClient_create() {
 }
 
 apiClient_t *apiClient_create_with_base_path(const char *basePath
-, const char *caPath
+, sslConfig_t *sslConfig
 , list_t *apiKeys
 ) {
     curl_global_init(CURL_GLOBAL_ALL);
@@ -34,10 +34,10 @@ apiClient_t *apiClient_create_with_base_path(const char *basePath
         apiClient->basePath = strdup("http://petstore.swagger.io/v2");
     }
 
-    if(caPath){
-        apiClient->caPath = strdup(caPath);
+    if(sslConfig){
+        apiClient->sslConfig = sslConfig;
     }else{
-        apiClient->caPath = NULL;
+        apiClient->sslConfig = NULL;
     }
 
     apiClient->dataReceived = NULL;
@@ -62,9 +62,6 @@ void apiClient_free(apiClient_t *apiClient) {
     if(apiClient->basePath) {
         free(apiClient->basePath);
     }
-    if(apiClient->caPath) {
-        free(apiClient->caPath);
-    }
     if(apiClient->apiKeys) {
         listEntry_t *listEntry = NULL;
         list_ForEach(listEntry, apiClient->apiKeys) {
@@ -84,6 +81,33 @@ void apiClient_free(apiClient_t *apiClient) {
     }
     free(apiClient);
     curl_global_cleanup();
+}
+
+sslConfig_t *sslConfig_create(const char *clientCertFile, const char *clientKeyFile, const char *CACertFile, int insecureSkipTlsVerify) {
+    sslConfig_t *sslConfig = calloc(1, sizeof(sslConfig_t));
+    if ( clientCertFile ) {
+        sslConfig->clientCertFile = strdup(clientCertFile);
+    }
+    if ( clientKeyFile ) {
+        sslConfig->clientKeyFile = strdup(clientKeyFile);
+    }
+    if ( CACertFile ) {
+        sslConfig->CACertFile = strdup(CACertFile);
+    }
+    sslConfig->insecureSkipTlsVerify = insecureSkipTlsVerify;
+}
+
+void sslConfig_free(sslConfig_t *sslConfig) {
+    if ( sslConfig->clientCertFile ) {
+        free(sslConfig->clientCertFile);
+    }
+    if ( sslConfig->clientKeyFile ) {
+        free(sslConfig->clientKeyFile);
+    }
+    if ( sslConfig->CACertFile ){
+        free(sslConfig->CACertFile);
+    }
+    free(sslConfig);
 }
 
 void replaceSpaceWithPlus(char *stringToProcess) {
@@ -342,13 +366,27 @@ void apiClient_invoke(apiClient_t    *apiClient,
             }
         }
 
-        if( strstr(apiClient->basePath, "https") != NULL ){
-            if (apiClient->caPath) {
-                curl_easy_setopt(handle, CURLOPT_SSL_VERIFYPEER, true);
-                curl_easy_setopt(handle, CURLOPT_CAINFO, apiClient->caPath);
+        if ( strstr(apiClient->basePath, "https") != NULL ) {
+            if ( apiClient->sslConfig ) {
+                if( apiClient->sslConfig->clientCertFile ) {
+                    curl_easy_setopt(handle, CURLOPT_SSLCERT, apiClient->sslConfig->clientCertFile);
+                }
+                if( apiClient->sslConfig->clientKeyFile ) {
+                    curl_easy_setopt(handle, CURLOPT_SSLKEY, apiClient->sslConfig->clientKeyFile);
+                }
+                if( apiClient->sslConfig->CACertFile ) {
+                    curl_easy_setopt(handle, CURLOPT_CAINFO, apiClient->sslConfig->CACertFile);
+                }
+                if ( 1 == apiClient->sslConfig->insecureSkipTlsVerify ) {
+                    curl_easy_setopt(handle, CURLOPT_SSL_VERIFYPEER, 0L);
+                    curl_easy_setopt(handle, CURLOPT_SSL_VERIFYHOST, 0L);
+                } else {
+                    curl_easy_setopt(handle, CURLOPT_SSL_VERIFYPEER, 1L);
+                    curl_easy_setopt(handle, CURLOPT_SSL_VERIFYHOST, 2L);
+                }
             } else {
-                curl_easy_setopt(handle, CURLOPT_SSL_VERIFYPEER, false);
-                curl_easy_setopt(handle, CURLOPT_SSL_VERIFYHOST, false);
+                curl_easy_setopt(handle, CURLOPT_SSL_VERIFYPEER, 0L);
+                curl_easy_setopt(handle, CURLOPT_SSL_VERIFYHOST, 0L);
             }
         }
 


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

The PR https://github.com/OpenAPITools/openapi-generator/pull/5140 has supported SSL server authentication, now this PR will support SSL client authentication.

<!-- Please check the completed items below -->
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [X] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [X] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@wing328 @zhemant @michelealbano