### PR TITLE
[C++] [Qt5] Updates to allow the setting of the dateTime format string

### DIFF
--- a/modules/openapi-generator/src/main/resources/cpp-qt5-client/helpers-body.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-client/helpers-body.mustache
@@ -7,13 +7,49 @@
 namespace {{this}} {
 {{/cppNamespaceDeclarations}}
 
+class {{prefix}}SerializerSettings {
+public:
+    static void setDateTimeFormat(const QString & dtFormat){
+        getInstance()->dateTimeFormat = dtFormat;
+    }
+    static QString getDateTimeFormat() {
+        return getInstance()->dateTimeFormat;
+    }
+    static {{prefix}}SerializerSettings *getInstance(){
+        if(instance == nullptr){
+            instance = new {{prefix}}SerializerSettings();
+        }
+        return instance;
+    }
+private:
+    explicit {{prefix}}SerializerSettings(){
+        instance = this;
+        dateTimeFormat.clear();
+    }
+    static {{prefix}}SerializerSettings *instance;
+    QString dateTimeFormat;
+};
+
+{{prefix}}SerializerSettings * {{prefix}}SerializerSettings::instance = nullptr;
+
+bool setDateTimeFormat(const QString& dateTimeFormat){
+    bool success = false;
+    auto dt = QDateTime::fromString(QDateTime::currentDateTime().toString(dateTimeFormat), dateTimeFormat);
+    if(dt.isValid()){
+        success = true;
+        {{prefix}}SerializerSettings::setDateTimeFormat(dateTimeFormat);
+    }
+    return success;
+}
+
+
 QString toStringValue(const QString &value) {
     return value;
 }
 
 QString toStringValue(const QDateTime &value) {
     // ISO 8601
-    return value.toString("yyyy-MM-ddTHH:mm:ss[Z|[+|-]HH:mm]");
+    return {{prefix}}SerializerSettings::getInstance()->getDateTimeFormat().isEmpty()? value.toString(Qt::ISODate):value.toString({{prefix}}SerializerSettings::getInstance()->getDateTimeFormat());
 }
 
 QString toStringValue(const QByteArray &value) {
@@ -62,7 +98,7 @@ QJsonValue toJsonValue(const QString &value) {
 }
 
 QJsonValue toJsonValue(const QDateTime &value) {
-    return QJsonValue(value.toString(Qt::ISODate));
+    return QJsonValue(value.toString({{prefix}}SerializerSettings::getInstance()->getDateTimeFormat().isEmpty()?value.toString(Qt::ISODate):value.toString({{prefix}}SerializerSettings::getInstance()->getDateTimeFormat())));
 }
 
 QJsonValue toJsonValue(const QByteArray &value) {
@@ -115,7 +151,7 @@ bool fromStringValue(const QString &inStr, QDateTime &value) {
     if (inStr.isEmpty()) {
         return false;
     } else {
-        auto dateTime = QDateTime::fromString(inStr, "yyyy-MM-ddTHH:mm:ss[Z|[+|-]HH:mm]");
+        auto dateTime = {{prefix}}SerializerSettings::getInstance()->getDateTimeFormat().isEmpty()?QDateTime::fromString(inStr, Qt::ISODate) :QDateTime::fromString(inStr, {{prefix}}SerializerSettings::getInstance()->getDateTimeFormat());
         if (dateTime.isValid()) {
             value.setDate(dateTime.date());
             value.setTime(dateTime.time());
@@ -220,7 +256,7 @@ bool fromJsonValue(QString &value, const QJsonValue &jval) {
 bool fromJsonValue(QDateTime &value, const QJsonValue &jval) {
     bool ok = true;
     if (!jval.isUndefined() && !jval.isNull() && jval.isString()) {
-        value = QDateTime::fromString(jval.toString(), Qt::ISODate);
+        value = {{prefix}}SerializerSettings::getInstance()->getDateTimeFormat().isEmpty()?QDateTime::fromString(jval.toString(), Qt::ISODate): QDateTime::fromString(jval.toString(), {{prefix}}SerializerSettings::getInstance()->getDateTimeFormat());
         ok = value.isValid();
     } else {
         ok = false;

--- a/modules/openapi-generator/src/main/resources/cpp-qt5-client/helpers-header.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-client/helpers-header.mustache
@@ -20,6 +20,8 @@
 namespace {{this}} {
 {{/cppNamespaceDeclarations}}
 
+bool setDateTimeFormat(const QString&);
+
 template <typename T>
 QString toStringValue(const QList<T> &val);
 

--- a/modules/openapi-generator/src/main/resources/cpp-qt5-qhttpengine-server/helpers-body.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-qhttpengine-server/helpers-body.mustache
@@ -7,13 +7,49 @@
 namespace {{this}} {
 {{/cppNamespaceDeclarations}}
 
+class {{prefix}}SerializerSettings {
+public:
+    static void setDateTimeFormat(const QString & dtFormat){
+        getInstance()->dateTimeFormat = dtFormat;
+    }
+    static QString getDateTimeFormat() {
+        return getInstance()->dateTimeFormat;
+    }
+    static {{prefix}}SerializerSettings *getInstance(){
+        if(instance == nullptr){
+            instance = new {{prefix}}SerializerSettings();
+        }
+        return instance;
+    }
+private:
+    explicit {{prefix}}SerializerSettings(){
+        instance = this;
+        dateTimeFormat.clear();
+    }
+    static {{prefix}}SerializerSettings *instance;
+    QString dateTimeFormat;
+};
+
+{{prefix}}SerializerSettings * {{prefix}}SerializerSettings::instance = nullptr;
+
+bool setDateTimeFormat(const QString& dateTimeFormat){
+    bool success = false;
+    auto dt = QDateTime::fromString(QDateTime::currentDateTime().toString(dateTimeFormat), dateTimeFormat);
+    if(dt.isValid()){
+        success = true;
+        {{prefix}}SerializerSettings::setDateTimeFormat(dateTimeFormat);
+    }
+    return success;
+}
+
+
 QString toStringValue(const QString &value) {
     return value;
 }
 
 QString toStringValue(const QDateTime &value) {
     // ISO 8601
-    return value.toString("yyyy-MM-ddTHH:mm:ss[Z|[+|-]HH:mm]");
+    return {{prefix}}SerializerSettings::getInstance()->getDateTimeFormat().isEmpty()? value.toString(Qt::ISODate):value.toString({{prefix}}SerializerSettings::getInstance()->getDateTimeFormat());
 }
 
 QString toStringValue(const QByteArray &value) {
@@ -62,7 +98,7 @@ QJsonValue toJsonValue(const QString &value) {
 }
 
 QJsonValue toJsonValue(const QDateTime &value) {
-    return QJsonValue(value.toString(Qt::ISODate));
+    return QJsonValue(value.toString({{prefix}}SerializerSettings::getInstance()->getDateTimeFormat().isEmpty()?value.toString(Qt::ISODate):value.toString({{prefix}}SerializerSettings::getInstance()->getDateTimeFormat())));
 }
 
 QJsonValue toJsonValue(const QByteArray &value) {
@@ -115,7 +151,7 @@ bool fromStringValue(const QString &inStr, QDateTime &value) {
     if (inStr.isEmpty()) {
         return false;
     } else {
-        auto dateTime = QDateTime::fromString(inStr, "yyyy-MM-ddTHH:mm:ss[Z|[+|-]HH:mm]");
+        auto dateTime = {{prefix}}SerializerSettings::getInstance()->getDateTimeFormat().isEmpty()?QDateTime::fromString(inStr, Qt::ISODate) :QDateTime::fromString(inStr, {{prefix}}SerializerSettings::getInstance()->getDateTimeFormat());
         if (dateTime.isValid()) {
             value.setDate(dateTime.date());
             value.setTime(dateTime.time());
@@ -220,7 +256,7 @@ bool fromJsonValue(QString &value, const QJsonValue &jval) {
 bool fromJsonValue(QDateTime &value, const QJsonValue &jval) {
     bool ok = true;
     if (!jval.isUndefined() && !jval.isNull() && jval.isString()) {
-        value = QDateTime::fromString(jval.toString(), Qt::ISODate);
+        value = {{prefix}}SerializerSettings::getInstance()->getDateTimeFormat().isEmpty()?QDateTime::fromString(jval.toString(), Qt::ISODate): QDateTime::fromString(jval.toString(), {{prefix}}SerializerSettings::getInstance()->getDateTimeFormat());
         ok = value.isValid();
     } else {
         ok = false;

--- a/modules/openapi-generator/src/main/resources/cpp-qt5-qhttpengine-server/helpers-header.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-qhttpengine-server/helpers-header.mustache
@@ -20,6 +20,8 @@
 namespace {{this}} {
 {{/cppNamespaceDeclarations}}
 
+bool setDateTimeFormat(const QString&);
+
 template <typename T>
 QString toStringValue(const QList<T> &val);
 

--- a/samples/client/petstore/cpp-qt5/PetStore/main.cpp
+++ b/samples/client/petstore/cpp-qt5/PetStore/main.cpp
@@ -1,12 +1,14 @@
 #include <QCoreApplication>
 #include <QTest>
 
+#include "PFXHelpers.h"
 #include "PetApiTests.h"
 #include "StoreApiTests.h"
 #include "UserApiTests.h"
 
 int main(int argc, char *argv[]) {
     QCoreApplication a(argc, argv);
+    ::test_namespace::setDateTimeFormat("yyyy-MM-ddTHH:mm:ss.zzzZ");
     PetApiTests petApiTests;
     StoreApiTests storeApiTests;
     UserApiTests userApiTests;

--- a/samples/client/petstore/cpp-qt5/client/PFXHelpers.h
+++ b/samples/client/petstore/cpp-qt5/client/PFXHelpers.h
@@ -28,6 +28,8 @@
 
 namespace test_namespace {
 
+bool setDateTimeFormat(const QString&);
+
 template <typename T>
 QString toStringValue(const QList<T> &val);
 

--- a/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/models/OAIHelpers.h
+++ b/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/models/OAIHelpers.h
@@ -28,6 +28,8 @@
 
 namespace OpenAPI {
 
+bool setDateTimeFormat(const QString&);
+
 template <typename T>
 QString toStringValue(const QList<T> &val);
 


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

Fixes #5708
`cc`
@DevASG
@stkrwork @MartinDelille @muttleyxd @ravinikam 

<!-- Please check the completed items below -->
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [X] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [X] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
