### PR TITLE
[typescript] Ensure `model.allParents` always includes `model.parent`.

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
@@ -1236,7 +1236,6 @@ public class ModelUtils {
     public static List<String> getAllParentsName(ComposedSchema composedSchema, Map<String, Schema> allSchemas, boolean includeAncestors) {
         List<Schema> interfaces = getInterfaces(composedSchema);
         List<String> names = new ArrayList<String>();
-        List<String> refedWithoutDiscriminator = new ArrayList<>();
 
         if (interfaces != null && !interfaces.isEmpty()) {
             for (Schema schema : interfaces) {
@@ -1255,7 +1254,6 @@ public class ModelUtils {
                         }
                     } else {
                         // not a parent since discriminator.propertyName is not set
-                        refedWithoutDiscriminator.add(parentName);
                     }
                 } else {
                     // not a ref, doing nothing
@@ -1263,10 +1261,11 @@ public class ModelUtils {
             }
         }
 
-        if (names.size() == 0 && refedWithoutDiscriminator.size() == 1) {
-            LOGGER.warn("[deprecated] inheritance without use of 'discriminator.propertyName' is deprecated " +
-                    "and will be removed in a future release. Generating model for {}. Title: {}", composedSchema.getName(), composedSchema.getTitle());
-            return refedWithoutDiscriminator;
+        // ensure `allParents` always includes `parent`
+        // this is more robust than keeping logic in getParentName() and getAllParentsName() in sync
+        String parentName = getParentName(composedSchema, allSchemas);
+        if (parentName != null && !names.contains(parentName)) {
+            names.add(parentName);
         }
 
         return names;

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
@@ -605,6 +605,18 @@ public class DefaultCodegenTest {
     }
 
     @Test
+    public void testAllOfSingleRefWithOwnPropsNoDiscriminator() {
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/2_0/composed-allof.yaml");
+        final DefaultCodegen codegen = new CodegenWithMultipleInheritance();
+
+        Schema schema = openAPI.getComponents().getSchemas().get("MessageEventCoreWithTimeListEntries");
+        codegen.setOpenAPI(openAPI);
+        CodegenModel model = codegen.fromModel("MessageEventCoreWithTimeListEntries", schema);
+        Assert.assertEquals(model.parent, "MessageEventCore");
+        Assert.assertEquals(model.allParents, Collections.singletonList("MessageEventCore"));
+    }
+
+    @Test
     public void testAllOfSingleRefNoOwnProps() {
         final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/2_0/composed-allof.yaml");
         final DefaultCodegen codegen = new CodegenWithMultipleInheritance();


### PR DESCRIPTION
Fixes a regression reported here https://github.com/OpenAPITools/openapi-generator/issues/927 (although originally that was a broader issue, not just typescript-specific)


`allParents` is used by generators with multiple inheritance, e.g typescript and perl.

Earlier there was an attempt to bring `parent` and `allParents` in sync: https://github.com/OpenAPITools/openapi-generator/pull/5182

Turned out it's not a robust approach, as it had duplicated logic in two methods. And a later change un-synced the two methods again (https://github.com/OpenAPITools/openapi-generator/pull/5526/files#diff-57d7532cf464a8d7c24aab4b22ceb993R1138)

This PR eliminates logic duplication (well, to some degree) and simply appends `parent` to the list of `allParents` if it was not there yet.

Note that there is no sample change. This reflects the sad fact that existing typescript samples don't cover inheritance cases.

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@TiFu (2017/07) @taxpon (2017/07) @sebastianhaas (2017/07) @kenisteward (2017/07) @Vrolijkx (2017/09) @macjohnny (2018/01) @nicokoenig (2018/09) @topce (2018/10) @akehir (2019/07) @petejohansonxo (2019/11) @amakhrov (2020/02)