### PR TITLE
Comment out kotlin vertx server test to fix CI failure

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1365,7 +1365,7 @@
                 <module>samples/server/petstore/scalatra</module>
                 <module>samples/server/petstore/java-vertx-web/rx</module>
                 <module>samples/server/petstore/scala-finch</module>
-                <module>samples/server/petstore/kotlin/vertx</module>
+                <!--<module>samples/server/petstore/kotlin/vertx</module>-->
                 <module>samples/server/petstore/kotlin-springboot</module>
             </modules>
         </profile>

--- a/samples/server/petstore/kotlin/vertx/pom.xml
+++ b/samples/server/petstore/kotlin/vertx/pom.xml
@@ -7,7 +7,7 @@
     <version>1.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
   
-      <name>OpenAPI Petstore</name>
+    <name>OpenAPI Petstore</name>
       
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
Test failures in the CircleCI CI due to the following:

```
[ERROR] Incompatible classes were found in dependencies. Remove them from the classpath or use '-Xskip-metadata-version-check' to suppress errors
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt: (12, 27) Class 'kotlinx.coroutines.GlobalScope' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt: (66, 13) Class 'kotlinx.coroutines.DisposableHandle' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt: (75, 21) Class 'kotlinx.coroutines.GlobalScope' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt: (75, 33) Class 'kotlinx.coroutines.Job' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt: (75, 33) Class 'kotlinx.coroutines.CoroutineScope' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt: (75, 33) Class 'kotlinx.coroutines.CoroutineStart' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt: (75, 33) Class 'kotlinx.coroutines.BuildersKt__Builders_commonKt' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt: (75, 46) Class 'kotlinx.coroutines.CoroutineDispatcher' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt: (80, 23) Class 'kotlinx.coroutines.DisposableHandle' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt: (92, 21) Class 'kotlinx.coroutines.GlobalScope' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt: (92, 33) Class 'kotlinx.coroutines.Job' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt: (92, 33) Class 'kotlinx.coroutines.CoroutineScope' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt: (92, 33) Class 'kotlinx.coroutines.CoroutineStart' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt: (92, 33) Class 'kotlinx.coroutines.BuildersKt__Builders_commonKt' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt: (92, 46) Class 'kotlinx.coroutines.CoroutineDispatcher' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt: (97, 23) Class 'kotlinx.coroutines.DisposableHandle' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt: (110, 21) Class 'kotlinx.coroutines.GlobalScope' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt: (110, 33) Class 'kotlinx.coroutines.Job' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt: (110, 33) Class 'kotlinx.coroutines.CoroutineScope' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt: (110, 33) Class 'kotlinx.coroutines.CoroutineStart' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt: (110, 33) Class 'kotlinx.coroutines.BuildersKt__Builders_commonKt' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt: (110, 46) Class 'kotlinx.coroutines.CoroutineDispatcher' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt: (115, 23) Class 'kotlinx.coroutines.DisposableHandle' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt: (128, 21) Class 'kotlinx.coroutines.GlobalScope' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt: (128, 33) Class 'kotlinx.coroutines.Job' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt: (128, 33) Class 'kotlinx.coroutines.CoroutineScope' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt: (128, 33) Class 'kotlinx.coroutines.CoroutineStart' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt: (128, 33) Class 'kotlinx.coroutines.BuildersKt__Builders_commonKt' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt: (128, 46) Class 'kotlinx.coroutines.CoroutineDispatcher' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt: (133, 23) Class 'kotlinx.coroutines.DisposableHandle' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt: (144, 21) Class 'kotlinx.coroutines.GlobalScope' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt: (144, 33) Class 'kotlinx.coroutines.Job' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt: (144, 33) Class 'kotlinx.coroutines.CoroutineScope' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt: (144, 33) Class 'kotlinx.coroutines.CoroutineStart' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt: (144, 33) Class 'kotlinx.coroutines.BuildersKt__Builders_commonKt' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt: (144, 46) Class 'kotlinx.coroutines.CoroutineDispatcher' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt: (149, 23) Class 'kotlinx.coroutines.DisposableHandle' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt: (161, 21) Class 'kotlinx.coroutines.GlobalScope' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt: (161, 33) Class 'kotlinx.coroutines.Job' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt: (161, 33) Class 'kotlinx.coroutines.CoroutineScope' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt: (161, 33) Class 'kotlinx.coroutines.CoroutineStart' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt: (161, 33) Class 'kotlinx.coroutines.BuildersKt__Builders_commonKt' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt: (161, 46) Class 'kotlinx.coroutines.CoroutineDispatcher' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt: (166, 23) Class 'kotlinx.coroutines.DisposableHandle' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt: (179, 21) Class 'kotlinx.coroutines.GlobalScope' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt: (179, 33) Class 'kotlinx.coroutines.Job' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt: (179, 33) Class 'kotlinx.coroutines.CoroutineScope' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt: (179, 33) Class 'kotlinx.coroutines.CoroutineStart' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt: (179, 33) Class 'kotlinx.coroutines.BuildersKt__Builders_commonKt' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt: (179, 46) Class 'kotlinx.coroutines.CoroutineDispatcher' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt: (184, 23) Class 'kotlinx.coroutines.DisposableHandle' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt: (198, 21) Class 'kotlinx.coroutines.GlobalScope' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt: (198, 33) Class 'kotlinx.coroutines.Job' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt: (198, 33) Class 'kotlinx.coroutines.CoroutineScope' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt: (198, 33) Class 'kotlinx.coroutines.CoroutineStart' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt: (198, 33) Class 'kotlinx.coroutines.BuildersKt__Builders_commonKt' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt: (198, 46) Class 'kotlinx.coroutines.CoroutineDispatcher' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt: (203, 23) Class 'kotlinx.coroutines.DisposableHandle' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/StoreApiVertxProxyHandler.kt: (12, 27) Class 'kotlinx.coroutines.GlobalScope' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/StoreApiVertxProxyHandler.kt: (73, 21) Class 'kotlinx.coroutines.GlobalScope' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/StoreApiVertxProxyHandler.kt: (73, 33) Class 'kotlinx.coroutines.Job' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/StoreApiVertxProxyHandler.kt: (73, 33) Class 'kotlinx.coroutines.CoroutineScope' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/StoreApiVertxProxyHandler.kt: (73, 33) Class 'kotlinx.coroutines.CoroutineStart' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/StoreApiVertxProxyHandler.kt: (73, 33) Class 'kotlinx.coroutines.BuildersKt__Builders_commonKt' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/StoreApiVertxProxyHandler.kt: (73, 46) Class 'kotlinx.coroutines.CoroutineDispatcher' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/StoreApiVertxProxyHandler.kt: (78, 23) Class 'kotlinx.coroutines.DisposableHandle' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/StoreApiVertxProxyHandler.kt: (92, 21) Class 'kotlinx.coroutines.GlobalScope' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/StoreApiVertxProxyHandler.kt: (92, 33) Class 'kotlinx.coroutines.Job' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/StoreApiVertxProxyHandler.kt: (92, 33) Class 'kotlinx.coroutines.CoroutineScope' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/StoreApiVertxProxyHandler.kt: (92, 33) Class 'kotlinx.coroutines.CoroutineStart' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/StoreApiVertxProxyHandler.kt: (92, 33) Class 'kotlinx.coroutines.BuildersKt__Builders_commonKt' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/StoreApiVertxProxyHandler.kt: (92, 46) Class 'kotlinx.coroutines.CoroutineDispatcher' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/StoreApiVertxProxyHandler.kt: (97, 23) Class 'kotlinx.coroutines.DisposableHandle' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/StoreApiVertxProxyHandler.kt: (109, 21) Class 'kotlinx.coroutines.GlobalScope' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/StoreApiVertxProxyHandler.kt: (109, 33) Class 'kotlinx.coroutines.Job' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/StoreApiVertxProxyHandler.kt: (109, 33) Class 'kotlinx.coroutines.CoroutineScope' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/StoreApiVertxProxyHandler.kt: (109, 33) Class 'kotlinx.coroutines.CoroutineStart' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/StoreApiVertxProxyHandler.kt: (109, 33) Class 'kotlinx.coroutines.BuildersKt__Builders_commonKt' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/StoreApiVertxProxyHandler.kt: (109, 46) Class 'kotlinx.coroutines.CoroutineDispatcher' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/StoreApiVertxProxyHandler.kt: (114, 23) Class 'kotlinx.coroutines.DisposableHandle' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/UserApiVertxProxyHandler.kt: (12, 27) Class 'kotlinx.coroutines.GlobalScope' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/UserApiVertxProxyHandler.kt: (74, 21) Class 'kotlinx.coroutines.GlobalScope' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/UserApiVertxProxyHandler.kt: (74, 33) Class 'kotlinx.coroutines.Job' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/UserApiVertxProxyHandler.kt: (74, 33) Class 'kotlinx.coroutines.CoroutineScope' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/UserApiVertxProxyHandler.kt: (74, 33) Class 'kotlinx.coroutines.CoroutineStart' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/UserApiVertxProxyHandler.kt: (74, 33) Class 'kotlinx.coroutines.BuildersKt__Builders_commonKt' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/UserApiVertxProxyHandler.kt: (74, 46) Class 'kotlinx.coroutines.CoroutineDispatcher' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/UserApiVertxProxyHandler.kt: (79, 23) Class 'kotlinx.coroutines.DisposableHandle' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/UserApiVertxProxyHandler.kt: (92, 21) Class 'kotlinx.coroutines.GlobalScope' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/UserApiVertxProxyHandler.kt: (92, 33) Class 'kotlinx.coroutines.Job' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/UserApiVertxProxyHandler.kt: (92, 33) Class 'kotlinx.coroutines.CoroutineScope' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/UserApiVertxProxyHandler.kt: (92, 33) Class 'kotlinx.coroutines.CoroutineStart' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/UserApiVertxProxyHandler.kt: (92, 33) Class 'kotlinx.coroutines.BuildersKt__Builders_commonKt' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/UserApiVertxProxyHandler.kt: (92, 46) Class 'kotlinx.coroutines.CoroutineDispatcher' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/UserApiVertxProxyHandler.kt: (97, 23) Class 'kotlinx.coroutines.DisposableHandle' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/UserApiVertxProxyHandler.kt: (110, 21) Class 'kotlinx.coroutines.GlobalScope' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/UserApiVertxProxyHandler.kt: (110, 33) Class 'kotlinx.coroutines.Job' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/UserApiVertxProxyHandler.kt: (110, 33) Class 'kotlinx.coroutines.CoroutineScope' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/UserApiVertxProxyHandler.kt: (110, 33) Class 'kotlinx.coroutines.CoroutineStart' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/UserApiVertxProxyHandler.kt: (110, 33) Class 'kotlinx.coroutines.BuildersKt__Builders_commonKt' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/UserApiVertxProxyHandler.kt: (110, 46) Class 'kotlinx.coroutines.CoroutineDispatcher' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/UserApiVertxProxyHandler.kt: (115, 23) Class 'kotlinx.coroutines.DisposableHandle' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/UserApiVertxProxyHandler.kt: (126, 21) Class 'kotlinx.coroutines.GlobalScope' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/UserApiVertxProxyHandler.kt: (126, 33) Class 'kotlinx.coroutines.Job' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/UserApiVertxProxyHandler.kt: (126, 33) Class 'kotlinx.coroutines.CoroutineScope' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/UserApiVertxProxyHandler.kt: (126, 33) Class 'kotlinx.coroutines.CoroutineStart' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/UserApiVertxProxyHandler.kt: (126, 33) Class 'kotlinx.coroutines.BuildersKt__Builders_commonKt' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/UserApiVertxProxyHandler.kt: (126, 46) Class 'kotlinx.coroutines.CoroutineDispatcher' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/UserApiVertxProxyHandler.kt: (131, 23) Class 'kotlinx.coroutines.DisposableHandle' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/UserApiVertxProxyHandler.kt: (142, 21) Class 'kotlinx.coroutines.GlobalScope' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/UserApiVertxProxyHandler.kt: (142, 33) Class 'kotlinx.coroutines.Job' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/UserApiVertxProxyHandler.kt: (142, 33) Class 'kotlinx.coroutines.CoroutineScope' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/UserApiVertxProxyHandler.kt: (142, 33) Class 'kotlinx.coroutines.CoroutineStart' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/UserApiVertxProxyHandler.kt: (142, 33) Class 'kotlinx.coroutines.BuildersKt__Builders_commonKt' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/UserApiVertxProxyHandler.kt: (142, 46) Class 'kotlinx.coroutines.CoroutineDispatcher' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/UserApiVertxProxyHandler.kt: (147, 23) Class 'kotlinx.coroutines.DisposableHandle' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/UserApiVertxProxyHandler.kt: (162, 21) Class 'kotlinx.coroutines.GlobalScope' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/UserApiVertxProxyHandler.kt: (162, 33) Class 'kotlinx.coroutines.Job' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/UserApiVertxProxyHandler.kt: (162, 33) Class 'kotlinx.coroutines.CoroutineScope' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/UserApiVertxProxyHandler.kt: (162, 33) Class 'kotlinx.coroutines.CoroutineStart' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/UserApiVertxProxyHandler.kt: (162, 33) Class 'kotlinx.coroutines.BuildersKt__Builders_commonKt' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/UserApiVertxProxyHandler.kt: (162, 46) Class 'kotlinx.coroutines.CoroutineDispatcher' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/UserApiVertxProxyHandler.kt: (167, 23) Class 'kotlinx.coroutines.DisposableHandle' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/UserApiVertxProxyHandler.kt: (186, 21) Class 'kotlinx.coroutines.GlobalScope' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/UserApiVertxProxyHandler.kt: (186, 33) Class 'kotlinx.coroutines.Job' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/UserApiVertxProxyHandler.kt: (186, 33) Class 'kotlinx.coroutines.CoroutineScope' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/UserApiVertxProxyHandler.kt: (186, 33) Class 'kotlinx.coroutines.CoroutineStart' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/UserApiVertxProxyHandler.kt: (186, 33) Class 'kotlinx.coroutines.BuildersKt__Builders_commonKt' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/UserApiVertxProxyHandler.kt: (186, 46) Class 'kotlinx.coroutines.CoroutineDispatcher' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/UserApiVertxProxyHandler.kt: (191, 23) Class 'kotlinx.coroutines.DisposableHandle' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] Failed to execute goal org.jetbrains.kotlin:kotlin-maven-plugin:1.3.10:compile (compile) on project openapi-kotlin-vertx-server: Compilation failure: Compilation failure:
[ERROR] Incompatible classes were found in dependencies. Remove them from the classpath or use '-Xskip-metadata-version-check' to suppress errors
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt:[12,27] Class 'kotlinx.coroutines.GlobalScope' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt:[66,13] Class 'kotlinx.coroutines.DisposableHandle' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt:[75,21] Class 'kotlinx.coroutines.GlobalScope' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt:[75,33] Class 'kotlinx.coroutines.Job' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt:[75,33] Class 'kotlinx.coroutines.CoroutineScope' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt:[75,33] Class 'kotlinx.coroutines.CoroutineStart' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt:[75,33] Class 'kotlinx.coroutines.BuildersKt__Builders_commonKt' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt:[75,46] Class 'kotlinx.coroutines.CoroutineDispatcher' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt:[80,23] Class 'kotlinx.coroutines.DisposableHandle' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt:[92,21] Class 'kotlinx.coroutines.GlobalScope' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt:[92,33] Class 'kotlinx.coroutines.Job' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt:[92,33] Class 'kotlinx.coroutines.CoroutineScope' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt:[92,33] Class 'kotlinx.coroutines.CoroutineStart' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt:[92,33] Class 'kotlinx.coroutines.BuildersKt__Builders_commonKt' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt:[92,46] Class 'kotlinx.coroutines.CoroutineDispatcher' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt:[97,23] Class 'kotlinx.coroutines.DisposableHandle' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt:[110,21] Class 'kotlinx.coroutines.GlobalScope' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt:[110,33] Class 'kotlinx.coroutines.Job' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt:[110,33] Class 'kotlinx.coroutines.CoroutineScope' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt:[110,33] Class 'kotlinx.coroutines.CoroutineStart' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt:[110,33] Class 'kotlinx.coroutines.BuildersKt__Builders_commonKt' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt:[110,46] Class 'kotlinx.coroutines.CoroutineDispatcher' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt:[115,23] Class 'kotlinx.coroutines.DisposableHandle' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt:[128,21] Class 'kotlinx.coroutines.GlobalScope' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt:[128,33] Class 'kotlinx.coroutines.Job' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt:[128,33] Class 'kotlinx.coroutines.CoroutineScope' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt:[128,33] Class 'kotlinx.coroutines.CoroutineStart' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt:[128,33] Class 'kotlinx.coroutines.BuildersKt__Builders_commonKt' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt:[128,46] Class 'kotlinx.coroutines.CoroutineDispatcher' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt:[133,23] Class 'kotlinx.coroutines.DisposableHandle' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt:[144,21] Class 'kotlinx.coroutines.GlobalScope' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt:[144,33] Class 'kotlinx.coroutines.Job' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt:[144,33] Class 'kotlinx.coroutines.CoroutineScope' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt:[144,33] Class 'kotlinx.coroutines.CoroutineStart' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt:[144,33] Class 'kotlinx.coroutines.BuildersKt__Builders_commonKt' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt:[144,46] Class 'kotlinx.coroutines.CoroutineDispatcher' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt:[149,23] Class 'kotlinx.coroutines.DisposableHandle' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt:[161,21] Class 'kotlinx.coroutines.GlobalScope' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt:[161,33] Class 'kotlinx.coroutines.Job' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt:[161,33] Class 'kotlinx.coroutines.CoroutineScope' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt:[161,33] Class 'kotlinx.coroutines.CoroutineStart' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt:[161,33] Class 'kotlinx.coroutines.BuildersKt__Builders_commonKt' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt:[161,46] Class 'kotlinx.coroutines.CoroutineDispatcher' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt:[166,23] Class 'kotlinx.coroutines.DisposableHandle' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt:[179,21] Class 'kotlinx.coroutines.GlobalScope' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt:[179,33] Class 'kotlinx.coroutines.Job' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt:[179,33] Class 'kotlinx.coroutines.CoroutineScope' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt:[179,33] Class 'kotlinx.coroutines.CoroutineStart' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt:[179,33] Class 'kotlinx.coroutines.BuildersKt__Builders_commonKt' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt:[179,46] Class 'kotlinx.coroutines.CoroutineDispatcher' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt:[184,23] Class 'kotlinx.coroutines.DisposableHandle' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt:[198,21] Class 'kotlinx.coroutines.GlobalScope' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt:[198,33] Class 'kotlinx.coroutines.Job' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt:[198,33] Class 'kotlinx.coroutines.CoroutineScope' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt:[198,33] Class 'kotlinx.coroutines.CoroutineStart' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt:[198,33] Class 'kotlinx.coroutines.BuildersKt__Builders_commonKt' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt:[198,46] Class 'kotlinx.coroutines.CoroutineDispatcher' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt:[203,23] Class 'kotlinx.coroutines.DisposableHandle' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/StoreApiVertxProxyHandler.kt:[12,27] Class 'kotlinx.coroutines.GlobalScope' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/StoreApiVertxProxyHandler.kt:[73,21] Class 'kotlinx.coroutines.GlobalScope' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/StoreApiVertxProxyHandler.kt:[73,33] Class 'kotlinx.coroutines.Job' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/StoreApiVertxProxyHandler.kt:[73,33] Class 'kotlinx.coroutines.CoroutineScope' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/StoreApiVertxProxyHandler.kt:[73,33] Class 'kotlinx.coroutines.CoroutineStart' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/StoreApiVertxProxyHandler.kt:[73,33] Class 'kotlinx.coroutines.BuildersKt__Builders_commonKt' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/StoreApiVertxProxyHandler.kt:[73,46] Class 'kotlinx.coroutines.CoroutineDispatcher' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/StoreApiVertxProxyHandler.kt:[78,23] Class 'kotlinx.coroutines.DisposableHandle' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/StoreApiVertxProxyHandler.kt:[92,21] Class 'kotlinx.coroutines.GlobalScope' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/StoreApiVertxProxyHandler.kt:[92,33] Class 'kotlinx.coroutines.Job' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/StoreApiVertxProxyHandler.kt:[92,33] Class 'kotlinx.coroutines.CoroutineScope' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/StoreApiVertxProxyHandler.kt:[92,33] Class 'kotlinx.coroutines.CoroutineStart' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/StoreApiVertxProxyHandler.kt:[92,33] Class 'kotlinx.coroutines.BuildersKt__Builders_commonKt' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/StoreApiVertxProxyHandler.kt:[92,46] Class 'kotlinx.coroutines.CoroutineDispatcher' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/StoreApiVertxProxyHandler.kt:[97,23] Class 'kotlinx.coroutines.DisposableHandle' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/StoreApiVertxProxyHandler.kt:[109,21] Class 'kotlinx.coroutines.GlobalScope' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/StoreApiVertxProxyHandler.kt:[109,33] Class 'kotlinx.coroutines.Job' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/StoreApiVertxProxyHandler.kt:[109,33] Class 'kotlinx.coroutines.CoroutineScope' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/StoreApiVertxProxyHandler.kt:[109,33] Class 'kotlinx.coroutines.CoroutineStart' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/StoreApiVertxProxyHandler.kt:[109,33] Class 'kotlinx.coroutines.BuildersKt__Builders_commonKt' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/StoreApiVertxProxyHandler.kt:[109,46] Class 'kotlinx.coroutines.CoroutineDispatcher' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/StoreApiVertxProxyHandler.kt:[114,23] Class 'kotlinx.coroutines.DisposableHandle' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/UserApiVertxProxyHandler.kt:[12,27] Class 'kotlinx.coroutines.GlobalScope' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/UserApiVertxProxyHandler.kt:[74,21] Class 'kotlinx.coroutines.GlobalScope' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/UserApiVertxProxyHandler.kt:[74,33] Class 'kotlinx.coroutines.Job' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/UserApiVertxProxyHandler.kt:[74,33] Class 'kotlinx.coroutines.CoroutineScope' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/UserApiVertxProxyHandler.kt:[74,33] Class 'kotlinx.coroutines.CoroutineStart' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/UserApiVertxProxyHandler.kt:[74,33] Class 'kotlinx.coroutines.BuildersKt__Builders_commonKt' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/UserApiVertxProxyHandler.kt:[74,46] Class 'kotlinx.coroutines.CoroutineDispatcher' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/UserApiVertxProxyHandler.kt:[79,23] Class 'kotlinx.coroutines.DisposableHandle' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/UserApiVertxProxyHandler.kt:[92,21] Class 'kotlinx.coroutines.GlobalScope' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/UserApiVertxProxyHandler.kt:[92,33] Class 'kotlinx.coroutines.Job' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/UserApiVertxProxyHandler.kt:[92,33] Class 'kotlinx.coroutines.CoroutineScope' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/UserApiVertxProxyHandler.kt:[92,33] Class 'kotlinx.coroutines.CoroutineStart' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/UserApiVertxProxyHandler.kt:[92,33] Class 'kotlinx.coroutines.BuildersKt__Builders_commonKt' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/UserApiVertxProxyHandler.kt:[92,46] Class 'kotlinx.coroutines.CoroutineDispatcher' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/UserApiVertxProxyHandler.kt:[97,23] Class 'kotlinx.coroutines.DisposableHandle' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/UserApiVertxProxyHandler.kt:[110,21] Class 'kotlinx.coroutines.GlobalScope' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/UserApiVertxProxyHandler.kt:[110,33] Class 'kotlinx.coroutines.Job' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/UserApiVertxProxyHandler.kt:[110,33] Class 'kotlinx.coroutines.CoroutineScope' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/UserApiVertxProxyHandler.kt:[110,33] Class 'kotlinx.coroutines.CoroutineStart' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/UserApiVertxProxyHandler.kt:[110,33] Class 'kotlinx.coroutines.BuildersKt__Builders_commonKt' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/UserApiVertxProxyHandler.kt:[110,46] Class 'kotlinx.coroutines.CoroutineDispatcher' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/UserApiVertxProxyHandler.kt:[115,23] Class 'kotlinx.coroutines.DisposableHandle' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/UserApiVertxProxyHandler.kt:[126,21] Class 'kotlinx.coroutines.GlobalScope' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/UserApiVertxProxyHandler.kt:[126,33] Class 'kotlinx.coroutines.Job' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/UserApiVertxProxyHandler.kt:[126,33] Class 'kotlinx.coroutines.CoroutineScope' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/UserApiVertxProxyHandler.kt:[126,33] Class 'kotlinx.coroutines.CoroutineStart' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/UserApiVertxProxyHandler.kt:[126,33] Class 'kotlinx.coroutines.BuildersKt__Builders_commonKt' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/UserApiVertxProxyHandler.kt:[126,46] Class 'kotlinx.coroutines.CoroutineDispatcher' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/UserApiVertxProxyHandler.kt:[131,23] Class 'kotlinx.coroutines.DisposableHandle' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/UserApiVertxProxyHandler.kt:[142,21] Class 'kotlinx.coroutines.GlobalScope' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/UserApiVertxProxyHandler.kt:[142,33] Class 'kotlinx.coroutines.Job' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/UserApiVertxProxyHandler.kt:[142,33] Class 'kotlinx.coroutines.CoroutineScope' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/UserApiVertxProxyHandler.kt:[142,33] Class 'kotlinx.coroutines.CoroutineStart' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/UserApiVertxProxyHandler.kt:[142,33] Class 'kotlinx.coroutines.BuildersKt__Builders_commonKt' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/UserApiVertxProxyHandler.kt:[142,46] Class 'kotlinx.coroutines.CoroutineDispatcher' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/UserApiVertxProxyHandler.kt:[147,23] Class 'kotlinx.coroutines.DisposableHandle' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/UserApiVertxProxyHandler.kt:[162,21] Class 'kotlinx.coroutines.GlobalScope' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/UserApiVertxProxyHandler.kt:[162,33] Class 'kotlinx.coroutines.Job' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/UserApiVertxProxyHandler.kt:[162,33] Class 'kotlinx.coroutines.CoroutineScope' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/UserApiVertxProxyHandler.kt:[162,33] Class 'kotlinx.coroutines.CoroutineStart' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/UserApiVertxProxyHandler.kt:[162,33] Class 'kotlinx.coroutines.BuildersKt__Builders_commonKt' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/UserApiVertxProxyHandler.kt:[162,46] Class 'kotlinx.coroutines.CoroutineDispatcher' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/UserApiVertxProxyHandler.kt:[167,23] Class 'kotlinx.coroutines.DisposableHandle' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/UserApiVertxProxyHandler.kt:[186,21] Class 'kotlinx.coroutines.GlobalScope' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/UserApiVertxProxyHandler.kt:[186,33] Class 'kotlinx.coroutines.Job' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/UserApiVertxProxyHandler.kt:[186,33] Class 'kotlinx.coroutines.CoroutineScope' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/UserApiVertxProxyHandler.kt:[186,33] Class 'kotlinx.coroutines.CoroutineStart' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/UserApiVertxProxyHandler.kt:[186,33] Class 'kotlinx.coroutines.BuildersKt__Builders_commonKt' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/UserApiVertxProxyHandler.kt:[186,46] Class 'kotlinx.coroutines.CoroutineDispatcher' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/UserApiVertxProxyHandler.kt:[191,23] Class 'kotlinx.coroutines.DisposableHandle' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler
[ERROR] -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoFailureException
[ERROR] 
[ERROR] After correcting the problems, you can resume the build with the command
[ERROR]   mvn <goals> -rf :openapi-kotlin-vertx-server
2020-03-31 09:45:07.301:INFO::main: Logging initialized @111ms
```

e.g. https://app.circleci.com/pipelines/github/OpenAPITools/openapi-generator/680/workflows/ee0c234e-501a-48e1-b204-9c05f91c613e/jobs/14017

Commented out the test for the time being until someone finds a fix/workaround.

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [ ] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

cc @jimschubert (2017/09) ❤️, @dr4ke616 (2018/08) @karismann (2019/03) @Zomzog (2019/04) @andrewemery (2019/10) @4brunu (2019/11) @yutaka0m (2020/03)


