### PR TITLE
[feat] Allow configuration of yaml minimize quotes

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonAbstractConnexionServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonAbstractConnexionServerCodegen.java
@@ -594,6 +594,7 @@ public class PythonAbstractConnexionServerCodegen extends DefaultCodegen impleme
             }
         }
 
+        generateJSONSpecFile(objs);
         generateYAMLSpecFile(objs);
 
         for (Map<String, Object> operations : getOperations(objs)) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/serializer/SerializerUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/serializer/SerializerUtils.java
@@ -2,25 +2,38 @@ package org.openapitools.codegen.serializer;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
-import io.swagger.v3.core.util.Yaml;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
 import io.swagger.v3.core.util.Json;
+import io.swagger.v3.core.util.Yaml;
 import io.swagger.v3.oas.models.OpenAPI;
+import org.openapitools.codegen.config.GlobalSettings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class SerializerUtils {
     private static final Logger LOGGER = LoggerFactory.getLogger(SerializerUtils.class);
+    private static final String YAML_MINIMIZE_QUOTES_PROPERTY = "org.openapitools.codegen.utils.yaml.minimize.quotes";
+    private static final boolean minimizeYamlQuotes = Boolean.parseBoolean(GlobalSettings.getProperty(YAML_MINIMIZE_QUOTES_PROPERTY, "true"));
 
     public static String toYamlString(OpenAPI openAPI) {
-        if(openAPI == null) {
+        if (openAPI == null) {
             return null;
         }
         SimpleModule module = createModule();
         try {
-            return Yaml.mapper()
-                    .copy()
-                    .registerModule(module)
+            ObjectMapper yamlMapper = Yaml.mapper().copy();
+            // there is an unfortunate YAML condition where user inputs should be treated as strings (e.g. "1234_1234"), but in yaml this is a valid number and
+            // removing quotes forcibly by default means we are potentially doing a data conversion resulting in an unexpected change to the user's YAML outputs.
+            // We may allow for property-based enable/disable, retaining the default of enabled for backward compatibility.
+            if (minimizeYamlQuotes) {
+                ((YAMLFactory) yamlMapper.getFactory()).enable(YAMLGenerator.Feature.MINIMIZE_QUOTES);
+            } else {
+                ((YAMLFactory) yamlMapper.getFactory()).disable(YAMLGenerator.Feature.MINIMIZE_QUOTES);
+            }
+            return yamlMapper.registerModule(module)
                     .configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true)
                     .writeValueAsString(openAPI)
                     .replace("\r\n", "\n");
@@ -34,7 +47,7 @@ public class SerializerUtils {
         if (openAPI == null) {
             return null;
         }
-        
+
         SimpleModule module = createModule();
         try {
             return Json.mapper()


### PR DESCRIPTION
There are cases where minimizing quotes results in invalid YAML. For example, an input YAML with string "1234_1234" will be converted to YAML value 1234_1234 which is an int in YAML 1.1 (https://yaml.org/type/int.html)

The only option in these cases is to either:

* Revert the option completely to always quote values
* Provide a user-customization to disable quotes minimization

This applies the latter with the assumption that this is an edge case and users who are unaffected will default to the "prettier" version.

An alternative would be to write a custom serializer for strings, and if they are in the format of of any of the valid formats defined in YAML:

```
[-+]?0b[0-1_]+ # (base 2)
|[-+]?0[0-7_]+ # (base 8)
|[-+]?(0|[1-9][0-9_]*) # (base 10)
|[-+]?0x[0-9a-fA-F_]+ # (base 16)
|[-+]?[1-9][0-9_]*(:[0-5]?[0-9])+ # (base 60)
```

Then wrap the result in quotes. That approach was not taken because of the potential for significant performance impact on very large specs, which our users are often tasked with transforming.

This is related to #3237, which wouldn't be a viable solution because it would remove support for OpenAPI 3.0 types and remove a handful of default configurations in the new YAML factory.

Users who are affected by this edge case or others resulting in the removal of quotes will be able to generate with the system property:

```
-Dorg.openapitools.codegen.utils.yaml.minimize.quotes=false
```

This will result in quote behavior similar to the Swagger YAML 1.x/2.x implementation without removing the new expectations for OpenAPI 3.x types.

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

cc @OpenAPITools/generator-core-team 