### PR TITLE
[go] Fixes problems with conflicting parameters

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractGoCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractGoCodegen.java
@@ -546,13 +546,16 @@ public abstract class AbstractGoCodegen extends DefaultCodegen implements Codege
                 }
             }
 
-            setExportParameterName(operation.queryParams);
-            setExportParameterName(operation.formParams);
-            setExportParameterName(operation.headerParams);
-            setExportParameterName(operation.bodyParams);
-            setExportParameterName(operation.cookieParams);
-            setExportParameterName(operation.optionalParams);
-            setExportParameterName(operation.requiredParams);
+            boolean hasFormParams = !operation.formParams.isEmpty();
+
+            setExportParameterName(operation.allParams, hasFormParams);
+            setExportParameterName(operation.queryParams, hasFormParams);
+            setExportParameterName(operation.formParams, hasFormParams);
+            setExportParameterName(operation.headerParams, hasFormParams);
+            setExportParameterName(operation.bodyParams, hasFormParams);
+            setExportParameterName(operation.cookieParams, hasFormParams);
+            setExportParameterName(operation.optionalParams, hasFormParams);
+            setExportParameterName(operation.requiredParams, hasFormParams);
 
         }
 
@@ -574,18 +577,22 @@ public abstract class AbstractGoCodegen extends DefaultCodegen implements Codege
         return objs;
     }
 
-    private void setExportParameterName(List<CodegenParameter> codegenParameters) {
+    private void setExportParameterName(List<CodegenParameter> codegenParameters, boolean hasFormParams) {
         for (CodegenParameter param : codegenParameters) {
-            char nameFirstChar = param.paramName.charAt(0);
-            if (Character.isUpperCase(nameFirstChar)) {
-                // First char is already uppercase, just use paramName.
-                param.vendorExtensions.put("x-export-param-name", param.paramName);
-            } else {
-                // It's a lowercase first char, let's convert it to uppercase
-                StringBuilder sb = new StringBuilder(param.paramName);
-                sb.setCharAt(0, Character.toUpperCase(nameFirstChar));
-                param.vendorExtensions.put("x-export-param-name", sb.toString());
-            }
+            param.vendorExtensions.put("x-export-param-name", exportParameterNameFor(param, hasFormParams));
+        }
+    }
+
+    protected String exportParameterNameFor(CodegenParameter param, boolean hasFormParams) {
+        char nameFirstChar = param.paramName.charAt(0);
+        if (Character.isUpperCase(nameFirstChar)) {
+            // First char is already uppercase, just use paramName.
+            return param.paramName;
+        } else {
+            // It's a lowercase first char, let's convert it to uppercase
+            StringBuilder sb = new StringBuilder(param.paramName);
+            sb.setCharAt(0, Character.toUpperCase(nameFirstChar));
+            return sb.toString();
         }
     }
 

--- a/modules/openapi-generator/src/main/resources/go/api.mustache
+++ b/modules/openapi-generator/src/main/resources/go/api.mustache
@@ -52,12 +52,12 @@ type {{#structPrefix}}{{&classname}}{{/structPrefix}}Api{{operationId}}Request s
 	ApiService *{{classname}}Service
 {{/generateInterfaces}}
 {{#allParams}}
-	{{paramName}} {{^isPathParam}}*{{/isPathParam}}{{{dataType}}}
+	{{vendorExtensions.x-namespaced-param-name}} {{^isPathParam}}*{{/isPathParam}}{{{dataType}}}
 {{/allParams}}
 }
 {{#allParams}}{{^isPathParam}}
 func (r {{#structPrefix}}{{&classname}}{{/structPrefix}}Api{{operationId}}Request) {{vendorExtensions.x-export-param-name}}({{paramName}} {{{dataType}}}) {{#structPrefix}}{{&classname}}{{/structPrefix}}Api{{operationId}}Request {
-	r.{{paramName}} = &{{paramName}}
+	r.{{vendorExtensions.x-namespaced-param-name}} = &{{paramName}}
 	return r
 }{{/isPathParam}}{{/allParams}}
 
@@ -78,7 +78,7 @@ func (a *{{{classname}}}Service) {{{nickname}}}(ctx _context.Context{{#pathParam
 	return {{#structPrefix}}{{&classname}}{{/structPrefix}}Api{{operationId}}Request{
 		ApiService: a,
 		ctx: ctx,{{#pathParams}}
-		{{paramName}}: {{paramName}},{{/pathParams}}
+		{{vendorExtensions.x-namespaced-param-name}}: {{paramName}},{{/pathParams}}
 	}
 }
 
@@ -104,7 +104,7 @@ func (a *{{{classname}}}Service) {{nickname}}Execute(r {{#structPrefix}}{{&class
 	}
 
 	localVarPath := localBasePath + "{{{path}}}"{{#pathParams}}
-	localVarPath = strings.Replace(localVarPath, "{"+"{{baseName}}"+"}", _neturl.PathEscape(parameterToString(r.{{paramName}}, "{{#collectionFormat}}{{collectionFormat}}{{/collectionFormat}}")), -1){{/pathParams}}
+	localVarPath = strings.Replace(localVarPath, "{"+"{{baseName}}"+"}", _neturl.PathEscape(parameterToString(r.{{vendorExtensions.x-namespaced-param-name}}, "{{#collectionFormat}}{{collectionFormat}}{{/collectionFormat}}")), -1){{/pathParams}}
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
@@ -112,48 +112,48 @@ func (a *{{{classname}}}Service) {{nickname}}Execute(r {{#structPrefix}}{{&class
 	{{#allParams}}
 	{{#required}}
 	{{^isPathParam}}
-	if r.{{paramName}} == nil {
+	if r.{{vendorExtensions.x-namespaced-param-name}} == nil {
 		return {{#returnType}}localVarReturnValue, {{/returnType}}nil, reportError("{{paramName}} is required and must be specified")
 	}
 	{{/isPathParam}}
 	{{#minItems}}
-	if len({{^isPathParam}}*{{/isPathParam}}r.{{paramName}}) < {{minItems}} {
+	if len({{^isPathParam}}*{{/isPathParam}}r.{{vendorExtensions.x-namespaced-param-name}}) < {{minItems}} {
 		return {{#returnType}}localVarReturnValue, {{/returnType}}nil, reportError("{{paramName}} must have at least {{minItems}} elements")
 	}
 	{{/minItems}}
 	{{#maxItems}}
-	if len({{^isPathParam}}*{{/isPathParam}}r.{{paramName}}) > {{maxItems}} {
+	if len({{^isPathParam}}*{{/isPathParam}}r.{{vendorExtensions.x-namespaced-param-name}}) > {{maxItems}} {
 		return {{#returnType}}localVarReturnValue, {{/returnType}}nil, reportError("{{paramName}} must have less than {{maxItems}} elements")
 	}
 	{{/maxItems}}
 	{{#minLength}}
-	if strlen({{^isPathParam}}*{{/isPathParam}}r.{{paramName}}) < {{minLength}} {
+	if strlen({{^isPathParam}}*{{/isPathParam}}r.{{vendorExtensions.x-namespaced-param-name}}) < {{minLength}} {
 		return {{#returnType}}localVarReturnValue, {{/returnType}}nil, reportError("{{paramName}} must have at least {{minLength}} elements")
 	}
 	{{/minLength}}
 	{{#maxLength}}
-	if strlen({{^isPathParam}}*{{/isPathParam}}r.{{paramName}}) > {{maxLength}} {
+	if strlen({{^isPathParam}}*{{/isPathParam}}r.{{vendorExtensions.x-namespaced-param-name}}) > {{maxLength}} {
 		return {{#returnType}}localVarReturnValue, {{/returnType}}nil, reportError("{{paramName}} must have less than {{maxLength}} elements")
 	}
 	{{/maxLength}}
 	{{#minimum}}
 	{{#isString}}
-	{{paramName}}Txt, err := atoi({{^isPathParam}}*{{/isPathParam}}r.{{paramName}})
-	if {{paramName}}Txt < {{minimum}} {
+	{{vendorExtensions.x-namespaced-param-name}}Txt, err := atoi({{^isPathParam}}*{{/isPathParam}}r.{{vendorExtensions.x-namespaced-param-name}})
+	if {{vendorExtensions.x-namespaced-param-name}}Txt < {{minimum}} {
 	{{/isString}}
 	{{^isString}}
-	if {{^isPathParam}}*{{/isPathParam}}r.{{paramName}} < {{minimum}} {
+	if {{^isPathParam}}*{{/isPathParam}}r.{{vendorExtensions.x-namespaced-param-name}} < {{minimum}} {
 	{{/isString}}
 		return {{#returnType}}localVarReturnValue, {{/returnType}}nil, reportError("{{paramName}} must be greater than {{minimum}}")
 	}
 	{{/minimum}}
 	{{#maximum}}
 	{{#isString}}
-	{{paramName}}Txt, err := atoi({{^isPathParam}}*{{/isPathParam}}r.{{paramName}})
-	if {{paramName}}Txt > {{maximum}} {
+	{{vendorExtensions.x-namespaced-param-name}}Txt, err := atoi({{^isPathParam}}*{{/isPathParam}}r.{{vendorExtensions.x-namespaced-param-name}})
+	if {{vendorExtensions.x-namespaced-param-name}}Txt > {{maximum}} {
 	{{/isString}}
 	{{^isString}}
-	if {{^isPathParam}}*{{/isPathParam}}r.{{paramName}} > {{maximum}} {
+	if {{^isPathParam}}*{{/isPathParam}}r.{{vendorExtensions.x-namespaced-param-name}} > {{maximum}} {
 	{{/isString}}
 		return {{#returnType}}localVarReturnValue, {{/returnType}}nil, reportError("{{paramName}} must be less than {{maximum}}")
 	}
@@ -165,7 +165,7 @@ func (a *{{{classname}}}Service) {{nickname}}Execute(r {{#structPrefix}}{{&class
 	{{#required}}
 	{{#isCollectionFormatMulti}}
 	{
-		t := *r.{{paramName}}
+		t := *r.{{vendorExtensions.x-namespaced-param-name}}
 		if reflect.TypeOf(t).Kind() == reflect.Slice {
 			s := reflect.ValueOf(t)
 			for i := 0; i < s.Len(); i++ {
@@ -177,13 +177,13 @@ func (a *{{{classname}}}Service) {{nickname}}Execute(r {{#structPrefix}}{{&class
 	}
 	{{/isCollectionFormatMulti}}
 	{{^isCollectionFormatMulti}}
-	localVarQueryParams.Add("{{baseName}}", parameterToString(*r.{{paramName}}, "{{#collectionFormat}}{{collectionFormat}}{{/collectionFormat}}"))
+	localVarQueryParams.Add("{{baseName}}", parameterToString(*r.{{vendorExtensions.x-namespaced-param-name}}, "{{#collectionFormat}}{{collectionFormat}}{{/collectionFormat}}"))
 	{{/isCollectionFormatMulti}}
 	{{/required}}
 	{{^required}}
-	if r.{{paramName}} != nil {
+	if r.{{vendorExtensions.x-namespaced-param-name}} != nil {
 	{{#isCollectionFormatMulti}}
-		t := *r.{{paramName}}
+		t := *r.{{vendorExtensions.x-namespaced-param-name}}
 		if reflect.TypeOf(t).Kind() == reflect.Slice {
 			s := reflect.ValueOf(t)
 			for i := 0; i < s.Len(); i++ {
@@ -194,7 +194,7 @@ func (a *{{{classname}}}Service) {{nickname}}Execute(r {{#structPrefix}}{{&class
 		}
 	{{/isCollectionFormatMulti}}
 	{{^isCollectionFormatMulti}}
-		localVarQueryParams.Add("{{baseName}}", parameterToString(*r.{{paramName}}, "{{#collectionFormat}}{{collectionFormat}}{{/collectionFormat}}"))
+		localVarQueryParams.Add("{{baseName}}", parameterToString(*r.{{vendorExtensions.x-namespaced-param-name}}, "{{#collectionFormat}}{{collectionFormat}}{{/collectionFormat}}"))
 	{{/isCollectionFormatMulti}}
 	}
 	{{/required}}
@@ -222,11 +222,11 @@ func (a *{{{classname}}}Service) {{nickname}}Execute(r {{#structPrefix}}{{&class
 	}
 {{#headerParams}}
 	{{#required}}
-	localVarHeaderParams["{{baseName}}"] = parameterToString(*r.{{paramName}}, "{{#collectionFormat}}{{collectionFormat}}{{/collectionFormat}}")
+	localVarHeaderParams["{{baseName}}"] = parameterToString(*r.{{vendorExtensions.x-namespaced-param-name}}, "{{#collectionFormat}}{{collectionFormat}}{{/collectionFormat}}")
 	{{/required}}
 	{{^required}}
-	if r.{{paramName}} != nil {
-		localVarHeaderParams["{{baseName}}"] = parameterToString(*r.{{paramName}}, "{{#collectionFormat}}{{collectionFormat}}{{/collectionFormat}}")
+	if r.{{vendorExtensions.x-namespaced-param-name}} != nil {
+		localVarHeaderParams["{{baseName}}"] = parameterToString(*r.{{vendorExtensions.x-namespaced-param-name}}, "{{#collectionFormat}}{{collectionFormat}}{{/collectionFormat}}")
 	}
 	{{/required}}
 {{/headerParams}}
@@ -234,12 +234,12 @@ func (a *{{{classname}}}Service) {{nickname}}Execute(r {{#structPrefix}}{{&class
 {{#isFile}}
 	localVarFormFileName = "{{baseName}}"
 {{#required}}
-	localVarFile := *r.{{paramName}}
+	localVarFile := *r.{{vendorExtensions.x-namespaced-param-name}}
 {{/required}}
 {{^required}}
 	var localVarFile {{dataType}}
-	if r.{{paramName}} != nil {
-		localVarFile = *r.{{paramName}}
+	if r.{{vendorExtensions.x-namespaced-param-name}} != nil {
+		localVarFile = *r.{{vendorExtensions.x-namespaced-param-name}}
 	}
 {{/required}}
 	if localVarFile != nil {
@@ -251,12 +251,12 @@ func (a *{{{classname}}}Service) {{nickname}}Execute(r {{#structPrefix}}{{&class
 {{/isFile}}
 {{^isFile}}
 {{#required}}
-	localVarFormParams.Add("{{baseName}}", parameterToString(*r.{{paramName}}, "{{#collectionFormat}}{{collectionFormat}}{{/collectionFormat}}"))
+	localVarFormParams.Add("{{baseName}}", parameterToString(*r.{{vendorExtensions.x-namespaced-param-name}}, "{{#collectionFormat}}{{collectionFormat}}{{/collectionFormat}}"))
 {{/required}}
 {{^required}}
 {{#isModel}}
-	if r.{{paramName}} != nil {
-		paramJson, err := parameterToJson(*r.{{paramName}})
+	if r.{{vendorExtensions.x-namespaced-param-name}} != nil {
+		paramJson, err := parameterToJson(*r.{{vendorExtensions.x-namespaced-param-name}})
 		if err != nil {
 			return {{#returnType}}localVarReturnValue, {{/returnType}}nil, err
 		}
@@ -264,8 +264,8 @@ func (a *{{{classname}}}Service) {{nickname}}Execute(r {{#structPrefix}}{{&class
 	}
 {{/isModel}}
 {{^isModel}}
-	if r.{{paramName}} != nil {
-		localVarFormParams.Add("{{baseName}}", parameterToString(*r.{{paramName}}, "{{#collectionFormat}}{{collectionFormat}}{{/collectionFormat}}"))
+	if r.{{vendorExtensions.x-namespaced-param-name}} != nil {
+		localVarFormParams.Add("{{baseName}}", parameterToString(*r.{{vendorExtensions.x-namespaced-param-name}}, "{{#collectionFormat}}{{collectionFormat}}{{/collectionFormat}}"))
 	}
 {{/isModel}}
 {{/required}}
@@ -273,7 +273,7 @@ func (a *{{{classname}}}Service) {{nickname}}Execute(r {{#structPrefix}}{{&class
 {{/formParams}}
 {{#bodyParams}}
 	// body params
-	localVarPostBody = r.{{paramName}}
+	localVarPostBody = r.{{vendorExtensions.x-namespaced-param-name}}
 {{/bodyParams}}
 {{#authMethods}}
 {{#isApiKey}}

--- a/modules/openapi-generator/src/test/resources/3_0/conflictingParameter.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/conflictingParameter.yaml
@@ -1,0 +1,57 @@
+openapi: 3.0.0
+
+info:
+  version: 1.0.0
+  title: OpenAPI Petstore
+
+paths:
+  /pet/{id}:
+    post:
+      operationId: create
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+            format: int32
+        - in: header
+          name: id
+          schema:
+            type: integer
+            format: int32
+        - in: cookie
+          name: id
+          schema:
+            type: integer
+            format: int32
+        - in: query
+          name: id
+          schema:
+            type: integer
+            format: int32
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                id:
+                  type: integer
+                  format: int32
+                pathid:
+                  type: integer
+                  format: int32
+                headerId2:
+                  type: integer
+                  format: int32
+                cookieId2:
+                  type: integer
+                  format: int32
+                queryId2:
+                  type: integer
+                  format: int32
+      responses:
+        '400':
+          description: Invalid pet value
+

--- a/samples/client/petstore/go/go-petstore/api_another_fake.go
+++ b/samples/client/petstore/go/go-petstore/api_another_fake.go
@@ -46,11 +46,11 @@ type AnotherFakeApiService service
 type ApiCall123TestSpecialTagsRequest struct {
 	ctx _context.Context
 	ApiService AnotherFakeApi
-	body *Client
+	bodybody *Client
 }
 
 func (r ApiCall123TestSpecialTagsRequest) Body(body Client) ApiCall123TestSpecialTagsRequest {
-	r.body = &body
+	r.bodybody = &body
 	return r
 }
 
@@ -95,7 +95,7 @@ func (a *AnotherFakeApiService) Call123TestSpecialTagsExecute(r ApiCall123TestSp
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
-	if r.body == nil {
+	if r.bodybody == nil {
 		return localVarReturnValue, nil, reportError("body is required and must be specified")
 	}
 
@@ -117,7 +117,7 @@ func (a *AnotherFakeApiService) Call123TestSpecialTagsExecute(r ApiCall123TestSp
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
 	// body params
-	localVarPostBody = r.body
+	localVarPostBody = r.bodybody
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return localVarReturnValue, nil, err

--- a/samples/client/petstore/go/go-petstore/api_fake.go
+++ b/samples/client/petstore/go/go-petstore/api_fake.go
@@ -222,11 +222,11 @@ type FakeApiService service
 type ApiCreateXmlItemRequest struct {
 	ctx _context.Context
 	ApiService FakeApi
-	xmlItem *XmlItem
+	bodyxmlItem *XmlItem
 }
 
 func (r ApiCreateXmlItemRequest) XmlItem(xmlItem XmlItem) ApiCreateXmlItemRequest {
-	r.xmlItem = &xmlItem
+	r.bodyxmlItem = &xmlItem
 	return r
 }
 
@@ -269,7 +269,7 @@ func (a *FakeApiService) CreateXmlItemExecute(r ApiCreateXmlItemRequest) (*_neth
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
-	if r.xmlItem == nil {
+	if r.bodyxmlItem == nil {
 		return nil, reportError("xmlItem is required and must be specified")
 	}
 
@@ -291,7 +291,7 @@ func (a *FakeApiService) CreateXmlItemExecute(r ApiCreateXmlItemRequest) (*_neth
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
 	// body params
-	localVarPostBody = r.xmlItem
+	localVarPostBody = r.bodyxmlItem
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return nil, err
@@ -323,11 +323,11 @@ func (a *FakeApiService) CreateXmlItemExecute(r ApiCreateXmlItemRequest) (*_neth
 type ApiFakeOuterBooleanSerializeRequest struct {
 	ctx _context.Context
 	ApiService FakeApi
-	body *bool
+	bodybody *bool
 }
 
 func (r ApiFakeOuterBooleanSerializeRequest) Body(body bool) ApiFakeOuterBooleanSerializeRequest {
-	r.body = &body
+	r.bodybody = &body
 	return r
 }
 
@@ -391,7 +391,7 @@ func (a *FakeApiService) FakeOuterBooleanSerializeExecute(r ApiFakeOuterBooleanS
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
 	// body params
-	localVarPostBody = r.body
+	localVarPostBody = r.bodybody
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return localVarReturnValue, nil, err
@@ -432,11 +432,11 @@ func (a *FakeApiService) FakeOuterBooleanSerializeExecute(r ApiFakeOuterBooleanS
 type ApiFakeOuterCompositeSerializeRequest struct {
 	ctx _context.Context
 	ApiService FakeApi
-	body *OuterComposite
+	bodybody *OuterComposite
 }
 
 func (r ApiFakeOuterCompositeSerializeRequest) Body(body OuterComposite) ApiFakeOuterCompositeSerializeRequest {
-	r.body = &body
+	r.bodybody = &body
 	return r
 }
 
@@ -500,7 +500,7 @@ func (a *FakeApiService) FakeOuterCompositeSerializeExecute(r ApiFakeOuterCompos
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
 	// body params
-	localVarPostBody = r.body
+	localVarPostBody = r.bodybody
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return localVarReturnValue, nil, err
@@ -541,11 +541,11 @@ func (a *FakeApiService) FakeOuterCompositeSerializeExecute(r ApiFakeOuterCompos
 type ApiFakeOuterNumberSerializeRequest struct {
 	ctx _context.Context
 	ApiService FakeApi
-	body *float32
+	bodybody *float32
 }
 
 func (r ApiFakeOuterNumberSerializeRequest) Body(body float32) ApiFakeOuterNumberSerializeRequest {
-	r.body = &body
+	r.bodybody = &body
 	return r
 }
 
@@ -609,7 +609,7 @@ func (a *FakeApiService) FakeOuterNumberSerializeExecute(r ApiFakeOuterNumberSer
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
 	// body params
-	localVarPostBody = r.body
+	localVarPostBody = r.bodybody
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return localVarReturnValue, nil, err
@@ -650,11 +650,11 @@ func (a *FakeApiService) FakeOuterNumberSerializeExecute(r ApiFakeOuterNumberSer
 type ApiFakeOuterStringSerializeRequest struct {
 	ctx _context.Context
 	ApiService FakeApi
-	body *string
+	bodybody *string
 }
 
 func (r ApiFakeOuterStringSerializeRequest) Body(body string) ApiFakeOuterStringSerializeRequest {
-	r.body = &body
+	r.bodybody = &body
 	return r
 }
 
@@ -718,7 +718,7 @@ func (a *FakeApiService) FakeOuterStringSerializeExecute(r ApiFakeOuterStringSer
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
 	// body params
-	localVarPostBody = r.body
+	localVarPostBody = r.bodybody
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return localVarReturnValue, nil, err
@@ -759,11 +759,11 @@ func (a *FakeApiService) FakeOuterStringSerializeExecute(r ApiFakeOuterStringSer
 type ApiTestBodyWithFileSchemaRequest struct {
 	ctx _context.Context
 	ApiService FakeApi
-	body *FileSchemaTestClass
+	bodybody *FileSchemaTestClass
 }
 
 func (r ApiTestBodyWithFileSchemaRequest) Body(body FileSchemaTestClass) ApiTestBodyWithFileSchemaRequest {
-	r.body = &body
+	r.bodybody = &body
 	return r
 }
 
@@ -806,7 +806,7 @@ func (a *FakeApiService) TestBodyWithFileSchemaExecute(r ApiTestBodyWithFileSche
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
-	if r.body == nil {
+	if r.bodybody == nil {
 		return nil, reportError("body is required and must be specified")
 	}
 
@@ -828,7 +828,7 @@ func (a *FakeApiService) TestBodyWithFileSchemaExecute(r ApiTestBodyWithFileSche
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
 	// body params
-	localVarPostBody = r.body
+	localVarPostBody = r.bodybody
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return nil, err
@@ -860,16 +860,16 @@ func (a *FakeApiService) TestBodyWithFileSchemaExecute(r ApiTestBodyWithFileSche
 type ApiTestBodyWithQueryParamsRequest struct {
 	ctx _context.Context
 	ApiService FakeApi
-	query *string
-	body *User
+	queryquery *string
+	bodybody *User
 }
 
-func (r ApiTestBodyWithQueryParamsRequest) Query(query string) ApiTestBodyWithQueryParamsRequest {
-	r.query = &query
+func (r ApiTestBodyWithQueryParamsRequest) QueryQuery(query string) ApiTestBodyWithQueryParamsRequest {
+	r.queryquery = &query
 	return r
 }
 func (r ApiTestBodyWithQueryParamsRequest) Body(body User) ApiTestBodyWithQueryParamsRequest {
-	r.body = &body
+	r.bodybody = &body
 	return r
 }
 
@@ -911,14 +911,14 @@ func (a *FakeApiService) TestBodyWithQueryParamsExecute(r ApiTestBodyWithQueryPa
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
-	if r.query == nil {
+	if r.queryquery == nil {
 		return nil, reportError("query is required and must be specified")
 	}
-	if r.body == nil {
+	if r.bodybody == nil {
 		return nil, reportError("body is required and must be specified")
 	}
 
-	localVarQueryParams.Add("query", parameterToString(*r.query, ""))
+	localVarQueryParams.Add("query", parameterToString(*r.queryquery, ""))
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{"application/json"}
 
@@ -937,7 +937,7 @@ func (a *FakeApiService) TestBodyWithQueryParamsExecute(r ApiTestBodyWithQueryPa
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
 	// body params
-	localVarPostBody = r.body
+	localVarPostBody = r.bodybody
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return nil, err
@@ -969,11 +969,11 @@ func (a *FakeApiService) TestBodyWithQueryParamsExecute(r ApiTestBodyWithQueryPa
 type ApiTestClientModelRequest struct {
 	ctx _context.Context
 	ApiService FakeApi
-	body *Client
+	bodybody *Client
 }
 
 func (r ApiTestClientModelRequest) Body(body Client) ApiTestClientModelRequest {
-	r.body = &body
+	r.bodybody = &body
 	return r
 }
 
@@ -1018,7 +1018,7 @@ func (a *FakeApiService) TestClientModelExecute(r ApiTestClientModelRequest) (Cl
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
-	if r.body == nil {
+	if r.bodybody == nil {
 		return localVarReturnValue, nil, reportError("body is required and must be specified")
 	}
 
@@ -1040,7 +1040,7 @@ func (a *FakeApiService) TestClientModelExecute(r ApiTestClientModelRequest) (Cl
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
 	// body params
-	localVarPostBody = r.body
+	localVarPostBody = r.bodybody
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return localVarReturnValue, nil, err
@@ -1081,76 +1081,76 @@ func (a *FakeApiService) TestClientModelExecute(r ApiTestClientModelRequest) (Cl
 type ApiTestEndpointParametersRequest struct {
 	ctx _context.Context
 	ApiService FakeApi
-	number *float32
-	double *float64
-	patternWithoutDelimiter *string
-	byte_ *string
-	integer *int32
-	int32_ *int32
-	int64_ *int64
-	float *float32
-	string_ *string
-	binary **os.File
-	date *string
-	dateTime *time.Time
-	password *string
-	callback *string
+	formnumber *float32
+	formdouble *float64
+	formpatternWithoutDelimiter *string
+	formbyte_ *string
+	forminteger *int32
+	formint32_ *int32
+	formint64_ *int64
+	formfloat *float32
+	formstring_ *string
+	formbinary **os.File
+	formdate *string
+	formdateTime *time.Time
+	formpassword *string
+	formcallback *string
 }
 
 func (r ApiTestEndpointParametersRequest) Number(number float32) ApiTestEndpointParametersRequest {
-	r.number = &number
+	r.formnumber = &number
 	return r
 }
 func (r ApiTestEndpointParametersRequest) Double(double float64) ApiTestEndpointParametersRequest {
-	r.double = &double
+	r.formdouble = &double
 	return r
 }
 func (r ApiTestEndpointParametersRequest) PatternWithoutDelimiter(patternWithoutDelimiter string) ApiTestEndpointParametersRequest {
-	r.patternWithoutDelimiter = &patternWithoutDelimiter
+	r.formpatternWithoutDelimiter = &patternWithoutDelimiter
 	return r
 }
 func (r ApiTestEndpointParametersRequest) Byte_(byte_ string) ApiTestEndpointParametersRequest {
-	r.byte_ = &byte_
+	r.formbyte_ = &byte_
 	return r
 }
 func (r ApiTestEndpointParametersRequest) Integer(integer int32) ApiTestEndpointParametersRequest {
-	r.integer = &integer
+	r.forminteger = &integer
 	return r
 }
 func (r ApiTestEndpointParametersRequest) Int32_(int32_ int32) ApiTestEndpointParametersRequest {
-	r.int32_ = &int32_
+	r.formint32_ = &int32_
 	return r
 }
 func (r ApiTestEndpointParametersRequest) Int64_(int64_ int64) ApiTestEndpointParametersRequest {
-	r.int64_ = &int64_
+	r.formint64_ = &int64_
 	return r
 }
 func (r ApiTestEndpointParametersRequest) Float(float float32) ApiTestEndpointParametersRequest {
-	r.float = &float
+	r.formfloat = &float
 	return r
 }
 func (r ApiTestEndpointParametersRequest) String_(string_ string) ApiTestEndpointParametersRequest {
-	r.string_ = &string_
+	r.formstring_ = &string_
 	return r
 }
 func (r ApiTestEndpointParametersRequest) Binary(binary *os.File) ApiTestEndpointParametersRequest {
-	r.binary = &binary
+	r.formbinary = &binary
 	return r
 }
 func (r ApiTestEndpointParametersRequest) Date(date string) ApiTestEndpointParametersRequest {
-	r.date = &date
+	r.formdate = &date
 	return r
 }
 func (r ApiTestEndpointParametersRequest) DateTime(dateTime time.Time) ApiTestEndpointParametersRequest {
-	r.dateTime = &dateTime
+	r.formdateTime = &dateTime
 	return r
 }
 func (r ApiTestEndpointParametersRequest) Password(password string) ApiTestEndpointParametersRequest {
-	r.password = &password
+	r.formpassword = &password
 	return r
 }
 func (r ApiTestEndpointParametersRequest) Callback(callback string) ApiTestEndpointParametersRequest {
-	r.callback = &callback
+	r.formcallback = &callback
 	return r
 }
 
@@ -1196,28 +1196,28 @@ func (a *FakeApiService) TestEndpointParametersExecute(r ApiTestEndpointParamete
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
-	if r.number == nil {
+	if r.formnumber == nil {
 		return nil, reportError("number is required and must be specified")
 	}
-	if *r.number < 32.1 {
+	if *r.formnumber < 32.1 {
 		return nil, reportError("number must be greater than 32.1")
 	}
-	if *r.number > 543.2 {
+	if *r.formnumber > 543.2 {
 		return nil, reportError("number must be less than 543.2")
 	}
-	if r.double == nil {
+	if r.formdouble == nil {
 		return nil, reportError("double is required and must be specified")
 	}
-	if *r.double < 67.8 {
+	if *r.formdouble < 67.8 {
 		return nil, reportError("double must be greater than 67.8")
 	}
-	if *r.double > 123.4 {
+	if *r.formdouble > 123.4 {
 		return nil, reportError("double must be less than 123.4")
 	}
-	if r.patternWithoutDelimiter == nil {
+	if r.formpatternWithoutDelimiter == nil {
 		return nil, reportError("patternWithoutDelimiter is required and must be specified")
 	}
-	if r.byte_ == nil {
+	if r.formbyte_ == nil {
 		return nil, reportError("byte_ is required and must be specified")
 	}
 
@@ -1238,29 +1238,29 @@ func (a *FakeApiService) TestEndpointParametersExecute(r ApiTestEndpointParamete
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
-	if r.integer != nil {
-		localVarFormParams.Add("integer", parameterToString(*r.integer, ""))
+	if r.forminteger != nil {
+		localVarFormParams.Add("integer", parameterToString(*r.forminteger, ""))
 	}
-	if r.int32_ != nil {
-		localVarFormParams.Add("int32", parameterToString(*r.int32_, ""))
+	if r.formint32_ != nil {
+		localVarFormParams.Add("int32", parameterToString(*r.formint32_, ""))
 	}
-	if r.int64_ != nil {
-		localVarFormParams.Add("int64", parameterToString(*r.int64_, ""))
+	if r.formint64_ != nil {
+		localVarFormParams.Add("int64", parameterToString(*r.formint64_, ""))
 	}
-	localVarFormParams.Add("number", parameterToString(*r.number, ""))
-	if r.float != nil {
-		localVarFormParams.Add("float", parameterToString(*r.float, ""))
+	localVarFormParams.Add("number", parameterToString(*r.formnumber, ""))
+	if r.formfloat != nil {
+		localVarFormParams.Add("float", parameterToString(*r.formfloat, ""))
 	}
-	localVarFormParams.Add("double", parameterToString(*r.double, ""))
-	if r.string_ != nil {
-		localVarFormParams.Add("string", parameterToString(*r.string_, ""))
+	localVarFormParams.Add("double", parameterToString(*r.formdouble, ""))
+	if r.formstring_ != nil {
+		localVarFormParams.Add("string", parameterToString(*r.formstring_, ""))
 	}
-	localVarFormParams.Add("pattern_without_delimiter", parameterToString(*r.patternWithoutDelimiter, ""))
-	localVarFormParams.Add("byte", parameterToString(*r.byte_, ""))
+	localVarFormParams.Add("pattern_without_delimiter", parameterToString(*r.formpatternWithoutDelimiter, ""))
+	localVarFormParams.Add("byte", parameterToString(*r.formbyte_, ""))
 	localVarFormFileName = "binary"
 	var localVarFile *os.File
-	if r.binary != nil {
-		localVarFile = *r.binary
+	if r.formbinary != nil {
+		localVarFile = *r.formbinary
 	}
 	if localVarFile != nil {
 		fbs, _ := _ioutil.ReadAll(localVarFile)
@@ -1268,17 +1268,17 @@ func (a *FakeApiService) TestEndpointParametersExecute(r ApiTestEndpointParamete
 		localVarFileName = localVarFile.Name()
 		localVarFile.Close()
 	}
-	if r.date != nil {
-		localVarFormParams.Add("date", parameterToString(*r.date, ""))
+	if r.formdate != nil {
+		localVarFormParams.Add("date", parameterToString(*r.formdate, ""))
 	}
-	if r.dateTime != nil {
-		localVarFormParams.Add("dateTime", parameterToString(*r.dateTime, ""))
+	if r.formdateTime != nil {
+		localVarFormParams.Add("dateTime", parameterToString(*r.formdateTime, ""))
 	}
-	if r.password != nil {
-		localVarFormParams.Add("password", parameterToString(*r.password, ""))
+	if r.formpassword != nil {
+		localVarFormParams.Add("password", parameterToString(*r.formpassword, ""))
 	}
-	if r.callback != nil {
-		localVarFormParams.Add("callback", parameterToString(*r.callback, ""))
+	if r.formcallback != nil {
+		localVarFormParams.Add("callback", parameterToString(*r.formcallback, ""))
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
@@ -1311,46 +1311,46 @@ func (a *FakeApiService) TestEndpointParametersExecute(r ApiTestEndpointParamete
 type ApiTestEnumParametersRequest struct {
 	ctx _context.Context
 	ApiService FakeApi
-	enumHeaderStringArray *[]string
-	enumHeaderString *string
-	enumQueryStringArray *[]string
-	enumQueryString *string
-	enumQueryInteger *int32
-	enumQueryDouble *float64
-	enumFormStringArray *[]string
-	enumFormString *string
+	headerenumHeaderStringArray *[]string
+	headerenumHeaderString *string
+	queryenumQueryStringArray *[]string
+	queryenumQueryString *string
+	queryenumQueryInteger *int32
+	queryenumQueryDouble *float64
+	formenumFormStringArray *[]string
+	formenumFormString *string
 }
 
-func (r ApiTestEnumParametersRequest) EnumHeaderStringArray(enumHeaderStringArray []string) ApiTestEnumParametersRequest {
-	r.enumHeaderStringArray = &enumHeaderStringArray
+func (r ApiTestEnumParametersRequest) HeaderEnumHeaderStringArray(enumHeaderStringArray []string) ApiTestEnumParametersRequest {
+	r.headerenumHeaderStringArray = &enumHeaderStringArray
 	return r
 }
-func (r ApiTestEnumParametersRequest) EnumHeaderString(enumHeaderString string) ApiTestEnumParametersRequest {
-	r.enumHeaderString = &enumHeaderString
+func (r ApiTestEnumParametersRequest) HeaderEnumHeaderString(enumHeaderString string) ApiTestEnumParametersRequest {
+	r.headerenumHeaderString = &enumHeaderString
 	return r
 }
-func (r ApiTestEnumParametersRequest) EnumQueryStringArray(enumQueryStringArray []string) ApiTestEnumParametersRequest {
-	r.enumQueryStringArray = &enumQueryStringArray
+func (r ApiTestEnumParametersRequest) QueryEnumQueryStringArray(enumQueryStringArray []string) ApiTestEnumParametersRequest {
+	r.queryenumQueryStringArray = &enumQueryStringArray
 	return r
 }
-func (r ApiTestEnumParametersRequest) EnumQueryString(enumQueryString string) ApiTestEnumParametersRequest {
-	r.enumQueryString = &enumQueryString
+func (r ApiTestEnumParametersRequest) QueryEnumQueryString(enumQueryString string) ApiTestEnumParametersRequest {
+	r.queryenumQueryString = &enumQueryString
 	return r
 }
-func (r ApiTestEnumParametersRequest) EnumQueryInteger(enumQueryInteger int32) ApiTestEnumParametersRequest {
-	r.enumQueryInteger = &enumQueryInteger
+func (r ApiTestEnumParametersRequest) QueryEnumQueryInteger(enumQueryInteger int32) ApiTestEnumParametersRequest {
+	r.queryenumQueryInteger = &enumQueryInteger
 	return r
 }
-func (r ApiTestEnumParametersRequest) EnumQueryDouble(enumQueryDouble float64) ApiTestEnumParametersRequest {
-	r.enumQueryDouble = &enumQueryDouble
+func (r ApiTestEnumParametersRequest) QueryEnumQueryDouble(enumQueryDouble float64) ApiTestEnumParametersRequest {
+	r.queryenumQueryDouble = &enumQueryDouble
 	return r
 }
 func (r ApiTestEnumParametersRequest) EnumFormStringArray(enumFormStringArray []string) ApiTestEnumParametersRequest {
-	r.enumFormStringArray = &enumFormStringArray
+	r.formenumFormStringArray = &enumFormStringArray
 	return r
 }
 func (r ApiTestEnumParametersRequest) EnumFormString(enumFormString string) ApiTestEnumParametersRequest {
-	r.enumFormString = &enumFormString
+	r.formenumFormString = &enumFormString
 	return r
 }
 
@@ -1394,17 +1394,17 @@ func (a *FakeApiService) TestEnumParametersExecute(r ApiTestEnumParametersReques
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 
-	if r.enumQueryStringArray != nil {
-		localVarQueryParams.Add("enum_query_string_array", parameterToString(*r.enumQueryStringArray, "csv"))
+	if r.queryenumQueryStringArray != nil {
+		localVarQueryParams.Add("enum_query_string_array", parameterToString(*r.queryenumQueryStringArray, "csv"))
 	}
-	if r.enumQueryString != nil {
-		localVarQueryParams.Add("enum_query_string", parameterToString(*r.enumQueryString, ""))
+	if r.queryenumQueryString != nil {
+		localVarQueryParams.Add("enum_query_string", parameterToString(*r.queryenumQueryString, ""))
 	}
-	if r.enumQueryInteger != nil {
-		localVarQueryParams.Add("enum_query_integer", parameterToString(*r.enumQueryInteger, ""))
+	if r.queryenumQueryInteger != nil {
+		localVarQueryParams.Add("enum_query_integer", parameterToString(*r.queryenumQueryInteger, ""))
 	}
-	if r.enumQueryDouble != nil {
-		localVarQueryParams.Add("enum_query_double", parameterToString(*r.enumQueryDouble, ""))
+	if r.queryenumQueryDouble != nil {
+		localVarQueryParams.Add("enum_query_double", parameterToString(*r.queryenumQueryDouble, ""))
 	}
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{"application/x-www-form-urlencoded"}
@@ -1423,17 +1423,17 @@ func (a *FakeApiService) TestEnumParametersExecute(r ApiTestEnumParametersReques
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
-	if r.enumHeaderStringArray != nil {
-		localVarHeaderParams["enum_header_string_array"] = parameterToString(*r.enumHeaderStringArray, "csv")
+	if r.headerenumHeaderStringArray != nil {
+		localVarHeaderParams["enum_header_string_array"] = parameterToString(*r.headerenumHeaderStringArray, "csv")
 	}
-	if r.enumHeaderString != nil {
-		localVarHeaderParams["enum_header_string"] = parameterToString(*r.enumHeaderString, "")
+	if r.headerenumHeaderString != nil {
+		localVarHeaderParams["enum_header_string"] = parameterToString(*r.headerenumHeaderString, "")
 	}
-	if r.enumFormStringArray != nil {
-		localVarFormParams.Add("enum_form_string_array", parameterToString(*r.enumFormStringArray, "csv"))
+	if r.formenumFormStringArray != nil {
+		localVarFormParams.Add("enum_form_string_array", parameterToString(*r.formenumFormStringArray, "csv"))
 	}
-	if r.enumFormString != nil {
-		localVarFormParams.Add("enum_form_string", parameterToString(*r.enumFormString, ""))
+	if r.formenumFormString != nil {
+		localVarFormParams.Add("enum_form_string", parameterToString(*r.formenumFormString, ""))
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
@@ -1466,36 +1466,36 @@ func (a *FakeApiService) TestEnumParametersExecute(r ApiTestEnumParametersReques
 type ApiTestGroupParametersRequest struct {
 	ctx _context.Context
 	ApiService FakeApi
-	requiredStringGroup *int32
-	requiredBooleanGroup *bool
-	requiredInt64Group *int64
-	stringGroup *int32
-	booleanGroup *bool
-	int64Group *int64
+	queryrequiredStringGroup *int32
+	headerrequiredBooleanGroup *bool
+	queryrequiredInt64Group *int64
+	querystringGroup *int32
+	headerbooleanGroup *bool
+	queryint64Group *int64
 }
 
 func (r ApiTestGroupParametersRequest) RequiredStringGroup(requiredStringGroup int32) ApiTestGroupParametersRequest {
-	r.requiredStringGroup = &requiredStringGroup
+	r.queryrequiredStringGroup = &requiredStringGroup
 	return r
 }
-func (r ApiTestGroupParametersRequest) RequiredBooleanGroup(requiredBooleanGroup bool) ApiTestGroupParametersRequest {
-	r.requiredBooleanGroup = &requiredBooleanGroup
+func (r ApiTestGroupParametersRequest) HeaderRequiredBooleanGroup(requiredBooleanGroup bool) ApiTestGroupParametersRequest {
+	r.headerrequiredBooleanGroup = &requiredBooleanGroup
 	return r
 }
 func (r ApiTestGroupParametersRequest) RequiredInt64Group(requiredInt64Group int64) ApiTestGroupParametersRequest {
-	r.requiredInt64Group = &requiredInt64Group
+	r.queryrequiredInt64Group = &requiredInt64Group
 	return r
 }
 func (r ApiTestGroupParametersRequest) StringGroup(stringGroup int32) ApiTestGroupParametersRequest {
-	r.stringGroup = &stringGroup
+	r.querystringGroup = &stringGroup
 	return r
 }
-func (r ApiTestGroupParametersRequest) BooleanGroup(booleanGroup bool) ApiTestGroupParametersRequest {
-	r.booleanGroup = &booleanGroup
+func (r ApiTestGroupParametersRequest) HeaderBooleanGroup(booleanGroup bool) ApiTestGroupParametersRequest {
+	r.headerbooleanGroup = &booleanGroup
 	return r
 }
 func (r ApiTestGroupParametersRequest) Int64Group(int64Group int64) ApiTestGroupParametersRequest {
-	r.int64Group = &int64Group
+	r.queryint64Group = &int64Group
 	return r
 }
 
@@ -1538,23 +1538,23 @@ func (a *FakeApiService) TestGroupParametersExecute(r ApiTestGroupParametersRequ
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
-	if r.requiredStringGroup == nil {
+	if r.queryrequiredStringGroup == nil {
 		return nil, reportError("requiredStringGroup is required and must be specified")
 	}
-	if r.requiredBooleanGroup == nil {
+	if r.headerrequiredBooleanGroup == nil {
 		return nil, reportError("requiredBooleanGroup is required and must be specified")
 	}
-	if r.requiredInt64Group == nil {
+	if r.queryrequiredInt64Group == nil {
 		return nil, reportError("requiredInt64Group is required and must be specified")
 	}
 
-	localVarQueryParams.Add("required_string_group", parameterToString(*r.requiredStringGroup, ""))
-	localVarQueryParams.Add("required_int64_group", parameterToString(*r.requiredInt64Group, ""))
-	if r.stringGroup != nil {
-		localVarQueryParams.Add("string_group", parameterToString(*r.stringGroup, ""))
+	localVarQueryParams.Add("required_string_group", parameterToString(*r.queryrequiredStringGroup, ""))
+	localVarQueryParams.Add("required_int64_group", parameterToString(*r.queryrequiredInt64Group, ""))
+	if r.querystringGroup != nil {
+		localVarQueryParams.Add("string_group", parameterToString(*r.querystringGroup, ""))
 	}
-	if r.int64Group != nil {
-		localVarQueryParams.Add("int64_group", parameterToString(*r.int64Group, ""))
+	if r.queryint64Group != nil {
+		localVarQueryParams.Add("int64_group", parameterToString(*r.queryint64Group, ""))
 	}
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{}
@@ -1573,9 +1573,9 @@ func (a *FakeApiService) TestGroupParametersExecute(r ApiTestGroupParametersRequ
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
-	localVarHeaderParams["required_boolean_group"] = parameterToString(*r.requiredBooleanGroup, "")
-	if r.booleanGroup != nil {
-		localVarHeaderParams["boolean_group"] = parameterToString(*r.booleanGroup, "")
+	localVarHeaderParams["required_boolean_group"] = parameterToString(*r.headerrequiredBooleanGroup, "")
+	if r.headerbooleanGroup != nil {
+		localVarHeaderParams["boolean_group"] = parameterToString(*r.headerbooleanGroup, "")
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
@@ -1608,11 +1608,11 @@ func (a *FakeApiService) TestGroupParametersExecute(r ApiTestGroupParametersRequ
 type ApiTestInlineAdditionalPropertiesRequest struct {
 	ctx _context.Context
 	ApiService FakeApi
-	param *map[string]string
+	bodyparam *map[string]string
 }
 
 func (r ApiTestInlineAdditionalPropertiesRequest) Param(param map[string]string) ApiTestInlineAdditionalPropertiesRequest {
-	r.param = &param
+	r.bodyparam = &param
 	return r
 }
 
@@ -1654,7 +1654,7 @@ func (a *FakeApiService) TestInlineAdditionalPropertiesExecute(r ApiTestInlineAd
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
-	if r.param == nil {
+	if r.bodyparam == nil {
 		return nil, reportError("param is required and must be specified")
 	}
 
@@ -1676,7 +1676,7 @@ func (a *FakeApiService) TestInlineAdditionalPropertiesExecute(r ApiTestInlineAd
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
 	// body params
-	localVarPostBody = r.param
+	localVarPostBody = r.bodyparam
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return nil, err
@@ -1708,16 +1708,16 @@ func (a *FakeApiService) TestInlineAdditionalPropertiesExecute(r ApiTestInlineAd
 type ApiTestJsonFormDataRequest struct {
 	ctx _context.Context
 	ApiService FakeApi
-	param *string
-	param2 *string
+	formparam *string
+	formparam2 *string
 }
 
 func (r ApiTestJsonFormDataRequest) Param(param string) ApiTestJsonFormDataRequest {
-	r.param = &param
+	r.formparam = &param
 	return r
 }
 func (r ApiTestJsonFormDataRequest) Param2(param2 string) ApiTestJsonFormDataRequest {
-	r.param2 = &param2
+	r.formparam2 = &param2
 	return r
 }
 
@@ -1759,10 +1759,10 @@ func (a *FakeApiService) TestJsonFormDataExecute(r ApiTestJsonFormDataRequest) (
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
-	if r.param == nil {
+	if r.formparam == nil {
 		return nil, reportError("param is required and must be specified")
 	}
-	if r.param2 == nil {
+	if r.formparam2 == nil {
 		return nil, reportError("param2 is required and must be specified")
 	}
 
@@ -1783,8 +1783,8 @@ func (a *FakeApiService) TestJsonFormDataExecute(r ApiTestJsonFormDataRequest) (
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
-	localVarFormParams.Add("param", parameterToString(*r.param, ""))
-	localVarFormParams.Add("param2", parameterToString(*r.param2, ""))
+	localVarFormParams.Add("param", parameterToString(*r.formparam, ""))
+	localVarFormParams.Add("param2", parameterToString(*r.formparam2, ""))
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return nil, err
@@ -1816,31 +1816,31 @@ func (a *FakeApiService) TestJsonFormDataExecute(r ApiTestJsonFormDataRequest) (
 type ApiTestQueryParameterCollectionFormatRequest struct {
 	ctx _context.Context
 	ApiService FakeApi
-	pipe *[]string
-	ioutil *[]string
-	http *[]string
-	url *[]string
-	context *[]string
+	querypipe *[]string
+	queryioutil *[]string
+	queryhttp *[]string
+	queryurl *[]string
+	querycontext *[]string
 }
 
 func (r ApiTestQueryParameterCollectionFormatRequest) Pipe(pipe []string) ApiTestQueryParameterCollectionFormatRequest {
-	r.pipe = &pipe
+	r.querypipe = &pipe
 	return r
 }
 func (r ApiTestQueryParameterCollectionFormatRequest) Ioutil(ioutil []string) ApiTestQueryParameterCollectionFormatRequest {
-	r.ioutil = &ioutil
+	r.queryioutil = &ioutil
 	return r
 }
 func (r ApiTestQueryParameterCollectionFormatRequest) Http(http []string) ApiTestQueryParameterCollectionFormatRequest {
-	r.http = &http
+	r.queryhttp = &http
 	return r
 }
 func (r ApiTestQueryParameterCollectionFormatRequest) Url(url []string) ApiTestQueryParameterCollectionFormatRequest {
-	r.url = &url
+	r.queryurl = &url
 	return r
 }
 func (r ApiTestQueryParameterCollectionFormatRequest) Context(context []string) ApiTestQueryParameterCollectionFormatRequest {
-	r.context = &context
+	r.querycontext = &context
 	return r
 }
 
@@ -1883,28 +1883,28 @@ func (a *FakeApiService) TestQueryParameterCollectionFormatExecute(r ApiTestQuer
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
-	if r.pipe == nil {
+	if r.querypipe == nil {
 		return nil, reportError("pipe is required and must be specified")
 	}
-	if r.ioutil == nil {
+	if r.queryioutil == nil {
 		return nil, reportError("ioutil is required and must be specified")
 	}
-	if r.http == nil {
+	if r.queryhttp == nil {
 		return nil, reportError("http is required and must be specified")
 	}
-	if r.url == nil {
+	if r.queryurl == nil {
 		return nil, reportError("url is required and must be specified")
 	}
-	if r.context == nil {
+	if r.querycontext == nil {
 		return nil, reportError("context is required and must be specified")
 	}
 
-	localVarQueryParams.Add("pipe", parameterToString(*r.pipe, "csv"))
-	localVarQueryParams.Add("ioutil", parameterToString(*r.ioutil, "csv"))
-	localVarQueryParams.Add("http", parameterToString(*r.http, "ssv"))
-	localVarQueryParams.Add("url", parameterToString(*r.url, "csv"))
+	localVarQueryParams.Add("pipe", parameterToString(*r.querypipe, "csv"))
+	localVarQueryParams.Add("ioutil", parameterToString(*r.queryioutil, "csv"))
+	localVarQueryParams.Add("http", parameterToString(*r.queryhttp, "ssv"))
+	localVarQueryParams.Add("url", parameterToString(*r.queryurl, "csv"))
 	{
-		t := *r.context
+		t := *r.querycontext
 		if reflect.TypeOf(t).Kind() == reflect.Slice {
 			s := reflect.ValueOf(t)
 			for i := 0; i < s.Len(); i++ {

--- a/samples/client/petstore/go/go-petstore/api_fake_classname_tags123.go
+++ b/samples/client/petstore/go/go-petstore/api_fake_classname_tags123.go
@@ -46,11 +46,11 @@ type FakeClassnameTags123ApiService service
 type ApiTestClassnameRequest struct {
 	ctx _context.Context
 	ApiService FakeClassnameTags123Api
-	body *Client
+	bodybody *Client
 }
 
 func (r ApiTestClassnameRequest) Body(body Client) ApiTestClassnameRequest {
-	r.body = &body
+	r.bodybody = &body
 	return r
 }
 
@@ -95,7 +95,7 @@ func (a *FakeClassnameTags123ApiService) TestClassnameExecute(r ApiTestClassname
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
-	if r.body == nil {
+	if r.bodybody == nil {
 		return localVarReturnValue, nil, reportError("body is required and must be specified")
 	}
 
@@ -117,7 +117,7 @@ func (a *FakeClassnameTags123ApiService) TestClassnameExecute(r ApiTestClassname
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
 	// body params
-	localVarPostBody = r.body
+	localVarPostBody = r.bodybody
 	if r.ctx != nil {
 		// API Key Authentication
 		if auth, ok := r.ctx.Value(ContextAPIKeys).(map[string]APIKey); ok {

--- a/samples/client/petstore/go/go-petstore/api_pet.go
+++ b/samples/client/petstore/go/go-petstore/api_pet.go
@@ -155,11 +155,11 @@ type PetApiService service
 type ApiAddPetRequest struct {
 	ctx _context.Context
 	ApiService PetApi
-	body *Pet
+	bodybody *Pet
 }
 
 func (r ApiAddPetRequest) Body(body Pet) ApiAddPetRequest {
-	r.body = &body
+	r.bodybody = &body
 	return r
 }
 
@@ -201,7 +201,7 @@ func (a *PetApiService) AddPetExecute(r ApiAddPetRequest) (*_nethttp.Response, e
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
-	if r.body == nil {
+	if r.bodybody == nil {
 		return nil, reportError("body is required and must be specified")
 	}
 
@@ -223,7 +223,7 @@ func (a *PetApiService) AddPetExecute(r ApiAddPetRequest) (*_nethttp.Response, e
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
 	// body params
-	localVarPostBody = r.body
+	localVarPostBody = r.bodybody
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return nil, err
@@ -255,12 +255,12 @@ func (a *PetApiService) AddPetExecute(r ApiAddPetRequest) (*_nethttp.Response, e
 type ApiDeletePetRequest struct {
 	ctx _context.Context
 	ApiService PetApi
-	petId int64
-	apiKey *string
+	pathpetId int64
+	headerapiKey *string
 }
 
-func (r ApiDeletePetRequest) ApiKey(apiKey string) ApiDeletePetRequest {
-	r.apiKey = &apiKey
+func (r ApiDeletePetRequest) HeaderApiKey(apiKey string) ApiDeletePetRequest {
+	r.headerapiKey = &apiKey
 	return r
 }
 
@@ -278,7 +278,7 @@ func (a *PetApiService) DeletePet(ctx _context.Context, petId int64) ApiDeletePe
 	return ApiDeletePetRequest{
 		ApiService: a,
 		ctx: ctx,
-		petId: petId,
+		pathpetId: petId,
 	}
 }
 
@@ -300,7 +300,7 @@ func (a *PetApiService) DeletePetExecute(r ApiDeletePetRequest) (*_nethttp.Respo
 	}
 
 	localVarPath := localBasePath + "/pet/{petId}"
-	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.PathEscape(parameterToString(r.petId, "")), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.PathEscape(parameterToString(r.pathpetId, "")), -1)
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
@@ -323,8 +323,8 @@ func (a *PetApiService) DeletePetExecute(r ApiDeletePetRequest) (*_nethttp.Respo
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
-	if r.apiKey != nil {
-		localVarHeaderParams["api_key"] = parameterToString(*r.apiKey, "")
+	if r.headerapiKey != nil {
+		localVarHeaderParams["api_key"] = parameterToString(*r.headerapiKey, "")
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
@@ -357,11 +357,11 @@ func (a *PetApiService) DeletePetExecute(r ApiDeletePetRequest) (*_nethttp.Respo
 type ApiFindPetsByStatusRequest struct {
 	ctx _context.Context
 	ApiService PetApi
-	status *[]string
+	querystatus *[]string
 }
 
 func (r ApiFindPetsByStatusRequest) Status(status []string) ApiFindPetsByStatusRequest {
-	r.status = &status
+	r.querystatus = &status
 	return r
 }
 
@@ -406,11 +406,11 @@ func (a *PetApiService) FindPetsByStatusExecute(r ApiFindPetsByStatusRequest) ([
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
-	if r.status == nil {
+	if r.querystatus == nil {
 		return localVarReturnValue, nil, reportError("status is required and must be specified")
 	}
 
-	localVarQueryParams.Add("status", parameterToString(*r.status, "csv"))
+	localVarQueryParams.Add("status", parameterToString(*r.querystatus, "csv"))
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{}
 
@@ -468,11 +468,11 @@ func (a *PetApiService) FindPetsByStatusExecute(r ApiFindPetsByStatusRequest) ([
 type ApiFindPetsByTagsRequest struct {
 	ctx _context.Context
 	ApiService PetApi
-	tags *[]string
+	querytags *[]string
 }
 
 func (r ApiFindPetsByTagsRequest) Tags(tags []string) ApiFindPetsByTagsRequest {
-	r.tags = &tags
+	r.querytags = &tags
 	return r
 }
 
@@ -517,11 +517,11 @@ func (a *PetApiService) FindPetsByTagsExecute(r ApiFindPetsByTagsRequest) ([]Pet
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
-	if r.tags == nil {
+	if r.querytags == nil {
 		return localVarReturnValue, nil, reportError("tags is required and must be specified")
 	}
 
-	localVarQueryParams.Add("tags", parameterToString(*r.tags, "csv"))
+	localVarQueryParams.Add("tags", parameterToString(*r.querytags, "csv"))
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{}
 
@@ -579,7 +579,7 @@ func (a *PetApiService) FindPetsByTagsExecute(r ApiFindPetsByTagsRequest) ([]Pet
 type ApiGetPetByIdRequest struct {
 	ctx _context.Context
 	ApiService PetApi
-	petId int64
+	pathpetId int64
 }
 
 
@@ -598,7 +598,7 @@ func (a *PetApiService) GetPetById(ctx _context.Context, petId int64) ApiGetPetB
 	return ApiGetPetByIdRequest{
 		ApiService: a,
 		ctx: ctx,
-		petId: petId,
+		pathpetId: petId,
 	}
 }
 
@@ -622,7 +622,7 @@ func (a *PetApiService) GetPetByIdExecute(r ApiGetPetByIdRequest) (Pet, *_nethtt
 	}
 
 	localVarPath := localBasePath + "/pet/{petId}"
-	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.PathEscape(parameterToString(r.petId, "")), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.PathEscape(parameterToString(r.pathpetId, "")), -1)
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
@@ -699,11 +699,11 @@ func (a *PetApiService) GetPetByIdExecute(r ApiGetPetByIdRequest) (Pet, *_nethtt
 type ApiUpdatePetRequest struct {
 	ctx _context.Context
 	ApiService PetApi
-	body *Pet
+	bodybody *Pet
 }
 
 func (r ApiUpdatePetRequest) Body(body Pet) ApiUpdatePetRequest {
-	r.body = &body
+	r.bodybody = &body
 	return r
 }
 
@@ -745,7 +745,7 @@ func (a *PetApiService) UpdatePetExecute(r ApiUpdatePetRequest) (*_nethttp.Respo
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
-	if r.body == nil {
+	if r.bodybody == nil {
 		return nil, reportError("body is required and must be specified")
 	}
 
@@ -767,7 +767,7 @@ func (a *PetApiService) UpdatePetExecute(r ApiUpdatePetRequest) (*_nethttp.Respo
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
 	// body params
-	localVarPostBody = r.body
+	localVarPostBody = r.bodybody
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return nil, err
@@ -799,17 +799,17 @@ func (a *PetApiService) UpdatePetExecute(r ApiUpdatePetRequest) (*_nethttp.Respo
 type ApiUpdatePetWithFormRequest struct {
 	ctx _context.Context
 	ApiService PetApi
-	petId int64
-	name *string
-	status *string
+	pathpetId int64
+	formname *string
+	formstatus *string
 }
 
 func (r ApiUpdatePetWithFormRequest) Name(name string) ApiUpdatePetWithFormRequest {
-	r.name = &name
+	r.formname = &name
 	return r
 }
 func (r ApiUpdatePetWithFormRequest) Status(status string) ApiUpdatePetWithFormRequest {
-	r.status = &status
+	r.formstatus = &status
 	return r
 }
 
@@ -827,7 +827,7 @@ func (a *PetApiService) UpdatePetWithForm(ctx _context.Context, petId int64) Api
 	return ApiUpdatePetWithFormRequest{
 		ApiService: a,
 		ctx: ctx,
-		petId: petId,
+		pathpetId: petId,
 	}
 }
 
@@ -849,7 +849,7 @@ func (a *PetApiService) UpdatePetWithFormExecute(r ApiUpdatePetWithFormRequest) 
 	}
 
 	localVarPath := localBasePath + "/pet/{petId}"
-	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.PathEscape(parameterToString(r.petId, "")), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.PathEscape(parameterToString(r.pathpetId, "")), -1)
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
@@ -872,11 +872,11 @@ func (a *PetApiService) UpdatePetWithFormExecute(r ApiUpdatePetWithFormRequest) 
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
-	if r.name != nil {
-		localVarFormParams.Add("name", parameterToString(*r.name, ""))
+	if r.formname != nil {
+		localVarFormParams.Add("name", parameterToString(*r.formname, ""))
 	}
-	if r.status != nil {
-		localVarFormParams.Add("status", parameterToString(*r.status, ""))
+	if r.formstatus != nil {
+		localVarFormParams.Add("status", parameterToString(*r.formstatus, ""))
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
@@ -909,17 +909,17 @@ func (a *PetApiService) UpdatePetWithFormExecute(r ApiUpdatePetWithFormRequest) 
 type ApiUploadFileRequest struct {
 	ctx _context.Context
 	ApiService PetApi
-	petId int64
-	additionalMetadata *string
-	file **os.File
+	pathpetId int64
+	formadditionalMetadata *string
+	formfile **os.File
 }
 
 func (r ApiUploadFileRequest) AdditionalMetadata(additionalMetadata string) ApiUploadFileRequest {
-	r.additionalMetadata = &additionalMetadata
+	r.formadditionalMetadata = &additionalMetadata
 	return r
 }
 func (r ApiUploadFileRequest) File(file *os.File) ApiUploadFileRequest {
-	r.file = &file
+	r.formfile = &file
 	return r
 }
 
@@ -937,7 +937,7 @@ func (a *PetApiService) UploadFile(ctx _context.Context, petId int64) ApiUploadF
 	return ApiUploadFileRequest{
 		ApiService: a,
 		ctx: ctx,
-		petId: petId,
+		pathpetId: petId,
 	}
 }
 
@@ -961,7 +961,7 @@ func (a *PetApiService) UploadFileExecute(r ApiUploadFileRequest) (ApiResponse, 
 	}
 
 	localVarPath := localBasePath + "/pet/{petId}/uploadImage"
-	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.PathEscape(parameterToString(r.petId, "")), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.PathEscape(parameterToString(r.pathpetId, "")), -1)
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
@@ -984,13 +984,13 @@ func (a *PetApiService) UploadFileExecute(r ApiUploadFileRequest) (ApiResponse, 
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
-	if r.additionalMetadata != nil {
-		localVarFormParams.Add("additionalMetadata", parameterToString(*r.additionalMetadata, ""))
+	if r.formadditionalMetadata != nil {
+		localVarFormParams.Add("additionalMetadata", parameterToString(*r.formadditionalMetadata, ""))
 	}
 	localVarFormFileName = "file"
 	var localVarFile *os.File
-	if r.file != nil {
-		localVarFile = *r.file
+	if r.formfile != nil {
+		localVarFile = *r.formfile
 	}
 	if localVarFile != nil {
 		fbs, _ := _ioutil.ReadAll(localVarFile)
@@ -1038,17 +1038,17 @@ func (a *PetApiService) UploadFileExecute(r ApiUploadFileRequest) (ApiResponse, 
 type ApiUploadFileWithRequiredFileRequest struct {
 	ctx _context.Context
 	ApiService PetApi
-	petId int64
-	requiredFile **os.File
-	additionalMetadata *string
+	pathpetId int64
+	formrequiredFile **os.File
+	formadditionalMetadata *string
 }
 
 func (r ApiUploadFileWithRequiredFileRequest) RequiredFile(requiredFile *os.File) ApiUploadFileWithRequiredFileRequest {
-	r.requiredFile = &requiredFile
+	r.formrequiredFile = &requiredFile
 	return r
 }
 func (r ApiUploadFileWithRequiredFileRequest) AdditionalMetadata(additionalMetadata string) ApiUploadFileWithRequiredFileRequest {
-	r.additionalMetadata = &additionalMetadata
+	r.formadditionalMetadata = &additionalMetadata
 	return r
 }
 
@@ -1066,7 +1066,7 @@ func (a *PetApiService) UploadFileWithRequiredFile(ctx _context.Context, petId i
 	return ApiUploadFileWithRequiredFileRequest{
 		ApiService: a,
 		ctx: ctx,
-		petId: petId,
+		pathpetId: petId,
 	}
 }
 
@@ -1090,12 +1090,12 @@ func (a *PetApiService) UploadFileWithRequiredFileExecute(r ApiUploadFileWithReq
 	}
 
 	localVarPath := localBasePath + "/fake/{petId}/uploadImageWithRequiredFile"
-	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.PathEscape(parameterToString(r.petId, "")), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.PathEscape(parameterToString(r.pathpetId, "")), -1)
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
-	if r.requiredFile == nil {
+	if r.formrequiredFile == nil {
 		return localVarReturnValue, nil, reportError("requiredFile is required and must be specified")
 	}
 
@@ -1116,11 +1116,11 @@ func (a *PetApiService) UploadFileWithRequiredFileExecute(r ApiUploadFileWithReq
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
-	if r.additionalMetadata != nil {
-		localVarFormParams.Add("additionalMetadata", parameterToString(*r.additionalMetadata, ""))
+	if r.formadditionalMetadata != nil {
+		localVarFormParams.Add("additionalMetadata", parameterToString(*r.formadditionalMetadata, ""))
 	}
 	localVarFormFileName = "requiredFile"
-	localVarFile := *r.requiredFile
+	localVarFile := *r.formrequiredFile
 	if localVarFile != nil {
 		fbs, _ := _ioutil.ReadAll(localVarFile)
 		localVarFileBytes = fbs

--- a/samples/client/petstore/go/go-petstore/api_store.go
+++ b/samples/client/petstore/go/go-petstore/api_store.go
@@ -89,7 +89,7 @@ type StoreApiService service
 type ApiDeleteOrderRequest struct {
 	ctx _context.Context
 	ApiService StoreApi
-	orderId string
+	pathorderId string
 }
 
 
@@ -108,7 +108,7 @@ func (a *StoreApiService) DeleteOrder(ctx _context.Context, orderId string) ApiD
 	return ApiDeleteOrderRequest{
 		ApiService: a,
 		ctx: ctx,
-		orderId: orderId,
+		pathorderId: orderId,
 	}
 }
 
@@ -130,7 +130,7 @@ func (a *StoreApiService) DeleteOrderExecute(r ApiDeleteOrderRequest) (*_nethttp
 	}
 
 	localVarPath := localBasePath + "/store/order/{order_id}"
-	localVarPath = strings.Replace(localVarPath, "{"+"order_id"+"}", _neturl.PathEscape(parameterToString(r.orderId, "")), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"order_id"+"}", _neturl.PathEscape(parameterToString(r.pathorderId, "")), -1)
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
@@ -300,7 +300,7 @@ func (a *StoreApiService) GetInventoryExecute(r ApiGetInventoryRequest) (map[str
 type ApiGetOrderByIdRequest struct {
 	ctx _context.Context
 	ApiService StoreApi
-	orderId int64
+	pathorderId int64
 }
 
 
@@ -319,7 +319,7 @@ func (a *StoreApiService) GetOrderById(ctx _context.Context, orderId int64) ApiG
 	return ApiGetOrderByIdRequest{
 		ApiService: a,
 		ctx: ctx,
-		orderId: orderId,
+		pathorderId: orderId,
 	}
 }
 
@@ -343,15 +343,15 @@ func (a *StoreApiService) GetOrderByIdExecute(r ApiGetOrderByIdRequest) (Order, 
 	}
 
 	localVarPath := localBasePath + "/store/order/{order_id}"
-	localVarPath = strings.Replace(localVarPath, "{"+"order_id"+"}", _neturl.PathEscape(parameterToString(r.orderId, "")), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"order_id"+"}", _neturl.PathEscape(parameterToString(r.pathorderId, "")), -1)
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
-	if r.orderId < 1 {
+	if r.pathorderId < 1 {
 		return localVarReturnValue, nil, reportError("orderId must be greater than 1")
 	}
-	if r.orderId > 5 {
+	if r.pathorderId > 5 {
 		return localVarReturnValue, nil, reportError("orderId must be less than 5")
 	}
 
@@ -412,11 +412,11 @@ func (a *StoreApiService) GetOrderByIdExecute(r ApiGetOrderByIdRequest) (Order, 
 type ApiPlaceOrderRequest struct {
 	ctx _context.Context
 	ApiService StoreApi
-	body *Order
+	bodybody *Order
 }
 
 func (r ApiPlaceOrderRequest) Body(body Order) ApiPlaceOrderRequest {
-	r.body = &body
+	r.bodybody = &body
 	return r
 }
 
@@ -460,7 +460,7 @@ func (a *StoreApiService) PlaceOrderExecute(r ApiPlaceOrderRequest) (Order, *_ne
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
-	if r.body == nil {
+	if r.bodybody == nil {
 		return localVarReturnValue, nil, reportError("body is required and must be specified")
 	}
 
@@ -482,7 +482,7 @@ func (a *StoreApiService) PlaceOrderExecute(r ApiPlaceOrderRequest) (Order, *_ne
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
 	// body params
-	localVarPostBody = r.body
+	localVarPostBody = r.bodybody
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return localVarReturnValue, nil, err

--- a/samples/client/petstore/go/go-petstore/api_user.go
+++ b/samples/client/petstore/go/go-petstore/api_user.go
@@ -137,11 +137,11 @@ type UserApiService service
 type ApiCreateUserRequest struct {
 	ctx _context.Context
 	ApiService UserApi
-	body *User
+	bodybody *User
 }
 
 func (r ApiCreateUserRequest) Body(body User) ApiCreateUserRequest {
-	r.body = &body
+	r.bodybody = &body
 	return r
 }
 
@@ -184,7 +184,7 @@ func (a *UserApiService) CreateUserExecute(r ApiCreateUserRequest) (*_nethttp.Re
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
-	if r.body == nil {
+	if r.bodybody == nil {
 		return nil, reportError("body is required and must be specified")
 	}
 
@@ -206,7 +206,7 @@ func (a *UserApiService) CreateUserExecute(r ApiCreateUserRequest) (*_nethttp.Re
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
 	// body params
-	localVarPostBody = r.body
+	localVarPostBody = r.bodybody
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return nil, err
@@ -238,11 +238,11 @@ func (a *UserApiService) CreateUserExecute(r ApiCreateUserRequest) (*_nethttp.Re
 type ApiCreateUsersWithArrayInputRequest struct {
 	ctx _context.Context
 	ApiService UserApi
-	body *[]User
+	bodybody *[]User
 }
 
 func (r ApiCreateUsersWithArrayInputRequest) Body(body []User) ApiCreateUsersWithArrayInputRequest {
-	r.body = &body
+	r.bodybody = &body
 	return r
 }
 
@@ -284,7 +284,7 @@ func (a *UserApiService) CreateUsersWithArrayInputExecute(r ApiCreateUsersWithAr
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
-	if r.body == nil {
+	if r.bodybody == nil {
 		return nil, reportError("body is required and must be specified")
 	}
 
@@ -306,7 +306,7 @@ func (a *UserApiService) CreateUsersWithArrayInputExecute(r ApiCreateUsersWithAr
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
 	// body params
-	localVarPostBody = r.body
+	localVarPostBody = r.bodybody
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return nil, err
@@ -338,11 +338,11 @@ func (a *UserApiService) CreateUsersWithArrayInputExecute(r ApiCreateUsersWithAr
 type ApiCreateUsersWithListInputRequest struct {
 	ctx _context.Context
 	ApiService UserApi
-	body *[]User
+	bodybody *[]User
 }
 
 func (r ApiCreateUsersWithListInputRequest) Body(body []User) ApiCreateUsersWithListInputRequest {
-	r.body = &body
+	r.bodybody = &body
 	return r
 }
 
@@ -384,7 +384,7 @@ func (a *UserApiService) CreateUsersWithListInputExecute(r ApiCreateUsersWithLis
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
-	if r.body == nil {
+	if r.bodybody == nil {
 		return nil, reportError("body is required and must be specified")
 	}
 
@@ -406,7 +406,7 @@ func (a *UserApiService) CreateUsersWithListInputExecute(r ApiCreateUsersWithLis
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
 	// body params
-	localVarPostBody = r.body
+	localVarPostBody = r.bodybody
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return nil, err
@@ -438,7 +438,7 @@ func (a *UserApiService) CreateUsersWithListInputExecute(r ApiCreateUsersWithLis
 type ApiDeleteUserRequest struct {
 	ctx _context.Context
 	ApiService UserApi
-	username string
+	pathusername string
 }
 
 
@@ -457,7 +457,7 @@ func (a *UserApiService) DeleteUser(ctx _context.Context, username string) ApiDe
 	return ApiDeleteUserRequest{
 		ApiService: a,
 		ctx: ctx,
-		username: username,
+		pathusername: username,
 	}
 }
 
@@ -479,7 +479,7 @@ func (a *UserApiService) DeleteUserExecute(r ApiDeleteUserRequest) (*_nethttp.Re
 	}
 
 	localVarPath := localBasePath + "/user/{username}"
-	localVarPath = strings.Replace(localVarPath, "{"+"username"+"}", _neturl.PathEscape(parameterToString(r.username, "")), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"username"+"}", _neturl.PathEscape(parameterToString(r.pathusername, "")), -1)
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
@@ -533,7 +533,7 @@ func (a *UserApiService) DeleteUserExecute(r ApiDeleteUserRequest) (*_nethttp.Re
 type ApiGetUserByNameRequest struct {
 	ctx _context.Context
 	ApiService UserApi
-	username string
+	pathusername string
 }
 
 
@@ -551,7 +551,7 @@ func (a *UserApiService) GetUserByName(ctx _context.Context, username string) Ap
 	return ApiGetUserByNameRequest{
 		ApiService: a,
 		ctx: ctx,
-		username: username,
+		pathusername: username,
 	}
 }
 
@@ -575,7 +575,7 @@ func (a *UserApiService) GetUserByNameExecute(r ApiGetUserByNameRequest) (User, 
 	}
 
 	localVarPath := localBasePath + "/user/{username}"
-	localVarPath = strings.Replace(localVarPath, "{"+"username"+"}", _neturl.PathEscape(parameterToString(r.username, "")), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"username"+"}", _neturl.PathEscape(parameterToString(r.pathusername, "")), -1)
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
@@ -638,16 +638,16 @@ func (a *UserApiService) GetUserByNameExecute(r ApiGetUserByNameRequest) (User, 
 type ApiLoginUserRequest struct {
 	ctx _context.Context
 	ApiService UserApi
-	username *string
-	password *string
+	queryusername *string
+	querypassword *string
 }
 
 func (r ApiLoginUserRequest) Username(username string) ApiLoginUserRequest {
-	r.username = &username
+	r.queryusername = &username
 	return r
 }
 func (r ApiLoginUserRequest) Password(password string) ApiLoginUserRequest {
-	r.password = &password
+	r.querypassword = &password
 	return r
 }
 
@@ -691,15 +691,15 @@ func (a *UserApiService) LoginUserExecute(r ApiLoginUserRequest) (string, *_neth
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
-	if r.username == nil {
+	if r.queryusername == nil {
 		return localVarReturnValue, nil, reportError("username is required and must be specified")
 	}
-	if r.password == nil {
+	if r.querypassword == nil {
 		return localVarReturnValue, nil, reportError("password is required and must be specified")
 	}
 
-	localVarQueryParams.Add("username", parameterToString(*r.username, ""))
-	localVarQueryParams.Add("password", parameterToString(*r.password, ""))
+	localVarQueryParams.Add("username", parameterToString(*r.queryusername, ""))
+	localVarQueryParams.Add("password", parameterToString(*r.querypassword, ""))
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{}
 
@@ -847,12 +847,12 @@ func (a *UserApiService) LogoutUserExecute(r ApiLogoutUserRequest) (*_nethttp.Re
 type ApiUpdateUserRequest struct {
 	ctx _context.Context
 	ApiService UserApi
-	username string
-	body *User
+	pathusername string
+	bodybody *User
 }
 
 func (r ApiUpdateUserRequest) Body(body User) ApiUpdateUserRequest {
-	r.body = &body
+	r.bodybody = &body
 	return r
 }
 
@@ -871,7 +871,7 @@ func (a *UserApiService) UpdateUser(ctx _context.Context, username string) ApiUp
 	return ApiUpdateUserRequest{
 		ApiService: a,
 		ctx: ctx,
-		username: username,
+		pathusername: username,
 	}
 }
 
@@ -893,12 +893,12 @@ func (a *UserApiService) UpdateUserExecute(r ApiUpdateUserRequest) (*_nethttp.Re
 	}
 
 	localVarPath := localBasePath + "/user/{username}"
-	localVarPath = strings.Replace(localVarPath, "{"+"username"+"}", _neturl.PathEscape(parameterToString(r.username, "")), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"username"+"}", _neturl.PathEscape(parameterToString(r.pathusername, "")), -1)
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
-	if r.body == nil {
+	if r.bodybody == nil {
 		return nil, reportError("body is required and must be specified")
 	}
 
@@ -920,7 +920,7 @@ func (a *UserApiService) UpdateUserExecute(r ApiUpdateUserRequest) (*_nethttp.Re
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
 	// body params
-	localVarPostBody = r.body
+	localVarPostBody = r.bodybody
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return nil, err

--- a/samples/client/petstore/go/go-petstore/docs/FakeApi.md
+++ b/samples/client/petstore/go/go-petstore/docs/FakeApi.md
@@ -415,7 +415,7 @@ No authorization required
 
 ## TestBodyWithQueryParams
 
-> TestBodyWithQueryParams(ctx).Query(query).Body(body).Execute()
+> TestBodyWithQueryParams(ctx).QueryQuery(query).Body(body).Execute()
 
 
 
@@ -437,7 +437,7 @@ func main() {
 
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
-    resp, r, err := api_client.FakeApi.TestBodyWithQueryParams(context.Background()).Query(query).Body(body).Execute()
+    resp, r, err := api_client.FakeApi.TestBodyWithQueryParams(context.Background()).QueryQuery(query).Body(body).Execute()
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.TestBodyWithQueryParams``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
@@ -636,7 +636,7 @@ Name | Type | Description  | Notes
 
 ## TestEnumParameters
 
-> TestEnumParameters(ctx).EnumHeaderStringArray(enumHeaderStringArray).EnumHeaderString(enumHeaderString).EnumQueryStringArray(enumQueryStringArray).EnumQueryString(enumQueryString).EnumQueryInteger(enumQueryInteger).EnumQueryDouble(enumQueryDouble).EnumFormStringArray(enumFormStringArray).EnumFormString(enumFormString).Execute()
+> TestEnumParameters(ctx).HeaderEnumHeaderStringArray(enumHeaderStringArray).HeaderEnumHeaderString(enumHeaderString).QueryEnumQueryStringArray(enumQueryStringArray).QueryEnumQueryString(enumQueryString).QueryEnumQueryInteger(enumQueryInteger).QueryEnumQueryDouble(enumQueryDouble).EnumFormStringArray(enumFormStringArray).EnumFormString(enumFormString).Execute()
 
 To test enum parameters
 
@@ -666,7 +666,7 @@ func main() {
 
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
-    resp, r, err := api_client.FakeApi.TestEnumParameters(context.Background()).EnumHeaderStringArray(enumHeaderStringArray).EnumHeaderString(enumHeaderString).EnumQueryStringArray(enumQueryStringArray).EnumQueryString(enumQueryString).EnumQueryInteger(enumQueryInteger).EnumQueryDouble(enumQueryDouble).EnumFormStringArray(enumFormStringArray).EnumFormString(enumFormString).Execute()
+    resp, r, err := api_client.FakeApi.TestEnumParameters(context.Background()).HeaderEnumHeaderStringArray(enumHeaderStringArray).HeaderEnumHeaderString(enumHeaderString).QueryEnumQueryStringArray(enumQueryStringArray).QueryEnumQueryString(enumQueryString).QueryEnumQueryInteger(enumQueryInteger).QueryEnumQueryDouble(enumQueryDouble).EnumFormStringArray(enumFormStringArray).EnumFormString(enumFormString).Execute()
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.TestEnumParameters``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
@@ -714,7 +714,7 @@ No authorization required
 
 ## TestGroupParameters
 
-> TestGroupParameters(ctx).RequiredStringGroup(requiredStringGroup).RequiredBooleanGroup(requiredBooleanGroup).RequiredInt64Group(requiredInt64Group).StringGroup(stringGroup).BooleanGroup(booleanGroup).Int64Group(int64Group).Execute()
+> TestGroupParameters(ctx).RequiredStringGroup(requiredStringGroup).HeaderRequiredBooleanGroup(requiredBooleanGroup).RequiredInt64Group(requiredInt64Group).StringGroup(stringGroup).HeaderBooleanGroup(booleanGroup).Int64Group(int64Group).Execute()
 
 Fake endpoint to test group parameters (optional)
 
@@ -742,7 +742,7 @@ func main() {
 
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
-    resp, r, err := api_client.FakeApi.TestGroupParameters(context.Background()).RequiredStringGroup(requiredStringGroup).RequiredBooleanGroup(requiredBooleanGroup).RequiredInt64Group(requiredInt64Group).StringGroup(stringGroup).BooleanGroup(booleanGroup).Int64Group(int64Group).Execute()
+    resp, r, err := api_client.FakeApi.TestGroupParameters(context.Background()).RequiredStringGroup(requiredStringGroup).HeaderRequiredBooleanGroup(requiredBooleanGroup).RequiredInt64Group(requiredInt64Group).StringGroup(stringGroup).HeaderBooleanGroup(booleanGroup).Int64Group(int64Group).Execute()
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.TestGroupParameters``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)

--- a/samples/client/petstore/go/go-petstore/docs/PetApi.md
+++ b/samples/client/petstore/go/go-petstore/docs/PetApi.md
@@ -80,7 +80,7 @@ Name | Type | Description  | Notes
 
 ## DeletePet
 
-> DeletePet(ctx, petId).ApiKey(apiKey).Execute()
+> DeletePet(ctx, petId).HeaderApiKey(apiKey).Execute()
 
 Deletes a pet
 
@@ -102,7 +102,7 @@ func main() {
 
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
-    resp, r, err := api_client.PetApi.DeletePet(context.Background(), petId).ApiKey(apiKey).Execute()
+    resp, r, err := api_client.PetApi.DeletePet(context.Background(), petId).HeaderApiKey(apiKey).Execute()
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `PetApi.DeletePet``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)

--- a/samples/openapi3/client/petstore/go/go-petstore/api_another_fake.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/api_another_fake.go
@@ -46,11 +46,11 @@ type AnotherFakeApiService service
 type ApiCall123TestSpecialTagsRequest struct {
 	ctx _context.Context
 	ApiService AnotherFakeApi
-	client *Client
+	bodyclient *Client
 }
 
 func (r ApiCall123TestSpecialTagsRequest) Client(client Client) ApiCall123TestSpecialTagsRequest {
-	r.client = &client
+	r.bodyclient = &client
 	return r
 }
 
@@ -95,7 +95,7 @@ func (a *AnotherFakeApiService) Call123TestSpecialTagsExecute(r ApiCall123TestSp
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
-	if r.client == nil {
+	if r.bodyclient == nil {
 		return localVarReturnValue, nil, reportError("client is required and must be specified")
 	}
 
@@ -117,7 +117,7 @@ func (a *AnotherFakeApiService) Call123TestSpecialTagsExecute(r ApiCall123TestSp
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
 	// body params
-	localVarPostBody = r.client
+	localVarPostBody = r.bodyclient
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return localVarReturnValue, nil, err

--- a/samples/openapi3/client/petstore/go/go-petstore/api_fake.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/api_fake.go
@@ -324,11 +324,11 @@ func (a *FakeApiService) FakeHealthGetExecute(r ApiFakeHealthGetRequest) (Health
 type ApiFakeOuterBooleanSerializeRequest struct {
 	ctx _context.Context
 	ApiService FakeApi
-	body *bool
+	bodybody *bool
 }
 
 func (r ApiFakeOuterBooleanSerializeRequest) Body(body bool) ApiFakeOuterBooleanSerializeRequest {
-	r.body = &body
+	r.bodybody = &body
 	return r
 }
 
@@ -392,7 +392,7 @@ func (a *FakeApiService) FakeOuterBooleanSerializeExecute(r ApiFakeOuterBooleanS
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
 	// body params
-	localVarPostBody = r.body
+	localVarPostBody = r.bodybody
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return localVarReturnValue, nil, err
@@ -433,11 +433,11 @@ func (a *FakeApiService) FakeOuterBooleanSerializeExecute(r ApiFakeOuterBooleanS
 type ApiFakeOuterCompositeSerializeRequest struct {
 	ctx _context.Context
 	ApiService FakeApi
-	outerComposite *OuterComposite
+	bodyouterComposite *OuterComposite
 }
 
 func (r ApiFakeOuterCompositeSerializeRequest) OuterComposite(outerComposite OuterComposite) ApiFakeOuterCompositeSerializeRequest {
-	r.outerComposite = &outerComposite
+	r.bodyouterComposite = &outerComposite
 	return r
 }
 
@@ -501,7 +501,7 @@ func (a *FakeApiService) FakeOuterCompositeSerializeExecute(r ApiFakeOuterCompos
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
 	// body params
-	localVarPostBody = r.outerComposite
+	localVarPostBody = r.bodyouterComposite
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return localVarReturnValue, nil, err
@@ -542,11 +542,11 @@ func (a *FakeApiService) FakeOuterCompositeSerializeExecute(r ApiFakeOuterCompos
 type ApiFakeOuterNumberSerializeRequest struct {
 	ctx _context.Context
 	ApiService FakeApi
-	body *float32
+	bodybody *float32
 }
 
 func (r ApiFakeOuterNumberSerializeRequest) Body(body float32) ApiFakeOuterNumberSerializeRequest {
-	r.body = &body
+	r.bodybody = &body
 	return r
 }
 
@@ -610,7 +610,7 @@ func (a *FakeApiService) FakeOuterNumberSerializeExecute(r ApiFakeOuterNumberSer
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
 	// body params
-	localVarPostBody = r.body
+	localVarPostBody = r.bodybody
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return localVarReturnValue, nil, err
@@ -651,11 +651,11 @@ func (a *FakeApiService) FakeOuterNumberSerializeExecute(r ApiFakeOuterNumberSer
 type ApiFakeOuterStringSerializeRequest struct {
 	ctx _context.Context
 	ApiService FakeApi
-	body *string
+	bodybody *string
 }
 
 func (r ApiFakeOuterStringSerializeRequest) Body(body string) ApiFakeOuterStringSerializeRequest {
-	r.body = &body
+	r.bodybody = &body
 	return r
 }
 
@@ -719,7 +719,7 @@ func (a *FakeApiService) FakeOuterStringSerializeExecute(r ApiFakeOuterStringSer
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
 	// body params
-	localVarPostBody = r.body
+	localVarPostBody = r.bodybody
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return localVarReturnValue, nil, err
@@ -760,11 +760,11 @@ func (a *FakeApiService) FakeOuterStringSerializeExecute(r ApiFakeOuterStringSer
 type ApiTestBodyWithFileSchemaRequest struct {
 	ctx _context.Context
 	ApiService FakeApi
-	fileSchemaTestClass *FileSchemaTestClass
+	bodyfileSchemaTestClass *FileSchemaTestClass
 }
 
 func (r ApiTestBodyWithFileSchemaRequest) FileSchemaTestClass(fileSchemaTestClass FileSchemaTestClass) ApiTestBodyWithFileSchemaRequest {
-	r.fileSchemaTestClass = &fileSchemaTestClass
+	r.bodyfileSchemaTestClass = &fileSchemaTestClass
 	return r
 }
 
@@ -807,7 +807,7 @@ func (a *FakeApiService) TestBodyWithFileSchemaExecute(r ApiTestBodyWithFileSche
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
-	if r.fileSchemaTestClass == nil {
+	if r.bodyfileSchemaTestClass == nil {
 		return nil, reportError("fileSchemaTestClass is required and must be specified")
 	}
 
@@ -829,7 +829,7 @@ func (a *FakeApiService) TestBodyWithFileSchemaExecute(r ApiTestBodyWithFileSche
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
 	// body params
-	localVarPostBody = r.fileSchemaTestClass
+	localVarPostBody = r.bodyfileSchemaTestClass
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return nil, err
@@ -861,16 +861,16 @@ func (a *FakeApiService) TestBodyWithFileSchemaExecute(r ApiTestBodyWithFileSche
 type ApiTestBodyWithQueryParamsRequest struct {
 	ctx _context.Context
 	ApiService FakeApi
-	query *string
-	user *User
+	queryquery *string
+	bodyuser *User
 }
 
-func (r ApiTestBodyWithQueryParamsRequest) Query(query string) ApiTestBodyWithQueryParamsRequest {
-	r.query = &query
+func (r ApiTestBodyWithQueryParamsRequest) QueryQuery(query string) ApiTestBodyWithQueryParamsRequest {
+	r.queryquery = &query
 	return r
 }
 func (r ApiTestBodyWithQueryParamsRequest) User(user User) ApiTestBodyWithQueryParamsRequest {
-	r.user = &user
+	r.bodyuser = &user
 	return r
 }
 
@@ -912,14 +912,14 @@ func (a *FakeApiService) TestBodyWithQueryParamsExecute(r ApiTestBodyWithQueryPa
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
-	if r.query == nil {
+	if r.queryquery == nil {
 		return nil, reportError("query is required and must be specified")
 	}
-	if r.user == nil {
+	if r.bodyuser == nil {
 		return nil, reportError("user is required and must be specified")
 	}
 
-	localVarQueryParams.Add("query", parameterToString(*r.query, ""))
+	localVarQueryParams.Add("query", parameterToString(*r.queryquery, ""))
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{"application/json"}
 
@@ -938,7 +938,7 @@ func (a *FakeApiService) TestBodyWithQueryParamsExecute(r ApiTestBodyWithQueryPa
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
 	// body params
-	localVarPostBody = r.user
+	localVarPostBody = r.bodyuser
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return nil, err
@@ -970,11 +970,11 @@ func (a *FakeApiService) TestBodyWithQueryParamsExecute(r ApiTestBodyWithQueryPa
 type ApiTestClientModelRequest struct {
 	ctx _context.Context
 	ApiService FakeApi
-	client *Client
+	bodyclient *Client
 }
 
 func (r ApiTestClientModelRequest) Client(client Client) ApiTestClientModelRequest {
-	r.client = &client
+	r.bodyclient = &client
 	return r
 }
 
@@ -1019,7 +1019,7 @@ func (a *FakeApiService) TestClientModelExecute(r ApiTestClientModelRequest) (Cl
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
-	if r.client == nil {
+	if r.bodyclient == nil {
 		return localVarReturnValue, nil, reportError("client is required and must be specified")
 	}
 
@@ -1041,7 +1041,7 @@ func (a *FakeApiService) TestClientModelExecute(r ApiTestClientModelRequest) (Cl
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
 	// body params
-	localVarPostBody = r.client
+	localVarPostBody = r.bodyclient
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return localVarReturnValue, nil, err
@@ -1082,76 +1082,76 @@ func (a *FakeApiService) TestClientModelExecute(r ApiTestClientModelRequest) (Cl
 type ApiTestEndpointParametersRequest struct {
 	ctx _context.Context
 	ApiService FakeApi
-	number *float32
-	double *float64
-	patternWithoutDelimiter *string
-	byte_ *string
-	integer *int32
-	int32_ *int32
-	int64_ *int64
-	float *float32
-	string_ *string
-	binary **os.File
-	date *string
-	dateTime *time.Time
-	password *string
-	callback *string
+	formnumber *float32
+	formdouble *float64
+	formpatternWithoutDelimiter *string
+	formbyte_ *string
+	forminteger *int32
+	formint32_ *int32
+	formint64_ *int64
+	formfloat *float32
+	formstring_ *string
+	formbinary **os.File
+	formdate *string
+	formdateTime *time.Time
+	formpassword *string
+	formcallback *string
 }
 
 func (r ApiTestEndpointParametersRequest) Number(number float32) ApiTestEndpointParametersRequest {
-	r.number = &number
+	r.formnumber = &number
 	return r
 }
 func (r ApiTestEndpointParametersRequest) Double(double float64) ApiTestEndpointParametersRequest {
-	r.double = &double
+	r.formdouble = &double
 	return r
 }
 func (r ApiTestEndpointParametersRequest) PatternWithoutDelimiter(patternWithoutDelimiter string) ApiTestEndpointParametersRequest {
-	r.patternWithoutDelimiter = &patternWithoutDelimiter
+	r.formpatternWithoutDelimiter = &patternWithoutDelimiter
 	return r
 }
 func (r ApiTestEndpointParametersRequest) Byte_(byte_ string) ApiTestEndpointParametersRequest {
-	r.byte_ = &byte_
+	r.formbyte_ = &byte_
 	return r
 }
 func (r ApiTestEndpointParametersRequest) Integer(integer int32) ApiTestEndpointParametersRequest {
-	r.integer = &integer
+	r.forminteger = &integer
 	return r
 }
 func (r ApiTestEndpointParametersRequest) Int32_(int32_ int32) ApiTestEndpointParametersRequest {
-	r.int32_ = &int32_
+	r.formint32_ = &int32_
 	return r
 }
 func (r ApiTestEndpointParametersRequest) Int64_(int64_ int64) ApiTestEndpointParametersRequest {
-	r.int64_ = &int64_
+	r.formint64_ = &int64_
 	return r
 }
 func (r ApiTestEndpointParametersRequest) Float(float float32) ApiTestEndpointParametersRequest {
-	r.float = &float
+	r.formfloat = &float
 	return r
 }
 func (r ApiTestEndpointParametersRequest) String_(string_ string) ApiTestEndpointParametersRequest {
-	r.string_ = &string_
+	r.formstring_ = &string_
 	return r
 }
 func (r ApiTestEndpointParametersRequest) Binary(binary *os.File) ApiTestEndpointParametersRequest {
-	r.binary = &binary
+	r.formbinary = &binary
 	return r
 }
 func (r ApiTestEndpointParametersRequest) Date(date string) ApiTestEndpointParametersRequest {
-	r.date = &date
+	r.formdate = &date
 	return r
 }
 func (r ApiTestEndpointParametersRequest) DateTime(dateTime time.Time) ApiTestEndpointParametersRequest {
-	r.dateTime = &dateTime
+	r.formdateTime = &dateTime
 	return r
 }
 func (r ApiTestEndpointParametersRequest) Password(password string) ApiTestEndpointParametersRequest {
-	r.password = &password
+	r.formpassword = &password
 	return r
 }
 func (r ApiTestEndpointParametersRequest) Callback(callback string) ApiTestEndpointParametersRequest {
-	r.callback = &callback
+	r.formcallback = &callback
 	return r
 }
 
@@ -1198,28 +1198,28 @@ func (a *FakeApiService) TestEndpointParametersExecute(r ApiTestEndpointParamete
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
-	if r.number == nil {
+	if r.formnumber == nil {
 		return nil, reportError("number is required and must be specified")
 	}
-	if *r.number < 32.1 {
+	if *r.formnumber < 32.1 {
 		return nil, reportError("number must be greater than 32.1")
 	}
-	if *r.number > 543.2 {
+	if *r.formnumber > 543.2 {
 		return nil, reportError("number must be less than 543.2")
 	}
-	if r.double == nil {
+	if r.formdouble == nil {
 		return nil, reportError("double is required and must be specified")
 	}
-	if *r.double < 67.8 {
+	if *r.formdouble < 67.8 {
 		return nil, reportError("double must be greater than 67.8")
 	}
-	if *r.double > 123.4 {
+	if *r.formdouble > 123.4 {
 		return nil, reportError("double must be less than 123.4")
 	}
-	if r.patternWithoutDelimiter == nil {
+	if r.formpatternWithoutDelimiter == nil {
 		return nil, reportError("patternWithoutDelimiter is required and must be specified")
 	}
-	if r.byte_ == nil {
+	if r.formbyte_ == nil {
 		return nil, reportError("byte_ is required and must be specified")
 	}
 
@@ -1240,29 +1240,29 @@ func (a *FakeApiService) TestEndpointParametersExecute(r ApiTestEndpointParamete
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
-	if r.integer != nil {
-		localVarFormParams.Add("integer", parameterToString(*r.integer, ""))
+	if r.forminteger != nil {
+		localVarFormParams.Add("integer", parameterToString(*r.forminteger, ""))
 	}
-	if r.int32_ != nil {
-		localVarFormParams.Add("int32", parameterToString(*r.int32_, ""))
+	if r.formint32_ != nil {
+		localVarFormParams.Add("int32", parameterToString(*r.formint32_, ""))
 	}
-	if r.int64_ != nil {
-		localVarFormParams.Add("int64", parameterToString(*r.int64_, ""))
+	if r.formint64_ != nil {
+		localVarFormParams.Add("int64", parameterToString(*r.formint64_, ""))
 	}
-	localVarFormParams.Add("number", parameterToString(*r.number, ""))
-	if r.float != nil {
-		localVarFormParams.Add("float", parameterToString(*r.float, ""))
+	localVarFormParams.Add("number", parameterToString(*r.formnumber, ""))
+	if r.formfloat != nil {
+		localVarFormParams.Add("float", parameterToString(*r.formfloat, ""))
 	}
-	localVarFormParams.Add("double", parameterToString(*r.double, ""))
-	if r.string_ != nil {
-		localVarFormParams.Add("string", parameterToString(*r.string_, ""))
+	localVarFormParams.Add("double", parameterToString(*r.formdouble, ""))
+	if r.formstring_ != nil {
+		localVarFormParams.Add("string", parameterToString(*r.formstring_, ""))
 	}
-	localVarFormParams.Add("pattern_without_delimiter", parameterToString(*r.patternWithoutDelimiter, ""))
-	localVarFormParams.Add("byte", parameterToString(*r.byte_, ""))
+	localVarFormParams.Add("pattern_without_delimiter", parameterToString(*r.formpatternWithoutDelimiter, ""))
+	localVarFormParams.Add("byte", parameterToString(*r.formbyte_, ""))
 	localVarFormFileName = "binary"
 	var localVarFile *os.File
-	if r.binary != nil {
-		localVarFile = *r.binary
+	if r.formbinary != nil {
+		localVarFile = *r.formbinary
 	}
 	if localVarFile != nil {
 		fbs, _ := _ioutil.ReadAll(localVarFile)
@@ -1270,17 +1270,17 @@ func (a *FakeApiService) TestEndpointParametersExecute(r ApiTestEndpointParamete
 		localVarFileName = localVarFile.Name()
 		localVarFile.Close()
 	}
-	if r.date != nil {
-		localVarFormParams.Add("date", parameterToString(*r.date, ""))
+	if r.formdate != nil {
+		localVarFormParams.Add("date", parameterToString(*r.formdate, ""))
 	}
-	if r.dateTime != nil {
-		localVarFormParams.Add("dateTime", parameterToString(*r.dateTime, ""))
+	if r.formdateTime != nil {
+		localVarFormParams.Add("dateTime", parameterToString(*r.formdateTime, ""))
 	}
-	if r.password != nil {
-		localVarFormParams.Add("password", parameterToString(*r.password, ""))
+	if r.formpassword != nil {
+		localVarFormParams.Add("password", parameterToString(*r.formpassword, ""))
 	}
-	if r.callback != nil {
-		localVarFormParams.Add("callback", parameterToString(*r.callback, ""))
+	if r.formcallback != nil {
+		localVarFormParams.Add("callback", parameterToString(*r.formcallback, ""))
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
@@ -1313,46 +1313,46 @@ func (a *FakeApiService) TestEndpointParametersExecute(r ApiTestEndpointParamete
 type ApiTestEnumParametersRequest struct {
 	ctx _context.Context
 	ApiService FakeApi
-	enumHeaderStringArray *[]string
-	enumHeaderString *string
-	enumQueryStringArray *[]string
-	enumQueryString *string
-	enumQueryInteger *int32
-	enumQueryDouble *float64
-	enumFormStringArray *[]string
-	enumFormString *string
+	headerenumHeaderStringArray *[]string
+	headerenumHeaderString *string
+	queryenumQueryStringArray *[]string
+	queryenumQueryString *string
+	queryenumQueryInteger *int32
+	queryenumQueryDouble *float64
+	formenumFormStringArray *[]string
+	formenumFormString *string
 }
 
-func (r ApiTestEnumParametersRequest) EnumHeaderStringArray(enumHeaderStringArray []string) ApiTestEnumParametersRequest {
-	r.enumHeaderStringArray = &enumHeaderStringArray
+func (r ApiTestEnumParametersRequest) HeaderEnumHeaderStringArray(enumHeaderStringArray []string) ApiTestEnumParametersRequest {
+	r.headerenumHeaderStringArray = &enumHeaderStringArray
 	return r
 }
-func (r ApiTestEnumParametersRequest) EnumHeaderString(enumHeaderString string) ApiTestEnumParametersRequest {
-	r.enumHeaderString = &enumHeaderString
+func (r ApiTestEnumParametersRequest) HeaderEnumHeaderString(enumHeaderString string) ApiTestEnumParametersRequest {
+	r.headerenumHeaderString = &enumHeaderString
 	return r
 }
-func (r ApiTestEnumParametersRequest) EnumQueryStringArray(enumQueryStringArray []string) ApiTestEnumParametersRequest {
-	r.enumQueryStringArray = &enumQueryStringArray
+func (r ApiTestEnumParametersRequest) QueryEnumQueryStringArray(enumQueryStringArray []string) ApiTestEnumParametersRequest {
+	r.queryenumQueryStringArray = &enumQueryStringArray
 	return r
 }
-func (r ApiTestEnumParametersRequest) EnumQueryString(enumQueryString string) ApiTestEnumParametersRequest {
-	r.enumQueryString = &enumQueryString
+func (r ApiTestEnumParametersRequest) QueryEnumQueryString(enumQueryString string) ApiTestEnumParametersRequest {
+	r.queryenumQueryString = &enumQueryString
 	return r
 }
-func (r ApiTestEnumParametersRequest) EnumQueryInteger(enumQueryInteger int32) ApiTestEnumParametersRequest {
-	r.enumQueryInteger = &enumQueryInteger
+func (r ApiTestEnumParametersRequest) QueryEnumQueryInteger(enumQueryInteger int32) ApiTestEnumParametersRequest {
+	r.queryenumQueryInteger = &enumQueryInteger
 	return r
 }
-func (r ApiTestEnumParametersRequest) EnumQueryDouble(enumQueryDouble float64) ApiTestEnumParametersRequest {
-	r.enumQueryDouble = &enumQueryDouble
+func (r ApiTestEnumParametersRequest) QueryEnumQueryDouble(enumQueryDouble float64) ApiTestEnumParametersRequest {
+	r.queryenumQueryDouble = &enumQueryDouble
 	return r
 }
 func (r ApiTestEnumParametersRequest) EnumFormStringArray(enumFormStringArray []string) ApiTestEnumParametersRequest {
-	r.enumFormStringArray = &enumFormStringArray
+	r.formenumFormStringArray = &enumFormStringArray
 	return r
 }
 func (r ApiTestEnumParametersRequest) EnumFormString(enumFormString string) ApiTestEnumParametersRequest {
-	r.enumFormString = &enumFormString
+	r.formenumFormString = &enumFormString
 	return r
 }
 
@@ -1396,8 +1396,8 @@ func (a *FakeApiService) TestEnumParametersExecute(r ApiTestEnumParametersReques
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 
-	if r.enumQueryStringArray != nil {
-		t := *r.enumQueryStringArray
+	if r.queryenumQueryStringArray != nil {
+		t := *r.queryenumQueryStringArray
 		if reflect.TypeOf(t).Kind() == reflect.Slice {
 			s := reflect.ValueOf(t)
 			for i := 0; i < s.Len(); i++ {
@@ -1407,14 +1407,14 @@ func (a *FakeApiService) TestEnumParametersExecute(r ApiTestEnumParametersReques
 			localVarQueryParams.Add("enum_query_string_array", parameterToString(t, "multi"))
 		}
 	}
-	if r.enumQueryString != nil {
-		localVarQueryParams.Add("enum_query_string", parameterToString(*r.enumQueryString, ""))
+	if r.queryenumQueryString != nil {
+		localVarQueryParams.Add("enum_query_string", parameterToString(*r.queryenumQueryString, ""))
 	}
-	if r.enumQueryInteger != nil {
-		localVarQueryParams.Add("enum_query_integer", parameterToString(*r.enumQueryInteger, ""))
+	if r.queryenumQueryInteger != nil {
+		localVarQueryParams.Add("enum_query_integer", parameterToString(*r.queryenumQueryInteger, ""))
 	}
-	if r.enumQueryDouble != nil {
-		localVarQueryParams.Add("enum_query_double", parameterToString(*r.enumQueryDouble, ""))
+	if r.queryenumQueryDouble != nil {
+		localVarQueryParams.Add("enum_query_double", parameterToString(*r.queryenumQueryDouble, ""))
 	}
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{"application/x-www-form-urlencoded"}
@@ -1433,17 +1433,17 @@ func (a *FakeApiService) TestEnumParametersExecute(r ApiTestEnumParametersReques
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
-	if r.enumHeaderStringArray != nil {
-		localVarHeaderParams["enum_header_string_array"] = parameterToString(*r.enumHeaderStringArray, "csv")
+	if r.headerenumHeaderStringArray != nil {
+		localVarHeaderParams["enum_header_string_array"] = parameterToString(*r.headerenumHeaderStringArray, "csv")
 	}
-	if r.enumHeaderString != nil {
-		localVarHeaderParams["enum_header_string"] = parameterToString(*r.enumHeaderString, "")
+	if r.headerenumHeaderString != nil {
+		localVarHeaderParams["enum_header_string"] = parameterToString(*r.headerenumHeaderString, "")
 	}
-	if r.enumFormStringArray != nil {
-		localVarFormParams.Add("enum_form_string_array", parameterToString(*r.enumFormStringArray, "csv"))
+	if r.formenumFormStringArray != nil {
+		localVarFormParams.Add("enum_form_string_array", parameterToString(*r.formenumFormStringArray, "csv"))
 	}
-	if r.enumFormString != nil {
-		localVarFormParams.Add("enum_form_string", parameterToString(*r.enumFormString, ""))
+	if r.formenumFormString != nil {
+		localVarFormParams.Add("enum_form_string", parameterToString(*r.formenumFormString, ""))
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
@@ -1476,36 +1476,36 @@ func (a *FakeApiService) TestEnumParametersExecute(r ApiTestEnumParametersReques
 type ApiTestGroupParametersRequest struct {
 	ctx _context.Context
 	ApiService FakeApi
-	requiredStringGroup *int32
-	requiredBooleanGroup *bool
-	requiredInt64Group *int64
-	stringGroup *int32
-	booleanGroup *bool
-	int64Group *int64
+	queryrequiredStringGroup *int32
+	headerrequiredBooleanGroup *bool
+	queryrequiredInt64Group *int64
+	querystringGroup *int32
+	headerbooleanGroup *bool
+	queryint64Group *int64
 }
 
 func (r ApiTestGroupParametersRequest) RequiredStringGroup(requiredStringGroup int32) ApiTestGroupParametersRequest {
-	r.requiredStringGroup = &requiredStringGroup
+	r.queryrequiredStringGroup = &requiredStringGroup
 	return r
 }
-func (r ApiTestGroupParametersRequest) RequiredBooleanGroup(requiredBooleanGroup bool) ApiTestGroupParametersRequest {
-	r.requiredBooleanGroup = &requiredBooleanGroup
+func (r ApiTestGroupParametersRequest) HeaderRequiredBooleanGroup(requiredBooleanGroup bool) ApiTestGroupParametersRequest {
+	r.headerrequiredBooleanGroup = &requiredBooleanGroup
 	return r
 }
 func (r ApiTestGroupParametersRequest) RequiredInt64Group(requiredInt64Group int64) ApiTestGroupParametersRequest {
-	r.requiredInt64Group = &requiredInt64Group
+	r.queryrequiredInt64Group = &requiredInt64Group
 	return r
 }
 func (r ApiTestGroupParametersRequest) StringGroup(stringGroup int32) ApiTestGroupParametersRequest {
-	r.stringGroup = &stringGroup
+	r.querystringGroup = &stringGroup
 	return r
 }
-func (r ApiTestGroupParametersRequest) BooleanGroup(booleanGroup bool) ApiTestGroupParametersRequest {
-	r.booleanGroup = &booleanGroup
+func (r ApiTestGroupParametersRequest) HeaderBooleanGroup(booleanGroup bool) ApiTestGroupParametersRequest {
+	r.headerbooleanGroup = &booleanGroup
 	return r
 }
 func (r ApiTestGroupParametersRequest) Int64Group(int64Group int64) ApiTestGroupParametersRequest {
-	r.int64Group = &int64Group
+	r.queryint64Group = &int64Group
 	return r
 }
 
@@ -1548,23 +1548,23 @@ func (a *FakeApiService) TestGroupParametersExecute(r ApiTestGroupParametersRequ
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
-	if r.requiredStringGroup == nil {
+	if r.queryrequiredStringGroup == nil {
 		return nil, reportError("requiredStringGroup is required and must be specified")
 	}
-	if r.requiredBooleanGroup == nil {
+	if r.headerrequiredBooleanGroup == nil {
 		return nil, reportError("requiredBooleanGroup is required and must be specified")
 	}
-	if r.requiredInt64Group == nil {
+	if r.queryrequiredInt64Group == nil {
 		return nil, reportError("requiredInt64Group is required and must be specified")
 	}
 
-	localVarQueryParams.Add("required_string_group", parameterToString(*r.requiredStringGroup, ""))
-	localVarQueryParams.Add("required_int64_group", parameterToString(*r.requiredInt64Group, ""))
-	if r.stringGroup != nil {
-		localVarQueryParams.Add("string_group", parameterToString(*r.stringGroup, ""))
+	localVarQueryParams.Add("required_string_group", parameterToString(*r.queryrequiredStringGroup, ""))
+	localVarQueryParams.Add("required_int64_group", parameterToString(*r.queryrequiredInt64Group, ""))
+	if r.querystringGroup != nil {
+		localVarQueryParams.Add("string_group", parameterToString(*r.querystringGroup, ""))
 	}
-	if r.int64Group != nil {
-		localVarQueryParams.Add("int64_group", parameterToString(*r.int64Group, ""))
+	if r.queryint64Group != nil {
+		localVarQueryParams.Add("int64_group", parameterToString(*r.queryint64Group, ""))
 	}
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{}
@@ -1583,9 +1583,9 @@ func (a *FakeApiService) TestGroupParametersExecute(r ApiTestGroupParametersRequ
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
-	localVarHeaderParams["required_boolean_group"] = parameterToString(*r.requiredBooleanGroup, "")
-	if r.booleanGroup != nil {
-		localVarHeaderParams["boolean_group"] = parameterToString(*r.booleanGroup, "")
+	localVarHeaderParams["required_boolean_group"] = parameterToString(*r.headerrequiredBooleanGroup, "")
+	if r.headerbooleanGroup != nil {
+		localVarHeaderParams["boolean_group"] = parameterToString(*r.headerbooleanGroup, "")
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
@@ -1618,11 +1618,11 @@ func (a *FakeApiService) TestGroupParametersExecute(r ApiTestGroupParametersRequ
 type ApiTestInlineAdditionalPropertiesRequest struct {
 	ctx _context.Context
 	ApiService FakeApi
-	requestBody *map[string]string
+	bodyrequestBody *map[string]string
 }
 
 func (r ApiTestInlineAdditionalPropertiesRequest) RequestBody(requestBody map[string]string) ApiTestInlineAdditionalPropertiesRequest {
-	r.requestBody = &requestBody
+	r.bodyrequestBody = &requestBody
 	return r
 }
 
@@ -1664,7 +1664,7 @@ func (a *FakeApiService) TestInlineAdditionalPropertiesExecute(r ApiTestInlineAd
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
-	if r.requestBody == nil {
+	if r.bodyrequestBody == nil {
 		return nil, reportError("requestBody is required and must be specified")
 	}
 
@@ -1686,7 +1686,7 @@ func (a *FakeApiService) TestInlineAdditionalPropertiesExecute(r ApiTestInlineAd
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
 	// body params
-	localVarPostBody = r.requestBody
+	localVarPostBody = r.bodyrequestBody
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return nil, err
@@ -1718,16 +1718,16 @@ func (a *FakeApiService) TestInlineAdditionalPropertiesExecute(r ApiTestInlineAd
 type ApiTestJsonFormDataRequest struct {
 	ctx _context.Context
 	ApiService FakeApi
-	param *string
-	param2 *string
+	formparam *string
+	formparam2 *string
 }
 
 func (r ApiTestJsonFormDataRequest) Param(param string) ApiTestJsonFormDataRequest {
-	r.param = &param
+	r.formparam = &param
 	return r
 }
 func (r ApiTestJsonFormDataRequest) Param2(param2 string) ApiTestJsonFormDataRequest {
-	r.param2 = &param2
+	r.formparam2 = &param2
 	return r
 }
 
@@ -1769,10 +1769,10 @@ func (a *FakeApiService) TestJsonFormDataExecute(r ApiTestJsonFormDataRequest) (
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
-	if r.param == nil {
+	if r.formparam == nil {
 		return nil, reportError("param is required and must be specified")
 	}
-	if r.param2 == nil {
+	if r.formparam2 == nil {
 		return nil, reportError("param2 is required and must be specified")
 	}
 
@@ -1793,8 +1793,8 @@ func (a *FakeApiService) TestJsonFormDataExecute(r ApiTestJsonFormDataRequest) (
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
-	localVarFormParams.Add("param", parameterToString(*r.param, ""))
-	localVarFormParams.Add("param2", parameterToString(*r.param2, ""))
+	localVarFormParams.Add("param", parameterToString(*r.formparam, ""))
+	localVarFormParams.Add("param2", parameterToString(*r.formparam2, ""))
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return nil, err
@@ -1826,31 +1826,31 @@ func (a *FakeApiService) TestJsonFormDataExecute(r ApiTestJsonFormDataRequest) (
 type ApiTestQueryParameterCollectionFormatRequest struct {
 	ctx _context.Context
 	ApiService FakeApi
-	pipe *[]string
-	ioutil *[]string
-	http *[]string
-	url *[]string
-	context *[]string
+	querypipe *[]string
+	queryioutil *[]string
+	queryhttp *[]string
+	queryurl *[]string
+	querycontext *[]string
 }
 
 func (r ApiTestQueryParameterCollectionFormatRequest) Pipe(pipe []string) ApiTestQueryParameterCollectionFormatRequest {
-	r.pipe = &pipe
+	r.querypipe = &pipe
 	return r
 }
 func (r ApiTestQueryParameterCollectionFormatRequest) Ioutil(ioutil []string) ApiTestQueryParameterCollectionFormatRequest {
-	r.ioutil = &ioutil
+	r.queryioutil = &ioutil
 	return r
 }
 func (r ApiTestQueryParameterCollectionFormatRequest) Http(http []string) ApiTestQueryParameterCollectionFormatRequest {
-	r.http = &http
+	r.queryhttp = &http
 	return r
 }
 func (r ApiTestQueryParameterCollectionFormatRequest) Url(url []string) ApiTestQueryParameterCollectionFormatRequest {
-	r.url = &url
+	r.queryurl = &url
 	return r
 }
 func (r ApiTestQueryParameterCollectionFormatRequest) Context(context []string) ApiTestQueryParameterCollectionFormatRequest {
-	r.context = &context
+	r.querycontext = &context
 	return r
 }
 
@@ -1893,24 +1893,24 @@ func (a *FakeApiService) TestQueryParameterCollectionFormatExecute(r ApiTestQuer
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
-	if r.pipe == nil {
+	if r.querypipe == nil {
 		return nil, reportError("pipe is required and must be specified")
 	}
-	if r.ioutil == nil {
+	if r.queryioutil == nil {
 		return nil, reportError("ioutil is required and must be specified")
 	}
-	if r.http == nil {
+	if r.queryhttp == nil {
 		return nil, reportError("http is required and must be specified")
 	}
-	if r.url == nil {
+	if r.queryurl == nil {
 		return nil, reportError("url is required and must be specified")
 	}
-	if r.context == nil {
+	if r.querycontext == nil {
 		return nil, reportError("context is required and must be specified")
 	}
 
 	{
-		t := *r.pipe
+		t := *r.querypipe
 		if reflect.TypeOf(t).Kind() == reflect.Slice {
 			s := reflect.ValueOf(t)
 			for i := 0; i < s.Len(); i++ {
@@ -1920,11 +1920,11 @@ func (a *FakeApiService) TestQueryParameterCollectionFormatExecute(r ApiTestQuer
 			localVarQueryParams.Add("pipe", parameterToString(t, "multi"))
 		}
 	}
-	localVarQueryParams.Add("ioutil", parameterToString(*r.ioutil, "csv"))
-	localVarQueryParams.Add("http", parameterToString(*r.http, "ssv"))
-	localVarQueryParams.Add("url", parameterToString(*r.url, "csv"))
+	localVarQueryParams.Add("ioutil", parameterToString(*r.queryioutil, "csv"))
+	localVarQueryParams.Add("http", parameterToString(*r.queryhttp, "ssv"))
+	localVarQueryParams.Add("url", parameterToString(*r.queryurl, "csv"))
 	{
-		t := *r.context
+		t := *r.querycontext
 		if reflect.TypeOf(t).Kind() == reflect.Slice {
 			s := reflect.ValueOf(t)
 			for i := 0; i < s.Len(); i++ {

--- a/samples/openapi3/client/petstore/go/go-petstore/api_fake_classname_tags123.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/api_fake_classname_tags123.go
@@ -46,11 +46,11 @@ type FakeClassnameTags123ApiService service
 type ApiTestClassnameRequest struct {
 	ctx _context.Context
 	ApiService FakeClassnameTags123Api
-	client *Client
+	bodyclient *Client
 }
 
 func (r ApiTestClassnameRequest) Client(client Client) ApiTestClassnameRequest {
-	r.client = &client
+	r.bodyclient = &client
 	return r
 }
 
@@ -95,7 +95,7 @@ func (a *FakeClassnameTags123ApiService) TestClassnameExecute(r ApiTestClassname
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
-	if r.client == nil {
+	if r.bodyclient == nil {
 		return localVarReturnValue, nil, reportError("client is required and must be specified")
 	}
 
@@ -117,7 +117,7 @@ func (a *FakeClassnameTags123ApiService) TestClassnameExecute(r ApiTestClassname
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
 	// body params
-	localVarPostBody = r.client
+	localVarPostBody = r.bodyclient
 	if r.ctx != nil {
 		// API Key Authentication
 		if auth, ok := r.ctx.Value(ContextAPIKeys).(map[string]APIKey); ok {

--- a/samples/openapi3/client/petstore/go/go-petstore/api_pet.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/api_pet.go
@@ -155,11 +155,11 @@ type PetApiService service
 type ApiAddPetRequest struct {
 	ctx _context.Context
 	ApiService PetApi
-	pet *Pet
+	bodypet *Pet
 }
 
 func (r ApiAddPetRequest) Pet(pet Pet) ApiAddPetRequest {
-	r.pet = &pet
+	r.bodypet = &pet
 	return r
 }
 
@@ -201,7 +201,7 @@ func (a *PetApiService) AddPetExecute(r ApiAddPetRequest) (*_nethttp.Response, e
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
-	if r.pet == nil {
+	if r.bodypet == nil {
 		return nil, reportError("pet is required and must be specified")
 	}
 
@@ -223,7 +223,7 @@ func (a *PetApiService) AddPetExecute(r ApiAddPetRequest) (*_nethttp.Response, e
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
 	// body params
-	localVarPostBody = r.pet
+	localVarPostBody = r.bodypet
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return nil, err
@@ -255,12 +255,12 @@ func (a *PetApiService) AddPetExecute(r ApiAddPetRequest) (*_nethttp.Response, e
 type ApiDeletePetRequest struct {
 	ctx _context.Context
 	ApiService PetApi
-	petId int64
-	apiKey *string
+	pathpetId int64
+	headerapiKey *string
 }
 
-func (r ApiDeletePetRequest) ApiKey(apiKey string) ApiDeletePetRequest {
-	r.apiKey = &apiKey
+func (r ApiDeletePetRequest) HeaderApiKey(apiKey string) ApiDeletePetRequest {
+	r.headerapiKey = &apiKey
 	return r
 }
 
@@ -278,7 +278,7 @@ func (a *PetApiService) DeletePet(ctx _context.Context, petId int64) ApiDeletePe
 	return ApiDeletePetRequest{
 		ApiService: a,
 		ctx: ctx,
-		petId: petId,
+		pathpetId: petId,
 	}
 }
 
@@ -300,7 +300,7 @@ func (a *PetApiService) DeletePetExecute(r ApiDeletePetRequest) (*_nethttp.Respo
 	}
 
 	localVarPath := localBasePath + "/pet/{petId}"
-	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.PathEscape(parameterToString(r.petId, "")), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.PathEscape(parameterToString(r.pathpetId, "")), -1)
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
@@ -323,8 +323,8 @@ func (a *PetApiService) DeletePetExecute(r ApiDeletePetRequest) (*_nethttp.Respo
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
-	if r.apiKey != nil {
-		localVarHeaderParams["api_key"] = parameterToString(*r.apiKey, "")
+	if r.headerapiKey != nil {
+		localVarHeaderParams["api_key"] = parameterToString(*r.headerapiKey, "")
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
@@ -357,11 +357,11 @@ func (a *PetApiService) DeletePetExecute(r ApiDeletePetRequest) (*_nethttp.Respo
 type ApiFindPetsByStatusRequest struct {
 	ctx _context.Context
 	ApiService PetApi
-	status *[]string
+	querystatus *[]string
 }
 
 func (r ApiFindPetsByStatusRequest) Status(status []string) ApiFindPetsByStatusRequest {
-	r.status = &status
+	r.querystatus = &status
 	return r
 }
 
@@ -406,11 +406,11 @@ func (a *PetApiService) FindPetsByStatusExecute(r ApiFindPetsByStatusRequest) ([
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
-	if r.status == nil {
+	if r.querystatus == nil {
 		return localVarReturnValue, nil, reportError("status is required and must be specified")
 	}
 
-	localVarQueryParams.Add("status", parameterToString(*r.status, "csv"))
+	localVarQueryParams.Add("status", parameterToString(*r.querystatus, "csv"))
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{}
 
@@ -468,11 +468,11 @@ func (a *PetApiService) FindPetsByStatusExecute(r ApiFindPetsByStatusRequest) ([
 type ApiFindPetsByTagsRequest struct {
 	ctx _context.Context
 	ApiService PetApi
-	tags *[]string
+	querytags *[]string
 }
 
 func (r ApiFindPetsByTagsRequest) Tags(tags []string) ApiFindPetsByTagsRequest {
-	r.tags = &tags
+	r.querytags = &tags
 	return r
 }
 
@@ -517,11 +517,11 @@ func (a *PetApiService) FindPetsByTagsExecute(r ApiFindPetsByTagsRequest) ([]Pet
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
-	if r.tags == nil {
+	if r.querytags == nil {
 		return localVarReturnValue, nil, reportError("tags is required and must be specified")
 	}
 
-	localVarQueryParams.Add("tags", parameterToString(*r.tags, "csv"))
+	localVarQueryParams.Add("tags", parameterToString(*r.querytags, "csv"))
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{}
 
@@ -579,7 +579,7 @@ func (a *PetApiService) FindPetsByTagsExecute(r ApiFindPetsByTagsRequest) ([]Pet
 type ApiGetPetByIdRequest struct {
 	ctx _context.Context
 	ApiService PetApi
-	petId int64
+	pathpetId int64
 }
 
 
@@ -598,7 +598,7 @@ func (a *PetApiService) GetPetById(ctx _context.Context, petId int64) ApiGetPetB
 	return ApiGetPetByIdRequest{
 		ApiService: a,
 		ctx: ctx,
-		petId: petId,
+		pathpetId: petId,
 	}
 }
 
@@ -622,7 +622,7 @@ func (a *PetApiService) GetPetByIdExecute(r ApiGetPetByIdRequest) (Pet, *_nethtt
 	}
 
 	localVarPath := localBasePath + "/pet/{petId}"
-	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.PathEscape(parameterToString(r.petId, "")), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.PathEscape(parameterToString(r.pathpetId, "")), -1)
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
@@ -699,11 +699,11 @@ func (a *PetApiService) GetPetByIdExecute(r ApiGetPetByIdRequest) (Pet, *_nethtt
 type ApiUpdatePetRequest struct {
 	ctx _context.Context
 	ApiService PetApi
-	pet *Pet
+	bodypet *Pet
 }
 
 func (r ApiUpdatePetRequest) Pet(pet Pet) ApiUpdatePetRequest {
-	r.pet = &pet
+	r.bodypet = &pet
 	return r
 }
 
@@ -745,7 +745,7 @@ func (a *PetApiService) UpdatePetExecute(r ApiUpdatePetRequest) (*_nethttp.Respo
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
-	if r.pet == nil {
+	if r.bodypet == nil {
 		return nil, reportError("pet is required and must be specified")
 	}
 
@@ -767,7 +767,7 @@ func (a *PetApiService) UpdatePetExecute(r ApiUpdatePetRequest) (*_nethttp.Respo
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
 	// body params
-	localVarPostBody = r.pet
+	localVarPostBody = r.bodypet
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return nil, err
@@ -799,17 +799,17 @@ func (a *PetApiService) UpdatePetExecute(r ApiUpdatePetRequest) (*_nethttp.Respo
 type ApiUpdatePetWithFormRequest struct {
 	ctx _context.Context
 	ApiService PetApi
-	petId int64
-	name *string
-	status *string
+	pathpetId int64
+	formname *string
+	formstatus *string
 }
 
 func (r ApiUpdatePetWithFormRequest) Name(name string) ApiUpdatePetWithFormRequest {
-	r.name = &name
+	r.formname = &name
 	return r
 }
 func (r ApiUpdatePetWithFormRequest) Status(status string) ApiUpdatePetWithFormRequest {
-	r.status = &status
+	r.formstatus = &status
 	return r
 }
 
@@ -827,7 +827,7 @@ func (a *PetApiService) UpdatePetWithForm(ctx _context.Context, petId int64) Api
 	return ApiUpdatePetWithFormRequest{
 		ApiService: a,
 		ctx: ctx,
-		petId: petId,
+		pathpetId: petId,
 	}
 }
 
@@ -849,7 +849,7 @@ func (a *PetApiService) UpdatePetWithFormExecute(r ApiUpdatePetWithFormRequest) 
 	}
 
 	localVarPath := localBasePath + "/pet/{petId}"
-	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.PathEscape(parameterToString(r.petId, "")), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.PathEscape(parameterToString(r.pathpetId, "")), -1)
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
@@ -872,11 +872,11 @@ func (a *PetApiService) UpdatePetWithFormExecute(r ApiUpdatePetWithFormRequest) 
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
-	if r.name != nil {
-		localVarFormParams.Add("name", parameterToString(*r.name, ""))
+	if r.formname != nil {
+		localVarFormParams.Add("name", parameterToString(*r.formname, ""))
 	}
-	if r.status != nil {
-		localVarFormParams.Add("status", parameterToString(*r.status, ""))
+	if r.formstatus != nil {
+		localVarFormParams.Add("status", parameterToString(*r.formstatus, ""))
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
@@ -909,17 +909,17 @@ func (a *PetApiService) UpdatePetWithFormExecute(r ApiUpdatePetWithFormRequest) 
 type ApiUploadFileRequest struct {
 	ctx _context.Context
 	ApiService PetApi
-	petId int64
-	additionalMetadata *string
-	file **os.File
+	pathpetId int64
+	formadditionalMetadata *string
+	formfile **os.File
 }
 
 func (r ApiUploadFileRequest) AdditionalMetadata(additionalMetadata string) ApiUploadFileRequest {
-	r.additionalMetadata = &additionalMetadata
+	r.formadditionalMetadata = &additionalMetadata
 	return r
 }
 func (r ApiUploadFileRequest) File(file *os.File) ApiUploadFileRequest {
-	r.file = &file
+	r.formfile = &file
 	return r
 }
 
@@ -937,7 +937,7 @@ func (a *PetApiService) UploadFile(ctx _context.Context, petId int64) ApiUploadF
 	return ApiUploadFileRequest{
 		ApiService: a,
 		ctx: ctx,
-		petId: petId,
+		pathpetId: petId,
 	}
 }
 
@@ -961,7 +961,7 @@ func (a *PetApiService) UploadFileExecute(r ApiUploadFileRequest) (ApiResponse, 
 	}
 
 	localVarPath := localBasePath + "/pet/{petId}/uploadImage"
-	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.PathEscape(parameterToString(r.petId, "")), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.PathEscape(parameterToString(r.pathpetId, "")), -1)
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
@@ -984,13 +984,13 @@ func (a *PetApiService) UploadFileExecute(r ApiUploadFileRequest) (ApiResponse, 
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
-	if r.additionalMetadata != nil {
-		localVarFormParams.Add("additionalMetadata", parameterToString(*r.additionalMetadata, ""))
+	if r.formadditionalMetadata != nil {
+		localVarFormParams.Add("additionalMetadata", parameterToString(*r.formadditionalMetadata, ""))
 	}
 	localVarFormFileName = "file"
 	var localVarFile *os.File
-	if r.file != nil {
-		localVarFile = *r.file
+	if r.formfile != nil {
+		localVarFile = *r.formfile
 	}
 	if localVarFile != nil {
 		fbs, _ := _ioutil.ReadAll(localVarFile)
@@ -1038,17 +1038,17 @@ func (a *PetApiService) UploadFileExecute(r ApiUploadFileRequest) (ApiResponse, 
 type ApiUploadFileWithRequiredFileRequest struct {
 	ctx _context.Context
 	ApiService PetApi
-	petId int64
-	requiredFile **os.File
-	additionalMetadata *string
+	pathpetId int64
+	formrequiredFile **os.File
+	formadditionalMetadata *string
 }
 
 func (r ApiUploadFileWithRequiredFileRequest) RequiredFile(requiredFile *os.File) ApiUploadFileWithRequiredFileRequest {
-	r.requiredFile = &requiredFile
+	r.formrequiredFile = &requiredFile
 	return r
 }
 func (r ApiUploadFileWithRequiredFileRequest) AdditionalMetadata(additionalMetadata string) ApiUploadFileWithRequiredFileRequest {
-	r.additionalMetadata = &additionalMetadata
+	r.formadditionalMetadata = &additionalMetadata
 	return r
 }
 
@@ -1066,7 +1066,7 @@ func (a *PetApiService) UploadFileWithRequiredFile(ctx _context.Context, petId i
 	return ApiUploadFileWithRequiredFileRequest{
 		ApiService: a,
 		ctx: ctx,
-		petId: petId,
+		pathpetId: petId,
 	}
 }
 
@@ -1090,12 +1090,12 @@ func (a *PetApiService) UploadFileWithRequiredFileExecute(r ApiUploadFileWithReq
 	}
 
 	localVarPath := localBasePath + "/fake/{petId}/uploadImageWithRequiredFile"
-	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.PathEscape(parameterToString(r.petId, "")), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.PathEscape(parameterToString(r.pathpetId, "")), -1)
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
-	if r.requiredFile == nil {
+	if r.formrequiredFile == nil {
 		return localVarReturnValue, nil, reportError("requiredFile is required and must be specified")
 	}
 
@@ -1116,11 +1116,11 @@ func (a *PetApiService) UploadFileWithRequiredFileExecute(r ApiUploadFileWithReq
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
-	if r.additionalMetadata != nil {
-		localVarFormParams.Add("additionalMetadata", parameterToString(*r.additionalMetadata, ""))
+	if r.formadditionalMetadata != nil {
+		localVarFormParams.Add("additionalMetadata", parameterToString(*r.formadditionalMetadata, ""))
 	}
 	localVarFormFileName = "requiredFile"
-	localVarFile := *r.requiredFile
+	localVarFile := *r.formrequiredFile
 	if localVarFile != nil {
 		fbs, _ := _ioutil.ReadAll(localVarFile)
 		localVarFileBytes = fbs

--- a/samples/openapi3/client/petstore/go/go-petstore/api_store.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/api_store.go
@@ -89,7 +89,7 @@ type StoreApiService service
 type ApiDeleteOrderRequest struct {
 	ctx _context.Context
 	ApiService StoreApi
-	orderId string
+	pathorderId string
 }
 
 
@@ -108,7 +108,7 @@ func (a *StoreApiService) DeleteOrder(ctx _context.Context, orderId string) ApiD
 	return ApiDeleteOrderRequest{
 		ApiService: a,
 		ctx: ctx,
-		orderId: orderId,
+		pathorderId: orderId,
 	}
 }
 
@@ -130,7 +130,7 @@ func (a *StoreApiService) DeleteOrderExecute(r ApiDeleteOrderRequest) (*_nethttp
 	}
 
 	localVarPath := localBasePath + "/store/order/{order_id}"
-	localVarPath = strings.Replace(localVarPath, "{"+"order_id"+"}", _neturl.PathEscape(parameterToString(r.orderId, "")), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"order_id"+"}", _neturl.PathEscape(parameterToString(r.pathorderId, "")), -1)
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
@@ -300,7 +300,7 @@ func (a *StoreApiService) GetInventoryExecute(r ApiGetInventoryRequest) (map[str
 type ApiGetOrderByIdRequest struct {
 	ctx _context.Context
 	ApiService StoreApi
-	orderId int64
+	pathorderId int64
 }
 
 
@@ -319,7 +319,7 @@ func (a *StoreApiService) GetOrderById(ctx _context.Context, orderId int64) ApiG
 	return ApiGetOrderByIdRequest{
 		ApiService: a,
 		ctx: ctx,
-		orderId: orderId,
+		pathorderId: orderId,
 	}
 }
 
@@ -343,15 +343,15 @@ func (a *StoreApiService) GetOrderByIdExecute(r ApiGetOrderByIdRequest) (Order, 
 	}
 
 	localVarPath := localBasePath + "/store/order/{order_id}"
-	localVarPath = strings.Replace(localVarPath, "{"+"order_id"+"}", _neturl.PathEscape(parameterToString(r.orderId, "")), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"order_id"+"}", _neturl.PathEscape(parameterToString(r.pathorderId, "")), -1)
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
-	if r.orderId < 1 {
+	if r.pathorderId < 1 {
 		return localVarReturnValue, nil, reportError("orderId must be greater than 1")
 	}
-	if r.orderId > 5 {
+	if r.pathorderId > 5 {
 		return localVarReturnValue, nil, reportError("orderId must be less than 5")
 	}
 
@@ -412,11 +412,11 @@ func (a *StoreApiService) GetOrderByIdExecute(r ApiGetOrderByIdRequest) (Order, 
 type ApiPlaceOrderRequest struct {
 	ctx _context.Context
 	ApiService StoreApi
-	order *Order
+	bodyorder *Order
 }
 
 func (r ApiPlaceOrderRequest) Order(order Order) ApiPlaceOrderRequest {
-	r.order = &order
+	r.bodyorder = &order
 	return r
 }
 
@@ -460,7 +460,7 @@ func (a *StoreApiService) PlaceOrderExecute(r ApiPlaceOrderRequest) (Order, *_ne
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
-	if r.order == nil {
+	if r.bodyorder == nil {
 		return localVarReturnValue, nil, reportError("order is required and must be specified")
 	}
 
@@ -482,7 +482,7 @@ func (a *StoreApiService) PlaceOrderExecute(r ApiPlaceOrderRequest) (Order, *_ne
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
 	// body params
-	localVarPostBody = r.order
+	localVarPostBody = r.bodyorder
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return localVarReturnValue, nil, err

--- a/samples/openapi3/client/petstore/go/go-petstore/api_user.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/api_user.go
@@ -137,11 +137,11 @@ type UserApiService service
 type ApiCreateUserRequest struct {
 	ctx _context.Context
 	ApiService UserApi
-	user *User
+	bodyuser *User
 }
 
 func (r ApiCreateUserRequest) User(user User) ApiCreateUserRequest {
-	r.user = &user
+	r.bodyuser = &user
 	return r
 }
 
@@ -184,7 +184,7 @@ func (a *UserApiService) CreateUserExecute(r ApiCreateUserRequest) (*_nethttp.Re
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
-	if r.user == nil {
+	if r.bodyuser == nil {
 		return nil, reportError("user is required and must be specified")
 	}
 
@@ -206,7 +206,7 @@ func (a *UserApiService) CreateUserExecute(r ApiCreateUserRequest) (*_nethttp.Re
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
 	// body params
-	localVarPostBody = r.user
+	localVarPostBody = r.bodyuser
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return nil, err
@@ -238,11 +238,11 @@ func (a *UserApiService) CreateUserExecute(r ApiCreateUserRequest) (*_nethttp.Re
 type ApiCreateUsersWithArrayInputRequest struct {
 	ctx _context.Context
 	ApiService UserApi
-	user *[]User
+	bodyuser *[]User
 }
 
 func (r ApiCreateUsersWithArrayInputRequest) User(user []User) ApiCreateUsersWithArrayInputRequest {
-	r.user = &user
+	r.bodyuser = &user
 	return r
 }
 
@@ -284,7 +284,7 @@ func (a *UserApiService) CreateUsersWithArrayInputExecute(r ApiCreateUsersWithAr
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
-	if r.user == nil {
+	if r.bodyuser == nil {
 		return nil, reportError("user is required and must be specified")
 	}
 
@@ -306,7 +306,7 @@ func (a *UserApiService) CreateUsersWithArrayInputExecute(r ApiCreateUsersWithAr
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
 	// body params
-	localVarPostBody = r.user
+	localVarPostBody = r.bodyuser
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return nil, err
@@ -338,11 +338,11 @@ func (a *UserApiService) CreateUsersWithArrayInputExecute(r ApiCreateUsersWithAr
 type ApiCreateUsersWithListInputRequest struct {
 	ctx _context.Context
 	ApiService UserApi
-	user *[]User
+	bodyuser *[]User
 }
 
 func (r ApiCreateUsersWithListInputRequest) User(user []User) ApiCreateUsersWithListInputRequest {
-	r.user = &user
+	r.bodyuser = &user
 	return r
 }
 
@@ -384,7 +384,7 @@ func (a *UserApiService) CreateUsersWithListInputExecute(r ApiCreateUsersWithLis
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
-	if r.user == nil {
+	if r.bodyuser == nil {
 		return nil, reportError("user is required and must be specified")
 	}
 
@@ -406,7 +406,7 @@ func (a *UserApiService) CreateUsersWithListInputExecute(r ApiCreateUsersWithLis
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
 	// body params
-	localVarPostBody = r.user
+	localVarPostBody = r.bodyuser
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return nil, err
@@ -438,7 +438,7 @@ func (a *UserApiService) CreateUsersWithListInputExecute(r ApiCreateUsersWithLis
 type ApiDeleteUserRequest struct {
 	ctx _context.Context
 	ApiService UserApi
-	username string
+	pathusername string
 }
 
 
@@ -457,7 +457,7 @@ func (a *UserApiService) DeleteUser(ctx _context.Context, username string) ApiDe
 	return ApiDeleteUserRequest{
 		ApiService: a,
 		ctx: ctx,
-		username: username,
+		pathusername: username,
 	}
 }
 
@@ -479,7 +479,7 @@ func (a *UserApiService) DeleteUserExecute(r ApiDeleteUserRequest) (*_nethttp.Re
 	}
 
 	localVarPath := localBasePath + "/user/{username}"
-	localVarPath = strings.Replace(localVarPath, "{"+"username"+"}", _neturl.PathEscape(parameterToString(r.username, "")), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"username"+"}", _neturl.PathEscape(parameterToString(r.pathusername, "")), -1)
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
@@ -533,7 +533,7 @@ func (a *UserApiService) DeleteUserExecute(r ApiDeleteUserRequest) (*_nethttp.Re
 type ApiGetUserByNameRequest struct {
 	ctx _context.Context
 	ApiService UserApi
-	username string
+	pathusername string
 }
 
 
@@ -551,7 +551,7 @@ func (a *UserApiService) GetUserByName(ctx _context.Context, username string) Ap
 	return ApiGetUserByNameRequest{
 		ApiService: a,
 		ctx: ctx,
-		username: username,
+		pathusername: username,
 	}
 }
 
@@ -575,7 +575,7 @@ func (a *UserApiService) GetUserByNameExecute(r ApiGetUserByNameRequest) (User, 
 	}
 
 	localVarPath := localBasePath + "/user/{username}"
-	localVarPath = strings.Replace(localVarPath, "{"+"username"+"}", _neturl.PathEscape(parameterToString(r.username, "")), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"username"+"}", _neturl.PathEscape(parameterToString(r.pathusername, "")), -1)
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
@@ -638,16 +638,16 @@ func (a *UserApiService) GetUserByNameExecute(r ApiGetUserByNameRequest) (User, 
 type ApiLoginUserRequest struct {
 	ctx _context.Context
 	ApiService UserApi
-	username *string
-	password *string
+	queryusername *string
+	querypassword *string
 }
 
 func (r ApiLoginUserRequest) Username(username string) ApiLoginUserRequest {
-	r.username = &username
+	r.queryusername = &username
 	return r
 }
 func (r ApiLoginUserRequest) Password(password string) ApiLoginUserRequest {
-	r.password = &password
+	r.querypassword = &password
 	return r
 }
 
@@ -691,15 +691,15 @@ func (a *UserApiService) LoginUserExecute(r ApiLoginUserRequest) (string, *_neth
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
-	if r.username == nil {
+	if r.queryusername == nil {
 		return localVarReturnValue, nil, reportError("username is required and must be specified")
 	}
-	if r.password == nil {
+	if r.querypassword == nil {
 		return localVarReturnValue, nil, reportError("password is required and must be specified")
 	}
 
-	localVarQueryParams.Add("username", parameterToString(*r.username, ""))
-	localVarQueryParams.Add("password", parameterToString(*r.password, ""))
+	localVarQueryParams.Add("username", parameterToString(*r.queryusername, ""))
+	localVarQueryParams.Add("password", parameterToString(*r.querypassword, ""))
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{}
 
@@ -847,12 +847,12 @@ func (a *UserApiService) LogoutUserExecute(r ApiLogoutUserRequest) (*_nethttp.Re
 type ApiUpdateUserRequest struct {
 	ctx _context.Context
 	ApiService UserApi
-	username string
-	user *User
+	pathusername string
+	bodyuser *User
 }
 
 func (r ApiUpdateUserRequest) User(user User) ApiUpdateUserRequest {
-	r.user = &user
+	r.bodyuser = &user
 	return r
 }
 
@@ -871,7 +871,7 @@ func (a *UserApiService) UpdateUser(ctx _context.Context, username string) ApiUp
 	return ApiUpdateUserRequest{
 		ApiService: a,
 		ctx: ctx,
-		username: username,
+		pathusername: username,
 	}
 }
 
@@ -893,12 +893,12 @@ func (a *UserApiService) UpdateUserExecute(r ApiUpdateUserRequest) (*_nethttp.Re
 	}
 
 	localVarPath := localBasePath + "/user/{username}"
-	localVarPath = strings.Replace(localVarPath, "{"+"username"+"}", _neturl.PathEscape(parameterToString(r.username, "")), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"username"+"}", _neturl.PathEscape(parameterToString(r.pathusername, "")), -1)
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
-	if r.user == nil {
+	if r.bodyuser == nil {
 		return nil, reportError("user is required and must be specified")
 	}
 
@@ -920,7 +920,7 @@ func (a *UserApiService) UpdateUserExecute(r ApiUpdateUserRequest) (*_nethttp.Re
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
 	// body params
-	localVarPostBody = r.user
+	localVarPostBody = r.bodyuser
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return nil, err

--- a/samples/openapi3/client/petstore/go/go-petstore/docs/FakeApi.md
+++ b/samples/openapi3/client/petstore/go/go-petstore/docs/FakeApi.md
@@ -410,7 +410,7 @@ No authorization required
 
 ## TestBodyWithQueryParams
 
-> TestBodyWithQueryParams(ctx).Query(query).User(user).Execute()
+> TestBodyWithQueryParams(ctx).QueryQuery(query).User(user).Execute()
 
 
 
@@ -432,7 +432,7 @@ func main() {
 
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
-    resp, r, err := api_client.FakeApi.TestBodyWithQueryParams(context.Background()).Query(query).User(user).Execute()
+    resp, r, err := api_client.FakeApi.TestBodyWithQueryParams(context.Background()).QueryQuery(query).User(user).Execute()
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.TestBodyWithQueryParams``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
@@ -631,7 +631,7 @@ Name | Type | Description  | Notes
 
 ## TestEnumParameters
 
-> TestEnumParameters(ctx).EnumHeaderStringArray(enumHeaderStringArray).EnumHeaderString(enumHeaderString).EnumQueryStringArray(enumQueryStringArray).EnumQueryString(enumQueryString).EnumQueryInteger(enumQueryInteger).EnumQueryDouble(enumQueryDouble).EnumFormStringArray(enumFormStringArray).EnumFormString(enumFormString).Execute()
+> TestEnumParameters(ctx).HeaderEnumHeaderStringArray(enumHeaderStringArray).HeaderEnumHeaderString(enumHeaderString).QueryEnumQueryStringArray(enumQueryStringArray).QueryEnumQueryString(enumQueryString).QueryEnumQueryInteger(enumQueryInteger).QueryEnumQueryDouble(enumQueryDouble).EnumFormStringArray(enumFormStringArray).EnumFormString(enumFormString).Execute()
 
 To test enum parameters
 
@@ -661,7 +661,7 @@ func main() {
 
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
-    resp, r, err := api_client.FakeApi.TestEnumParameters(context.Background()).EnumHeaderStringArray(enumHeaderStringArray).EnumHeaderString(enumHeaderString).EnumQueryStringArray(enumQueryStringArray).EnumQueryString(enumQueryString).EnumQueryInteger(enumQueryInteger).EnumQueryDouble(enumQueryDouble).EnumFormStringArray(enumFormStringArray).EnumFormString(enumFormString).Execute()
+    resp, r, err := api_client.FakeApi.TestEnumParameters(context.Background()).HeaderEnumHeaderStringArray(enumHeaderStringArray).HeaderEnumHeaderString(enumHeaderString).QueryEnumQueryStringArray(enumQueryStringArray).QueryEnumQueryString(enumQueryString).QueryEnumQueryInteger(enumQueryInteger).QueryEnumQueryDouble(enumQueryDouble).EnumFormStringArray(enumFormStringArray).EnumFormString(enumFormString).Execute()
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.TestEnumParameters``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
@@ -709,7 +709,7 @@ No authorization required
 
 ## TestGroupParameters
 
-> TestGroupParameters(ctx).RequiredStringGroup(requiredStringGroup).RequiredBooleanGroup(requiredBooleanGroup).RequiredInt64Group(requiredInt64Group).StringGroup(stringGroup).BooleanGroup(booleanGroup).Int64Group(int64Group).Execute()
+> TestGroupParameters(ctx).RequiredStringGroup(requiredStringGroup).HeaderRequiredBooleanGroup(requiredBooleanGroup).RequiredInt64Group(requiredInt64Group).StringGroup(stringGroup).HeaderBooleanGroup(booleanGroup).Int64Group(int64Group).Execute()
 
 Fake endpoint to test group parameters (optional)
 
@@ -737,7 +737,7 @@ func main() {
 
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
-    resp, r, err := api_client.FakeApi.TestGroupParameters(context.Background()).RequiredStringGroup(requiredStringGroup).RequiredBooleanGroup(requiredBooleanGroup).RequiredInt64Group(requiredInt64Group).StringGroup(stringGroup).BooleanGroup(booleanGroup).Int64Group(int64Group).Execute()
+    resp, r, err := api_client.FakeApi.TestGroupParameters(context.Background()).RequiredStringGroup(requiredStringGroup).HeaderRequiredBooleanGroup(requiredBooleanGroup).RequiredInt64Group(requiredInt64Group).StringGroup(stringGroup).HeaderBooleanGroup(booleanGroup).Int64Group(int64Group).Execute()
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.TestGroupParameters``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)

--- a/samples/openapi3/client/petstore/go/go-petstore/docs/PetApi.md
+++ b/samples/openapi3/client/petstore/go/go-petstore/docs/PetApi.md
@@ -80,7 +80,7 @@ Name | Type | Description  | Notes
 
 ## DeletePet
 
-> DeletePet(ctx, petId).ApiKey(apiKey).Execute()
+> DeletePet(ctx, petId).HeaderApiKey(apiKey).Execute()
 
 Deletes a pet
 
@@ -102,7 +102,7 @@ func main() {
 
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
-    resp, r, err := api_client.PetApi.DeletePet(context.Background(), petId).ApiKey(apiKey).Execute()
+    resp, r, err := api_client.PetApi.DeletePet(context.Background(), petId).HeaderApiKey(apiKey).Execute()
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `PetApi.DeletePet``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)


### PR DESCRIPTION
OpenAPI allows parameters to bear the same name if they appear in different settings inside the same operation.

The code generated by the ~~go-experimental~~ go generator, though, can sometimes fail to compile due to parameters with the same name. Both the field in the `api*Request` struct and the setter method names can clash if there are multiple parameteres with the same name.

This change fixes that by namespacing all the param names in the generated code with their origin.

~~This may also affect the stable Go generator because it messes with setExportParameterName, even though I've tried to limit my changes to the internal parts of the generated code. Please review accordingly.~~

**Update:** this PR was written before `go-experimental` graduated to become the main go client and was edited accordingly.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

cc @antihax @bvwells @grokify @kemokemo @bkabrda
