### PR TITLE
Fixes issue 5876

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
@@ -1165,14 +1165,6 @@ public class ModelUtils {
         int nullSchemaChildrenCount = 0;
         boolean hasAmbiguousParents = false;
         List<String> refedWithoutDiscriminator = new ArrayList<>();
-        String schemaName = "";
-        for (String thisSchemaName : allSchemas.keySet()) {
-            Schema sc = allSchemas.get(thisSchemaName);
-            if (isComposedSchema(sc) && (ComposedSchema) sc == composedSchema) {
-                schemaName = thisSchemaName;
-                break;
-            }
-        }
 
         if (interfaces != null && !interfaces.isEmpty()) {
             for (Schema schema : interfaces) {
@@ -1189,10 +1181,7 @@ public class ModelUtils {
                     } else {
                         // not a parent since discriminator.propertyName is not set
                         hasAmbiguousParents = true;
-                        boolean isNotExtractedInlineSchema = !parentName.equals(schemaName+"_allOf");
-                        if (isNotExtractedInlineSchema) {
-                            refedWithoutDiscriminator.add(parentName);
-                        }
+                        refedWithoutDiscriminator.add(parentName);
                     }
                 } else {
                     // not a ref, doing nothing, except counting the number of times the 'null' type

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
@@ -1104,9 +1104,9 @@ public class ModelUtils {
     public static Map<String, List<String>> getChildrenMap(OpenAPI openAPI) {
         Map<String, Schema> allSchemas = getSchemas(openAPI);
 
-        // FIXME: The collect here will throw NPE if a spec document has only a single oneOf hierarchy.
         Map<String, List<Entry<String, Schema>>> groupedByParent = allSchemas.entrySet().stream()
             .filter(entry -> isComposedSchema(entry.getValue()))
+                .filter(entry -> getParentName((ComposedSchema) entry.getValue(), allSchemas)!=null)
             .collect(Collectors.groupingBy(entry -> getParentName((ComposedSchema) entry.getValue(), allSchemas)));
 
         return groupedByParent.entrySet().stream()

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
@@ -612,8 +612,8 @@ public class DefaultCodegenTest {
         Schema schema = openAPI.getComponents().getSchemas().get("MessageEventCoreWithTimeListEntries");
         codegen.setOpenAPI(openAPI);
         CodegenModel model = codegen.fromModel("MessageEventCoreWithTimeListEntries", schema);
-        Assert.assertEquals(model.parent, "MessageEventCore");
-        Assert.assertEquals(model.allParents, Collections.singletonList("MessageEventCore"));
+        Assert.assertEquals(model.parent, null);
+        Assert.assertEquals(model.allParents, null);
     }
 
     @Test

--- a/samples/client/petstore/python-experimental/docs/Child.md
+++ b/samples/client/petstore/python-experimental/docs/Child.md
@@ -3,9 +3,9 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**inter_net** | **bool** |  | [optional] 
 **radio_waves** | **bool** |  | [optional] 
 **tele_vision** | **bool** |  | [optional] 
+**inter_net** | **bool** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/python-experimental/docs/Parent.md
+++ b/samples/client/petstore/python-experimental/docs/Parent.md
@@ -3,8 +3,8 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**tele_vision** | **bool** |  | [optional] 
 **radio_waves** | **bool** |  | [optional] 
+**tele_vision** | **bool** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/python-experimental/petstore_api/models/child.py
+++ b/samples/client/petstore/python-experimental/petstore_api/models/child.py
@@ -84,9 +84,9 @@ class Child(ModelComposed):
                 and the value is attribute type.
         """
         return {
-            'inter_net': (bool,),  # noqa: E501
             'radio_waves': (bool,),  # noqa: E501
             'tele_vision': (bool,),  # noqa: E501
+            'inter_net': (bool,),  # noqa: E501
         }
 
     @staticmethod
@@ -94,9 +94,9 @@ class Child(ModelComposed):
         return None
 
     attribute_map = {
-        'inter_net': 'interNet',  # noqa: E501
         'radio_waves': 'radioWaves',  # noqa: E501
         'tele_vision': 'teleVision',  # noqa: E501
+        'inter_net': 'interNet',  # noqa: E501
     }
 
     required_properties = set([
@@ -127,9 +127,9 @@ class Child(ModelComposed):
                                 deserializing a file_type parameter.
                                 If passed, type conversion is attempted
                                 If omitted no type conversion is done.
-            inter_net (bool): [optional]  # noqa: E501
             radio_waves (bool): [optional]  # noqa: E501
             tele_vision (bool): [optional]  # noqa: E501
+            inter_net (bool): [optional]  # noqa: E501
         """
 
         self._data_store = {}

--- a/samples/client/petstore/python-experimental/petstore_api/models/parent.py
+++ b/samples/client/petstore/python-experimental/petstore_api/models/parent.py
@@ -84,8 +84,8 @@ class Parent(ModelComposed):
                 and the value is attribute type.
         """
         return {
-            'tele_vision': (bool,),  # noqa: E501
             'radio_waves': (bool,),  # noqa: E501
+            'tele_vision': (bool,),  # noqa: E501
         }
 
     @staticmethod
@@ -93,8 +93,8 @@ class Parent(ModelComposed):
         return None
 
     attribute_map = {
-        'tele_vision': 'teleVision',  # noqa: E501
         'radio_waves': 'radioWaves',  # noqa: E501
+        'tele_vision': 'teleVision',  # noqa: E501
     }
 
     required_properties = set([
@@ -125,8 +125,8 @@ class Parent(ModelComposed):
                                 deserializing a file_type parameter.
                                 If passed, type conversion is attempted
                                 If omitted no type conversion is done.
-            tele_vision (bool): [optional]  # noqa: E501
             radio_waves (bool): [optional]  # noqa: E501
+            tele_vision (bool): [optional]  # noqa: E501
         """
 
         self._data_store = {}


### PR DESCRIPTION
This PR fixes [issue 5876](https://github.com/OpenAPITools/openapi-generator/issues/5876)
We are reverting the code back to the prior state to make it so
codegenModel.parentSchema, .parent, and parentModel return back to previous behavior for composed schemas.

@amakhrov this update changes result for the test testAllOfSingleRefWithOwnPropsNoDiscriminator which you added in https://github.com/OpenAPITools/openapi-generator/pull/5738

### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [ ] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [ ] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
