### PR TITLE
fixed README/doc of bearer auth support for csharp-netcore

### DIFF
--- a/modules/openapi-generator/src/main/resources/csharp-netcore/README.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/README.mustache
@@ -105,11 +105,15 @@ namespace Example
             config.BasePath = "{{{basePath}}}";
             {{#hasAuthMethods}}
             {{#authMethods}}
-            {{#isBasic}}
+            {{#isBasicBasic}}
             // Configure HTTP basic authorization: {{{name}}}
             config.Username = "YOUR_USERNAME";
             config.Password = "YOUR_PASSWORD";
-            {{/isBasic}}
+            {{/isBasicBasic}}
+            {{#isBasicBearer}}
+            // Configure Bearer token for authorization: {{{name}}}
+            config.AccessToken = "YOUR_BEARER_TOKEN";
+            {{/isBasicBearer}}
             {{#isApiKey}}
             // Configure API key authorization: {{{name}}}
             config.ApiKey.Add("{{{keyParamName}}}", "YOUR_API_KEY");
@@ -193,8 +197,10 @@ Authentication schemes defined for the API:
 - **API key parameter name**: {{keyParamName}}
 - **Location**: {{#isKeyInQuery}}URL query string{{/isKeyInQuery}}{{#isKeyInHeader}}HTTP header{{/isKeyInHeader}}
 {{/isApiKey}}
-{{#isBasic}}- **Type**: HTTP basic authentication
-{{/isBasic}}
+{{#isBasicBasic}}- **Type**: HTTP basic authentication
+{{/isBasicBasic}}
+{{#isBasicBearer}}- **Type**: Bearer Authentication
+{{/isBasicBearer}}
 {{#isOAuth}}- **Type**: OAuth
 - **Flow**: {{flow}}
 - **Authorization URL**: {{authorizationUrl}}

--- a/modules/openapi-generator/src/main/resources/csharp-netcore/api_doc.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/api_doc.mustache
@@ -36,11 +36,15 @@ namespace Example
             config.BasePath = "{{{basePath}}}";
             {{#hasAuthMethods}}
             {{#authMethods}}
-            {{#isBasic}}
+            {{#isBasicBasic}}
             // Configure HTTP basic authorization: {{{name}}}
             config.Username = "YOUR_USERNAME";
             config.Password = "YOUR_PASSWORD";
-            {{/isBasic}}
+            {{/isBasicBasic}}
+            {{#isBasicBearer}}
+            // Configure Bearer token for authorization: {{{name}}}
+            config.AccessToken = "YOUR_BEARER_TOKEN";
+            {{/isBasicBearer}}
             {{#isApiKey}}
             // Configure API key authorization: {{{name}}}
             config.AddApiKey("{{{keyParamName}}}", "YOUR_API_KEY");


### PR DESCRIPTION
Fixed README/doc generation after bearer support added by @wing328 #5921 for issue #5915

@mandrean (2017/08), @jimschubert (2017/09) heart @frankyjuang (2019/09) @shibayan (2020/02)

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
