### PR TITLE
[Java][Native]Add option to use the builder pattern for API parameters

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/native/README.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/native/README.mustache
@@ -81,7 +81,11 @@ Please follow the [installation](#installation) instruction and execute the foll
 {{#apiInfo}}{{#apis}}{{#-first}}{{#operations}}{{#operation}}{{#-first}}
 import {{{invokerPackage}}}.*;
 import {{{modelPackage}}}.*;
-import {{{package}}}.{{{classname}}};
+import {{{package}}}.{{{classname}}};{{#vendorExtensions.x-group-parameters}}
+import {{{package}}}.{{{classname}}}.*;{{/vendorExtensions.x-group-parameters}}
+{{#asyncNative}}
+import java.util.concurrent.CompletableFuture;
+{{/asyncNative}}
 
 public class {{{classname}}}Example {
 
@@ -94,7 +98,12 @@ public class {{{classname}}}Example {
         {{{dataType}}} {{{paramName}}} = {{{example}}}; // {{{dataType}}} | {{{description}}}
         {{/allParams}}
         try {
-            {{#returnType}}{{{returnType}}} result = {{/returnType}}apiInstance.{{{operationId}}}({{#allParams}}{{{paramName}}}{{#hasMore}}, {{/hasMore}}{{/allParams}});{{#returnType}}
+            {{^vendorExtensions.x-group-parameters}}
+            {{#returnType}}{{#asyncNative}}CompletableFuture<{{{returnType}}}>{{/asyncNative}}{{^asyncNative}}{{{returnType}}}{{/asyncNative}} result = {{/returnType}}{{^returnType}}{{#asyncNative}}CompletableFuture<Void> result = {{/asyncNative}}{{/returnType}}apiInstance.{{{operationId}}}({{#allParams}}{{{paramName}}}{{#hasMore}}, {{/hasMore}}{{/allParams}});{{/vendorExtensions.x-group-parameters}}{{#vendorExtensions.x-group-parameters}}{{#hasParams}}
+            API{{operationId}}Request request = API{{operationId}}Request.newBuilder(){{#allParams}}
+                .{{paramName}}({{paramName}}){{/allParams}}
+                .build();{{/hasParams}}
+            {{#returnType}}{{#asyncNative}}CompletableFuture<{{{returnType}}}>{{/asyncNative}}{{^asyncNative}}{{{returnType}}}{{/asyncNative}} result = {{/returnType}}{{^returnType}}{{#asyncNative}}CompletableFuture<Void> result = {{/asyncNative}}{{/returnType}}apiInstance.{{operationId}}({{#hasParams}}request{{/hasParams}});{{/vendorExtensions.x-group-parameters}}{{#returnType}}
             System.out.println(result);{{/returnType}}
         } catch (ApiException e) {
             System.err.println("Exception when calling {{{classname}}}#{{{operationId}}}");

--- a/modules/openapi-generator/src/main/resources/Java/libraries/native/api.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/native/api.mustache
@@ -41,7 +41,7 @@ public class {{classname}} {
   private final Consumer<HttpRequest.Builder> memberVarInterceptor;
   private final Duration memberVarReadTimeout;
   private final Consumer<HttpResponse<InputStream>> memberVarResponseInterceptor;
-  
+
   public {{classname}}() {
     this(new ApiClient());
   }
@@ -56,6 +56,36 @@ public class {{classname}} {
   }
 
   {{#operation}}
+  {{#vendorExtensions.x-group-parameters}}
+  {{#hasParams}}
+  /**
+   * {{summary}}
+   * {{notes}}
+   * @param {{operationId}}Request {@link API{{operationId}}Request}
+   {{#returnType}}
+   * @return {{returnType}}
+   {{/returnType}}
+   * @throws ApiException if fails to make API call
+   {{#isDeprecated}}
+   * @deprecated
+   {{/isDeprecated}}
+   {{#externalDocs}}
+   * {{description}}
+   * @see <a href="{{url}}">{{summary}} Documentation</a>
+   {{/externalDocs}}
+   */
+  {{#isDeprecated}}
+  @Deprecated
+  {{/isDeprecated}}
+  public {{#returnType}}{{#asyncNative}}CompletableFuture<{{{returnType}}}>{{/asyncNative}}{{^asyncNative}}{{{returnType}}}{{/asyncNative}}{{/returnType}}{{^returnType}}{{#asyncNative}}CompletableFuture<Void>{{/asyncNative}}{{^asyncNative}}void{{/asyncNative}}{{/returnType}} {{operationId}}({{#hasParams}}API{{operationId}}Request {{operationId}}Request{{/hasParams}}) throws ApiException {
+    {{#allParams}}
+    {{{dataType}}} {{paramName}} = {{operationId}}Request.{{paramName}}();
+    {{/allParams}}
+    {{#returnType}}return {{/returnType}}{{^returnType}}{{#asyncNative}}return {{/asyncNative}}{{/returnType}}{{operationId}}({{#allParams}}{{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}});
+  }
+
+  {{/hasParams}}
+  {{/vendorExtensions.x-group-parameters}}
   /**
    * {{summary}}
    * {{notes}}
@@ -158,7 +188,7 @@ public class {{classname}} {
       HttpResponse.BodyHandlers.ofInputStream());
       if (memberVarResponseInterceptor != null) {
         memberVarResponseInterceptor.accept(localVarResponse);
-      }          
+      }
       if (localVarResponse.statusCode()/ 100 != 2) {
           throw new ApiException(localVarResponse.statusCode(),
               "{{operationId}} call received non-success response",
@@ -180,18 +210,17 @@ public class {{classname}} {
                   localVarResponse.body())
               );
           } else {
-               try {
+              {{#returnType}}
+              try {
                   return CompletableFuture.completedFuture(
-                      {{#returnType}}
-                          memberVarObjectMapper.readValue(localVarResponse.body(), new TypeReference<{{{returnType}}}>() {})
-                      {{/returnType}}
-                      {{^returnType}}
-                          null
-                      {{/returnType}}
+                      memberVarObjectMapper.readValue(localVarResponse.body(), new TypeReference<{{{returnType}}}>() {})
                   );
               } catch (IOException e) {
                   return CompletableFuture.failedFuture(new ApiException(e));
               }
+              {{/returnType}}{{^returnType}}
+              return CompletableFuture.completedFuture(null);
+              {{/returnType}}
           }
       });
       {{/asyncNative}}
@@ -214,6 +243,56 @@ public class {{classname}} {
     }
     {{/asyncNative}}
   }
+  {{#vendorExtensions.x-group-parameters}}
+  {{#hasParams}}
+
+  public static final class API{{operationId}}Request {
+    {{#requiredParams}}
+    private {{{dataType}}} {{paramName}}; // {{description}} (required)
+    {{/requiredParams}}
+    {{#optionalParams}}
+    private {{{dataType}}} {{paramName}}; // {{description}} (optional{{^isContainer}}{{#defaultValue}}, default to {{.}}{{/defaultValue}}){{/isContainer}}
+    {{/optionalParams}}
+
+    private API{{operationId}}Request(Builder builder) {
+      {{#requiredParams}}
+      this.{{paramName}} = builder.{{paramName}};
+      {{/requiredParams}}
+      {{#optionalParams}}
+      this.{{paramName}} = builder.{{paramName}};
+      {{/optionalParams}}
+    }
+    {{#allParams}}
+    public {{{dataType}}} {{paramName}}() {
+      return {{paramName}};
+    }
+    {{/allParams}}
+    public static Builder newBuilder() {
+      return new Builder();
+    }
+
+    public static class Builder {
+      {{#requiredParams}}
+      private {{{dataType}}} {{paramName}};
+      {{/requiredParams}}
+      {{#optionalParams}}
+      private {{{dataType}}} {{paramName}};
+      {{/optionalParams}}
+
+      {{#allParams}}
+      public Builder {{paramName}}({{{dataType}}} {{paramName}}) {
+        this.{{paramName}} = {{paramName}};
+        return this;
+      }
+      {{/allParams}}
+      public API{{operationId}}Request build() {
+        return new API{{operationId}}Request(this);
+      }
+    }
+  }
+
+  {{/hasParams}}
+  {{/vendorExtensions.x-group-parameters}}
   {{/operation}}
 }
 {{/operations}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/native/api_doc.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/native/api_doc.mustache
@@ -1,0 +1,140 @@
+# {{classname}}{{#description}}
+
+{{description}}{{/description}}
+
+All URIs are relative to *{{basePath}}*
+
+Method | HTTP request | Description
+------------- | ------------- | -------------
+{{#operations}}{{#operation}}[**{{operationId}}**]({{classname}}.md#{{operationId}}) | **{{httpMethod}}** {{path}} | {{#summary}}{{summary}}{{/summary}}
+{{/operation}}{{/operations}}
+
+{{#operations}}
+{{#operation}}
+
+## {{operationId}}
+
+{{^vendorExtensions.x-group-parameters}}
+> {{#returnType}}{{#asyncNative}}CompletableFuture<{{{returnType}}}>{{/asyncNative}}{{^asyncNative}}{{{returnType}}}{{/asyncNative}}{{/returnType}}{{^returnType}}{{#asyncNative}}CompletableFuture<Void>{{/asyncNative}}{{^asyncNative}}void{{/asyncNative}}{{/returnType}} {{operationId}}({{#allParams}}{{{paramName}}}{{#hasMore}}, {{/hasMore}}{{/allParams}})
+{{/vendorExtensions.x-group-parameters}}
+{{#vendorExtensions.x-group-parameters}}
+> {{#returnType}}{{#asyncNative}}CompletableFuture<{{{returnType}}}>{{/asyncNative}}{{^asyncNative}}{{{returnType}}}{{/asyncNative}}{{/returnType}}{{^returnType}}{{#asyncNative}}CompletableFuture<Void>{{/asyncNative}}{{^asyncNative}}void{{/asyncNative}}{{/returnType}} {{operationId}}({{#hasParams}}{{operationId}}Request{{/hasParams}})
+{{/vendorExtensions.x-group-parameters}}
+
+{{summary}}{{#notes}}
+
+{{notes}}{{/notes}}
+
+### Example
+
+```java
+// Import classes:
+import {{{invokerPackage}}}.ApiClient;
+import {{{invokerPackage}}}.ApiException;
+import {{{invokerPackage}}}.Configuration;{{#hasAuthMethods}}
+import {{{invokerPackage}}}.auth.*;{{/hasAuthMethods}}
+import {{{invokerPackage}}}.models.*;
+import {{{package}}}.{{{classname}}};{{#vendorExtensions.x-group-parameters}}
+import {{{package}}}.{{{classname}}}.*;{{/vendorExtensions.x-group-parameters}}
+{{#asyncNative}}
+import java.util.concurrent.CompletableFuture;
+{{/asyncNative}}
+
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("{{{basePath}}}");
+        {{#hasAuthMethods}}
+        {{#authMethods}}{{#isBasic}}{{#isBasicBasic}}
+        // Configure HTTP basic authorization: {{{name}}}
+        HttpBasicAuth {{{name}}} = (HttpBasicAuth) defaultClient.getAuthentication("{{{name}}}");
+        {{{name}}}.setUsername("YOUR USERNAME");
+        {{{name}}}.setPassword("YOUR PASSWORD");{{/isBasicBasic}}{{#isBasicBearer}}
+        // Configure HTTP bearer authorization: {{{name}}}
+        HttpBearerAuth {{{name}}} = (HttpBearerAuth) defaultClient.getAuthentication("{{{name}}}");
+        {{{name}}}.setBearerToken("BEARER TOKEN");{{/isBasicBearer}}{{/isBasic}}{{#isApiKey}}
+        // Configure API key authorization: {{{name}}}
+        ApiKeyAuth {{{name}}} = (ApiKeyAuth) defaultClient.getAuthentication("{{{name}}}");
+        {{{name}}}.setApiKey("YOUR API KEY");
+        // Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+        //{{{name}}}.setApiKeyPrefix("Token");{{/isApiKey}}{{#isOAuth}}
+        // Configure OAuth2 access token for authorization: {{{name}}}
+        OAuth {{{name}}} = (OAuth) defaultClient.getAuthentication("{{{name}}}");
+        {{{name}}}.setAccessToken("YOUR ACCESS TOKEN");{{/isOAuth}}
+        {{/authMethods}}
+        {{/hasAuthMethods}}
+
+        {{{classname}}} apiInstance = new {{{classname}}}(defaultClient);
+        {{#allParams}}
+        {{{dataType}}} {{{paramName}}} = {{{example}}}; // {{{dataType}}} | {{{description}}}
+        {{/allParams}}
+        try {
+            {{^vendorExtensions.x-group-parameters}}
+            {{#returnType}}{{#asyncNative}}CompletableFuture<{{{returnType}}}>{{/asyncNative}}{{^asyncNative}}{{{returnType}}}{{/asyncNative}} result = {{/returnType}}{{^returnType}}{{#asyncNative}}CompletableFuture<Void> result = {{/asyncNative}}{{/returnType}}apiInstance.{{{operationId}}}({{#allParams}}{{{paramName}}}{{#hasMore}}, {{/hasMore}}{{/allParams}});{{/vendorExtensions.x-group-parameters}}{{#vendorExtensions.x-group-parameters}}{{#hasParams}}
+            API{{operationId}}Request request = API{{operationId}}Request.newBuilder(){{#allParams}}
+                .{{paramName}}({{paramName}}){{/allParams}}
+                .build();{{/hasParams}}
+            {{#returnType}}{{#asyncNative}}CompletableFuture<{{{returnType}}}>{{/asyncNative}}{{^asyncNative}}{{{returnType}}}{{/asyncNative}} result = {{/returnType}}{{^returnType}}{{#asyncNative}}CompletableFuture<Void> result = {{/asyncNative}}{{/returnType}}apiInstance.{{operationId}}({{#hasParams}}request{{/hasParams}});{{/vendorExtensions.x-group-parameters}}{{#returnType}}
+            System.out.println(result);{{/returnType}}
+        } catch (ApiException e) {
+            System.err.println("Exception when calling {{{classname}}}#{{{operationId}}}");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
+}
+```
+
+### Parameters
+
+{{^allParams}}This endpoint does not need any parameter.{{/allParams}}{{^vendorExtensions.x-group-parameters}}{{#allParams}}{{#-last}}
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------{{/-last}}{{/allParams}}
+{{#allParams}} **{{paramName}}** | {{#isPrimitiveType}}**{{dataType}}**{{/isPrimitiveType}}{{^isPrimitiveType}}{{#isFile}}**{{dataType}}**{{/isFile}}{{^isFile}}[**{{dataType}}**]({{baseType}}.md){{/isFile}}{{/isPrimitiveType}}| {{description}} |{{^required}} [optional]{{/required}}{{^isContainer}}{{#defaultValue}} [default to {{defaultValue}}]{{/defaultValue}}{{/isContainer}}{{#allowableValues}} [enum: {{#values}}{{{.}}}{{^-last}}, {{/-last}}{{/values}}]{{/allowableValues}}
+{{/allParams}}
+{{/vendorExtensions.x-group-parameters}}
+{{#vendorExtensions.x-group-parameters}}
+{{#hasParams}}
+|    Name      |    Type       | Description   |     Notes    |
+|------------- | ------------- | ------------- | -------------|
+| {{operationId}}Request | [**API{{operationId}}Request**]({{classname}}.md#API{{operationId}}Request)|-|-|{{/hasParams}}
+{{/vendorExtensions.x-group-parameters}}
+
+### Return type
+
+{{#returnType}}{{#asyncNative}}CompletableFuture<{{/asyncNative}}{{#returnTypeIsPrimitive}}**{{returnType}}**{{/returnTypeIsPrimitive}}{{^returnTypeIsPrimitive}}[**{{returnType}}**]({{returnBaseType}}.md){{/returnTypeIsPrimitive}}{{#asyncNative}}>{{/asyncNative}}{{/returnType}}
+{{^returnType}}{{#asyncNative}}CompletableFuture<void>{{/asyncNative}}{{^asyncNative}}null{{/asyncNative}} (empty response body){{/returnType}}
+
+### Authorization
+
+{{^authMethods}}No authorization required{{/authMethods}}{{#authMethods}}[{{name}}](../README.md#{{name}}){{^-last}}, {{/-last}}{{/authMethods}}
+
+### HTTP request headers
+
+- **Content-Type**: {{#consumes}}{{{mediaType}}}{{#hasMore}}, {{/hasMore}}{{/consumes}}{{^consumes}}Not defined{{/consumes}}
+- **Accept**: {{#produces}}{{{mediaType}}}{{#hasMore}}, {{/hasMore}}{{/produces}}{{^produces}}Not defined{{/produces}}
+
+{{#responses.0}}
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+{{#responses}}
+| **{{code}}** | {{message}} | {{#headers}} * {{baseName}} - {{description}} <br> {{/headers}}{{^headers.0}} - {{/headers.0}} |
+{{/responses}}
+{{/responses.0}}
+{{#vendorExtensions.x-group-parameters}}{{#hasParams}}
+
+<a name="API{{operationId}}Request"></a>
+## API{{operationId}}Request
+### Properties
+{{#allParams}}{{#-last}}
+|     Name      |    Type       | Description   |     Notes    |
+| ------------- | ------------- | ------------- | -------------|{{/-last}}{{/allParams}}
+{{#allParams}} **{{paramName}}** | {{#isPrimitiveType}}**{{dataType}}**{{/isPrimitiveType}}{{^isPrimitiveType}}{{#isFile}}**{{dataType}}**{{/isFile}}{{^isFile}}[**{{dataType}}**]({{baseType}}.md){{/isFile}}{{/isPrimitiveType}} | {{description}} |{{^required}} [optional]{{/required}}{{^isContainer}}{{#defaultValue}} [default to {{defaultValue}}]{{/defaultValue}}{{/isContainer}}{{#allowableValues}} [enum: {{#values}}{{{.}}}{{^-last}}, {{/-last}}{{/values}}]{{/allowableValues}}
+{{/allParams}}
+
+{{/hasParams}}{{/vendorExtensions.x-group-parameters}}
+{{/operation}}
+{{/operations}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/native/api_test.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/native/api_test.mustache
@@ -1,0 +1,59 @@
+{{>licenseInfo}}
+
+package {{package}};
+
+import {{invokerPackage}}.ApiException;
+{{#imports}}import {{import}};
+{{/imports}}
+import org.junit.Test;
+import org.junit.Ignore;
+
+{{^fullJavaUtil}}
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+{{/fullJavaUtil}}
+
+{{#asyncNative}}
+import java.util.concurrent.CompletableFuture;
+{{/asyncNative}}
+
+/**
+ * API tests for {{classname}}
+ */
+@Ignore
+public class {{classname}}Test {
+
+    private final {{classname}} api = new {{classname}}();
+
+    {{#operations}}{{#operation}}
+    /**
+     * {{summary}}
+     *
+     * {{notes}}
+     *
+     * @throws ApiException
+     *          if the Api call fails
+     */
+    @Test
+    public void {{operationId}}Test() throws ApiException {
+        {{#allParams}}
+        {{{dataType}}} {{paramName}} = null;
+        {{/allParams}}
+        {{^vendorExtensions.x-group-parameters}}
+        {{#returnType}}{{#asyncNative}}CompletableFuture<{{{returnType}}}>{{/asyncNative}}{{^asyncNative}}{{{returnType}}}{{/asyncNative}} response = {{/returnType}}
+        {{^returnType}}{{#asyncNative}}CompletableFuture<Void> response = {{/asyncNative}}{{/returnType}}api.{{operationId}}({{#allParams}}{{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}});
+        {{/vendorExtensions.x-group-parameters}}
+        {{#vendorExtensions.x-group-parameters}}{{#hasParams}}
+        {{classname}}.API{{operationId}}Request request = {{classname}}.API{{operationId}}Request.newBuilder(){{#allParams}}
+          .{{paramName}}({{paramName}}){{/allParams}}
+          .build();{{/hasParams}}
+        {{#returnType}}{{#asyncNative}}CompletableFuture<{{{returnType}}}>{{/asyncNative}}{{^asyncNative}}{{{returnType}}}{{/asyncNative}} response = {{/returnType}}
+        {{^returnType}}{{#asyncNative}}CompletableFuture<Void> response = {{/asyncNative}}{{/returnType}}api.{{operationId}}({{#hasParams}}request{{/hasParams}});
+        {{/vendorExtensions.x-group-parameters}}
+
+        // TODO: test validations
+    }
+    {{/operation}}{{/operations}}
+}

--- a/samples/client/petstore/java/native/docs/AnotherFakeApi.md
+++ b/samples/client/petstore/java/native/docs/AnotherFakeApi.md
@@ -58,6 +58,7 @@ Name | Type | Description  | Notes
 
 [**Client**](Client.md)
 
+
 ### Authorization
 
 No authorization required

--- a/samples/client/petstore/java/native/docs/FakeApi.md
+++ b/samples/client/petstore/java/native/docs/FakeApi.md
@@ -23,7 +23,7 @@ Method | HTTP request | Description
 
 ## createXmlItem
 
-> createXmlItem(xmlItem)
+> void createXmlItem(xmlItem)
 
 creates an XmlItem
 
@@ -67,6 +67,7 @@ Name | Type | Description  | Notes
  **xmlItem** | [**XmlItem**](XmlItem.md)| XmlItem Body |
 
 ### Return type
+
 
 null (empty response body)
 
@@ -135,6 +136,7 @@ Name | Type | Description  | Notes
 
 **Boolean**
 
+
 ### Authorization
 
 No authorization required
@@ -199,6 +201,7 @@ Name | Type | Description  | Notes
 ### Return type
 
 [**OuterComposite**](OuterComposite.md)
+
 
 ### Authorization
 
@@ -265,6 +268,7 @@ Name | Type | Description  | Notes
 
 [**BigDecimal**](BigDecimal.md)
 
+
 ### Authorization
 
 No authorization required
@@ -330,6 +334,7 @@ Name | Type | Description  | Notes
 
 **String**
 
+
 ### Authorization
 
 No authorization required
@@ -347,7 +352,7 @@ No authorization required
 
 ## testBodyWithFileSchema
 
-> testBodyWithFileSchema(body)
+> void testBodyWithFileSchema(body)
 
 
 
@@ -392,6 +397,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
+
 null (empty response body)
 
 ### Authorization
@@ -411,7 +417,7 @@ No authorization required
 
 ## testBodyWithQueryParams
 
-> testBodyWithQueryParams(query, body)
+> void testBodyWithQueryParams(query, body)
 
 
 
@@ -455,6 +461,7 @@ Name | Type | Description  | Notes
  **body** | [**User**](User.md)|  |
 
 ### Return type
+
 
 null (empty response body)
 
@@ -523,6 +530,7 @@ Name | Type | Description  | Notes
 
 [**Client**](Client.md)
 
+
 ### Authorization
 
 No authorization required
@@ -540,7 +548,7 @@ No authorization required
 
 ## testEndpointParameters
 
-> testEndpointParameters(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, paramCallback)
+> void testEndpointParameters(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, paramCallback)
 
 Fake endpoint for testing various parameters  假端點  偽のエンドポイント  가짜 엔드 포인트
 
@@ -617,6 +625,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
+
 null (empty response body)
 
 ### Authorization
@@ -637,7 +646,7 @@ null (empty response body)
 
 ## testEnumParameters
 
-> testEnumParameters(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString)
+> void testEnumParameters(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString)
 
 To test enum parameters
 
@@ -696,6 +705,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
+
 null (empty response body)
 
 ### Authorization
@@ -716,7 +726,7 @@ No authorization required
 
 ## testGroupParameters
 
-> testGroupParameters(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group)
+> void testGroupParameters(testGroupParametersRequest)
 
 Fake endpoint to test group parameters (optional)
 
@@ -731,6 +741,7 @@ import org.openapitools.client.ApiException;
 import org.openapitools.client.Configuration;
 import org.openapitools.client.models.*;
 import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.api.FakeApi.*;
 
 public class Example {
     public static void main(String[] args) {
@@ -745,7 +756,16 @@ public class Example {
         Boolean booleanGroup = true; // Boolean | Boolean in group parameters
         Long int64Group = 56L; // Long | Integer in group parameters
         try {
-            apiInstance.testGroupParameters(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group);
+
+            APItestGroupParametersRequest request = APItestGroupParametersRequest.newBuilder()
+                .requiredStringGroup(requiredStringGroup)
+                .requiredBooleanGroup(requiredBooleanGroup)
+                .requiredInt64Group(requiredInt64Group)
+                .stringGroup(stringGroup)
+                .booleanGroup(booleanGroup)
+                .int64Group(int64Group)
+                .build();
+            apiInstance.testGroupParameters(request);
         } catch (ApiException e) {
             System.err.println("Exception when calling FakeApi#testGroupParameters");
             System.err.println("Status code: " + e.getCode());
@@ -759,17 +779,12 @@ public class Example {
 
 ### Parameters
 
-
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **requiredStringGroup** | **Integer**| Required String in group parameters |
- **requiredBooleanGroup** | **Boolean**| Required Boolean in group parameters |
- **requiredInt64Group** | **Long**| Required Integer in group parameters |
- **stringGroup** | **Integer**| String in group parameters | [optional]
- **booleanGroup** | **Boolean**| Boolean in group parameters | [optional]
- **int64Group** | **Long**| Integer in group parameters | [optional]
+|    Name      |    Type       | Description   |     Notes    |
+|------------- | ------------- | ------------- | -------------|
+| testGroupParametersRequest | [**APItestGroupParametersRequest**](FakeApi.md#APItestGroupParametersRequest)|-|-|
 
 ### Return type
+
 
 null (empty response body)
 
@@ -788,9 +803,24 @@ No authorization required
 | **400** | Someting wrong |  -  |
 
 
+<a name="APItestGroupParametersRequest"></a>
+## APItestGroupParametersRequest
+### Properties
+
+|     Name      |    Type       | Description   |     Notes    |
+| ------------- | ------------- | ------------- | -------------|
+ **requiredStringGroup** | **Integer** | Required String in group parameters |
+ **requiredBooleanGroup** | **Boolean** | Required Boolean in group parameters |
+ **requiredInt64Group** | **Long** | Required Integer in group parameters |
+ **stringGroup** | **Integer** | String in group parameters | [optional]
+ **booleanGroup** | **Boolean** | Boolean in group parameters | [optional]
+ **int64Group** | **Long** | Integer in group parameters | [optional]
+
+
+
 ## testInlineAdditionalProperties
 
-> testInlineAdditionalProperties(param)
+> void testInlineAdditionalProperties(param)
 
 test inline additionalProperties
 
@@ -833,6 +863,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
+
 null (empty response body)
 
 ### Authorization
@@ -852,7 +883,7 @@ No authorization required
 
 ## testJsonFormData
 
-> testJsonFormData(param, param2)
+> void testJsonFormData(param, param2)
 
 test json serialization of form data
 
@@ -897,6 +928,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
+
 null (empty response body)
 
 ### Authorization
@@ -916,7 +948,7 @@ No authorization required
 
 ## testQueryParameterCollectionFormat
 
-> testQueryParameterCollectionFormat(pipe, ioutil, http, url, context)
+> void testQueryParameterCollectionFormat(pipe, ioutil, http, url, context)
 
 
 
@@ -968,6 +1000,7 @@ Name | Type | Description  | Notes
  **context** | [**List&lt;String&gt;**](String.md)|  |
 
 ### Return type
+
 
 null (empty response body)
 

--- a/samples/client/petstore/java/native/docs/FakeClassnameTags123Api.md
+++ b/samples/client/petstore/java/native/docs/FakeClassnameTags123Api.md
@@ -65,6 +65,7 @@ Name | Type | Description  | Notes
 
 [**Client**](Client.md)
 
+
 ### Authorization
 
 [api_key_query](../README.md#api_key_query)

--- a/samples/client/petstore/java/native/docs/PetApi.md
+++ b/samples/client/petstore/java/native/docs/PetApi.md
@@ -18,7 +18,7 @@ Method | HTTP request | Description
 
 ## addPet
 
-> addPet(body)
+> void addPet(body)
 
 Add a new pet to the store
 
@@ -66,6 +66,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
+
 null (empty response body)
 
 ### Authorization
@@ -86,7 +87,7 @@ null (empty response body)
 
 ## deletePet
 
-> deletePet(petId, apiKey)
+> void deletePet(petId, apiKey)
 
 Deletes a pet
 
@@ -136,6 +137,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
+
 null (empty response body)
 
 ### Authorization
@@ -156,7 +158,7 @@ null (empty response body)
 
 ## findPetsByStatus
 
-> List&lt;Pet&gt; findPetsByStatus(status)
+> List<Pet> findPetsByStatus(status)
 
 Finds Pets by status
 
@@ -209,6 +211,7 @@ Name | Type | Description  | Notes
 
 [**List&lt;Pet&gt;**](Pet.md)
 
+
 ### Authorization
 
 [petstore_auth](../README.md#petstore_auth)
@@ -227,7 +230,7 @@ Name | Type | Description  | Notes
 
 ## findPetsByTags
 
-> Set&lt;Pet&gt; findPetsByTags(tags)
+> Set<Pet> findPetsByTags(tags)
 
 Finds Pets by tags
 
@@ -279,6 +282,7 @@ Name | Type | Description  | Notes
 ### Return type
 
 [**Set&lt;Pet&gt;**](Pet.md)
+
 
 ### Authorization
 
@@ -353,6 +357,7 @@ Name | Type | Description  | Notes
 
 [**Pet**](Pet.md)
 
+
 ### Authorization
 
 [api_key](../README.md#api_key)
@@ -372,7 +377,7 @@ Name | Type | Description  | Notes
 
 ## updatePet
 
-> updatePet(body)
+> void updatePet(body)
 
 Update an existing pet
 
@@ -420,6 +425,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
+
 null (empty response body)
 
 ### Authorization
@@ -442,7 +448,7 @@ null (empty response body)
 
 ## updatePetWithForm
 
-> updatePetWithForm(petId, name, status)
+> void updatePetWithForm(petId, name, status)
 
 Updates a pet in the store with form data
 
@@ -493,6 +499,7 @@ Name | Type | Description  | Notes
  **status** | **String**| Updated status of the pet | [optional]
 
 ### Return type
+
 
 null (empty response body)
 
@@ -568,6 +575,7 @@ Name | Type | Description  | Notes
 
 [**ModelApiResponse**](ModelApiResponse.md)
 
+
 ### Authorization
 
 [petstore_auth](../README.md#petstore_auth)
@@ -639,6 +647,7 @@ Name | Type | Description  | Notes
 ### Return type
 
 [**ModelApiResponse**](ModelApiResponse.md)
+
 
 ### Authorization
 

--- a/samples/client/petstore/java/native/docs/StoreApi.md
+++ b/samples/client/petstore/java/native/docs/StoreApi.md
@@ -13,7 +13,7 @@ Method | HTTP request | Description
 
 ## deleteOrder
 
-> deleteOrder(orderId)
+> void deleteOrder(orderId)
 
 Delete purchase order by ID
 
@@ -58,6 +58,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
+
 null (empty response body)
 
 ### Authorization
@@ -78,7 +79,7 @@ No authorization required
 
 ## getInventory
 
-> Map&lt;String, Integer&gt; getInventory()
+> Map<String, Integer> getInventory()
 
 Returns pet inventories by status
 
@@ -128,6 +129,7 @@ This endpoint does not need any parameter.
 ### Return type
 
 **Map&lt;String, Integer&gt;**
+
 
 ### Authorization
 
@@ -194,6 +196,7 @@ Name | Type | Description  | Notes
 
 [**Order**](Order.md)
 
+
 ### Authorization
 
 No authorization required
@@ -258,6 +261,7 @@ Name | Type | Description  | Notes
 ### Return type
 
 [**Order**](Order.md)
+
 
 ### Authorization
 

--- a/samples/client/petstore/java/native/docs/UserApi.md
+++ b/samples/client/petstore/java/native/docs/UserApi.md
@@ -17,7 +17,7 @@ Method | HTTP request | Description
 
 ## createUser
 
-> createUser(body)
+> void createUser(body)
 
 Create user
 
@@ -62,6 +62,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
+
 null (empty response body)
 
 ### Authorization
@@ -81,7 +82,7 @@ No authorization required
 
 ## createUsersWithArrayInput
 
-> createUsersWithArrayInput(body)
+> void createUsersWithArrayInput(body)
 
 Creates list of users with given input array
 
@@ -124,6 +125,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
+
 null (empty response body)
 
 ### Authorization
@@ -143,7 +145,7 @@ No authorization required
 
 ## createUsersWithListInput
 
-> createUsersWithListInput(body)
+> void createUsersWithListInput(body)
 
 Creates list of users with given input array
 
@@ -186,6 +188,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
+
 null (empty response body)
 
 ### Authorization
@@ -205,7 +208,7 @@ No authorization required
 
 ## deleteUser
 
-> deleteUser(username)
+> void deleteUser(username)
 
 Delete user
 
@@ -249,6 +252,7 @@ Name | Type | Description  | Notes
  **username** | **String**| The name that needs to be deleted |
 
 ### Return type
+
 
 null (empty response body)
 
@@ -315,6 +319,7 @@ Name | Type | Description  | Notes
 ### Return type
 
 [**User**](User.md)
+
 
 ### Authorization
 
@@ -383,6 +388,7 @@ Name | Type | Description  | Notes
 
 **String**
 
+
 ### Authorization
 
 No authorization required
@@ -401,7 +407,7 @@ No authorization required
 
 ## logoutUser
 
-> logoutUser()
+> void logoutUser()
 
 Logs out current logged in user session
 
@@ -440,6 +446,7 @@ This endpoint does not need any parameter.
 
 ### Return type
 
+
 null (empty response body)
 
 ### Authorization
@@ -459,7 +466,7 @@ No authorization required
 
 ## updateUser
 
-> updateUser(username, body)
+> void updateUser(username, body)
 
 Updated user
 
@@ -505,6 +512,7 @@ Name | Type | Description  | Notes
  **body** | [**User**](User.md)| Updated user object |
 
 ### Return type
+
 
 null (empty response body)
 

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
@@ -44,7 +44,7 @@ public class AnotherFakeApi {
   private final Consumer<HttpRequest.Builder> memberVarInterceptor;
   private final Duration memberVarReadTimeout;
   private final Consumer<HttpResponse<InputStream>> memberVarResponseInterceptor;
-  
+
   public AnotherFakeApi() {
     this(new ApiClient());
   }
@@ -94,7 +94,7 @@ public class AnotherFakeApi {
       HttpResponse.BodyHandlers.ofInputStream());
       if (memberVarResponseInterceptor != null) {
         memberVarResponseInterceptor.accept(localVarResponse);
-      }          
+      }
       if (localVarResponse.statusCode()/ 100 != 2) {
           throw new ApiException(localVarResponse.statusCode(),
               "call123testSpecialTags call received non-success response",

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -52,7 +52,7 @@ public class FakeApi {
   private final Consumer<HttpRequest.Builder> memberVarInterceptor;
   private final Duration memberVarReadTimeout;
   private final Consumer<HttpResponse<InputStream>> memberVarResponseInterceptor;
-  
+
   public FakeApi() {
     this(new ApiClient());
   }
@@ -101,7 +101,7 @@ public class FakeApi {
       HttpResponse.BodyHandlers.ofInputStream());
       if (memberVarResponseInterceptor != null) {
         memberVarResponseInterceptor.accept(localVarResponse);
-      }          
+      }
       if (localVarResponse.statusCode()/ 100 != 2) {
           throw new ApiException(localVarResponse.statusCode(),
               "createXmlItem call received non-success response",
@@ -148,7 +148,7 @@ public class FakeApi {
       HttpResponse.BodyHandlers.ofInputStream());
       if (memberVarResponseInterceptor != null) {
         memberVarResponseInterceptor.accept(localVarResponse);
-      }          
+      }
       if (localVarResponse.statusCode()/ 100 != 2) {
           throw new ApiException(localVarResponse.statusCode(),
               "fakeOuterBooleanSerialize call received non-success response",
@@ -196,7 +196,7 @@ public class FakeApi {
       HttpResponse.BodyHandlers.ofInputStream());
       if (memberVarResponseInterceptor != null) {
         memberVarResponseInterceptor.accept(localVarResponse);
-      }          
+      }
       if (localVarResponse.statusCode()/ 100 != 2) {
           throw new ApiException(localVarResponse.statusCode(),
               "fakeOuterCompositeSerialize call received non-success response",
@@ -244,7 +244,7 @@ public class FakeApi {
       HttpResponse.BodyHandlers.ofInputStream());
       if (memberVarResponseInterceptor != null) {
         memberVarResponseInterceptor.accept(localVarResponse);
-      }          
+      }
       if (localVarResponse.statusCode()/ 100 != 2) {
           throw new ApiException(localVarResponse.statusCode(),
               "fakeOuterNumberSerialize call received non-success response",
@@ -292,7 +292,7 @@ public class FakeApi {
       HttpResponse.BodyHandlers.ofInputStream());
       if (memberVarResponseInterceptor != null) {
         memberVarResponseInterceptor.accept(localVarResponse);
-      }          
+      }
       if (localVarResponse.statusCode()/ 100 != 2) {
           throw new ApiException(localVarResponse.statusCode(),
               "fakeOuterStringSerialize call received non-success response",
@@ -343,7 +343,7 @@ public class FakeApi {
       HttpResponse.BodyHandlers.ofInputStream());
       if (memberVarResponseInterceptor != null) {
         memberVarResponseInterceptor.accept(localVarResponse);
-      }          
+      }
       if (localVarResponse.statusCode()/ 100 != 2) {
           throw new ApiException(localVarResponse.statusCode(),
               "testBodyWithFileSchema call received non-success response",
@@ -407,7 +407,7 @@ public class FakeApi {
       HttpResponse.BodyHandlers.ofInputStream());
       if (memberVarResponseInterceptor != null) {
         memberVarResponseInterceptor.accept(localVarResponse);
-      }          
+      }
       if (localVarResponse.statusCode()/ 100 != 2) {
           throw new ApiException(localVarResponse.statusCode(),
               "testBodyWithQueryParams call received non-success response",
@@ -458,7 +458,7 @@ public class FakeApi {
       HttpResponse.BodyHandlers.ofInputStream());
       if (memberVarResponseInterceptor != null) {
         memberVarResponseInterceptor.accept(localVarResponse);
-      }          
+      }
       if (localVarResponse.statusCode()/ 100 != 2) {
           throw new ApiException(localVarResponse.statusCode(),
               "testClientModel call received non-success response",
@@ -532,7 +532,7 @@ public class FakeApi {
       HttpResponse.BodyHandlers.ofInputStream());
       if (memberVarResponseInterceptor != null) {
         memberVarResponseInterceptor.accept(localVarResponse);
-      }          
+      }
       if (localVarResponse.statusCode()/ 100 != 2) {
           throw new ApiException(localVarResponse.statusCode(),
               "testEndpointParameters call received non-success response",
@@ -601,7 +601,7 @@ public class FakeApi {
       HttpResponse.BodyHandlers.ofInputStream());
       if (memberVarResponseInterceptor != null) {
         memberVarResponseInterceptor.accept(localVarResponse);
-      }          
+      }
       if (localVarResponse.statusCode()/ 100 != 2) {
           throw new ApiException(localVarResponse.statusCode(),
               "testEnumParameters call received non-success response",
@@ -616,6 +616,22 @@ public class FakeApi {
       throw new ApiException(e);
     }
   }
+  /**
+   * Fake endpoint to test group parameters (optional)
+   * Fake endpoint to test group parameters (optional)
+   * @param testGroupParametersRequest {@link APItestGroupParametersRequest}
+   * @throws ApiException if fails to make API call
+   */
+  public void testGroupParameters(APItestGroupParametersRequest testGroupParametersRequest) throws ApiException {
+    Integer requiredStringGroup = testGroupParametersRequest.requiredStringGroup();
+    Boolean requiredBooleanGroup = testGroupParametersRequest.requiredBooleanGroup();
+    Long requiredInt64Group = testGroupParametersRequest.requiredInt64Group();
+    Integer stringGroup = testGroupParametersRequest.stringGroup();
+    Boolean booleanGroup = testGroupParametersRequest.booleanGroup();
+    Long int64Group = testGroupParametersRequest.int64Group();
+    testGroupParameters(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group);
+  }
+
   /**
    * Fake endpoint to test group parameters (optional)
    * Fake endpoint to test group parameters (optional)
@@ -680,7 +696,7 @@ public class FakeApi {
       HttpResponse.BodyHandlers.ofInputStream());
       if (memberVarResponseInterceptor != null) {
         memberVarResponseInterceptor.accept(localVarResponse);
-      }          
+      }
       if (localVarResponse.statusCode()/ 100 != 2) {
           throw new ApiException(localVarResponse.statusCode(),
               "testGroupParameters call received non-success response",
@@ -695,6 +711,83 @@ public class FakeApi {
       throw new ApiException(e);
     }
   }
+
+  public static final class APItestGroupParametersRequest {
+    private Integer requiredStringGroup; // Required String in group parameters (required)
+    private Boolean requiredBooleanGroup; // Required Boolean in group parameters (required)
+    private Long requiredInt64Group; // Required Integer in group parameters (required)
+    private Integer stringGroup; // String in group parameters (optional)
+    private Boolean booleanGroup; // Boolean in group parameters (optional)
+    private Long int64Group; // Integer in group parameters (optional)
+
+    private APItestGroupParametersRequest(Builder builder) {
+      this.requiredStringGroup = builder.requiredStringGroup;
+      this.requiredBooleanGroup = builder.requiredBooleanGroup;
+      this.requiredInt64Group = builder.requiredInt64Group;
+      this.stringGroup = builder.stringGroup;
+      this.booleanGroup = builder.booleanGroup;
+      this.int64Group = builder.int64Group;
+    }
+    public Integer requiredStringGroup() {
+      return requiredStringGroup;
+    }
+    public Boolean requiredBooleanGroup() {
+      return requiredBooleanGroup;
+    }
+    public Long requiredInt64Group() {
+      return requiredInt64Group;
+    }
+    public Integer stringGroup() {
+      return stringGroup;
+    }
+    public Boolean booleanGroup() {
+      return booleanGroup;
+    }
+    public Long int64Group() {
+      return int64Group;
+    }
+    public static Builder newBuilder() {
+      return new Builder();
+    }
+
+    public static class Builder {
+      private Integer requiredStringGroup;
+      private Boolean requiredBooleanGroup;
+      private Long requiredInt64Group;
+      private Integer stringGroup;
+      private Boolean booleanGroup;
+      private Long int64Group;
+
+      public Builder requiredStringGroup(Integer requiredStringGroup) {
+        this.requiredStringGroup = requiredStringGroup;
+        return this;
+      }
+      public Builder requiredBooleanGroup(Boolean requiredBooleanGroup) {
+        this.requiredBooleanGroup = requiredBooleanGroup;
+        return this;
+      }
+      public Builder requiredInt64Group(Long requiredInt64Group) {
+        this.requiredInt64Group = requiredInt64Group;
+        return this;
+      }
+      public Builder stringGroup(Integer stringGroup) {
+        this.stringGroup = stringGroup;
+        return this;
+      }
+      public Builder booleanGroup(Boolean booleanGroup) {
+        this.booleanGroup = booleanGroup;
+        return this;
+      }
+      public Builder int64Group(Long int64Group) {
+        this.int64Group = int64Group;
+        return this;
+      }
+      public APItestGroupParametersRequest build() {
+        return new APItestGroupParametersRequest(this);
+      }
+    }
+  }
+
   /**
    * test inline additionalProperties
    * 
@@ -730,7 +823,7 @@ public class FakeApi {
       HttpResponse.BodyHandlers.ofInputStream());
       if (memberVarResponseInterceptor != null) {
         memberVarResponseInterceptor.accept(localVarResponse);
-      }          
+      }
       if (localVarResponse.statusCode()/ 100 != 2) {
           throw new ApiException(localVarResponse.statusCode(),
               "testInlineAdditionalProperties call received non-success response",
@@ -783,7 +876,7 @@ public class FakeApi {
       HttpResponse.BodyHandlers.ofInputStream());
       if (memberVarResponseInterceptor != null) {
         memberVarResponseInterceptor.accept(localVarResponse);
-      }          
+      }
       if (localVarResponse.statusCode()/ 100 != 2) {
           throw new ApiException(localVarResponse.statusCode(),
               "testJsonFormData call received non-success response",
@@ -864,7 +957,7 @@ public class FakeApi {
       HttpResponse.BodyHandlers.ofInputStream());
       if (memberVarResponseInterceptor != null) {
         memberVarResponseInterceptor.accept(localVarResponse);
-      }          
+      }
       if (localVarResponse.statusCode()/ 100 != 2) {
           throw new ApiException(localVarResponse.statusCode(),
               "testQueryParameterCollectionFormat call received non-success response",

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
@@ -44,7 +44,7 @@ public class FakeClassnameTags123Api {
   private final Consumer<HttpRequest.Builder> memberVarInterceptor;
   private final Duration memberVarReadTimeout;
   private final Consumer<HttpResponse<InputStream>> memberVarResponseInterceptor;
-  
+
   public FakeClassnameTags123Api() {
     this(new ApiClient());
   }
@@ -94,7 +94,7 @@ public class FakeClassnameTags123Api {
       HttpResponse.BodyHandlers.ofInputStream());
       if (memberVarResponseInterceptor != null) {
         memberVarResponseInterceptor.accept(localVarResponse);
-      }          
+      }
       if (localVarResponse.statusCode()/ 100 != 2) {
           throw new ApiException(localVarResponse.statusCode(),
               "testClassname call received non-success response",

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/api/PetApi.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/api/PetApi.java
@@ -47,7 +47,7 @@ public class PetApi {
   private final Consumer<HttpRequest.Builder> memberVarInterceptor;
   private final Duration memberVarReadTimeout;
   private final Consumer<HttpResponse<InputStream>> memberVarResponseInterceptor;
-  
+
   public PetApi() {
     this(new ApiClient());
   }
@@ -96,7 +96,7 @@ public class PetApi {
       HttpResponse.BodyHandlers.ofInputStream());
       if (memberVarResponseInterceptor != null) {
         memberVarResponseInterceptor.accept(localVarResponse);
-      }          
+      }
       if (localVarResponse.statusCode()/ 100 != 2) {
           throw new ApiException(localVarResponse.statusCode(),
               "addPet call received non-success response",
@@ -149,7 +149,7 @@ public class PetApi {
       HttpResponse.BodyHandlers.ofInputStream());
       if (memberVarResponseInterceptor != null) {
         memberVarResponseInterceptor.accept(localVarResponse);
-      }          
+      }
       if (localVarResponse.statusCode()/ 100 != 2) {
           throw new ApiException(localVarResponse.statusCode(),
               "deletePet call received non-success response",
@@ -207,7 +207,7 @@ public class PetApi {
       HttpResponse.BodyHandlers.ofInputStream());
       if (memberVarResponseInterceptor != null) {
         memberVarResponseInterceptor.accept(localVarResponse);
-      }          
+      }
       if (localVarResponse.statusCode()/ 100 != 2) {
           throw new ApiException(localVarResponse.statusCode(),
               "findPetsByStatus call received non-success response",
@@ -268,7 +268,7 @@ public class PetApi {
       HttpResponse.BodyHandlers.ofInputStream());
       if (memberVarResponseInterceptor != null) {
         memberVarResponseInterceptor.accept(localVarResponse);
-      }          
+      }
       if (localVarResponse.statusCode()/ 100 != 2) {
           throw new ApiException(localVarResponse.statusCode(),
               "findPetsByTags call received non-success response",
@@ -319,7 +319,7 @@ public class PetApi {
       HttpResponse.BodyHandlers.ofInputStream());
       if (memberVarResponseInterceptor != null) {
         memberVarResponseInterceptor.accept(localVarResponse);
-      }          
+      }
       if (localVarResponse.statusCode()/ 100 != 2) {
           throw new ApiException(localVarResponse.statusCode(),
               "getPetById call received non-success response",
@@ -370,7 +370,7 @@ public class PetApi {
       HttpResponse.BodyHandlers.ofInputStream());
       if (memberVarResponseInterceptor != null) {
         memberVarResponseInterceptor.accept(localVarResponse);
-      }          
+      }
       if (localVarResponse.statusCode()/ 100 != 2) {
           throw new ApiException(localVarResponse.statusCode(),
               "updatePet call received non-success response",
@@ -421,7 +421,7 @@ public class PetApi {
       HttpResponse.BodyHandlers.ofInputStream());
       if (memberVarResponseInterceptor != null) {
         memberVarResponseInterceptor.accept(localVarResponse);
-      }          
+      }
       if (localVarResponse.statusCode()/ 100 != 2) {
           throw new ApiException(localVarResponse.statusCode(),
               "updatePetWithForm call received non-success response",
@@ -473,7 +473,7 @@ public class PetApi {
       HttpResponse.BodyHandlers.ofInputStream());
       if (memberVarResponseInterceptor != null) {
         memberVarResponseInterceptor.accept(localVarResponse);
-      }          
+      }
       if (localVarResponse.statusCode()/ 100 != 2) {
           throw new ApiException(localVarResponse.statusCode(),
               "uploadFile call received non-success response",
@@ -530,7 +530,7 @@ public class PetApi {
       HttpResponse.BodyHandlers.ofInputStream());
       if (memberVarResponseInterceptor != null) {
         memberVarResponseInterceptor.accept(localVarResponse);
-      }          
+      }
       if (localVarResponse.statusCode()/ 100 != 2) {
           throw new ApiException(localVarResponse.statusCode(),
               "uploadFileWithRequiredFile call received non-success response",

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/api/StoreApi.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/api/StoreApi.java
@@ -44,7 +44,7 @@ public class StoreApi {
   private final Consumer<HttpRequest.Builder> memberVarInterceptor;
   private final Duration memberVarReadTimeout;
   private final Consumer<HttpResponse<InputStream>> memberVarResponseInterceptor;
-  
+
   public StoreApi() {
     this(new ApiClient());
   }
@@ -92,7 +92,7 @@ public class StoreApi {
       HttpResponse.BodyHandlers.ofInputStream());
       if (memberVarResponseInterceptor != null) {
         memberVarResponseInterceptor.accept(localVarResponse);
-      }          
+      }
       if (localVarResponse.statusCode()/ 100 != 2) {
           throw new ApiException(localVarResponse.statusCode(),
               "deleteOrder call received non-success response",
@@ -136,7 +136,7 @@ public class StoreApi {
       HttpResponse.BodyHandlers.ofInputStream());
       if (memberVarResponseInterceptor != null) {
         memberVarResponseInterceptor.accept(localVarResponse);
-      }          
+      }
       if (localVarResponse.statusCode()/ 100 != 2) {
           throw new ApiException(localVarResponse.statusCode(),
               "getInventory call received non-success response",
@@ -187,7 +187,7 @@ public class StoreApi {
       HttpResponse.BodyHandlers.ofInputStream());
       if (memberVarResponseInterceptor != null) {
         memberVarResponseInterceptor.accept(localVarResponse);
-      }          
+      }
       if (localVarResponse.statusCode()/ 100 != 2) {
           throw new ApiException(localVarResponse.statusCode(),
               "getOrderById call received non-success response",
@@ -239,7 +239,7 @@ public class StoreApi {
       HttpResponse.BodyHandlers.ofInputStream());
       if (memberVarResponseInterceptor != null) {
         memberVarResponseInterceptor.accept(localVarResponse);
-      }          
+      }
       if (localVarResponse.statusCode()/ 100 != 2) {
           throw new ApiException(localVarResponse.statusCode(),
               "placeOrder call received non-success response",

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/api/UserApi.java
@@ -44,7 +44,7 @@ public class UserApi {
   private final Consumer<HttpRequest.Builder> memberVarInterceptor;
   private final Duration memberVarReadTimeout;
   private final Consumer<HttpResponse<InputStream>> memberVarResponseInterceptor;
-  
+
   public UserApi() {
     this(new ApiClient());
   }
@@ -93,7 +93,7 @@ public class UserApi {
       HttpResponse.BodyHandlers.ofInputStream());
       if (memberVarResponseInterceptor != null) {
         memberVarResponseInterceptor.accept(localVarResponse);
-      }          
+      }
       if (localVarResponse.statusCode()/ 100 != 2) {
           throw new ApiException(localVarResponse.statusCode(),
               "createUser call received non-success response",
@@ -143,7 +143,7 @@ public class UserApi {
       HttpResponse.BodyHandlers.ofInputStream());
       if (memberVarResponseInterceptor != null) {
         memberVarResponseInterceptor.accept(localVarResponse);
-      }          
+      }
       if (localVarResponse.statusCode()/ 100 != 2) {
           throw new ApiException(localVarResponse.statusCode(),
               "createUsersWithArrayInput call received non-success response",
@@ -193,7 +193,7 @@ public class UserApi {
       HttpResponse.BodyHandlers.ofInputStream());
       if (memberVarResponseInterceptor != null) {
         memberVarResponseInterceptor.accept(localVarResponse);
-      }          
+      }
       if (localVarResponse.statusCode()/ 100 != 2) {
           throw new ApiException(localVarResponse.statusCode(),
               "createUsersWithListInput call received non-success response",
@@ -242,7 +242,7 @@ public class UserApi {
       HttpResponse.BodyHandlers.ofInputStream());
       if (memberVarResponseInterceptor != null) {
         memberVarResponseInterceptor.accept(localVarResponse);
-      }          
+      }
       if (localVarResponse.statusCode()/ 100 != 2) {
           throw new ApiException(localVarResponse.statusCode(),
               "deleteUser call received non-success response",
@@ -292,7 +292,7 @@ public class UserApi {
       HttpResponse.BodyHandlers.ofInputStream());
       if (memberVarResponseInterceptor != null) {
         memberVarResponseInterceptor.accept(localVarResponse);
-      }          
+      }
       if (localVarResponse.statusCode()/ 100 != 2) {
           throw new ApiException(localVarResponse.statusCode(),
               "getUserByName call received non-success response",
@@ -357,7 +357,7 @@ public class UserApi {
       HttpResponse.BodyHandlers.ofInputStream());
       if (memberVarResponseInterceptor != null) {
         memberVarResponseInterceptor.accept(localVarResponse);
-      }          
+      }
       if (localVarResponse.statusCode()/ 100 != 2) {
           throw new ApiException(localVarResponse.statusCode(),
               "loginUser call received non-success response",
@@ -401,7 +401,7 @@ public class UserApi {
       HttpResponse.BodyHandlers.ofInputStream());
       if (memberVarResponseInterceptor != null) {
         memberVarResponseInterceptor.accept(localVarResponse);
-      }          
+      }
       if (localVarResponse.statusCode()/ 100 != 2) {
           throw new ApiException(localVarResponse.statusCode(),
               "logoutUser call received non-success response",
@@ -457,7 +457,7 @@ public class UserApi {
       HttpResponse.BodyHandlers.ofInputStream());
       if (memberVarResponseInterceptor != null) {
         memberVarResponseInterceptor.accept(localVarResponse);
-      }          
+      }
       if (localVarResponse.statusCode()/ 100 != 2) {
           throw new ApiException(localVarResponse.statusCode(),
               "updateUser call received non-success response",

--- a/samples/client/petstore/java/native/src/test/java/org/openapitools/client/api/FakeApiTest.java
+++ b/samples/client/petstore/java/native/src/test/java/org/openapitools/client/api/FakeApiTest.java
@@ -170,9 +170,9 @@ public class FakeApiTest {
     }
     
     /**
-     * Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
+     * Fake endpoint for testing various parameters  假端點  偽のエンドポイント  가짜 엔드 포인트
      *
-     * Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
+     * Fake endpoint for testing various parameters  假端點  偽のエンドポイント  가짜 엔드 포인트
      *
      * @throws ApiException
      *          if the Api call fails
@@ -237,7 +237,16 @@ public class FakeApiTest {
         Integer stringGroup = null;
         Boolean booleanGroup = null;
         Long int64Group = null;
-        api.testGroupParameters(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group);
+
+        FakeApi.APItestGroupParametersRequest request = FakeApi.APItestGroupParametersRequest.newBuilder()
+          .requiredStringGroup(requiredStringGroup)
+          .requiredBooleanGroup(requiredBooleanGroup)
+          .requiredInt64Group(requiredInt64Group)
+          .stringGroup(stringGroup)
+          .booleanGroup(booleanGroup)
+          .int64Group(int64Group)
+          .build();
+        api.testGroupParameters(request);
 
         // TODO: test validations
     }
@@ -271,6 +280,26 @@ public class FakeApiTest {
         String param = null;
         String param2 = null;
         api.testJsonFormData(param, param2);
+
+        // TODO: test validations
+    }
+    
+    /**
+     * 
+     *
+     * To test the collection format in query parameters
+     *
+     * @throws ApiException
+     *          if the Api call fails
+     */
+    @Test
+    public void testQueryParameterCollectionFormatTest() throws ApiException {
+        List<String> pipe = null;
+        List<String> ioutil = null;
+        List<String> http = null;
+        List<String> url = null;
+        List<String> context = null;
+        api.testQueryParameterCollectionFormat(pipe, ioutil, http, url, context);
 
         // TODO: test validations
     }


### PR DESCRIPTION
Ths PR added the option to build API requests using builder pattern for Client-Java-Native based on the [request](https://github.com/OpenAPITools/openapi-generator/issues/5451)

It includes the changes below:
- update the template of API
- update the template of README
- add modified template of api test under native
- add modified template of api doc under native
- update Petstore samples for native

- fixed [build error with null async return](https://github.com/OpenAPITools/openapi-generator/issues/6550)

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [ ] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [ ] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@wing328 @cbornet @jeff9finger @bbdouglas @sreeshas @jfiala @lukoyanov @karismann @Zomzog @lwlee2608  @bkabrda @jfeltesse-mdsol @jcarres-mdsol