### PR TITLE
Add context to the go-server generated code

### DIFF
--- a/modules/openapi-generator/src/main/resources/go-server/api.mustache
+++ b/modules/openapi-generator/src/main/resources/go-server/api.mustache
@@ -2,6 +2,7 @@
 package {{packageName}}
 
 import (
+	"context"
 	"net/http"{{#apiInfo}}{{#apis}}{{#imports}}
 	"{{import}}"{{/imports}}{{/apis}}{{/apiInfo}}
 )
@@ -20,5 +21,5 @@ type {{classname}}Router interface { {{#operations}}{{#operation}}
 // while the service implementation can ignored with the .openapi-generator-ignore file 
 // and updated with the logic required for the API.
 type {{classname}}Servicer interface { {{#operations}}{{#operation}}
-	{{operationId}}({{#allParams}}{{dataType}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) (interface{}, error){{/operation}}{{/operations}}
+	{{operationId}}(context.Context{{#allParams}}, {{dataType}}{{/allParams}}) (interface{}, int, error){{/operation}}{{/operations}}
 }{{/apis}}{{/apiInfo}}

--- a/modules/openapi-generator/src/main/resources/go-server/controller-api.mustache
+++ b/modules/openapi-generator/src/main/resources/go-server/controller-api.mustache
@@ -35,51 +35,55 @@ func (c *{{classname}}Controller) Routes() Routes {
 func (c *{{classname}}Controller) {{nickname}}(w http.ResponseWriter, r *http.Request) { {{#hasFormParams}}
 	err := r.ParseForm()
 	if err != nil {
-		w.WriteHeader(500)
+		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
 	{{/hasFormParams}}{{#hasPathParams}}
 	params := mux.Vars(r){{/hasPathParams}}{{#hasQueryParams}}
 	query := r.URL.Query(){{/hasQueryParams}}{{#allParams}}{{#isPathParam}}{{#isLong}}
-	{{paramName}}, err := parseIntParameter(params["{{paramName}}"])
+	{{paramName}}, err := parseIntParameter(params["{{baseName}}"])
 	if err != nil {
-		w.WriteHeader(500)
+		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
 	{{/isLong}}{{^isLong}}
-	{{paramName}} := params["{{paramName}}"]{{/isLong}}{{/isPathParam}}{{#isQueryParam}}{{#isLong}}
-	{{paramName}}, err := parseIntParameter(query.Get("{{paramName}}"))
+	{{paramName}} := params["{{baseName}}"]{{/isLong}}{{/isPathParam}}{{#isQueryParam}}{{#isLong}}
+	{{paramName}}, err := parseIntParameter(query.Get("{{baseName}}"))
 	if err != nil {
-		w.WriteHeader(500)
+		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
 	{{/isLong}}{{^isLong}}
-	{{paramName}} := {{#isListContainer}}strings.Split({{/isListContainer}}query.Get("{{paramName}}"){{#isListContainer}}, ","){{/isListContainer}}{{/isLong}}{{/isQueryParam}}{{#isFormParam}}{{#isFile}}
-	{{paramName}}, err := ReadFormFileToTempFile(r, "{{paramName}}")
+	{{paramName}} := {{#isListContainer}}strings.Split({{/isListContainer}}query.Get("{{baseName}}"){{#isListContainer}}, ","){{/isListContainer}}{{/isLong}}{{/isQueryParam}}{{#isFormParam}}{{#isFile}}
+	{{paramName}}, err := ReadFormFileToTempFile(r, "{{baseName}}")
 	if err != nil {
-		w.WriteHeader(500)
+		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
 	{{/isFile}}{{#isLong}}
-	{{paramName}}, err := parseIntParameter( r.FormValue("{{paramName}}"))
+	{{paramName}}, err := parseIntParameter( r.FormValue("{{baseName}}"))
 	if err != nil {
-		w.WriteHeader(500)
+		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
 	{{/isLong}}{{^isFile}}{{^isLong}}
-	{{paramName}} := r.FormValue("{{paramName}}"){{/isLong}}{{/isFile}}{{/isFormParam}}{{#isHeaderParam}}
-	{{paramName}} := r.Header.Get("{{paramName}}"){{/isHeaderParam}}{{#isBodyParam}}
+	{{paramName}} := r.FormValue("{{baseName}}"){{/isLong}}{{/isFile}}{{/isFormParam}}{{#isHeaderParam}}
+	{{paramName}} := r.Header.Get("{{baseName}}"){{/isHeaderParam}}{{#isBodyParam}}
 	{{paramName}} := &{{dataType}}{}
 	if err := json.NewDecoder(r.Body).Decode(&{{paramName}}); err != nil {
-		w.WriteHeader(500)
+		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
 	{{/isBodyParam}}{{/allParams}}
-	result, err := c.service.{{nickname}}({{#allParams}}{{#isBodyParam}}*{{/isBodyParam}}{{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}})
+	result, status, err := c.service.{{nickname}}(r.Context(){{#allParams}}, {{#isBodyParam}}*{{/isBodyParam}}{{paramName}}{{/allParams}})
 	if err != nil {
-		w.WriteHeader(500)
+		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
 	
-	EncodeJSONResponse(result, nil, w)
+	if genericResponseHandler, ok := result.(GenericResponseHandler); ok {
+		genericResponseHandler(w)
+	} else {
+		JSONResponseEncoder(result, &status, w)
+	}
 }{{/operation}}{{/operations}}

--- a/modules/openapi-generator/src/main/resources/go-server/routers.mustache
+++ b/modules/openapi-generator/src/main/resources/go-server/routers.mustache
@@ -52,8 +52,12 @@ func NewRouter(routers ...Router) *mux.Router {
 	return router
 }
 
-// EncodeJSONResponse uses the json encoder to write an interface to the http response with an optional status code
-func EncodeJSONResponse(i interface{}, status *int, w http.ResponseWriter) error {
+// GenericResponseHandler allows a service to return a generic function to parseIntParameter
+// an HTTP response for the caller
+type GenericResponseHandler func(w http.ResponseWriter)
+
+// JSONResponseEncoder uses the json encoder to write an interface to the http response with an optional status code
+func JSONResponseEncoder(i interface{}, status *int, w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
 	if status != nil {
 		w.WriteHeader(*status)

--- a/modules/openapi-generator/src/main/resources/go-server/service.mustache
+++ b/modules/openapi-generator/src/main/resources/go-server/service.mustache
@@ -2,6 +2,7 @@
 package {{packageName}}
 
 import (
+	"context"
 	"errors"{{#imports}}
 	"{{import}}"{{/imports}}
 )
@@ -18,8 +19,8 @@ func New{{classname}}Service() {{classname}}Servicer {
 }{{#operations}}{{#operation}}
 
 // {{nickname}} - {{summary}}
-func (s *{{classname}}Service) {{nickname}}({{#allParams}}{{paramName}} {{dataType}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) (interface{}, error) {
+func (s *{{classname}}Service) {{nickname}}(ctx context.Context, {{#allParams}}{{paramName}} {{dataType}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) (interface{}, int, error) {
 	// TODO - update {{nickname}} with the required logic for this service method.
 	// Add {{classFilename}}_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
-	return nil, errors.New("service method '{{nickname}}' not implemented")
+	return nil, 0, errors.New("service method '{{nickname}}' not implemented")
 }{{/operation}}{{/operations}}

--- a/samples/server/petstore/go-api-server/go/api.go
+++ b/samples/server/petstore/go-api-server/go/api.go
@@ -10,6 +10,7 @@
 package petstoreserver
 
 import (
+	"context"
 	"net/http"
 	"os"
 )
@@ -57,14 +58,14 @@ type UserApiRouter interface {
 // while the service implementation can ignored with the .openapi-generator-ignore file 
 // and updated with the logic required for the API.
 type PetApiServicer interface { 
-	AddPet(Pet) (interface{}, error)
-	DeletePet(int64, string) (interface{}, error)
-	FindPetsByStatus([]string) (interface{}, error)
-	FindPetsByTags([]string) (interface{}, error)
-	GetPetById(int64) (interface{}, error)
-	UpdatePet(Pet) (interface{}, error)
-	UpdatePetWithForm(int64, string, string) (interface{}, error)
-	UploadFile(int64, string, *os.File) (interface{}, error)
+	AddPet(context.Context, Pet) (interface{}, int, error)
+	DeletePet(context.Context, int64, string) (interface{}, int, error)
+	FindPetsByStatus(context.Context, []string) (interface{}, int, error)
+	FindPetsByTags(context.Context, []string) (interface{}, int, error)
+	GetPetById(context.Context, int64) (interface{}, int, error)
+	UpdatePet(context.Context, Pet) (interface{}, int, error)
+	UpdatePetWithForm(context.Context, int64, string, string) (interface{}, int, error)
+	UploadFile(context.Context, int64, string, *os.File) (interface{}, int, error)
 }
 
 
@@ -73,10 +74,10 @@ type PetApiServicer interface {
 // while the service implementation can ignored with the .openapi-generator-ignore file 
 // and updated with the logic required for the API.
 type StoreApiServicer interface { 
-	DeleteOrder(string) (interface{}, error)
-	GetInventory() (interface{}, error)
-	GetOrderById(int64) (interface{}, error)
-	PlaceOrder(Order) (interface{}, error)
+	DeleteOrder(context.Context, string) (interface{}, int, error)
+	GetInventory(context.Context) (interface{}, int, error)
+	GetOrderById(context.Context, int64) (interface{}, int, error)
+	PlaceOrder(context.Context, Order) (interface{}, int, error)
 }
 
 
@@ -85,12 +86,12 @@ type StoreApiServicer interface {
 // while the service implementation can ignored with the .openapi-generator-ignore file 
 // and updated with the logic required for the API.
 type UserApiServicer interface { 
-	CreateUser(User) (interface{}, error)
-	CreateUsersWithArrayInput([]User) (interface{}, error)
-	CreateUsersWithListInput([]User) (interface{}, error)
-	DeleteUser(string) (interface{}, error)
-	GetUserByName(string) (interface{}, error)
-	LoginUser(string, string) (interface{}, error)
-	LogoutUser() (interface{}, error)
-	UpdateUser(string, User) (interface{}, error)
+	CreateUser(context.Context, User) (interface{}, int, error)
+	CreateUsersWithArrayInput(context.Context, []User) (interface{}, int, error)
+	CreateUsersWithListInput(context.Context, []User) (interface{}, int, error)
+	DeleteUser(context.Context, string) (interface{}, int, error)
+	GetUserByName(context.Context, string) (interface{}, int, error)
+	LoginUser(context.Context, string, string) (interface{}, int, error)
+	LogoutUser(context.Context) (interface{}, int, error)
+	UpdateUser(context.Context, string, User) (interface{}, int, error)
 }

--- a/samples/server/petstore/go-api-server/go/api_pet_service.go
+++ b/samples/server/petstore/go-api-server/go/api_pet_service.go
@@ -10,6 +10,7 @@
 package petstoreserver
 
 import (
+	"context"
 	"errors"
 	"os"
 )
@@ -26,57 +27,57 @@ func NewPetApiService() PetApiServicer {
 }
 
 // AddPet - Add a new pet to the store
-func (s *PetApiService) AddPet(body Pet) (interface{}, error) {
+func (s *PetApiService) AddPet(ctx context.Context, body Pet) (interface{}, int, error) {
 	// TODO - update AddPet with the required logic for this service method.
 	// Add api_pet_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
-	return nil, errors.New("service method 'AddPet' not implemented")
+	return nil, 0, errors.New("service method 'AddPet' not implemented")
 }
 
 // DeletePet - Deletes a pet
-func (s *PetApiService) DeletePet(petId int64, apiKey string) (interface{}, error) {
+func (s *PetApiService) DeletePet(ctx context.Context, petId int64, apiKey string) (interface{}, int, error) {
 	// TODO - update DeletePet with the required logic for this service method.
 	// Add api_pet_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
-	return nil, errors.New("service method 'DeletePet' not implemented")
+	return nil, 0, errors.New("service method 'DeletePet' not implemented")
 }
 
 // FindPetsByStatus - Finds Pets by status
-func (s *PetApiService) FindPetsByStatus(status []string) (interface{}, error) {
+func (s *PetApiService) FindPetsByStatus(ctx context.Context, status []string) (interface{}, int, error) {
 	// TODO - update FindPetsByStatus with the required logic for this service method.
 	// Add api_pet_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
-	return nil, errors.New("service method 'FindPetsByStatus' not implemented")
+	return nil, 0, errors.New("service method 'FindPetsByStatus' not implemented")
 }
 
 // FindPetsByTags - Finds Pets by tags
-func (s *PetApiService) FindPetsByTags(tags []string) (interface{}, error) {
+func (s *PetApiService) FindPetsByTags(ctx context.Context, tags []string) (interface{}, int, error) {
 	// TODO - update FindPetsByTags with the required logic for this service method.
 	// Add api_pet_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
-	return nil, errors.New("service method 'FindPetsByTags' not implemented")
+	return nil, 0, errors.New("service method 'FindPetsByTags' not implemented")
 }
 
 // GetPetById - Find pet by ID
-func (s *PetApiService) GetPetById(petId int64) (interface{}, error) {
+func (s *PetApiService) GetPetById(ctx context.Context, petId int64) (interface{}, int, error) {
 	// TODO - update GetPetById with the required logic for this service method.
 	// Add api_pet_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
-	return nil, errors.New("service method 'GetPetById' not implemented")
+	return nil, 0, errors.New("service method 'GetPetById' not implemented")
 }
 
 // UpdatePet - Update an existing pet
-func (s *PetApiService) UpdatePet(body Pet) (interface{}, error) {
+func (s *PetApiService) UpdatePet(ctx context.Context, body Pet) (interface{}, int, error) {
 	// TODO - update UpdatePet with the required logic for this service method.
 	// Add api_pet_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
-	return nil, errors.New("service method 'UpdatePet' not implemented")
+	return nil, 0, errors.New("service method 'UpdatePet' not implemented")
 }
 
 // UpdatePetWithForm - Updates a pet in the store with form data
-func (s *PetApiService) UpdatePetWithForm(petId int64, name string, status string) (interface{}, error) {
+func (s *PetApiService) UpdatePetWithForm(ctx context.Context, petId int64, name string, status string) (interface{}, int, error) {
 	// TODO - update UpdatePetWithForm with the required logic for this service method.
 	// Add api_pet_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
-	return nil, errors.New("service method 'UpdatePetWithForm' not implemented")
+	return nil, 0, errors.New("service method 'UpdatePetWithForm' not implemented")
 }
 
 // UploadFile - uploads an image
-func (s *PetApiService) UploadFile(petId int64, additionalMetadata string, file *os.File) (interface{}, error) {
+func (s *PetApiService) UploadFile(ctx context.Context, petId int64, additionalMetadata string, file *os.File) (interface{}, int, error) {
 	// TODO - update UploadFile with the required logic for this service method.
 	// Add api_pet_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
-	return nil, errors.New("service method 'UploadFile' not implemented")
+	return nil, 0, errors.New("service method 'UploadFile' not implemented")
 }

--- a/samples/server/petstore/go-api-server/go/api_store.go
+++ b/samples/server/petstore/go-api-server/go/api_store.go
@@ -61,24 +61,32 @@ func (c *StoreApiController) Routes() Routes {
 func (c *StoreApiController) DeleteOrder(w http.ResponseWriter, r *http.Request) { 
 	params := mux.Vars(r)
 	orderId := params["orderId"]
-	result, err := c.service.DeleteOrder(orderId)
+	result, status, err := c.service.DeleteOrder(r.Context(), orderId)
 	if err != nil {
-		w.WriteHeader(500)
+		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
 	
-	EncodeJSONResponse(result, nil, w)
+	if genericResponseHandler, ok := result.(GenericResponseHandler); ok {
+		genericResponseHandler(w)
+	} else {
+		JSONResponseEncoder(result, &status, w)
+	}
 }
 
 // GetInventory - Returns pet inventories by status
 func (c *StoreApiController) GetInventory(w http.ResponseWriter, r *http.Request) { 
-	result, err := c.service.GetInventory()
+	result, status, err := c.service.GetInventory(r.Context())
 	if err != nil {
-		w.WriteHeader(500)
+		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
 	
-	EncodeJSONResponse(result, nil, w)
+	if genericResponseHandler, ok := result.(GenericResponseHandler); ok {
+		genericResponseHandler(w)
+	} else {
+		JSONResponseEncoder(result, &status, w)
+	}
 }
 
 // GetOrderById - Find purchase order by ID
@@ -86,32 +94,40 @@ func (c *StoreApiController) GetOrderById(w http.ResponseWriter, r *http.Request
 	params := mux.Vars(r)
 	orderId, err := parseIntParameter(params["orderId"])
 	if err != nil {
-		w.WriteHeader(500)
+		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
 	
-	result, err := c.service.GetOrderById(orderId)
+	result, status, err := c.service.GetOrderById(r.Context(), orderId)
 	if err != nil {
-		w.WriteHeader(500)
+		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
 	
-	EncodeJSONResponse(result, nil, w)
+	if genericResponseHandler, ok := result.(GenericResponseHandler); ok {
+		genericResponseHandler(w)
+	} else {
+		JSONResponseEncoder(result, &status, w)
+	}
 }
 
 // PlaceOrder - Place an order for a pet
 func (c *StoreApiController) PlaceOrder(w http.ResponseWriter, r *http.Request) { 
 	body := &Order{}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-		w.WriteHeader(500)
+		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
 	
-	result, err := c.service.PlaceOrder(*body)
+	result, status, err := c.service.PlaceOrder(r.Context(), *body)
 	if err != nil {
-		w.WriteHeader(500)
+		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
 	
-	EncodeJSONResponse(result, nil, w)
+	if genericResponseHandler, ok := result.(GenericResponseHandler); ok {
+		genericResponseHandler(w)
+	} else {
+		JSONResponseEncoder(result, &status, w)
+	}
 }

--- a/samples/server/petstore/go-api-server/go/api_store_service.go
+++ b/samples/server/petstore/go-api-server/go/api_store_service.go
@@ -10,6 +10,7 @@
 package petstoreserver
 
 import (
+	"context"
 	"errors"
 )
 
@@ -25,29 +26,29 @@ func NewStoreApiService() StoreApiServicer {
 }
 
 // DeleteOrder - Delete purchase order by ID
-func (s *StoreApiService) DeleteOrder(orderId string) (interface{}, error) {
+func (s *StoreApiService) DeleteOrder(ctx context.Context, orderId string) (interface{}, int, error) {
 	// TODO - update DeleteOrder with the required logic for this service method.
 	// Add api_store_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
-	return nil, errors.New("service method 'DeleteOrder' not implemented")
+	return nil, 0, errors.New("service method 'DeleteOrder' not implemented")
 }
 
 // GetInventory - Returns pet inventories by status
-func (s *StoreApiService) GetInventory() (interface{}, error) {
+func (s *StoreApiService) GetInventory(ctx context.Context, ) (interface{}, int, error) {
 	// TODO - update GetInventory with the required logic for this service method.
 	// Add api_store_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
-	return nil, errors.New("service method 'GetInventory' not implemented")
+	return nil, 0, errors.New("service method 'GetInventory' not implemented")
 }
 
 // GetOrderById - Find purchase order by ID
-func (s *StoreApiService) GetOrderById(orderId int64) (interface{}, error) {
+func (s *StoreApiService) GetOrderById(ctx context.Context, orderId int64) (interface{}, int, error) {
 	// TODO - update GetOrderById with the required logic for this service method.
 	// Add api_store_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
-	return nil, errors.New("service method 'GetOrderById' not implemented")
+	return nil, 0, errors.New("service method 'GetOrderById' not implemented")
 }
 
 // PlaceOrder - Place an order for a pet
-func (s *StoreApiService) PlaceOrder(body Order) (interface{}, error) {
+func (s *StoreApiService) PlaceOrder(ctx context.Context, body Order) (interface{}, int, error) {
 	// TODO - update PlaceOrder with the required logic for this service method.
 	// Add api_store_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
-	return nil, errors.New("service method 'PlaceOrder' not implemented")
+	return nil, 0, errors.New("service method 'PlaceOrder' not implemented")
 }

--- a/samples/server/petstore/go-api-server/go/api_user.go
+++ b/samples/server/petstore/go-api-server/go/api_user.go
@@ -85,77 +85,97 @@ func (c *UserApiController) Routes() Routes {
 func (c *UserApiController) CreateUser(w http.ResponseWriter, r *http.Request) { 
 	body := &User{}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-		w.WriteHeader(500)
+		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
 	
-	result, err := c.service.CreateUser(*body)
+	result, status, err := c.service.CreateUser(r.Context(), *body)
 	if err != nil {
-		w.WriteHeader(500)
+		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
 	
-	EncodeJSONResponse(result, nil, w)
+	if genericResponseHandler, ok := result.(GenericResponseHandler); ok {
+		genericResponseHandler(w)
+	} else {
+		JSONResponseEncoder(result, &status, w)
+	}
 }
 
 // CreateUsersWithArrayInput - Creates list of users with given input array
 func (c *UserApiController) CreateUsersWithArrayInput(w http.ResponseWriter, r *http.Request) { 
 	body := &[]User{}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-		w.WriteHeader(500)
+		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
 	
-	result, err := c.service.CreateUsersWithArrayInput(*body)
+	result, status, err := c.service.CreateUsersWithArrayInput(r.Context(), *body)
 	if err != nil {
-		w.WriteHeader(500)
+		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
 	
-	EncodeJSONResponse(result, nil, w)
+	if genericResponseHandler, ok := result.(GenericResponseHandler); ok {
+		genericResponseHandler(w)
+	} else {
+		JSONResponseEncoder(result, &status, w)
+	}
 }
 
 // CreateUsersWithListInput - Creates list of users with given input array
 func (c *UserApiController) CreateUsersWithListInput(w http.ResponseWriter, r *http.Request) { 
 	body := &[]User{}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-		w.WriteHeader(500)
+		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
 	
-	result, err := c.service.CreateUsersWithListInput(*body)
+	result, status, err := c.service.CreateUsersWithListInput(r.Context(), *body)
 	if err != nil {
-		w.WriteHeader(500)
+		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
 	
-	EncodeJSONResponse(result, nil, w)
+	if genericResponseHandler, ok := result.(GenericResponseHandler); ok {
+		genericResponseHandler(w)
+	} else {
+		JSONResponseEncoder(result, &status, w)
+	}
 }
 
 // DeleteUser - Delete user
 func (c *UserApiController) DeleteUser(w http.ResponseWriter, r *http.Request) { 
 	params := mux.Vars(r)
 	username := params["username"]
-	result, err := c.service.DeleteUser(username)
+	result, status, err := c.service.DeleteUser(r.Context(), username)
 	if err != nil {
-		w.WriteHeader(500)
+		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
 	
-	EncodeJSONResponse(result, nil, w)
+	if genericResponseHandler, ok := result.(GenericResponseHandler); ok {
+		genericResponseHandler(w)
+	} else {
+		JSONResponseEncoder(result, &status, w)
+	}
 }
 
 // GetUserByName - Get user by user name
 func (c *UserApiController) GetUserByName(w http.ResponseWriter, r *http.Request) { 
 	params := mux.Vars(r)
 	username := params["username"]
-	result, err := c.service.GetUserByName(username)
+	result, status, err := c.service.GetUserByName(r.Context(), username)
 	if err != nil {
-		w.WriteHeader(500)
+		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
 	
-	EncodeJSONResponse(result, nil, w)
+	if genericResponseHandler, ok := result.(GenericResponseHandler); ok {
+		genericResponseHandler(w)
+	} else {
+		JSONResponseEncoder(result, &status, w)
+	}
 }
 
 // LoginUser - Logs user into the system
@@ -163,24 +183,32 @@ func (c *UserApiController) LoginUser(w http.ResponseWriter, r *http.Request) {
 	query := r.URL.Query()
 	username := query.Get("username")
 	password := query.Get("password")
-	result, err := c.service.LoginUser(username, password)
+	result, status, err := c.service.LoginUser(r.Context(), username, password)
 	if err != nil {
-		w.WriteHeader(500)
+		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
 	
-	EncodeJSONResponse(result, nil, w)
+	if genericResponseHandler, ok := result.(GenericResponseHandler); ok {
+		genericResponseHandler(w)
+	} else {
+		JSONResponseEncoder(result, &status, w)
+	}
 }
 
 // LogoutUser - Logs out current logged in user session
 func (c *UserApiController) LogoutUser(w http.ResponseWriter, r *http.Request) { 
-	result, err := c.service.LogoutUser()
+	result, status, err := c.service.LogoutUser(r.Context())
 	if err != nil {
-		w.WriteHeader(500)
+		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
 	
-	EncodeJSONResponse(result, nil, w)
+	if genericResponseHandler, ok := result.(GenericResponseHandler); ok {
+		genericResponseHandler(w)
+	} else {
+		JSONResponseEncoder(result, &status, w)
+	}
 }
 
 // UpdateUser - Updated user
@@ -189,15 +217,19 @@ func (c *UserApiController) UpdateUser(w http.ResponseWriter, r *http.Request) {
 	username := params["username"]
 	body := &User{}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-		w.WriteHeader(500)
+		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
 	
-	result, err := c.service.UpdateUser(username, *body)
+	result, status, err := c.service.UpdateUser(r.Context(), username, *body)
 	if err != nil {
-		w.WriteHeader(500)
+		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
 	
-	EncodeJSONResponse(result, nil, w)
+	if genericResponseHandler, ok := result.(GenericResponseHandler); ok {
+		genericResponseHandler(w)
+	} else {
+		JSONResponseEncoder(result, &status, w)
+	}
 }

--- a/samples/server/petstore/go-api-server/go/api_user_service.go
+++ b/samples/server/petstore/go-api-server/go/api_user_service.go
@@ -10,6 +10,7 @@
 package petstoreserver
 
 import (
+	"context"
 	"errors"
 )
 
@@ -25,57 +26,57 @@ func NewUserApiService() UserApiServicer {
 }
 
 // CreateUser - Create user
-func (s *UserApiService) CreateUser(body User) (interface{}, error) {
+func (s *UserApiService) CreateUser(ctx context.Context, body User) (interface{}, int, error) {
 	// TODO - update CreateUser with the required logic for this service method.
 	// Add api_user_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
-	return nil, errors.New("service method 'CreateUser' not implemented")
+	return nil, 0, errors.New("service method 'CreateUser' not implemented")
 }
 
 // CreateUsersWithArrayInput - Creates list of users with given input array
-func (s *UserApiService) CreateUsersWithArrayInput(body []User) (interface{}, error) {
+func (s *UserApiService) CreateUsersWithArrayInput(ctx context.Context, body []User) (interface{}, int, error) {
 	// TODO - update CreateUsersWithArrayInput with the required logic for this service method.
 	// Add api_user_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
-	return nil, errors.New("service method 'CreateUsersWithArrayInput' not implemented")
+	return nil, 0, errors.New("service method 'CreateUsersWithArrayInput' not implemented")
 }
 
 // CreateUsersWithListInput - Creates list of users with given input array
-func (s *UserApiService) CreateUsersWithListInput(body []User) (interface{}, error) {
+func (s *UserApiService) CreateUsersWithListInput(ctx context.Context, body []User) (interface{}, int, error) {
 	// TODO - update CreateUsersWithListInput with the required logic for this service method.
 	// Add api_user_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
-	return nil, errors.New("service method 'CreateUsersWithListInput' not implemented")
+	return nil, 0, errors.New("service method 'CreateUsersWithListInput' not implemented")
 }
 
 // DeleteUser - Delete user
-func (s *UserApiService) DeleteUser(username string) (interface{}, error) {
+func (s *UserApiService) DeleteUser(ctx context.Context, username string) (interface{}, int, error) {
 	// TODO - update DeleteUser with the required logic for this service method.
 	// Add api_user_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
-	return nil, errors.New("service method 'DeleteUser' not implemented")
+	return nil, 0, errors.New("service method 'DeleteUser' not implemented")
 }
 
 // GetUserByName - Get user by user name
-func (s *UserApiService) GetUserByName(username string) (interface{}, error) {
+func (s *UserApiService) GetUserByName(ctx context.Context, username string) (interface{}, int, error) {
 	// TODO - update GetUserByName with the required logic for this service method.
 	// Add api_user_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
-	return nil, errors.New("service method 'GetUserByName' not implemented")
+	return nil, 0, errors.New("service method 'GetUserByName' not implemented")
 }
 
 // LoginUser - Logs user into the system
-func (s *UserApiService) LoginUser(username string, password string) (interface{}, error) {
+func (s *UserApiService) LoginUser(ctx context.Context, username string, password string) (interface{}, int, error) {
 	// TODO - update LoginUser with the required logic for this service method.
 	// Add api_user_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
-	return nil, errors.New("service method 'LoginUser' not implemented")
+	return nil, 0, errors.New("service method 'LoginUser' not implemented")
 }
 
 // LogoutUser - Logs out current logged in user session
-func (s *UserApiService) LogoutUser() (interface{}, error) {
+func (s *UserApiService) LogoutUser(ctx context.Context, ) (interface{}, int, error) {
 	// TODO - update LogoutUser with the required logic for this service method.
 	// Add api_user_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
-	return nil, errors.New("service method 'LogoutUser' not implemented")
+	return nil, 0, errors.New("service method 'LogoutUser' not implemented")
 }
 
 // UpdateUser - Updated user
-func (s *UserApiService) UpdateUser(username string, body User) (interface{}, error) {
+func (s *UserApiService) UpdateUser(ctx context.Context, username string, body User) (interface{}, int, error) {
 	// TODO - update UpdateUser with the required logic for this service method.
 	// Add api_user_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
-	return nil, errors.New("service method 'UpdateUser' not implemented")
+	return nil, 0, errors.New("service method 'UpdateUser' not implemented")
 }

--- a/samples/server/petstore/go-api-server/go/routers.go
+++ b/samples/server/petstore/go-api-server/go/routers.go
@@ -54,8 +54,12 @@ func NewRouter(routers ...Router) *mux.Router {
 	return router
 }
 
-// EncodeJSONResponse uses the json encoder to write an interface to the http response with an optional status code
-func EncodeJSONResponse(i interface{}, status *int, w http.ResponseWriter) error {
+// GenericResponseHandler allows a service to return a generic function to parseIntParameter
+// an HTTP response for the caller
+type GenericResponseHandler func(w http.ResponseWriter)
+
+// JSONResponseEncoder uses the json encoder to write an interface to the http response with an optional status code
+func JSONResponseEncoder(i interface{}, status *int, w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
 	if status != nil {
 		w.WriteHeader(*status)


### PR DESCRIPTION
### PR checklist
* [x]  Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
* [x]  If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
* [x]  Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
* [x]  File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
* [x]  Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

Update the go-server code genertor in order to:

1. return 400 in case of an invalid input parameter (very likely is not an internal error).
2. use baseName instead of paramName when gettin a parameter from maps (this makes difference for a parameter like "user-id")
3. pass the ctx to the called handlers, so that they can take decisions based on the calling context and propagate it in ase of down calls.
4. allow handlers to return a status code. And handler that creates a resource should be allowed to return HTTP 201 instead of HTTP 200.
5. allow an handler to return a reponse function in order to fully customize the response. This is useful when, for example, redirecting a requestor; in this case both a custom state and custom headers have to be returned.

@antihax @bvwells @grokify @kemokemo @bkabrda please review.