### PR TITLE
[maven] mark Mojo threadSafe=true + fix concurrency issue in CodegenConfigurator

### DIFF
--- a/modules/openapi-generator-maven-plugin/src/main/java/org/openapitools/codegen/plugin/CodeGenMojo.java
+++ b/modules/openapi-generator-maven-plugin/src/main/java/org/openapitools/codegen/plugin/CodeGenMojo.java
@@ -70,7 +70,7 @@ import com.google.common.io.Files;
  * Goal which generates client/server code from a OpenAPI json/yaml definition.
  */
 @SuppressWarnings({"unused", "MismatchedQueryAndUpdateOfCollection"})
-@Mojo(name = "generate", defaultPhase = LifecyclePhase.GENERATE_SOURCES)
+@Mojo(name = "generate", defaultPhase = LifecyclePhase.GENERATE_SOURCES, threadSafe = true)
 public class CodeGenMojo extends AbstractMojo {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CodeGenMojo.class);

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/config/CodegenConfigurator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/config/CodegenConfigurator.java
@@ -79,67 +79,72 @@ public class CodegenConfigurator {
     public static CodegenConfigurator fromFile(String configFile, Module... modules) {
 
         if (isNotEmpty(configFile)) {
-            ObjectMapper mapper;
+            DynamicSettings settings = readDynamicSettings(configFile, modules);
 
-            if (FilenameUtils.isExtension(configFile, new String[]{"yml", "yaml"})) {
-                mapper = Yaml.mapper();
-            } else {
-                mapper = Json.mapper();
+            CodegenConfigurator configurator = new CodegenConfigurator();
+
+            GeneratorSettings generatorSettings = settings.getGeneratorSettings();
+            WorkflowSettings workflowSettings = settings.getWorkflowSettings();
+
+            // We copy "cached" properties into configurator so it is appropriately configured with all settings in external files.
+            // FIXME: target is to eventually move away from CodegenConfigurator properties except gen/workflow settings.
+            configurator.generatorName = generatorSettings.getGeneratorName();
+            configurator.inputSpec = workflowSettings.getInputSpec();
+            configurator.templatingEngineName = workflowSettings.getTemplatingEngineName();
+            if (workflowSettings.getSystemProperties() != null) {
+                configurator.systemProperties.putAll(workflowSettings.getSystemProperties());
+            }
+            if(generatorSettings.getInstantiationTypes() != null) {
+                configurator.instantiationTypes.putAll(generatorSettings.getInstantiationTypes());
+            }
+            if(generatorSettings.getTypeMappings() != null) {
+                configurator.typeMappings.putAll(generatorSettings.getTypeMappings());
+            }
+            if(generatorSettings.getAdditionalProperties() != null) {
+                configurator.additionalProperties.putAll(generatorSettings.getAdditionalProperties());
+            }
+            if(generatorSettings.getImportMappings() != null) {
+                configurator.importMappings.putAll(generatorSettings.getImportMappings());
+            }
+            if(generatorSettings.getLanguageSpecificPrimitives() != null) {
+                configurator.languageSpecificPrimitives.addAll(generatorSettings.getLanguageSpecificPrimitives());
+            }
+            if(generatorSettings.getReservedWordMappings() != null) {
+                configurator.reservedWordMappings.putAll(generatorSettings.getReservedWordMappings());
+            }
+            if(generatorSettings.getServerVariables() != null) {
+                configurator.serverVariables.putAll(generatorSettings.getServerVariables());
             }
 
-            if (modules != null && modules.length > 0) {
-                mapper.registerModules(modules);
-            }
+            configurator.generatorSettingsBuilder = GeneratorSettings.newBuilder(generatorSettings);
+            configurator.workflowSettingsBuilder = WorkflowSettings.newBuilder(workflowSettings);
 
-            mapper.registerModule(new GuavaModule());
-
-            try {
-                DynamicSettings settings = mapper.readValue(new File(configFile), DynamicSettings.class);
-                CodegenConfigurator configurator = new CodegenConfigurator();
-
-                GeneratorSettings generatorSettings = settings.getGeneratorSettings();
-                WorkflowSettings workflowSettings = settings.getWorkflowSettings();
-
-                // We copy "cached" properties into configurator so it is appropriately configured with all settings in external files.
-                // FIXME: target is to eventually move away from CodegenConfigurator properties except gen/workflow settings.
-                configurator.generatorName = generatorSettings.getGeneratorName();
-                configurator.inputSpec = workflowSettings.getInputSpec();
-                configurator.templatingEngineName = workflowSettings.getTemplatingEngineName();
-                if (workflowSettings.getSystemProperties() != null) {
-                    configurator.systemProperties.putAll(workflowSettings.getSystemProperties());
-                }
-                if(generatorSettings.getInstantiationTypes() != null) {
-                    configurator.instantiationTypes.putAll(generatorSettings.getInstantiationTypes());
-                }
-                if(generatorSettings.getTypeMappings() != null) {
-                    configurator.typeMappings.putAll(generatorSettings.getTypeMappings());
-                }
-                if(generatorSettings.getAdditionalProperties() != null) {
-                    configurator.additionalProperties.putAll(generatorSettings.getAdditionalProperties());
-                }
-                if(generatorSettings.getImportMappings() != null) {
-                    configurator.importMappings.putAll(generatorSettings.getImportMappings());
-                }
-                if(generatorSettings.getLanguageSpecificPrimitives() != null) {
-                    configurator.languageSpecificPrimitives.addAll(generatorSettings.getLanguageSpecificPrimitives());
-                }
-                if(generatorSettings.getReservedWordMappings() != null) {
-                    configurator.reservedWordMappings.putAll(generatorSettings.getReservedWordMappings());
-                }
-                if(generatorSettings.getServerVariables() != null) {
-                    configurator.serverVariables.putAll(generatorSettings.getServerVariables());
-                }
-
-                configurator.generatorSettingsBuilder = GeneratorSettings.newBuilder(generatorSettings);
-                configurator.workflowSettingsBuilder = WorkflowSettings.newBuilder(workflowSettings);
-
-                return configurator;
-            } catch (IOException ex) {
-                LOGGER.error(ex.getMessage());
-                throw new RuntimeException("Unable to deserialize config file: " + configFile);
-            }
+            return configurator;
         }
         return null;
+    }
+
+    private static DynamicSettings readDynamicSettings(String configFile, Module... modules) {
+        ObjectMapper mapper;
+
+        if (FilenameUtils.isExtension(configFile.toLowerCase(Locale.ROOT), new String[]{"yml", "yaml"})) {
+            mapper = Yaml.mapper().copy();
+        } else {
+            mapper = Json.mapper().copy();
+        }
+
+        if (modules != null && modules.length > 0) {
+            mapper.registerModules(modules);
+        }
+
+        mapper.registerModule(new GuavaModule());
+
+        try {
+            return mapper.readValue(new File(configFile), DynamicSettings.class);
+        } catch (IOException ex) {
+            LOGGER.error(ex.getMessage());
+            throw new RuntimeException("Unable to deserialize config file: " + configFile);
+        }
     }
 
     public CodegenConfigurator addServerVariable(String key, String value) {


### PR DESCRIPTION
Fixes #5862.

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [ ] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04) @lwlee2608 (2019/10) @bkabrda (2020/01)

---

The change to `CodegenConfigurator` looks more than it really is. I just pulled out everything that is related to actually _parse_ the file into a `synchronized` method to resolve the following concurrency issue: https://github.com/OpenAPITools/openapi-generator/issues/5862#issuecomment-611023874

I must say though, that the existing approach to mutate a singleton `ObjectMapper` seems rather dodgy.

Before my change, I was able to provoke the issue in my current project (which I am not allowed to share) after max. 30 mins via:
```
time while mvn -T2 openapi-generator:generate@generate-code -pl moduleA,moduleB -Dopenapi-generator-maven-plugin.version=4.3.1-SNAPSHOT; do :; done
```
After my change I stopped the loop after 2 hours.