### PR TITLE
[PS] Add ErrorActionPreferencel to API doc

### DIFF
--- a/modules/openapi-generator/src/main/resources/powershell-experimental/api_doc.mustache
+++ b/modules/openapi-generator/src/main/resources/powershell-experimental/api_doc.mustache
@@ -25,6 +25,9 @@ Method | HTTP request | Description
 ```powershell
 Import-Module -Name {{{packageName}}}
 
+# Displays the error message and stops executing. (Default: Continue)
+$ErrorActionPreference = "Stop"
+
 {{#hasAuthMethods}}
 $Configuration = Get-{{{packageName}}}Configuration
 {{#authMethods}}

--- a/samples/client/petstore/powershell-experimental/Test1.ps1
+++ b/samples/client/petstore/powershell-experimental/Test1.ps1
@@ -29,33 +29,37 @@ try {
     #Write-Host $pet
     $Result = Add-PSPet -Pet $pet
     Set-PSConfigurationApiKey -Id "api_key" -ApiKey "zzZZZZZZZZZZZZZ"
-    $result = Get-PSPetById -petId $Id -Verbose #-testHeader "testing only" -testQuery "testing something here"
+    #$result = Get-PSPetById -petId ($Id+1) -Verbose #-testHeader "testing only" -testQuery "testing something here"
+    #Write-Host "after get pet by id"
 } catch {
-    Write-Host ("Exception occured when calling '': {0}" -f ($_.ErrorDetails | ConvertFrom-Json))
+    Write-Host ("Exception occured when calling: {0}" -f ($_.ErrorDetails | ConvertFrom-Json))
     Write-Host ("Response headers: {0}" -f ($_.Exception.Response.Headers | ConvertTo-Json))
 }
+
+$result = Get-PSPetById -petId ($Id+1) -Verbose -WithHttpInfo #-testHeader "testing only" -testQuery "testing something here"
+Write-Host "after get pet by id"
+Write-Host $result.gettype()
 
 #$result | Write-Host
 
 #$result | Select-Object -Property "photoUrls" | ConvertTo-Json | Write-Host
 #Write-Host "result =" + $result.photoUrls
 
-
-$pet2 = Initialize-PSPet -Id 20129 -Name '2foo' -Category (
-    Initialize-PSCategory -Id 20129 -Name '2bar'
-) -PhotoUrls @(
-    'http://example.com/2foo',
-    'http://example.com/2bar'
-) -Tags (
-    Initialize-PSTag -Id 3 -Name 'baz'
-) -Status Available
-
-#Write-Host $pet
-$Result = Add-PSPet -Pet $pet2
-
-$Result = Find-PSPetsByTags 'baz'
-Write-Host $Result.GetType().Name
-Write-Host $Result
+#$pet2 = Initialize-PSPet -Id 20129 -Name '2foo' -Category (
+#    Initialize-PSCategory -Id 20129 -Name '2bar'
+#) -PhotoUrls @(
+#    'http://example.com/2foo',
+#    'http://example.com/2bar'
+#) -Tags (
+#    Initialize-PSTag -Id 3 -Name 'baz'
+#) -Status Available
+#
+##Write-Host $pet
+#$Result = Add-PSPet -Pet $pet2
+#
+#$Result = Find-PSPetsByTags 'baz'
+#Write-Host $Result.GetType().Name
+#Write-Host $Result
 
 #$Result = Invoke-PetApiUpdatePetWithForm -petId $Id -Name "PowerShell Update" -Status "Pending"
 

--- a/samples/client/petstore/powershell-experimental/docs/PSPetApi.md
+++ b/samples/client/petstore/powershell-experimental/docs/PSPetApi.md
@@ -25,6 +25,9 @@ Add a new pet to the store
 ```powershell
 Import-Module -Name PSPetstore
 
+# Displays the error message and stops executing. (Default: Continue)
+$ErrorActionPreference = "Stop"
+
 $Configuration = Get-PSPetstoreConfiguration
 # Configure OAuth2 access token for authorization: petstore_auth
 $Configuration["AccessToken"] = "YOUR_ACCESS_TOKEN";
@@ -72,6 +75,9 @@ Deletes a pet
 ### Example
 ```powershell
 Import-Module -Name PSPetstore
+
+# Displays the error message and stops executing. (Default: Continue)
+$ErrorActionPreference = "Stop"
 
 $Configuration = Get-PSPetstoreConfiguration
 # Configure OAuth2 access token for authorization: petstore_auth
@@ -124,6 +130,9 @@ Multiple status values can be provided with comma separated strings
 ```powershell
 Import-Module -Name PSPetstore
 
+# Displays the error message and stops executing. (Default: Continue)
+$ErrorActionPreference = "Stop"
+
 $Configuration = Get-PSPetstoreConfiguration
 # Configure OAuth2 access token for authorization: petstore_auth
 $Configuration["AccessToken"] = "YOUR_ACCESS_TOKEN";
@@ -172,6 +181,9 @@ Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3
 ### Example
 ```powershell
 Import-Module -Name PSPetstore
+
+# Displays the error message and stops executing. (Default: Continue)
+$ErrorActionPreference = "Stop"
 
 $Configuration = Get-PSPetstoreConfiguration
 # Configure OAuth2 access token for authorization: petstore_auth
@@ -222,6 +234,9 @@ Returns a single pet
 ```powershell
 Import-Module -Name PSPetstore
 
+# Displays the error message and stops executing. (Default: Continue)
+$ErrorActionPreference = "Stop"
+
 $Configuration = Get-PSPetstoreConfiguration
 # Configure API key authorization: api_key
 $Configuration["ApiKey"]["api_key"] = "YOUR_API_KEY"
@@ -271,6 +286,9 @@ Update an existing pet
 ```powershell
 Import-Module -Name PSPetstore
 
+# Displays the error message and stops executing. (Default: Continue)
+$ErrorActionPreference = "Stop"
+
 $Configuration = Get-PSPetstoreConfiguration
 # Configure OAuth2 access token for authorization: petstore_auth
 $Configuration["AccessToken"] = "YOUR_ACCESS_TOKEN";
@@ -319,6 +337,9 @@ Updates a pet in the store with form data
 ### Example
 ```powershell
 Import-Module -Name PSPetstore
+
+# Displays the error message and stops executing. (Default: Continue)
+$ErrorActionPreference = "Stop"
 
 $Configuration = Get-PSPetstoreConfiguration
 # Configure OAuth2 access token for authorization: petstore_auth
@@ -372,6 +393,9 @@ uploads an image
 ### Example
 ```powershell
 Import-Module -Name PSPetstore
+
+# Displays the error message and stops executing. (Default: Continue)
+$ErrorActionPreference = "Stop"
 
 $Configuration = Get-PSPetstoreConfiguration
 # Configure OAuth2 access token for authorization: petstore_auth

--- a/samples/client/petstore/powershell-experimental/docs/PSStoreApi.md
+++ b/samples/client/petstore/powershell-experimental/docs/PSStoreApi.md
@@ -23,6 +23,9 @@ For valid response try integer IDs with value < 1000. Anything above 1000 or non
 ```powershell
 Import-Module -Name PSPetstore
 
+# Displays the error message and stops executing. (Default: Continue)
+$ErrorActionPreference = "Stop"
+
 $OrderId = "OrderId_example" # String | ID of the order that needs to be deleted (default to null)
 
 # Delete purchase order by ID
@@ -66,6 +69,9 @@ Returns a map of status codes to quantities
 ### Example
 ```powershell
 Import-Module -Name PSPetstore
+
+# Displays the error message and stops executing. (Default: Continue)
+$ErrorActionPreference = "Stop"
 
 $Configuration = Get-PSPetstoreConfiguration
 # Configure API key authorization: api_key
@@ -114,6 +120,9 @@ For valid response try integer IDs with value <= 5 or > 10. Other values will ge
 ```powershell
 Import-Module -Name PSPetstore
 
+# Displays the error message and stops executing. (Default: Continue)
+$ErrorActionPreference = "Stop"
+
 $OrderId = 987 # Int64 | ID of pet that needs to be fetched (default to null)
 
 # Find purchase order by ID
@@ -156,6 +165,9 @@ Place an order for a pet
 ### Example
 ```powershell
 Import-Module -Name PSPetstore
+
+# Displays the error message and stops executing. (Default: Continue)
+$ErrorActionPreference = "Stop"
 
 $Order = (Initialize-Order-Id 123 -PetId 123 -Quantity 123 -ShipDate Get-Date -Status "Status_example" -Complete $false) # Order | order placed for purchasing the pet
 

--- a/samples/client/petstore/powershell-experimental/docs/PSUserApi.md
+++ b/samples/client/petstore/powershell-experimental/docs/PSUserApi.md
@@ -27,6 +27,9 @@ This can only be done by the logged in user.
 ```powershell
 Import-Module -Name PSPetstore
 
+# Displays the error message and stops executing. (Default: Continue)
+$ErrorActionPreference = "Stop"
+
 $Configuration = Get-PSPetstoreConfiguration
 # Configure API key authorization: auth_cookie
 $Configuration["ApiKey"]["AUTH_KEY"] = "YOUR_API_KEY"
@@ -76,6 +79,9 @@ Creates list of users with given input array
 ```powershell
 Import-Module -Name PSPetstore
 
+# Displays the error message and stops executing. (Default: Continue)
+$ErrorActionPreference = "Stop"
+
 $Configuration = Get-PSPetstoreConfiguration
 # Configure API key authorization: auth_cookie
 $Configuration["ApiKey"]["AUTH_KEY"] = "YOUR_API_KEY"
@@ -124,6 +130,9 @@ Creates list of users with given input array
 ### Example
 ```powershell
 Import-Module -Name PSPetstore
+
+# Displays the error message and stops executing. (Default: Continue)
+$ErrorActionPreference = "Stop"
 
 $Configuration = Get-PSPetstoreConfiguration
 # Configure API key authorization: auth_cookie
@@ -176,6 +185,9 @@ This can only be done by the logged in user.
 ```powershell
 Import-Module -Name PSPetstore
 
+# Displays the error message and stops executing. (Default: Continue)
+$ErrorActionPreference = "Stop"
+
 $Configuration = Get-PSPetstoreConfiguration
 # Configure API key authorization: auth_cookie
 $Configuration["ApiKey"]["AUTH_KEY"] = "YOUR_API_KEY"
@@ -225,6 +237,9 @@ Get user by user name
 ```powershell
 Import-Module -Name PSPetstore
 
+# Displays the error message and stops executing. (Default: Continue)
+$ErrorActionPreference = "Stop"
+
 $Username = "Username_example" # String | The name that needs to be fetched. Use user1 for testing. (default to null)
 
 # Get user by user name
@@ -269,6 +284,9 @@ Logs user into the system
 ```powershell
 Import-Module -Name PSPetstore
 
+# Displays the error message and stops executing. (Default: Continue)
+$ErrorActionPreference = "Stop"
+
 $Username = "Username_example" # String | The user name for login (default to null)
 $Password = "Password_example" # String | The password for login in clear text (default to null)
 
@@ -312,6 +330,9 @@ Logs out current logged in user session
 ### Example
 ```powershell
 Import-Module -Name PSPetstore
+
+# Displays the error message and stops executing. (Default: Continue)
+$ErrorActionPreference = "Stop"
 
 $Configuration = Get-PSPetstoreConfiguration
 # Configure API key authorization: auth_cookie
@@ -360,6 +381,9 @@ This can only be done by the logged in user.
 ### Example
 ```powershell
 Import-Module -Name PSPetstore
+
+# Displays the error message and stops executing. (Default: Continue)
+$ErrorActionPreference = "Stop"
 
 $Configuration = Get-PSPetstoreConfiguration
 # Configure API key authorization: auth_cookie


### PR DESCRIPTION
- Add $ErrorActionPreferencel to API doc

<!-- Please check the completed items below -->
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [ ] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [ ] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
