### PR TITLE
Expose `isDeprecated` variable to model template

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenModel.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenModel.java
@@ -74,7 +74,7 @@ public class CodegenModel implements IJsonSchemaValidationProperties {
     public Set<String> allMandatory = new TreeSet<String>(); // with parent's required properties
 
     public Set<String> imports = new TreeSet<String>();
-    public boolean hasVars, emptyVars, hasMoreModels, hasEnums, isEnum, isNullable, hasRequired, hasOptional, isArrayModel, hasChildren, isMapModel;
+    public boolean hasVars, emptyVars, hasMoreModels, hasEnums, isEnum, isNullable, hasRequired, hasOptional, isArrayModel, hasChildren, isMapModel, isDeprecated;
     public boolean hasOnlyReadOnly = true; // true if all properties are read-only
     public ExternalDocumentation externalDocumentation;
 
@@ -543,6 +543,7 @@ public class CodegenModel implements IJsonSchemaValidationProperties {
                 isArrayModel == that.isArrayModel &&
                 hasChildren == that.hasChildren &&
                 isMapModel == that.isMapModel &&
+                isDeprecated == that.isDeprecated &&
                 hasOnlyReadOnly == that.hasOnlyReadOnly &&
                 getUniqueItems() == that.getUniqueItems() &&
                 getExclusiveMinimum() == that.getExclusiveMinimum() &&
@@ -609,7 +610,7 @@ public class CodegenModel implements IJsonSchemaValidationProperties {
                 getVars(), getAllVars(), getRequiredVars(), getOptionalVars(), getReadOnlyVars(), getReadWriteVars(),
                 getParentVars(), getAllowableValues(), getMandatory(), getAllMandatory(), getImports(), hasVars,
                 isEmptyVars(), hasMoreModels, hasEnums, isEnum, isNullable, hasRequired, hasOptional, isArrayModel,
-                hasChildren, isMapModel, hasOnlyReadOnly, getExternalDocumentation(), getVendorExtensions(),
+                hasChildren, isMapModel, isDeprecated, hasOnlyReadOnly, getExternalDocumentation(), getVendorExtensions(),
                 getAdditionalPropertiesType(), getMaxProperties(), getMinProperties(), getUniqueItems(), getMaxItems(),
                 getMinItems(), getMaxLength(), getMinLength(), getExclusiveMinimum(), getExclusiveMaximum(), getMinimum(),
                 getMaximum(), getPattern(), getMultipleOf());
@@ -673,6 +674,7 @@ public class CodegenModel implements IJsonSchemaValidationProperties {
         sb.append(", isArrayModel=").append(isArrayModel);
         sb.append(", hasChildren=").append(hasChildren);
         sb.append(", isMapModel=").append(isMapModel);
+        sb.append(", isDeprecated=").append(isDeprecated);
         sb.append(", hasOnlyReadOnly=").append(hasOnlyReadOnly);
         sb.append(", externalDocumentation=").append(externalDocumentation);
         sb.append(", vendorExtensions=").append(vendorExtensions);

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -2117,6 +2117,10 @@ public class DefaultCodegen implements CodegenConfig {
                 || isAliasOfSimpleTypes(schema)); // check if the unaliased schema is an alias of simple OAS types
         m.discriminator = createDiscriminator(name, schema);
 
+        if (schema.getDeprecated() != null) {
+            m.isDeprecated = schema.getDeprecated();
+        }
+
         if (schema.getXml() != null) {
             m.xmlPrefix = schema.getXml().getPrefix();
             m.xmlNamespace = schema.getXml().getNamespace();

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
@@ -775,6 +775,19 @@ public class DefaultCodegenTest {
     }
 
     @Test
+    public void testDeprecatedModel() {
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/component-deprecated.yml");
+        new InlineModelResolver().flatten(openAPI);
+        final DefaultCodegen codegen = new DefaultCodegen();
+
+        CodegenModel codedenPetModel = codegen.fromModel("Pet", openAPI.getComponents().getSchemas().get("Pet"));
+        Assert.assertTrue(codedenPetModel.isDeprecated);
+
+        CodegenModel codegenFoodModel = codegen.fromModel("Food", openAPI.getComponents().getSchemas().get("Food"));
+        Assert.assertTrue(codegenFoodModel.isDeprecated);
+    }
+
+    @Test
     public void testDeprecatedProperty() {
         final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/property-deplicated.yaml");
         new InlineModelResolver().flatten(openAPI);

--- a/modules/openapi-generator/src/test/resources/3_0/component-deprecated.yml
+++ b/modules/openapi-generator/src/test/resources/3_0/component-deprecated.yml
@@ -1,0 +1,37 @@
+openapi: 3.0.1
+info:
+  version: 1.0.0
+  title: Example
+  license:
+    name: MIT
+servers:
+  - url: http://api.example.xyz/v1
+
+components:
+  schemas:
+    Food:
+      deprecated: true
+      type: string
+      enum:
+        - dry
+        - wet
+
+    Pet:
+      title: a Pet
+      deprecated: true
+      description: A pet up for adoption
+      type: object
+      required:
+        - name
+        - status
+      properties:
+        name:
+          type: string
+          example: doggie
+        status:
+          type: string
+          description: pet status
+          enum:
+            - available
+            - pending
+            - adopted


### PR DESCRIPTION
We're using openapi-generator to generate models but we want to mark the deprecated ones as such. I realized that the `deprecated` attribute was not available for a model, so I'm adding that with this pull-request. This PR (https://github.com/OpenAPITools/openapi-generator/pull/5090) made it pretty easy but please let me know if I forgot something.
This is the follow-up of https://github.com/OpenAPITools/openapi-generator/issues/3358 which makes the deprecated attribute available to a model template.

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [ ] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
