### PR TITLE
[codegen] Helper function for discriminator mapping allowed values

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenDiscriminator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenDiscriminator.java
@@ -11,6 +11,7 @@ public class CodegenDiscriminator {
     private String propertyName;
     private String propertyBaseName;
     private String propertyGetter;
+    // The implementation type for the language generator being executed.
     private String propertyType;
     private Map<String, String> mapping;
     private Set<MappedModel> mappedModels = new LinkedHashSet<>();

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenModel.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenModel.java
@@ -250,7 +250,7 @@ public class CodegenModel implements IJsonSchemaValidationProperties {
      * 
      * @return the list of allowed discriminator mapping values.
      */
-    public List<String> getValidDiscriminatorMappings() {
+    public List<String> getAllowedDiscriminatorMappingValues() {
         List<String> mappingValues = new ArrayList<String>();
         for (CodegenDiscriminator.MappedModel mm : discriminator.getMappedModels()) {
             if (name.equals(mm.getModelName())) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenModel.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenModel.java
@@ -201,6 +201,11 @@ public class CodegenModel implements IJsonSchemaValidationProperties {
     /**
      * Returns the discriminator for this schema object, or null if no discriminator has been specified.
      * 
+     * The returned value is null if no discriminator is defined for this local schema.
+     * The value is also null when the discriminators are inherited through references in the
+     * OpenAPI document. For example, a schema may have a 'allOf' attribute and the allOf
+     * referenced children define a discriminator, recursively.
+     * 
      * @return the discriminator.
      */
     public CodegenDiscriminator getDiscriminator() {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenModel.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenModel.java
@@ -22,6 +22,9 @@ import io.swagger.v3.oas.models.ExternalDocumentation;
 
 import java.util.*;
 
+/**
+ * CodegenModel represents a schema object in a OpenAPI document.
+ */
 @JsonIgnoreProperties({"parentModel", "interfaceModels"})
 public class CodegenModel implements IJsonSchemaValidationProperties {
     // The parent model name from the schemas. The parent is determined by inspecting the allOf, anyOf and
@@ -195,6 +198,11 @@ public class CodegenModel implements IJsonSchemaValidationProperties {
         this.description = description;
     }
 
+    /**
+     * Returns the discriminator for this schema object, or null if no discriminator has been specified.
+     * 
+     * @return the discriminator.
+     */
     public CodegenDiscriminator getDiscriminator() {
         return discriminator;
     }
@@ -203,6 +211,25 @@ public class CodegenModel implements IJsonSchemaValidationProperties {
         this.discriminator = discriminator;
     }
 
+    /**
+     * Returns a list of allowed discriminator mapping values for this schema object.
+     * 
+     * @return the list of allowed discriminator mapping values.
+     */
+    public List<String> getValidDiscriminatorMappings() {
+        List<String> mappingValues = new ArrayList<String>();
+        for (CodegenDiscriminator.MappedModel mm : discriminator.getMappedModels()) {
+            if (name.equals(mm.getModelName())) {
+                mappingValues.add(mm.getMappingName());
+            }
+        }     
+        return mappingValues;   
+    }
+
+    /**
+     * Returns the name of the discriminator property for this schema in the OpenAPI document.
+     * @return the name of the discriminator property.
+     */
     public String getDiscriminatorName() {
         return discriminator == null ? null : discriminator.getPropertyName();
     }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenModel.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenModel.java
@@ -262,6 +262,10 @@ public class CodegenModel implements IJsonSchemaValidationProperties {
 
     /**
      * Returns the name of the discriminator property for this schema in the OpenAPI document.
+     * In the OpenAPI document, the discriminator may be specified in the local schema or
+     * it may be inherited, such as through a 'allOf' schema which references another schema
+     * that has a discriminator, recursively.
+     * 
      * @return the name of the discriminator property.
      */
     public String getDiscriminatorName() {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenModel.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenModel.java
@@ -214,6 +214,40 @@ public class CodegenModel implements IJsonSchemaValidationProperties {
     /**
      * Returns a list of allowed discriminator mapping values for this schema object.
      * 
+     * The list of all possible schema discriminator mapping values is obtained
+     * from explicit discriminator mapping values in the OpenAPI document, and from
+     * inherited discriminators through oneOf, allOf, anyOf.
+     * For example, a discriminator may be defined in a 'Pet' schema as shown below.
+     * The Dog and Cat schemas inherit the discriminator through the allOf reference.
+     * In the 'Pet' schema, the supported discriminator mapping values for the
+     * 'objectType' properties are 'Dog' and 'Cat'.
+     * The allowed discriminator mapping value for the Dog schema is 'Dog'.
+     * The allowed discriminator mapping value for the Cat schema is 'Dog'.
+     * 
+     * Pet:
+     *   type: object
+     *   discriminator:
+     *     propertyName: objectType
+     *   required:
+     *     - objectType
+     *   properties:
+     *     objectType:
+     *     type: string
+     * Dog:
+     *   allOf:
+     *   - $ref: '#/components/schemas/Pet'
+     *   - type: object
+     *     properties:
+     *       p1:
+     *         type: string
+     * Cat:
+     *   allOf:
+     *   - $ref: '#/components/schemas/Pet'
+     *   - type: object
+     *     properties:
+     *       p2:
+     *         type: string
+     * 
      * @return the list of allowed discriminator mapping values.
      */
     public List<String> getValidDiscriminatorMappings() {


### PR DESCRIPTION
Add a helper function that returns a list of allowed discriminator mapping values for a schema object.

The list of all possible schema discriminator mapping values is obtained from explicit discriminator mapping values in the OpenAPI document, and from inherited discriminators through oneOf, allOf, anyOf.

For example, a discriminator may be defined in a 'Pet' schema as shown below.
The Dog and Cat schemas inherit the discriminator through the allOf reference.
In the 'Pet' schema, the supported discriminator mapping values for the 'objectType' properties are 'Dog' and 'Cat'.
     * The allowed discriminator mapping value for the Dog schema is 'Dog'.
     * The allowed discriminator mapping value for the Cat schema is 'Dog'.

Currently, I don't see any helper function that would return a list of allowed discriminator mapping values, such as "Dog" for the Dog schema.

```yaml 
Pet:
   type: object
   discriminator:
     propertyName: objectType
   required:
     - objectType
   properties:
     objectType:
     type: string
 Dog:
   allOf:
   - $ref: '#/components/schemas/Pet'
   - type: object
     properties:
       p1:
        type: string
 Cat:
   allOf:
   - $ref: '#/components/schemas/Pet'
   - type: object
     properties:
       p2:
         type: string
```
<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [ ] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [ ] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
