### PR TITLE
feat(java-jersey2): adding retry configuration

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/ApiClient.mustache
@@ -34,6 +34,7 @@ import org.glassfish.jersey.filter.LoggingFilter;
 {{/supportJava6}}
 import java.util.Collection;
 import java.util.Collections;
+import java.util.concurrent.TimeUnit;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.HashMap;
@@ -147,6 +148,9 @@ public class ApiClient {
   protected Map<String, String> authenticationLookup;
 
   protected DateFormat dateFormat;
+
+  private List<Integer> retryStatusCodes;
+  private int maxRetries;
 
   public ApiClient() {
     json = new JSON();
@@ -506,6 +510,16 @@ public class ApiClient {
   public String formatDate(Date date) {
     return dateFormat.format(date);
   }
+  
+  /**
+   * Set the configuration for retrying on given http status codes.
+   * @param retryStatusCodes List of http status codes
+   * @param maxRetries Maximum number of times to retry with exponential backoff
+   */
+  public void setRetryConfiguration(List<Integer> retryStatusCodes, int maxRetries) {
+    this.retryStatusCodes = retryStatusCodes;
+    this.maxRetries = maxRetries;
+  }
 
   /**
    * Format the given parameter object into string.
@@ -787,9 +801,53 @@ public class ApiClient {
     else
       return File.createTempFile(prefix, suffix, new File(tempFolderPath));
   }
+  
+  public <T> ApiResponse<T> invokeAPI(String operation, String path, String method, List<Pair> queryParams, Object body, Map<String, String> headerParams, Map<String, String> cookieParams, Map<String, Object> formParams, String accept, String contentType, String[] authNames, GenericType<T> returnType) throws ApiException {
+    
+    ApiResponse<T> response = null;
+    boolean isRetry = true;
+    int retryCount = 0;
+    if (this.retryStatusCodes != null) {
+      // Making first api call and setting 'isRetry' based on the status codes.
+      try {
+        response = execute(operation, path, method, queryParams, body, headerParams, cookieParams, formParams, accept, contentType, authNames, returnType);
+        isRetry = isRetry(response);
+      } catch (ApiException ex) {
+        if (!isRetry(ex))
+          throw ex;
+      }
+      // Further retrying the request based on status codes (isRetry) and till the
+      // retry count reaches maxRetries.
+      while (retryCount < maxRetries && isRetry == true) {
+        retryCount++;
+        try {
+          TimeUnit.SECONDS.sleep((int) Math.pow(2, retryCount));
+          response = execute(operation, path, method, queryParams, body, headerParams, cookieParams, formParams, accept, contentType, authNames, returnType);
+          isRetry = isRetry(response);
+        } catch (ApiException ex) {
+          if (!isRetry(ex) || retryCount >= maxRetries)
+            throw ex;
+        } catch (InterruptedException ex) {
+          throw new ApiException(ex);
+        }
+      }
+      return response;
+    } else {
+      return execute(operation, path, method, queryParams, body, headerParams, cookieParams, formParams, accept, contentType,
+          authNames, returnType);
+    }
+  }
+  
+  private <T> boolean isRetry(ApiResponse<T> response) {
+    return this.retryStatusCodes.contains(response.getStatusCode());
+  }
+
+  private boolean isRetry(ApiException ex) {
+    return this.retryStatusCodes.contains(ex.getCode());
+  }
 
   /**
-   * Invoke API by sending HTTP request with the given options.
+   * Execute API call by sending HTTP request with the given options.
    *
    * @param <T> Type
    * @param operation The qualified name of the operation
@@ -807,7 +865,7 @@ public class ApiClient {
    * @return The response body in type of string
    * @throws ApiException API exception
    */
-  public <T> ApiResponse<T> invokeAPI(String operation, String path, String method, List<Pair> queryParams, Object body, Map<String, String> headerParams, Map<String, String> cookieParams, Map<String, Object> formParams, String accept, String contentType, String[] authNames, GenericType<T> returnType) throws ApiException {
+  private <T> ApiResponse<T> execute(String operation, String path, String method, List<Pair> queryParams, Object body, Map<String, String> headerParams, Map<String, String> cookieParams, Map<String, Object> formParams, String accept, String contentType, String[] authNames, GenericType<T> returnType) throws ApiException {
     updateParamsForAuth(authNames, queryParams, headerParams, cookieParams);
 
     // Not using `.target(targetURL).path(path)` below,

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/ApiClient.java
@@ -28,6 +28,7 @@ import java.nio.file.StandardCopyOption;
 import org.glassfish.jersey.logging.LoggingFeature;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.concurrent.TimeUnit;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.HashMap;
@@ -84,6 +85,9 @@ public class ApiClient {
   protected Map<String, String> authenticationLookup;
 
   protected DateFormat dateFormat;
+
+  private List<Integer> retryStatusCodes;
+  private int maxRetries;
 
   public ApiClient() {
     json = new JSON();
@@ -440,6 +444,16 @@ public class ApiClient {
   public String formatDate(Date date) {
     return dateFormat.format(date);
   }
+  
+  /**
+   * Set the configuration for retrying on given http status codes.
+   * @param retryStatusCodes List of http status codes
+   * @param maxRetries Maximum number of times to retry with exponential backoff
+   */
+  public void setRetryConfiguration(List<Integer> retryStatusCodes, int maxRetries) {
+    this.retryStatusCodes = retryStatusCodes;
+    this.maxRetries = maxRetries;
+  }
 
   /**
    * Format the given parameter object into string.
@@ -715,9 +729,53 @@ public class ApiClient {
     else
       return File.createTempFile(prefix, suffix, new File(tempFolderPath));
   }
+  
+  public <T> ApiResponse<T> invokeAPI(String operation, String path, String method, List<Pair> queryParams, Object body, Map<String, String> headerParams, Map<String, String> cookieParams, Map<String, Object> formParams, String accept, String contentType, String[] authNames, GenericType<T> returnType) throws ApiException {
+    
+    ApiResponse<T> response = null;
+    boolean isRetry = true;
+    int retryCount = 0;
+    if (this.retryStatusCodes != null) {
+      // Making first api call and setting 'isRetry' based on the status codes.
+      try {
+        response = execute(operation, path, method, queryParams, body, headerParams, cookieParams, formParams, accept, contentType, authNames, returnType);
+        isRetry = isRetry(response);
+      } catch (ApiException ex) {
+        if (!isRetry(ex))
+          throw ex;
+      }
+      // Further retrying the request based on status codes (isRetry) and till the
+      // retry count reaches maxRetries.
+      while (retryCount < maxRetries && isRetry == true) {
+        retryCount++;
+        try {
+          TimeUnit.SECONDS.sleep((int) Math.pow(2, retryCount));
+          response = execute(operation, path, method, queryParams, body, headerParams, cookieParams, formParams, accept, contentType, authNames, returnType);
+          isRetry = isRetry(response);
+        } catch (ApiException ex) {
+          if (!isRetry(ex) || retryCount >= maxRetries)
+            throw ex;
+        } catch (InterruptedException ex) {
+          throw new ApiException(ex);
+        }
+      }
+      return response;
+    } else {
+      return execute(operation, path, method, queryParams, body, headerParams, cookieParams, formParams, accept, contentType,
+          authNames, returnType);
+    }
+  }
+  
+  private <T> boolean isRetry(ApiResponse<T> response) {
+    return this.retryStatusCodes.contains(response.getStatusCode());
+  }
+
+  private boolean isRetry(ApiException ex) {
+    return this.retryStatusCodes.contains(ex.getCode());
+  }
 
   /**
-   * Invoke API by sending HTTP request with the given options.
+   * Execute API call by sending HTTP request with the given options.
    *
    * @param <T> Type
    * @param operation The qualified name of the operation
@@ -735,7 +793,7 @@ public class ApiClient {
    * @return The response body in type of string
    * @throws ApiException API exception
    */
-  public <T> ApiResponse<T> invokeAPI(String operation, String path, String method, List<Pair> queryParams, Object body, Map<String, String> headerParams, Map<String, String> cookieParams, Map<String, Object> formParams, String accept, String contentType, String[] authNames, GenericType<T> returnType) throws ApiException {
+  private <T> ApiResponse<T> execute(String operation, String path, String method, List<Pair> queryParams, Object body, Map<String, String> headerParams, Map<String, String> cookieParams, Map<String, Object> formParams, String accept, String contentType, String[] authNames, GenericType<T> returnType) throws ApiException {
     updateParamsForAuth(authNames, queryParams, headerParams, cookieParams);
 
     // Not using `.target(targetURL).path(path)` below,


### PR DESCRIPTION
### PR Description

Configuration to retry for the specified http status codes and specifying the maximum number of retries.

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

CC
@bbdouglas  @sreeshas  @jfiala  @lukoyanov  @cbornet  @jeff9finger  @karismann  @Zomzog  @lwlee2608  @bkabrda 
@saigiridhar21 @wing328 