### PR TITLE
[C++] [Qt5] Remove warning for unused camel case vendor extension for Qt5 client

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppQt5AbstractCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppQt5AbstractCodegen.java
@@ -316,9 +316,6 @@ public class CppQt5AbstractCodegen extends AbstractCppCodegen implements Codegen
         List<Map<String, String>> imports = (List<Map<String, String>>) objs.get("imports");
         Map<String, CodegenModel> codegenModels = new HashMap<String, CodegenModel>();
 
-        // TODO: 5.0: Remove the camelCased vendorExtension below and ensure templates use the newer property naming.
-        once(LOGGER).warn("4.3.0 has deprecated the use of vendor extensions which don't follow lower-kebab casing standards with x- prefix.");
-
         for (Object moObj : allModels) {
             CodegenModel mo = ((Map<String, CodegenModel>) moObj).get("model");
             if (mo.isEnum) {
@@ -328,7 +325,6 @@ public class CppQt5AbstractCodegen extends AbstractCppCodegen implements Codegen
         for (CodegenOperation operation : operations) {
             if (operation.returnType != null) {
                 if (codegenModels.containsKey(operation.returnType)) {
-                    operation.vendorExtensions.put("returnsEnum", true); // TODO: 5.0 Remove
                     operation.vendorExtensions.put("x-returns-enum", true);
                 }
             }


### PR DESCRIPTION

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
Removed unused vendor extension and warning

@wing328 

<!-- Please check the completed items below -->
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [X] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [X] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

