### PR TITLE
[jaxrs-cxf-cdi] Generate better fluent api in case of inheritance

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
@@ -1004,10 +1004,24 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
             codegenModel.imports.add("JsonSubTypes");
             codegenModel.imports.add("JsonTypeInfo");
         }
-        if (allDefinitions != null && codegenModel.parentSchema != null && codegenModel.hasEnums) {
+        if (allDefinitions != null && codegenModel.parentSchema != null) {
             final Schema parentModel = allDefinitions.get(codegenModel.parentSchema);
             final CodegenModel parentCodegenModel = super.fromModel(codegenModel.parent, parentModel);
-            codegenModel = AbstractJavaCodegen.reconcileInlineEnums(codegenModel, parentCodegenModel);
+            if (codegenModel.hasEnums) {
+                codegenModel = AbstractJavaCodegen.reconcileInlineEnums(codegenModel, parentCodegenModel);
+            }
+            // parentVars eases templating
+            Map<String, CodegenProperty> propertyHash = new HashMap<>(codegenModel.vars.size());
+            for (final CodegenProperty property : codegenModel.vars) {
+                propertyHash.put(property.name, property);
+            }
+            for (final CodegenProperty property : parentCodegenModel.vars) {
+                if (!propertyHash.containsKey(property.name)) {
+                    final CodegenProperty parentVar = property.clone();
+                    parentVar.isInherited = true;
+                    codegenModel.parentVars.add(parentVar);
+                }
+            }
         }
         if ("BigDecimal".equals(codegenModel.dataType)) {
             codegenModel.imports.add("BigDecimal");

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf-cdi/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf-cdi/pojo.mustache
@@ -70,6 +70,30 @@ public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}} {{#seriali
   {{/isMapContainer}}
 
   {{/vars}}
+  {{#parentVars}}
+
+  @Override
+  public {{classname}} {{name}}({{{datatypeWithEnum}}} {{name}}) {
+    {{setter}}({{name}});
+    return this;
+  }
+  {{#isListContainer}}
+
+  @Override
+  public {{classname}} add{{nameInCamelCase}}Item({{{items.datatypeWithEnum}}} {{name}}Item) {
+    super.add{{nameInCamelCase}}Item({{name}}Item);
+    return this;
+  }
+  {{/isListContainer}}
+  {{#isMapContainer}}
+
+  @Override
+  public {{classname}} put{{nameInCamelCase}}Item(String key, {{{items.datatypeWithEnum}}} {{name}}Item) {
+    super.put{{nameInCamelCase}}Item(key, {{name}}Item);
+    return this;
+  }
+  {{/isMapContainer}}
+  {{/parentVars}}
 
   @Override
   public boolean equals(java.lang.Object o) {


### PR DESCRIPTION
When there is a use of "allOf" in a model definition, since openapi-generator 4.3.2 the generated model class uses inheritance, and only defines fluent interface methods for local fields.
This is rather inconvenient when creating objects, because some fluent setters return an object of the super type, and not the actual type. This also breaks client code that used that feature from 4.3.x.

I added overridden definitions for the fluent setters when needed. I also included a fix proposed in another pull request #5756, to fix the definition of "equals" and "hashCode". I'm proposing this into a new PR instead of appending to that one because while the "equals" and "hashCode" change is really just a bugfix change, this one may raise more debate.

<!-- Please check the completed items below -->
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [X] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [X] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04) @lwlee2608 (2019/10) @bkabrda (2020/01)
JAX-RS CXF (CDI): @nickcmaynard