### PR TITLE
[Python-experimental] Use DER encoding for ECDSA signatures, add parameter to configure hash algorithm

### DIFF
--- a/modules/openapi-generator/src/main/resources/python/python-experimental/signing.mustache
+++ b/modules/openapi-generator/src/main/resources/python/python-experimental/signing.mustache
@@ -340,7 +340,9 @@ class HttpSigningConfiguration(object):
             if sig_alg is None:
                 sig_alg = ALGORITHM_ECDSA_MODE_FIPS_186_3
             if sig_alg in ALGORITHM_ECDSA_KEY_SIGNING_ALGORITHMS:
-                signature = DSS.new(self.private_key, sig_alg).sign(digest)
+                # draft-ietf-httpbis-message-signatures-00 does not specify the ECDSA encoding.
+                # Issue: https://github.com/w3c-ccg/http-signatures/issues/107
+                signature = DSS.new(key=self.private_key, mode=sig_alg, encoding='der').sign(digest)
             else:
                 raise Exception("Unsupported signature algorithm: {0}".format(sig_alg))
         else:

--- a/modules/openapi-generator/src/main/resources/python/python-experimental/signing.mustache
+++ b/modules/openapi-generator/src/main/resources/python/python-experimental/signing.mustache
@@ -132,19 +132,19 @@ class HttpSigningConfiguration(object):
         self.signing_algorithm = signing_algorithm
         self.hash_algorithm = hash_algorithm
         if signing_scheme == SCHEME_RSA_SHA256:
-            if self.hash_algorithm == None:
+            if self.hash_algorithm is None:
                 self.hash_algorithm = HASH_SHA256
             elif self.hash_algorithm != HASH_SHA256:
                 raise Exception("Hash algorithm must be sha256 when security scheme is %s" %
                     SCHEME_RSA_SHA256)
         elif signing_scheme == SCHEME_RSA_SHA512:
-            if self.hash_algorithm == None:
+            if self.hash_algorithm is None:
                 self.hash_algorithm = HASH_SHA512
             elif self.hash_algorithm != HASH_SHA512:
                 raise Exception("Hash algorithm must be sha512 when security scheme is %s" %
                     SCHEME_RSA_SHA512)
         elif signing_scheme == SCHEME_HS2019:
-            if self.hash_algorithm == None:
+            if self.hash_algorithm is None:
                 self.hash_algorithm = HASH_SHA256
             elif self.hash_algorithm not in {HASH_SHA256, HASH_SHA512}:
                 raise Exception("Invalid hash algorithm")

--- a/modules/openapi-generator/src/main/resources/python/python-experimental/signing.mustache
+++ b/modules/openapi-generator/src/main/resources/python/python-experimental/signing.mustache
@@ -58,7 +58,6 @@ HASH_SHA256 = 'sha256'
 HASH_SHA512 = 'sha512'
 
 
-
 class HttpSigningConfiguration(object):
     """The configuration parameters for the HTTP signature security scheme.
     The HTTP signature security scheme is used to sign HTTP requests with a private key
@@ -136,13 +135,13 @@ class HttpSigningConfiguration(object):
                 self.hash_algorithm = HASH_SHA256
             elif self.hash_algorithm != HASH_SHA256:
                 raise Exception("Hash algorithm must be sha256 when security scheme is %s" %
-                    SCHEME_RSA_SHA256)
+                                    SCHEME_RSA_SHA256)
         elif signing_scheme == SCHEME_RSA_SHA512:
             if self.hash_algorithm is None:
                 self.hash_algorithm = HASH_SHA512
             elif self.hash_algorithm != HASH_SHA512:
                 raise Exception("Hash algorithm must be sha512 when security scheme is %s" %
-                    SCHEME_RSA_SHA512)
+                                    SCHEME_RSA_SHA512)
         elif signing_scheme == SCHEME_HS2019:
             if self.hash_algorithm is None:
                 self.hash_algorithm = HASH_SHA256
@@ -372,7 +371,8 @@ class HttpSigningConfiguration(object):
             if sig_alg in ALGORITHM_ECDSA_KEY_SIGNING_ALGORITHMS:
                 # draft-ietf-httpbis-message-signatures-00 does not specify the ECDSA encoding.
                 # Issue: https://github.com/w3c-ccg/http-signatures/issues/107
-                signature = DSS.new(key=self.private_key, mode=sig_alg, encoding='der').sign(digest)
+                signature = DSS.new(key=self.private_key, mode=sig_alg,
+                                    encoding='der').sign(digest)
             else:
                 raise Exception("Unsupported signature algorithm: {0}".format(sig_alg))
         else:

--- a/modules/openapi-generator/src/main/resources/python/python-experimental/signing.mustache
+++ b/modules/openapi-generator/src/main/resources/python/python-experimental/signing.mustache
@@ -53,6 +53,11 @@ ALGORITHM_ECDSA_KEY_SIGNING_ALGORITHMS = {
     ALGORITHM_ECDSA_MODE_DETERMINISTIC_RFC6979
 }
 
+# The cryptographic hash algorithm for the message signature.
+HASH_SHA256 = 'sha256'
+HASH_SHA512 = 'sha512'
+
+
 
 class HttpSigningConfiguration(object):
     """The configuration parameters for the HTTP signature security scheme.
@@ -98,9 +103,15 @@ class HttpSigningConfiguration(object):
         Supported values are:
         1. For RSA keys: RSASSA-PSS, RSASSA-PKCS1-v1_5.
         2. For ECDSA keys: fips-186-3, deterministic-rfc6979.
-        The default value is inferred from the private key.
-        The default value for RSA keys is RSASSA-PSS.
-        The default value for ECDSA keys is fips-186-3.
+        If None, the signing algorithm is inferred from the private key.
+        The default signing algorithm for RSA keys is RSASSA-PSS.
+        The default signing algorithm for ECDSA keys is fips-186-3.
+    :param hash_algorithm: The hash algorithm for the signature. Supported values are
+        sha256 and sha512.
+        If the signing_scheme is rsa-sha256, the hash algorithm must be set
+        to None or sha256.
+        If the signing_scheme is rsa-sha512, the hash algorithm must be set
+        to None or sha512.
     :param signature_max_validity: The signature max validity, expressed as
         a datetime.timedelta value. It must be a positive value.
     """
@@ -108,6 +119,7 @@ class HttpSigningConfiguration(object):
                  private_key_passphrase=None,
                  signed_headers=None,
                  signing_algorithm=None,
+                 hash_algorithm=None,
                  signature_max_validity=None):
         self.key_id = key_id
         if signing_scheme not in {SCHEME_HS2019, SCHEME_RSA_SHA256, SCHEME_RSA_SHA512}:
@@ -118,6 +130,24 @@ class HttpSigningConfiguration(object):
         self.private_key_path = private_key_path
         self.private_key_passphrase = private_key_passphrase
         self.signing_algorithm = signing_algorithm
+        self.hash_algorithm = hash_algorithm
+        if signing_scheme == SCHEME_RSA_SHA256:
+            if self.hash_algorithm == None:
+                self.hash_algorithm = HASH_SHA256
+            elif self.hash_algorithm != HASH_SHA256:
+                raise Exception("Hash algorithm must be sha256 when security scheme is %s" %
+                    SCHEME_RSA_SHA256)
+        elif signing_scheme == SCHEME_RSA_SHA512:
+            if self.hash_algorithm == None:
+                self.hash_algorithm = HASH_SHA512
+            elif self.hash_algorithm != HASH_SHA512:
+                raise Exception("Hash algorithm must be sha512 when security scheme is %s" %
+                    SCHEME_RSA_SHA512)
+        elif signing_scheme == SCHEME_HS2019:
+            if self.hash_algorithm == None:
+                self.hash_algorithm = HASH_SHA256
+            elif self.hash_algorithm not in {HASH_SHA256, HASH_SHA512}:
+                raise Exception("Invalid hash algorithm")
         if signature_max_validity is not None and signature_max_validity.total_seconds() < 0:
             raise Exception("The signature max validity must be a positive value")
         self.signature_max_validity = signature_max_validity
@@ -309,14 +339,14 @@ class HttpSigningConfiguration(object):
             The prefix is a string that identifies the cryptographc hash. It is used
             to generate the 'Digest' header as specified in RFC 3230.
         """
-        if self.signing_scheme in {SCHEME_RSA_SHA512, SCHEME_HS2019}:
+        if self.hash_algorithm == HASH_SHA512:
             digest = SHA512.new()
             prefix = 'SHA-512='
-        elif self.signing_scheme == SCHEME_RSA_SHA256:
+        elif self.hash_algorithm == HASH_SHA256:
             digest = SHA256.new()
             prefix = 'SHA-256='
         else:
-            raise Exception("Unsupported signing algorithm: {0}".format(self.signing_scheme))
+            raise Exception("Unsupported hash algorithm: {0}".format(self.hash_algorithm))
         digest.update(data)
         return digest, prefix
 

--- a/modules/openapi-generator/src/main/resources/python/python-experimental/signing.mustache
+++ b/modules/openapi-generator/src/main/resources/python/python-experimental/signing.mustache
@@ -135,13 +135,13 @@ class HttpSigningConfiguration(object):
                 self.hash_algorithm = HASH_SHA256
             elif self.hash_algorithm != HASH_SHA256:
                 raise Exception("Hash algorithm must be sha256 when security scheme is %s" %
-                                    SCHEME_RSA_SHA256)
+                                SCHEME_RSA_SHA256)
         elif signing_scheme == SCHEME_RSA_SHA512:
             if self.hash_algorithm is None:
                 self.hash_algorithm = HASH_SHA512
             elif self.hash_algorithm != HASH_SHA512:
                 raise Exception("Hash algorithm must be sha512 when security scheme is %s" %
-                                    SCHEME_RSA_SHA512)
+                                SCHEME_RSA_SHA512)
         elif signing_scheme == SCHEME_HS2019:
             if self.hash_algorithm is None:
                 self.hash_algorithm = HASH_SHA256

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/signing.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/signing.py
@@ -140,19 +140,19 @@ class HttpSigningConfiguration(object):
         self.signing_algorithm = signing_algorithm
         self.hash_algorithm = hash_algorithm
         if signing_scheme == SCHEME_RSA_SHA256:
-            if self.hash_algorithm == None:
+            if self.hash_algorithm is None:
                 self.hash_algorithm = HASH_SHA256
             elif self.hash_algorithm != HASH_SHA256:
                 raise Exception("Hash algorithm must be sha256 when security scheme is %s" %
                     SCHEME_RSA_SHA256)
         elif signing_scheme == SCHEME_RSA_SHA512:
-            if self.hash_algorithm == None:
+            if self.hash_algorithm is None:
                 self.hash_algorithm = HASH_SHA512
             elif self.hash_algorithm != HASH_SHA512:
                 raise Exception("Hash algorithm must be sha512 when security scheme is %s" %
                     SCHEME_RSA_SHA512)
         elif signing_scheme == SCHEME_HS2019:
-            if self.hash_algorithm == None:
+            if self.hash_algorithm is None:
                 self.hash_algorithm = HASH_SHA256
             elif self.hash_algorithm not in {HASH_SHA256, HASH_SHA512}:
                 raise Exception("Invalid hash algorithm")

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/signing.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/signing.py
@@ -348,7 +348,9 @@ class HttpSigningConfiguration(object):
             if sig_alg is None:
                 sig_alg = ALGORITHM_ECDSA_MODE_FIPS_186_3
             if sig_alg in ALGORITHM_ECDSA_KEY_SIGNING_ALGORITHMS:
-                signature = DSS.new(self.private_key, sig_alg).sign(digest)
+                # draft-ietf-httpbis-message-signatures-00 does not specify the ECDSA encoding.
+                # Issue: https://github.com/w3c-ccg/http-signatures/issues/107
+                signature = DSS.new(key=self.private_key, mode=sig_alg, encoding='der').sign(digest)
             else:
                 raise Exception("Unsupported signature algorithm: {0}".format(sig_alg))
         else:

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/signing.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/signing.py
@@ -61,6 +61,11 @@ ALGORITHM_ECDSA_KEY_SIGNING_ALGORITHMS = {
     ALGORITHM_ECDSA_MODE_DETERMINISTIC_RFC6979
 }
 
+# The cryptographic hash algorithm for the message signature.
+HASH_SHA256 = 'sha256'
+HASH_SHA512 = 'sha512'
+
+
 
 class HttpSigningConfiguration(object):
     """The configuration parameters for the HTTP signature security scheme.
@@ -106,9 +111,15 @@ class HttpSigningConfiguration(object):
         Supported values are:
         1. For RSA keys: RSASSA-PSS, RSASSA-PKCS1-v1_5.
         2. For ECDSA keys: fips-186-3, deterministic-rfc6979.
-        The default value is inferred from the private key.
-        The default value for RSA keys is RSASSA-PSS.
-        The default value for ECDSA keys is fips-186-3.
+        If None, the signing algorithm is inferred from the private key.
+        The default signing algorithm for RSA keys is RSASSA-PSS.
+        The default signing algorithm for ECDSA keys is fips-186-3.
+    :param hash_algorithm: The hash algorithm for the signature. Supported values are
+        sha256 and sha512.
+        If the signing_scheme is rsa-sha256, the hash algorithm must be set
+        to None or sha256.
+        If the signing_scheme is rsa-sha512, the hash algorithm must be set
+        to None or sha512.
     :param signature_max_validity: The signature max validity, expressed as
         a datetime.timedelta value. It must be a positive value.
     """
@@ -116,6 +127,7 @@ class HttpSigningConfiguration(object):
                  private_key_passphrase=None,
                  signed_headers=None,
                  signing_algorithm=None,
+                 hash_algorithm=None,
                  signature_max_validity=None):
         self.key_id = key_id
         if signing_scheme not in {SCHEME_HS2019, SCHEME_RSA_SHA256, SCHEME_RSA_SHA512}:
@@ -126,6 +138,24 @@ class HttpSigningConfiguration(object):
         self.private_key_path = private_key_path
         self.private_key_passphrase = private_key_passphrase
         self.signing_algorithm = signing_algorithm
+        self.hash_algorithm = hash_algorithm
+        if signing_scheme == SCHEME_RSA_SHA256:
+            if self.hash_algorithm == None:
+                self.hash_algorithm = HASH_SHA256
+            elif self.hash_algorithm != HASH_SHA256:
+                raise Exception("Hash algorithm must be sha256 when security scheme is %s" %
+                    SCHEME_RSA_SHA256)
+        elif signing_scheme == SCHEME_RSA_SHA512:
+            if self.hash_algorithm == None:
+                self.hash_algorithm = HASH_SHA512
+            elif self.hash_algorithm != HASH_SHA512:
+                raise Exception("Hash algorithm must be sha512 when security scheme is %s" %
+                    SCHEME_RSA_SHA512)
+        elif signing_scheme == SCHEME_HS2019:
+            if self.hash_algorithm == None:
+                self.hash_algorithm = HASH_SHA256
+            elif self.hash_algorithm not in {HASH_SHA256, HASH_SHA512}:
+                raise Exception("Invalid hash algorithm")
         if signature_max_validity is not None and signature_max_validity.total_seconds() < 0:
             raise Exception("The signature max validity must be a positive value")
         self.signature_max_validity = signature_max_validity
@@ -317,14 +347,14 @@ class HttpSigningConfiguration(object):
             The prefix is a string that identifies the cryptographc hash. It is used
             to generate the 'Digest' header as specified in RFC 3230.
         """
-        if self.signing_scheme in {SCHEME_RSA_SHA512, SCHEME_HS2019}:
+        if self.hash_algorithm == HASH_SHA512:
             digest = SHA512.new()
             prefix = 'SHA-512='
-        elif self.signing_scheme == SCHEME_RSA_SHA256:
+        elif self.hash_algorithm == HASH_SHA256:
             digest = SHA256.new()
             prefix = 'SHA-256='
         else:
-            raise Exception("Unsupported signing algorithm: {0}".format(self.signing_scheme))
+            raise Exception("Unsupported hash algorithm: {0}".format(self.hash_algorithm))
         digest.update(data)
         return digest, prefix
 

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/signing.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/signing.py
@@ -143,13 +143,13 @@ class HttpSigningConfiguration(object):
                 self.hash_algorithm = HASH_SHA256
             elif self.hash_algorithm != HASH_SHA256:
                 raise Exception("Hash algorithm must be sha256 when security scheme is %s" %
-                                    SCHEME_RSA_SHA256)
+                                SCHEME_RSA_SHA256)
         elif signing_scheme == SCHEME_RSA_SHA512:
             if self.hash_algorithm is None:
                 self.hash_algorithm = HASH_SHA512
             elif self.hash_algorithm != HASH_SHA512:
                 raise Exception("Hash algorithm must be sha512 when security scheme is %s" %
-                                    SCHEME_RSA_SHA512)
+                                SCHEME_RSA_SHA512)
         elif signing_scheme == SCHEME_HS2019:
             if self.hash_algorithm is None:
                 self.hash_algorithm = HASH_SHA256

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/signing.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/signing.py
@@ -66,7 +66,6 @@ HASH_SHA256 = 'sha256'
 HASH_SHA512 = 'sha512'
 
 
-
 class HttpSigningConfiguration(object):
     """The configuration parameters for the HTTP signature security scheme.
     The HTTP signature security scheme is used to sign HTTP requests with a private key
@@ -144,13 +143,13 @@ class HttpSigningConfiguration(object):
                 self.hash_algorithm = HASH_SHA256
             elif self.hash_algorithm != HASH_SHA256:
                 raise Exception("Hash algorithm must be sha256 when security scheme is %s" %
-                    SCHEME_RSA_SHA256)
+                                    SCHEME_RSA_SHA256)
         elif signing_scheme == SCHEME_RSA_SHA512:
             if self.hash_algorithm is None:
                 self.hash_algorithm = HASH_SHA512
             elif self.hash_algorithm != HASH_SHA512:
                 raise Exception("Hash algorithm must be sha512 when security scheme is %s" %
-                    SCHEME_RSA_SHA512)
+                                    SCHEME_RSA_SHA512)
         elif signing_scheme == SCHEME_HS2019:
             if self.hash_algorithm is None:
                 self.hash_algorithm = HASH_SHA256
@@ -380,7 +379,8 @@ class HttpSigningConfiguration(object):
             if sig_alg in ALGORITHM_ECDSA_KEY_SIGNING_ALGORITHMS:
                 # draft-ietf-httpbis-message-signatures-00 does not specify the ECDSA encoding.
                 # Issue: https://github.com/w3c-ccg/http-signatures/issues/107
-                signature = DSS.new(key=self.private_key, mode=sig_alg, encoding='der').sign(digest)
+                signature = DSS.new(key=self.private_key, mode=sig_alg,
+                                    encoding='der').sign(digest)
             else:
                 raise Exception("Unsupported signature algorithm: {0}".format(sig_alg))
         else:

--- a/samples/openapi3/client/petstore/python-experimental/tests/test_http_signature.py
+++ b/samples/openapi3/client/petstore/python-experimental/tests/test_http_signature.py
@@ -156,7 +156,7 @@ class MockPoolManager(object):
         elif self.signing_cfg.hash_algorithm == signing.HASH_SHA256:
             digest = SHA256.new()
         else:
-            self._tc.fail("Unsupported signature scheme: {0}".format(self.signing_cfg.signing_scheme))
+            self._tc.fail("Unsupported hash algorithm: {0}".format(self.signing_cfg.hash_algorithm))
         digest.update(string_to_sign.encode())
         b64_body_digest = base64.b64encode(digest.digest()).decode()
 
@@ -165,7 +165,7 @@ class MockPoolManager(object):
         m2 = r2.search(authorization_header)
         self._tc.assertIsNotNone(m2)
         b64_signature = m2.group(1)
-        signature = base64.b64decode(b64_signature, validate=True)
+        signature = base64.b64decode(b64_signature)
         # Build the message
         signing_alg = self.signing_cfg.signing_algorithm
         if signing_alg is None:

--- a/samples/openapi3/client/petstore/python-experimental/tests/test_http_signature.py
+++ b/samples/openapi3/client/petstore/python-experimental/tests/test_http_signature.py
@@ -295,7 +295,7 @@ class PetApiTests(unittest.TestCase):
                                  headers={'Content-Type': r'application/json',
                                           'Authorization': r'Signature keyId="my-key-id",algorithm="hs2019",created=[0-9]+,'
                                                 r'headers="\(request-target\) \(created\) host date digest content-type",'
-                                                r'signature="[a-zA-Z0-9+/]+="',
+                                                r'signature="[a-zA-Z0-9+/=]+"',
                                           'User-Agent': r'OpenAPI-Generator/1.0.0/python'},
                                  preload_content=True, timeout=None)
 
@@ -326,7 +326,7 @@ class PetApiTests(unittest.TestCase):
                                  headers={'Content-Type': r'application/json',
                                           'Authorization': r'Signature keyId="my-key-id",algorithm="hs2019",created=[0-9]+,'
                                                 r'headers="\(created\)",'
-                                                r'signature="[a-zA-Z0-9+/]+="',
+                                                r'signature="[a-zA-Z0-9+/=]+"',
                                           'User-Agent': r'OpenAPI-Generator/1.0.0/python'},
                                  preload_content=True, timeout=None)
 
@@ -362,7 +362,7 @@ class PetApiTests(unittest.TestCase):
                                  headers={'Content-Type': r'application/json',
                                           'Authorization': r'Signature keyId="my-key-id",algorithm="hs2019",created=[0-9]+,'
                                                 r'headers="\(request-target\) \(created\)",'
-                                                r'signature="[a-zA-Z0-9+/]+="',
+                                                r'signature="[a-zA-Z0-9+/=]+"',
                                           'User-Agent': r'OpenAPI-Generator/1.0.0/python'},
                                  preload_content=True, timeout=None)
 
@@ -398,7 +398,7 @@ class PetApiTests(unittest.TestCase):
                                  headers={'Content-Type': r'application/json',
                                           'Authorization': r'Signature keyId="my-key-id",algorithm="hs2019",created=[0-9]+,'
                                                 r'headers="\(request-target\) \(created\)",'
-                                                r'signature="[a-zA-Z0-9+/]+="',
+                                                r'signature="[a-zA-Z0-9+/=]+"',
                                           'User-Agent': r'OpenAPI-Generator/1.0.0/python'},
                                  preload_content=True, timeout=None)
 
@@ -433,7 +433,7 @@ class PetApiTests(unittest.TestCase):
                                  headers={'Content-Type': r'application/json',
                                           'Authorization': r'Signature keyId="my-key-id",algorithm="hs2019",created=[0-9]+,'
                                                 r'headers="\(request-target\) \(created\)",'
-                                                r'signature="[a-zA-Z0-9+/]+"',
+                                                r'signature="[a-zA-Z0-9+/=]+"',
                                           'User-Agent': r'OpenAPI-Generator/1.0.0/python'},
                                  preload_content=True, timeout=None)
 

--- a/samples/openapi3/client/petstore/python-experimental/tests/test_http_signature.py
+++ b/samples/openapi3/client/petstore/python-experimental/tests/test_http_signature.py
@@ -151,9 +151,9 @@ class MockPoolManager(object):
             "{0}: {1}".format(key.lower(), value) for key, value in signed_headers_list]
         string_to_sign = "\n".join(header_items)
         digest = None
-        if self.signing_cfg.signing_scheme in {signing.SCHEME_RSA_SHA512, signing.SCHEME_HS2019}:
+        if self.signing_cfg.hash_algorithm == signing.HASH_SHA512:
             digest = SHA512.new()
-        elif self.signing_cfg.signing_scheme == signing.SCHEME_RSA_SHA256:
+        elif self.signing_cfg.hash_algorithm == signing.HASH_SHA256:
             digest = SHA256.new()
         else:
             self._tc.fail("Unsupported signature scheme: {0}".format(self.signing_cfg.signing_scheme))
@@ -165,7 +165,7 @@ class MockPoolManager(object):
         m2 = r2.search(authorization_header)
         self._tc.assertIsNotNone(m2)
         b64_signature = m2.group(1)
-        signature = base64.b64decode(b64_signature)
+        signature = base64.b64decode(b64_signature, validate=True)
         # Build the message
         signing_alg = self.signing_cfg.signing_algorithm
         if signing_alg is None:
@@ -182,10 +182,12 @@ class MockPoolManager(object):
         elif signing_alg == signing.ALGORITHM_RSASSA_PSS:
             pss.new(self.pubkey).verify(digest, signature)
         elif signing_alg == signing.ALGORITHM_ECDSA_MODE_FIPS_186_3:
-            verifier = DSS.new(self.pubkey, signing.ALGORITHM_ECDSA_MODE_FIPS_186_3)
+            verifier = DSS.new(key=self.pubkey, mode=signing.ALGORITHM_ECDSA_MODE_FIPS_186_3,
+                                encoding='der')
             verifier.verify(digest, signature)
         elif signing_alg == signing.ALGORITHM_ECDSA_MODE_DETERMINISTIC_RFC6979:
-            verifier = DSS.new(self.pubkey, signing.ALGORITHM_ECDSA_MODE_DETERMINISTIC_RFC6979)
+            verifier = DSS.new(key=self.pubkey, mode=signing.ALGORITHM_ECDSA_MODE_DETERMINISTIC_RFC6979,
+                                encoding='der')
             verifier.verify(digest, signature)
         else:
             self._tc.fail("Unsupported signing algorithm: {0}".format(signing_alg))
@@ -411,6 +413,7 @@ class PetApiTests(unittest.TestCase):
             signing_scheme=signing.SCHEME_HS2019,
             private_key_path=privkey_path,
             private_key_passphrase=self.private_key_passphrase,
+            hash_algorithm=signing.HASH_SHA512,
             signed_headers=[
                 signing.HEADER_REQUEST_TARGET,
                 signing.HEADER_CREATED,


### PR DESCRIPTION
ECDSA signatures can be encoded using raw binary or ASN.1 encoding. This PR uses the same ASN1 encoding as the go-experimental implementation.

Add hash algorithm parameter in the configuration.py for HTTP signatures.

The IETF is still actively working on the draft and I opened an issue with the IETF HTTP working group to clarify the encoding of ECDSA signatures.

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [ ] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
