### PR TITLE
Update beanValidationCore.mustache

### DIFF
--- a/modules/openapi-generator/src/main/resources/JavaSpring/beanValidationCore.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/beanValidationCore.mustache
@@ -1,4 +1,4 @@
-{{#pattern}}@Pattern(regexp="{{{pattern}}}") {{/pattern}}{{!
+{{#pattern}}@Pattern(regexp="{{{pattern}}}"{{#vendorExtensions.x-pattern-message}}, message="{{vendorExtensions.x-pattern-message}}"{{/vendorExtensions.x-pattern-message}}) {{/pattern}}{{!
 minLength && maxLength set
 }}{{#minLength}}{{#maxLength}}@Size(min={{minLength}},max={{maxLength}}) {{/maxLength}}{{/minLength}}{{!
 minLength set, maxLength not


### PR DESCRIPTION
-> Currently we don't have support for custom error message when pattern is not matched and get validation error.
-> With this commit, we can provide custom error message like x-pattern-message: "Pattern is not satisfied, invalid input"
PR checklist
 - Read the contribution guidelines.

 - build the project

 - Ran the shell script(s) under ./bin/ (or Windows batch scripts under.\bin\windows) to update Petstore samples related to your fix. This is important, as CI jobs will verify all generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run ./bin/{LANG}-petstore.sh, ./bin/openapi3/{LANG}-petstore.sh if updating the code or mustache templates for a language ({LANG}) (e.g. php, ruby, python, etc).

 - File the PR against the correct branch: master, 4.3.x, 5.0.x. Default: master.

- Copied the technical committee to review the pull request if your PR is targeting a particular programming language.

@bbdouglas @sreeshas @jfiala @lukoyanov @cbornet @jeff9finger @karismann @Zomzog @lwlee2608 @bkabrda

fixes #3519