### PR TITLE
[codegen] Make name cache configurable using system properties

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -132,9 +132,11 @@ public class DefaultCodegen implements CodegenConfig {
                 )
                 .build();
 
+        int cacheSize = Integer.parseInt(GlobalSettings.getProperty(NAME_CACHE_SIZE_PROPERTY, "500"));
+        int cacheExpiry = Integer.parseInt(GlobalSettings.getProperty(NAME_CACHE_EXPIRY_PROPERTY, "10"));
         sanitizedNameCache = Caffeine.newBuilder()
-                .maximumSize(500)
-                .expireAfterAccess(10, TimeUnit.SECONDS)
+                .maximumSize(cacheSize)
+                .expireAfterAccess(cacheExpiry, TimeUnit.SECONDS)
                 .ticker(Ticker.systemTicker())
                 .build();
     }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/StringUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/StringUtils.java
@@ -5,6 +5,7 @@ import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.Ticker;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
+import org.openapitools.codegen.config.GlobalSettings;
 
 import java.util.List;
 import java.util.Locale;
@@ -16,6 +17,15 @@ import java.util.regex.Pattern;
 
 public class StringUtils {
 
+    /**
+     * Modify the cache size of the sanitizedNameCache, camelizedWordsCache and underscoreWords.
+     */
+    public static final String NAME_CACHE_SIZE_PROPERTY = "org.openapitools.codegen.utils.namecache.cachesize";
+    /**
+     * Modify the cache expiry of the sanitizedNameCache, camelizedWordsCache and underscoreWords.
+     */
+    public static final String NAME_CACHE_EXPIRY_PROPERTY = "org.openapitools.codegen.utils.namecache.expireafter";
+
     // A cache of camelized words. The camelize() method is invoked many times with the same
     // arguments, this cache is used to optimized performance.
     private static Cache<Pair<String, Boolean>, String> camelizedWordsCache;
@@ -23,15 +33,17 @@ public class StringUtils {
     // A cache of underscored words, used to optimize the performance of the underscore() method.
     private static Cache<String, String> underscoreWords;
     static {
+        int cacheSize = Integer.parseInt(GlobalSettings.getProperty(NAME_CACHE_SIZE_PROPERTY, "200"));
+        int cacheExpiry = Integer.parseInt(GlobalSettings.getProperty(NAME_CACHE_EXPIRY_PROPERTY, "5"));
         camelizedWordsCache = Caffeine.newBuilder()
-                .maximumSize(200)
-                .expireAfterAccess(5, TimeUnit.SECONDS)
+                .maximumSize(cacheSize)
+                .expireAfterAccess(cacheExpiry, TimeUnit.SECONDS)
                 .ticker(Ticker.systemTicker())
                 .build();
 
         underscoreWords = Caffeine.newBuilder()
-                .maximumSize(200)
-                .expireAfterAccess(5, TimeUnit.SECONDS)
+                .maximumSize(cacheSize)
+                .expireAfterAccess(cacheExpiry, TimeUnit.SECONDS)
                 .ticker(Ticker.systemTicker())
                 .build();
     }


### PR DESCRIPTION
This is a follow-up to Jim's PR #5484. The cache parameters are configurable using system properties.

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [ ] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
