### PR TITLE
[Rust Server] Bugfix #5947 multi tag generate multi method issue.

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustServerCodegen.java
@@ -1056,6 +1056,27 @@ public class RustServerCodegen extends DefaultCodegen implements CodegenConfig {
         return dataType != null && dataType.equals(typeMapping.get("File").toString());
     }
 
+    /**
+     * Add operation to group
+     *
+     * @param tag          name of the tag
+     * @param resourcePath path of the resource
+     * @param operation    OAS Operation object
+     * @param co           Codegen Operation object
+     * @param operations   map of Codegen operations
+     */
+    @SuppressWarnings("static-method")
+    @Override
+    public void addOperationToGroup(String tag, String resourcePath, Operation operation, CodegenOperation
+            co, Map<String, List<CodegenOperation>> operations) {
+        // only generate operation for the first tag of the tags
+        if (tag != null && co.tags.size() > 1 && !tag.equals(co.tags.get(0).getName())) {
+            LOGGER.info("generated skip additional tag `" + tag + "` with operationId=" + co.operationId);
+            return;
+        }
+        super.addOperationToGroup(tag, resourcePath, operation, co, operations);
+    }
+
     // This is a really terrible hack. We're working around the fact that the
     // base version of `fromRequestBody` checks to see whether the body is a
     // ref. If so, it unwraps the reference and replaces it with its inner

--- a/modules/openapi-generator/src/test/resources/3_0/rust-server/openapi-v3.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/rust-server/openapi-v3.yaml
@@ -367,7 +367,7 @@ paths:
           type: string
         required: true
     get:
-      tags: [Repo]
+      tags: [Repo, Info]
       operationId: GetRepoInfo
       responses:
         "200":

--- a/samples/server/petstore/rust-server/output/openapi-v3/api/openapi.yaml
+++ b/samples/server/petstore/rust-server/output/openapi-v3/api/openapi.yaml
@@ -380,6 +380,7 @@ paths:
           description: OK
       tags:
       - Repo
+      - Info
 components:
   schemas:
     EnumWithStarObject:

--- a/samples/server/petstore/rust-server/output/openapi-v3/docs/info_api.md
+++ b/samples/server/petstore/rust-server/output/openapi-v3/docs/info_api.md
@@ -1,0 +1,8 @@
+# info_api
+
+All URIs are relative to *http://localhost*
+
+Method | HTTP request | Description
+------------- | ------------- | -------------
+
+

--- a/samples/server/petstore/rust-server/output/openapi-v3/docs/repo_api.md
+++ b/samples/server/petstore/rust-server/output/openapi-v3/docs/repo_api.md
@@ -1,0 +1,34 @@
+# repo_api
+
+All URIs are relative to *http://localhost*
+
+Method | HTTP request | Description
+------------- | ------------- | -------------
+**GetRepoInfo**](repo_api.md#GetRepoInfo) | **GET** /repos/{repoId} | 
+
+
+# **GetRepoInfo**
+> String GetRepoInfo(repo_id)
+
+
+### Required Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+  **repo_id** | **String**|  | 
+
+### Return type
+
+[**String**](string.md)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: application/json
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+


### PR DESCRIPTION
#5947  [BUG] [Rust Server] Generated code with yaml multi tag compile error.

### Rust Server Technical Committee

- @frol
- @farcaller 
- @bjgill

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
