### PR TITLE
[Rust Server] Bugfix #5969 (Not support free-form object code generated issue.)

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenModel.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenModel.java
@@ -768,8 +768,8 @@ public class CodegenModel implements IJsonSchemaValidationProperties {
                 // TODO cp shouldn't be null. Show a warning message instead
             } else {
                 // detect self import
-                if (this.classname.equalsIgnoreCase(cp.dataType) ||
-                        (cp.isContainer && cp.items != null && this.classname.equalsIgnoreCase(cp.items.dataType))) {
+                if (this.classname.equalsIgnoreCase(cp.baseType) ||
+                        (cp.isContainer && cp.items != null && this.classname.equalsIgnoreCase(cp.items.baseType))) {
                     this.imports.remove(this.classname); // remove self import
                     cp.isSelfReference = true;
                 }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -393,9 +393,17 @@ public class DefaultCodegen implements CodegenConfig {
             List<Map<String, Object>> models = (List<Map<String, Object>>) inner.get("models");
             for (Map<String, Object> mo : models) {
                 CodegenModel cm = (CodegenModel) mo.get("model");
+                for (CodegenProperty cp : cm.vars) {
+                    // detect self import
+                    if (cp.baseType.equalsIgnoreCase(getTypeDeclaration(cm.classname)) ||
+                            (cp.isContainer && cp.items != null && cp.items.dataType.equalsIgnoreCase(cm.classname))) {
+                        cm.imports.remove(cm.classname); // remove self import
+                        cp.isSelfReference = true;
+                    }
+                }
                 for (CodegenProperty cp : cm.allVars) {
                     // detect self import
-                    if (cp.dataType.equalsIgnoreCase(cm.classname) ||
+                    if (cp.baseType.equalsIgnoreCase(getTypeDeclaration(cm.classname)) ||
                             (cp.isContainer && cp.items != null && cp.items.dataType.equalsIgnoreCase(cm.classname))) {
                         cm.imports.remove(cm.classname); // remove self import
                         cp.isSelfReference = true;

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
@@ -448,7 +448,7 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
 
                 if (ModelUtils.isFreeFormObject(schema)) { // check to see if it'a a free-form object
                     LOGGER.info("Model " + name + " not generated since it's a free-form object");
-                    continue;
+                    //continue;
                 } else if (ModelUtils.isMapSchema(schema)) { // check to see if it's a "map" model
                     if (!ModelUtils.isGenerateAliasAsModel() && (schema.getProperties() == null || schema.getProperties().isEmpty())) {
                         // schema without property, i.e. alias to map

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustServerCodegen.java
@@ -1103,7 +1103,8 @@ public class RustServerCodegen extends DefaultCodegen implements CodegenConfig {
             // defined.
             if (codegenParameter.vendorExtensions != null && codegenParameter.vendorExtensions.containsKey("x-example")) {
                 codegenParameter.example = Json.pretty(codegenParameter.vendorExtensions.get("x-example"));
-            } else {
+            } else if (!codegenParameter.required) {
+                //mandatory parameter use the example in the yaml. if no example, it is also null.
                 codegenParameter.example = null;
             }
         }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustServerCodegen.java
@@ -1572,7 +1572,7 @@ public class RustServerCodegen extends DefaultCodegen implements CodegenConfig {
         } else {
             param.vendorExtensions.put("formatString", "{:?}");
             if (param.example != null) {
-                example = "serde_json::from_str::<" + param.dataType + ">(\"" + param.example + "\").expect(\"Failed to parse JSON example\")";
+                example = "serde_json::from_str::<" + param.dataType + ">(r#\"" + param.example + "\"#).expect(\"Failed to parse JSON example\")";
             }
         }
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustServerCodegen.java
@@ -439,7 +439,7 @@ public class RustServerCodegen extends DefaultCodegen implements CodegenConfig {
             operationId = "call_" + operationId;
         }
 
-        return camelize(operationId);
+        return camelize(operationId).replace(" ", "");
     }
 
     @Override

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustServerCodegen.java
@@ -1056,6 +1056,26 @@ public class RustServerCodegen extends DefaultCodegen implements CodegenConfig {
         return dataType != null && dataType.equals(typeMapping.get("File").toString());
     }
 
+    /**
+     * Add operation to group
+     *
+     * @param tag          name of the tag
+     * @param resourcePath path of the resource
+     * @param operation    OAS Operation object
+     * @param co           Codegen Operation object
+     * @param operations   map of Codegen operations
+     */
+    @SuppressWarnings("static-method")
+    public void addOperationToGroup(String tag, String resourcePath, Operation operation, CodegenOperation
+            co, Map<String, List<CodegenOperation>> operations) {
+        // only generate operation for the first tag of the tags
+        if (tag != null && co.tags.size() > 1 && !tag.equals(co.tags.get(0).getName())) {
+            LOGGER.warn("generated skip operationId `" + co.operationId + "` with the repeating tag=" + tag);
+            return;
+        }
+        super.addOperationToGroup(tag, resourcePath, operation, co, operations);
+    }
+
     // This is a really terrible hack. We're working around the fact that the
     // base version of `fromRequestBody` checks to see whether the body is a
     // ref. If so, it unwraps the reference and replaces it with its inner

--- a/modules/openapi-generator/src/main/resources/rust-server/README.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/README.mustache
@@ -109,7 +109,7 @@ All URIs are relative to *{{{basePath}}}*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
-{{#apiInfo}}{{#apis}}{{#operations}}{{#operation}}[**{{{operationIdOriginal}}}**]({{{apiDocPath}}}{{classname}}_api.md#{{{operationIdOriginal}}}) | **{{{httpMethod}}}** {{{path}}} | {{#summary}}{{{summary}}}{{/summary}}
+{{#apiInfo}}{{#apis}}{{#operations}}{{#operation}}[**{{{operationId}}}**]({{{apiDocPath}}}{{classname}}_api.md#{{{operationId}}}) | **{{{httpMethod}}}** {{{path}}} | {{#summary}}{{{summary}}}{{/summary}}
 {{/operation}}{{/operations}}{{/apis}}{{/apiInfo}}
 
 ## Documentation For Models

--- a/modules/openapi-generator/src/main/resources/rust-server/api_doc.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/api_doc.mustache
@@ -5,13 +5,13 @@ All URIs are relative to *{{{basePath}}}*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
-{{#operations}}{{#operation}}**{{{operationIdOriginal}}}**]({{classname}}_api.md#{{{operationIdOriginal}}}) | **{{{httpMethod}}}** {{{path}}} | {{#summary}}{{{summary}}}{{/summary}}
+{{#operations}}{{#operation}}**{{{operationId}}}**]({{classname}}_api.md#{{{operationId}}}) | **{{{httpMethod}}}** {{{path}}} | {{#summary}}{{{summary}}}{{/summary}}
 {{/operation}}{{/operations}}
 
 {{#operations}}
 {{#operation}}
-# **{{{operationIdOriginal}}}**
-> {{#returnType}}{{{returnType}}} {{/returnType}}{{{operationIdOriginal}}}({{#authMethods}}ctx, {{/authMethods}}{{#allParams}}{{#required}}{{{paramName}}}{{#hasMore}}, {{/hasMore}}{{/required}}{{/allParams}}{{#hasOptionalParams}}optional{{/hasOptionalParams}})
+# **{{{operationId}}}**
+> {{#returnType}}{{{returnType}}} {{/returnType}}{{{operationId}}}({{#authMethods}}ctx, {{/authMethods}}{{#allParams}}{{#required}}{{{paramName}}}{{#hasMore}}, {{/hasMore}}{{/required}}{{/allParams}}{{#hasOptionalParams}}optional{{/hasOptionalParams}})
 {{{summary}}}{{#notes}}
 
 {{{notes}}}{{/notes}}

--- a/modules/openapi-generator/src/main/resources/rust-server/example-client-main.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/example-client-main.mustache
@@ -31,7 +31,7 @@ mod server;
 #[allow(unused_imports)]
 use futures::{Future, future, Stream, stream};
 #[allow(unused_imports)]
-use {{{externCrateName}}}::{Api, ApiNoContext, Client, ContextWrapperExt,
+use {{{externCrateName}}}::{Api, ApiNoContext, Client, ContextWrapperExt, models,
                       ApiError{{#apiInfo}}{{#apis}}{{#operations}}{{#operation}},
                       {{{operationId}}}Response{{/operation}}{{/operations}}{{/apis}}{{/apiInfo}}
                      };

--- a/modules/openapi-generator/src/main/resources/rust-server/models.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/models.mustache
@@ -249,7 +249,7 @@ pub struct {{{classname}}} {
     #[serde(deserialize_with = "swagger::nullable_format::deserialize_optional_nullable")]
     #[serde(default = "swagger::nullable_format::default_optional_nullable")]{{/isNullable}}
     #[serde(skip_serializing_if="Option::is_none")]
-    pub {{{name}}}: Option<{{#isNullable}}swagger::Nullable<{{/isNullable}}{{{dataType}}}{{#isNullable}}>{{/isNullable}}>,
+    pub {{{name}}}: {{#isSelfReference}}Box<{{/isSelfReference}}Option<{{#isNullable}}swagger::Nullable<{{/isNullable}}{{{dataType}}}{{#isNullable}}>{{/isNullable}}>{{#isSelfReference}}>{{/isSelfReference}},
 {{/required}}
 
 {{/vars}}
@@ -258,7 +258,7 @@ pub struct {{{classname}}} {
 impl {{{classname}}} {
     pub fn new({{#vars}}{{^defaultValue}}{{{name}}}: {{#isNullable}}swagger::Nullable<{{/isNullable}}{{{dataType}}}{{#isNullable}}>{{/isNullable}}, {{/defaultValue}}{{/vars}}) -> {{{classname}}} {
         {{{classname}}} {
-{{#vars}}            {{{name}}}: {{#defaultValue}}{{{defaultValue}}}{{/defaultValue}}{{^defaultValue}}{{{name}}}{{/defaultValue}},
+{{#vars}}            {{{name}}}: {{#isSelfReference}}Box::new({{/isSelfReference}}{{#defaultValue}}{{{defaultValue}}}{{/defaultValue}}{{^defaultValue}}{{{name}}}{{/defaultValue}}{{#isSelfReference}}){{/isSelfReference}},
 {{/vars}}
         }
     }
@@ -397,7 +397,7 @@ impl std::str::FromStr for {{{classname}}} {
             {{{name}}}: std::result::Result::Err("Nullable types not supported in {{{classname}}}".to_string())?,
             {{/isNullable}}
             {{^isNullable}}
-            {{{name}}}: intermediate_rep.{{{name}}}.into_iter().next(){{#required}}.ok_or("{{{baseName}}} missing in {{{classname}}}".to_string())?{{/required}},
+            {{{name}}}: {{#isSelfReference}}Box::new({{/isSelfReference}}intermediate_rep.{{{name}}}.into_iter().next(){{#required}}.ok_or("{{{baseName}}} missing in {{{classname}}}".to_string())?{{/required}}{{#isSelfReference}}){{/isSelfReference}},
             {{/isNullable}}
             {{/vars}}
         })

--- a/modules/openapi-generator/src/test/resources/3_0/rust-server/openapi-v3.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/rust-server/openapi-v3.yaml
@@ -368,14 +368,14 @@ paths:
         required: true
     get:
       tags: [Repo, Info]
-      operationId: GetRepoInfo
+      operationId: Get Repo\Info
       responses:
         "200":
           description: OK
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/StringObject"
+                $ref: "#/components/schemas/RepoObject"
   /repos:
     post:
       tags: [Repo]
@@ -485,6 +485,9 @@ components:
            $ref: '#/components/schemas/StringObject'
     StringObject:
       type: string
+    RepoObject:
+      type: object
+
     MyIDList:
       type:  array
       items:

--- a/modules/openapi-generator/src/test/resources/3_0/rust-server/openapi-v3.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/rust-server/openapi-v3.yaml
@@ -392,6 +392,10 @@ paths:
       responses:
         '200':
           description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
 
 components:
   securitySchemes:
@@ -554,9 +558,31 @@ components:
         - BAR
     Ok:
       type: string
-    Error:
-      type: string
     Err:
       type: string
     Result:
       type: string
+    Error:
+      type: object
+      required:
+        - code
+        - retryable
+        - message
+      properties:
+        code:
+          type: integer
+        retryable:
+          type: boolean
+        message:
+          type: string
+          example: NotFound
+        innerError:
+          $ref: "#/components/schemas/Error"
+      additionalProperties: true
+      example:
+        code: -1
+        retryable: false
+        message: We failed to update the object in your request
+        innerError:
+          code: -100
+          message: You are trying to access an absent object

--- a/modules/openapi-generator/src/test/resources/3_0/rust-server/openapi-v3.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/rust-server/openapi-v3.yaml
@@ -396,6 +396,21 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+    put:
+      tags: [Repo]
+      operationId: OverwriteRepo
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RepoObject"
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
 
 components:
   securitySchemes:

--- a/modules/openapi-generator/src/test/resources/3_0/rust-server/openapi-v3.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/rust-server/openapi-v3.yaml
@@ -367,7 +367,7 @@ paths:
           type: string
         required: true
     get:
-      tags: [Repo]
+      tags: [Repo, Info]
       operationId: GetRepoInfo
       responses:
         "200":

--- a/modules/openapi-generator/src/test/resources/3_0/rust-server/openapi-v3.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/rust-server/openapi-v3.yaml
@@ -376,6 +376,22 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/StringObject"
+  /repos:
+    post:
+      tags: [Repo]
+      operationId: CreateRepo
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ObjectParam"
+            example:
+              # Properties of a referenced object
+              requiredParam: true
+      responses:
+        '200':
+          description: Success
 
 components:
   securitySchemes:

--- a/samples/server/petstore/rust-server/output/multipart-v3/docs/default_api.md
+++ b/samples/server/petstore/rust-server/output/multipart-v3/docs/default_api.md
@@ -4,13 +4,13 @@ All URIs are relative to *http://localhost*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
-****](default_api.md#) | **POST** /multipart_related_request | 
-****](default_api.md#) | **POST** /multipart_request | 
-****](default_api.md#) | **POST** /multiple-identical-mime-types | 
+**MultipartRelatedRequestPost**](default_api.md#MultipartRelatedRequestPost) | **POST** /multipart_related_request | 
+**MultipartRequestPost**](default_api.md#MultipartRequestPost) | **POST** /multipart_request | 
+**MultipleIdenticalMimeTypesPost**](default_api.md#MultipleIdenticalMimeTypesPost) | **POST** /multiple-identical-mime-types | 
 
 
-# ****
-> (required_binary_field, optional)
+# **MultipartRelatedRequestPost**
+> MultipartRelatedRequestPost(required_binary_field, optional)
 
 
 ### Required Parameters
@@ -44,8 +44,8 @@ No authorization required
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
-# ****
-> (string_field, binary_field, optional)
+# **MultipartRequestPost**
+> MultipartRequestPost(string_field, binary_field, optional)
 
 
 ### Required Parameters
@@ -81,8 +81,8 @@ No authorization required
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
-# ****
-> (optional)
+# **MultipleIdenticalMimeTypesPost**
+> MultipleIdenticalMimeTypesPost(optional)
 
 
 ### Required Parameters

--- a/samples/server/petstore/rust-server/output/multipart-v3/examples/client/main.rs
+++ b/samples/server/petstore/rust-server/output/multipart-v3/examples/client/main.rs
@@ -15,7 +15,7 @@ extern crate tokio;
 #[allow(unused_imports)]
 use futures::{Future, future, Stream, stream};
 #[allow(unused_imports)]
-use multipart_v3::{Api, ApiNoContext, Client, ContextWrapperExt,
+use multipart_v3::{Api, ApiNoContext, Client, ContextWrapperExt, models,
                       ApiError,
                       MultipartRelatedRequestPostResponse,
                       MultipartRequestPostResponse,

--- a/samples/server/petstore/rust-server/output/no-example-v3/docs/default_api.md
+++ b/samples/server/petstore/rust-server/output/no-example-v3/docs/default_api.md
@@ -4,11 +4,11 @@ All URIs are relative to *http://localhost*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
-****](default_api.md#) | **GET** /op | 
+**OpGet**](default_api.md#OpGet) | **GET** /op | 
 
 
-# ****
-> (inline_object)
+# **OpGet**
+> OpGet(inline_object)
 
 
 ### Required Parameters

--- a/samples/server/petstore/rust-server/output/no-example-v3/examples/client/main.rs
+++ b/samples/server/petstore/rust-server/output/no-example-v3/examples/client/main.rs
@@ -15,7 +15,7 @@ extern crate tokio;
 #[allow(unused_imports)]
 use futures::{Future, future, Stream, stream};
 #[allow(unused_imports)]
-use no_example_v3::{Api, ApiNoContext, Client, ContextWrapperExt,
+use no_example_v3::{Api, ApiNoContext, Client, ContextWrapperExt, models,
                       ApiError,
                       OpGetResponse
                      };

--- a/samples/server/petstore/rust-server/output/openapi-v3/README.md
+++ b/samples/server/petstore/rust-server/output/openapi-v3/README.md
@@ -160,6 +160,7 @@ Method | HTTP request | Description
  - [ObjectWithArrayOfObjects](docs/ObjectWithArrayOfObjects.md)
  - [Ok](docs/Ok.md)
  - [OptionalObjectHeader](docs/OptionalObjectHeader.md)
+ - [RepoObject](docs/RepoObject.md)
  - [RequiredObjectHeader](docs/RequiredObjectHeader.md)
  - [Result](docs/Result.md)
  - [StringEnum](docs/StringEnum.md)

--- a/samples/server/petstore/rust-server/output/openapi-v3/README.md
+++ b/samples/server/petstore/rust-server/output/openapi-v3/README.md
@@ -81,6 +81,8 @@ cargo run --example client XmlOtherPost
 cargo run --example client XmlOtherPut
 cargo run --example client XmlPost
 cargo run --example client XmlPut
+cargo run --example client CreateRepo
+cargo run --example client GetRepoInfo
 ```
 
 ### HTTPS
@@ -114,27 +116,29 @@ All URIs are relative to *http://localhost*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
-[****](docs/default_api.md#) | **POST** /callback-with-header | 
-[****](docs/default_api.md#) | **GET** /complex-query-param | 
-[****](docs/default_api.md#) | **GET** /enum_in_path/{path_param} | 
-[****](docs/default_api.md#) | **GET** /mandatory-request-header | 
-[****](docs/default_api.md#) | **GET** /merge-patch-json | 
-[****](docs/default_api.md#) | **GET** /multiget | Get some stuff.
-[****](docs/default_api.md#) | **GET** /multiple_auth_scheme | 
-[****](docs/default_api.md#) | **GET** /override-server | 
-[****](docs/default_api.md#) | **GET** /paramget | Get some stuff with parameters.
-[****](docs/default_api.md#) | **GET** /readonly_auth_scheme | 
-[****](docs/default_api.md#) | **POST** /register-callback | 
-[****](docs/default_api.md#) | **PUT** /required_octet_stream | 
-[****](docs/default_api.md#) | **GET** /responses_with_headers | 
-[****](docs/default_api.md#) | **GET** /rfc7807 | 
-[****](docs/default_api.md#) | **GET** /untyped_property | 
-[****](docs/default_api.md#) | **GET** /uuid | 
-[****](docs/default_api.md#) | **POST** /xml_extra | 
-[****](docs/default_api.md#) | **POST** /xml_other | 
-[****](docs/default_api.md#) | **PUT** /xml_other | 
-[****](docs/default_api.md#) | **POST** /xml | Post an array
-[****](docs/default_api.md#) | **PUT** /xml | 
+[**CallbackWithHeaderPost**](docs/default_api.md#CallbackWithHeaderPost) | **POST** /callback-with-header | 
+[**ComplexQueryParamGet**](docs/default_api.md#ComplexQueryParamGet) | **GET** /complex-query-param | 
+[**EnumInPathPathParamGet**](docs/default_api.md#EnumInPathPathParamGet) | **GET** /enum_in_path/{path_param} | 
+[**MandatoryRequestHeaderGet**](docs/default_api.md#MandatoryRequestHeaderGet) | **GET** /mandatory-request-header | 
+[**MergePatchJsonGet**](docs/default_api.md#MergePatchJsonGet) | **GET** /merge-patch-json | 
+[**MultigetGet**](docs/default_api.md#MultigetGet) | **GET** /multiget | Get some stuff.
+[**MultipleAuthSchemeGet**](docs/default_api.md#MultipleAuthSchemeGet) | **GET** /multiple_auth_scheme | 
+[**OverrideServerGet**](docs/default_api.md#OverrideServerGet) | **GET** /override-server | 
+[**ParamgetGet**](docs/default_api.md#ParamgetGet) | **GET** /paramget | Get some stuff with parameters.
+[**ReadonlyAuthSchemeGet**](docs/default_api.md#ReadonlyAuthSchemeGet) | **GET** /readonly_auth_scheme | 
+[**RegisterCallbackPost**](docs/default_api.md#RegisterCallbackPost) | **POST** /register-callback | 
+[**RequiredOctetStreamPut**](docs/default_api.md#RequiredOctetStreamPut) | **PUT** /required_octet_stream | 
+[**ResponsesWithHeadersGet**](docs/default_api.md#ResponsesWithHeadersGet) | **GET** /responses_with_headers | 
+[**Rfc7807Get**](docs/default_api.md#Rfc7807Get) | **GET** /rfc7807 | 
+[**UntypedPropertyGet**](docs/default_api.md#UntypedPropertyGet) | **GET** /untyped_property | 
+[**UuidGet**](docs/default_api.md#UuidGet) | **GET** /uuid | 
+[**XmlExtraPost**](docs/default_api.md#XmlExtraPost) | **POST** /xml_extra | 
+[**XmlOtherPost**](docs/default_api.md#XmlOtherPost) | **POST** /xml_other | 
+[**XmlOtherPut**](docs/default_api.md#XmlOtherPut) | **PUT** /xml_other | 
+[**XmlPost**](docs/default_api.md#XmlPost) | **POST** /xml | Post an array
+[**XmlPut**](docs/default_api.md#XmlPut) | **PUT** /xml | 
+[**CreateRepo**](docs/repo_api.md#CreateRepo) | **POST** /repos | 
+[**GetRepoInfo**](docs/repo_api.md#GetRepoInfo) | **GET** /repos/{repoId} | 
 
 
 ## Documentation For Models

--- a/samples/server/petstore/rust-server/output/openapi-v3/api/openapi.yaml
+++ b/samples/server/petstore/rust-server/output/openapi-v3/api/openapi.yaml
@@ -381,6 +381,22 @@ paths:
       tags:
       - Repo
       - Info
+  /repos:
+    post:
+      operationId: CreateRepo
+      requestBody:
+        content:
+          application/json:
+            example:
+              requiredParam: true
+            schema:
+              $ref: '#/components/schemas/ObjectParam'
+        required: true
+      responses:
+        "200":
+          description: Success
+      tags:
+      - Repo
 components:
   schemas:
     EnumWithStarObject:
@@ -491,6 +507,9 @@ components:
       - required_untyped_nullable
       type: object
     ObjectParam:
+      example:
+        requiredParam: true
+        optionalParam: 0
       properties:
         requiredParam:
           type: boolean

--- a/samples/server/petstore/rust-server/output/openapi-v3/api/openapi.yaml
+++ b/samples/server/petstore/rust-server/output/openapi-v3/api/openapi.yaml
@@ -380,6 +380,7 @@ paths:
           description: OK
       tags:
       - Repo
+      - Info
 components:
   schemas:
     EnumWithStarObject:

--- a/samples/server/petstore/rust-server/output/openapi-v3/api/openapi.yaml
+++ b/samples/server/petstore/rust-server/output/openapi-v3/api/openapi.yaml
@@ -394,6 +394,10 @@ paths:
         required: true
       responses:
         "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
           description: Success
       tags:
       - Repo
@@ -562,12 +566,34 @@ components:
       type: string
     Ok:
       type: string
-    Error:
-      type: string
     Err:
       type: string
     Result:
       type: string
+    Error:
+      additionalProperties: true
+      example:
+        code: -1
+        retryable: false
+        message: We failed to update the object in your request
+        innerError:
+          code: -100
+          message: You are trying to access an absent object
+      properties:
+        code:
+          type: integer
+        retryable:
+          type: boolean
+        message:
+          example: NotFound
+          type: string
+        innerError:
+          $ref: '#/components/schemas/Error'
+      required:
+      - code
+      - message
+      - retryable
+      type: object
     inline_response_201:
       properties:
         foo:

--- a/samples/server/petstore/rust-server/output/openapi-v3/api/openapi.yaml
+++ b/samples/server/petstore/rust-server/output/openapi-v3/api/openapi.yaml
@@ -401,6 +401,22 @@ paths:
           description: Success
       tags:
       - Repo
+    put:
+      operationId: OverwriteRepo
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RepoObject'
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: OK
+      tags:
+      - Repo
 components:
   schemas:
     EnumWithStarObject:

--- a/samples/server/petstore/rust-server/output/openapi-v3/api/openapi.yaml
+++ b/samples/server/petstore/rust-server/output/openapi-v3/api/openapi.yaml
@@ -362,7 +362,7 @@ paths:
           description: Success
   /repos/{repoId}:
     get:
-      operationId: GetRepoInfo
+      operationId: Get Repo\Info
       parameters:
       - explode: false
         in: path
@@ -376,7 +376,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/StringObject'
+                $ref: '#/components/schemas/RepoObject'
           description: OK
       tags:
       - Repo
@@ -485,6 +485,8 @@ components:
       type: object
     StringObject:
       type: string
+    RepoObject:
+      type: object
     MyIDList:
       items:
         $ref: '#/components/schemas/MyID'

--- a/samples/server/petstore/rust-server/output/openapi-v3/docs/Error.md
+++ b/samples/server/petstore/rust-server/output/openapi-v3/docs/Error.md
@@ -3,6 +3,10 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
+**code** | **isize** |  | 
+**retryable** | **bool** |  | 
+**message** | **String** |  | 
+**inner_error** | [***models::Error**](Error.md) |  | [optional] [default to None]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/server/petstore/rust-server/output/openapi-v3/docs/RepoObject.md
+++ b/samples/server/petstore/rust-server/output/openapi-v3/docs/RepoObject.md
@@ -1,0 +1,9 @@
+# RepoObject
+
+## Properties
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+
+

--- a/samples/server/petstore/rust-server/output/openapi-v3/docs/default_api.md
+++ b/samples/server/petstore/rust-server/output/openapi-v3/docs/default_api.md
@@ -4,31 +4,31 @@ All URIs are relative to *http://localhost*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
-****](default_api.md#) | **POST** /callback-with-header | 
-****](default_api.md#) | **GET** /complex-query-param | 
-****](default_api.md#) | **GET** /enum_in_path/{path_param} | 
-****](default_api.md#) | **GET** /mandatory-request-header | 
-****](default_api.md#) | **GET** /merge-patch-json | 
-****](default_api.md#) | **GET** /multiget | Get some stuff.
-****](default_api.md#) | **GET** /multiple_auth_scheme | 
-****](default_api.md#) | **GET** /override-server | 
-****](default_api.md#) | **GET** /paramget | Get some stuff with parameters.
-****](default_api.md#) | **GET** /readonly_auth_scheme | 
-****](default_api.md#) | **POST** /register-callback | 
-****](default_api.md#) | **PUT** /required_octet_stream | 
-****](default_api.md#) | **GET** /responses_with_headers | 
-****](default_api.md#) | **GET** /rfc7807 | 
-****](default_api.md#) | **GET** /untyped_property | 
-****](default_api.md#) | **GET** /uuid | 
-****](default_api.md#) | **POST** /xml_extra | 
-****](default_api.md#) | **POST** /xml_other | 
-****](default_api.md#) | **PUT** /xml_other | 
-****](default_api.md#) | **POST** /xml | Post an array
-****](default_api.md#) | **PUT** /xml | 
+**CallbackWithHeaderPost**](default_api.md#CallbackWithHeaderPost) | **POST** /callback-with-header | 
+**ComplexQueryParamGet**](default_api.md#ComplexQueryParamGet) | **GET** /complex-query-param | 
+**EnumInPathPathParamGet**](default_api.md#EnumInPathPathParamGet) | **GET** /enum_in_path/{path_param} | 
+**MandatoryRequestHeaderGet**](default_api.md#MandatoryRequestHeaderGet) | **GET** /mandatory-request-header | 
+**MergePatchJsonGet**](default_api.md#MergePatchJsonGet) | **GET** /merge-patch-json | 
+**MultigetGet**](default_api.md#MultigetGet) | **GET** /multiget | Get some stuff.
+**MultipleAuthSchemeGet**](default_api.md#MultipleAuthSchemeGet) | **GET** /multiple_auth_scheme | 
+**OverrideServerGet**](default_api.md#OverrideServerGet) | **GET** /override-server | 
+**ParamgetGet**](default_api.md#ParamgetGet) | **GET** /paramget | Get some stuff with parameters.
+**ReadonlyAuthSchemeGet**](default_api.md#ReadonlyAuthSchemeGet) | **GET** /readonly_auth_scheme | 
+**RegisterCallbackPost**](default_api.md#RegisterCallbackPost) | **POST** /register-callback | 
+**RequiredOctetStreamPut**](default_api.md#RequiredOctetStreamPut) | **PUT** /required_octet_stream | 
+**ResponsesWithHeadersGet**](default_api.md#ResponsesWithHeadersGet) | **GET** /responses_with_headers | 
+**Rfc7807Get**](default_api.md#Rfc7807Get) | **GET** /rfc7807 | 
+**UntypedPropertyGet**](default_api.md#UntypedPropertyGet) | **GET** /untyped_property | 
+**UuidGet**](default_api.md#UuidGet) | **GET** /uuid | 
+**XmlExtraPost**](default_api.md#XmlExtraPost) | **POST** /xml_extra | 
+**XmlOtherPost**](default_api.md#XmlOtherPost) | **POST** /xml_other | 
+**XmlOtherPut**](default_api.md#XmlOtherPut) | **PUT** /xml_other | 
+**XmlPost**](default_api.md#XmlPost) | **POST** /xml | Post an array
+**XmlPut**](default_api.md#XmlPut) | **PUT** /xml | 
 
 
-# ****
-> (url)
+# **CallbackWithHeaderPost**
+> CallbackWithHeaderPost(url)
 
 
 ### Required Parameters
@@ -52,8 +52,8 @@ No authorization required
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
-# ****
-> (optional)
+# **ComplexQueryParamGet**
+> ComplexQueryParamGet(optional)
 
 
 ### Required Parameters
@@ -84,8 +84,8 @@ No authorization required
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
-# ****
-> (path_param)
+# **EnumInPathPathParamGet**
+> EnumInPathPathParamGet(path_param)
 
 
 ### Required Parameters
@@ -109,8 +109,8 @@ No authorization required
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
-# ****
-> (x_header)
+# **MandatoryRequestHeaderGet**
+> MandatoryRequestHeaderGet(x_header)
 
 
 ### Required Parameters
@@ -134,8 +134,8 @@ No authorization required
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
-# ****
-> models::AnotherXmlObject ()
+# **MergePatchJsonGet**
+> models::AnotherXmlObject MergePatchJsonGet()
 
 
 ### Required Parameters
@@ -156,8 +156,8 @@ No authorization required
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
-# ****
-> models::AnotherXmlObject ()
+# **MultigetGet**
+> models::AnotherXmlObject MultigetGet()
 Get some stuff.
 
 ### Required Parameters
@@ -178,8 +178,8 @@ No authorization required
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
-# ****
-> (ctx, )
+# **MultipleAuthSchemeGet**
+> MultipleAuthSchemeGet(ctx, )
 
 
 ### Required Parameters
@@ -200,8 +200,8 @@ This endpoint does not need any parameter.
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
-# ****
-> ()
+# **OverrideServerGet**
+> OverrideServerGet()
 
 
 ### Required Parameters
@@ -222,8 +222,8 @@ No authorization required
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
-# ****
-> models::AnotherXmlObject (optional)
+# **ParamgetGet**
+> models::AnotherXmlObject ParamgetGet(optional)
 Get some stuff with parameters.
 
 ### Required Parameters
@@ -256,8 +256,8 @@ No authorization required
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
-# ****
-> (ctx, )
+# **ReadonlyAuthSchemeGet**
+> ReadonlyAuthSchemeGet(ctx, )
 
 
 ### Required Parameters
@@ -278,8 +278,8 @@ This endpoint does not need any parameter.
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
-# ****
-> (url)
+# **RegisterCallbackPost**
+> RegisterCallbackPost(url)
 
 
 ### Required Parameters
@@ -303,8 +303,8 @@ No authorization required
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
-# ****
-> (body)
+# **RequiredOctetStreamPut**
+> RequiredOctetStreamPut(body)
 
 
 ### Required Parameters
@@ -328,8 +328,8 @@ No authorization required
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
-# ****
-> String ()
+# **ResponsesWithHeadersGet**
+> String ResponsesWithHeadersGet()
 
 
 ### Required Parameters
@@ -350,8 +350,8 @@ No authorization required
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
-# ****
-> models::ObjectWithArrayOfObjects ()
+# **Rfc7807Get**
+> models::ObjectWithArrayOfObjects Rfc7807Get()
 
 
 ### Required Parameters
@@ -372,8 +372,8 @@ No authorization required
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
-# ****
-> (optional)
+# **UntypedPropertyGet**
+> UntypedPropertyGet(optional)
 
 
 ### Required Parameters
@@ -404,8 +404,8 @@ No authorization required
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
-# ****
-> uuid::Uuid ()
+# **UuidGet**
+> uuid::Uuid UuidGet()
 
 
 ### Required Parameters
@@ -426,8 +426,8 @@ No authorization required
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
-# ****
-> (optional)
+# **XmlExtraPost**
+> XmlExtraPost(optional)
 
 
 ### Required Parameters
@@ -458,8 +458,8 @@ No authorization required
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
-# ****
-> (optional)
+# **XmlOtherPost**
+> XmlOtherPost(optional)
 
 
 ### Required Parameters
@@ -490,8 +490,8 @@ No authorization required
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
-# ****
-> (optional)
+# **XmlOtherPut**
+> XmlOtherPut(optional)
 
 
 ### Required Parameters
@@ -522,8 +522,8 @@ No authorization required
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
-# ****
-> (optional)
+# **XmlPost**
+> XmlPost(optional)
 Post an array
 
 ### Required Parameters
@@ -554,8 +554,8 @@ No authorization required
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
-# ****
-> (optional)
+# **XmlPut**
+> XmlPut(optional)
 
 
 ### Required Parameters

--- a/samples/server/petstore/rust-server/output/openapi-v3/docs/info_api.md
+++ b/samples/server/petstore/rust-server/output/openapi-v3/docs/info_api.md
@@ -1,0 +1,8 @@
+# info_api
+
+All URIs are relative to *http://localhost*
+
+Method | HTTP request | Description
+------------- | ------------- | -------------
+
+

--- a/samples/server/petstore/rust-server/output/openapi-v3/docs/info_api.md
+++ b/samples/server/petstore/rust-server/output/openapi-v3/docs/info_api.md
@@ -1,8 +1,0 @@
-# info_api
-
-All URIs are relative to *http://localhost*
-
-Method | HTTP request | Description
-------------- | ------------- | -------------
-
-

--- a/samples/server/petstore/rust-server/output/openapi-v3/docs/repo_api.md
+++ b/samples/server/petstore/rust-server/output/openapi-v3/docs/repo_api.md
@@ -5,7 +5,7 @@ All URIs are relative to *http://localhost*
 Method | HTTP request | Description
 ------------- | ------------- | -------------
 **CreateRepo**](repo_api.md#CreateRepo) | **POST** /repos | 
-**Get Repo\Info**](repo_api.md#Get Repo\Info) | **GET** /repos/{repoId} | 
+**GetRepoInfo**](repo_api.md#GetRepoInfo) | **GET** /repos/{repoId} | 
 
 
 # **CreateRepo**
@@ -33,8 +33,8 @@ No authorization required
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
-# **Get Repo\Info**
-> serde_json::Value Get Repo\Info(repo_id)
+# **GetRepoInfo**
+> serde_json::Value GetRepoInfo(repo_id)
 
 
 ### Required Parameters

--- a/samples/server/petstore/rust-server/output/openapi-v3/docs/repo_api.md
+++ b/samples/server/petstore/rust-server/output/openapi-v3/docs/repo_api.md
@@ -4,8 +4,34 @@ All URIs are relative to *http://localhost*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
+**CreateRepo**](repo_api.md#CreateRepo) | **POST** /repos | 
 **GetRepoInfo**](repo_api.md#GetRepoInfo) | **GET** /repos/{repoId} | 
 
+
+# **CreateRepo**
+> CreateRepo(object_param)
+
+
+### Required Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+  **object_param** | [**ObjectParam**](ObjectParam.md)|  | 
+
+### Return type
+
+ (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: application/json
+ - **Accept**: Not defined
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **GetRepoInfo**
 > String GetRepoInfo(repo_id)

--- a/samples/server/petstore/rust-server/output/openapi-v3/docs/repo_api.md
+++ b/samples/server/petstore/rust-server/output/openapi-v3/docs/repo_api.md
@@ -9,7 +9,7 @@ Method | HTTP request | Description
 
 
 # **CreateRepo**
-> CreateRepo(object_param)
+> models::Error CreateRepo(object_param)
 
 
 ### Required Parameters
@@ -20,7 +20,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
- (empty response body)
+[**models::Error**](Error.md)
 
 ### Authorization
 
@@ -29,7 +29,7 @@ No authorization required
 ### HTTP request headers
 
  - **Content-Type**: application/json
- - **Accept**: Not defined
+ - **Accept**: application/json, 
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 

--- a/samples/server/petstore/rust-server/output/openapi-v3/docs/repo_api.md
+++ b/samples/server/petstore/rust-server/output/openapi-v3/docs/repo_api.md
@@ -5,7 +5,7 @@ All URIs are relative to *http://localhost*
 Method | HTTP request | Description
 ------------- | ------------- | -------------
 **CreateRepo**](repo_api.md#CreateRepo) | **POST** /repos | 
-**GetRepoInfo**](repo_api.md#GetRepoInfo) | **GET** /repos/{repoId} | 
+**Get Repo\Info**](repo_api.md#Get Repo\Info) | **GET** /repos/{repoId} | 
 
 
 # **CreateRepo**
@@ -33,8 +33,8 @@ No authorization required
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
-# **GetRepoInfo**
-> String GetRepoInfo(repo_id)
+# **Get Repo\Info**
+> serde_json::Value Get Repo\Info(repo_id)
 
 
 ### Required Parameters
@@ -45,7 +45,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-[**String**](string.md)
+[**serde_json::Value**](object.md)
 
 ### Authorization
 

--- a/samples/server/petstore/rust-server/output/openapi-v3/docs/repo_api.md
+++ b/samples/server/petstore/rust-server/output/openapi-v3/docs/repo_api.md
@@ -6,6 +6,7 @@ Method | HTTP request | Description
 ------------- | ------------- | -------------
 **CreateRepo**](repo_api.md#CreateRepo) | **POST** /repos | 
 **GetRepoInfo**](repo_api.md#GetRepoInfo) | **GET** /repos/{repoId} | 
+**OverwriteRepo**](repo_api.md#OverwriteRepo) | **PUT** /repos | 
 
 
 # **CreateRepo**
@@ -54,6 +55,38 @@ No authorization required
 ### HTTP request headers
 
  - **Content-Type**: Not defined
+ - **Accept**: application/json, 
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+# **OverwriteRepo**
+> models::Error OverwriteRepo(optional)
+
+
+### Required Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **optional** | **map[string]interface{}** | optional parameters | nil if no parameters
+
+### Optional Parameters
+Optional parameters are passed through a map[string]interface{}.
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **body** | [**object**](object.md)|  | 
+
+### Return type
+
+[**models::Error**](Error.md)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: application/json
  - **Accept**: application/json
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)

--- a/samples/server/petstore/rust-server/output/openapi-v3/docs/repo_api.md
+++ b/samples/server/petstore/rust-server/output/openapi-v3/docs/repo_api.md
@@ -1,0 +1,34 @@
+# repo_api
+
+All URIs are relative to *http://localhost*
+
+Method | HTTP request | Description
+------------- | ------------- | -------------
+**GetRepoInfo**](repo_api.md#GetRepoInfo) | **GET** /repos/{repoId} | 
+
+
+# **GetRepoInfo**
+> String GetRepoInfo(repo_id)
+
+
+### Required Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+  **repo_id** | **String**|  | 
+
+### Return type
+
+[**String**](string.md)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: application/json
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+

--- a/samples/server/petstore/rust-server/output/openapi-v3/examples/client/main.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/examples/client/main.rs
@@ -51,7 +51,7 @@ use openapi_v3::{Api, ApiNoContext, Client, ContextWrapperExt, models,
                       XmlPostResponse,
                       XmlPutResponse,
                       CreateRepoResponse,
-                      Get RepoInfoResponse
+                      GetRepoInfoResponse
                      };
 use clap::{App, Arg};
 
@@ -89,7 +89,7 @@ fn main() {
                 "XmlPost",
                 "XmlPut",
                 "CreateRepo",
-                "Get RepoInfo",
+                "GetRepoInfo",
             ])
             .required(true)
             .index(1))
@@ -264,7 +264,7 @@ fn main() {
             ));
             info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
-        Some("Get RepoInfo") => {
+        Some("GetRepoInfo") => {
             let result = rt.block_on(client.get_repo_info(
                   "repo_id_example".to_string()
             ));

--- a/samples/server/petstore/rust-server/output/openapi-v3/examples/client/main.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/examples/client/main.rs
@@ -51,7 +51,8 @@ use openapi_v3::{Api, ApiNoContext, Client, ContextWrapperExt, models,
                       XmlPostResponse,
                       XmlPutResponse,
                       CreateRepoResponse,
-                      GetRepoInfoResponse
+                      GetRepoInfoResponse,
+                      OverwriteRepoResponse
                      };
 use clap::{App, Arg};
 
@@ -90,6 +91,7 @@ fn main() {
                 "XmlPut",
                 "CreateRepo",
                 "GetRepoInfo",
+                "OverwriteRepo",
             ])
             .required(true)
             .index(1))
@@ -267,6 +269,12 @@ fn main() {
         Some("GetRepoInfo") => {
             let result = rt.block_on(client.get_repo_info(
                   "repo_id_example".to_string()
+            ));
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
+        },
+        Some("OverwriteRepo") => {
+            let result = rt.block_on(client.overwrite_repo(
+                  None
             ));
             info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },

--- a/samples/server/petstore/rust-server/output/openapi-v3/examples/client/main.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/examples/client/main.rs
@@ -51,7 +51,7 @@ use openapi_v3::{Api, ApiNoContext, Client, ContextWrapperExt, models,
                       XmlPostResponse,
                       XmlPutResponse,
                       CreateRepoResponse,
-                      GetRepoInfoResponse
+                      Get RepoInfoResponse
                      };
 use clap::{App, Arg};
 
@@ -89,7 +89,7 @@ fn main() {
                 "XmlPost",
                 "XmlPut",
                 "CreateRepo",
-                "GetRepoInfo",
+                "Get RepoInfo",
             ])
             .required(true)
             .index(1))
@@ -264,7 +264,7 @@ fn main() {
             ));
             info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
-        Some("GetRepoInfo") => {
+        Some("Get RepoInfo") => {
             let result = rt.block_on(client.get_repo_info(
                   "repo_id_example".to_string()
             ));

--- a/samples/server/petstore/rust-server/output/openapi-v3/examples/client/main.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/examples/client/main.rs
@@ -27,7 +27,7 @@ mod server;
 #[allow(unused_imports)]
 use futures::{Future, future, Stream, stream};
 #[allow(unused_imports)]
-use openapi_v3::{Api, ApiNoContext, Client, ContextWrapperExt,
+use openapi_v3::{Api, ApiNoContext, Client, ContextWrapperExt, models,
                       ApiError,
                       CallbackWithHeaderPostResponse,
                       ComplexQueryParamGetResponse,
@@ -88,6 +88,7 @@ fn main() {
                 "XmlOtherPut",
                 "XmlPost",
                 "XmlPut",
+                "CreateRepo",
                 "GetRepoInfo",
             ])
             .required(true)
@@ -183,7 +184,7 @@ fn main() {
         },
         Some("ParamgetGet") => {
             let result = rt.block_on(client.paramget_get(
-                  Some(serde_json::from_str::<uuid::Uuid>("38400000-8cf0-11bd-b23e-10b96e4ef00d").expect("Failed to parse JSON example")),
+                  Some(serde_json::from_str::<uuid::Uuid>(r#"38400000-8cf0-11bd-b23e-10b96e4ef00d"#).expect("Failed to parse JSON example")),
                   None,
                   None
             ));
@@ -257,14 +258,12 @@ fn main() {
             ));
             info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
-        /* Disabled because there's no example.
         Some("CreateRepo") => {
             let result = rt.block_on(client.create_repo(
-                  ???
+                  serde_json::from_str::<models::ObjectParam>(r#"{"requiredParam":true}"#).expect("Failed to parse JSON example")
             ));
             info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
-        */
         Some("GetRepoInfo") => {
             let result = rt.block_on(client.get_repo_info(
                   "repo_id_example".to_string()

--- a/samples/server/petstore/rust-server/output/openapi-v3/examples/client/main.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/examples/client/main.rs
@@ -50,6 +50,7 @@ use openapi_v3::{Api, ApiNoContext, Client, ContextWrapperExt,
                       XmlOtherPutResponse,
                       XmlPostResponse,
                       XmlPutResponse,
+                      CreateRepoResponse,
                       GetRepoInfoResponse
                      };
 use clap::{App, Arg};
@@ -256,6 +257,14 @@ fn main() {
             ));
             info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
+        /* Disabled because there's no example.
+        Some("CreateRepo") => {
+            let result = rt.block_on(client.create_repo(
+                  ???
+            ));
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
+        },
+        */
         Some("GetRepoInfo") => {
             let result = rt.block_on(client.get_repo_info(
                   "repo_id_example".to_string()

--- a/samples/server/petstore/rust-server/output/openapi-v3/examples/server/server.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/examples/server/server.rs
@@ -128,6 +128,7 @@ use openapi_v3::{
     XmlPutResponse,
     CreateRepoResponse,
     GetRepoInfoResponse,
+    OverwriteRepoResponse,
 };
 use openapi_v3::server::MakeService;
 
@@ -356,6 +357,16 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
     {
         let context = context.clone();
         info!("get_repo_info(\"{}\") - X-Span-ID: {:?}", repo_id, context.get().0.clone());
+        Box::new(future::err("Generic failure".into()))
+    }
+
+    fn overwrite_repo(
+        &self,
+        body: Option<models::RepoObject>,
+        context: &C) -> Box<dyn Future<Item=OverwriteRepoResponse, Error=ApiError> + Send>
+    {
+        let context = context.clone();
+        info!("overwrite_repo({:?}) - X-Span-ID: {:?}", body, context.get().0.clone());
         Box::new(future::err("Generic failure".into()))
     }
 

--- a/samples/server/petstore/rust-server/output/openapi-v3/examples/server/server.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/examples/server/server.rs
@@ -126,6 +126,7 @@ use openapi_v3::{
     XmlOtherPutResponse,
     XmlPostResponse,
     XmlPutResponse,
+    CreateRepoResponse,
     GetRepoInfoResponse,
 };
 use openapi_v3::server::MakeService;
@@ -335,6 +336,16 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
     {
         let context = context.clone();
         info!("xml_put({:?}) - X-Span-ID: {:?}", xml_object, context.get().0.clone());
+        Box::new(future::err("Generic failure".into()))
+    }
+
+    fn create_repo(
+        &self,
+        object_param: models::ObjectParam,
+        context: &C) -> Box<dyn Future<Item=CreateRepoResponse, Error=ApiError> + Send>
+    {
+        let context = context.clone();
+        info!("create_repo({:?}) - X-Span-ID: {:?}", object_param, context.get().0.clone());
         Box::new(future::err("Generic failure".into()))
     }
 

--- a/samples/server/petstore/rust-server/output/openapi-v3/examples/server/server.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/examples/server/server.rs
@@ -127,7 +127,7 @@ use openapi_v3::{
     XmlPostResponse,
     XmlPutResponse,
     CreateRepoResponse,
-    GetRepoInfoResponse,
+    Get RepoInfoResponse,
 };
 use openapi_v3::server::MakeService;
 
@@ -352,7 +352,7 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
     fn get_repo_info(
         &self,
         repo_id: String,
-        context: &C) -> Box<dyn Future<Item=GetRepoInfoResponse, Error=ApiError> + Send>
+        context: &C) -> Box<dyn Future<Item=Get RepoInfoResponse, Error=ApiError> + Send>
     {
         let context = context.clone();
         info!("get_repo_info(\"{}\") - X-Span-ID: {:?}", repo_id, context.get().0.clone());

--- a/samples/server/petstore/rust-server/output/openapi-v3/examples/server/server.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/examples/server/server.rs
@@ -127,7 +127,7 @@ use openapi_v3::{
     XmlPostResponse,
     XmlPutResponse,
     CreateRepoResponse,
-    Get RepoInfoResponse,
+    GetRepoInfoResponse,
 };
 use openapi_v3::server::MakeService;
 
@@ -352,7 +352,7 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
     fn get_repo_info(
         &self,
         repo_id: String,
-        context: &C) -> Box<dyn Future<Item=Get RepoInfoResponse, Error=ApiError> + Send>
+        context: &C) -> Box<dyn Future<Item=GetRepoInfoResponse, Error=ApiError> + Send>
     {
         let context = context.clone();
         info!("get_repo_info(\"{}\") - X-Span-ID: {:?}", repo_id, context.get().0.clone());

--- a/samples/server/petstore/rust-server/output/openapi-v3/src/client/mod.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/src/client/mod.rs
@@ -57,7 +57,7 @@ use {Api,
      XmlPostResponse,
      XmlPutResponse,
      CreateRepoResponse,
-     GetRepoInfoResponse
+     Get RepoInfoResponse
      };
 
 pub mod callbacks;
@@ -2316,7 +2316,7 @@ impl<C, F> Api<C> for Client<F> where
     fn get_repo_info(
         &self,
         param_repo_id: String,
-        context: &C) -> Box<dyn Future<Item=GetRepoInfoResponse, Error=ApiError> + Send>
+        context: &C) -> Box<dyn Future<Item=Get RepoInfoResponse, Error=ApiError> + Send>
     {
         let mut uri = format!(
             "{}/repos/{repo_id}",
@@ -2365,12 +2365,12 @@ impl<C, F> Api<C> for Client<F> where
                         str::from_utf8(&body)
                                              .map_err(|e| ApiError(format!("Response was not valid UTF8: {}", e)))
                                              .and_then(|body|
-                                                 serde_json::from_str::<String>(body)
+                                                 serde_json::from_str::<serde_json::Value>(body)
                                                      .map_err(|e| e.into())
                                              )
                                  )
                         .map(move |body| {
-                            GetRepoInfoResponse::OK
+                            Get RepoInfoResponse::OK
                             (body)
                         })
                     ) as Box<dyn Future<Item=_, Error=_> + Send>

--- a/samples/server/petstore/rust-server/output/openapi-v3/src/client/mod.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/src/client/mod.rs
@@ -57,7 +57,7 @@ use {Api,
      XmlPostResponse,
      XmlPutResponse,
      CreateRepoResponse,
-     Get RepoInfoResponse
+     GetRepoInfoResponse
      };
 
 pub mod callbacks;
@@ -2316,7 +2316,7 @@ impl<C, F> Api<C> for Client<F> where
     fn get_repo_info(
         &self,
         param_repo_id: String,
-        context: &C) -> Box<dyn Future<Item=Get RepoInfoResponse, Error=ApiError> + Send>
+        context: &C) -> Box<dyn Future<Item=GetRepoInfoResponse, Error=ApiError> + Send>
     {
         let mut uri = format!(
             "{}/repos/{repo_id}",
@@ -2370,7 +2370,7 @@ impl<C, F> Api<C> for Client<F> where
                                              )
                                  )
                         .map(move |body| {
-                            Get RepoInfoResponse::OK
+                            GetRepoInfoResponse::OK
                             (body)
                         })
                     ) as Box<dyn Future<Item=_, Error=_> + Send>

--- a/samples/server/petstore/rust-server/output/openapi-v3/src/client/mod.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/src/client/mod.rs
@@ -57,7 +57,8 @@ use {Api,
      XmlPostResponse,
      XmlPutResponse,
      CreateRepoResponse,
-     GetRepoInfoResponse
+     GetRepoInfoResponse,
+     OverwriteRepoResponse
      };
 
 pub mod callbacks;
@@ -2371,6 +2372,104 @@ impl<C, F> Api<C> for Client<F> where
                                  )
                         .map(move |body| {
                             GetRepoInfoResponse::OK
+                            (body)
+                        })
+                    ) as Box<dyn Future<Item=_, Error=_> + Send>
+                },
+                code => {
+                    let headers = response.headers().clone();
+                    Box::new(response.into_body()
+                            .take(100)
+                            .concat2()
+                            .then(move |body|
+                                future::err(ApiError(format!("Unexpected response code {}:\n{:?}\n\n{}",
+                                    code,
+                                    headers,
+                                    match body {
+                                        Ok(ref body) => match str::from_utf8(body) {
+                                            Ok(body) => Cow::from(body),
+                                            Err(e) => Cow::from(format!("<Body was not UTF8: {:?}>", e)),
+                                        },
+                                        Err(e) => Cow::from(format!("<Failed to read body: {}>", e)),
+                                    })))
+                            )
+                    ) as Box<dyn Future<Item=_, Error=_> + Send>
+                }
+            }
+        }))
+    }
+
+    fn overwrite_repo(
+        &self,
+        param_body: Option<models::RepoObject>,
+        context: &C) -> Box<dyn Future<Item=OverwriteRepoResponse, Error=ApiError> + Send>
+    {
+        let mut uri = format!(
+            "{}/repos",
+            self.base_path
+        );
+
+        // Query parameters
+        let mut query_string = url::form_urlencoded::Serializer::new("".to_owned());
+        let query_string_str = query_string.finish();
+        if !query_string_str.is_empty() {
+            uri += "?";
+            uri += &query_string_str;
+        }
+
+        let uri = match Uri::from_str(&uri) {
+            Ok(uri) => uri,
+            Err(err) => return Box::new(future::err(ApiError(format!("Unable to build URI: {}", err)))),
+        };
+
+        let mut request = match hyper::Request::builder()
+            .method("PUT")
+            .uri(uri)
+            .body(Body::empty()) {
+                Ok(req) => req,
+                Err(e) => return Box::new(future::err(ApiError(format!("Unable to create request: {}", e))))
+        };
+
+        let body = param_body.map(|ref body| {
+            serde_json::to_string(body).expect("impossible to fail to serialize")
+        });
+
+        if let Some(body) = body {
+                *request.body_mut() = Body::from(body);
+        }
+
+        let header = "application/json";
+        request.headers_mut().insert(CONTENT_TYPE, match HeaderValue::from_str(header) {
+            Ok(h) => h,
+            Err(e) => return Box::new(future::err(ApiError(format!("Unable to create header: {} - {}", header, e))))
+        });
+
+        let header = HeaderValue::from_str((context as &dyn Has<XSpanIdString>).get().0.clone().to_string().as_str());
+        request.headers_mut().insert(HeaderName::from_static("x-span-id"), match header {
+            Ok(h) => h,
+            Err(e) => return Box::new(future::err(ApiError(format!("Unable to create X-Span ID header value: {}", e))))
+        });
+
+        Box::new(self.client_service.request(request)
+                             .map_err(|e| ApiError(format!("No response received: {}", e)))
+                             .and_then(|mut response| {
+            match response.status().as_u16() {
+                200 => {
+                    let body = response.into_body();
+                    Box::new(
+                        body
+                        .concat2()
+                        .map_err(|e| ApiError(format!("Failed to read response: {}", e)))
+                        .and_then(|body|
+                        str::from_utf8(&body)
+                                             .map_err(|e| ApiError(format!("Response was not valid UTF8: {}", e)))
+                                             .and_then(|body|
+                                                 serde_json::from_str::<models::Error>(body)
+                                                     .map_err(|e| e.into())
+                                             )
+                                 )
+                        .map(move |body| {
+                            OverwriteRepoResponse::OK
                             (body)
                         })
                     ) as Box<dyn Future<Item=_, Error=_> + Send>

--- a/samples/server/petstore/rust-server/output/openapi-v3/src/client/mod.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/src/client/mod.rs
@@ -56,6 +56,7 @@ use {Api,
      XmlOtherPutResponse,
      XmlPostResponse,
      XmlPutResponse,
+     CreateRepoResponse,
      GetRepoInfoResponse
      };
 
@@ -2193,6 +2194,87 @@ impl<C, F> Api<C> for Client<F> where
                     Box::new(
                         future::ok(
                             XmlPutResponse::BadRequest
+                        )
+                    ) as Box<dyn Future<Item=_, Error=_> + Send>
+                },
+                code => {
+                    let headers = response.headers().clone();
+                    Box::new(response.into_body()
+                            .take(100)
+                            .concat2()
+                            .then(move |body|
+                                future::err(ApiError(format!("Unexpected response code {}:\n{:?}\n\n{}",
+                                    code,
+                                    headers,
+                                    match body {
+                                        Ok(ref body) => match str::from_utf8(body) {
+                                            Ok(body) => Cow::from(body),
+                                            Err(e) => Cow::from(format!("<Body was not UTF8: {:?}>", e)),
+                                        },
+                                        Err(e) => Cow::from(format!("<Failed to read body: {}>", e)),
+                                    })))
+                            )
+                    ) as Box<dyn Future<Item=_, Error=_> + Send>
+                }
+            }
+        }))
+    }
+
+    fn create_repo(
+        &self,
+        param_object_param: models::ObjectParam,
+        context: &C) -> Box<dyn Future<Item=CreateRepoResponse, Error=ApiError> + Send>
+    {
+        let mut uri = format!(
+            "{}/repos",
+            self.base_path
+        );
+
+        // Query parameters
+        let mut query_string = url::form_urlencoded::Serializer::new("".to_owned());
+        let query_string_str = query_string.finish();
+        if !query_string_str.is_empty() {
+            uri += "?";
+            uri += &query_string_str;
+        }
+
+        let uri = match Uri::from_str(&uri) {
+            Ok(uri) => uri,
+            Err(err) => return Box::new(future::err(ApiError(format!("Unable to build URI: {}", err)))),
+        };
+
+        let mut request = match hyper::Request::builder()
+            .method("POST")
+            .uri(uri)
+            .body(Body::empty()) {
+                Ok(req) => req,
+                Err(e) => return Box::new(future::err(ApiError(format!("Unable to create request: {}", e))))
+        };
+
+        // Body parameter
+        let body = serde_json::to_string(&param_object_param).expect("impossible to fail to serialize");
+                *request.body_mut() = Body::from(body);
+
+        let header = "application/json";
+        request.headers_mut().insert(CONTENT_TYPE, match HeaderValue::from_str(header) {
+            Ok(h) => h,
+            Err(e) => return Box::new(future::err(ApiError(format!("Unable to create header: {} - {}", header, e))))
+        });
+        let header = HeaderValue::from_str((context as &dyn Has<XSpanIdString>).get().0.clone().to_string().as_str());
+        request.headers_mut().insert(HeaderName::from_static("x-span-id"), match header {
+            Ok(h) => h,
+            Err(e) => return Box::new(future::err(ApiError(format!("Unable to create X-Span ID header value: {}", e))))
+        });
+
+        Box::new(self.client_service.request(request)
+                             .map_err(|e| ApiError(format!("No response received: {}", e)))
+                             .and_then(|mut response| {
+            match response.status().as_u16() {
+                200 => {
+                    let body = response.into_body();
+                    Box::new(
+                        future::ok(
+                            CreateRepoResponse::Success
                         )
                     ) as Box<dyn Future<Item=_, Error=_> + Send>
                 },

--- a/samples/server/petstore/rust-server/output/openapi-v3/src/lib.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/src/lib.rs
@@ -266,7 +266,7 @@ pub enum CreateRepoResponse {
 }
 
 #[derive(Debug, PartialEq)]
-pub enum Get RepoInfoResponse {
+pub enum GetRepoInfoResponse {
     /// OK
     OK
     (serde_json::Value)
@@ -384,7 +384,7 @@ pub trait Api<C> {
     fn get_repo_info(
         &self,
         repo_id: String,
-        context: &C) -> Box<dyn Future<Item=Get RepoInfoResponse, Error=ApiError> + Send>;
+        context: &C) -> Box<dyn Future<Item=GetRepoInfoResponse, Error=ApiError> + Send>;
 
 }
 
@@ -500,7 +500,7 @@ pub trait ApiNoContext {
     fn get_repo_info(
         &self,
         repo_id: String,
-        ) -> Box<dyn Future<Item=Get RepoInfoResponse, Error=ApiError> + Send>;
+        ) -> Box<dyn Future<Item=GetRepoInfoResponse, Error=ApiError> + Send>;
 
 }
 
@@ -693,7 +693,7 @@ impl<'a, T: Api<C>, C> ApiNoContext for ContextWrapper<'a, T, C> {
     fn get_repo_info(
         &self,
         repo_id: String,
-        ) -> Box<dyn Future<Item=Get RepoInfoResponse, Error=ApiError> + Send>
+        ) -> Box<dyn Future<Item=GetRepoInfoResponse, Error=ApiError> + Send>
     {
         self.api().get_repo_info(repo_id, &self.context())
     }

--- a/samples/server/petstore/rust-server/output/openapi-v3/src/lib.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/src/lib.rs
@@ -259,6 +259,12 @@ pub enum XmlPutResponse {
 }
 
 #[derive(Debug, PartialEq)]
+pub enum CreateRepoResponse {
+    /// Success
+    Success
+}
+
+#[derive(Debug, PartialEq)]
 pub enum GetRepoInfoResponse {
     /// OK
     OK
@@ -368,6 +374,11 @@ pub trait Api<C> {
         &self,
         xml_object: Option<models::XmlObject>,
         context: &C) -> Box<dyn Future<Item=XmlPutResponse, Error=ApiError> + Send>;
+
+    fn create_repo(
+        &self,
+        object_param: models::ObjectParam,
+        context: &C) -> Box<dyn Future<Item=CreateRepoResponse, Error=ApiError> + Send>;
 
     fn get_repo_info(
         &self,
@@ -479,6 +490,11 @@ pub trait ApiNoContext {
         &self,
         xml_object: Option<models::XmlObject>,
         ) -> Box<dyn Future<Item=XmlPutResponse, Error=ApiError> + Send>;
+
+    fn create_repo(
+        &self,
+        object_param: models::ObjectParam,
+        ) -> Box<dyn Future<Item=CreateRepoResponse, Error=ApiError> + Send>;
 
     fn get_repo_info(
         &self,
@@ -663,6 +679,14 @@ impl<'a, T: Api<C>, C> ApiNoContext for ContextWrapper<'a, T, C> {
         ) -> Box<dyn Future<Item=XmlPutResponse, Error=ApiError> + Send>
     {
         self.api().xml_put(xml_object, &self.context())
+    }
+
+    fn create_repo(
+        &self,
+        object_param: models::ObjectParam,
+        ) -> Box<dyn Future<Item=CreateRepoResponse, Error=ApiError> + Send>
+    {
+        self.api().create_repo(object_param, &self.context())
     }
 
     fn get_repo_info(

--- a/samples/server/petstore/rust-server/output/openapi-v3/src/lib.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/src/lib.rs
@@ -266,10 +266,10 @@ pub enum CreateRepoResponse {
 }
 
 #[derive(Debug, PartialEq)]
-pub enum GetRepoInfoResponse {
+pub enum Get RepoInfoResponse {
     /// OK
     OK
-    (String)
+    (serde_json::Value)
 }
 
 /// API
@@ -384,7 +384,7 @@ pub trait Api<C> {
     fn get_repo_info(
         &self,
         repo_id: String,
-        context: &C) -> Box<dyn Future<Item=GetRepoInfoResponse, Error=ApiError> + Send>;
+        context: &C) -> Box<dyn Future<Item=Get RepoInfoResponse, Error=ApiError> + Send>;
 
 }
 
@@ -500,7 +500,7 @@ pub trait ApiNoContext {
     fn get_repo_info(
         &self,
         repo_id: String,
-        ) -> Box<dyn Future<Item=GetRepoInfoResponse, Error=ApiError> + Send>;
+        ) -> Box<dyn Future<Item=Get RepoInfoResponse, Error=ApiError> + Send>;
 
 }
 
@@ -693,7 +693,7 @@ impl<'a, T: Api<C>, C> ApiNoContext for ContextWrapper<'a, T, C> {
     fn get_repo_info(
         &self,
         repo_id: String,
-        ) -> Box<dyn Future<Item=GetRepoInfoResponse, Error=ApiError> + Send>
+        ) -> Box<dyn Future<Item=Get RepoInfoResponse, Error=ApiError> + Send>
     {
         self.api().get_repo_info(repo_id, &self.context())
     }

--- a/samples/server/petstore/rust-server/output/openapi-v3/src/lib.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/src/lib.rs
@@ -262,6 +262,7 @@ pub enum XmlPutResponse {
 pub enum CreateRepoResponse {
     /// Success
     Success
+    (models::Error)
 }
 
 #[derive(Debug, PartialEq)]

--- a/samples/server/petstore/rust-server/output/openapi-v3/src/lib.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/src/lib.rs
@@ -272,6 +272,13 @@ pub enum GetRepoInfoResponse {
     (serde_json::Value)
 }
 
+#[derive(Debug, PartialEq)]
+pub enum OverwriteRepoResponse {
+    /// OK
+    OK
+    (models::Error)
+}
+
 /// API
 pub trait Api<C> {
     fn callback_with_header_post(
@@ -385,6 +392,11 @@ pub trait Api<C> {
         &self,
         repo_id: String,
         context: &C) -> Box<dyn Future<Item=GetRepoInfoResponse, Error=ApiError> + Send>;
+
+    fn overwrite_repo(
+        &self,
+        body: Option<models::RepoObject>,
+        context: &C) -> Box<dyn Future<Item=OverwriteRepoResponse, Error=ApiError> + Send>;
 
 }
 
@@ -501,6 +513,11 @@ pub trait ApiNoContext {
         &self,
         repo_id: String,
         ) -> Box<dyn Future<Item=GetRepoInfoResponse, Error=ApiError> + Send>;
+
+    fn overwrite_repo(
+        &self,
+        body: Option<models::RepoObject>,
+        ) -> Box<dyn Future<Item=OverwriteRepoResponse, Error=ApiError> + Send>;
 
 }
 
@@ -696,6 +713,14 @@ impl<'a, T: Api<C>, C> ApiNoContext for ContextWrapper<'a, T, C> {
         ) -> Box<dyn Future<Item=GetRepoInfoResponse, Error=ApiError> + Send>
     {
         self.api().get_repo_info(repo_id, &self.context())
+    }
+
+    fn overwrite_repo(
+        &self,
+        body: Option<models::RepoObject>,
+        ) -> Box<dyn Future<Item=OverwriteRepoResponse, Error=ApiError> + Send>
+    {
+        self.api().overwrite_repo(body, &self.context())
     }
 
 }

--- a/samples/server/petstore/rust-server/output/openapi-v3/src/models.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/src/models.rs
@@ -519,45 +519,125 @@ impl Err {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, PartialOrd, Serialize, Deserialize)]
-#[cfg_attr(feature = "conversion", derive(LabelledGeneric))]
-pub struct Error(String);
+// Methods for converting between header::IntoHeaderValue<Error> and hyper::header::HeaderValue
 
-impl std::convert::From<String> for Error {
-    fn from(x: String) -> Self {
-        Error(x)
+#[cfg(any(feature = "client", feature = "server"))]
+impl From<header::IntoHeaderValue<Error>> for hyper::header::HeaderValue {
+    fn from(hdr_value: header::IntoHeaderValue<Error>) -> Self {
+        hyper::header::HeaderValue::from_str(&hdr_value.to_string()).unwrap()
     }
 }
 
+#[cfg(any(feature = "client", feature = "server"))]
+impl From<hyper::header::HeaderValue> for header::IntoHeaderValue<Error> {
+    fn from(hdr_value: hyper::header::HeaderValue) -> Self {
+        header::IntoHeaderValue(<Error as std::str::FromStr>::from_str(hdr_value.to_str().unwrap()).unwrap())
+    }
+}
+
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "conversion", derive(LabelledGeneric))]
+pub struct Error {
+    #[serde(rename = "code")]
+    pub code: isize,
+
+    #[serde(rename = "retryable")]
+    pub retryable: bool,
+
+    #[serde(rename = "message")]
+    pub message: String,
+
+    #[serde(rename = "innerError")]
+    #[serde(skip_serializing_if="Option::is_none")]
+    pub inner_error: Option<models::Error>,
+
+}
+
+impl Error {
+    pub fn new(code: isize, retryable: bool, message: String, ) -> Error {
+        Error {
+            code: code,
+            retryable: retryable,
+            message: message,
+            inner_error: None,
+        }
+    }
+}
+
+/// Converts the Error value to the Query Parameters representation (style=form, explode=false)
+/// specified in https://swagger.io/docs/specification/serialization/
+/// Should be implemented in a serde serializer
 impl std::string::ToString for Error {
     fn to_string(&self) -> String {
-       self.0.to_string()
+        let mut params: Vec<String> = vec![];
+
+        params.push("code".to_string());
+        params.push(self.code.to_string());
+
+
+        params.push("retryable".to_string());
+        params.push(self.retryable.to_string());
+
+
+        params.push("message".to_string());
+        params.push(self.message.to_string());
+
+        // Skipping innerError in query parameter serialization
+
+        params.join(",").to_string()
     }
 }
 
+/// Converts Query Parameters representation (style=form, explode=false) to a Error value
+/// as specified in https://swagger.io/docs/specification/serialization/
+/// Should be implemented in a serde deserializer
 impl std::str::FromStr for Error {
-    type Err = std::string::ParseError;
-    fn from_str(x: &str) -> std::result::Result<Self, Self::Err> {
-        std::result::Result::Ok(Error(x.to_string()))
-    }
-}
+    type Err = String;
 
-impl std::convert::From<Error> for String {
-    fn from(x: Error) -> Self {
-        x.0
-    }
-}
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        #[derive(Default)]
+        // An intermediate representation of the struct to use for parsing.
+        struct IntermediateRep {
+            pub code: Vec<isize>,
+            pub retryable: Vec<bool>,
+            pub message: Vec<String>,
+            pub inner_error: Vec<models::Error>,
+        }
 
-impl std::ops::Deref for Error {
-    type Target = String;
-    fn deref(&self) -> &String {
-        &self.0
-    }
-}
+        let mut intermediate_rep = IntermediateRep::default();
 
-impl std::ops::DerefMut for Error {
-    fn deref_mut(&mut self) -> &mut String {
-        &mut self.0
+        // Parse into intermediate representation
+        let mut string_iter = s.split(',').into_iter();
+        let mut key_result = string_iter.next();
+
+        while key_result.is_some() {
+            let val = match string_iter.next() {
+                Some(x) => x,
+                None => return std::result::Result::Err("Missing value while parsing Error".to_string())
+            };
+
+            if let Some(key) = key_result {
+                match key {
+                    "code" => intermediate_rep.code.push(isize::from_str(val).map_err(|x| format!("{}", x))?),
+                    "retryable" => intermediate_rep.retryable.push(bool::from_str(val).map_err(|x| format!("{}", x))?),
+                    "message" => intermediate_rep.message.push(String::from_str(val).map_err(|x| format!("{}", x))?),
+                    "innerError" => intermediate_rep.inner_error.push(models::Error::from_str(val).map_err(|x| format!("{}", x))?),
+                    _ => return std::result::Result::Err("Unexpected key while parsing Error".to_string())
+                }
+            }
+
+            // Get the next key
+            key_result = string_iter.next();
+        }
+
+        // Use the intermediate representation to return the struct
+        std::result::Result::Ok(Error {
+            code: intermediate_rep.code.into_iter().next().ok_or("code missing in Error".to_string())?,
+            retryable: intermediate_rep.retryable.into_iter().next().ok_or("retryable missing in Error".to_string())?,
+            message: intermediate_rep.message.into_iter().next().ok_or("message missing in Error".to_string())?,
+            inner_error: intermediate_rep.inner_error.into_iter().next(),
+        })
     }
 }
 

--- a/samples/server/petstore/rust-server/output/openapi-v3/src/models.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/src/models.rs
@@ -1621,6 +1621,95 @@ impl OptionalObjectHeader {
     }
 }
 
+// Methods for converting between header::IntoHeaderValue<RepoObject> and hyper::header::HeaderValue
+
+#[cfg(any(feature = "client", feature = "server"))]
+impl From<header::IntoHeaderValue<RepoObject>> for hyper::header::HeaderValue {
+    fn from(hdr_value: header::IntoHeaderValue<RepoObject>) -> Self {
+        hyper::header::HeaderValue::from_str(&hdr_value.to_string()).unwrap()
+    }
+}
+
+#[cfg(any(feature = "client", feature = "server"))]
+impl From<hyper::header::HeaderValue> for header::IntoHeaderValue<RepoObject> {
+    fn from(hdr_value: hyper::header::HeaderValue) -> Self {
+        header::IntoHeaderValue(<RepoObject as std::str::FromStr>::from_str(hdr_value.to_str().unwrap()).unwrap())
+    }
+}
+
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "conversion", derive(LabelledGeneric))]
+pub struct RepoObject {
+}
+
+impl RepoObject {
+    pub fn new() -> RepoObject {
+        RepoObject {
+        }
+    }
+}
+
+/// Converts the RepoObject value to the Query Parameters representation (style=form, explode=false)
+/// specified in https://swagger.io/docs/specification/serialization/
+/// Should be implemented in a serde serializer
+impl std::string::ToString for RepoObject {
+    fn to_string(&self) -> String {
+        let mut params: Vec<String> = vec![];
+        params.join(",").to_string()
+    }
+}
+
+/// Converts Query Parameters representation (style=form, explode=false) to a RepoObject value
+/// as specified in https://swagger.io/docs/specification/serialization/
+/// Should be implemented in a serde deserializer
+impl std::str::FromStr for RepoObject {
+    type Err = String;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        #[derive(Default)]
+        // An intermediate representation of the struct to use for parsing.
+        struct IntermediateRep {
+        }
+
+        let mut intermediate_rep = IntermediateRep::default();
+
+        // Parse into intermediate representation
+        let mut string_iter = s.split(',').into_iter();
+        let mut key_result = string_iter.next();
+
+        while key_result.is_some() {
+            let val = match string_iter.next() {
+                Some(x) => x,
+                None => return std::result::Result::Err("Missing value while parsing RepoObject".to_string())
+            };
+
+            if let Some(key) = key_result {
+                match key {
+                    _ => return std::result::Result::Err("Unexpected key while parsing RepoObject".to_string())
+                }
+            }
+
+            // Get the next key
+            key_result = string_iter.next();
+        }
+
+        // Use the intermediate representation to return the struct
+        std::result::Result::Ok(RepoObject {
+        })
+    }
+}
+
+
+impl RepoObject {
+    /// Helper function to allow us to convert this model to an XML string.
+    /// Will panic if serialisation fails.
+    #[allow(dead_code)]
+    pub(crate) fn to_xml(&self) -> String {
+        serde_xml_rs::to_string(&self).expect("impossible to fail to serialize")
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, PartialOrd, Serialize, Deserialize)]
 #[cfg_attr(feature = "conversion", derive(LabelledGeneric))]
 pub struct RequiredObjectHeader(bool);

--- a/samples/server/petstore/rust-server/output/openapi-v3/src/models.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/src/models.rs
@@ -550,7 +550,7 @@ pub struct Error {
 
     #[serde(rename = "innerError")]
     #[serde(skip_serializing_if="Option::is_none")]
-    pub inner_error: Option<models::Error>,
+    pub inner_error: Box<Option<models::Error>>,
 
 }
 
@@ -560,7 +560,7 @@ impl Error {
             code: code,
             retryable: retryable,
             message: message,
-            inner_error: None,
+            inner_error: Box::new(None),
         }
     }
 }
@@ -636,7 +636,7 @@ impl std::str::FromStr for Error {
             code: intermediate_rep.code.into_iter().next().ok_or("code missing in Error".to_string())?,
             retryable: intermediate_rep.retryable.into_iter().next().ok_or("retryable missing in Error".to_string())?,
             message: intermediate_rep.message.into_iter().next().ok_or("message missing in Error".to_string())?,
-            inner_error: intermediate_rep.inner_error.into_iter().next(),
+            inner_error: Box::new(intermediate_rep.inner_error.into_iter().next()),
         })
     }
 }

--- a/samples/server/petstore/rust-server/output/openapi-v3/src/server/mod.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/src/server/mod.rs
@@ -43,6 +43,7 @@ use {Api,
      XmlOtherPutResponse,
      XmlPostResponse,
      XmlPutResponse,
+     CreateRepoResponse,
      GetRepoInfoResponse
 };
 
@@ -64,6 +65,7 @@ mod paths {
             r"^/paramget$",
             r"^/readonly_auth_scheme$",
             r"^/register-callback$",
+            r"^/repos$",
             r"^/repos/(?P<repoId>[^/?#]*)$",
             r"^/required_octet_stream$",
             r"^/responses_with_headers$",
@@ -92,20 +94,21 @@ mod paths {
     pub static ID_PARAMGET: usize = 8;
     pub static ID_READONLY_AUTH_SCHEME: usize = 9;
     pub static ID_REGISTER_CALLBACK: usize = 10;
-    pub static ID_REPOS_REPOID: usize = 11;
+    pub static ID_REPOS: usize = 11;
+    pub static ID_REPOS_REPOID: usize = 12;
     lazy_static! {
         pub static ref REGEX_REPOS_REPOID: regex::Regex =
             regex::Regex::new(r"^/repos/(?P<repoId>[^/?#]*)$")
                 .expect("Unable to create regex for REPOS_REPOID");
     }
-    pub static ID_REQUIRED_OCTET_STREAM: usize = 12;
-    pub static ID_RESPONSES_WITH_HEADERS: usize = 13;
-    pub static ID_RFC7807: usize = 14;
-    pub static ID_UNTYPED_PROPERTY: usize = 15;
-    pub static ID_UUID: usize = 16;
-    pub static ID_XML: usize = 17;
-    pub static ID_XML_EXTRA: usize = 18;
-    pub static ID_XML_OTHER: usize = 19;
+    pub static ID_REQUIRED_OCTET_STREAM: usize = 13;
+    pub static ID_RESPONSES_WITH_HEADERS: usize = 14;
+    pub static ID_RFC7807: usize = 15;
+    pub static ID_UNTYPED_PROPERTY: usize = 16;
+    pub static ID_UUID: usize = 17;
+    pub static ID_XML: usize = 18;
+    pub static ID_XML_EXTRA: usize = 19;
+    pub static ID_XML_OTHER: usize = 20;
 }
 
 pub struct MakeService<T, RC> {
@@ -1509,6 +1512,85 @@ where
                 ) as Self::Future
             },
 
+            // CreateRepo - POST /repos
+            &hyper::Method::POST if path.matched(paths::ID_REPOS) => {
+                // Body parameters (note that non-required body parameters will ignore garbage
+                // values, rather than causing a 400 response). Produce warning header and logs for
+                // any unused fields.
+                Box::new(body.concat2()
+                    .then(move |result| -> Self::Future {
+                        match result {
+                            Ok(body) => {
+                                let mut unused_elements = Vec::new();
+                                let param_object_param: Option<models::ObjectParam> = if !body.is_empty() {
+                                    let deserializer = &mut serde_json::Deserializer::from_slice(&*body);
+                                    match serde_ignored::deserialize(deserializer, |path| {
+                                            warn!("Ignoring unknown field in body: {}", path);
+                                            unused_elements.push(path.to_string());
+                                    }) {
+                                        Ok(param_object_param) => param_object_param,
+                                        Err(e) => return Box::new(future::ok(Response::builder()
+                                                        .status(StatusCode::BAD_REQUEST)
+                                                        .body(Body::from(format!("Couldn't parse body parameter ObjectParam - doesn't match schema: {}", e)))
+                                                        .expect("Unable to create Bad Request response for invalid body parameter ObjectParam due to schema"))),
+                                    }
+                                } else {
+                                    None
+                                };
+                                let param_object_param = match param_object_param {
+                                    Some(param_object_param) => param_object_param,
+                                    None => return Box::new(future::ok(Response::builder()
+                                                        .status(StatusCode::BAD_REQUEST)
+                                                        .body(Body::from("Missing required body parameter ObjectParam"))
+                                                        .expect("Unable to create Bad Request response for missing body parameter ObjectParam"))),
+                                };
+
+                                Box::new(
+                                    api_impl.create_repo(
+                                            param_object_param,
+                                        &context
+                                    ).then(move |result| {
+                                        let mut response = Response::new(Body::empty());
+                                        response.headers_mut().insert(
+                                            HeaderName::from_static("x-span-id"),
+                                            HeaderValue::from_str((&context as &dyn Has<XSpanIdString>).get().0.clone().to_string().as_str())
+                                                .expect("Unable to create X-Span-ID header value"));
+
+                                        if !unused_elements.is_empty() {
+                                            response.headers_mut().insert(
+                                                HeaderName::from_static("warning"),
+                                                HeaderValue::from_str(format!("Ignoring unknown fields in body: {:?}", unused_elements).as_str())
+                                                    .expect("Unable to create Warning header value"));
+                                        }
+
+                                        match result {
+                                            Ok(rsp) => match rsp {
+                                                CreateRepoResponse::Success
+                                                => {
+                                                    *response.status_mut() = StatusCode::from_u16(200).expect("Unable to turn 200 into a StatusCode");
+                                                },
+                                            },
+                                            Err(_) => {
+                                                // Application code returned an error. This should not happen, as the implementation should
+                                                // return a valid response.
+                                                *response.status_mut() = StatusCode::INTERNAL_SERVER_ERROR;
+                                                *response.body_mut() = Body::from("An internal error occurred");
+                                            },
+                                        }
+
+                                        future::ok(response)
+                                    }
+                                ))
+                            },
+                            Err(e) => Box::new(future::ok(Response::builder()
+                                                .status(StatusCode::BAD_REQUEST)
+                                                .body(Body::from(format!("Couldn't read body parameter ObjectParam: {}", e)))
+                                                .expect("Unable to create Bad Request response due to unable to read body parameter ObjectParam"))),
+                        }
+                    })
+                ) as Self::Future
+            },
+
             // GetRepoInfo - GET /repos/{repoId}
             &hyper::Method::GET if path.matched(paths::ID_REPOS_REPOID) => {
                 // Path parameters
@@ -1587,6 +1669,7 @@ where
             _ if path.matched(paths::ID_PARAMGET) => method_not_allowed(),
             _ if path.matched(paths::ID_READONLY_AUTH_SCHEME) => method_not_allowed(),
             _ if path.matched(paths::ID_REGISTER_CALLBACK) => method_not_allowed(),
+            _ if path.matched(paths::ID_REPOS) => method_not_allowed(),
             _ if path.matched(paths::ID_REPOS_REPOID) => method_not_allowed(),
             _ if path.matched(paths::ID_REQUIRED_OCTET_STREAM) => method_not_allowed(),
             _ if path.matched(paths::ID_RESPONSES_WITH_HEADERS) => method_not_allowed(),
@@ -1663,6 +1746,8 @@ impl<T> RequestParser<T> for ApiRequestParser {
             &hyper::Method::POST if path.matched(paths::ID_XML) => Ok("XmlPost"),
             // XmlPut - PUT /xml
             &hyper::Method::PUT if path.matched(paths::ID_XML) => Ok("XmlPut"),
+            // CreateRepo - POST /repos
+            &hyper::Method::POST if path.matched(paths::ID_REPOS) => Ok("CreateRepo"),
             // GetRepoInfo - GET /repos/{repoId}
             &hyper::Method::GET if path.matched(paths::ID_REPOS_REPOID) => Ok("GetRepoInfo"),
             _ => Err(()),

--- a/samples/server/petstore/rust-server/output/openapi-v3/src/server/mod.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/src/server/mod.rs
@@ -1566,8 +1566,15 @@ where
                                         match result {
                                             Ok(rsp) => match rsp {
                                                 CreateRepoResponse::Success
+                                                    (body)
                                                 => {
                                                     *response.status_mut() = StatusCode::from_u16(200).expect("Unable to turn 200 into a StatusCode");
+                                                    response.headers_mut().insert(
+                                                        CONTENT_TYPE,
+                                                        HeaderValue::from_str("application/json")
+                                                            .expect("Unable to create Content-Type header for CREATE_REPO_SUCCESS"));
+                                                    let body = serde_json::to_string(&body).expect("impossible to fail to serialize");
+                                                    *response.body_mut() = Body::from(body);
                                                 },
                                             },
                                             Err(_) => {

--- a/samples/server/petstore/rust-server/output/openapi-v3/src/server/mod.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/src/server/mod.rs
@@ -44,7 +44,7 @@ use {Api,
      XmlPostResponse,
      XmlPutResponse,
      CreateRepoResponse,
-     Get RepoInfoResponse
+     GetRepoInfoResponse
 };
 
 pub mod callbacks;
@@ -1598,7 +1598,7 @@ where
                 ) as Self::Future
             },
 
-            // Get RepoInfo - GET /repos/{repoId}
+            // GetRepoInfo - GET /repos/{repoId}
             &hyper::Method::GET if path.matched(paths::ID_REPOS_REPOID) => {
                 // Path parameters
                 let path: &str = &uri.path().to_string();
@@ -1638,7 +1638,7 @@ where
 
                                         match result {
                                             Ok(rsp) => match rsp {
-                                                Get RepoInfoResponse::OK
+                                                GetRepoInfoResponse::OK
                                                     (body)
                                                 => {
                                                     *response.status_mut() = StatusCode::from_u16(200).expect("Unable to turn 200 into a StatusCode");
@@ -1755,8 +1755,8 @@ impl<T> RequestParser<T> for ApiRequestParser {
             &hyper::Method::PUT if path.matched(paths::ID_XML) => Ok("XmlPut"),
             // CreateRepo - POST /repos
             &hyper::Method::POST if path.matched(paths::ID_REPOS) => Ok("CreateRepo"),
-            // Get RepoInfo - GET /repos/{repoId}
-            &hyper::Method::GET if path.matched(paths::ID_REPOS_REPOID) => Ok("Get RepoInfo"),
+            // GetRepoInfo - GET /repos/{repoId}
+            &hyper::Method::GET if path.matched(paths::ID_REPOS_REPOID) => Ok("GetRepoInfo"),
             _ => Err(()),
         }
     }

--- a/samples/server/petstore/rust-server/output/openapi-v3/src/server/mod.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/src/server/mod.rs
@@ -44,7 +44,7 @@ use {Api,
      XmlPostResponse,
      XmlPutResponse,
      CreateRepoResponse,
-     GetRepoInfoResponse
+     Get RepoInfoResponse
 };
 
 pub mod callbacks;
@@ -1598,7 +1598,7 @@ where
                 ) as Self::Future
             },
 
-            // GetRepoInfo - GET /repos/{repoId}
+            // Get RepoInfo - GET /repos/{repoId}
             &hyper::Method::GET if path.matched(paths::ID_REPOS_REPOID) => {
                 // Path parameters
                 let path: &str = &uri.path().to_string();
@@ -1638,7 +1638,7 @@ where
 
                                         match result {
                                             Ok(rsp) => match rsp {
-                                                GetRepoInfoResponse::OK
+                                                Get RepoInfoResponse::OK
                                                     (body)
                                                 => {
                                                     *response.status_mut() = StatusCode::from_u16(200).expect("Unable to turn 200 into a StatusCode");
@@ -1755,8 +1755,8 @@ impl<T> RequestParser<T> for ApiRequestParser {
             &hyper::Method::PUT if path.matched(paths::ID_XML) => Ok("XmlPut"),
             // CreateRepo - POST /repos
             &hyper::Method::POST if path.matched(paths::ID_REPOS) => Ok("CreateRepo"),
-            // GetRepoInfo - GET /repos/{repoId}
-            &hyper::Method::GET if path.matched(paths::ID_REPOS_REPOID) => Ok("GetRepoInfo"),
+            // Get RepoInfo - GET /repos/{repoId}
+            &hyper::Method::GET if path.matched(paths::ID_REPOS_REPOID) => Ok("Get RepoInfo"),
             _ => Err(()),
         }
     }

--- a/samples/server/petstore/rust-server/output/ops-v3/docs/default_api.md
+++ b/samples/server/petstore/rust-server/output/ops-v3/docs/default_api.md
@@ -4,69 +4,47 @@ All URIs are relative to *http://localhost*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
-****](default_api.md#) | **GET** /op10 | 
-****](default_api.md#) | **GET** /op11 | 
-****](default_api.md#) | **GET** /op12 | 
-****](default_api.md#) | **GET** /op13 | 
-****](default_api.md#) | **GET** /op14 | 
-****](default_api.md#) | **GET** /op15 | 
-****](default_api.md#) | **GET** /op16 | 
-****](default_api.md#) | **GET** /op17 | 
-****](default_api.md#) | **GET** /op18 | 
-****](default_api.md#) | **GET** /op19 | 
-****](default_api.md#) | **GET** /op1 | 
-****](default_api.md#) | **GET** /op20 | 
-****](default_api.md#) | **GET** /op21 | 
-****](default_api.md#) | **GET** /op22 | 
-****](default_api.md#) | **GET** /op23 | 
-****](default_api.md#) | **GET** /op24 | 
-****](default_api.md#) | **GET** /op25 | 
-****](default_api.md#) | **GET** /op26 | 
-****](default_api.md#) | **GET** /op27 | 
-****](default_api.md#) | **GET** /op28 | 
-****](default_api.md#) | **GET** /op29 | 
-****](default_api.md#) | **GET** /op2 | 
-****](default_api.md#) | **GET** /op30 | 
-****](default_api.md#) | **GET** /op31 | 
-****](default_api.md#) | **GET** /op32 | 
-****](default_api.md#) | **GET** /op33 | 
-****](default_api.md#) | **GET** /op34 | 
-****](default_api.md#) | **GET** /op35 | 
-****](default_api.md#) | **GET** /op36 | 
-****](default_api.md#) | **GET** /op37 | 
-****](default_api.md#) | **GET** /op3 | 
-****](default_api.md#) | **GET** /op4 | 
-****](default_api.md#) | **GET** /op5 | 
-****](default_api.md#) | **GET** /op6 | 
-****](default_api.md#) | **GET** /op7 | 
-****](default_api.md#) | **GET** /op8 | 
-****](default_api.md#) | **GET** /op9 | 
+**Op10Get**](default_api.md#Op10Get) | **GET** /op10 | 
+**Op11Get**](default_api.md#Op11Get) | **GET** /op11 | 
+**Op12Get**](default_api.md#Op12Get) | **GET** /op12 | 
+**Op13Get**](default_api.md#Op13Get) | **GET** /op13 | 
+**Op14Get**](default_api.md#Op14Get) | **GET** /op14 | 
+**Op15Get**](default_api.md#Op15Get) | **GET** /op15 | 
+**Op16Get**](default_api.md#Op16Get) | **GET** /op16 | 
+**Op17Get**](default_api.md#Op17Get) | **GET** /op17 | 
+**Op18Get**](default_api.md#Op18Get) | **GET** /op18 | 
+**Op19Get**](default_api.md#Op19Get) | **GET** /op19 | 
+**Op1Get**](default_api.md#Op1Get) | **GET** /op1 | 
+**Op20Get**](default_api.md#Op20Get) | **GET** /op20 | 
+**Op21Get**](default_api.md#Op21Get) | **GET** /op21 | 
+**Op22Get**](default_api.md#Op22Get) | **GET** /op22 | 
+**Op23Get**](default_api.md#Op23Get) | **GET** /op23 | 
+**Op24Get**](default_api.md#Op24Get) | **GET** /op24 | 
+**Op25Get**](default_api.md#Op25Get) | **GET** /op25 | 
+**Op26Get**](default_api.md#Op26Get) | **GET** /op26 | 
+**Op27Get**](default_api.md#Op27Get) | **GET** /op27 | 
+**Op28Get**](default_api.md#Op28Get) | **GET** /op28 | 
+**Op29Get**](default_api.md#Op29Get) | **GET** /op29 | 
+**Op2Get**](default_api.md#Op2Get) | **GET** /op2 | 
+**Op30Get**](default_api.md#Op30Get) | **GET** /op30 | 
+**Op31Get**](default_api.md#Op31Get) | **GET** /op31 | 
+**Op32Get**](default_api.md#Op32Get) | **GET** /op32 | 
+**Op33Get**](default_api.md#Op33Get) | **GET** /op33 | 
+**Op34Get**](default_api.md#Op34Get) | **GET** /op34 | 
+**Op35Get**](default_api.md#Op35Get) | **GET** /op35 | 
+**Op36Get**](default_api.md#Op36Get) | **GET** /op36 | 
+**Op37Get**](default_api.md#Op37Get) | **GET** /op37 | 
+**Op3Get**](default_api.md#Op3Get) | **GET** /op3 | 
+**Op4Get**](default_api.md#Op4Get) | **GET** /op4 | 
+**Op5Get**](default_api.md#Op5Get) | **GET** /op5 | 
+**Op6Get**](default_api.md#Op6Get) | **GET** /op6 | 
+**Op7Get**](default_api.md#Op7Get) | **GET** /op7 | 
+**Op8Get**](default_api.md#Op8Get) | **GET** /op8 | 
+**Op9Get**](default_api.md#Op9Get) | **GET** /op9 | 
 
 
-# ****
-> ()
-
-
-### Required Parameters
-This endpoint does not need any parameter.
-
-### Return type
-
- (empty response body)
-
-### Authorization
-
-No authorization required
-
-### HTTP request headers
-
- - **Content-Type**: Not defined
- - **Accept**: Not defined
-
-[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
-
-# ****
-> ()
+# **Op10Get**
+> Op10Get()
 
 
 ### Required Parameters
@@ -87,8 +65,8 @@ No authorization required
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
-# ****
-> ()
+# **Op11Get**
+> Op11Get()
 
 
 ### Required Parameters
@@ -109,8 +87,8 @@ No authorization required
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
-# ****
-> ()
+# **Op12Get**
+> Op12Get()
 
 
 ### Required Parameters
@@ -131,8 +109,8 @@ No authorization required
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
-# ****
-> ()
+# **Op13Get**
+> Op13Get()
 
 
 ### Required Parameters
@@ -153,8 +131,8 @@ No authorization required
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
-# ****
-> ()
+# **Op14Get**
+> Op14Get()
 
 
 ### Required Parameters
@@ -175,8 +153,8 @@ No authorization required
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
-# ****
-> ()
+# **Op15Get**
+> Op15Get()
 
 
 ### Required Parameters
@@ -197,8 +175,8 @@ No authorization required
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
-# ****
-> ()
+# **Op16Get**
+> Op16Get()
 
 
 ### Required Parameters
@@ -219,8 +197,8 @@ No authorization required
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
-# ****
-> ()
+# **Op17Get**
+> Op17Get()
 
 
 ### Required Parameters
@@ -241,8 +219,8 @@ No authorization required
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
-# ****
-> ()
+# **Op18Get**
+> Op18Get()
 
 
 ### Required Parameters
@@ -263,8 +241,8 @@ No authorization required
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
-# ****
-> ()
+# **Op19Get**
+> Op19Get()
 
 
 ### Required Parameters
@@ -285,8 +263,8 @@ No authorization required
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
-# ****
-> ()
+# **Op1Get**
+> Op1Get()
 
 
 ### Required Parameters
@@ -307,8 +285,8 @@ No authorization required
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
-# ****
-> ()
+# **Op20Get**
+> Op20Get()
 
 
 ### Required Parameters
@@ -329,8 +307,8 @@ No authorization required
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
-# ****
-> ()
+# **Op21Get**
+> Op21Get()
 
 
 ### Required Parameters
@@ -351,8 +329,8 @@ No authorization required
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
-# ****
-> ()
+# **Op22Get**
+> Op22Get()
 
 
 ### Required Parameters
@@ -373,8 +351,8 @@ No authorization required
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
-# ****
-> ()
+# **Op23Get**
+> Op23Get()
 
 
 ### Required Parameters
@@ -395,8 +373,8 @@ No authorization required
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
-# ****
-> ()
+# **Op24Get**
+> Op24Get()
 
 
 ### Required Parameters
@@ -417,8 +395,8 @@ No authorization required
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
-# ****
-> ()
+# **Op25Get**
+> Op25Get()
 
 
 ### Required Parameters
@@ -439,8 +417,8 @@ No authorization required
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
-# ****
-> ()
+# **Op26Get**
+> Op26Get()
 
 
 ### Required Parameters
@@ -461,8 +439,8 @@ No authorization required
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
-# ****
-> ()
+# **Op27Get**
+> Op27Get()
 
 
 ### Required Parameters
@@ -483,8 +461,8 @@ No authorization required
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
-# ****
-> ()
+# **Op28Get**
+> Op28Get()
 
 
 ### Required Parameters
@@ -505,8 +483,8 @@ No authorization required
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
-# ****
-> ()
+# **Op29Get**
+> Op29Get()
 
 
 ### Required Parameters
@@ -527,8 +505,8 @@ No authorization required
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
-# ****
-> ()
+# **Op2Get**
+> Op2Get()
 
 
 ### Required Parameters
@@ -549,8 +527,8 @@ No authorization required
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
-# ****
-> ()
+# **Op30Get**
+> Op30Get()
 
 
 ### Required Parameters
@@ -571,8 +549,8 @@ No authorization required
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
-# ****
-> ()
+# **Op31Get**
+> Op31Get()
 
 
 ### Required Parameters
@@ -593,8 +571,8 @@ No authorization required
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
-# ****
-> ()
+# **Op32Get**
+> Op32Get()
 
 
 ### Required Parameters
@@ -615,8 +593,8 @@ No authorization required
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
-# ****
-> ()
+# **Op33Get**
+> Op33Get()
 
 
 ### Required Parameters
@@ -637,8 +615,8 @@ No authorization required
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
-# ****
-> ()
+# **Op34Get**
+> Op34Get()
 
 
 ### Required Parameters
@@ -659,8 +637,8 @@ No authorization required
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
-# ****
-> ()
+# **Op35Get**
+> Op35Get()
 
 
 ### Required Parameters
@@ -681,8 +659,8 @@ No authorization required
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
-# ****
-> ()
+# **Op36Get**
+> Op36Get()
 
 
 ### Required Parameters
@@ -703,8 +681,8 @@ No authorization required
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
-# ****
-> ()
+# **Op37Get**
+> Op37Get()
 
 
 ### Required Parameters
@@ -725,8 +703,8 @@ No authorization required
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
-# ****
-> ()
+# **Op3Get**
+> Op3Get()
 
 
 ### Required Parameters
@@ -747,8 +725,8 @@ No authorization required
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
-# ****
-> ()
+# **Op4Get**
+> Op4Get()
 
 
 ### Required Parameters
@@ -769,8 +747,8 @@ No authorization required
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
-# ****
-> ()
+# **Op5Get**
+> Op5Get()
 
 
 ### Required Parameters
@@ -791,8 +769,8 @@ No authorization required
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
-# ****
-> ()
+# **Op6Get**
+> Op6Get()
 
 
 ### Required Parameters
@@ -813,8 +791,8 @@ No authorization required
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
-# ****
-> ()
+# **Op7Get**
+> Op7Get()
 
 
 ### Required Parameters
@@ -835,8 +813,30 @@ No authorization required
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
-# ****
-> ()
+# **Op8Get**
+> Op8Get()
+
+
+### Required Parameters
+This endpoint does not need any parameter.
+
+### Return type
+
+ (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: Not defined
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+# **Op9Get**
+> Op9Get()
 
 
 ### Required Parameters

--- a/samples/server/petstore/rust-server/output/ops-v3/examples/client/main.rs
+++ b/samples/server/petstore/rust-server/output/ops-v3/examples/client/main.rs
@@ -15,7 +15,7 @@ extern crate tokio;
 #[allow(unused_imports)]
 use futures::{Future, future, Stream, stream};
 #[allow(unused_imports)]
-use ops_v3::{Api, ApiNoContext, Client, ContextWrapperExt,
+use ops_v3::{Api, ApiNoContext, Client, ContextWrapperExt, models,
                       ApiError,
                       Op10GetResponse,
                       Op11GetResponse,

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/docs/another_fake_api.md
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/docs/another_fake_api.md
@@ -4,11 +4,11 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
-**test_special_tags**](another_fake_api.md#test_special_tags) | **PATCH** /another-fake/dummy | To test special tags
+**TestSpecialTags**](another_fake_api.md#TestSpecialTags) | **PATCH** /another-fake/dummy | To test special tags
 
 
-# **test_special_tags**
-> models::Client test_special_tags(body)
+# **TestSpecialTags**
+> models::Client TestSpecialTags(body)
 To test special tags
 
 To test special tags

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/docs/fake_api.md
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/docs/fake_api.md
@@ -4,23 +4,23 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
-**123example**](fake_api.md#123example) | **GET** /fake/operation-with-numeric-id | 
-**fakeOuterBooleanSerialize**](fake_api.md#fakeOuterBooleanSerialize) | **POST** /fake/outer/boolean | 
-**fakeOuterCompositeSerialize**](fake_api.md#fakeOuterCompositeSerialize) | **POST** /fake/outer/composite | 
-**fakeOuterNumberSerialize**](fake_api.md#fakeOuterNumberSerialize) | **POST** /fake/outer/number | 
-**fakeOuterStringSerialize**](fake_api.md#fakeOuterStringSerialize) | **POST** /fake/outer/string | 
-**fake_response_with_numerical_description**](fake_api.md#fake_response_with_numerical_description) | **GET** /fake/response-with-numerical-description | 
-**hyphenParam**](fake_api.md#hyphenParam) | **GET** /fake/hyphenParam/{hyphen-param} | 
-**testBodyWithQueryParams**](fake_api.md#testBodyWithQueryParams) | **PUT** /fake/body-with-query-params | 
-**testClientModel**](fake_api.md#testClientModel) | **PATCH** /fake | To test \"client\" model
-**testEndpointParameters**](fake_api.md#testEndpointParameters) | **POST** /fake | Fake endpoint for testing various parameters  假端點  偽のエンドポイント  가짜 엔드 포인트
-**testEnumParameters**](fake_api.md#testEnumParameters) | **GET** /fake | To test enum parameters
-**testInlineAdditionalProperties**](fake_api.md#testInlineAdditionalProperties) | **POST** /fake/inline-additionalProperties | test inline additionalProperties
-**testJsonFormData**](fake_api.md#testJsonFormData) | **GET** /fake/jsonFormData | test json serialization of form data
+**Call123example**](fake_api.md#Call123example) | **GET** /fake/operation-with-numeric-id | 
+**FakeOuterBooleanSerialize**](fake_api.md#FakeOuterBooleanSerialize) | **POST** /fake/outer/boolean | 
+**FakeOuterCompositeSerialize**](fake_api.md#FakeOuterCompositeSerialize) | **POST** /fake/outer/composite | 
+**FakeOuterNumberSerialize**](fake_api.md#FakeOuterNumberSerialize) | **POST** /fake/outer/number | 
+**FakeOuterStringSerialize**](fake_api.md#FakeOuterStringSerialize) | **POST** /fake/outer/string | 
+**FakeResponseWithNumericalDescription**](fake_api.md#FakeResponseWithNumericalDescription) | **GET** /fake/response-with-numerical-description | 
+**HyphenParam**](fake_api.md#HyphenParam) | **GET** /fake/hyphenParam/{hyphen-param} | 
+**TestBodyWithQueryParams**](fake_api.md#TestBodyWithQueryParams) | **PUT** /fake/body-with-query-params | 
+**TestClientModel**](fake_api.md#TestClientModel) | **PATCH** /fake | To test \"client\" model
+**TestEndpointParameters**](fake_api.md#TestEndpointParameters) | **POST** /fake | Fake endpoint for testing various parameters  假端點  偽のエンドポイント  가짜 엔드 포인트
+**TestEnumParameters**](fake_api.md#TestEnumParameters) | **GET** /fake | To test enum parameters
+**TestInlineAdditionalProperties**](fake_api.md#TestInlineAdditionalProperties) | **POST** /fake/inline-additionalProperties | test inline additionalProperties
+**TestJsonFormData**](fake_api.md#TestJsonFormData) | **GET** /fake/jsonFormData | test json serialization of form data
 
 
-# **123example**
-> 123example()
+# **Call123example**
+> Call123example()
 
 
 ### Required Parameters
@@ -41,8 +41,8 @@ No authorization required
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
-# **fakeOuterBooleanSerialize**
-> bool fakeOuterBooleanSerialize(optional)
+# **FakeOuterBooleanSerialize**
+> bool FakeOuterBooleanSerialize(optional)
 
 
 Test serialization of outer boolean types
@@ -75,8 +75,8 @@ No authorization required
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
-# **fakeOuterCompositeSerialize**
-> models::OuterComposite fakeOuterCompositeSerialize(optional)
+# **FakeOuterCompositeSerialize**
+> models::OuterComposite FakeOuterCompositeSerialize(optional)
 
 
 Test serialization of object with outer number type
@@ -109,8 +109,8 @@ No authorization required
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
-# **fakeOuterNumberSerialize**
-> f64 fakeOuterNumberSerialize(optional)
+# **FakeOuterNumberSerialize**
+> f64 FakeOuterNumberSerialize(optional)
 
 
 Test serialization of outer number types
@@ -143,8 +143,8 @@ No authorization required
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
-# **fakeOuterStringSerialize**
-> String fakeOuterStringSerialize(optional)
+# **FakeOuterStringSerialize**
+> String FakeOuterStringSerialize(optional)
 
 
 Test serialization of outer string types
@@ -177,8 +177,8 @@ No authorization required
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
-# **fake_response_with_numerical_description**
-> fake_response_with_numerical_description()
+# **FakeResponseWithNumericalDescription**
+> FakeResponseWithNumericalDescription()
 
 
 ### Required Parameters
@@ -199,8 +199,8 @@ No authorization required
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
-# **hyphenParam**
-> hyphenParam(hyphen_param)
+# **HyphenParam**
+> HyphenParam(hyphen_param)
 
 
 To test hyphen in path parameter name
@@ -226,8 +226,8 @@ No authorization required
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
-# **testBodyWithQueryParams**
-> testBodyWithQueryParams(query, body)
+# **TestBodyWithQueryParams**
+> TestBodyWithQueryParams(query, body)
 
 
 ### Required Parameters
@@ -252,8 +252,8 @@ No authorization required
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
-# **testClientModel**
-> models::Client testClientModel(body)
+# **TestClientModel**
+> models::Client TestClientModel(body)
 To test \"client\" model
 
 To test \"client\" model
@@ -279,8 +279,8 @@ No authorization required
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
-# **testEndpointParameters**
-> testEndpointParameters(ctx, number, double, pattern_without_delimiter, byte, optional)
+# **TestEndpointParameters**
+> TestEndpointParameters(ctx, number, double, pattern_without_delimiter, byte, optional)
 Fake endpoint for testing various parameters  假端點  偽のエンドポイント  가짜 엔드 포인트
 
 Fake endpoint for testing various parameters  假端點  偽のエンドポイント  가짜 엔드 포인트
@@ -331,8 +331,8 @@ Name | Type | Description  | Notes
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
-# **testEnumParameters**
-> testEnumParameters(optional)
+# **TestEnumParameters**
+> TestEnumParameters(optional)
 To test enum parameters
 
 To test enum parameters
@@ -371,8 +371,8 @@ No authorization required
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
-# **testInlineAdditionalProperties**
-> testInlineAdditionalProperties(param)
+# **TestInlineAdditionalProperties**
+> TestInlineAdditionalProperties(param)
 test inline additionalProperties
 
 ### Required Parameters
@@ -396,8 +396,8 @@ No authorization required
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
-# **testJsonFormData**
-> testJsonFormData(param, param2)
+# **TestJsonFormData**
+> TestJsonFormData(param, param2)
 test json serialization of form data
 
 ### Required Parameters

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/docs/fake_classname_tags123_api.md
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/docs/fake_classname_tags123_api.md
@@ -4,11 +4,11 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
-**testClassname**](fake_classname_tags123_api.md#testClassname) | **PATCH** /fake_classname_test | To test class name in snake case
+**TestClassname**](fake_classname_tags123_api.md#TestClassname) | **PATCH** /fake_classname_test | To test class name in snake case
 
 
-# **testClassname**
-> models::Client testClassname(ctx, body)
+# **TestClassname**
+> models::Client TestClassname(ctx, body)
 To test class name in snake case
 
 To test class name in snake case

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/docs/pet_api.md
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/docs/pet_api.md
@@ -4,18 +4,18 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
-**addPet**](pet_api.md#addPet) | **POST** /pet | Add a new pet to the store
-**deletePet**](pet_api.md#deletePet) | **DELETE** /pet/{petId} | Deletes a pet
-**findPetsByStatus**](pet_api.md#findPetsByStatus) | **GET** /pet/findByStatus | Finds Pets by status
-**findPetsByTags**](pet_api.md#findPetsByTags) | **GET** /pet/findByTags | Finds Pets by tags
-**getPetById**](pet_api.md#getPetById) | **GET** /pet/{petId} | Find pet by ID
-**updatePet**](pet_api.md#updatePet) | **PUT** /pet | Update an existing pet
-**updatePetWithForm**](pet_api.md#updatePetWithForm) | **POST** /pet/{petId} | Updates a pet in the store with form data
-**uploadFile**](pet_api.md#uploadFile) | **POST** /pet/{petId}/uploadImage | uploads an image
+**AddPet**](pet_api.md#AddPet) | **POST** /pet | Add a new pet to the store
+**DeletePet**](pet_api.md#DeletePet) | **DELETE** /pet/{petId} | Deletes a pet
+**FindPetsByStatus**](pet_api.md#FindPetsByStatus) | **GET** /pet/findByStatus | Finds Pets by status
+**FindPetsByTags**](pet_api.md#FindPetsByTags) | **GET** /pet/findByTags | Finds Pets by tags
+**GetPetById**](pet_api.md#GetPetById) | **GET** /pet/{petId} | Find pet by ID
+**UpdatePet**](pet_api.md#UpdatePet) | **PUT** /pet | Update an existing pet
+**UpdatePetWithForm**](pet_api.md#UpdatePetWithForm) | **POST** /pet/{petId} | Updates a pet in the store with form data
+**UploadFile**](pet_api.md#UploadFile) | **POST** /pet/{petId}/uploadImage | uploads an image
 
 
-# **addPet**
-> addPet(ctx, body)
+# **AddPet**
+> AddPet(ctx, body)
 Add a new pet to the store
 
 ### Required Parameters
@@ -40,8 +40,8 @@ Name | Type | Description  | Notes
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
-# **deletePet**
-> deletePet(ctx, pet_id, optional)
+# **DeletePet**
+> DeletePet(ctx, pet_id, optional)
 Deletes a pet
 
 ### Required Parameters
@@ -75,8 +75,8 @@ Name | Type | Description  | Notes
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
-# **findPetsByStatus**
-> Vec<models::Pet> findPetsByStatus(ctx, status)
+# **FindPetsByStatus**
+> Vec<models::Pet> FindPetsByStatus(ctx, status)
 Finds Pets by status
 
 Multiple status values can be provided with comma separated strings
@@ -103,8 +103,8 @@ Name | Type | Description  | Notes
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
-# **findPetsByTags**
-> Vec<models::Pet> findPetsByTags(ctx, tags)
+# **FindPetsByTags**
+> Vec<models::Pet> FindPetsByTags(ctx, tags)
 Finds Pets by tags
 
 Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
@@ -131,8 +131,8 @@ Name | Type | Description  | Notes
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
-# **getPetById**
-> models::Pet getPetById(ctx, pet_id)
+# **GetPetById**
+> models::Pet GetPetById(ctx, pet_id)
 Find pet by ID
 
 Returns a single pet
@@ -159,8 +159,8 @@ Name | Type | Description  | Notes
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
-# **updatePet**
-> updatePet(ctx, body)
+# **UpdatePet**
+> UpdatePet(ctx, body)
 Update an existing pet
 
 ### Required Parameters
@@ -185,8 +185,8 @@ Name | Type | Description  | Notes
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
-# **updatePetWithForm**
-> updatePetWithForm(ctx, pet_id, optional)
+# **UpdatePetWithForm**
+> UpdatePetWithForm(ctx, pet_id, optional)
 Updates a pet in the store with form data
 
 ### Required Parameters
@@ -221,8 +221,8 @@ Name | Type | Description  | Notes
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
-# **uploadFile**
-> models::ApiResponse uploadFile(ctx, pet_id, optional)
+# **UploadFile**
+> models::ApiResponse UploadFile(ctx, pet_id, optional)
 uploads an image
 
 ### Required Parameters

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/docs/store_api.md
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/docs/store_api.md
@@ -4,14 +4,14 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
-**deleteOrder**](store_api.md#deleteOrder) | **DELETE** /store/order/{order_id} | Delete purchase order by ID
-**getInventory**](store_api.md#getInventory) | **GET** /store/inventory | Returns pet inventories by status
-**getOrderById**](store_api.md#getOrderById) | **GET** /store/order/{order_id} | Find purchase order by ID
-**placeOrder**](store_api.md#placeOrder) | **POST** /store/order | Place an order for a pet
+**DeleteOrder**](store_api.md#DeleteOrder) | **DELETE** /store/order/{order_id} | Delete purchase order by ID
+**GetInventory**](store_api.md#GetInventory) | **GET** /store/inventory | Returns pet inventories by status
+**GetOrderById**](store_api.md#GetOrderById) | **GET** /store/order/{order_id} | Find purchase order by ID
+**PlaceOrder**](store_api.md#PlaceOrder) | **POST** /store/order | Place an order for a pet
 
 
-# **deleteOrder**
-> deleteOrder(order_id)
+# **DeleteOrder**
+> DeleteOrder(order_id)
 Delete purchase order by ID
 
 For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
@@ -37,8 +37,8 @@ No authorization required
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
-# **getInventory**
-> std::collections::HashMap<String, i32> getInventory(ctx, )
+# **GetInventory**
+> std::collections::HashMap<String, i32> GetInventory(ctx, )
 Returns pet inventories by status
 
 Returns a map of status codes to quantities
@@ -61,8 +61,8 @@ This endpoint does not need any parameter.
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
-# **getOrderById**
-> models::Order getOrderById(order_id)
+# **GetOrderById**
+> models::Order GetOrderById(order_id)
 Find purchase order by ID
 
 For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
@@ -88,8 +88,8 @@ No authorization required
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
-# **placeOrder**
-> models::Order placeOrder(body)
+# **PlaceOrder**
+> models::Order PlaceOrder(body)
 Place an order for a pet
 
 ### Required Parameters

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/docs/user_api.md
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/docs/user_api.md
@@ -4,18 +4,18 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
-**createUser**](user_api.md#createUser) | **POST** /user | Create user
-**createUsersWithArrayInput**](user_api.md#createUsersWithArrayInput) | **POST** /user/createWithArray | Creates list of users with given input array
-**createUsersWithListInput**](user_api.md#createUsersWithListInput) | **POST** /user/createWithList | Creates list of users with given input array
-**deleteUser**](user_api.md#deleteUser) | **DELETE** /user/{username} | Delete user
-**getUserByName**](user_api.md#getUserByName) | **GET** /user/{username} | Get user by user name
-**loginUser**](user_api.md#loginUser) | **GET** /user/login | Logs user into the system
-**logoutUser**](user_api.md#logoutUser) | **GET** /user/logout | Logs out current logged in user session
-**updateUser**](user_api.md#updateUser) | **PUT** /user/{username} | Updated user
+**CreateUser**](user_api.md#CreateUser) | **POST** /user | Create user
+**CreateUsersWithArrayInput**](user_api.md#CreateUsersWithArrayInput) | **POST** /user/createWithArray | Creates list of users with given input array
+**CreateUsersWithListInput**](user_api.md#CreateUsersWithListInput) | **POST** /user/createWithList | Creates list of users with given input array
+**DeleteUser**](user_api.md#DeleteUser) | **DELETE** /user/{username} | Delete user
+**GetUserByName**](user_api.md#GetUserByName) | **GET** /user/{username} | Get user by user name
+**LoginUser**](user_api.md#LoginUser) | **GET** /user/login | Logs user into the system
+**LogoutUser**](user_api.md#LogoutUser) | **GET** /user/logout | Logs out current logged in user session
+**UpdateUser**](user_api.md#UpdateUser) | **PUT** /user/{username} | Updated user
 
 
-# **createUser**
-> createUser(body)
+# **CreateUser**
+> CreateUser(body)
 Create user
 
 This can only be done by the logged in user.
@@ -41,8 +41,8 @@ No authorization required
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
-# **createUsersWithArrayInput**
-> createUsersWithArrayInput(body)
+# **CreateUsersWithArrayInput**
+> CreateUsersWithArrayInput(body)
 Creates list of users with given input array
 
 ### Required Parameters
@@ -66,8 +66,8 @@ No authorization required
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
-# **createUsersWithListInput**
-> createUsersWithListInput(body)
+# **CreateUsersWithListInput**
+> CreateUsersWithListInput(body)
 Creates list of users with given input array
 
 ### Required Parameters
@@ -91,8 +91,8 @@ No authorization required
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
-# **deleteUser**
-> deleteUser(username)
+# **DeleteUser**
+> DeleteUser(username)
 Delete user
 
 This can only be done by the logged in user.
@@ -118,8 +118,8 @@ No authorization required
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
-# **getUserByName**
-> models::User getUserByName(username)
+# **GetUserByName**
+> models::User GetUserByName(username)
 Get user by user name
 
 ### Required Parameters
@@ -143,8 +143,8 @@ No authorization required
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
-# **loginUser**
-> String loginUser(username, password)
+# **LoginUser**
+> String LoginUser(username, password)
 Logs user into the system
 
 ### Required Parameters
@@ -169,8 +169,8 @@ No authorization required
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
-# **logoutUser**
-> logoutUser()
+# **LogoutUser**
+> LogoutUser()
 Logs out current logged in user session
 
 ### Required Parameters
@@ -191,8 +191,8 @@ No authorization required
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
-# **updateUser**
-> updateUser(username, body)
+# **UpdateUser**
+> UpdateUser(username, body)
 Updated user
 
 This can only be done by the logged in user.

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/examples/client/main.rs
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/examples/client/main.rs
@@ -15,7 +15,7 @@ extern crate tokio;
 #[allow(unused_imports)]
 use futures::{Future, future, Stream, stream};
 #[allow(unused_imports)]
-use petstore_with_fake_endpoints_models_for_testing::{Api, ApiNoContext, Client, ContextWrapperExt,
+use petstore_with_fake_endpoints_models_for_testing::{Api, ApiNoContext, Client, ContextWrapperExt, models,
                       ApiError,
                       TestSpecialTagsResponse,
                       Call123exampleResponse,

--- a/samples/server/petstore/rust-server/output/rust-server-test/docs/default_api.md
+++ b/samples/server/petstore/rust-server/output/rust-server-test/docs/default_api.md
@@ -4,19 +4,19 @@ All URIs are relative to *http://localhost*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
-**AllOf_Get**](default_api.md#AllOf_Get) | **GET** /allOf | 
-**dummyGet**](default_api.md#dummyGet) | **GET** /dummy | A dummy endpoint to make the spec valid.
-**dummyPut**](default_api.md#dummyPut) | **PUT** /dummy | 
-**file_responseGet**](default_api.md#file_responseGet) | **GET** /file_response | Get a file
-**getStructuredYaml**](default_api.md#getStructuredYaml) | **GET** /get-structured-yaml | 
-**htmlPost**](default_api.md#htmlPost) | **POST** /html | Test HTML handling
-**post_yaml**](default_api.md#post_yaml) | **POST** /post-yaml | 
-**raw_jsonGet**](default_api.md#raw_jsonGet) | **GET** /raw_json | Get an arbitrary JSON blob.
-**solo_objectPost**](default_api.md#solo_objectPost) | **POST** /solo-object | Send an arbitrary JSON blob
+**AllOfGet**](default_api.md#AllOfGet) | **GET** /allOf | 
+**DummyGet**](default_api.md#DummyGet) | **GET** /dummy | A dummy endpoint to make the spec valid.
+**DummyPut**](default_api.md#DummyPut) | **PUT** /dummy | 
+**FileResponseGet**](default_api.md#FileResponseGet) | **GET** /file_response | Get a file
+**GetStructuredYaml**](default_api.md#GetStructuredYaml) | **GET** /get-structured-yaml | 
+**HtmlPost**](default_api.md#HtmlPost) | **POST** /html | Test HTML handling
+**PostYaml**](default_api.md#PostYaml) | **POST** /post-yaml | 
+**RawJsonGet**](default_api.md#RawJsonGet) | **GET** /raw_json | Get an arbitrary JSON blob.
+**SoloObjectPost**](default_api.md#SoloObjectPost) | **POST** /solo-object | Send an arbitrary JSON blob
 
 
-# **AllOf_Get**
-> models::AllOfObject AllOf_Get()
+# **AllOfGet**
+> models::AllOfObject AllOfGet()
 
 
 Test getting an object which uses allOf
@@ -39,8 +39,8 @@ No authorization required
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
-# **dummyGet**
-> dummyGet()
+# **DummyGet**
+> DummyGet()
 A dummy endpoint to make the spec valid.
 
 ### Required Parameters
@@ -61,8 +61,8 @@ No authorization required
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
-# **dummyPut**
-> dummyPut(nested_response)
+# **DummyPut**
+> DummyPut(nested_response)
 
 
 ### Required Parameters
@@ -86,8 +86,8 @@ No authorization required
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
-# **file_responseGet**
-> swagger::ByteArray file_responseGet()
+# **FileResponseGet**
+> swagger::ByteArray FileResponseGet()
 Get a file
 
 ### Required Parameters
@@ -108,8 +108,8 @@ No authorization required
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
-# **getStructuredYaml**
-> models::GetYamlResponse getStructuredYaml()
+# **GetStructuredYaml**
+> models::GetYamlResponse GetStructuredYaml()
 
 
 Test returning arbitrary structured YAML
@@ -132,8 +132,8 @@ No authorization required
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
-# **htmlPost**
-> String htmlPost(body)
+# **HtmlPost**
+> String HtmlPost(body)
 Test HTML handling
 
 ### Required Parameters
@@ -157,8 +157,8 @@ No authorization required
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
-# **post_yaml**
-> post_yaml(value)
+# **PostYaml**
+> PostYaml(value)
 
 
 Test sending an arbitrary unsupported format - e.g. YAML
@@ -184,8 +184,8 @@ No authorization required
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
-# **raw_jsonGet**
-> serde_json::Value raw_jsonGet()
+# **RawJsonGet**
+> serde_json::Value RawJsonGet()
 Get an arbitrary JSON blob.
 
 ### Required Parameters
@@ -206,8 +206,8 @@ No authorization required
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
-# **solo_objectPost**
-> solo_objectPost(value)
+# **SoloObjectPost**
+> SoloObjectPost(value)
 Send an arbitrary JSON blob
 
 ### Required Parameters

--- a/samples/server/petstore/rust-server/output/rust-server-test/examples/client/main.rs
+++ b/samples/server/petstore/rust-server/output/rust-server-test/examples/client/main.rs
@@ -15,7 +15,7 @@ extern crate tokio;
 #[allow(unused_imports)]
 use futures::{Future, future, Stream, stream};
 #[allow(unused_imports)]
-use rust_server_test::{Api, ApiNoContext, Client, ContextWrapperExt,
+use rust_server_test::{Api, ApiNoContext, Client, ContextWrapperExt, models,
                       ApiError,
                       AllOfGetResponse,
                       DummyGetResponse,


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
#5969 [BUG] [Rust Server] Not support free-form object code generated issue. 

<!-- Please check the completed items below -->
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [ ] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [ ] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
