### PR TITLE
[csharp-netcore]: retry configuration for given http status codes

### DIFF
--- a/modules/openapi-generator/src/main/resources/csharp-netcore/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/ApiClient.mustache
@@ -17,12 +17,14 @@ using System.Net;
 using System.Runtime.Serialization;
 using System.Runtime.Serialization.Formatters;
 using System.Text;
+using System.Threading;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 using RestSharp;
 using RestSharp.Deserializers;
 using ErrorEventArgs = Newtonsoft.Json.Serialization.ErrorEventArgs;
 using RestSharpMethod = RestSharp.Method;
+using Polly;
 
 namespace {{packageName}}.Client
 {
@@ -408,7 +410,26 @@ namespace {{packageName}}.Client
 
             InterceptRequest(req);
 
-            var response = client.Execute<T>(req);
+            IRestResponse<T> response;
+            if (configuration.RetryStatusCodes != null)	
+            {
+                Random jitterer = new Random();
+                var policy = Policy
+                    .HandleResult<IRestResponse<T>>(resp => (configuration.RetryStatusCodes.Contains(resp.StatusCode)))
+                    .WaitAndRetry(configuration.MaxRetries, retryAttempt => TimeSpan.FromSeconds(Math.Pow(2, retryAttempt))
+                                                          + TimeSpan.FromMilliseconds(jitterer.Next(0, 1000))
+                     );
+                var policyResult = policy.ExecuteAndCapture(() => client.Execute<T>(req));
+                response = (policyResult.Outcome == OutcomeType.Successful) ? policyResult.Result : new RestResponse<T>
+                {
+                    Request = req,
+                    ErrorException = policyResult.FinalException
+                };
+            }
+            else
+            {
+                response = client.Execute<T>(req);
+            }
 
             InterceptResponse(req, response);
 
@@ -479,7 +500,26 @@ namespace {{packageName}}.Client
 
             InterceptRequest(req);
 
-            var response = await client.ExecuteAsync<T>(req);
+            IRestResponse<T> response;
+            if (configuration.RetryStatusCodes != null)
+            {
+                Random jitterer = new Random();
+                var policy = Policy
+                    .HandleResult<IRestResponse<T>>(resp => (configuration.RetryStatusCodes.Contains(resp.StatusCode)))
+                    .WaitAndRetryAsync(configuration.MaxRetries, retryAttempt => TimeSpan.FromSeconds(Math.Pow(2, retryAttempt))
+                                                          + TimeSpan.FromMilliseconds(jitterer.Next(0, 1000))
+                     );
+                var policyResult = await policy.ExecuteAndCaptureAsync(() => client.ExecuteAsync<T>(req));
+                response = (policyResult.Outcome == OutcomeType.Successful) ? policyResult.Result : new RestResponse<T>
+                {
+                    Request = req,
+                    ErrorException = policyResult.FinalException
+                };
+            }
+            else
+            {
+                 response = await client.ExecuteAsync<T>(req);
+            }
 
             InterceptResponse(req, response);
 

--- a/modules/openapi-generator/src/main/resources/csharp-netcore/Configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/Configuration.mustache
@@ -346,7 +346,6 @@ namespace {{packageName}}.Client
 
         /// <summary>
         /// Gets or sets the maximum number of retry attempts on the retry status codes.
-        /// Default value is 2.
         /// </summary>
         /// <value>Maximum number of retries</value>
         public int MaxRetries {get; set;}

--- a/modules/openapi-generator/src/main/resources/csharp-netcore/Configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/Configuration.mustache
@@ -10,6 +10,8 @@ using System.IO;
 using System.Linq;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
+using System.Net;
+using Polly;
 
 namespace {{packageName}}.Client
 {
@@ -336,6 +338,19 @@ namespace {{packageName}}.Client
             }
         }
 
+        /// <summary>
+        /// Gets or sets the status codes for retry policy.
+        /// </summary>
+        /// <value>List of http status codes</value>
+        public IList<HttpStatusCode> RetryStatusCodes { get; set; }
+
+        /// <summary>
+        /// Gets or sets the maximum number of retry attempts on the retry status codes.
+        /// Default value is 2.
+        /// </summary>
+        /// <value>Maximum number of retries</value>
+        public int MaxRetries {get; set;}
+
         #endregion Properties
 
         #region Methods
@@ -415,7 +430,9 @@ namespace {{packageName}}.Client
                 Password = second.Password ?? first.Password,
                 AccessToken = second.AccessToken ?? first.AccessToken,
                 TempFolderPath = second.TempFolderPath ?? first.TempFolderPath,
-                DateTimeFormat = second.DateTimeFormat ?? first.DateTimeFormat
+                DateTimeFormat = second.DateTimeFormat ?? first.DateTimeFormat,
+                RetryStatusCodes = second.RetryStatusCodes ?? first.RetryStatusCodes,
+                MaxRetries = second.MaxRetries == 0 ? first.MaxRetries : second.MaxRetries
             };
             return config;
         }

--- a/modules/openapi-generator/src/main/resources/csharp-netcore/IReadableConfiguration.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/IReadableConfiguration.mustache
@@ -2,7 +2,9 @@
 
 using System;
 using System.Collections.Generic;
+using System.Net;
 using System.Security.Cryptography.X509Certificates;
+using Polly;
 
 namespace {{packageName}}.Client
 {
@@ -96,5 +98,18 @@ namespace {{packageName}}.Client
         /// </summary>
         /// <value>X509 Certificate collection.</value>
         X509CertificateCollection ClientCertificates { get; }
+
+        /// <summary>
+        /// Status codes to apply the retry policy
+        /// </summary>
+        /// <value>List of http status codes.</value>
+        IList<HttpStatusCode> RetryStatusCodes { get;}
+
+        /// <summary>
+        /// Maximum number of retry attempts to make on given retry status codes.
+        /// </summary>
+        /// <value>Maximum number of retries</value>
+        int MaxRetries { get;}
+
     }
 }

--- a/modules/openapi-generator/src/main/resources/csharp-netcore/Project.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/Project.mustache
@@ -42,6 +42,7 @@
     <PackageReference Include="JsonSubTypes" Version="1.5.2" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
     <PackageReference Include="RestSharp" Version="106.10.1" />
+    <PackageReference Include="Polly" Version="7.2.0" />
     {{#validatable}}
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.5.0" />
     {{/validatable}}

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Client/Configuration.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Client/Configuration.cs
@@ -349,7 +349,6 @@ namespace Org.OpenAPITools.Client
 
         /// <summary>
         /// Gets or sets the maximum number of retry attempts on the retry status codes.
-        /// Default value is 2.
         /// </summary>
         /// <value>Maximum number of retries</value>
         public int MaxRetries {get; set;}

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Client/Configuration.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Client/Configuration.cs
@@ -17,6 +17,8 @@ using System.IO;
 using System.Linq;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
+using System.Net;
+using Polly;
 
 namespace Org.OpenAPITools.Client
 {
@@ -339,6 +341,19 @@ namespace Org.OpenAPITools.Client
             }
         }
 
+        /// <summary>
+        /// Gets or sets the status codes for retry policy.
+        /// </summary>
+        /// <value>List of http status codes</value>
+        public IList<HttpStatusCode> RetryStatusCodes { get; set; }
+
+        /// <summary>
+        /// Gets or sets the maximum number of retry attempts on the retry status codes.
+        /// Default value is 2.
+        /// </summary>
+        /// <value>Maximum number of retries</value>
+        public int MaxRetries {get; set;}
+
         #endregion Properties
 
         #region Methods
@@ -410,7 +425,9 @@ namespace Org.OpenAPITools.Client
                 Password = second.Password ?? first.Password,
                 AccessToken = second.AccessToken ?? first.AccessToken,
                 TempFolderPath = second.TempFolderPath ?? first.TempFolderPath,
-                DateTimeFormat = second.DateTimeFormat ?? first.DateTimeFormat
+                DateTimeFormat = second.DateTimeFormat ?? first.DateTimeFormat,
+                RetryStatusCodes = second.RetryStatusCodes ?? first.RetryStatusCodes,
+                MaxRetries = second.MaxRetries == 0 ? first.MaxRetries : second.MaxRetries
             };
             return config;
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Client/IReadableConfiguration.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Client/IReadableConfiguration.cs
@@ -11,7 +11,9 @@
 
 using System;
 using System.Collections.Generic;
+using System.Net;
 using System.Security.Cryptography.X509Certificates;
+using Polly;
 
 namespace Org.OpenAPITools.Client
 {
@@ -105,5 +107,18 @@ namespace Org.OpenAPITools.Client
         /// </summary>
         /// <value>X509 Certificate collection.</value>
         X509CertificateCollection ClientCertificates { get; }
+
+        /// <summary>
+        /// Status codes to apply the retry policy
+        /// </summary>
+        /// <value>List of http status codes.</value>
+        IList<HttpStatusCode> RetryStatusCodes { get;}
+
+        /// <summary>
+        /// Maximum number of retry attempts to make on given retry status codes.
+        /// </summary>
+        /// <value>Maximum number of retries</value>
+        int MaxRetries { get;}
+
     }
 }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Org.OpenAPITools.csproj
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Org.OpenAPITools.csproj
@@ -34,6 +34,7 @@ The version of the OpenAPI document: 1.0.0
     <PackageReference Include="JsonSubTypes" Version="1.5.2" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
     <PackageReference Include="RestSharp" Version="106.10.1" />
+    <PackageReference Include="Polly" Version="7.2.0" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.5.0" />
   </ItemGroup>
 </Project>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -22,12 +22,14 @@ using System.Net;
 using System.Runtime.Serialization;
 using System.Runtime.Serialization.Formatters;
 using System.Text;
+using System.Threading;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 using RestSharp;
 using RestSharp.Deserializers;
 using ErrorEventArgs = Newtonsoft.Json.Serialization.ErrorEventArgs;
 using RestSharpMethod = RestSharp.Method;
+using Polly;
 
 namespace Org.OpenAPITools.Client
 {
@@ -412,7 +414,26 @@ namespace Org.OpenAPITools.Client
 
             InterceptRequest(req);
 
-            var response = client.Execute<T>(req);
+            IRestResponse<T> response;
+            if (configuration.RetryStatusCodes != null)	
+            {
+                Random jitterer = new Random();
+                var policy = Policy
+                    .HandleResult<IRestResponse<T>>(resp => (configuration.RetryStatusCodes.Contains(resp.StatusCode)))
+                    .WaitAndRetry(configuration.MaxRetries, retryAttempt => TimeSpan.FromSeconds(Math.Pow(2, retryAttempt))
+                                                          + TimeSpan.FromMilliseconds(jitterer.Next(0, 1000))
+                     );
+                var policyResult = policy.ExecuteAndCapture(() => client.Execute<T>(req));
+                response = (policyResult.Outcome == OutcomeType.Successful) ? policyResult.Result : new RestResponse<T>
+                {
+                    Request = req,
+                    ErrorException = policyResult.FinalException
+                };
+            }
+            else
+            {
+                response = client.Execute<T>(req);
+            }
 
             InterceptResponse(req, response);
 
@@ -482,7 +503,26 @@ namespace Org.OpenAPITools.Client
 
             InterceptRequest(req);
 
-            var response = await client.ExecuteAsync<T>(req);
+            IRestResponse<T> response;
+            if (configuration.RetryStatusCodes != null)
+            {
+                Random jitterer = new Random();
+                var policy = Policy
+                    .HandleResult<IRestResponse<T>>(resp => (configuration.RetryStatusCodes.Contains(resp.StatusCode)))
+                    .WaitAndRetryAsync(configuration.MaxRetries, retryAttempt => TimeSpan.FromSeconds(Math.Pow(2, retryAttempt))
+                                                          + TimeSpan.FromMilliseconds(jitterer.Next(0, 1000))
+                     );
+                var policyResult = await policy.ExecuteAndCaptureAsync(() => client.ExecuteAsync<T>(req));
+                response = (policyResult.Outcome == OutcomeType.Successful) ? policyResult.Result : new RestResponse<T>
+                {
+                    Request = req,
+                    ErrorException = policyResult.FinalException
+                };
+            }
+            else
+            {
+                 response = await client.ExecuteAsync<T>(req);
+            }
 
             InterceptResponse(req, response);
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Client/Configuration.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Client/Configuration.cs
@@ -353,7 +353,6 @@ namespace Org.OpenAPITools.Client
 
         /// <summary>
         /// Gets or sets the maximum number of retry attempts on the retry status codes.
-        /// Default value is 2.
         /// </summary>
         /// <value>Maximum number of retries</value>
         public int MaxRetries {get; set;}

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Client/Configuration.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Client/Configuration.cs
@@ -17,6 +17,8 @@ using System.IO;
 using System.Linq;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
+using System.Net;
+using Polly;
 
 namespace Org.OpenAPITools.Client
 {
@@ -343,6 +345,19 @@ namespace Org.OpenAPITools.Client
             }
         }
 
+        /// <summary>
+        /// Gets or sets the status codes for retry policy.
+        /// </summary>
+        /// <value>List of http status codes</value>
+        public IList<HttpStatusCode> RetryStatusCodes { get; set; }
+
+        /// <summary>
+        /// Gets or sets the maximum number of retry attempts on the retry status codes.
+        /// Default value is 2.
+        /// </summary>
+        /// <value>Maximum number of retries</value>
+        public int MaxRetries {get; set;}
+
         #endregion Properties
 
         #region Methods
@@ -415,7 +430,9 @@ namespace Org.OpenAPITools.Client
                 Password = second.Password ?? first.Password,
                 AccessToken = second.AccessToken ?? first.AccessToken,
                 TempFolderPath = second.TempFolderPath ?? first.TempFolderPath,
-                DateTimeFormat = second.DateTimeFormat ?? first.DateTimeFormat
+                DateTimeFormat = second.DateTimeFormat ?? first.DateTimeFormat,
+                RetryStatusCodes = second.RetryStatusCodes ?? first.RetryStatusCodes,
+                MaxRetries = second.MaxRetries == 0 ? first.MaxRetries : second.MaxRetries
             };
             return config;
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Client/IReadableConfiguration.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Client/IReadableConfiguration.cs
@@ -11,7 +11,9 @@
 
 using System;
 using System.Collections.Generic;
+using System.Net;
 using System.Security.Cryptography.X509Certificates;
+using Polly;
 
 namespace Org.OpenAPITools.Client
 {
@@ -105,5 +107,18 @@ namespace Org.OpenAPITools.Client
         /// </summary>
         /// <value>X509 Certificate collection.</value>
         X509CertificateCollection ClientCertificates { get; }
+
+        /// <summary>
+        /// Status codes to apply the retry policy
+        /// </summary>
+        /// <value>List of http status codes.</value>
+        IList<HttpStatusCode> RetryStatusCodes { get;}
+
+        /// <summary>
+        /// Maximum number of retry attempts to make on given retry status codes.
+        /// </summary>
+        /// <value>Maximum number of retries</value>
+        int MaxRetries { get;}
+
     }
 }


### PR DESCRIPTION
### PR Description
Added the provision setup the retry configuration, to retry the requests on the status codes specified through "RetryStatusCode" and the max number of attempts by "MaxRetries" property.
Polly library is used for handling the retry logic.

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

CC
@mandrean  @jimschubert  @frankyjuang @shibayan 
@saigiridhar21 @wing328 