### PR TITLE
[Rust Server] Fix #5906 (yaml with path parameter error)

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustServerCodegen.java
@@ -336,7 +336,7 @@ public class RustServerCodegen extends DefaultCodegen implements CodegenConfig {
 
         URL url = URLPathUtils.getServerURL(openAPI, serverVariableOverrides());
         additionalProperties.put("serverHost", url.getHost());
-        additionalProperties.put("serverPort", URLPathUtils.getPort(url, 80));
+        additionalProperties.put("serverPort", URLPathUtils.getPort(url, serverPort));
 
         if (packageVersion == null || "".equals(packageVersion)) {
             List<String> versionComponents = new ArrayList<>(Arrays.asList(info.getVersion().split("[.]")));
@@ -706,9 +706,9 @@ public class RustServerCodegen extends DefaultCodegen implements CodegenConfig {
             // Don't prefix with '^' so that the templates can put the
             // basePath on the front.
             for (CodegenParameter param : op.pathParams) {
-                // Replace {paramName} with (?P<paramName>[^/?#]*) for regex
+                // Replace {baseName} with (?P<baseName>[^/?#]*) for regex
                 String paramSearch = "{" + param.baseName + "}";
-                String paramReplace = "(?P<" + param.paramName + ">[^/?#]*)";
+                String paramReplace = "(?P<" + param.baseName + ">[^/?#]*)";
 
                 regex = regex.replace(paramSearch, paramReplace);
             }

--- a/modules/openapi-generator/src/main/resources/rust-server/example-client-main.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/example-client-main.mustache
@@ -126,7 +126,7 @@ fn main() {
                   {{{vendorExtensions.example}}}{{^-last}},{{/-last}}
                 {{/allParams}}
             ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         {{#vendorExtensions}}
           {{#noClientExample}}

--- a/modules/openapi-generator/src/main/resources/rust-server/example-server-operation.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/example-server-operation.mustache
@@ -11,7 +11,7 @@
 {{#allParams}}
         {{{paramName}}}: {{^required}}Option<{{/required}}{{#isListContainer}}&{{/isListContainer}}{{{dataType}}}{{^required}}>{{/required}},
 {{/allParams}}
-        context: &C) -> Box<Future<Item={{{operationId}}}Response, Error=ApiError> + Send>
+        context: &C) -> Box<dyn Future<Item={{{operationId}}}Response, Error=ApiError> + Send>
     {
         let context = context.clone();
         info!("{{#vendorExtensions}}{{{operation_id}}}{{/vendorExtensions}}({{#allParams}}{{#vendorExtensions}}{{{formatString}}}{{/vendorExtensions}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) - X-Span-ID: {:?}"{{#allParams}}, {{{paramName}}}{{/allParams}}, context.get().0.clone());

--- a/modules/openapi-generator/src/test/resources/3_0/rust-server/openapi-v3.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/rust-server/openapi-v3.yaml
@@ -359,6 +359,24 @@ paths:
         '200':
           description: Success
 
+  /repos/{repoId}:
+    parameters:
+      - in: path
+        name: repoId
+        schema:
+          type: string
+        required: true
+    get:
+      tags: [Repo]
+      operationId: GetRepoInfo
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/StringObject"
+
 components:
   securitySchemes:
     authScheme:

--- a/samples/server/petstore/rust-server/output/multipart-v3/examples/client/main.rs
+++ b/samples/server/petstore/rust-server/output/multipart-v3/examples/client/main.rs
@@ -53,7 +53,7 @@ fn main() {
         .arg(Arg::with_name("port")
             .long("port")
             .takes_value(true)
-            .default_value("80")
+            .default_value("8080")
             .help("Port to contact"))
         .get_matches();
 
@@ -88,7 +88,7 @@ fn main() {
                   None,
                   Some(swagger::ByteArray(Vec::from("BINARY_DATA_HERE")))
             ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         Some("MultipartRequestPost") => {
             let result = rt.block_on(client.multipart_request_post(
@@ -97,14 +97,14 @@ fn main() {
                   Some("optional_string_field_example".to_string()),
                   None
             ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         Some("MultipleIdenticalMimeTypesPost") => {
             let result = rt.block_on(client.multiple_identical_mime_types_post(
                   Some(swagger::ByteArray(Vec::from("BINARY_DATA_HERE"))),
                   Some(swagger::ByteArray(Vec::from("BINARY_DATA_HERE")))
             ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         _ => {
             panic!("Invalid operation provided")

--- a/samples/server/petstore/rust-server/output/multipart-v3/examples/server/main.rs
+++ b/samples/server/petstore/rust-server/output/multipart-v3/examples/server/main.rs
@@ -42,7 +42,7 @@ fn main() {
             .help("Whether to use HTTPS or not"))
         .get_matches();
 
-    let addr = "127.0.0.1:80";
+    let addr = "127.0.0.1:8080";
 
     hyper::rt::run(server::create(addr, matches.is_present("https")));
 }

--- a/samples/server/petstore/rust-server/output/multipart-v3/examples/server/server.rs
+++ b/samples/server/petstore/rust-server/output/multipart-v3/examples/server/server.rs
@@ -117,7 +117,7 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
         required_binary_field: swagger::ByteArray,
         object_field: Option<models::MultipartRequestObjectField>,
         optional_binary_field: Option<swagger::ByteArray>,
-        context: &C) -> Box<Future<Item=MultipartRelatedRequestPostResponse, Error=ApiError> + Send>
+        context: &C) -> Box<dyn Future<Item=MultipartRelatedRequestPostResponse, Error=ApiError> + Send>
     {
         let context = context.clone();
         info!("multipart_related_request_post({:?}, {:?}, {:?}) - X-Span-ID: {:?}", required_binary_field, object_field, optional_binary_field, context.get().0.clone());
@@ -130,7 +130,7 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
         binary_field: swagger::ByteArray,
         optional_string_field: Option<String>,
         object_field: Option<models::MultipartRequestObjectField>,
-        context: &C) -> Box<Future<Item=MultipartRequestPostResponse, Error=ApiError> + Send>
+        context: &C) -> Box<dyn Future<Item=MultipartRequestPostResponse, Error=ApiError> + Send>
     {
         let context = context.clone();
         info!("multipart_request_post(\"{}\", {:?}, {:?}, {:?}) - X-Span-ID: {:?}", string_field, binary_field, optional_string_field, object_field, context.get().0.clone());
@@ -141,7 +141,7 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
         &self,
         binary1: Option<swagger::ByteArray>,
         binary2: Option<swagger::ByteArray>,
-        context: &C) -> Box<Future<Item=MultipleIdenticalMimeTypesPostResponse, Error=ApiError> + Send>
+        context: &C) -> Box<dyn Future<Item=MultipleIdenticalMimeTypesPostResponse, Error=ApiError> + Send>
     {
         let context = context.clone();
         info!("multiple_identical_mime_types_post({:?}, {:?}) - X-Span-ID: {:?}", binary1, binary2, context.get().0.clone());

--- a/samples/server/petstore/rust-server/output/no-example-v3/examples/client/main.rs
+++ b/samples/server/petstore/rust-server/output/no-example-v3/examples/client/main.rs
@@ -48,7 +48,7 @@ fn main() {
         .arg(Arg::with_name("port")
             .long("port")
             .takes_value(true)
-            .default_value("80")
+            .default_value("8080")
             .help("Port to contact"))
         .get_matches();
 
@@ -82,7 +82,7 @@ fn main() {
             let result = rt.block_on(client.op_get(
                   ???
             ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         */
         _ => {

--- a/samples/server/petstore/rust-server/output/no-example-v3/examples/server/main.rs
+++ b/samples/server/petstore/rust-server/output/no-example-v3/examples/server/main.rs
@@ -42,7 +42,7 @@ fn main() {
             .help("Whether to use HTTPS or not"))
         .get_matches();
 
-    let addr = "127.0.0.1:80";
+    let addr = "127.0.0.1:8080";
 
     hyper::rt::run(server::create(addr, matches.is_present("https")));
 }

--- a/samples/server/petstore/rust-server/output/no-example-v3/examples/server/server.rs
+++ b/samples/server/petstore/rust-server/output/no-example-v3/examples/server/server.rs
@@ -113,7 +113,7 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
     fn op_get(
         &self,
         inline_object: models::InlineObject,
-        context: &C) -> Box<Future<Item=OpGetResponse, Error=ApiError> + Send>
+        context: &C) -> Box<dyn Future<Item=OpGetResponse, Error=ApiError> + Send>
     {
         let context = context.clone();
         info!("op_get({:?}) - X-Span-ID: {:?}", inline_object, context.get().0.clone());

--- a/samples/server/petstore/rust-server/output/openapi-v3/api/openapi.yaml
+++ b/samples/server/petstore/rust-server/output/openapi-v3/api/openapi.yaml
@@ -360,6 +360,26 @@ paths:
       responses:
         "200":
           description: Success
+  /repos/{repoId}:
+    get:
+      operationId: GetRepoInfo
+      parameters:
+      - explode: false
+        in: path
+        name: repoId
+        required: true
+        schema:
+          type: string
+        style: simple
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StringObject'
+          description: OK
+      tags:
+      - Repo
 components:
   schemas:
     EnumWithStarObject:

--- a/samples/server/petstore/rust-server/output/openapi-v3/examples/client/main.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/examples/client/main.rs
@@ -49,7 +49,8 @@ use openapi_v3::{Api, ApiNoContext, Client, ContextWrapperExt,
                       XmlOtherPostResponse,
                       XmlOtherPutResponse,
                       XmlPostResponse,
-                      XmlPutResponse
+                      XmlPutResponse,
+                      GetRepoInfoResponse
                      };
 use clap::{App, Arg};
 
@@ -86,6 +87,7 @@ fn main() {
                 "XmlOtherPut",
                 "XmlPost",
                 "XmlPut",
+                "GetRepoInfo",
             ])
             .required(true)
             .index(1))
@@ -100,7 +102,7 @@ fn main() {
         .arg(Arg::with_name("port")
             .long("port")
             .takes_value(true)
-            .default_value("80")
+            .default_value("8080")
             .help("Port to contact"))
         .get_matches();
 
@@ -136,47 +138,47 @@ fn main() {
             let result = rt.block_on(client.callback_with_header_post(
                   "url_example".to_string()
             ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         Some("ComplexQueryParamGet") => {
             let result = rt.block_on(client.complex_query_param_get(
                   Some(&Vec::new())
             ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         /* Disabled because there's no example.
         Some("EnumInPathPathParamGet") => {
             let result = rt.block_on(client.enum_in_path_path_param_get(
                   ???
             ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         */
         Some("MandatoryRequestHeaderGet") => {
             let result = rt.block_on(client.mandatory_request_header_get(
                   "x_header_example".to_string()
             ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         Some("MergePatchJsonGet") => {
             let result = rt.block_on(client.merge_patch_json_get(
             ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         Some("MultigetGet") => {
             let result = rt.block_on(client.multiget_get(
             ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         Some("MultipleAuthSchemeGet") => {
             let result = rt.block_on(client.multiple_auth_scheme_get(
             ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         Some("OverrideServerGet") => {
             let result = rt.block_on(client.override_server_get(
             ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         Some("ParamgetGet") => {
             let result = rt.block_on(client.paramget_get(
@@ -184,75 +186,81 @@ fn main() {
                   None,
                   None
             ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         Some("ReadonlyAuthSchemeGet") => {
             let result = rt.block_on(client.readonly_auth_scheme_get(
             ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         Some("RegisterCallbackPost") => {
             let result = rt.block_on(client.register_callback_post(
                   "url_example".to_string()
             ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         Some("RequiredOctetStreamPut") => {
             let result = rt.block_on(client.required_octet_stream_put(
                   swagger::ByteArray(Vec::from("BYTE_ARRAY_DATA_HERE"))
             ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         Some("ResponsesWithHeadersGet") => {
             let result = rt.block_on(client.responses_with_headers_get(
             ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         Some("Rfc7807Get") => {
             let result = rt.block_on(client.rfc7807_get(
             ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         Some("UntypedPropertyGet") => {
             let result = rt.block_on(client.untyped_property_get(
                   None
             ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         Some("UuidGet") => {
             let result = rt.block_on(client.uuid_get(
             ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         Some("XmlExtraPost") => {
             let result = rt.block_on(client.xml_extra_post(
                   None
             ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         Some("XmlOtherPost") => {
             let result = rt.block_on(client.xml_other_post(
                   None
             ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         Some("XmlOtherPut") => {
             let result = rt.block_on(client.xml_other_put(
                   None
             ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         Some("XmlPost") => {
             let result = rt.block_on(client.xml_post(
                   None
             ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         Some("XmlPut") => {
             let result = rt.block_on(client.xml_put(
                   None
             ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
+        },
+        Some("GetRepoInfo") => {
+            let result = rt.block_on(client.get_repo_info(
+                  "repo_id_example".to_string()
+            ));
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         _ => {
             panic!("Invalid operation provided")

--- a/samples/server/petstore/rust-server/output/openapi-v3/examples/client/server.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/examples/client/server.rs
@@ -111,7 +111,7 @@ impl<C> CallbackApi<C> for Server<C> where C: Has<XSpanIdString>{
         &self,
         callback_request_query_url: String,
         information: Option<String>,
-        context: &C) -> Box<Future<Item=CallbackCallbackWithHeaderPostResponse, Error=ApiError> + Send>
+        context: &C) -> Box<dyn Future<Item=CallbackCallbackWithHeaderPostResponse, Error=ApiError> + Send>
     {
         let context = context.clone();
         info!("callback_callback_with_header_post({:?}) - X-Span-ID: {:?}", information, context.get().0.clone());
@@ -121,7 +121,7 @@ impl<C> CallbackApi<C> for Server<C> where C: Has<XSpanIdString>{
     fn callback_callback_post(
         &self,
         callback_request_query_url: String,
-        context: &C) -> Box<Future<Item=CallbackCallbackPostResponse, Error=ApiError> + Send>
+        context: &C) -> Box<dyn Future<Item=CallbackCallbackPostResponse, Error=ApiError> + Send>
     {
         let context = context.clone();
         info!("callback_callback_post() - X-Span-ID: {:?}", context.get().0.clone());

--- a/samples/server/petstore/rust-server/output/openapi-v3/examples/server/main.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/examples/server/main.rs
@@ -43,7 +43,7 @@ fn main() {
             .help("Whether to use HTTPS or not"))
         .get_matches();
 
-    let addr = "127.0.0.1:80";
+    let addr = "127.0.0.1:8080";
 
     hyper::rt::run(server::create(addr, matches.is_present("https")));
 }

--- a/samples/server/petstore/rust-server/output/openapi-v3/examples/server/server.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/examples/server/server.rs
@@ -126,6 +126,7 @@ use openapi_v3::{
     XmlOtherPutResponse,
     XmlPostResponse,
     XmlPutResponse,
+    GetRepoInfoResponse,
 };
 use openapi_v3::server::MakeService;
 
@@ -133,7 +134,7 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
     fn callback_with_header_post(
         &self,
         url: String,
-        context: &C) -> Box<Future<Item=CallbackWithHeaderPostResponse, Error=ApiError> + Send>
+        context: &C) -> Box<dyn Future<Item=CallbackWithHeaderPostResponse, Error=ApiError> + Send>
     {
         let context = context.clone();
         info!("callback_with_header_post(\"{}\") - X-Span-ID: {:?}", url, context.get().0.clone());
@@ -143,7 +144,7 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
     fn complex_query_param_get(
         &self,
         list_of_strings: Option<&Vec<models::StringObject>>,
-        context: &C) -> Box<Future<Item=ComplexQueryParamGetResponse, Error=ApiError> + Send>
+        context: &C) -> Box<dyn Future<Item=ComplexQueryParamGetResponse, Error=ApiError> + Send>
     {
         let context = context.clone();
         info!("complex_query_param_get({:?}) - X-Span-ID: {:?}", list_of_strings, context.get().0.clone());
@@ -153,7 +154,7 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
     fn enum_in_path_path_param_get(
         &self,
         path_param: models::StringEnum,
-        context: &C) -> Box<Future<Item=EnumInPathPathParamGetResponse, Error=ApiError> + Send>
+        context: &C) -> Box<dyn Future<Item=EnumInPathPathParamGetResponse, Error=ApiError> + Send>
     {
         let context = context.clone();
         info!("enum_in_path_path_param_get({:?}) - X-Span-ID: {:?}", path_param, context.get().0.clone());
@@ -163,7 +164,7 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
     fn mandatory_request_header_get(
         &self,
         x_header: String,
-        context: &C) -> Box<Future<Item=MandatoryRequestHeaderGetResponse, Error=ApiError> + Send>
+        context: &C) -> Box<dyn Future<Item=MandatoryRequestHeaderGetResponse, Error=ApiError> + Send>
     {
         let context = context.clone();
         info!("mandatory_request_header_get(\"{}\") - X-Span-ID: {:?}", x_header, context.get().0.clone());
@@ -172,7 +173,7 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
 
     fn merge_patch_json_get(
         &self,
-        context: &C) -> Box<Future<Item=MergePatchJsonGetResponse, Error=ApiError> + Send>
+        context: &C) -> Box<dyn Future<Item=MergePatchJsonGetResponse, Error=ApiError> + Send>
     {
         let context = context.clone();
         info!("merge_patch_json_get() - X-Span-ID: {:?}", context.get().0.clone());
@@ -182,7 +183,7 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
     /// Get some stuff.
     fn multiget_get(
         &self,
-        context: &C) -> Box<Future<Item=MultigetGetResponse, Error=ApiError> + Send>
+        context: &C) -> Box<dyn Future<Item=MultigetGetResponse, Error=ApiError> + Send>
     {
         let context = context.clone();
         info!("multiget_get() - X-Span-ID: {:?}", context.get().0.clone());
@@ -191,7 +192,7 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
 
     fn multiple_auth_scheme_get(
         &self,
-        context: &C) -> Box<Future<Item=MultipleAuthSchemeGetResponse, Error=ApiError> + Send>
+        context: &C) -> Box<dyn Future<Item=MultipleAuthSchemeGetResponse, Error=ApiError> + Send>
     {
         let context = context.clone();
         info!("multiple_auth_scheme_get() - X-Span-ID: {:?}", context.get().0.clone());
@@ -200,7 +201,7 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
 
     fn override_server_get(
         &self,
-        context: &C) -> Box<Future<Item=OverrideServerGetResponse, Error=ApiError> + Send>
+        context: &C) -> Box<dyn Future<Item=OverrideServerGetResponse, Error=ApiError> + Send>
     {
         let context = context.clone();
         info!("override_server_get() - X-Span-ID: {:?}", context.get().0.clone());
@@ -213,7 +214,7 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
         uuid: Option<uuid::Uuid>,
         some_object: Option<models::ObjectParam>,
         some_list: Option<models::MyIdList>,
-        context: &C) -> Box<Future<Item=ParamgetGetResponse, Error=ApiError> + Send>
+        context: &C) -> Box<dyn Future<Item=ParamgetGetResponse, Error=ApiError> + Send>
     {
         let context = context.clone();
         info!("paramget_get({:?}, {:?}, {:?}) - X-Span-ID: {:?}", uuid, some_object, some_list, context.get().0.clone());
@@ -222,7 +223,7 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
 
     fn readonly_auth_scheme_get(
         &self,
-        context: &C) -> Box<Future<Item=ReadonlyAuthSchemeGetResponse, Error=ApiError> + Send>
+        context: &C) -> Box<dyn Future<Item=ReadonlyAuthSchemeGetResponse, Error=ApiError> + Send>
     {
         let context = context.clone();
         info!("readonly_auth_scheme_get() - X-Span-ID: {:?}", context.get().0.clone());
@@ -232,7 +233,7 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
     fn register_callback_post(
         &self,
         url: String,
-        context: &C) -> Box<Future<Item=RegisterCallbackPostResponse, Error=ApiError> + Send>
+        context: &C) -> Box<dyn Future<Item=RegisterCallbackPostResponse, Error=ApiError> + Send>
     {
         let context = context.clone();
         info!("register_callback_post(\"{}\") - X-Span-ID: {:?}", url, context.get().0.clone());
@@ -242,7 +243,7 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
     fn required_octet_stream_put(
         &self,
         body: swagger::ByteArray,
-        context: &C) -> Box<Future<Item=RequiredOctetStreamPutResponse, Error=ApiError> + Send>
+        context: &C) -> Box<dyn Future<Item=RequiredOctetStreamPutResponse, Error=ApiError> + Send>
     {
         let context = context.clone();
         info!("required_octet_stream_put({:?}) - X-Span-ID: {:?}", body, context.get().0.clone());
@@ -251,7 +252,7 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
 
     fn responses_with_headers_get(
         &self,
-        context: &C) -> Box<Future<Item=ResponsesWithHeadersGetResponse, Error=ApiError> + Send>
+        context: &C) -> Box<dyn Future<Item=ResponsesWithHeadersGetResponse, Error=ApiError> + Send>
     {
         let context = context.clone();
         info!("responses_with_headers_get() - X-Span-ID: {:?}", context.get().0.clone());
@@ -260,7 +261,7 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
 
     fn rfc7807_get(
         &self,
-        context: &C) -> Box<Future<Item=Rfc7807GetResponse, Error=ApiError> + Send>
+        context: &C) -> Box<dyn Future<Item=Rfc7807GetResponse, Error=ApiError> + Send>
     {
         let context = context.clone();
         info!("rfc7807_get() - X-Span-ID: {:?}", context.get().0.clone());
@@ -270,7 +271,7 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
     fn untyped_property_get(
         &self,
         object_untyped_props: Option<models::ObjectUntypedProps>,
-        context: &C) -> Box<Future<Item=UntypedPropertyGetResponse, Error=ApiError> + Send>
+        context: &C) -> Box<dyn Future<Item=UntypedPropertyGetResponse, Error=ApiError> + Send>
     {
         let context = context.clone();
         info!("untyped_property_get({:?}) - X-Span-ID: {:?}", object_untyped_props, context.get().0.clone());
@@ -279,7 +280,7 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
 
     fn uuid_get(
         &self,
-        context: &C) -> Box<Future<Item=UuidGetResponse, Error=ApiError> + Send>
+        context: &C) -> Box<dyn Future<Item=UuidGetResponse, Error=ApiError> + Send>
     {
         let context = context.clone();
         info!("uuid_get() - X-Span-ID: {:?}", context.get().0.clone());
@@ -289,7 +290,7 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
     fn xml_extra_post(
         &self,
         duplicate_xml_object: Option<models::DuplicateXmlObject>,
-        context: &C) -> Box<Future<Item=XmlExtraPostResponse, Error=ApiError> + Send>
+        context: &C) -> Box<dyn Future<Item=XmlExtraPostResponse, Error=ApiError> + Send>
     {
         let context = context.clone();
         info!("xml_extra_post({:?}) - X-Span-ID: {:?}", duplicate_xml_object, context.get().0.clone());
@@ -299,7 +300,7 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
     fn xml_other_post(
         &self,
         another_xml_object: Option<models::AnotherXmlObject>,
-        context: &C) -> Box<Future<Item=XmlOtherPostResponse, Error=ApiError> + Send>
+        context: &C) -> Box<dyn Future<Item=XmlOtherPostResponse, Error=ApiError> + Send>
     {
         let context = context.clone();
         info!("xml_other_post({:?}) - X-Span-ID: {:?}", another_xml_object, context.get().0.clone());
@@ -309,7 +310,7 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
     fn xml_other_put(
         &self,
         string: Option<models::AnotherXmlArray>,
-        context: &C) -> Box<Future<Item=XmlOtherPutResponse, Error=ApiError> + Send>
+        context: &C) -> Box<dyn Future<Item=XmlOtherPutResponse, Error=ApiError> + Send>
     {
         let context = context.clone();
         info!("xml_other_put({:?}) - X-Span-ID: {:?}", string, context.get().0.clone());
@@ -320,7 +321,7 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
     fn xml_post(
         &self,
         string: Option<models::XmlArray>,
-        context: &C) -> Box<Future<Item=XmlPostResponse, Error=ApiError> + Send>
+        context: &C) -> Box<dyn Future<Item=XmlPostResponse, Error=ApiError> + Send>
     {
         let context = context.clone();
         info!("xml_post({:?}) - X-Span-ID: {:?}", string, context.get().0.clone());
@@ -330,10 +331,20 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
     fn xml_put(
         &self,
         xml_object: Option<models::XmlObject>,
-        context: &C) -> Box<Future<Item=XmlPutResponse, Error=ApiError> + Send>
+        context: &C) -> Box<dyn Future<Item=XmlPutResponse, Error=ApiError> + Send>
     {
         let context = context.clone();
         info!("xml_put({:?}) - X-Span-ID: {:?}", xml_object, context.get().0.clone());
+        Box::new(future::err("Generic failure".into()))
+    }
+
+    fn get_repo_info(
+        &self,
+        repo_id: String,
+        context: &C) -> Box<dyn Future<Item=GetRepoInfoResponse, Error=ApiError> + Send>
+    {
+        let context = context.clone();
+        info!("get_repo_info(\"{}\") - X-Span-ID: {:?}", repo_id, context.get().0.clone());
         Box::new(future::err("Generic failure".into()))
     }
 

--- a/samples/server/petstore/rust-server/output/openapi-v3/src/client/mod.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/src/client/mod.rs
@@ -55,7 +55,8 @@ use {Api,
      XmlOtherPostResponse,
      XmlOtherPutResponse,
      XmlPostResponse,
-     XmlPutResponse
+     XmlPutResponse,
+     GetRepoInfoResponse
      };
 
 pub mod callbacks;
@@ -2193,6 +2194,91 @@ impl<C, F> Api<C> for Client<F> where
                         future::ok(
                             XmlPutResponse::BadRequest
                         )
+                    ) as Box<dyn Future<Item=_, Error=_> + Send>
+                },
+                code => {
+                    let headers = response.headers().clone();
+                    Box::new(response.into_body()
+                            .take(100)
+                            .concat2()
+                            .then(move |body|
+                                future::err(ApiError(format!("Unexpected response code {}:\n{:?}\n\n{}",
+                                    code,
+                                    headers,
+                                    match body {
+                                        Ok(ref body) => match str::from_utf8(body) {
+                                            Ok(body) => Cow::from(body),
+                                            Err(e) => Cow::from(format!("<Body was not UTF8: {:?}>", e)),
+                                        },
+                                        Err(e) => Cow::from(format!("<Failed to read body: {}>", e)),
+                                    })))
+                            )
+                    ) as Box<dyn Future<Item=_, Error=_> + Send>
+                }
+            }
+        }))
+    }
+
+    fn get_repo_info(
+        &self,
+        param_repo_id: String,
+        context: &C) -> Box<dyn Future<Item=GetRepoInfoResponse, Error=ApiError> + Send>
+    {
+        let mut uri = format!(
+            "{}/repos/{repo_id}",
+            self.base_path
+            ,repo_id=utf8_percent_encode(&param_repo_id.to_string(), ID_ENCODE_SET)
+        );
+
+        // Query parameters
+        let mut query_string = url::form_urlencoded::Serializer::new("".to_owned());
+        let query_string_str = query_string.finish();
+        if !query_string_str.is_empty() {
+            uri += "?";
+            uri += &query_string_str;
+        }
+
+        let uri = match Uri::from_str(&uri) {
+            Ok(uri) => uri,
+            Err(err) => return Box::new(future::err(ApiError(format!("Unable to build URI: {}", err)))),
+        };
+
+        let mut request = match hyper::Request::builder()
+            .method("GET")
+            .uri(uri)
+            .body(Body::empty()) {
+                Ok(req) => req,
+                Err(e) => return Box::new(future::err(ApiError(format!("Unable to create request: {}", e))))
+        };
+
+        let header = HeaderValue::from_str((context as &dyn Has<XSpanIdString>).get().0.clone().to_string().as_str());
+        request.headers_mut().insert(HeaderName::from_static("x-span-id"), match header {
+            Ok(h) => h,
+            Err(e) => return Box::new(future::err(ApiError(format!("Unable to create X-Span ID header value: {}", e))))
+        });
+
+        Box::new(self.client_service.request(request)
+                             .map_err(|e| ApiError(format!("No response received: {}", e)))
+                             .and_then(|mut response| {
+            match response.status().as_u16() {
+                200 => {
+                    let body = response.into_body();
+                    Box::new(
+                        body
+                        .concat2()
+                        .map_err(|e| ApiError(format!("Failed to read response: {}", e)))
+                        .and_then(|body|
+                        str::from_utf8(&body)
+                                             .map_err(|e| ApiError(format!("Response was not valid UTF8: {}", e)))
+                                             .and_then(|body|
+                                                 serde_json::from_str::<String>(body)
+                                                     .map_err(|e| e.into())
+                                             )
+                                 )
+                        .map(move |body| {
+                            GetRepoInfoResponse::OK
+                            (body)
+                        })
                     ) as Box<dyn Future<Item=_, Error=_> + Send>
                 },
                 code => {

--- a/samples/server/petstore/rust-server/output/openapi-v3/src/lib.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/src/lib.rs
@@ -258,6 +258,13 @@ pub enum XmlPutResponse {
     BadRequest
 }
 
+#[derive(Debug, PartialEq)]
+pub enum GetRepoInfoResponse {
+    /// OK
+    OK
+    (String)
+}
+
 /// API
 pub trait Api<C> {
     fn callback_with_header_post(
@@ -361,6 +368,11 @@ pub trait Api<C> {
         &self,
         xml_object: Option<models::XmlObject>,
         context: &C) -> Box<dyn Future<Item=XmlPutResponse, Error=ApiError> + Send>;
+
+    fn get_repo_info(
+        &self,
+        repo_id: String,
+        context: &C) -> Box<dyn Future<Item=GetRepoInfoResponse, Error=ApiError> + Send>;
 
 }
 
@@ -467,6 +479,11 @@ pub trait ApiNoContext {
         &self,
         xml_object: Option<models::XmlObject>,
         ) -> Box<dyn Future<Item=XmlPutResponse, Error=ApiError> + Send>;
+
+    fn get_repo_info(
+        &self,
+        repo_id: String,
+        ) -> Box<dyn Future<Item=GetRepoInfoResponse, Error=ApiError> + Send>;
 
 }
 
@@ -646,6 +663,14 @@ impl<'a, T: Api<C>, C> ApiNoContext for ContextWrapper<'a, T, C> {
         ) -> Box<dyn Future<Item=XmlPutResponse, Error=ApiError> + Send>
     {
         self.api().xml_put(xml_object, &self.context())
+    }
+
+    fn get_repo_info(
+        &self,
+        repo_id: String,
+        ) -> Box<dyn Future<Item=GetRepoInfoResponse, Error=ApiError> + Send>
+    {
+        self.api().get_repo_info(repo_id, &self.context())
     }
 
 }

--- a/samples/server/petstore/rust-server/output/ops-v3/examples/client/main.rs
+++ b/samples/server/petstore/rust-server/output/ops-v3/examples/client/main.rs
@@ -121,7 +121,7 @@ fn main() {
         .arg(Arg::with_name("port")
             .long("port")
             .takes_value(true)
-            .default_value("80")
+            .default_value("8080")
             .help("Port to contact"))
         .get_matches();
 
@@ -153,187 +153,187 @@ fn main() {
         Some("Op10Get") => {
             let result = rt.block_on(client.op10_get(
             ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         Some("Op11Get") => {
             let result = rt.block_on(client.op11_get(
             ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         Some("Op12Get") => {
             let result = rt.block_on(client.op12_get(
             ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         Some("Op13Get") => {
             let result = rt.block_on(client.op13_get(
             ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         Some("Op14Get") => {
             let result = rt.block_on(client.op14_get(
             ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         Some("Op15Get") => {
             let result = rt.block_on(client.op15_get(
             ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         Some("Op16Get") => {
             let result = rt.block_on(client.op16_get(
             ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         Some("Op17Get") => {
             let result = rt.block_on(client.op17_get(
             ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         Some("Op18Get") => {
             let result = rt.block_on(client.op18_get(
             ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         Some("Op19Get") => {
             let result = rt.block_on(client.op19_get(
             ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         Some("Op1Get") => {
             let result = rt.block_on(client.op1_get(
             ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         Some("Op20Get") => {
             let result = rt.block_on(client.op20_get(
             ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         Some("Op21Get") => {
             let result = rt.block_on(client.op21_get(
             ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         Some("Op22Get") => {
             let result = rt.block_on(client.op22_get(
             ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         Some("Op23Get") => {
             let result = rt.block_on(client.op23_get(
             ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         Some("Op24Get") => {
             let result = rt.block_on(client.op24_get(
             ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         Some("Op25Get") => {
             let result = rt.block_on(client.op25_get(
             ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         Some("Op26Get") => {
             let result = rt.block_on(client.op26_get(
             ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         Some("Op27Get") => {
             let result = rt.block_on(client.op27_get(
             ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         Some("Op28Get") => {
             let result = rt.block_on(client.op28_get(
             ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         Some("Op29Get") => {
             let result = rt.block_on(client.op29_get(
             ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         Some("Op2Get") => {
             let result = rt.block_on(client.op2_get(
             ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         Some("Op30Get") => {
             let result = rt.block_on(client.op30_get(
             ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         Some("Op31Get") => {
             let result = rt.block_on(client.op31_get(
             ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         Some("Op32Get") => {
             let result = rt.block_on(client.op32_get(
             ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         Some("Op33Get") => {
             let result = rt.block_on(client.op33_get(
             ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         Some("Op34Get") => {
             let result = rt.block_on(client.op34_get(
             ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         Some("Op35Get") => {
             let result = rt.block_on(client.op35_get(
             ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         Some("Op36Get") => {
             let result = rt.block_on(client.op36_get(
             ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         Some("Op37Get") => {
             let result = rt.block_on(client.op37_get(
             ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         Some("Op3Get") => {
             let result = rt.block_on(client.op3_get(
             ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         Some("Op4Get") => {
             let result = rt.block_on(client.op4_get(
             ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         Some("Op5Get") => {
             let result = rt.block_on(client.op5_get(
             ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         Some("Op6Get") => {
             let result = rt.block_on(client.op6_get(
             ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         Some("Op7Get") => {
             let result = rt.block_on(client.op7_get(
             ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         Some("Op8Get") => {
             let result = rt.block_on(client.op8_get(
             ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         Some("Op9Get") => {
             let result = rt.block_on(client.op9_get(
             ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         _ => {
             panic!("Invalid operation provided")

--- a/samples/server/petstore/rust-server/output/ops-v3/examples/server/main.rs
+++ b/samples/server/petstore/rust-server/output/ops-v3/examples/server/main.rs
@@ -42,7 +42,7 @@ fn main() {
             .help("Whether to use HTTPS or not"))
         .get_matches();
 
-    let addr = "127.0.0.1:80";
+    let addr = "127.0.0.1:8080";
 
     hyper::rt::run(server::create(addr, matches.is_present("https")));
 }

--- a/samples/server/petstore/rust-server/output/ops-v3/examples/server/server.rs
+++ b/samples/server/petstore/rust-server/output/ops-v3/examples/server/server.rs
@@ -148,7 +148,7 @@ use ops_v3::server::MakeService;
 impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
     fn op10_get(
         &self,
-        context: &C) -> Box<Future<Item=Op10GetResponse, Error=ApiError> + Send>
+        context: &C) -> Box<dyn Future<Item=Op10GetResponse, Error=ApiError> + Send>
     {
         let context = context.clone();
         info!("op10_get() - X-Span-ID: {:?}", context.get().0.clone());
@@ -157,7 +157,7 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
 
     fn op11_get(
         &self,
-        context: &C) -> Box<Future<Item=Op11GetResponse, Error=ApiError> + Send>
+        context: &C) -> Box<dyn Future<Item=Op11GetResponse, Error=ApiError> + Send>
     {
         let context = context.clone();
         info!("op11_get() - X-Span-ID: {:?}", context.get().0.clone());
@@ -166,7 +166,7 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
 
     fn op12_get(
         &self,
-        context: &C) -> Box<Future<Item=Op12GetResponse, Error=ApiError> + Send>
+        context: &C) -> Box<dyn Future<Item=Op12GetResponse, Error=ApiError> + Send>
     {
         let context = context.clone();
         info!("op12_get() - X-Span-ID: {:?}", context.get().0.clone());
@@ -175,7 +175,7 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
 
     fn op13_get(
         &self,
-        context: &C) -> Box<Future<Item=Op13GetResponse, Error=ApiError> + Send>
+        context: &C) -> Box<dyn Future<Item=Op13GetResponse, Error=ApiError> + Send>
     {
         let context = context.clone();
         info!("op13_get() - X-Span-ID: {:?}", context.get().0.clone());
@@ -184,7 +184,7 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
 
     fn op14_get(
         &self,
-        context: &C) -> Box<Future<Item=Op14GetResponse, Error=ApiError> + Send>
+        context: &C) -> Box<dyn Future<Item=Op14GetResponse, Error=ApiError> + Send>
     {
         let context = context.clone();
         info!("op14_get() - X-Span-ID: {:?}", context.get().0.clone());
@@ -193,7 +193,7 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
 
     fn op15_get(
         &self,
-        context: &C) -> Box<Future<Item=Op15GetResponse, Error=ApiError> + Send>
+        context: &C) -> Box<dyn Future<Item=Op15GetResponse, Error=ApiError> + Send>
     {
         let context = context.clone();
         info!("op15_get() - X-Span-ID: {:?}", context.get().0.clone());
@@ -202,7 +202,7 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
 
     fn op16_get(
         &self,
-        context: &C) -> Box<Future<Item=Op16GetResponse, Error=ApiError> + Send>
+        context: &C) -> Box<dyn Future<Item=Op16GetResponse, Error=ApiError> + Send>
     {
         let context = context.clone();
         info!("op16_get() - X-Span-ID: {:?}", context.get().0.clone());
@@ -211,7 +211,7 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
 
     fn op17_get(
         &self,
-        context: &C) -> Box<Future<Item=Op17GetResponse, Error=ApiError> + Send>
+        context: &C) -> Box<dyn Future<Item=Op17GetResponse, Error=ApiError> + Send>
     {
         let context = context.clone();
         info!("op17_get() - X-Span-ID: {:?}", context.get().0.clone());
@@ -220,7 +220,7 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
 
     fn op18_get(
         &self,
-        context: &C) -> Box<Future<Item=Op18GetResponse, Error=ApiError> + Send>
+        context: &C) -> Box<dyn Future<Item=Op18GetResponse, Error=ApiError> + Send>
     {
         let context = context.clone();
         info!("op18_get() - X-Span-ID: {:?}", context.get().0.clone());
@@ -229,7 +229,7 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
 
     fn op19_get(
         &self,
-        context: &C) -> Box<Future<Item=Op19GetResponse, Error=ApiError> + Send>
+        context: &C) -> Box<dyn Future<Item=Op19GetResponse, Error=ApiError> + Send>
     {
         let context = context.clone();
         info!("op19_get() - X-Span-ID: {:?}", context.get().0.clone());
@@ -238,7 +238,7 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
 
     fn op1_get(
         &self,
-        context: &C) -> Box<Future<Item=Op1GetResponse, Error=ApiError> + Send>
+        context: &C) -> Box<dyn Future<Item=Op1GetResponse, Error=ApiError> + Send>
     {
         let context = context.clone();
         info!("op1_get() - X-Span-ID: {:?}", context.get().0.clone());
@@ -247,7 +247,7 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
 
     fn op20_get(
         &self,
-        context: &C) -> Box<Future<Item=Op20GetResponse, Error=ApiError> + Send>
+        context: &C) -> Box<dyn Future<Item=Op20GetResponse, Error=ApiError> + Send>
     {
         let context = context.clone();
         info!("op20_get() - X-Span-ID: {:?}", context.get().0.clone());
@@ -256,7 +256,7 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
 
     fn op21_get(
         &self,
-        context: &C) -> Box<Future<Item=Op21GetResponse, Error=ApiError> + Send>
+        context: &C) -> Box<dyn Future<Item=Op21GetResponse, Error=ApiError> + Send>
     {
         let context = context.clone();
         info!("op21_get() - X-Span-ID: {:?}", context.get().0.clone());
@@ -265,7 +265,7 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
 
     fn op22_get(
         &self,
-        context: &C) -> Box<Future<Item=Op22GetResponse, Error=ApiError> + Send>
+        context: &C) -> Box<dyn Future<Item=Op22GetResponse, Error=ApiError> + Send>
     {
         let context = context.clone();
         info!("op22_get() - X-Span-ID: {:?}", context.get().0.clone());
@@ -274,7 +274,7 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
 
     fn op23_get(
         &self,
-        context: &C) -> Box<Future<Item=Op23GetResponse, Error=ApiError> + Send>
+        context: &C) -> Box<dyn Future<Item=Op23GetResponse, Error=ApiError> + Send>
     {
         let context = context.clone();
         info!("op23_get() - X-Span-ID: {:?}", context.get().0.clone());
@@ -283,7 +283,7 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
 
     fn op24_get(
         &self,
-        context: &C) -> Box<Future<Item=Op24GetResponse, Error=ApiError> + Send>
+        context: &C) -> Box<dyn Future<Item=Op24GetResponse, Error=ApiError> + Send>
     {
         let context = context.clone();
         info!("op24_get() - X-Span-ID: {:?}", context.get().0.clone());
@@ -292,7 +292,7 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
 
     fn op25_get(
         &self,
-        context: &C) -> Box<Future<Item=Op25GetResponse, Error=ApiError> + Send>
+        context: &C) -> Box<dyn Future<Item=Op25GetResponse, Error=ApiError> + Send>
     {
         let context = context.clone();
         info!("op25_get() - X-Span-ID: {:?}", context.get().0.clone());
@@ -301,7 +301,7 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
 
     fn op26_get(
         &self,
-        context: &C) -> Box<Future<Item=Op26GetResponse, Error=ApiError> + Send>
+        context: &C) -> Box<dyn Future<Item=Op26GetResponse, Error=ApiError> + Send>
     {
         let context = context.clone();
         info!("op26_get() - X-Span-ID: {:?}", context.get().0.clone());
@@ -310,7 +310,7 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
 
     fn op27_get(
         &self,
-        context: &C) -> Box<Future<Item=Op27GetResponse, Error=ApiError> + Send>
+        context: &C) -> Box<dyn Future<Item=Op27GetResponse, Error=ApiError> + Send>
     {
         let context = context.clone();
         info!("op27_get() - X-Span-ID: {:?}", context.get().0.clone());
@@ -319,7 +319,7 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
 
     fn op28_get(
         &self,
-        context: &C) -> Box<Future<Item=Op28GetResponse, Error=ApiError> + Send>
+        context: &C) -> Box<dyn Future<Item=Op28GetResponse, Error=ApiError> + Send>
     {
         let context = context.clone();
         info!("op28_get() - X-Span-ID: {:?}", context.get().0.clone());
@@ -328,7 +328,7 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
 
     fn op29_get(
         &self,
-        context: &C) -> Box<Future<Item=Op29GetResponse, Error=ApiError> + Send>
+        context: &C) -> Box<dyn Future<Item=Op29GetResponse, Error=ApiError> + Send>
     {
         let context = context.clone();
         info!("op29_get() - X-Span-ID: {:?}", context.get().0.clone());
@@ -337,7 +337,7 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
 
     fn op2_get(
         &self,
-        context: &C) -> Box<Future<Item=Op2GetResponse, Error=ApiError> + Send>
+        context: &C) -> Box<dyn Future<Item=Op2GetResponse, Error=ApiError> + Send>
     {
         let context = context.clone();
         info!("op2_get() - X-Span-ID: {:?}", context.get().0.clone());
@@ -346,7 +346,7 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
 
     fn op30_get(
         &self,
-        context: &C) -> Box<Future<Item=Op30GetResponse, Error=ApiError> + Send>
+        context: &C) -> Box<dyn Future<Item=Op30GetResponse, Error=ApiError> + Send>
     {
         let context = context.clone();
         info!("op30_get() - X-Span-ID: {:?}", context.get().0.clone());
@@ -355,7 +355,7 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
 
     fn op31_get(
         &self,
-        context: &C) -> Box<Future<Item=Op31GetResponse, Error=ApiError> + Send>
+        context: &C) -> Box<dyn Future<Item=Op31GetResponse, Error=ApiError> + Send>
     {
         let context = context.clone();
         info!("op31_get() - X-Span-ID: {:?}", context.get().0.clone());
@@ -364,7 +364,7 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
 
     fn op32_get(
         &self,
-        context: &C) -> Box<Future<Item=Op32GetResponse, Error=ApiError> + Send>
+        context: &C) -> Box<dyn Future<Item=Op32GetResponse, Error=ApiError> + Send>
     {
         let context = context.clone();
         info!("op32_get() - X-Span-ID: {:?}", context.get().0.clone());
@@ -373,7 +373,7 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
 
     fn op33_get(
         &self,
-        context: &C) -> Box<Future<Item=Op33GetResponse, Error=ApiError> + Send>
+        context: &C) -> Box<dyn Future<Item=Op33GetResponse, Error=ApiError> + Send>
     {
         let context = context.clone();
         info!("op33_get() - X-Span-ID: {:?}", context.get().0.clone());
@@ -382,7 +382,7 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
 
     fn op34_get(
         &self,
-        context: &C) -> Box<Future<Item=Op34GetResponse, Error=ApiError> + Send>
+        context: &C) -> Box<dyn Future<Item=Op34GetResponse, Error=ApiError> + Send>
     {
         let context = context.clone();
         info!("op34_get() - X-Span-ID: {:?}", context.get().0.clone());
@@ -391,7 +391,7 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
 
     fn op35_get(
         &self,
-        context: &C) -> Box<Future<Item=Op35GetResponse, Error=ApiError> + Send>
+        context: &C) -> Box<dyn Future<Item=Op35GetResponse, Error=ApiError> + Send>
     {
         let context = context.clone();
         info!("op35_get() - X-Span-ID: {:?}", context.get().0.clone());
@@ -400,7 +400,7 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
 
     fn op36_get(
         &self,
-        context: &C) -> Box<Future<Item=Op36GetResponse, Error=ApiError> + Send>
+        context: &C) -> Box<dyn Future<Item=Op36GetResponse, Error=ApiError> + Send>
     {
         let context = context.clone();
         info!("op36_get() - X-Span-ID: {:?}", context.get().0.clone());
@@ -409,7 +409,7 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
 
     fn op37_get(
         &self,
-        context: &C) -> Box<Future<Item=Op37GetResponse, Error=ApiError> + Send>
+        context: &C) -> Box<dyn Future<Item=Op37GetResponse, Error=ApiError> + Send>
     {
         let context = context.clone();
         info!("op37_get() - X-Span-ID: {:?}", context.get().0.clone());
@@ -418,7 +418,7 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
 
     fn op3_get(
         &self,
-        context: &C) -> Box<Future<Item=Op3GetResponse, Error=ApiError> + Send>
+        context: &C) -> Box<dyn Future<Item=Op3GetResponse, Error=ApiError> + Send>
     {
         let context = context.clone();
         info!("op3_get() - X-Span-ID: {:?}", context.get().0.clone());
@@ -427,7 +427,7 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
 
     fn op4_get(
         &self,
-        context: &C) -> Box<Future<Item=Op4GetResponse, Error=ApiError> + Send>
+        context: &C) -> Box<dyn Future<Item=Op4GetResponse, Error=ApiError> + Send>
     {
         let context = context.clone();
         info!("op4_get() - X-Span-ID: {:?}", context.get().0.clone());
@@ -436,7 +436,7 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
 
     fn op5_get(
         &self,
-        context: &C) -> Box<Future<Item=Op5GetResponse, Error=ApiError> + Send>
+        context: &C) -> Box<dyn Future<Item=Op5GetResponse, Error=ApiError> + Send>
     {
         let context = context.clone();
         info!("op5_get() - X-Span-ID: {:?}", context.get().0.clone());
@@ -445,7 +445,7 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
 
     fn op6_get(
         &self,
-        context: &C) -> Box<Future<Item=Op6GetResponse, Error=ApiError> + Send>
+        context: &C) -> Box<dyn Future<Item=Op6GetResponse, Error=ApiError> + Send>
     {
         let context = context.clone();
         info!("op6_get() - X-Span-ID: {:?}", context.get().0.clone());
@@ -454,7 +454,7 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
 
     fn op7_get(
         &self,
-        context: &C) -> Box<Future<Item=Op7GetResponse, Error=ApiError> + Send>
+        context: &C) -> Box<dyn Future<Item=Op7GetResponse, Error=ApiError> + Send>
     {
         let context = context.clone();
         info!("op7_get() - X-Span-ID: {:?}", context.get().0.clone());
@@ -463,7 +463,7 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
 
     fn op8_get(
         &self,
-        context: &C) -> Box<Future<Item=Op8GetResponse, Error=ApiError> + Send>
+        context: &C) -> Box<dyn Future<Item=Op8GetResponse, Error=ApiError> + Send>
     {
         let context = context.clone();
         info!("op8_get() - X-Span-ID: {:?}", context.get().0.clone());
@@ -472,7 +472,7 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
 
     fn op9_get(
         &self,
-        context: &C) -> Box<Future<Item=Op9GetResponse, Error=ApiError> + Send>
+        context: &C) -> Box<dyn Future<Item=Op9GetResponse, Error=ApiError> + Send>
     {
         let context = context.clone();
         info!("op9_get() - X-Span-ID: {:?}", context.get().0.clone());

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/examples/client/main.rs
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/examples/client/main.rs
@@ -141,48 +141,48 @@ fn main() {
             let result = rt.block_on(client.test_special_tags(
                   ???
             ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         */
         Some("Call123example") => {
             let result = rt.block_on(client.call123example(
             ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         Some("FakeOuterBooleanSerialize") => {
             let result = rt.block_on(client.fake_outer_boolean_serialize(
                   None
             ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         Some("FakeOuterCompositeSerialize") => {
             let result = rt.block_on(client.fake_outer_composite_serialize(
                   None
             ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         Some("FakeOuterNumberSerialize") => {
             let result = rt.block_on(client.fake_outer_number_serialize(
                   None
             ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         Some("FakeOuterStringSerialize") => {
             let result = rt.block_on(client.fake_outer_string_serialize(
                   None
             ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         Some("FakeResponseWithNumericalDescription") => {
             let result = rt.block_on(client.fake_response_with_numerical_description(
             ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         Some("HyphenParam") => {
             let result = rt.block_on(client.hyphen_param(
                   "hyphen_param_example".to_string()
             ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         /* Disabled because there's no example.
         Some("TestBodyWithQueryParams") => {
@@ -190,7 +190,7 @@ fn main() {
                   "query_example".to_string(),
                   ???
             ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         */
         /* Disabled because there's no example.
@@ -198,7 +198,7 @@ fn main() {
             let result = rt.block_on(client.test_client_model(
                   ???
             ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         */
         Some("TestEndpointParameters") => {
@@ -218,7 +218,7 @@ fn main() {
                   Some("password_example".to_string()),
                   Some("callback_example".to_string())
             ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         Some("TestEnumParameters") => {
             let result = rt.block_on(client.test_enum_parameters(
@@ -230,14 +230,14 @@ fn main() {
                   Some(1.2),
                   Some("enum_form_string_example".to_string())
             ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         /* Disabled because there's no example.
         Some("TestInlineAdditionalProperties") => {
             let result = rt.block_on(client.test_inline_additional_properties(
                   ???
             ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         */
         Some("TestJsonFormData") => {
@@ -245,14 +245,14 @@ fn main() {
                   "param_example".to_string(),
                   "param2_example".to_string()
             ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         /* Disabled because there's no example.
         Some("TestClassname") => {
             let result = rt.block_on(client.test_classname(
                   ???
             ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         */
         /* Disabled because there's no example.
@@ -260,7 +260,7 @@ fn main() {
             let result = rt.block_on(client.add_pet(
                   ???
             ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         */
         Some("DeletePet") => {
@@ -268,32 +268,32 @@ fn main() {
                   789,
                   Some("api_key_example".to_string())
             ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         Some("FindPetsByStatus") => {
             let result = rt.block_on(client.find_pets_by_status(
                   &Vec::new()
             ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         Some("FindPetsByTags") => {
             let result = rt.block_on(client.find_pets_by_tags(
                   &Vec::new()
             ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         Some("GetPetById") => {
             let result = rt.block_on(client.get_pet_by_id(
                   789
             ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         /* Disabled because there's no example.
         Some("UpdatePet") => {
             let result = rt.block_on(client.update_pet(
                   ???
             ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         */
         Some("UpdatePetWithForm") => {
@@ -302,7 +302,7 @@ fn main() {
                   Some("name_example".to_string()),
                   Some("status_example".to_string())
             ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         Some("UploadFile") => {
             let result = rt.block_on(client.upload_file(
@@ -310,31 +310,31 @@ fn main() {
                   Some("additional_metadata_example".to_string()),
                   Some(swagger::ByteArray(Vec::from("BINARY_DATA_HERE")))
             ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         Some("DeleteOrder") => {
             let result = rt.block_on(client.delete_order(
                   "order_id_example".to_string()
             ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         Some("GetInventory") => {
             let result = rt.block_on(client.get_inventory(
             ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         Some("GetOrderById") => {
             let result = rt.block_on(client.get_order_by_id(
                   789
             ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         /* Disabled because there's no example.
         Some("PlaceOrder") => {
             let result = rt.block_on(client.place_order(
                   ???
             ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         */
         /* Disabled because there's no example.
@@ -342,44 +342,44 @@ fn main() {
             let result = rt.block_on(client.create_user(
                   ???
             ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         */
         Some("CreateUsersWithArrayInput") => {
             let result = rt.block_on(client.create_users_with_array_input(
                   &Vec::new()
             ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         Some("CreateUsersWithListInput") => {
             let result = rt.block_on(client.create_users_with_list_input(
                   &Vec::new()
             ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         Some("DeleteUser") => {
             let result = rt.block_on(client.delete_user(
                   "username_example".to_string()
             ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         Some("GetUserByName") => {
             let result = rt.block_on(client.get_user_by_name(
                   "username_example".to_string()
             ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         Some("LoginUser") => {
             let result = rt.block_on(client.login_user(
                   "username_example".to_string(),
                   "password_example".to_string()
             ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         Some("LogoutUser") => {
             let result = rt.block_on(client.logout_user(
             ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         /* Disabled because there's no example.
         Some("UpdateUser") => {
@@ -387,7 +387,7 @@ fn main() {
                   "username_example".to_string(),
                   ???
             ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         */
         _ => {

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/examples/server/server.rs
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/examples/server/server.rs
@@ -148,7 +148,7 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
     fn test_special_tags(
         &self,
         body: models::Client,
-        context: &C) -> Box<Future<Item=TestSpecialTagsResponse, Error=ApiError> + Send>
+        context: &C) -> Box<dyn Future<Item=TestSpecialTagsResponse, Error=ApiError> + Send>
     {
         let context = context.clone();
         info!("test_special_tags({:?}) - X-Span-ID: {:?}", body, context.get().0.clone());
@@ -157,7 +157,7 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
 
     fn call123example(
         &self,
-        context: &C) -> Box<Future<Item=Call123exampleResponse, Error=ApiError> + Send>
+        context: &C) -> Box<dyn Future<Item=Call123exampleResponse, Error=ApiError> + Send>
     {
         let context = context.clone();
         info!("call123example() - X-Span-ID: {:?}", context.get().0.clone());
@@ -167,7 +167,7 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
     fn fake_outer_boolean_serialize(
         &self,
         body: Option<models::OuterBoolean>,
-        context: &C) -> Box<Future<Item=FakeOuterBooleanSerializeResponse, Error=ApiError> + Send>
+        context: &C) -> Box<dyn Future<Item=FakeOuterBooleanSerializeResponse, Error=ApiError> + Send>
     {
         let context = context.clone();
         info!("fake_outer_boolean_serialize({:?}) - X-Span-ID: {:?}", body, context.get().0.clone());
@@ -177,7 +177,7 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
     fn fake_outer_composite_serialize(
         &self,
         body: Option<models::OuterComposite>,
-        context: &C) -> Box<Future<Item=FakeOuterCompositeSerializeResponse, Error=ApiError> + Send>
+        context: &C) -> Box<dyn Future<Item=FakeOuterCompositeSerializeResponse, Error=ApiError> + Send>
     {
         let context = context.clone();
         info!("fake_outer_composite_serialize({:?}) - X-Span-ID: {:?}", body, context.get().0.clone());
@@ -187,7 +187,7 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
     fn fake_outer_number_serialize(
         &self,
         body: Option<models::OuterNumber>,
-        context: &C) -> Box<Future<Item=FakeOuterNumberSerializeResponse, Error=ApiError> + Send>
+        context: &C) -> Box<dyn Future<Item=FakeOuterNumberSerializeResponse, Error=ApiError> + Send>
     {
         let context = context.clone();
         info!("fake_outer_number_serialize({:?}) - X-Span-ID: {:?}", body, context.get().0.clone());
@@ -197,7 +197,7 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
     fn fake_outer_string_serialize(
         &self,
         body: Option<models::OuterString>,
-        context: &C) -> Box<Future<Item=FakeOuterStringSerializeResponse, Error=ApiError> + Send>
+        context: &C) -> Box<dyn Future<Item=FakeOuterStringSerializeResponse, Error=ApiError> + Send>
     {
         let context = context.clone();
         info!("fake_outer_string_serialize({:?}) - X-Span-ID: {:?}", body, context.get().0.clone());
@@ -206,7 +206,7 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
 
     fn fake_response_with_numerical_description(
         &self,
-        context: &C) -> Box<Future<Item=FakeResponseWithNumericalDescriptionResponse, Error=ApiError> + Send>
+        context: &C) -> Box<dyn Future<Item=FakeResponseWithNumericalDescriptionResponse, Error=ApiError> + Send>
     {
         let context = context.clone();
         info!("fake_response_with_numerical_description() - X-Span-ID: {:?}", context.get().0.clone());
@@ -216,7 +216,7 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
     fn hyphen_param(
         &self,
         hyphen_param: String,
-        context: &C) -> Box<Future<Item=HyphenParamResponse, Error=ApiError> + Send>
+        context: &C) -> Box<dyn Future<Item=HyphenParamResponse, Error=ApiError> + Send>
     {
         let context = context.clone();
         info!("hyphen_param(\"{}\") - X-Span-ID: {:?}", hyphen_param, context.get().0.clone());
@@ -227,7 +227,7 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
         &self,
         query: String,
         body: models::User,
-        context: &C) -> Box<Future<Item=TestBodyWithQueryParamsResponse, Error=ApiError> + Send>
+        context: &C) -> Box<dyn Future<Item=TestBodyWithQueryParamsResponse, Error=ApiError> + Send>
     {
         let context = context.clone();
         info!("test_body_with_query_params(\"{}\", {:?}) - X-Span-ID: {:?}", query, body, context.get().0.clone());
@@ -238,7 +238,7 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
     fn test_client_model(
         &self,
         body: models::Client,
-        context: &C) -> Box<Future<Item=TestClientModelResponse, Error=ApiError> + Send>
+        context: &C) -> Box<dyn Future<Item=TestClientModelResponse, Error=ApiError> + Send>
     {
         let context = context.clone();
         info!("test_client_model({:?}) - X-Span-ID: {:?}", body, context.get().0.clone());
@@ -262,7 +262,7 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
         date_time: Option<chrono::DateTime::<chrono::Utc>>,
         password: Option<String>,
         callback: Option<String>,
-        context: &C) -> Box<Future<Item=TestEndpointParametersResponse, Error=ApiError> + Send>
+        context: &C) -> Box<dyn Future<Item=TestEndpointParametersResponse, Error=ApiError> + Send>
     {
         let context = context.clone();
         info!("test_endpoint_parameters({}, {}, \"{}\", {:?}, {:?}, {:?}, {:?}, {:?}, {:?}, {:?}, {:?}, {:?}, {:?}, {:?}) - X-Span-ID: {:?}", number, double, pattern_without_delimiter, byte, integer, int32, int64, float, string, binary, date, date_time, password, callback, context.get().0.clone());
@@ -279,7 +279,7 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
         enum_query_integer: Option<i32>,
         enum_query_double: Option<f64>,
         enum_form_string: Option<String>,
-        context: &C) -> Box<Future<Item=TestEnumParametersResponse, Error=ApiError> + Send>
+        context: &C) -> Box<dyn Future<Item=TestEnumParametersResponse, Error=ApiError> + Send>
     {
         let context = context.clone();
         info!("test_enum_parameters({:?}, {:?}, {:?}, {:?}, {:?}, {:?}, {:?}) - X-Span-ID: {:?}", enum_header_string_array, enum_header_string, enum_query_string_array, enum_query_string, enum_query_integer, enum_query_double, enum_form_string, context.get().0.clone());
@@ -290,7 +290,7 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
     fn test_inline_additional_properties(
         &self,
         param: std::collections::HashMap<String, String>,
-        context: &C) -> Box<Future<Item=TestInlineAdditionalPropertiesResponse, Error=ApiError> + Send>
+        context: &C) -> Box<dyn Future<Item=TestInlineAdditionalPropertiesResponse, Error=ApiError> + Send>
     {
         let context = context.clone();
         info!("test_inline_additional_properties({:?}) - X-Span-ID: {:?}", param, context.get().0.clone());
@@ -302,7 +302,7 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
         &self,
         param: String,
         param2: String,
-        context: &C) -> Box<Future<Item=TestJsonFormDataResponse, Error=ApiError> + Send>
+        context: &C) -> Box<dyn Future<Item=TestJsonFormDataResponse, Error=ApiError> + Send>
     {
         let context = context.clone();
         info!("test_json_form_data(\"{}\", \"{}\") - X-Span-ID: {:?}", param, param2, context.get().0.clone());
@@ -313,7 +313,7 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
     fn test_classname(
         &self,
         body: models::Client,
-        context: &C) -> Box<Future<Item=TestClassnameResponse, Error=ApiError> + Send>
+        context: &C) -> Box<dyn Future<Item=TestClassnameResponse, Error=ApiError> + Send>
     {
         let context = context.clone();
         info!("test_classname({:?}) - X-Span-ID: {:?}", body, context.get().0.clone());
@@ -324,7 +324,7 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
     fn add_pet(
         &self,
         body: models::Pet,
-        context: &C) -> Box<Future<Item=AddPetResponse, Error=ApiError> + Send>
+        context: &C) -> Box<dyn Future<Item=AddPetResponse, Error=ApiError> + Send>
     {
         let context = context.clone();
         info!("add_pet({:?}) - X-Span-ID: {:?}", body, context.get().0.clone());
@@ -336,7 +336,7 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
         &self,
         pet_id: i64,
         api_key: Option<String>,
-        context: &C) -> Box<Future<Item=DeletePetResponse, Error=ApiError> + Send>
+        context: &C) -> Box<dyn Future<Item=DeletePetResponse, Error=ApiError> + Send>
     {
         let context = context.clone();
         info!("delete_pet({}, {:?}) - X-Span-ID: {:?}", pet_id, api_key, context.get().0.clone());
@@ -347,7 +347,7 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
     fn find_pets_by_status(
         &self,
         status: &Vec<String>,
-        context: &C) -> Box<Future<Item=FindPetsByStatusResponse, Error=ApiError> + Send>
+        context: &C) -> Box<dyn Future<Item=FindPetsByStatusResponse, Error=ApiError> + Send>
     {
         let context = context.clone();
         info!("find_pets_by_status({:?}) - X-Span-ID: {:?}", status, context.get().0.clone());
@@ -358,7 +358,7 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
     fn find_pets_by_tags(
         &self,
         tags: &Vec<String>,
-        context: &C) -> Box<Future<Item=FindPetsByTagsResponse, Error=ApiError> + Send>
+        context: &C) -> Box<dyn Future<Item=FindPetsByTagsResponse, Error=ApiError> + Send>
     {
         let context = context.clone();
         info!("find_pets_by_tags({:?}) - X-Span-ID: {:?}", tags, context.get().0.clone());
@@ -369,7 +369,7 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
     fn get_pet_by_id(
         &self,
         pet_id: i64,
-        context: &C) -> Box<Future<Item=GetPetByIdResponse, Error=ApiError> + Send>
+        context: &C) -> Box<dyn Future<Item=GetPetByIdResponse, Error=ApiError> + Send>
     {
         let context = context.clone();
         info!("get_pet_by_id({}) - X-Span-ID: {:?}", pet_id, context.get().0.clone());
@@ -380,7 +380,7 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
     fn update_pet(
         &self,
         body: models::Pet,
-        context: &C) -> Box<Future<Item=UpdatePetResponse, Error=ApiError> + Send>
+        context: &C) -> Box<dyn Future<Item=UpdatePetResponse, Error=ApiError> + Send>
     {
         let context = context.clone();
         info!("update_pet({:?}) - X-Span-ID: {:?}", body, context.get().0.clone());
@@ -393,7 +393,7 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
         pet_id: i64,
         name: Option<String>,
         status: Option<String>,
-        context: &C) -> Box<Future<Item=UpdatePetWithFormResponse, Error=ApiError> + Send>
+        context: &C) -> Box<dyn Future<Item=UpdatePetWithFormResponse, Error=ApiError> + Send>
     {
         let context = context.clone();
         info!("update_pet_with_form({}, {:?}, {:?}) - X-Span-ID: {:?}", pet_id, name, status, context.get().0.clone());
@@ -406,7 +406,7 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
         pet_id: i64,
         additional_metadata: Option<String>,
         file: Option<swagger::ByteArray>,
-        context: &C) -> Box<Future<Item=UploadFileResponse, Error=ApiError> + Send>
+        context: &C) -> Box<dyn Future<Item=UploadFileResponse, Error=ApiError> + Send>
     {
         let context = context.clone();
         info!("upload_file({}, {:?}, {:?}) - X-Span-ID: {:?}", pet_id, additional_metadata, file, context.get().0.clone());
@@ -417,7 +417,7 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
     fn delete_order(
         &self,
         order_id: String,
-        context: &C) -> Box<Future<Item=DeleteOrderResponse, Error=ApiError> + Send>
+        context: &C) -> Box<dyn Future<Item=DeleteOrderResponse, Error=ApiError> + Send>
     {
         let context = context.clone();
         info!("delete_order(\"{}\") - X-Span-ID: {:?}", order_id, context.get().0.clone());
@@ -427,7 +427,7 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
     /// Returns pet inventories by status
     fn get_inventory(
         &self,
-        context: &C) -> Box<Future<Item=GetInventoryResponse, Error=ApiError> + Send>
+        context: &C) -> Box<dyn Future<Item=GetInventoryResponse, Error=ApiError> + Send>
     {
         let context = context.clone();
         info!("get_inventory() - X-Span-ID: {:?}", context.get().0.clone());
@@ -438,7 +438,7 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
     fn get_order_by_id(
         &self,
         order_id: i64,
-        context: &C) -> Box<Future<Item=GetOrderByIdResponse, Error=ApiError> + Send>
+        context: &C) -> Box<dyn Future<Item=GetOrderByIdResponse, Error=ApiError> + Send>
     {
         let context = context.clone();
         info!("get_order_by_id({}) - X-Span-ID: {:?}", order_id, context.get().0.clone());
@@ -449,7 +449,7 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
     fn place_order(
         &self,
         body: models::Order,
-        context: &C) -> Box<Future<Item=PlaceOrderResponse, Error=ApiError> + Send>
+        context: &C) -> Box<dyn Future<Item=PlaceOrderResponse, Error=ApiError> + Send>
     {
         let context = context.clone();
         info!("place_order({:?}) - X-Span-ID: {:?}", body, context.get().0.clone());
@@ -460,7 +460,7 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
     fn create_user(
         &self,
         body: models::User,
-        context: &C) -> Box<Future<Item=CreateUserResponse, Error=ApiError> + Send>
+        context: &C) -> Box<dyn Future<Item=CreateUserResponse, Error=ApiError> + Send>
     {
         let context = context.clone();
         info!("create_user({:?}) - X-Span-ID: {:?}", body, context.get().0.clone());
@@ -471,7 +471,7 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
     fn create_users_with_array_input(
         &self,
         body: &Vec<models::User>,
-        context: &C) -> Box<Future<Item=CreateUsersWithArrayInputResponse, Error=ApiError> + Send>
+        context: &C) -> Box<dyn Future<Item=CreateUsersWithArrayInputResponse, Error=ApiError> + Send>
     {
         let context = context.clone();
         info!("create_users_with_array_input({:?}) - X-Span-ID: {:?}", body, context.get().0.clone());
@@ -482,7 +482,7 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
     fn create_users_with_list_input(
         &self,
         body: &Vec<models::User>,
-        context: &C) -> Box<Future<Item=CreateUsersWithListInputResponse, Error=ApiError> + Send>
+        context: &C) -> Box<dyn Future<Item=CreateUsersWithListInputResponse, Error=ApiError> + Send>
     {
         let context = context.clone();
         info!("create_users_with_list_input({:?}) - X-Span-ID: {:?}", body, context.get().0.clone());
@@ -493,7 +493,7 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
     fn delete_user(
         &self,
         username: String,
-        context: &C) -> Box<Future<Item=DeleteUserResponse, Error=ApiError> + Send>
+        context: &C) -> Box<dyn Future<Item=DeleteUserResponse, Error=ApiError> + Send>
     {
         let context = context.clone();
         info!("delete_user(\"{}\") - X-Span-ID: {:?}", username, context.get().0.clone());
@@ -504,7 +504,7 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
     fn get_user_by_name(
         &self,
         username: String,
-        context: &C) -> Box<Future<Item=GetUserByNameResponse, Error=ApiError> + Send>
+        context: &C) -> Box<dyn Future<Item=GetUserByNameResponse, Error=ApiError> + Send>
     {
         let context = context.clone();
         info!("get_user_by_name(\"{}\") - X-Span-ID: {:?}", username, context.get().0.clone());
@@ -516,7 +516,7 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
         &self,
         username: String,
         password: String,
-        context: &C) -> Box<Future<Item=LoginUserResponse, Error=ApiError> + Send>
+        context: &C) -> Box<dyn Future<Item=LoginUserResponse, Error=ApiError> + Send>
     {
         let context = context.clone();
         info!("login_user(\"{}\", \"{}\") - X-Span-ID: {:?}", username, password, context.get().0.clone());
@@ -526,7 +526,7 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
     /// Logs out current logged in user session
     fn logout_user(
         &self,
-        context: &C) -> Box<Future<Item=LogoutUserResponse, Error=ApiError> + Send>
+        context: &C) -> Box<dyn Future<Item=LogoutUserResponse, Error=ApiError> + Send>
     {
         let context = context.clone();
         info!("logout_user() - X-Span-ID: {:?}", context.get().0.clone());
@@ -538,7 +538,7 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
         &self,
         username: String,
         body: models::User,
-        context: &C) -> Box<Future<Item=UpdateUserResponse, Error=ApiError> + Send>
+        context: &C) -> Box<dyn Future<Item=UpdateUserResponse, Error=ApiError> + Send>
     {
         let context = context.clone();
         info!("update_user(\"{}\", {:?}) - X-Span-ID: {:?}", username, body, context.get().0.clone());

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/src/server/mod.rs
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/src/server/mod.rs
@@ -69,7 +69,7 @@ mod paths {
             r"^/v2/another-fake/dummy$",
             r"^/v2/fake$",
             r"^/v2/fake/body-with-query-params$",
-            r"^/v2/fake/hyphenParam/(?P<hyphen_param>[^/?#]*)$",
+            r"^/v2/fake/hyphenParam/(?P<hyphen-param>[^/?#]*)$",
             r"^/v2/fake/inline-additionalProperties$",
             r"^/v2/fake/jsonFormData$",
             r"^/v2/fake/operation-with-numeric-id$",
@@ -82,8 +82,8 @@ mod paths {
             r"^/v2/pet$",
             r"^/v2/pet/findByStatus$",
             r"^/v2/pet/findByTags$",
-            r"^/v2/pet/(?P<pet_id>[^/?#]*)$",
-            r"^/v2/pet/(?P<pet_id>[^/?#]*)/uploadImage$",
+            r"^/v2/pet/(?P<petId>[^/?#]*)$",
+            r"^/v2/pet/(?P<petId>[^/?#]*)/uploadImage$",
             r"^/v2/store/inventory$",
             r"^/v2/store/order$",
             r"^/v2/store/order/(?P<order_id>[^/?#]*)$",
@@ -102,7 +102,7 @@ mod paths {
     pub static ID_FAKE_HYPHENPARAM_HYPHEN_PARAM: usize = 3;
     lazy_static! {
         pub static ref REGEX_FAKE_HYPHENPARAM_HYPHEN_PARAM: regex::Regex =
-            regex::Regex::new(r"^/v2/fake/hyphenParam/(?P<hyphen_param>[^/?#]*)$")
+            regex::Regex::new(r"^/v2/fake/hyphenParam/(?P<hyphen-param>[^/?#]*)$")
                 .expect("Unable to create regex for FAKE_HYPHENPARAM_HYPHEN_PARAM");
     }
     pub static ID_FAKE_INLINE_ADDITIONALPROPERTIES: usize = 4;
@@ -120,13 +120,13 @@ mod paths {
     pub static ID_PET_PETID: usize = 16;
     lazy_static! {
         pub static ref REGEX_PET_PETID: regex::Regex =
-            regex::Regex::new(r"^/v2/pet/(?P<pet_id>[^/?#]*)$")
+            regex::Regex::new(r"^/v2/pet/(?P<petId>[^/?#]*)$")
                 .expect("Unable to create regex for PET_PETID");
     }
     pub static ID_PET_PETID_UPLOADIMAGE: usize = 17;
     lazy_static! {
         pub static ref REGEX_PET_PETID_UPLOADIMAGE: regex::Regex =
-            regex::Regex::new(r"^/v2/pet/(?P<pet_id>[^/?#]*)/uploadImage$")
+            regex::Regex::new(r"^/v2/pet/(?P<petId>[^/?#]*)/uploadImage$")
                 .expect("Unable to create regex for PET_PETID_UPLOADIMAGE");
     }
     pub static ID_STORE_INVENTORY: usize = 18;

--- a/samples/server/petstore/rust-server/output/rust-server-test/examples/client/main.rs
+++ b/samples/server/petstore/rust-server/output/rust-server-test/examples/client/main.rs
@@ -63,7 +63,7 @@ fn main() {
         .arg(Arg::with_name("port")
             .long("port")
             .takes_value(true)
-            .default_value("80")
+            .default_value("8080")
             .help("Port to contact"))
         .get_matches();
 
@@ -95,54 +95,54 @@ fn main() {
         Some("AllOfGet") => {
             let result = rt.block_on(client.all_of_get(
             ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         Some("DummyGet") => {
             let result = rt.block_on(client.dummy_get(
             ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         /* Disabled because there's no example.
         Some("DummyPut") => {
             let result = rt.block_on(client.dummy_put(
                   ???
             ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         */
         Some("FileResponseGet") => {
             let result = rt.block_on(client.file_response_get(
             ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         Some("GetStructuredYaml") => {
             let result = rt.block_on(client.get_structured_yaml(
             ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         Some("HtmlPost") => {
             let result = rt.block_on(client.html_post(
                   "body_example".to_string()
             ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         Some("PostYaml") => {
             let result = rt.block_on(client.post_yaml(
                   "value_example".to_string()
             ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         Some("RawJsonGet") => {
             let result = rt.block_on(client.raw_json_get(
             ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         /* Disabled because there's no example.
         Some("SoloObjectPost") => {
             let result = rt.block_on(client.solo_object_post(
                   ???
             ));
-            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         */
         _ => {

--- a/samples/server/petstore/rust-server/output/rust-server-test/examples/server/main.rs
+++ b/samples/server/petstore/rust-server/output/rust-server-test/examples/server/main.rs
@@ -42,7 +42,7 @@ fn main() {
             .help("Whether to use HTTPS or not"))
         .get_matches();
 
-    let addr = "127.0.0.1:80";
+    let addr = "127.0.0.1:8080";
 
     hyper::rt::run(server::create(addr, matches.is_present("https")));
 }

--- a/samples/server/petstore/rust-server/output/rust-server-test/examples/server/server.rs
+++ b/samples/server/petstore/rust-server/output/rust-server-test/examples/server/server.rs
@@ -120,7 +120,7 @@ use rust_server_test::server::MakeService;
 impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
     fn all_of_get(
         &self,
-        context: &C) -> Box<Future<Item=AllOfGetResponse, Error=ApiError> + Send>
+        context: &C) -> Box<dyn Future<Item=AllOfGetResponse, Error=ApiError> + Send>
     {
         let context = context.clone();
         info!("all_of_get() - X-Span-ID: {:?}", context.get().0.clone());
@@ -130,7 +130,7 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
     /// A dummy endpoint to make the spec valid.
     fn dummy_get(
         &self,
-        context: &C) -> Box<Future<Item=DummyGetResponse, Error=ApiError> + Send>
+        context: &C) -> Box<dyn Future<Item=DummyGetResponse, Error=ApiError> + Send>
     {
         let context = context.clone();
         info!("dummy_get() - X-Span-ID: {:?}", context.get().0.clone());
@@ -140,7 +140,7 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
     fn dummy_put(
         &self,
         nested_response: models::InlineObject,
-        context: &C) -> Box<Future<Item=DummyPutResponse, Error=ApiError> + Send>
+        context: &C) -> Box<dyn Future<Item=DummyPutResponse, Error=ApiError> + Send>
     {
         let context = context.clone();
         info!("dummy_put({:?}) - X-Span-ID: {:?}", nested_response, context.get().0.clone());
@@ -150,7 +150,7 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
     /// Get a file
     fn file_response_get(
         &self,
-        context: &C) -> Box<Future<Item=FileResponseGetResponse, Error=ApiError> + Send>
+        context: &C) -> Box<dyn Future<Item=FileResponseGetResponse, Error=ApiError> + Send>
     {
         let context = context.clone();
         info!("file_response_get() - X-Span-ID: {:?}", context.get().0.clone());
@@ -159,7 +159,7 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
 
     fn get_structured_yaml(
         &self,
-        context: &C) -> Box<Future<Item=GetStructuredYamlResponse, Error=ApiError> + Send>
+        context: &C) -> Box<dyn Future<Item=GetStructuredYamlResponse, Error=ApiError> + Send>
     {
         let context = context.clone();
         info!("get_structured_yaml() - X-Span-ID: {:?}", context.get().0.clone());
@@ -170,7 +170,7 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
     fn html_post(
         &self,
         body: String,
-        context: &C) -> Box<Future<Item=HtmlPostResponse, Error=ApiError> + Send>
+        context: &C) -> Box<dyn Future<Item=HtmlPostResponse, Error=ApiError> + Send>
     {
         let context = context.clone();
         info!("html_post(\"{}\") - X-Span-ID: {:?}", body, context.get().0.clone());
@@ -180,7 +180,7 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
     fn post_yaml(
         &self,
         value: String,
-        context: &C) -> Box<Future<Item=PostYamlResponse, Error=ApiError> + Send>
+        context: &C) -> Box<dyn Future<Item=PostYamlResponse, Error=ApiError> + Send>
     {
         let context = context.clone();
         info!("post_yaml(\"{}\") - X-Span-ID: {:?}", value, context.get().0.clone());
@@ -190,7 +190,7 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
     /// Get an arbitrary JSON blob.
     fn raw_json_get(
         &self,
-        context: &C) -> Box<Future<Item=RawJsonGetResponse, Error=ApiError> + Send>
+        context: &C) -> Box<dyn Future<Item=RawJsonGetResponse, Error=ApiError> + Send>
     {
         let context = context.clone();
         info!("raw_json_get() - X-Span-ID: {:?}", context.get().0.clone());
@@ -201,7 +201,7 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
     fn solo_object_post(
         &self,
         value: serde_json::Value,
-        context: &C) -> Box<Future<Item=SoloObjectPostResponse, Error=ApiError> + Send>
+        context: &C) -> Box<dyn Future<Item=SoloObjectPostResponse, Error=ApiError> + Send>
     {
         let context = context.clone();
         info!("solo_object_post({:?}) - X-Span-ID: {:?}", value, context.get().0.clone());


### PR DESCRIPTION
https://github.com/OpenAPITools/openapi-generator/issues/5906

Modification list
1. Fix generated code with Rust 1.39+ issue
```
help: use dyn: dyn Future<Item=CallbackWithHeaderPostResponse, Error=ApiError> + Send
error: trait objects without an explicit dyn are deprecated
--> output/openapi-v3/examples/server/server.rs:137:29
|
137 | context: &C) -> Box<Future<Item=CallbackWithHeaderPostResponse, Error=ApiError> + Send>
| ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use dyn: dyn Future<Item=CallbackWithHeaderPostResponse, Error=ApiError> + Send
|
= note: -D bare-trait-objects implied by -D warnings
error: trait objects without an explicit dyn are deprecated
--> output/openapi-v3/examples/server/server.rs:147:29
|
147 | context: &C) -> Box<Future<Item=ComplexQueryParamGetResponse, Error=ApiError> + Send>
| ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use dyn: dyn Future<Item=ComplexQueryParamGetResponse, Error=ApiError> + Send
```
2. Generate Rust code "repoId", Not "Repoid", and compile error.
`regex::Regex::new(r"^/v2/repos/(?P[^/?#]*)$")`

3. Modify default serverPort from 80 to var "serverPort" with 8080, 8080 is more easy for test.


### Rust Server Technical Committee

- @frol
- @farcaller 
- @bjgill

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [X] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [X] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.