### PR TITLE
[mysql] Add OAuth2 framework tables

### DIFF
--- a/modules/openapi-generator/src/main/resources/mysql-schema/mysql_schema.mustache
+++ b/modules/openapi-generator/src/main/resources/mysql-schema/mysql_schema.mustache
@@ -100,7 +100,7 @@ CREATE TABLE IF NOT EXISTS `oauth_refresh_tokens` (
 --
 CREATE TABLE IF NOT EXISTS `oauth_users` (
   `username`            VARCHAR(80)    DEFAULT NULL,
-  `password`            VARCHAR(80)    DEFAULT NULL,
+  `password`            VARCHAR(255)   DEFAULT NULL,
   `first_name`          VARCHAR(80)    DEFAULT NULL,
   `last_name`           VARCHAR(80)    DEFAULT NULL,
   `email`               VARCHAR(2000)  DEFAULT NULL,

--- a/modules/openapi-generator/src/main/resources/mysql-schema/mysql_schema.mustache
+++ b/modules/openapi-generator/src/main/resources/mysql-schema/mysql_schema.mustache
@@ -43,3 +43,107 @@ CREATE TABLE IF NOT EXISTS {{#defaultDatabaseName}}`{{{defaultDatabaseName}}}`.{
 {{/vendorExtensions}}
 
 {{/isArrayModel}}{{/hasVars}}{{/model}}{{/models}}
+{{#hasOAuthMethods}}
+--
+-- Table structure for table `oauth_clients`
+--
+CREATE TABLE IF NOT EXISTS `oauth_clients` (
+  `client_id`            VARCHAR(80)    NOT NULL,
+  `client_secret`        VARCHAR(80)    DEFAULT NULL,
+  `redirect_uri`         VARCHAR(2000)  DEFAULT NULL,
+  `grant_types`          VARCHAR(80)    DEFAULT NULL,
+  `scope`                VARCHAR(4000)  DEFAULT NULL,
+  `user_id`              VARCHAR(80)    DEFAULT NULL,
+  PRIMARY KEY (`client_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+--
+-- Table structure for table `oauth_access_tokens`
+--
+CREATE TABLE IF NOT EXISTS `oauth_access_tokens` (
+  `access_token`         VARCHAR(40)    NOT NULL,
+  `client_id`            VARCHAR(80)    DEFAULT NULL,
+  `user_id`              VARCHAR(80)    DEFAULT NULL,
+  `expires`              TIMESTAMP      NOT NULL,
+  `scope`                VARCHAR(4000)  DEFAULT NULL,
+  PRIMARY KEY (`access_token`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+--
+-- Table structure for table `oauth_authorization_codes`
+--
+CREATE TABLE IF NOT EXISTS `oauth_authorization_codes` (
+  `authorization_code`  VARCHAR(40)    NOT NULL,
+  `client_id`           VARCHAR(80)    DEFAULT NULL,
+  `user_id`             VARCHAR(80)    DEFAULT NULL,
+  `redirect_uri`        VARCHAR(2000)  NOT NULL,
+  `expires`             TIMESTAMP      NOT NULL,
+  `scope`               VARCHAR(4000)  DEFAULT NULL,
+  `id_token`            VARCHAR(1000)  DEFAULT NULL,
+  PRIMARY KEY (`authorization_code`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+--
+-- Table structure for table `oauth_refresh_tokens`
+--
+CREATE TABLE IF NOT EXISTS `oauth_refresh_tokens` (
+  `refresh_token`       VARCHAR(40)    NOT NULL,
+  `client_id`           VARCHAR(80)    DEFAULT NULL,
+  `user_id`             VARCHAR(80)    DEFAULT NULL,
+  `expires`             TIMESTAMP      on update CURRENT_TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `scope`               VARCHAR(4000)  DEFAULT NULL,
+  PRIMARY KEY (`refresh_token`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+--
+-- Table structure for table `oauth_users`
+--
+CREATE TABLE IF NOT EXISTS `oauth_users` (
+  `username`            VARCHAR(80)    DEFAULT NULL,
+  `password`            VARCHAR(80)    DEFAULT NULL,
+  `first_name`          VARCHAR(80)    DEFAULT NULL,
+  `last_name`           VARCHAR(80)    DEFAULT NULL,
+  `email`               VARCHAR(2000)  DEFAULT NULL,
+  `email_verified`      TINYINT(1)     DEFAULT NULL,
+  `scope`               VARCHAR(4000)  DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+--
+-- Table structure for table `oauth_scopes`
+--
+CREATE TABLE IF NOT EXISTS `oauth_scopes` (
+  `scope`               VARCHAR(80)  NOT NULL,
+  `is_default`          TINYINT(1)   DEFAULT NULL,
+  PRIMARY KEY (`scope`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+--
+-- Table structure for table `oauth_jwt`
+--
+CREATE TABLE IF NOT EXISTS `oauth_jwt` (
+  `client_id`           VARCHAR(80)    NOT NULL,
+  `subject`             VARCHAR(80)    DEFAULT NULL,
+  `public_key`          VARCHAR(2000)  NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+--
+-- Table structure for table `oauth_jti`
+--
+CREATE TABLE IF NOT EXISTS `oauth_jti` (
+  `issuer`              VARCHAR(80)    NOT NULL,
+  `subject`             VARCHAR(80)    DEFAULT NULL,
+  `audiance`            VARCHAR(80)    DEFAULT NULL,
+  `expires`             TIMESTAMP      NOT NULL,
+  `jti`                 VARCHAR(2000)  NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+--
+-- Table structure for table `oauth_public_keys`
+--
+CREATE TABLE IF NOT EXISTS `oauth_public_keys` (
+  `client_id`            VARCHAR(80)    DEFAULT NULL,
+  `public_key`           VARCHAR(2000)  DEFAULT NULL,
+  `private_key`          VARCHAR(2000)  DEFAULT NULL,
+  `encryption_algorithm` VARCHAR(100)   DEFAULT 'RS256'
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+{{/hasOAuthMethods}}

--- a/modules/openapi-generator/src/main/resources/mysql-schema/mysql_schema.mustache
+++ b/modules/openapi-generator/src/main/resources/mysql-schema/mysql_schema.mustache
@@ -45,6 +45,11 @@ CREATE TABLE IF NOT EXISTS {{#defaultDatabaseName}}`{{{defaultDatabaseName}}}`.{
 {{/isArrayModel}}{{/hasVars}}{{/model}}{{/models}}
 {{#hasOAuthMethods}}
 --
+-- OAuth2 framework tables
+-- Thanks to https://github.com/dsquier/oauth2-server-php-mysql repo
+--
+
+--
 -- Table structure for table `oauth_clients`
 --
 CREATE TABLE IF NOT EXISTS `oauth_clients` (

--- a/samples/schema/petstore/mysql/mysql_schema.sql
+++ b/samples/schema/petstore/mysql/mysql_schema.sql
@@ -495,6 +495,11 @@ CREATE TABLE IF NOT EXISTS `XmlItem` (
 
 
 --
+-- OAuth2 framework tables
+-- Thanks to https://github.com/dsquier/oauth2-server-php-mysql repo
+--
+
+--
 -- Table structure for table `oauth_clients`
 --
 CREATE TABLE IF NOT EXISTS `oauth_clients` (
@@ -550,7 +555,7 @@ CREATE TABLE IF NOT EXISTS `oauth_refresh_tokens` (
 --
 CREATE TABLE IF NOT EXISTS `oauth_users` (
   `username`            VARCHAR(80)    DEFAULT NULL,
-  `password`            VARCHAR(80)    DEFAULT NULL,
+  `password`            VARCHAR(255)   DEFAULT NULL,
   `first_name`          VARCHAR(80)    DEFAULT NULL,
   `last_name`           VARCHAR(80)    DEFAULT NULL,
   `email`               VARCHAR(2000)  DEFAULT NULL,

--- a/samples/schema/petstore/mysql/mysql_schema.sql
+++ b/samples/schema/petstore/mysql/mysql_schema.sql
@@ -493,3 +493,106 @@ CREATE TABLE IF NOT EXISTS `XmlItem` (
   `prefix_ns_wrapped_array` JSON DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
+
+--
+-- Table structure for table `oauth_clients`
+--
+CREATE TABLE IF NOT EXISTS `oauth_clients` (
+  `client_id`            VARCHAR(80)    NOT NULL,
+  `client_secret`        VARCHAR(80)    DEFAULT NULL,
+  `redirect_uri`         VARCHAR(2000)  DEFAULT NULL,
+  `grant_types`          VARCHAR(80)    DEFAULT NULL,
+  `scope`                VARCHAR(4000)  DEFAULT NULL,
+  `user_id`              VARCHAR(80)    DEFAULT NULL,
+  PRIMARY KEY (`client_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+--
+-- Table structure for table `oauth_access_tokens`
+--
+CREATE TABLE IF NOT EXISTS `oauth_access_tokens` (
+  `access_token`         VARCHAR(40)    NOT NULL,
+  `client_id`            VARCHAR(80)    DEFAULT NULL,
+  `user_id`              VARCHAR(80)    DEFAULT NULL,
+  `expires`              TIMESTAMP      NOT NULL,
+  `scope`                VARCHAR(4000)  DEFAULT NULL,
+  PRIMARY KEY (`access_token`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+--
+-- Table structure for table `oauth_authorization_codes`
+--
+CREATE TABLE IF NOT EXISTS `oauth_authorization_codes` (
+  `authorization_code`  VARCHAR(40)    NOT NULL,
+  `client_id`           VARCHAR(80)    DEFAULT NULL,
+  `user_id`             VARCHAR(80)    DEFAULT NULL,
+  `redirect_uri`        VARCHAR(2000)  NOT NULL,
+  `expires`             TIMESTAMP      NOT NULL,
+  `scope`               VARCHAR(4000)  DEFAULT NULL,
+  `id_token`            VARCHAR(1000)  DEFAULT NULL,
+  PRIMARY KEY (`authorization_code`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+--
+-- Table structure for table `oauth_refresh_tokens`
+--
+CREATE TABLE IF NOT EXISTS `oauth_refresh_tokens` (
+  `refresh_token`       VARCHAR(40)    NOT NULL,
+  `client_id`           VARCHAR(80)    DEFAULT NULL,
+  `user_id`             VARCHAR(80)    DEFAULT NULL,
+  `expires`             TIMESTAMP      on update CURRENT_TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `scope`               VARCHAR(4000)  DEFAULT NULL,
+  PRIMARY KEY (`refresh_token`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+--
+-- Table structure for table `oauth_users`
+--
+CREATE TABLE IF NOT EXISTS `oauth_users` (
+  `username`            VARCHAR(80)    DEFAULT NULL,
+  `password`            VARCHAR(80)    DEFAULT NULL,
+  `first_name`          VARCHAR(80)    DEFAULT NULL,
+  `last_name`           VARCHAR(80)    DEFAULT NULL,
+  `email`               VARCHAR(2000)  DEFAULT NULL,
+  `email_verified`      TINYINT(1)     DEFAULT NULL,
+  `scope`               VARCHAR(4000)  DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+--
+-- Table structure for table `oauth_scopes`
+--
+CREATE TABLE IF NOT EXISTS `oauth_scopes` (
+  `scope`               VARCHAR(80)  NOT NULL,
+  `is_default`          TINYINT(1)   DEFAULT NULL,
+  PRIMARY KEY (`scope`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+--
+-- Table structure for table `oauth_jwt`
+--
+CREATE TABLE IF NOT EXISTS `oauth_jwt` (
+  `client_id`           VARCHAR(80)    NOT NULL,
+  `subject`             VARCHAR(80)    DEFAULT NULL,
+  `public_key`          VARCHAR(2000)  NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+--
+-- Table structure for table `oauth_jti`
+--
+CREATE TABLE IF NOT EXISTS `oauth_jti` (
+  `issuer`              VARCHAR(80)    NOT NULL,
+  `subject`             VARCHAR(80)    DEFAULT NULL,
+  `audiance`            VARCHAR(80)    DEFAULT NULL,
+  `expires`             TIMESTAMP      NOT NULL,
+  `jti`                 VARCHAR(2000)  NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+--
+-- Table structure for table `oauth_public_keys`
+--
+CREATE TABLE IF NOT EXISTS `oauth_public_keys` (
+  `client_id`            VARCHAR(80)    DEFAULT NULL,
+  `public_key`           VARCHAR(2000)  DEFAULT NULL,
+  `private_key`          VARCHAR(2000)  DEFAULT NULL,
+  `encryption_algorithm` VARCHAR(100)   DEFAULT 'RS256'
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
Database schema copied from [oauth2-server-php-mysql](https://github.com/dsquier/oauth2-server-php-mysql/) repo.

I can't say that I'm fully satisfied with mentioned schema. My complaints are:
* ~`oauth_users`.`password` column limited to 80 characters which can be not enough for future password encryption algorithms. In PHP docs [`password_hash`](https://www.php.net/manual/en/function.password-hash.php) recommended length is 255.~
* Schema doesn't set column collations. It's important for case-sensitive tokens(base64 e.g.). More info in submitted [issue](https://github.com/dsquier/oauth2-server-php-mysql/issues/12)
* It's not obvious that `oauth_users`.`username` is `user_id` mentioned in other tables. Maybe column comment can make it more clear.

Tables structure described in related issue.

Closes #3550

@jimschubert is welcome to review or throw an opinion.

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
