### PR TITLE
feat(r): retry configuration for status codes

### DIFF
--- a/modules/openapi-generator/src/main/resources/r/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/r/api_client.mustache
@@ -25,7 +25,7 @@
 #' @field accessToken
 #' @field timeout Default timeout in seconds
 #' @field retryStatusCodes vector of status codes to retry
-#' @field maxRetryAttemps maximum number of retries for the status codes
+#' @field maxRetryAttempts maximum number of retries for the status codes
 #' @importFrom httr add_headers accept timeout content
 {{#useRlangExceptionHandling}}
 #' @importFrom rlang abort
@@ -93,7 +93,7 @@ ApiClient  <- R6::R6Class(
       if (!is.null(retryStatusCodes)) {
         self$retryStatusCodes <- retryStatusCodes
       }
-	  
+
       if (!is.null(maxRetryAttempts)) {
         self$maxRetryAttempts <- maxRetryAttempts
       }
@@ -104,25 +104,24 @@ ApiClient  <- R6::R6Class(
       resp <- self$Execute(url, method, queryParams, headerParams, body, ...)
       statusCode <- httr::status_code(resp)
 
-      if(is.null(self$maxRetryAttempts)){
+      if (is.null(self$maxRetryAttempts)) {
         self$maxRetryAttempts = 3
       }
       
-	  if(!is.null(self$retryStatusCodes)){
+      if (!is.null(self$retryStatusCodes)) {
 
-        for(i in 1: self$maxRetryAttempts){
-          if(statusCode %in% self$retryStatusCodes){
+        for (i in 1 : self$maxRetryAttempts) {
+          if (statusCode %in% self$retryStatusCodes) {
             Sys.sleep((2 ^ i) + stats::runif(n = 1, min = 0, max = 1))
             resp <- self$Execute(url, method, queryParams, headerParams, body, ...)
             statusCode <- httr::status_code(resp)
-          }
-          else{
+          } else {
             break;
           }
-        }	  
-	  }
+        }  
+      }
 
-	  resp
+      resp
     },
 
     Execute = function(url, method, queryParams, headerParams, body, ...){

--- a/modules/openapi-generator/src/main/resources/r/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/r/api_client.mustache
@@ -24,6 +24,8 @@
 #' @field apiKeys
 #' @field accessToken
 #' @field timeout Default timeout in seconds
+#' @field retryStatusCodes vector of status codes to retry
+#' @field maxRetryAttemps maximum number of retries for the status codes
 #' @importFrom httr add_headers accept timeout content
 {{#useRlangExceptionHandling}}
 #' @importFrom rlang abort
@@ -48,8 +50,12 @@ ApiClient  <- R6::R6Class(
     accessToken = NULL,
     # Time Out (seconds)
     timeout = NULL,
+    # Vector of status codes to retry
+    retryStatusCodes=NULL,
+    # Maximum number of retry attempts for the retry status codes
+    maxRetryAttempts = NULL,
     # constructor
-    initialize = function(basePath=NULL, userAgent=NULL, defaultHeaders=NULL, username=NULL, password=NULL, apiKeys=NULL, accessToken=NULL, timeout=NULL){
+    initialize = function(basePath=NULL, userAgent=NULL, defaultHeaders=NULL, username=NULL, password=NULL, apiKeys=NULL, accessToken=NULL, timeout=NULL,  retryStatusCodes=NULL, maxRetryAttempts=NULL){
       if (!is.null(basePath)) {
         self$basePath <- basePath
       }
@@ -83,8 +89,43 @@ ApiClient  <- R6::R6Class(
       if (!is.null(timeout)) {
         self$timeout <- timeout
       }
+
+      if (!is.null(retryStatusCodes)) {
+        self$retryStatusCodes <- retryStatusCodes
+      }
+	  
+      if (!is.null(maxRetryAttempts)) {
+        self$maxRetryAttempts <- maxRetryAttempts
+      }
     },
+
     CallApi = function(url, method, queryParams, headerParams, body, ...){
+
+      resp <- self$Execute(url, method, queryParams, headerParams, body, ...)
+      statusCode <- httr::status_code(resp)
+
+      if(is.null(self$maxRetryAttempts)){
+        self$maxRetryAttempts = 3
+      }
+      
+	  if(!is.null(self$retryStatusCodes)){
+
+        for(i in 1: self$maxRetryAttempts){
+          if(statusCode %in% self$retryStatusCodes){
+            Sys.sleep((2 ^ i) + stats::runif(n = 1, min = 0, max = 1))
+            resp <- self$Execute(url, method, queryParams, headerParams, body, ...)
+            statusCode <- httr::status_code(resp)
+          }
+          else{
+            break;
+          }
+        }	  
+	  }
+
+	  resp
+    },
+
+    Execute = function(url, method, queryParams, headerParams, body, ...){
       headers <- httr::add_headers(c(headerParams, self$defaultHeaders))
 
       {{! Adding timeout that can be set at the apiClient object level}}

--- a/samples/client/petstore/R/R/api_client.R
+++ b/samples/client/petstore/R/R/api_client.R
@@ -32,7 +32,7 @@
 #' @field accessToken
 #' @field timeout Default timeout in seconds
 #' @field retryStatusCodes vector of status codes to retry
-#' @field maxRetryAttemps maximum number of retries for the status codes
+#' @field maxRetryAttempts maximum number of retries for the status codes
 #' @importFrom httr add_headers accept timeout content
 #' @export
 ApiClient  <- R6::R6Class(
@@ -97,7 +97,7 @@ ApiClient  <- R6::R6Class(
       if (!is.null(retryStatusCodes)) {
         self$retryStatusCodes <- retryStatusCodes
       }
-	  
+
       if (!is.null(maxRetryAttempts)) {
         self$maxRetryAttempts <- maxRetryAttempts
       }
@@ -108,25 +108,24 @@ ApiClient  <- R6::R6Class(
       resp <- self$Execute(url, method, queryParams, headerParams, body, ...)
       statusCode <- httr::status_code(resp)
 
-      if(is.null(self$maxRetryAttempts)){
+      if (is.null(self$maxRetryAttempts)) {
         self$maxRetryAttempts = 3
       }
       
-	  if(!is.null(self$retryStatusCodes)){
+      if (!is.null(self$retryStatusCodes)) {
 
-        for(i in 1: self$maxRetryAttempts){
-          if(statusCode %in% self$retryStatusCodes){
+        for (i in 1 : self$maxRetryAttempts) {
+          if (statusCode %in% self$retryStatusCodes) {
             Sys.sleep((2 ^ i) + stats::runif(n = 1, min = 0, max = 1))
             resp <- self$Execute(url, method, queryParams, headerParams, body, ...)
             statusCode <- httr::status_code(resp)
-          }
-          else{
+          } else {
             break;
           }
-        }	  
-	  }
+        }  
+      }
 
-	  resp
+      resp
     },
 
     Execute = function(url, method, queryParams, headerParams, body, ...){

--- a/samples/client/petstore/R/R/api_client.R
+++ b/samples/client/petstore/R/R/api_client.R
@@ -31,6 +31,8 @@
 #' @field apiKeys
 #' @field accessToken
 #' @field timeout Default timeout in seconds
+#' @field retryStatusCodes vector of status codes to retry
+#' @field maxRetryAttemps maximum number of retries for the status codes
 #' @importFrom httr add_headers accept timeout content
 #' @export
 ApiClient  <- R6::R6Class(
@@ -52,8 +54,12 @@ ApiClient  <- R6::R6Class(
     accessToken = NULL,
     # Time Out (seconds)
     timeout = NULL,
+    # Vector of status codes to retry
+    retryStatusCodes=NULL,
+    # Maximum number of retry attempts for the retry status codes
+    maxRetryAttempts = NULL,
     # constructor
-    initialize = function(basePath=NULL, userAgent=NULL, defaultHeaders=NULL, username=NULL, password=NULL, apiKeys=NULL, accessToken=NULL, timeout=NULL){
+    initialize = function(basePath=NULL, userAgent=NULL, defaultHeaders=NULL, username=NULL, password=NULL, apiKeys=NULL, accessToken=NULL, timeout=NULL,  retryStatusCodes=NULL, maxRetryAttempts=NULL){
       if (!is.null(basePath)) {
         self$basePath <- basePath
       }
@@ -87,8 +93,43 @@ ApiClient  <- R6::R6Class(
       if (!is.null(timeout)) {
         self$timeout <- timeout
       }
+
+      if (!is.null(retryStatusCodes)) {
+        self$retryStatusCodes <- retryStatusCodes
+      }
+	  
+      if (!is.null(maxRetryAttempts)) {
+        self$maxRetryAttempts <- maxRetryAttempts
+      }
     },
+
     CallApi = function(url, method, queryParams, headerParams, body, ...){
+
+      resp <- self$Execute(url, method, queryParams, headerParams, body, ...)
+      statusCode <- httr::status_code(resp)
+
+      if(is.null(self$maxRetryAttempts)){
+        self$maxRetryAttempts = 3
+      }
+      
+	  if(!is.null(self$retryStatusCodes)){
+
+        for(i in 1: self$maxRetryAttempts){
+          if(statusCode %in% self$retryStatusCodes){
+            Sys.sleep((2 ^ i) + stats::runif(n = 1, min = 0, max = 1))
+            resp <- self$Execute(url, method, queryParams, headerParams, body, ...)
+            statusCode <- httr::status_code(resp)
+          }
+          else{
+            break;
+          }
+        }	  
+	  }
+
+	  resp
+    },
+
+    Execute = function(url, method, queryParams, headerParams, body, ...){
       headers <- httr::add_headers(c(headerParams, self$defaultHeaders))
 
       httpTimeout <- NULL


### PR DESCRIPTION
Adding retry configuration that can be set on ApiClient.

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

CC @wing328 , @saigiridhar21 