### PR TITLE
[BUG] [TYPESCRIPT-AXIOS] Fixing issue where dist folder is not published when publishing typescript-axios generated client with npm publish

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptAxiosClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptAxiosClientCodegen.java
@@ -110,6 +110,7 @@ public class TypeScriptAxiosClientCodegen extends AbstractTypeScriptClientCodege
         supportingFiles.add(new SupportingFile("configuration.mustache", "", "configuration.ts"));
         supportingFiles.add(new SupportingFile("git_push.sh.mustache", "", "git_push.sh"));
         supportingFiles.add(new SupportingFile("gitignore", "", ".gitignore"));
+        supportingFiles.add(new SupportingFile("npmignore", "", ".npmignore"));
 
         if (additionalProperties.containsKey(SEPARATE_MODELS_AND_API)) {
             boolean separateModelsAndApi = Boolean.parseBoolean(additionalProperties.get(SEPARATE_MODELS_AND_API).toString());

--- a/modules/openapi-generator/src/main/resources/typescript-axios/gitignore
+++ b/modules/openapi-generator/src/main/resources/typescript-axios/gitignore
@@ -1,3 +1,4 @@
 wwwroot/*.js
 node_modules
 typings
+dist

--- a/modules/openapi-generator/src/main/resources/typescript-axios/gitignore
+++ b/modules/openapi-generator/src/main/resources/typescript-axios/gitignore
@@ -1,4 +1,3 @@
 wwwroot/*.js
 node_modules
 typings
-dist

--- a/modules/openapi-generator/src/main/resources/typescript-axios/npmignore
+++ b/modules/openapi-generator/src/main/resources/typescript-axios/npmignore
@@ -1,0 +1,1 @@
+# empty npmignore to ensure all required files (e.g., in the dist folder) are published by npm

--- a/samples/client/petstore/typescript-axios/builds/default/.gitignore
+++ b/samples/client/petstore/typescript-axios/builds/default/.gitignore
@@ -1,3 +1,4 @@
 wwwroot/*.js
 node_modules
 typings
+dist

--- a/samples/client/petstore/typescript-axios/builds/default/.gitignore
+++ b/samples/client/petstore/typescript-axios/builds/default/.gitignore
@@ -1,4 +1,3 @@
 wwwroot/*.js
 node_modules
 typings
-dist

--- a/samples/client/petstore/typescript-axios/builds/default/.npmignore
+++ b/samples/client/petstore/typescript-axios/builds/default/.npmignore
@@ -1,0 +1,1 @@
+# empty npmignore to ensure all required files (e.g., in the dist folder) are published by npm

--- a/samples/client/petstore/typescript-axios/builds/es6-target/.gitignore
+++ b/samples/client/petstore/typescript-axios/builds/es6-target/.gitignore
@@ -1,3 +1,4 @@
 wwwroot/*.js
 node_modules
 typings
+dist

--- a/samples/client/petstore/typescript-axios/builds/es6-target/.gitignore
+++ b/samples/client/petstore/typescript-axios/builds/es6-target/.gitignore
@@ -1,4 +1,3 @@
 wwwroot/*.js
 node_modules
 typings
-dist

--- a/samples/client/petstore/typescript-axios/builds/es6-target/.npmignore
+++ b/samples/client/petstore/typescript-axios/builds/es6-target/.npmignore
@@ -1,0 +1,1 @@
+# empty npmignore to ensure all required files (e.g., in the dist folder) are published by npm

--- a/samples/client/petstore/typescript-axios/builds/with-complex-headers/.gitignore
+++ b/samples/client/petstore/typescript-axios/builds/with-complex-headers/.gitignore
@@ -1,3 +1,4 @@
 wwwroot/*.js
 node_modules
 typings
+dist

--- a/samples/client/petstore/typescript-axios/builds/with-complex-headers/.gitignore
+++ b/samples/client/petstore/typescript-axios/builds/with-complex-headers/.gitignore
@@ -1,4 +1,3 @@
 wwwroot/*.js
 node_modules
 typings
-dist

--- a/samples/client/petstore/typescript-axios/builds/with-complex-headers/.npmignore
+++ b/samples/client/petstore/typescript-axios/builds/with-complex-headers/.npmignore
@@ -1,0 +1,1 @@
+# empty npmignore to ensure all required files (e.g., in the dist folder) are published by npm

--- a/samples/client/petstore/typescript-axios/builds/with-interfaces/.gitignore
+++ b/samples/client/petstore/typescript-axios/builds/with-interfaces/.gitignore
@@ -1,3 +1,4 @@
 wwwroot/*.js
 node_modules
 typings
+dist

--- a/samples/client/petstore/typescript-axios/builds/with-interfaces/.gitignore
+++ b/samples/client/petstore/typescript-axios/builds/with-interfaces/.gitignore
@@ -1,4 +1,3 @@
 wwwroot/*.js
 node_modules
 typings
-dist

--- a/samples/client/petstore/typescript-axios/builds/with-interfaces/.npmignore
+++ b/samples/client/petstore/typescript-axios/builds/with-interfaces/.npmignore
@@ -1,0 +1,1 @@
+# empty npmignore to ensure all required files (e.g., in the dist folder) are published by npm

--- a/samples/client/petstore/typescript-axios/builds/with-npm-version-and-separate-models-and-api/.gitignore
+++ b/samples/client/petstore/typescript-axios/builds/with-npm-version-and-separate-models-and-api/.gitignore
@@ -1,3 +1,4 @@
 wwwroot/*.js
 node_modules
 typings
+dist

--- a/samples/client/petstore/typescript-axios/builds/with-npm-version-and-separate-models-and-api/.gitignore
+++ b/samples/client/petstore/typescript-axios/builds/with-npm-version-and-separate-models-and-api/.gitignore
@@ -1,4 +1,3 @@
 wwwroot/*.js
 node_modules
 typings
-dist

--- a/samples/client/petstore/typescript-axios/builds/with-npm-version-and-separate-models-and-api/.npmignore
+++ b/samples/client/petstore/typescript-axios/builds/with-npm-version-and-separate-models-and-api/.npmignore
@@ -1,0 +1,1 @@
+# empty npmignore to ensure all required files (e.g., in the dist folder) are published by npm

--- a/samples/client/petstore/typescript-axios/builds/with-npm-version/.gitignore
+++ b/samples/client/petstore/typescript-axios/builds/with-npm-version/.gitignore
@@ -1,3 +1,4 @@
 wwwroot/*.js
 node_modules
 typings
+dist

--- a/samples/client/petstore/typescript-axios/builds/with-npm-version/.gitignore
+++ b/samples/client/petstore/typescript-axios/builds/with-npm-version/.gitignore
@@ -1,4 +1,3 @@
 wwwroot/*.js
 node_modules
 typings
-dist

--- a/samples/client/petstore/typescript-axios/builds/with-npm-version/.npmignore
+++ b/samples/client/petstore/typescript-axios/builds/with-npm-version/.npmignore
@@ -1,0 +1,1 @@
+# empty npmignore to ensure all required files (e.g., in the dist folder) are published by npm


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
This pull requests fixes the issue described in https://github.com/OpenAPITools/openapi-generator/issues/3224 where the dist folder is not published when the ```npm publish``` command is run. This appears to be because the dist folder is included in the ```.gitignore```. This PR removes the ```dist``` entry from gitignore which ensures that the dist folder is included and that generated libraries can be safely published to npm etc.

fixes #3224

Without this fix, the generated library works when linked locally but not when published, ensuing in much confusion.

<!-- Please check the completed items below -->
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [X] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [X] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

- Copying technical committee
CC @TiFu (2017/07) @taxpon (2017/07) @sebastianhaas (2017/07) @kenisteward (2017/07) @Vrolijkx (2017/09) @macjohnny (2018/01) @nicokoenig (2018/09) @topce (2018/10) @akehir (2019/07) @petejohansonxo (2019/11) @amakhrov (2020/02)
