### PR TITLE
[Rust Server] Support complex query parameters

### DIFF
--- a/modules/openapi-generator/src/main/resources/rust-server/Cargo.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/Cargo.mustache
@@ -87,7 +87,6 @@ mime_multipart = {version = "0.5", optional = true}
 hyper_0_10 = {package = "hyper", version = "0.10", default-features = false, optional=true}
 {{/apiUsesMultipartRelated}}
 serde_ignored = {version = "0.0.4", optional = true}
-tokio = {version = "0.1.17", optional = true}
 url = {version = "1.5", optional = true}
 
 # Client-specific
@@ -111,6 +110,7 @@ frunk-enum-core = { version = "0.2.0", optional = true }
 clap = "2.25"
 error-chain = "0.12"
 env_logger = "0.6"
+tokio = "0.1.17"
 {{^apiUsesUuid}}
 uuid = {version = "0.7", features = ["serde", "v4"]}
 {{/apiUsesUuid}}

--- a/modules/openapi-generator/src/main/resources/rust-server/client-operation.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/client-operation.mustache
@@ -34,7 +34,7 @@
   {{^required}}
         if let Some(param_{{{paramName}}}) = param_{{{paramName}}} {
   {{/required}}
-            query_string.append_pair("{{{baseName}}}", &param_{{{paramName}}}{{#isListContainer}}.join(","){{/isListContainer}}{{^isListContainer}}.to_string(){{/isListContainer}});
+            query_string.append_pair("{{{baseName}}}", &param_{{{paramName}}}{{#isListContainer}}.iter().map(ToString::to_string).collect::<Vec<String>>().join(","){{/isListContainer}}{{^isListContainer}}.to_string(){{/isListContainer}});
   {{^required}}
         }
   {{/required}}

--- a/modules/openapi-generator/src/main/resources/rust-server/lib.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/lib.mustache
@@ -67,8 +67,6 @@ extern crate mime_multipart;
 extern crate percent_encoding;
 #[cfg(any(feature = "client", feature = "server"))]
 extern crate serde_ignored;
-#[cfg(any(feature = "client", feature = "server"))]
-extern crate tokio;
 
 #[cfg(any(feature = "client", feature = "server"))]
 {{#apiUsesUuid}}extern crate uuid;{{/apiUsesUuid}}

--- a/modules/openapi-generator/src/main/resources/rust-server/models.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/models.mustache
@@ -64,6 +64,12 @@ impl std::convert::From<{{{dataType}}}> for {{{classname}}} {
 }
 
 {{#vendorExtensions.isString}}
+impl std::string::ToString for {{{classname}}} {
+    fn to_string(&self) -> String {
+       self.0.to_string()
+    }
+}
+
 impl std::str::FromStr for {{{classname}}} {
     type Err = std::string::ParseError;
     fn from_str(x: &str) -> std::result::Result<Self, Self::Err> {

--- a/modules/openapi-generator/src/main/resources/rust-server/server-operation.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/server-operation.mustache
@@ -112,7 +112,7 @@
 {{/-first}}
                 let param_{{{paramName}}} = query_params.iter().filter(|e| e.0 == "{{{baseName}}}").map(|e| e.1.to_owned())
 {{#isListContainer}}
-                    .filter_map(|param_{{{paramName}}}| param_{{{paramName}}}.parse::<{{{baseType}}}>().ok())
+                    .filter_map(|param_{{{paramName}}}| param_{{{paramName}}}.parse().ok())
                     .collect::<Vec<_>>();
 {{^required}}
                 let param_{{{paramName}}} = if !param_{{{paramName}}}.is_empty() {

--- a/modules/openapi-generator/src/test/resources/3_0/rust-server/openapi-v3.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/rust-server/openapi-v3.yaml
@@ -337,6 +337,27 @@ paths:
       responses:
         "204":
           description: Success.
+  /merge-patch-json:
+    get:
+      responses:
+        200:
+          description: merge-patch+json-encoded response
+          content:
+            application/merge-patch+json:
+              schema:
+                $ref: "#/components/schemas/anotherXmlObject"
+  /complex-query-param:
+    get:
+      parameters:
+        - name: list-of-strings
+          in: query
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/StringObject'
+      responses:
+        '200':
+          description: Success
 
 components:
   securitySchemes:

--- a/samples/server/petstore/rust-server/output/multipart-v3/Cargo.toml
+++ b/samples/server/petstore/rust-server/output/multipart-v3/Cargo.toml
@@ -49,7 +49,6 @@ hyper = {version = "0.12", optional = true}
 mime_multipart = {version = "0.5", optional = true}
 hyper_0_10 = {package = "hyper", version = "0.10", default-features = false, optional=true}
 serde_ignored = {version = "0.0.4", optional = true}
-tokio = {version = "0.1.17", optional = true}
 url = {version = "1.5", optional = true}
 
 # Client-specific
@@ -70,6 +69,7 @@ frunk-enum-core = { version = "0.2.0", optional = true }
 clap = "2.25"
 error-chain = "0.12"
 env_logger = "0.6"
+tokio = "0.1.17"
 uuid = {version = "0.7", features = ["serde", "v4"]}
 
 [target.'cfg(not(any(target_os = "macos", target_os = "windows", target_os = "ios")))'.dev-dependencies]

--- a/samples/server/petstore/rust-server/output/multipart-v3/src/lib.rs
+++ b/samples/server/petstore/rust-server/output/multipart-v3/src/lib.rs
@@ -46,8 +46,6 @@ extern crate mime_multipart;
 extern crate percent_encoding;
 #[cfg(any(feature = "client", feature = "server"))]
 extern crate serde_ignored;
-#[cfg(any(feature = "client", feature = "server"))]
-extern crate tokio;
 
 #[cfg(any(feature = "client", feature = "server"))]
 

--- a/samples/server/petstore/rust-server/output/no-example-v3/Cargo.toml
+++ b/samples/server/petstore/rust-server/output/no-example-v3/Cargo.toml
@@ -39,7 +39,6 @@ serde_json = "1.0"
 # Common between server and client features
 hyper = {version = "0.12", optional = true}
 serde_ignored = {version = "0.0.4", optional = true}
-tokio = {version = "0.1.17", optional = true}
 url = {version = "1.5", optional = true}
 
 # Client-specific
@@ -60,6 +59,7 @@ frunk-enum-core = { version = "0.2.0", optional = true }
 clap = "2.25"
 error-chain = "0.12"
 env_logger = "0.6"
+tokio = "0.1.17"
 uuid = {version = "0.7", features = ["serde", "v4"]}
 
 [target.'cfg(not(any(target_os = "macos", target_os = "windows", target_os = "ios")))'.dev-dependencies]

--- a/samples/server/petstore/rust-server/output/no-example-v3/src/lib.rs
+++ b/samples/server/petstore/rust-server/output/no-example-v3/src/lib.rs
@@ -39,8 +39,6 @@ extern crate hyper_openssl;
 extern crate percent_encoding;
 #[cfg(any(feature = "client", feature = "server"))]
 extern crate serde_ignored;
-#[cfg(any(feature = "client", feature = "server"))]
-extern crate tokio;
 
 #[cfg(any(feature = "client", feature = "server"))]
 

--- a/samples/server/petstore/rust-server/output/openapi-v3/Cargo.toml
+++ b/samples/server/petstore/rust-server/output/openapi-v3/Cargo.toml
@@ -45,7 +45,6 @@ uuid = {version = "0.7", features = ["serde", "v4"]}
 # Common between server and client features
 hyper = {version = "0.12", optional = true}
 serde_ignored = {version = "0.0.4", optional = true}
-tokio = {version = "0.1.17", optional = true}
 url = {version = "1.5", optional = true}
 
 # Client-specific
@@ -66,6 +65,7 @@ frunk-enum-core = { version = "0.2.0", optional = true }
 clap = "2.25"
 error-chain = "0.12"
 env_logger = "0.6"
+tokio = "0.1.17"
 
 [target.'cfg(not(any(target_os = "macos", target_os = "windows", target_os = "ios")))'.dev-dependencies]
 tokio-openssl = "0.3"

--- a/samples/server/petstore/rust-server/output/openapi-v3/README.md
+++ b/samples/server/petstore/rust-server/output/openapi-v3/README.md
@@ -62,6 +62,7 @@ To run a client, follow one of the following simple steps:
 
 ```
 cargo run --example client CallbackWithHeaderPost
+cargo run --example client ComplexQueryParamGet
 cargo run --example client MandatoryRequestHeaderGet
 cargo run --example client MergePatchJsonGet
 cargo run --example client MultigetGet
@@ -114,6 +115,7 @@ All URIs are relative to *http://localhost*
 Method | HTTP request | Description
 ------------- | ------------- | -------------
 [****](docs/default_api.md#) | **POST** /callback-with-header | 
+[****](docs/default_api.md#) | **GET** /complex-query-param | 
 [****](docs/default_api.md#) | **GET** /enum_in_path/{path_param} | 
 [****](docs/default_api.md#) | **GET** /mandatory-request-header | 
 [****](docs/default_api.md#) | **GET** /merge-patch-json | 

--- a/samples/server/petstore/rust-server/output/openapi-v3/api/openapi.yaml
+++ b/samples/server/petstore/rust-server/output/openapi-v3/api/openapi.yaml
@@ -345,6 +345,21 @@ paths:
           description: Success.
       servers:
       - url: /override
+  /complex-query-param:
+    get:
+      parameters:
+      - explode: true
+        in: query
+        name: list-of-strings
+        required: false
+        schema:
+          items:
+            $ref: '#/components/schemas/StringObject'
+          type: array
+        style: form
+      responses:
+        "200":
+          description: Success
 components:
   schemas:
     EnumWithStarObject:

--- a/samples/server/petstore/rust-server/output/openapi-v3/docs/default_api.md
+++ b/samples/server/petstore/rust-server/output/openapi-v3/docs/default_api.md
@@ -5,6 +5,7 @@ All URIs are relative to *http://localhost*
 Method | HTTP request | Description
 ------------- | ------------- | -------------
 ****](default_api.md#) | **POST** /callback-with-header | 
+****](default_api.md#) | **GET** /complex-query-param | 
 ****](default_api.md#) | **GET** /enum_in_path/{path_param} | 
 ****](default_api.md#) | **GET** /mandatory-request-header | 
 ****](default_api.md#) | **GET** /merge-patch-json | 
@@ -35,6 +36,38 @@ Method | HTTP request | Description
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
   **url** | **String**|  | 
+
+### Return type
+
+ (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: Not defined
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+# ****
+> (optional)
+
+
+### Required Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **optional** | **map[string]interface{}** | optional parameters | nil if no parameters
+
+### Optional Parameters
+Optional parameters are passed through a map[string]interface{}.
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **list_of_strings** | [**String**](String.md)|  | 
 
 ### Return type
 

--- a/samples/server/petstore/rust-server/output/openapi-v3/examples/client/main.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/examples/client/main.rs
@@ -30,6 +30,7 @@ use futures::{Future, future, Stream, stream};
 use openapi_v3::{Api, ApiNoContext, Client, ContextWrapperExt,
                       ApiError,
                       CallbackWithHeaderPostResponse,
+                      ComplexQueryParamGetResponse,
                       EnumInPathPathParamGetResponse,
                       MandatoryRequestHeaderGetResponse,
                       MergePatchJsonGetResponse,
@@ -66,6 +67,7 @@ fn main() {
             .help("Sets the operation to run")
             .possible_values(&[
                 "CallbackWithHeaderPost",
+                "ComplexQueryParamGet",
                 "MandatoryRequestHeaderGet",
                 "MergePatchJsonGet",
                 "MultigetGet",
@@ -133,6 +135,12 @@ fn main() {
         Some("CallbackWithHeaderPost") => {
             let result = rt.block_on(client.callback_with_header_post(
                   "url_example".to_string()
+            ));
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+        },
+        Some("ComplexQueryParamGet") => {
+            let result = rt.block_on(client.complex_query_param_get(
+                  Some(&Vec::new())
             ));
             info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
         },

--- a/samples/server/petstore/rust-server/output/openapi-v3/examples/server/server.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/examples/server/server.rs
@@ -106,6 +106,7 @@ use openapi_v3::{
     Api,
     ApiError,
     CallbackWithHeaderPostResponse,
+    ComplexQueryParamGetResponse,
     EnumInPathPathParamGetResponse,
     MandatoryRequestHeaderGetResponse,
     MergePatchJsonGetResponse,
@@ -136,6 +137,16 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
     {
         let context = context.clone();
         info!("callback_with_header_post(\"{}\") - X-Span-ID: {:?}", url, context.get().0.clone());
+        Box::new(future::err("Generic failure".into()))
+    }
+
+    fn complex_query_param_get(
+        &self,
+        list_of_strings: Option<&Vec<models::StringObject>>,
+        context: &C) -> Box<Future<Item=ComplexQueryParamGetResponse, Error=ApiError> + Send>
+    {
+        let context = context.clone();
+        info!("complex_query_param_get({:?}) - X-Span-ID: {:?}", list_of_strings, context.get().0.clone());
         Box::new(future::err("Generic failure".into()))
     }
 

--- a/samples/server/petstore/rust-server/output/openapi-v3/src/client/mod.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/src/client/mod.rs
@@ -36,6 +36,7 @@ define_encode_set! {
 
 use {Api,
      CallbackWithHeaderPostResponse,
+     ComplexQueryParamGetResponse,
      EnumInPathPathParamGetResponse,
      MandatoryRequestHeaderGetResponse,
      MergePatchJsonGetResponse,
@@ -320,6 +321,81 @@ impl<C, F> Api<C> for Client<F> where
                     Box::new(
                         future::ok(
                             CallbackWithHeaderPostResponse::OK
+                        )
+                    ) as Box<dyn Future<Item=_, Error=_> + Send>
+                },
+                code => {
+                    let headers = response.headers().clone();
+                    Box::new(response.into_body()
+                            .take(100)
+                            .concat2()
+                            .then(move |body|
+                                future::err(ApiError(format!("Unexpected response code {}:\n{:?}\n\n{}",
+                                    code,
+                                    headers,
+                                    match body {
+                                        Ok(ref body) => match str::from_utf8(body) {
+                                            Ok(body) => Cow::from(body),
+                                            Err(e) => Cow::from(format!("<Body was not UTF8: {:?}>", e)),
+                                        },
+                                        Err(e) => Cow::from(format!("<Failed to read body: {}>", e)),
+                                    })))
+                            )
+                    ) as Box<dyn Future<Item=_, Error=_> + Send>
+                }
+            }
+        }))
+    }
+
+    fn complex_query_param_get(
+        &self,
+        param_list_of_strings: Option<&Vec<models::StringObject>>,
+        context: &C) -> Box<dyn Future<Item=ComplexQueryParamGetResponse, Error=ApiError> + Send>
+    {
+        let mut uri = format!(
+            "{}/complex-query-param",
+            self.base_path
+        );
+
+        // Query parameters
+        let mut query_string = url::form_urlencoded::Serializer::new("".to_owned());
+        if let Some(param_list_of_strings) = param_list_of_strings {
+            query_string.append_pair("list-of-strings", &param_list_of_strings.iter().map(ToString::to_string).collect::<Vec<String>>().join(","));
+        }
+        let query_string_str = query_string.finish();
+        if !query_string_str.is_empty() {
+            uri += "?";
+            uri += &query_string_str;
+        }
+
+        let uri = match Uri::from_str(&uri) {
+            Ok(uri) => uri,
+            Err(err) => return Box::new(future::err(ApiError(format!("Unable to build URI: {}", err)))),
+        };
+
+        let mut request = match hyper::Request::builder()
+            .method("GET")
+            .uri(uri)
+            .body(Body::empty()) {
+                Ok(req) => req,
+                Err(e) => return Box::new(future::err(ApiError(format!("Unable to create request: {}", e))))
+        };
+
+        let header = HeaderValue::from_str((context as &dyn Has<XSpanIdString>).get().0.clone().to_string().as_str());
+        request.headers_mut().insert(HeaderName::from_static("x-span-id"), match header {
+            Ok(h) => h,
+            Err(e) => return Box::new(future::err(ApiError(format!("Unable to create X-Span ID header value: {}", e))))
+        });
+
+        Box::new(self.client_service.request(request)
+                             .map_err(|e| ApiError(format!("No response received: {}", e)))
+                             .and_then(|mut response| {
+            match response.status().as_u16() {
+                200 => {
+                    let body = response.into_body();
+                    Box::new(
+                        future::ok(
+                            ComplexQueryParamGetResponse::Success
                         )
                     ) as Box<dyn Future<Item=_, Error=_> + Send>
                 },

--- a/samples/server/petstore/rust-server/output/openapi-v3/src/lib.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/src/lib.rs
@@ -39,8 +39,6 @@ extern crate hyper_openssl;
 extern crate percent_encoding;
 #[cfg(any(feature = "client", feature = "server"))]
 extern crate serde_ignored;
-#[cfg(any(feature = "client", feature = "server"))]
-extern crate tokio;
 
 #[cfg(any(feature = "client", feature = "server"))]
 extern crate uuid;
@@ -66,6 +64,12 @@ pub const API_VERSION: &'static str = "1.0.7";
 pub enum CallbackWithHeaderPostResponse {
     /// OK
     OK
+}
+
+#[derive(Debug, PartialEq)]
+pub enum ComplexQueryParamGetResponse {
+    /// Success
+    Success
 }
 
 #[derive(Debug, PartialEq)]
@@ -261,6 +265,11 @@ pub trait Api<C> {
         url: String,
         context: &C) -> Box<dyn Future<Item=CallbackWithHeaderPostResponse, Error=ApiError> + Send>;
 
+    fn complex_query_param_get(
+        &self,
+        list_of_strings: Option<&Vec<models::StringObject>>,
+        context: &C) -> Box<dyn Future<Item=ComplexQueryParamGetResponse, Error=ApiError> + Send>;
+
     fn enum_in_path_path_param_get(
         &self,
         path_param: models::StringEnum,
@@ -361,6 +370,11 @@ pub trait ApiNoContext {
         &self,
         url: String,
         ) -> Box<dyn Future<Item=CallbackWithHeaderPostResponse, Error=ApiError> + Send>;
+
+    fn complex_query_param_get(
+        &self,
+        list_of_strings: Option<&Vec<models::StringObject>>,
+        ) -> Box<dyn Future<Item=ComplexQueryParamGetResponse, Error=ApiError> + Send>;
 
     fn enum_in_path_path_param_get(
         &self,
@@ -475,6 +489,14 @@ impl<'a, T: Api<C>, C> ApiNoContext for ContextWrapper<'a, T, C> {
         ) -> Box<dyn Future<Item=CallbackWithHeaderPostResponse, Error=ApiError> + Send>
     {
         self.api().callback_with_header_post(url, &self.context())
+    }
+
+    fn complex_query_param_get(
+        &self,
+        list_of_strings: Option<&Vec<models::StringObject>>,
+        ) -> Box<dyn Future<Item=ComplexQueryParamGetResponse, Error=ApiError> + Send>
+    {
+        self.api().complex_query_param_get(list_of_strings, &self.context())
     }
 
     fn enum_in_path_path_param_get(

--- a/samples/server/petstore/rust-server/output/openapi-v3/src/models.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/src/models.rs
@@ -138,6 +138,12 @@ impl std::convert::From<String> for AnotherXmlInner {
     }
 }
 
+impl std::string::ToString for AnotherXmlInner {
+    fn to_string(&self) -> String {
+       self.0.to_string()
+    }
+}
+
 impl std::str::FromStr for AnotherXmlInner {
     type Err = std::string::ParseError;
     fn from_str(x: &str) -> std::result::Result<Self, Self::Err> {
@@ -471,6 +477,12 @@ impl std::convert::From<String> for Err {
     }
 }
 
+impl std::string::ToString for Err {
+    fn to_string(&self) -> String {
+       self.0.to_string()
+    }
+}
+
 impl std::str::FromStr for Err {
     type Err = std::string::ParseError;
     fn from_str(x: &str) -> std::result::Result<Self, Self::Err> {
@@ -514,6 +526,12 @@ pub struct Error(String);
 impl std::convert::From<String> for Error {
     fn from(x: String) -> Self {
         Error(x)
+    }
+}
+
+impl std::string::ToString for Error {
+    fn to_string(&self) -> String {
+       self.0.to_string()
     }
 }
 
@@ -1441,6 +1459,12 @@ impl std::convert::From<String> for Ok {
     }
 }
 
+impl std::string::ToString for Ok {
+    fn to_string(&self) -> String {
+       self.0.to_string()
+    }
+}
+
 impl std::str::FromStr for Ok {
     type Err = std::string::ParseError;
     fn from_str(x: &str) -> std::result::Result<Self, Self::Err> {
@@ -1567,6 +1591,12 @@ impl std::convert::From<String> for Result {
     }
 }
 
+impl std::string::ToString for Result {
+    fn to_string(&self) -> String {
+       self.0.to_string()
+    }
+}
+
 impl std::str::FromStr for Result {
     type Err = std::string::ParseError;
     fn from_str(x: &str) -> std::result::Result<Self, Self::Err> {
@@ -1654,6 +1684,12 @@ pub struct StringObject(String);
 impl std::convert::From<String> for StringObject {
     fn from(x: String) -> Self {
         StringObject(x)
+    }
+}
+
+impl std::string::ToString for StringObject {
+    fn to_string(&self) -> String {
+       self.0.to_string()
     }
 }
 
@@ -1864,6 +1900,12 @@ pub struct XmlInner(String);
 impl std::convert::From<String> for XmlInner {
     fn from(x: String) -> Self {
         XmlInner(x)
+    }
+}
+
+impl std::string::ToString for XmlInner {
+    fn to_string(&self) -> String {
+       self.0.to_string()
     }
 }
 

--- a/samples/server/petstore/rust-server/output/ops-v3/Cargo.toml
+++ b/samples/server/petstore/rust-server/output/ops-v3/Cargo.toml
@@ -39,7 +39,6 @@ serde_json = "1.0"
 # Common between server and client features
 hyper = {version = "0.12", optional = true}
 serde_ignored = {version = "0.0.4", optional = true}
-tokio = {version = "0.1.17", optional = true}
 url = {version = "1.5", optional = true}
 
 # Client-specific
@@ -60,6 +59,7 @@ frunk-enum-core = { version = "0.2.0", optional = true }
 clap = "2.25"
 error-chain = "0.12"
 env_logger = "0.6"
+tokio = "0.1.17"
 uuid = {version = "0.7", features = ["serde", "v4"]}
 
 [target.'cfg(not(any(target_os = "macos", target_os = "windows", target_os = "ios")))'.dev-dependencies]

--- a/samples/server/petstore/rust-server/output/ops-v3/src/lib.rs
+++ b/samples/server/petstore/rust-server/output/ops-v3/src/lib.rs
@@ -39,8 +39,6 @@ extern crate hyper_openssl;
 extern crate percent_encoding;
 #[cfg(any(feature = "client", feature = "server"))]
 extern crate serde_ignored;
-#[cfg(any(feature = "client", feature = "server"))]
-extern crate tokio;
 
 #[cfg(any(feature = "client", feature = "server"))]
 

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/Cargo.toml
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/Cargo.toml
@@ -50,7 +50,6 @@ uuid = {version = "0.7", features = ["serde", "v4"]}
 # Common between server and client features
 hyper = {version = "0.12", optional = true}
 serde_ignored = {version = "0.0.4", optional = true}
-tokio = {version = "0.1.17", optional = true}
 url = {version = "1.5", optional = true}
 
 # Client-specific
@@ -72,6 +71,7 @@ frunk-enum-core = { version = "0.2.0", optional = true }
 clap = "2.25"
 error-chain = "0.12"
 env_logger = "0.6"
+tokio = "0.1.17"
 
 [target.'cfg(not(any(target_os = "macos", target_os = "windows", target_os = "ios")))'.dev-dependencies]
 tokio-openssl = "0.3"

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/src/client/mod.rs
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/src/client/mod.rs
@@ -1310,7 +1310,7 @@ impl<C, F> Api<C> for Client<F> where
         // Query parameters
         let mut query_string = url::form_urlencoded::Serializer::new("".to_owned());
         if let Some(param_enum_query_string_array) = param_enum_query_string_array {
-            query_string.append_pair("enum_query_string_array", &param_enum_query_string_array.join(","));
+            query_string.append_pair("enum_query_string_array", &param_enum_query_string_array.iter().map(ToString::to_string).collect::<Vec<String>>().join(","));
         }
         if let Some(param_enum_query_string) = param_enum_query_string {
             query_string.append_pair("enum_query_string", &param_enum_query_string.to_string());
@@ -1887,7 +1887,7 @@ impl<C, F> Api<C> for Client<F> where
 
         // Query parameters
         let mut query_string = url::form_urlencoded::Serializer::new("".to_owned());
-            query_string.append_pair("status", &param_status.join(","));
+            query_string.append_pair("status", &param_status.iter().map(ToString::to_string).collect::<Vec<String>>().join(","));
         let query_string_str = query_string.finish();
         if !query_string_str.is_empty() {
             uri += "?";
@@ -1999,7 +1999,7 @@ impl<C, F> Api<C> for Client<F> where
 
         // Query parameters
         let mut query_string = url::form_urlencoded::Serializer::new("".to_owned());
-            query_string.append_pair("tags", &param_tags.join(","));
+            query_string.append_pair("tags", &param_tags.iter().map(ToString::to_string).collect::<Vec<String>>().join(","));
         let query_string_str = query_string.finish();
         if !query_string_str.is_empty() {
             uri += "?";

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/src/lib.rs
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/src/lib.rs
@@ -41,8 +41,6 @@ extern crate mime_0_2;
 extern crate percent_encoding;
 #[cfg(any(feature = "client", feature = "server"))]
 extern crate serde_ignored;
-#[cfg(any(feature = "client", feature = "server"))]
-extern crate tokio;
 
 #[cfg(any(feature = "client", feature = "server"))]
 extern crate uuid;

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/src/models.rs
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/src/models.rs
@@ -3887,6 +3887,12 @@ impl std::convert::From<String> for OuterString {
     }
 }
 
+impl std::string::ToString for OuterString {
+    fn to_string(&self) -> String {
+       self.0.to_string()
+    }
+}
+
 impl std::str::FromStr for OuterString {
     type Err = std::string::ParseError;
     fn from_str(x: &str) -> std::result::Result<Self, Self::Err> {

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/src/server/mod.rs
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/src/server/mod.rs
@@ -1037,7 +1037,7 @@ where
                 // Query parameters (note that non-required or collection query parameters will ignore garbage values, rather than causing a 400 response)
                 let query_params = form_urlencoded::parse(uri.query().unwrap_or_default().as_bytes()).collect::<Vec<_>>();
                 let param_enum_query_string_array = query_params.iter().filter(|e| e.0 == "enum_query_string_array").map(|e| e.1.to_owned())
-                    .filter_map(|param_enum_query_string_array| param_enum_query_string_array.parse::<String>().ok())
+                    .filter_map(|param_enum_query_string_array| param_enum_query_string_array.parse().ok())
                     .collect::<Vec<_>>();
                 let param_enum_query_string_array = if !param_enum_query_string_array.is_empty() {
                     Some(param_enum_query_string_array)
@@ -1561,7 +1561,7 @@ where
                 // Query parameters (note that non-required or collection query parameters will ignore garbage values, rather than causing a 400 response)
                 let query_params = form_urlencoded::parse(uri.query().unwrap_or_default().as_bytes()).collect::<Vec<_>>();
                 let param_status = query_params.iter().filter(|e| e.0 == "status").map(|e| e.1.to_owned())
-                    .filter_map(|param_status| param_status.parse::<String>().ok())
+                    .filter_map(|param_status| param_status.parse().ok())
                     .collect::<Vec<_>>();
 
                 Box::new({
@@ -1645,7 +1645,7 @@ where
                 // Query parameters (note that non-required or collection query parameters will ignore garbage values, rather than causing a 400 response)
                 let query_params = form_urlencoded::parse(uri.query().unwrap_or_default().as_bytes()).collect::<Vec<_>>();
                 let param_tags = query_params.iter().filter(|e| e.0 == "tags").map(|e| e.1.to_owned())
-                    .filter_map(|param_tags| param_tags.parse::<String>().ok())
+                    .filter_map(|param_tags| param_tags.parse().ok())
                     .collect::<Vec<_>>();
 
                 Box::new({

--- a/samples/server/petstore/rust-server/output/rust-server-test/Cargo.toml
+++ b/samples/server/petstore/rust-server/output/rust-server-test/Cargo.toml
@@ -39,7 +39,6 @@ serde_json = "1.0"
 # Common between server and client features
 hyper = {version = "0.12", optional = true}
 serde_ignored = {version = "0.0.4", optional = true}
-tokio = {version = "0.1.17", optional = true}
 url = {version = "1.5", optional = true}
 
 # Client-specific
@@ -60,6 +59,7 @@ frunk-enum-core = { version = "0.2.0", optional = true }
 clap = "2.25"
 error-chain = "0.12"
 env_logger = "0.6"
+tokio = "0.1.17"
 uuid = {version = "0.7", features = ["serde", "v4"]}
 
 [target.'cfg(not(any(target_os = "macos", target_os = "windows", target_os = "ios")))'.dev-dependencies]

--- a/samples/server/petstore/rust-server/output/rust-server-test/src/lib.rs
+++ b/samples/server/petstore/rust-server/output/rust-server-test/src/lib.rs
@@ -39,8 +39,6 @@ extern crate hyper_openssl;
 extern crate percent_encoding;
 #[cfg(any(feature = "client", feature = "server"))]
 extern crate serde_ignored;
-#[cfg(any(feature = "client", feature = "server"))]
-extern crate tokio;
 
 #[cfg(any(feature = "client", feature = "server"))]
 


### PR DESCRIPTION
Support complex query parameters by using the correct FromStr implementation and using ToString at all.

This enables support for definitions such as:

```
      parameters:
        - name: list-of-strings
          in: query
          schema:
            type: array
            items:
              $ref: '#/components/schemas/StringObject'
```

This fix was contributed by @mirw and reviewed by myself on behalf of @Metaswitch.

### Rust Server Technical Committee

- @frol
- @farcaller 
- @bjgill

### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [X] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [X] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.