### PR TITLE
fix scala-akka java8 serializers

### DIFF
--- a/modules/openapi-generator/src/main/resources/scala-akka-client/serializers.mustache
+++ b/modules/openapi-generator/src/main/resources/scala-akka-client/serializers.mustache
@@ -28,7 +28,8 @@ object Serializers {
   case object LocalDateSerializer extends CustomSerializer[LocalDate]( _ => ( {
     case JString(s) => LocalDate.parse(s)
   }, {
-    JString(d.format(DateTimeFormatter.ISO_LOCAL_DATE))
+    case d: LocalDate =>
+      JString(d.format(DateTimeFormatter.ISO_LOCAL_DATE))
   }))
 {{/java8}}
 {{#joda}}

--- a/samples/client/petstore/scala-akka/src/main/scala/org/openapitools/client/core/Serializers.scala
+++ b/samples/client/petstore/scala-akka/src/main/scala/org/openapitools/client/core/Serializers.scala
@@ -21,7 +21,8 @@ object Serializers {
   case object LocalDateSerializer extends CustomSerializer[LocalDate]( _ => ( {
     case JString(s) => LocalDate.parse(s)
   }, {
-    JString(d.format(DateTimeFormatter.ISO_LOCAL_DATE))
+    case d: LocalDate =>
+      JString(d.format(DateTimeFormatter.ISO_LOCAL_DATE))
   }))
 
  def all: Seq[Serializer[_]] = Seq[Serializer[_]]() :+ DateTimeSerializer :+ LocalDateSerializer

--- a/samples/openapi3/client/petstore/scala-akka/src/main/scala/org/openapitools/client/core/Serializers.scala
+++ b/samples/openapi3/client/petstore/scala-akka/src/main/scala/org/openapitools/client/core/Serializers.scala
@@ -21,7 +21,8 @@ object Serializers {
   case object LocalDateSerializer extends CustomSerializer[LocalDate]( _ => ( {
     case JString(s) => LocalDate.parse(s)
   }, {
-    JString(d.format(DateTimeFormatter.ISO_LOCAL_DATE))
+    case d: LocalDate =>
+      JString(d.format(DateTimeFormatter.ISO_LOCAL_DATE))
   }))
 
  def all: Seq[Serializer[_]] = Seq[Serializer[_]]() :+ DateTimeSerializer :+ LocalDateSerializer


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

scala-akka with default `java8` serializers won't compile due missed argument in match case 

 <!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@clasnake (2017/07), @jimschubert (2017/09) ❤️, @shijinkui (2018/01), @ramzimaalej (2018/03), @chameleon82 (2020/03)