### PR TITLE
Add default case to handle response code

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -3299,7 +3299,7 @@ public class DefaultCodegen implements CodegenConfig {
             }
         }
 
-        if ("default".equals(responseCode)) {
+        if ("default".equals(responseCode) || "defaultResponse".equals(responseCode)) {
             r.code = "0";
         } else {
             r.code = responseCode;

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -25,7 +25,6 @@ import com.google.common.collect.ImmutableMap;
 import com.samskivert.mustache.Mustache;
 import com.samskivert.mustache.Mustache.Compiler;
 import com.samskivert.mustache.Mustache.Lambda;
-
 import io.swagger.v3.core.util.Json;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.Operation;
@@ -57,16 +56,11 @@ import org.openapitools.codegen.meta.Stability;
 import org.openapitools.codegen.meta.features.*;
 import org.openapitools.codegen.serializer.SerializerUtils;
 import org.openapitools.codegen.templating.MustacheEngineAdapter;
-import org.openapitools.codegen.templating.mustache.CamelCaseLambda;
-import org.openapitools.codegen.templating.mustache.IndentedLambda;
-import org.openapitools.codegen.templating.mustache.LowercaseLambda;
-import org.openapitools.codegen.templating.mustache.TitlecaseLambda;
-import org.openapitools.codegen.templating.mustache.UppercaseLambda;
+import org.openapitools.codegen.templating.mustache.*;
 import org.openapitools.codegen.utils.ModelUtils;
 import org.openapitools.codegen.utils.OneOfImplementorAdditionalData;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import static org.openapitools.codegen.utils.OnceLogger.once;
 
 import java.io.File;
 import java.util.*;
@@ -78,6 +72,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static org.openapitools.codegen.utils.OnceLogger.once;
 import static org.openapitools.codegen.utils.StringUtils.*;
 
 public class DefaultCodegen implements CodegenConfig {
@@ -504,34 +499,34 @@ public class DefaultCodegen implements CodegenConfig {
 
     public void setCircularReferences(Map<String, CodegenModel> models) {
         final Map<String, List<CodegenProperty>> dependencyMap = models.entrySet().stream()
-            .collect(Collectors.toMap(Entry::getKey, entry -> getModelDependencies(entry.getValue())));
+                .collect(Collectors.toMap(Entry::getKey, entry -> getModelDependencies(entry.getValue())));
 
         models.keySet().forEach(name -> setCircularReferencesOnProperties(name, dependencyMap));
     }
 
     private List<CodegenProperty> getModelDependencies(CodegenModel model) {
         return model.getAllVars().stream()
-            .map(prop -> {
-                if (prop.isContainer) {
-                    return prop.items.dataType == null ? null : prop;
-                }
-                return prop.dataType == null ? null : prop;
-            })
-            .filter(prop -> prop != null)
-            .collect(Collectors.toList());
+                .map(prop -> {
+                    if (prop.isContainer) {
+                        return prop.items.dataType == null ? null : prop;
+                    }
+                    return prop.dataType == null ? null : prop;
+                })
+                .filter(prop -> prop != null)
+                .collect(Collectors.toList());
     }
 
     private void setCircularReferencesOnProperties(final String root,
                                                    final Map<String, List<CodegenProperty>> dependencyMap) {
         dependencyMap.getOrDefault(root, new ArrayList<>()).stream()
-            .forEach(prop -> {
-                final List<String> unvisited =
-                    Collections.singletonList(prop.isContainer ? prop.items.dataType : prop.dataType);
-                prop.isCircularReference = isCircularReference(root,
-                                                               new HashSet<>(),
-                                                               new ArrayList<>(unvisited),
-                                                               dependencyMap);
-            });
+                .forEach(prop -> {
+                    final List<String> unvisited =
+                            Collections.singletonList(prop.isContainer ? prop.items.dataType : prop.dataType);
+                    prop.isCircularReference = isCircularReference(root,
+                            new HashSet<>(),
+                            new ArrayList<>(unvisited),
+                            dependencyMap);
+                });
     }
 
     private boolean isCircularReference(final String root,
@@ -545,7 +540,7 @@ public class DefaultCodegen implements CodegenConfig {
                     return true;
                 }
                 dependencyMap.getOrDefault(next, new ArrayList<>())
-                    .forEach(prop -> unvisited.add(prop.isContainer ? prop.items.dataType : prop.dataType));
+                        .forEach(prop -> unvisited.add(prop.isContainer ? prop.items.dataType : prop.dataType));
                 visited.add(next);
             }
         }
@@ -1122,7 +1117,9 @@ public class DefaultCodegen implements CodegenConfig {
         this.allowUnicodeIdentifiers = allowUnicodeIdentifiers;
     }
 
-    public Boolean getUseOneOfInterfaces() { return useOneOfInterfaces; }
+    public Boolean getUseOneOfInterfaces() {
+        return useOneOfInterfaces;
+    }
 
     public void setUseOneOfInterfaces(Boolean useOneOfInterfaces) {
         this.useOneOfInterfaces = useOneOfInterfaces;
@@ -1805,7 +1802,7 @@ public class DefaultCodegen implements CodegenConfig {
 
     /**
      * Return the name of the 'allOf' composed schema.
-     * 
+     *
      * @param names          List of names
      * @param composedSchema composed schema
      * @return name of the allOf schema
@@ -1857,7 +1854,7 @@ public class DefaultCodegen implements CodegenConfig {
 
     /**
      * Return a string representation of the schema type, resolving aliasing and references if necessary.
-     * 
+     *
      * @param schema
      * @return the string representation of the schema type.
      */
@@ -1884,7 +1881,7 @@ public class DefaultCodegen implements CodegenConfig {
     /**
      * Return the OAI type (e.g. integer, long, etc) corresponding to a schema.
      * <pre>$ref</pre> is not taken into account by this method.
-     * 
+     * <p>
      * If the schema is free-form (i.e. 'type: object' with no properties) or inline
      * schema, the returned OAI type is 'object'.
      *
@@ -2117,7 +2114,7 @@ public class DefaultCodegen implements CodegenConfig {
             m.getVendorExtensions().putAll(schema.getExtensions());
         }
         m.isAlias = (typeAliases.containsKey(name)
-                        || isAliasOfSimpleTypes(schema)); // check if the unaliased schema is an alias of simple OAS types
+                || isAliasOfSimpleTypes(schema)); // check if the unaliased schema is an alias of simple OAS types
         m.discriminator = createDiscriminator(name, schema);
 
         if (schema.getXml() != null) {
@@ -3306,12 +3303,24 @@ public class DefaultCodegen implements CodegenConfig {
             r.code = "0";
         } else {
             r.code = responseCode;
-            switch(r.code.charAt(0)) {
-                case '1': r.is1xx = true; break;
-                case '2': r.is2xx = true; break;
-                case '3': r.is3xx = true; break;
-                case '4': r.is4xx = true; break;
-                case '5': r.is5xx = true; break;
+            switch (r.code.charAt(0)) {
+                case '1':
+                    r.is1xx = true;
+                    break;
+                case '2':
+                    r.is2xx = true;
+                    break;
+                case '3':
+                    r.is3xx = true;
+                    break;
+                case '4':
+                    r.is4xx = true;
+                    break;
+                case '5':
+                    r.is5xx = true;
+                    break;
+                default:
+                    throw new RuntimeException("Invalid response code " + responseCode);
             }
         }
         Schema responseSchema;
@@ -5755,9 +5764,11 @@ public class DefaultCodegen implements CodegenConfig {
     }
 
     //// Following methods are related to the "useOneOfInterfaces" feature
+
     /**
      * Add "x-oneOf-name" extension to a given oneOf schema (assuming it has at least 1 oneOf elements)
-     * @param s schema to add the extension to
+     *
+     * @param s    schema to add the extension to
      * @param name name of the parent oneOf schema
      */
     public void addOneOfNameExtension(ComposedSchema s, String name) {
@@ -5768,7 +5779,8 @@ public class DefaultCodegen implements CodegenConfig {
 
     /**
      * Add a given ComposedSchema as an interface model to be generated, assuming it has `oneOf` defined
-     * @param cs ComposedSchema object to create as interface model
+     *
+     * @param cs   ComposedSchema object to create as interface model
      * @param type name to use for the generated interface model
      */
     public void addOneOfInterfaceModel(ComposedSchema cs, String type) {
@@ -5800,7 +5812,8 @@ public class DefaultCodegen implements CodegenConfig {
         addOneOfInterfaces.add(cm);
     }
 
-    public void addImportsToOneOfInterface(List<Map<String, String>> imports) {}
+    public void addImportsToOneOfInterface(List<Map<String, String>> imports) {
+    }
     //// End of methods related to the "useOneOfInterfaces" feature
 
     protected void modifyFeatureSet(Consumer<FeatureSet.Builder> processor) {

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/javascript/JavascriptClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/javascript/JavascriptClientCodegenTest.java
@@ -18,11 +18,9 @@
 package org.openapitools.codegen.javascript;
 
 import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.media.Schema;
-import org.openapitools.codegen.CodegenConstants;
-import org.openapitools.codegen.CodegenModel;
-import org.openapitools.codegen.CodegenProperty;
-import org.openapitools.codegen.TestUtils;
+import org.openapitools.codegen.*;
 import org.openapitools.codegen.languages.JavascriptClientCodegen;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -96,6 +94,23 @@ public class JavascriptClientCodegenTest {
         Assert.assertEquals(property2.defaultValueWithParam, " = ApiClient.convertToType(data['name'], 'String');");
         Assert.assertTrue(property2.required); // test required
         Assert.assertFalse(property2.isContainer);
+    }
+
+    @Test(description = "test isDefualt in the response")
+    public void testResponseIsDefault() throws Exception {
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/2_0/petstore.yaml");
+        final DefaultCodegen codegen = new DefaultCodegen();
+        codegen.setOpenAPI(openAPI);
+
+        Operation textOperation = openAPI.getPaths().get("/user").getPost();
+        CodegenOperation coText = codegen.fromOperation("/user", "post", textOperation, null);
+
+        for (CodegenResponse cr : coText.responses) {
+            Assert.assertTrue(cr.isDefault);
+        }
+
+        Assert.assertEquals(coText.responses.size(), 1);
+
     }
 
 }


### PR DESCRIPTION
- Add default case to handle response code by throwing runtime exception as it shouldn't happen https://github.com/OpenAPITools/openapi-generator/compare/response_default?expand=1#diff-7cb46fa53f89a458a7b7cb201d2214a8R3322

- bug fix with "defaultResponse" (new value from parser)

- better code format

cc @OpenAPITools/generator-core-team 

<!-- Please check the completed items below -->
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [ ] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [ ] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
