### PR TITLE
Fix #5026: don't add @NotNull annotation if property is readOnly.

### DIFF
--- a/modules/openapi-generator/src/main/resources/JavaSpring/beanValidation.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/beanValidation.mustache
@@ -1,5 +1,7 @@
 {{#required}}
+  {{^isReadOnly}}
   @NotNull
+  {{/isReadOnly}}
 {{/required}}{{#isContainer}}{{^isPrimitiveType}}{{^isEnum}}
   @Valid{{/isEnum}}{{/isPrimitiveType}}{{/isContainer}}{{^isContainer}}{{^isPrimitiveType}}
   @Valid{{/isPrimitiveType}}{{/isContainer}}


### PR DESCRIPTION
This is a simple fix for issue #5026 that works by changing the beanValidation template to only annotate with @ NotNull if required is set and isReadOnly is not set.

Copy for review: @bbdouglas @sreeshas @jfiala @lukoyanov @cborn @jeff9finger @karismann @Zomzog @lwlee2608 @bkabrda 

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
