### PR TITLE
[Rust Server] Bugfix #5948 (Generated client code "Disabled because there's no example")

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustServerCodegen.java
@@ -1159,7 +1159,8 @@ public class RustServerCodegen extends DefaultCodegen implements CodegenConfig {
             // defined.
             if (codegenParameter.vendorExtensions != null && codegenParameter.vendorExtensions.containsKey("x-example")) {
                 codegenParameter.example = Json.pretty(codegenParameter.vendorExtensions.get("x-example"));
-            } else {
+            } else if (!codegenParameter.required) {
+                //mandatory parameter use the example in the yaml. if no example, it is also null.
                 codegenParameter.example = null;
             }
         }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustServerCodegen.java
@@ -1651,7 +1651,7 @@ public class RustServerCodegen extends DefaultCodegen implements CodegenConfig {
             param.vendorExtensions.put("formatString", "{:?}"); // TODO: 5.0 Remove
             param.vendorExtensions.put("x-format-string", "{:?}");
             if (param.example != null) {
-                example = "serde_json::from_str::<" + param.dataType + ">(\"" + param.example + "\").expect(\"Failed to parse JSON example\")";
+                example = "serde_json::from_str::<" + param.dataType + ">(r#\"" + param.example + "\"#).expect(\"Failed to parse JSON example\")";
             }
         }
 

--- a/modules/openapi-generator/src/main/resources/rust-server/example-client-main.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/example-client-main.mustache
@@ -31,7 +31,7 @@ mod server;
 #[allow(unused_imports)]
 use futures::{Future, future, Stream, stream};
 #[allow(unused_imports)]
-use {{{externCrateName}}}::{Api, ApiNoContext, Client, ContextWrapperExt,
+use {{{externCrateName}}}::{Api, ApiNoContext, Client, ContextWrapperExt, models,
                       ApiError{{#apiInfo}}{{#apis}}{{#operations}}{{#operation}},
                       {{{operationId}}}Response{{/operation}}{{/operations}}{{/apis}}{{/apiInfo}}
                      };

--- a/modules/openapi-generator/src/test/resources/3_0/rust-server/openapi-v3.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/rust-server/openapi-v3.yaml
@@ -371,6 +371,22 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/StringObject"
+  /repos:
+    post:
+      tags: [Repo]
+      operationId: CreateRepo
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ObjectParam"
+            example:
+              # Properties of a referenced object
+              requiredParam: true
+      responses:
+        '200':
+          description: Success
 
 components:
   securitySchemes:

--- a/samples/server/petstore/rust-server/output/multipart-v3/examples/client/main.rs
+++ b/samples/server/petstore/rust-server/output/multipart-v3/examples/client/main.rs
@@ -15,7 +15,7 @@ extern crate tokio;
 #[allow(unused_imports)]
 use futures::{Future, future, Stream, stream};
 #[allow(unused_imports)]
-use multipart_v3::{Api, ApiNoContext, Client, ContextWrapperExt,
+use multipart_v3::{Api, ApiNoContext, Client, ContextWrapperExt, models,
                       ApiError,
                       MultipartRelatedRequestPostResponse,
                       MultipartRequestPostResponse,

--- a/samples/server/petstore/rust-server/output/no-example-v3/examples/client/main.rs
+++ b/samples/server/petstore/rust-server/output/no-example-v3/examples/client/main.rs
@@ -15,7 +15,7 @@ extern crate tokio;
 #[allow(unused_imports)]
 use futures::{Future, future, Stream, stream};
 #[allow(unused_imports)]
-use no_example_v3::{Api, ApiNoContext, Client, ContextWrapperExt,
+use no_example_v3::{Api, ApiNoContext, Client, ContextWrapperExt, models,
                       ApiError,
                       OpGetResponse
                      };

--- a/samples/server/petstore/rust-server/output/openapi-v3/README.md
+++ b/samples/server/petstore/rust-server/output/openapi-v3/README.md
@@ -81,6 +81,7 @@ cargo run --example client XmlOtherPost
 cargo run --example client XmlOtherPut
 cargo run --example client XmlPost
 cargo run --example client XmlPut
+cargo run --example client CreateRepo
 cargo run --example client GetRepoInfo
 ```
 
@@ -136,6 +137,7 @@ Method | HTTP request | Description
 [****](docs/default_api.md#) | **PUT** /xml_other | 
 [****](docs/default_api.md#) | **POST** /xml | Post an array
 [****](docs/default_api.md#) | **PUT** /xml | 
+[**CreateRepo**](docs/repo_api.md#CreateRepo) | **POST** /repos | 
 [**GetRepoInfo**](docs/repo_api.md#GetRepoInfo) | **GET** /repos/{repoId} | 
 
 

--- a/samples/server/petstore/rust-server/output/openapi-v3/api/openapi.yaml
+++ b/samples/server/petstore/rust-server/output/openapi-v3/api/openapi.yaml
@@ -385,6 +385,22 @@ paths:
       tags:
       - Repo
       - Info
+  /repos:
+    post:
+      operationId: CreateRepo
+      requestBody:
+        content:
+          application/json:
+            example:
+              requiredParam: true
+            schema:
+              $ref: '#/components/schemas/ObjectParam'
+        required: true
+      responses:
+        "200":
+          description: Success
+      tags:
+      - Repo
 components:
   schemas:
     EnumWithStarObject:
@@ -495,6 +511,9 @@ components:
       - required_untyped_nullable
       type: object
     ObjectParam:
+      example:
+        requiredParam: true
+        optionalParam: 0
       properties:
         requiredParam:
           type: boolean

--- a/samples/server/petstore/rust-server/output/openapi-v3/docs/info_api.md
+++ b/samples/server/petstore/rust-server/output/openapi-v3/docs/info_api.md
@@ -1,8 +1,0 @@
-# info_api
-
-All URIs are relative to *http://localhost*
-
-Method | HTTP request | Description
-------------- | ------------- | -------------
-
-

--- a/samples/server/petstore/rust-server/output/openapi-v3/docs/repo_api.md
+++ b/samples/server/petstore/rust-server/output/openapi-v3/docs/repo_api.md
@@ -4,8 +4,34 @@ All URIs are relative to *http://localhost*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
+**CreateRepo**](repo_api.md#CreateRepo) | **POST** /repos | 
 **GetRepoInfo**](repo_api.md#GetRepoInfo) | **GET** /repos/{repoId} | 
 
+
+# **CreateRepo**
+> CreateRepo(object_param)
+
+
+### Required Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+  **object_param** | [**ObjectParam**](ObjectParam.md)|  | 
+
+### Return type
+
+ (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: application/json
+ - **Accept**: Not defined
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **GetRepoInfo**
 > String GetRepoInfo(repo_id)

--- a/samples/server/petstore/rust-server/output/openapi-v3/examples/client/main.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/examples/client/main.rs
@@ -27,7 +27,7 @@ mod server;
 #[allow(unused_imports)]
 use futures::{Future, future, Stream, stream};
 #[allow(unused_imports)]
-use openapi_v3::{Api, ApiNoContext, Client, ContextWrapperExt,
+use openapi_v3::{Api, ApiNoContext, Client, ContextWrapperExt, models,
                       ApiError,
                       CallbackWithHeaderPostResponse,
                       ComplexQueryParamGetResponse,
@@ -88,6 +88,7 @@ fn main() {
                 "XmlOtherPut",
                 "XmlPost",
                 "XmlPut",
+                "CreateRepo",
                 "GetRepoInfo",
             ])
             .required(true)
@@ -183,7 +184,7 @@ fn main() {
         },
         Some("ParamgetGet") => {
             let result = rt.block_on(client.paramget_get(
-                  Some(serde_json::from_str::<uuid::Uuid>("38400000-8cf0-11bd-b23e-10b96e4ef00d").expect("Failed to parse JSON example")),
+                  Some(serde_json::from_str::<uuid::Uuid>(r#"38400000-8cf0-11bd-b23e-10b96e4ef00d"#).expect("Failed to parse JSON example")),
                   None,
                   None
             ));
@@ -257,14 +258,12 @@ fn main() {
             ));
             info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
-        /* Disabled because there's no example.
         Some("CreateRepo") => {
             let result = rt.block_on(client.create_repo(
-                  ???
+                  serde_json::from_str::<models::ObjectParam>(r#"{"requiredParam":true}"#).expect("Failed to parse JSON example")
             ));
             info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
-        */
         Some("GetRepoInfo") => {
             let result = rt.block_on(client.get_repo_info(
                   "repo_id_example".to_string()

--- a/samples/server/petstore/rust-server/output/openapi-v3/examples/client/main.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/examples/client/main.rs
@@ -50,6 +50,7 @@ use openapi_v3::{Api, ApiNoContext, Client, ContextWrapperExt,
                       XmlOtherPutResponse,
                       XmlPostResponse,
                       XmlPutResponse,
+                      CreateRepoResponse,
                       GetRepoInfoResponse
                      };
 use clap::{App, Arg};
@@ -256,6 +257,14 @@ fn main() {
             ));
             info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
+        /* Disabled because there's no example.
+        Some("CreateRepo") => {
+            let result = rt.block_on(client.create_repo(
+                  ???
+            ));
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
+        },
+        */
         Some("GetRepoInfo") => {
             let result = rt.block_on(client.get_repo_info(
                   "repo_id_example".to_string()

--- a/samples/server/petstore/rust-server/output/openapi-v3/examples/server/server.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/examples/server/server.rs
@@ -126,6 +126,7 @@ use openapi_v3::{
     XmlOtherPutResponse,
     XmlPostResponse,
     XmlPutResponse,
+    CreateRepoResponse,
     GetRepoInfoResponse,
 };
 use openapi_v3::server::MakeService;
@@ -335,6 +336,16 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
     {
         let context = context.clone();
         info!("xml_put({:?}) - X-Span-ID: {:?}", xml_object, context.get().0.clone());
+        Box::new(future::err("Generic failure".into()))
+    }
+
+    fn create_repo(
+        &self,
+        object_param: models::ObjectParam,
+        context: &C) -> Box<dyn Future<Item=CreateRepoResponse, Error=ApiError> + Send>
+    {
+        let context = context.clone();
+        info!("create_repo({:?}) - X-Span-ID: {:?}", object_param, context.get().0.clone());
         Box::new(future::err("Generic failure".into()))
     }
 

--- a/samples/server/petstore/rust-server/output/openapi-v3/src/client/mod.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/src/client/mod.rs
@@ -56,6 +56,7 @@ use {Api,
      XmlOtherPutResponse,
      XmlPostResponse,
      XmlPutResponse,
+     CreateRepoResponse,
      GetRepoInfoResponse
      };
 
@@ -2207,6 +2208,87 @@ impl<C, F> Api<C> for Client<F> where
                     Box::new(
                         future::ok(
                             XmlPutResponse::BadRequest
+                        )
+                    ) as Box<dyn Future<Item=_, Error=_> + Send>
+                },
+                code => {
+                    let headers = response.headers().clone();
+                    Box::new(response.into_body()
+                            .take(100)
+                            .concat2()
+                            .then(move |body|
+                                future::err(ApiError(format!("Unexpected response code {}:\n{:?}\n\n{}",
+                                    code,
+                                    headers,
+                                    match body {
+                                        Ok(ref body) => match str::from_utf8(body) {
+                                            Ok(body) => Cow::from(body),
+                                            Err(e) => Cow::from(format!("<Body was not UTF8: {:?}>", e)),
+                                        },
+                                        Err(e) => Cow::from(format!("<Failed to read body: {}>", e)),
+                                    })))
+                            )
+                    ) as Box<dyn Future<Item=_, Error=_> + Send>
+                }
+            }
+        }))
+    }
+
+    fn create_repo(
+        &self,
+        param_object_param: models::ObjectParam,
+        context: &C) -> Box<dyn Future<Item=CreateRepoResponse, Error=ApiError> + Send>
+    {
+        let mut uri = format!(
+            "{}/repos",
+            self.base_path
+        );
+
+        // Query parameters
+        let mut query_string = url::form_urlencoded::Serializer::new("".to_owned());
+        let query_string_str = query_string.finish();
+        if !query_string_str.is_empty() {
+            uri += "?";
+            uri += &query_string_str;
+        }
+
+        let uri = match Uri::from_str(&uri) {
+            Ok(uri) => uri,
+            Err(err) => return Box::new(future::err(ApiError(format!("Unable to build URI: {}", err)))),
+        };
+
+        let mut request = match hyper::Request::builder()
+            .method("POST")
+            .uri(uri)
+            .body(Body::empty()) {
+                Ok(req) => req,
+                Err(e) => return Box::new(future::err(ApiError(format!("Unable to create request: {}", e))))
+        };
+
+        // Body parameter
+        let body = serde_json::to_string(&param_object_param).expect("impossible to fail to serialize");
+                *request.body_mut() = Body::from(body);
+
+        let header = "application/json";
+        request.headers_mut().insert(CONTENT_TYPE, match HeaderValue::from_str(header) {
+            Ok(h) => h,
+            Err(e) => return Box::new(future::err(ApiError(format!("Unable to create header: {} - {}", header, e))))
+        });
+        let header = HeaderValue::from_str((context as &dyn Has<XSpanIdString>).get().0.clone().to_string().as_str());
+        request.headers_mut().insert(HeaderName::from_static("x-span-id"), match header {
+            Ok(h) => h,
+            Err(e) => return Box::new(future::err(ApiError(format!("Unable to create X-Span ID header value: {}", e))))
+        });
+
+        Box::new(self.client_service.request(request)
+                             .map_err(|e| ApiError(format!("No response received: {}", e)))
+                             .and_then(|mut response| {
+            match response.status().as_u16() {
+                200 => {
+                    let body = response.into_body();
+                    Box::new(
+                        future::ok(
+                            CreateRepoResponse::Success
                         )
                     ) as Box<dyn Future<Item=_, Error=_> + Send>
                 },

--- a/samples/server/petstore/rust-server/output/openapi-v3/src/lib.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/src/lib.rs
@@ -260,6 +260,12 @@ pub enum XmlPutResponse {
 }
 
 #[derive(Debug, PartialEq)]
+pub enum CreateRepoResponse {
+    /// Success
+    Success
+}
+
+#[derive(Debug, PartialEq)]
 pub enum GetRepoInfoResponse {
     /// OK
     OK
@@ -369,6 +375,11 @@ pub trait Api<C> {
         &self,
         xml_object: Option<models::XmlObject>,
         context: &C) -> Box<dyn Future<Item=XmlPutResponse, Error=ApiError> + Send>;
+
+    fn create_repo(
+        &self,
+        object_param: models::ObjectParam,
+        context: &C) -> Box<dyn Future<Item=CreateRepoResponse, Error=ApiError> + Send>;
 
     fn get_repo_info(
         &self,
@@ -480,6 +491,11 @@ pub trait ApiNoContext {
         &self,
         xml_object: Option<models::XmlObject>,
         ) -> Box<dyn Future<Item=XmlPutResponse, Error=ApiError> + Send>;
+
+    fn create_repo(
+        &self,
+        object_param: models::ObjectParam,
+        ) -> Box<dyn Future<Item=CreateRepoResponse, Error=ApiError> + Send>;
 
     fn get_repo_info(
         &self,
@@ -664,6 +680,14 @@ impl<'a, T: Api<C>, C> ApiNoContext for ContextWrapper<'a, T, C> {
         ) -> Box<dyn Future<Item=XmlPutResponse, Error=ApiError> + Send>
     {
         self.api().xml_put(xml_object, &self.context())
+    }
+
+    fn create_repo(
+        &self,
+        object_param: models::ObjectParam,
+        ) -> Box<dyn Future<Item=CreateRepoResponse, Error=ApiError> + Send>
+    {
+        self.api().create_repo(object_param, &self.context())
     }
 
     fn get_repo_info(

--- a/samples/server/petstore/rust-server/output/openapi-v3/src/server/mod.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/src/server/mod.rs
@@ -43,6 +43,7 @@ use {Api,
      XmlOtherPutResponse,
      XmlPostResponse,
      XmlPutResponse,
+     CreateRepoResponse,
      GetRepoInfoResponse
 };
 
@@ -64,6 +65,7 @@ mod paths {
             r"^/paramget$",
             r"^/readonly_auth_scheme$",
             r"^/register-callback$",
+            r"^/repos$",
             r"^/repos/(?P<repoId>[^/?#]*)$",
             r"^/required_octet_stream$",
             r"^/responses_with_headers$",
@@ -92,20 +94,21 @@ mod paths {
     pub static ID_PARAMGET: usize = 8;
     pub static ID_READONLY_AUTH_SCHEME: usize = 9;
     pub static ID_REGISTER_CALLBACK: usize = 10;
-    pub static ID_REPOS_REPOID: usize = 11;
+    pub static ID_REPOS: usize = 11;
+    pub static ID_REPOS_REPOID: usize = 12;
     lazy_static! {
         pub static ref REGEX_REPOS_REPOID: regex::Regex =
             regex::Regex::new(r"^/repos/(?P<repoId>[^/?#]*)$")
                 .expect("Unable to create regex for REPOS_REPOID");
     }
-    pub static ID_REQUIRED_OCTET_STREAM: usize = 12;
-    pub static ID_RESPONSES_WITH_HEADERS: usize = 13;
-    pub static ID_RFC7807: usize = 14;
-    pub static ID_UNTYPED_PROPERTY: usize = 15;
-    pub static ID_UUID: usize = 16;
-    pub static ID_XML: usize = 17;
-    pub static ID_XML_EXTRA: usize = 18;
-    pub static ID_XML_OTHER: usize = 19;
+    pub static ID_REQUIRED_OCTET_STREAM: usize = 13;
+    pub static ID_RESPONSES_WITH_HEADERS: usize = 14;
+    pub static ID_RFC7807: usize = 15;
+    pub static ID_UNTYPED_PROPERTY: usize = 16;
+    pub static ID_UUID: usize = 17;
+    pub static ID_XML: usize = 18;
+    pub static ID_XML_EXTRA: usize = 19;
+    pub static ID_XML_OTHER: usize = 20;
 }
 
 pub struct MakeService<T, RC> {
@@ -1520,6 +1523,85 @@ where
                 ) as Self::Future
             },
 
+            // CreateRepo - POST /repos
+            &hyper::Method::POST if path.matched(paths::ID_REPOS) => {
+                // Body parameters (note that non-required body parameters will ignore garbage
+                // values, rather than causing a 400 response). Produce warning header and logs for
+                // any unused fields.
+                Box::new(body.concat2()
+                    .then(move |result| -> Self::Future {
+                        match result {
+                            Ok(body) => {
+                                let mut unused_elements = Vec::new();
+                                let param_object_param: Option<models::ObjectParam> = if !body.is_empty() {
+                                    let deserializer = &mut serde_json::Deserializer::from_slice(&*body);
+                                    match serde_ignored::deserialize(deserializer, |path| {
+                                            warn!("Ignoring unknown field in body: {}", path);
+                                            unused_elements.push(path.to_string());
+                                    }) {
+                                        Ok(param_object_param) => param_object_param,
+                                        Err(e) => return Box::new(future::ok(Response::builder()
+                                                        .status(StatusCode::BAD_REQUEST)
+                                                        .body(Body::from(format!("Couldn't parse body parameter ObjectParam - doesn't match schema: {}", e)))
+                                                        .expect("Unable to create Bad Request response for invalid body parameter ObjectParam due to schema"))),
+                                    }
+                                } else {
+                                    None
+                                };
+                                let param_object_param = match param_object_param {
+                                    Some(param_object_param) => param_object_param,
+                                    None => return Box::new(future::ok(Response::builder()
+                                                        .status(StatusCode::BAD_REQUEST)
+                                                        .body(Body::from("Missing required body parameter ObjectParam"))
+                                                        .expect("Unable to create Bad Request response for missing body parameter ObjectParam"))),
+                                };
+
+                                Box::new(
+                                    api_impl.create_repo(
+                                            param_object_param,
+                                        &context
+                                    ).then(move |result| {
+                                        let mut response = Response::new(Body::empty());
+                                        response.headers_mut().insert(
+                                            HeaderName::from_static("x-span-id"),
+                                            HeaderValue::from_str((&context as &dyn Has<XSpanIdString>).get().0.clone().to_string().as_str())
+                                                .expect("Unable to create X-Span-ID header value"));
+
+                                        if !unused_elements.is_empty() {
+                                            response.headers_mut().insert(
+                                                HeaderName::from_static("warning"),
+                                                HeaderValue::from_str(format!("Ignoring unknown fields in body: {:?}", unused_elements).as_str())
+                                                    .expect("Unable to create Warning header value"));
+                                        }
+
+                                        match result {
+                                            Ok(rsp) => match rsp {
+                                                CreateRepoResponse::Success
+                                                => {
+                                                    *response.status_mut() = StatusCode::from_u16(200).expect("Unable to turn 200 into a StatusCode");
+                                                },
+                                            },
+                                            Err(_) => {
+                                                // Application code returned an error. This should not happen, as the implementation should
+                                                // return a valid response.
+                                                *response.status_mut() = StatusCode::INTERNAL_SERVER_ERROR;
+                                                *response.body_mut() = Body::from("An internal error occurred");
+                                            },
+                                        }
+
+                                        future::ok(response)
+                                    }
+                                ))
+                            },
+                            Err(e) => Box::new(future::ok(Response::builder()
+                                                .status(StatusCode::BAD_REQUEST)
+                                                .body(Body::from(format!("Couldn't read body parameter ObjectParam: {}", e)))
+                                                .expect("Unable to create Bad Request response due to unable to read body parameter ObjectParam"))),
+                        }
+                    })
+                ) as Self::Future
+            },
+
             // GetRepoInfo - GET /repos/{repoId}
             &hyper::Method::GET if path.matched(paths::ID_REPOS_REPOID) => {
                 // Path parameters
@@ -1598,6 +1680,7 @@ where
             _ if path.matched(paths::ID_PARAMGET) => method_not_allowed(),
             _ if path.matched(paths::ID_READONLY_AUTH_SCHEME) => method_not_allowed(),
             _ if path.matched(paths::ID_REGISTER_CALLBACK) => method_not_allowed(),
+            _ if path.matched(paths::ID_REPOS) => method_not_allowed(),
             _ if path.matched(paths::ID_REPOS_REPOID) => method_not_allowed(),
             _ if path.matched(paths::ID_REQUIRED_OCTET_STREAM) => method_not_allowed(),
             _ if path.matched(paths::ID_RESPONSES_WITH_HEADERS) => method_not_allowed(),
@@ -1674,6 +1757,8 @@ impl<T> RequestParser<T> for ApiRequestParser {
             &hyper::Method::POST if path.matched(paths::ID_XML) => Ok("XmlPost"),
             // XmlPut - PUT /xml
             &hyper::Method::PUT if path.matched(paths::ID_XML) => Ok("XmlPut"),
+            // CreateRepo - POST /repos
+            &hyper::Method::POST if path.matched(paths::ID_REPOS) => Ok("CreateRepo"),
             // GetRepoInfo - GET /repos/{repoId}
             &hyper::Method::GET if path.matched(paths::ID_REPOS_REPOID) => Ok("GetRepoInfo"),
             _ => Err(()),

--- a/samples/server/petstore/rust-server/output/ops-v3/examples/client/main.rs
+++ b/samples/server/petstore/rust-server/output/ops-v3/examples/client/main.rs
@@ -15,7 +15,7 @@ extern crate tokio;
 #[allow(unused_imports)]
 use futures::{Future, future, Stream, stream};
 #[allow(unused_imports)]
-use ops_v3::{Api, ApiNoContext, Client, ContextWrapperExt,
+use ops_v3::{Api, ApiNoContext, Client, ContextWrapperExt, models,
                       ApiError,
                       Op10GetResponse,
                       Op11GetResponse,

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/examples/client/main.rs
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/examples/client/main.rs
@@ -15,7 +15,7 @@ extern crate tokio;
 #[allow(unused_imports)]
 use futures::{Future, future, Stream, stream};
 #[allow(unused_imports)]
-use petstore_with_fake_endpoints_models_for_testing::{Api, ApiNoContext, Client, ContextWrapperExt,
+use petstore_with_fake_endpoints_models_for_testing::{Api, ApiNoContext, Client, ContextWrapperExt, models,
                       ApiError,
                       TestSpecialTagsResponse,
                       Call123exampleResponse,

--- a/samples/server/petstore/rust-server/output/rust-server-test/examples/client/main.rs
+++ b/samples/server/petstore/rust-server/output/rust-server-test/examples/client/main.rs
@@ -15,7 +15,7 @@ extern crate tokio;
 #[allow(unused_imports)]
 use futures::{Future, future, Stream, stream};
 #[allow(unused_imports)]
-use rust_server_test::{Api, ApiNoContext, Client, ContextWrapperExt,
+use rust_server_test::{Api, ApiNoContext, Client, ContextWrapperExt, models,
                       ApiError,
                       AllOfGetResponse,
                       DummyGetResponse,


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
Fix #5948 (Generated client code "Disabled because there's no example")

<!-- Please check the completed items below -->
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [ ] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [ ] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
