### PR TITLE
Update bump.sh to go SNAPSHOT to version

### DIFF
--- a/bin/utils/release/bump.sh
+++ b/bin/utils/release/bump.sh
@@ -163,11 +163,13 @@ if [[ -z "${to}" ]]; then
             ;;
         snapshot)
             if [[ true = ${from_parts[3]} ]]; then
-                err "Can't move from SNAPSHOT to SNAPSHOT (from=${from})."
+                # Going from -SNAPSHOT to its release
+                to="${from_parts[0]}.${from_parts[1]}.${from_parts[2]}"
             else
+                # Going from some version to its next version and -SNAPSHOT
                 to="${from_parts[0]}.${from_parts[1]}.$(( ${from_parts[2]} + 1 ))-SNAPSHOT"
-                version "$to" to_parts
             fi
+            version "$to" to_parts
             ;;
     esac
    fi


### PR DESCRIPTION
This updates the release script to go from `-SNAPSHOT` to its next version automatically.

From 4.3.0-SNAPSHOT:

![image](https://user-images.githubusercontent.com/109659/77756457-967ad080-7005-11ea-8e58-34f2f813804e.png)

Then, from 4.3.0 to 4.3.1-SNAPSHOT:

![image](https://user-images.githubusercontent.com/109659/77756505-aeeaeb00-7005-11ea-9baa-7e547a8a5d19.png)

When I (or anyone else) gets time, maybe we could add some bats tests for `bump.sh`.

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.


cc @OpenAPITools/build 