### PR TITLE
return a null instead of application/json when no content types are set

### DIFF
--- a/modules/openapi-generator/src/main/resources/csharp-netcore/ClientUtils.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/ClientUtils.mustache
@@ -169,7 +169,7 @@ namespace {{packageName}}.Client
         public static String SelectHeaderContentType(String[] contentTypes)
         {
             if (contentTypes.Length == 0)
-                return "application/json";
+                return null;
 
             foreach (var contentType in contentTypes)
             {

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Client/ClientUtils.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Client/ClientUtils.cs
@@ -174,7 +174,7 @@ namespace Org.OpenAPITools.Client
         public static String SelectHeaderContentType(String[] contentTypes)
         {
             if (contentTypes.Length == 0)
-                return "application/json";
+                return null;
 
             foreach (var contentType in contentTypes)
             {

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Client/ClientUtils.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Client/ClientUtils.cs
@@ -174,7 +174,7 @@ namespace Org.OpenAPITools.Client
         public static String SelectHeaderContentType(String[] contentTypes)
         {
             if (contentTypes.Length == 0)
-                return "application/json";
+                return null;
 
             foreach (var contentType in contentTypes)
             {


### PR DESCRIPTION
For GET-methods no Content-Type is required, since there is no body. This has been requested and discussed already at #476 and #1061. This is the dotnet-core implementation of it, since I only have the capabilities to do it for that right now. I came across an API that reacts differently depending on the content type, thats why I fixed this here.

@mandrean (2017/08), @jimschubert (2017/09) heart @frankyjuang (2019/09) @shibayan (2020/02)

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
