### PR TITLE
[python/asyncio] fix passing proxy parameters to aiohttp

### DIFF
--- a/modules/openapi-generator/src/main/resources/python/asyncio/rest.mustache
+++ b/modules/openapi-generator/src/main/resources/python/asyncio/rest.mustache
@@ -65,16 +65,13 @@ class RESTClientObject(object):
             ssl=ssl_context
         )
 
+        self.proxy = configuration.proxy
+        self.proxy_headers = configuration.proxy_headers
+
         # https pool manager
-        if configuration.proxy:
-            self.pool_manager = aiohttp.ClientSession(
-                connector=connector,
-                proxy=configuration.proxy
-            )
-        else:
-            self.pool_manager = aiohttp.ClientSession(
-                connector=connector
-            )
+        self.pool_manager = aiohttp.ClientSession(
+            connector=connector
+        )
 
     async def close(self):
         await self.pool_manager.close()
@@ -121,6 +118,11 @@ class RESTClientObject(object):
             "timeout": timeout,
             "headers": headers
         }
+
+        if self.proxy:
+            args["proxy"] = self.proxy
+        if self.proxy_headers:
+            args["proxy_headers"] = self.proxy_headers
 
         if query_params:
             args["url"] += '?' + urlencode(query_params)

--- a/samples/client/petstore/python-asyncio/petstore_api/rest.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/rest.py
@@ -73,16 +73,13 @@ class RESTClientObject(object):
             ssl=ssl_context
         )
 
+        self.proxy = configuration.proxy
+        self.proxy_headers = configuration.proxy_headers
+
         # https pool manager
-        if configuration.proxy:
-            self.pool_manager = aiohttp.ClientSession(
-                connector=connector,
-                proxy=configuration.proxy
-            )
-        else:
-            self.pool_manager = aiohttp.ClientSession(
-                connector=connector
-            )
+        self.pool_manager = aiohttp.ClientSession(
+            connector=connector
+        )
 
     async def close(self):
         await self.pool_manager.close()
@@ -129,6 +126,11 @@ class RESTClientObject(object):
             "timeout": timeout,
             "headers": headers
         }
+
+        if self.proxy:
+            args["proxy"] = self.proxy
+        if self.proxy_headers:
+            args["proxy_headers"] = self.proxy_headers
 
         if query_params:
             args["url"] += '?' + urlencode(query_params)

--- a/samples/client/petstore/python-asyncio/tests/test_pet_api.py
+++ b/samples/client/petstore/python-asyncio/tests/test_pet_api.py
@@ -192,6 +192,19 @@ class TestPetApiTests(unittest.TestCase):
         except ApiException as e:
             self.assertEqual(404, e.status)
 
+    @async_test
+    async def test_proxy(self):
+        config = Configuration()
+        # set not-existent proxy and catch an error to verify that
+        # the client library (aiohttp) tried to use it.
+        config.proxy = 'http://localhost:8080/proxy'
+        async with petstore_api.ApiClient(config) as client:
+            pet_api = petstore_api.PetApi(client)
+
+            with self.assertRaisesRegex(petstore_api.rest.aiohttp.client_exceptions.ClientProxyConnectionError,
+                                        'Cannot connect to host localhost:8080'):
+                await pet_api.get_pet_by_id(self.pet.id)
+
 
 if __name__ == '__main__':
     import logging


### PR DESCRIPTION
API Client will fail if proxy parameters are passed. `aiohttp` raises `unexpected keyword argument 'proxy'` - `query()` method accepts them instead of the constructor.

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

Please review: @taxpon (2017/07) @frol (2017/07) @mbohlool (2017/07) @cbornet (2017/09) @kenjones-cisco (2017/11) @tomplus (2018/10) @Jyhess (2019/01) @slash-arun (2019/11) @spacether (2019/11)