### PR TITLE
[Python] Fix delimiter collision issue #5981

### DIFF
--- a/docs/generators/python-experimental.md
+++ b/docs/generators/python-experimental.md
@@ -31,7 +31,6 @@ sidebar_label: python-experimental
 
 <ul class="column-ul">
 <li>bool</li>
-<li>bytes</li>
 <li>date</li>
 <li>datetime</li>
 <li>dict</li>

--- a/docs/generators/python.md
+++ b/docs/generators/python.md
@@ -31,7 +31,6 @@ sidebar_label: python
 
 <ul class="column-ul">
 <li>bool</li>
-<li>bytes</li>
 <li>date</li>
 <li>datetime</li>
 <li>dict</li>

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonClientCodegen.java
@@ -682,7 +682,8 @@ public class PythonClientCodegen extends DefaultCodegen implements CodegenConfig
                 if (Pattern.compile("\r\n|\r|\n").matcher((String) p.getDefault()).find())
                     return "'''" + p.getDefault() + "'''";
                 else
-                    return "'" + ((String) p.getDefault()).replaceAll("'", "\'") + "'";
+                    // wrap using double quotes to avoid the need to escape any embedded single quotes
+                    return "\"" + p.getDefault() + "\"";
             }
         } else if (ModelUtils.isArraySchema(p)) {
             if (p.getDefault() != null) {
@@ -726,7 +727,8 @@ public class PythonClientCodegen extends DefaultCodegen implements CodegenConfig
 
         if (StringUtils.isNotBlank(example) && !"null".equals(example)) {
             if (ModelUtils.isStringSchema(schema)) {
-                example = "'" + example + "'";
+                // wrap using double quotes to avoid the need to escape any embedded single quotes
+                example = "\"" + example + "\"";
             }
             return example;
         }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/python/PythonClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/python/PythonClientCodegenTest.java
@@ -93,12 +93,21 @@ public class PythonClientCodegenTest {
         Assert.assertEquals(op.allParams.get(5).pattern, "/^pattern\\d{3}$/i");
     }
 
-    @Test(description = "test single quotes escape")
-    public void testSingleQuotes() {
+    @Test(description = "test default value with single quotes")
+    public void testSingleQuotesDefaultValue() {
         final PythonClientCodegen codegen = new PythonClientCodegen();
         StringSchema schema = new StringSchema();
         schema.setDefault("Text containing 'single' quote");
         String defaultValue = codegen.toDefaultValue(schema);
-        Assert.assertEquals("'Text containing \'single\' quote'", defaultValue);
+        Assert.assertEquals(defaultValue, "\"Text containing 'single' quote\"");
+    }
+
+    @Test(description = "test example value with single quotes")
+    public void testSingleQuotesExampleValue() {
+        final PythonClientCodegen codegen = new PythonClientCodegen();
+        StringSchema schema = new StringSchema();
+        schema.setExample("Text containing 'single' quote");
+        String exampleValue = codegen.toExampleValue(schema);
+        Assert.assertEquals(exampleValue, "\"Text containing 'single' quote\"");
     }
 }

--- a/samples/client/petstore/dart2/openapi/lib/api/pet_api.dart
+++ b/samples/client/petstore/dart2/openapi/lib/api/pet_api.dart
@@ -28,10 +28,10 @@ class PetApi {
 
     List<String> contentTypes = ["application/json","application/xml"];
 
-    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
+    String nullableContentType = contentTypes.isNotEmpty ? contentTypes[0] : null;
     List<String> authNames = ["petstore_auth"];
 
-    if(contentType.startsWith("multipart/form-data")) {
+    if(nullableContentType != null && nullableContentType.startsWith("multipart/form-data")) {
       bool hasFields = false;
       MultipartRequest mp = MultipartRequest(null, null);
       if(hasFields)
@@ -46,7 +46,7 @@ class PetApi {
                                              postBody,
                                              headerParams,
                                              formParams,
-                                             contentType,
+                                             nullableContentType,
                                              authNames);
     return response;
   }
@@ -86,10 +86,10 @@ class PetApi {
 
     List<String> contentTypes = [];
 
-    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
+    String nullableContentType = contentTypes.isNotEmpty ? contentTypes[0] : null;
     List<String> authNames = ["petstore_auth"];
 
-    if(contentType.startsWith("multipart/form-data")) {
+    if(nullableContentType != null && nullableContentType.startsWith("multipart/form-data")) {
       bool hasFields = false;
       MultipartRequest mp = MultipartRequest(null, null);
       if(hasFields)
@@ -104,7 +104,7 @@ class PetApi {
                                              postBody,
                                              headerParams,
                                              formParams,
-                                             contentType,
+                                             nullableContentType,
                                              authNames);
     return response;
   }
@@ -144,10 +144,10 @@ class PetApi {
 
     List<String> contentTypes = [];
 
-    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
+    String nullableContentType = contentTypes.isNotEmpty ? contentTypes[0] : null;
     List<String> authNames = ["petstore_auth"];
 
-    if(contentType.startsWith("multipart/form-data")) {
+    if(nullableContentType != null && nullableContentType.startsWith("multipart/form-data")) {
       bool hasFields = false;
       MultipartRequest mp = MultipartRequest(null, null);
       if(hasFields)
@@ -162,7 +162,7 @@ class PetApi {
                                              postBody,
                                              headerParams,
                                              formParams,
-                                             contentType,
+                                             nullableContentType,
                                              authNames);
     return response;
   }
@@ -203,10 +203,10 @@ class PetApi {
 
     List<String> contentTypes = [];
 
-    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
+    String nullableContentType = contentTypes.isNotEmpty ? contentTypes[0] : null;
     List<String> authNames = ["petstore_auth"];
 
-    if(contentType.startsWith("multipart/form-data")) {
+    if(nullableContentType != null && nullableContentType.startsWith("multipart/form-data")) {
       bool hasFields = false;
       MultipartRequest mp = MultipartRequest(null, null);
       if(hasFields)
@@ -221,7 +221,7 @@ class PetApi {
                                              postBody,
                                              headerParams,
                                              formParams,
-                                             contentType,
+                                             nullableContentType,
                                              authNames);
     return response;
   }
@@ -261,10 +261,10 @@ class PetApi {
 
     List<String> contentTypes = [];
 
-    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
+    String nullableContentType = contentTypes.isNotEmpty ? contentTypes[0] : null;
     List<String> authNames = ["api_key"];
 
-    if(contentType.startsWith("multipart/form-data")) {
+    if(nullableContentType != null && nullableContentType.startsWith("multipart/form-data")) {
       bool hasFields = false;
       MultipartRequest mp = MultipartRequest(null, null);
       if(hasFields)
@@ -279,7 +279,7 @@ class PetApi {
                                              postBody,
                                              headerParams,
                                              formParams,
-                                             contentType,
+                                             nullableContentType,
                                              authNames);
     return response;
   }
@@ -319,10 +319,10 @@ class PetApi {
 
     List<String> contentTypes = ["application/json","application/xml"];
 
-    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
+    String nullableContentType = contentTypes.isNotEmpty ? contentTypes[0] : null;
     List<String> authNames = ["petstore_auth"];
 
-    if(contentType.startsWith("multipart/form-data")) {
+    if(nullableContentType != null && nullableContentType.startsWith("multipart/form-data")) {
       bool hasFields = false;
       MultipartRequest mp = MultipartRequest(null, null);
       if(hasFields)
@@ -337,7 +337,7 @@ class PetApi {
                                              postBody,
                                              headerParams,
                                              formParams,
-                                             contentType,
+                                             nullableContentType,
                                              authNames);
     return response;
   }
@@ -376,10 +376,10 @@ class PetApi {
 
     List<String> contentTypes = ["application/x-www-form-urlencoded"];
 
-    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
+    String nullableContentType = contentTypes.isNotEmpty ? contentTypes[0] : null;
     List<String> authNames = ["petstore_auth"];
 
-    if(contentType.startsWith("multipart/form-data")) {
+    if(nullableContentType != null && nullableContentType.startsWith("multipart/form-data")) {
       bool hasFields = false;
       MultipartRequest mp = MultipartRequest(null, null);
       if (name != null) {
@@ -406,7 +406,7 @@ class PetApi {
                                              postBody,
                                              headerParams,
                                              formParams,
-                                             contentType,
+                                             nullableContentType,
                                              authNames);
     return response;
   }
@@ -445,10 +445,10 @@ class PetApi {
 
     List<String> contentTypes = ["multipart/form-data"];
 
-    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
+    String nullableContentType = contentTypes.isNotEmpty ? contentTypes[0] : null;
     List<String> authNames = ["petstore_auth"];
 
-    if(contentType.startsWith("multipart/form-data")) {
+    if(nullableContentType != null && nullableContentType.startsWith("multipart/form-data")) {
       bool hasFields = false;
       MultipartRequest mp = MultipartRequest(null, null);
       if (additionalMetadata != null) {
@@ -474,7 +474,7 @@ class PetApi {
                                              postBody,
                                              headerParams,
                                              formParams,
-                                             contentType,
+                                             nullableContentType,
                                              authNames);
     return response;
   }

--- a/samples/client/petstore/dart2/openapi/lib/api/store_api.dart
+++ b/samples/client/petstore/dart2/openapi/lib/api/store_api.dart
@@ -28,10 +28,10 @@ class StoreApi {
 
     List<String> contentTypes = [];
 
-    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
+    String nullableContentType = contentTypes.isNotEmpty ? contentTypes[0] : null;
     List<String> authNames = [];
 
-    if(contentType.startsWith("multipart/form-data")) {
+    if(nullableContentType != null && nullableContentType.startsWith("multipart/form-data")) {
       bool hasFields = false;
       MultipartRequest mp = MultipartRequest(null, null);
       if(hasFields)
@@ -46,7 +46,7 @@ class StoreApi {
                                              postBody,
                                              headerParams,
                                              formParams,
-                                             contentType,
+                                             nullableContentType,
                                              authNames);
     return response;
   }
@@ -82,10 +82,10 @@ class StoreApi {
 
     List<String> contentTypes = [];
 
-    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
+    String nullableContentType = contentTypes.isNotEmpty ? contentTypes[0] : null;
     List<String> authNames = ["api_key"];
 
-    if(contentType.startsWith("multipart/form-data")) {
+    if(nullableContentType != null && nullableContentType.startsWith("multipart/form-data")) {
       bool hasFields = false;
       MultipartRequest mp = MultipartRequest(null, null);
       if(hasFields)
@@ -100,7 +100,7 @@ class StoreApi {
                                              postBody,
                                              headerParams,
                                              formParams,
-                                             contentType,
+                                             nullableContentType,
                                              authNames);
     return response;
   }
@@ -141,10 +141,10 @@ class StoreApi {
 
     List<String> contentTypes = [];
 
-    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
+    String nullableContentType = contentTypes.isNotEmpty ? contentTypes[0] : null;
     List<String> authNames = [];
 
-    if(contentType.startsWith("multipart/form-data")) {
+    if(nullableContentType != null && nullableContentType.startsWith("multipart/form-data")) {
       bool hasFields = false;
       MultipartRequest mp = MultipartRequest(null, null);
       if(hasFields)
@@ -159,7 +159,7 @@ class StoreApi {
                                              postBody,
                                              headerParams,
                                              formParams,
-                                             contentType,
+                                             nullableContentType,
                                              authNames);
     return response;
   }
@@ -199,10 +199,10 @@ class StoreApi {
 
     List<String> contentTypes = [];
 
-    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
+    String nullableContentType = contentTypes.isNotEmpty ? contentTypes[0] : null;
     List<String> authNames = [];
 
-    if(contentType.startsWith("multipart/form-data")) {
+    if(nullableContentType != null && nullableContentType.startsWith("multipart/form-data")) {
       bool hasFields = false;
       MultipartRequest mp = MultipartRequest(null, null);
       if(hasFields)
@@ -217,7 +217,7 @@ class StoreApi {
                                              postBody,
                                              headerParams,
                                              formParams,
-                                             contentType,
+                                             nullableContentType,
                                              authNames);
     return response;
   }

--- a/samples/client/petstore/dart2/openapi/lib/api/user_api.dart
+++ b/samples/client/petstore/dart2/openapi/lib/api/user_api.dart
@@ -28,10 +28,10 @@ class UserApi {
 
     List<String> contentTypes = [];
 
-    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
+    String nullableContentType = contentTypes.isNotEmpty ? contentTypes[0] : null;
     List<String> authNames = [];
 
-    if(contentType.startsWith("multipart/form-data")) {
+    if(nullableContentType != null && nullableContentType.startsWith("multipart/form-data")) {
       bool hasFields = false;
       MultipartRequest mp = MultipartRequest(null, null);
       if(hasFields)
@@ -46,7 +46,7 @@ class UserApi {
                                              postBody,
                                              headerParams,
                                              formParams,
-                                             contentType,
+                                             nullableContentType,
                                              authNames);
     return response;
   }
@@ -85,10 +85,10 @@ class UserApi {
 
     List<String> contentTypes = [];
 
-    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
+    String nullableContentType = contentTypes.isNotEmpty ? contentTypes[0] : null;
     List<String> authNames = [];
 
-    if(contentType.startsWith("multipart/form-data")) {
+    if(nullableContentType != null && nullableContentType.startsWith("multipart/form-data")) {
       bool hasFields = false;
       MultipartRequest mp = MultipartRequest(null, null);
       if(hasFields)
@@ -103,7 +103,7 @@ class UserApi {
                                              postBody,
                                              headerParams,
                                              formParams,
-                                             contentType,
+                                             nullableContentType,
                                              authNames);
     return response;
   }
@@ -142,10 +142,10 @@ class UserApi {
 
     List<String> contentTypes = [];
 
-    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
+    String nullableContentType = contentTypes.isNotEmpty ? contentTypes[0] : null;
     List<String> authNames = [];
 
-    if(contentType.startsWith("multipart/form-data")) {
+    if(nullableContentType != null && nullableContentType.startsWith("multipart/form-data")) {
       bool hasFields = false;
       MultipartRequest mp = MultipartRequest(null, null);
       if(hasFields)
@@ -160,7 +160,7 @@ class UserApi {
                                              postBody,
                                              headerParams,
                                              formParams,
-                                             contentType,
+                                             nullableContentType,
                                              authNames);
     return response;
   }
@@ -199,10 +199,10 @@ class UserApi {
 
     List<String> contentTypes = [];
 
-    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
+    String nullableContentType = contentTypes.isNotEmpty ? contentTypes[0] : null;
     List<String> authNames = [];
 
-    if(contentType.startsWith("multipart/form-data")) {
+    if(nullableContentType != null && nullableContentType.startsWith("multipart/form-data")) {
       bool hasFields = false;
       MultipartRequest mp = MultipartRequest(null, null);
       if(hasFields)
@@ -217,7 +217,7 @@ class UserApi {
                                              postBody,
                                              headerParams,
                                              formParams,
-                                             contentType,
+                                             nullableContentType,
                                              authNames);
     return response;
   }
@@ -256,10 +256,10 @@ class UserApi {
 
     List<String> contentTypes = [];
 
-    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
+    String nullableContentType = contentTypes.isNotEmpty ? contentTypes[0] : null;
     List<String> authNames = [];
 
-    if(contentType.startsWith("multipart/form-data")) {
+    if(nullableContentType != null && nullableContentType.startsWith("multipart/form-data")) {
       bool hasFields = false;
       MultipartRequest mp = MultipartRequest(null, null);
       if(hasFields)
@@ -274,7 +274,7 @@ class UserApi {
                                              postBody,
                                              headerParams,
                                              formParams,
-                                             contentType,
+                                             nullableContentType,
                                              authNames);
     return response;
   }
@@ -319,10 +319,10 @@ class UserApi {
 
     List<String> contentTypes = [];
 
-    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
+    String nullableContentType = contentTypes.isNotEmpty ? contentTypes[0] : null;
     List<String> authNames = [];
 
-    if(contentType.startsWith("multipart/form-data")) {
+    if(nullableContentType != null && nullableContentType.startsWith("multipart/form-data")) {
       bool hasFields = false;
       MultipartRequest mp = MultipartRequest(null, null);
       if(hasFields)
@@ -337,7 +337,7 @@ class UserApi {
                                              postBody,
                                              headerParams,
                                              formParams,
-                                             contentType,
+                                             nullableContentType,
                                              authNames);
     return response;
   }
@@ -374,10 +374,10 @@ class UserApi {
 
     List<String> contentTypes = [];
 
-    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
+    String nullableContentType = contentTypes.isNotEmpty ? contentTypes[0] : null;
     List<String> authNames = [];
 
-    if(contentType.startsWith("multipart/form-data")) {
+    if(nullableContentType != null && nullableContentType.startsWith("multipart/form-data")) {
       bool hasFields = false;
       MultipartRequest mp = MultipartRequest(null, null);
       if(hasFields)
@@ -392,7 +392,7 @@ class UserApi {
                                              postBody,
                                              headerParams,
                                              formParams,
-                                             contentType,
+                                             nullableContentType,
                                              authNames);
     return response;
   }
@@ -434,10 +434,10 @@ class UserApi {
 
     List<String> contentTypes = [];
 
-    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
+    String nullableContentType = contentTypes.isNotEmpty ? contentTypes[0] : null;
     List<String> authNames = [];
 
-    if(contentType.startsWith("multipart/form-data")) {
+    if(nullableContentType != null && nullableContentType.startsWith("multipart/form-data")) {
       bool hasFields = false;
       MultipartRequest mp = MultipartRequest(null, null);
       if(hasFields)
@@ -452,7 +452,7 @@ class UserApi {
                                              postBody,
                                              headerParams,
                                              formParams,
-                                             contentType,
+                                             nullableContentType,
                                              authNames);
     return response;
   }

--- a/samples/client/petstore/dart2/openapi/lib/api_client.dart
+++ b/samples/client/petstore/dart2/openapi/lib/api_client.dart
@@ -100,7 +100,7 @@ class ApiClient {
                              Object body,
                              Map<String, String> headerParams,
                              Map<String, String> formParams,
-                             String contentType,
+                             String nullableContentType,
                              List<String> authNames) async {
 
     _updateParamsForAuth(authNames, queryParams, headerParams);
@@ -116,7 +116,10 @@ class ApiClient {
     String url = basePath + path + queryString;
 
     headerParams.addAll(_defaultHeaderMap);
-    headerParams['Content-Type'] = contentType;
+    if (nullableContentType != null) {
+      final contentType = nullableContentType;
+      headerParams['Content-Type'] = contentType;
+    }
 
     if(body is MultipartRequest) {
       var request = MultipartRequest(method, Uri.parse(url));
@@ -127,20 +130,21 @@ class ApiClient {
       var response = await client.send(request);
       return Response.fromStream(response);
     } else {
-      var msgBody = contentType == "application/x-www-form-urlencoded" ? formParams : serialize(body);
+      var msgBody = nullableContentType == "application/x-www-form-urlencoded" ? formParams : serialize(body);
+      final nullableHeaderParams = (headerParams.isEmpty)? null: headerParams;
       switch(method) {
         case "POST":
-          return client.post(url, headers: headerParams, body: msgBody);
+          return client.post(url, headers: nullableHeaderParams, body: msgBody);
         case "PUT":
-          return client.put(url, headers: headerParams, body: msgBody);
+          return client.put(url, headers: nullableHeaderParams, body: msgBody);
         case "DELETE":
-          return client.delete(url, headers: headerParams);
+          return client.delete(url, headers: nullableHeaderParams);
         case "PATCH":
-          return client.patch(url, headers: headerParams, body: msgBody);
+          return client.patch(url, headers: nullableHeaderParams, body: msgBody);
         case "HEAD":
-          return client.head(url, headers: headerParams);
+          return client.head(url, headers: nullableHeaderParams);
         default:
-          return client.get(url, headers: headerParams);
+          return client.get(url, headers: nullableHeaderParams);
       }
     }
   }

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -25,9 +25,6 @@ import io.swagger.annotations.ApiModelProperty;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
-import javax.validation.constraints.*;
-import javax.validation.Valid;
-import org.hibernate.validator.constraints.*;
 
 /**
  * AdditionalPropertiesAnyType

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -26,9 +26,6 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import javax.validation.constraints.*;
-import javax.validation.Valid;
-import org.hibernate.validator.constraints.*;
 
 /**
  * AdditionalPropertiesArray

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -25,9 +25,6 @@ import io.swagger.annotations.ApiModelProperty;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
-import javax.validation.constraints.*;
-import javax.validation.Valid;
-import org.hibernate.validator.constraints.*;
 
 /**
  * AdditionalPropertiesBoolean

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -27,9 +27,6 @@ import java.math.BigDecimal;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import javax.validation.constraints.*;
-import javax.validation.Valid;
-import org.hibernate.validator.constraints.*;
 
 /**
  * AdditionalPropertiesClass
@@ -131,7 +128,6 @@ public class AdditionalPropertiesClass {
    * @return mapNumber
   **/
   @javax.annotation.Nullable
-  @Valid
   @ApiModelProperty(value = "")
 
   public Map<String, BigDecimal> getMapNumber() {
@@ -225,7 +221,6 @@ public class AdditionalPropertiesClass {
    * @return mapArrayInteger
   **/
   @javax.annotation.Nullable
-  @Valid
   @ApiModelProperty(value = "")
 
   public Map<String, List<Integer>> getMapArrayInteger() {
@@ -257,7 +252,6 @@ public class AdditionalPropertiesClass {
    * @return mapArrayAnytype
   **/
   @javax.annotation.Nullable
-  @Valid
   @ApiModelProperty(value = "")
 
   public Map<String, List<Object>> getMapArrayAnytype() {
@@ -289,7 +283,6 @@ public class AdditionalPropertiesClass {
    * @return mapMapString
   **/
   @javax.annotation.Nullable
-  @Valid
   @ApiModelProperty(value = "")
 
   public Map<String, Map<String, String>> getMapMapString() {
@@ -321,7 +314,6 @@ public class AdditionalPropertiesClass {
    * @return mapMapAnytype
   **/
   @javax.annotation.Nullable
-  @Valid
   @ApiModelProperty(value = "")
 
   public Map<String, Map<String, Object>> getMapMapAnytype() {
@@ -345,7 +337,6 @@ public class AdditionalPropertiesClass {
    * @return anytype1
   **/
   @javax.annotation.Nullable
-  @Valid
   @ApiModelProperty(value = "")
 
   public Object getAnytype1() {
@@ -369,7 +360,6 @@ public class AdditionalPropertiesClass {
    * @return anytype2
   **/
   @javax.annotation.Nullable
-  @Valid
   @ApiModelProperty(value = "")
 
   public Object getAnytype2() {
@@ -393,7 +383,6 @@ public class AdditionalPropertiesClass {
    * @return anytype3
   **/
   @javax.annotation.Nullable
-  @Valid
   @ApiModelProperty(value = "")
 
   public Object getAnytype3() {

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -25,9 +25,6 @@ import io.swagger.annotations.ApiModelProperty;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
-import javax.validation.constraints.*;
-import javax.validation.Valid;
-import org.hibernate.validator.constraints.*;
 
 /**
  * AdditionalPropertiesInteger

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -26,9 +26,6 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.HashMap;
 import java.util.Map;
-import javax.validation.constraints.*;
-import javax.validation.Valid;
-import org.hibernate.validator.constraints.*;
 
 /**
  * AdditionalPropertiesNumber

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -25,9 +25,6 @@ import io.swagger.annotations.ApiModelProperty;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
-import javax.validation.constraints.*;
-import javax.validation.Valid;
-import org.hibernate.validator.constraints.*;
 
 /**
  * AdditionalPropertiesObject

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -25,9 +25,6 @@ import io.swagger.annotations.ApiModelProperty;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
-import javax.validation.constraints.*;
-import javax.validation.Valid;
-import org.hibernate.validator.constraints.*;
 
 /**
  * AdditionalPropertiesString

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Animal.java
@@ -23,9 +23,6 @@ import com.google.gson.stream.JsonWriter;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.io.IOException;
-import javax.validation.constraints.*;
-import javax.validation.Valid;
-import org.hibernate.validator.constraints.*;
 
 /**
  * Animal
@@ -55,7 +52,6 @@ public class Animal {
    * Get className
    * @return className
   **/
-  @NotNull
   @ApiModelProperty(required = true, value = "")
 
   public String getClassName() {

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -26,9 +26,6 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
-import javax.validation.constraints.*;
-import javax.validation.Valid;
-import org.hibernate.validator.constraints.*;
 
 /**
  * ArrayOfArrayOfNumberOnly
@@ -59,7 +56,6 @@ public class ArrayOfArrayOfNumberOnly {
    * @return arrayArrayNumber
   **/
   @javax.annotation.Nullable
-  @Valid
   @ApiModelProperty(value = "")
 
   public List<List<BigDecimal>> getArrayArrayNumber() {

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -26,9 +26,6 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
-import javax.validation.constraints.*;
-import javax.validation.Valid;
-import org.hibernate.validator.constraints.*;
 
 /**
  * ArrayOfNumberOnly
@@ -59,7 +56,6 @@ public class ArrayOfNumberOnly {
    * @return arrayNumber
   **/
   @javax.annotation.Nullable
-  @Valid
   @ApiModelProperty(value = "")
 
   public List<BigDecimal> getArrayNumber() {

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -26,9 +26,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import org.openapitools.client.model.ReadOnlyFirst;
-import javax.validation.constraints.*;
-import javax.validation.Valid;
-import org.hibernate.validator.constraints.*;
 
 /**
  * ArrayTest
@@ -98,7 +95,6 @@ public class ArrayTest {
    * @return arrayArrayOfInteger
   **/
   @javax.annotation.Nullable
-  @Valid
   @ApiModelProperty(value = "")
 
   public List<List<Long>> getArrayArrayOfInteger() {
@@ -130,7 +126,6 @@ public class ArrayTest {
    * @return arrayArrayOfModel
   **/
   @javax.annotation.Nullable
-  @Valid
   @ApiModelProperty(value = "")
 
   public List<List<ReadOnlyFirst>> getArrayArrayOfModel() {

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/BigCat.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/BigCat.java
@@ -25,9 +25,6 @@ import io.swagger.annotations.ApiModelProperty;
 import java.io.IOException;
 import org.openapitools.client.model.BigCatAllOf;
 import org.openapitools.client.model.Cat;
-import javax.validation.constraints.*;
-import javax.validation.Valid;
-import org.hibernate.validator.constraints.*;
 
 /**
  * BigCat

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/BigCatAllOf.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/BigCatAllOf.java
@@ -23,9 +23,6 @@ import com.google.gson.stream.JsonWriter;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.io.IOException;
-import javax.validation.constraints.*;
-import javax.validation.Valid;
-import org.hibernate.validator.constraints.*;
 
 /**
  * BigCatAllOf

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -23,9 +23,6 @@ import com.google.gson.stream.JsonWriter;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.io.IOException;
-import javax.validation.constraints.*;
-import javax.validation.Valid;
-import org.hibernate.validator.constraints.*;
 
 /**
  * Capitalization

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Cat.java
@@ -25,9 +25,6 @@ import io.swagger.annotations.ApiModelProperty;
 import java.io.IOException;
 import org.openapitools.client.model.Animal;
 import org.openapitools.client.model.CatAllOf;
-import javax.validation.constraints.*;
-import javax.validation.Valid;
-import org.hibernate.validator.constraints.*;
 
 /**
  * Cat

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -23,9 +23,6 @@ import com.google.gson.stream.JsonWriter;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.io.IOException;
-import javax.validation.constraints.*;
-import javax.validation.Valid;
-import org.hibernate.validator.constraints.*;
 
 /**
  * CatAllOf

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Category.java
@@ -23,9 +23,6 @@ import com.google.gson.stream.JsonWriter;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.io.IOException;
-import javax.validation.constraints.*;
-import javax.validation.Valid;
-import org.hibernate.validator.constraints.*;
 
 /**
  * Category
@@ -74,7 +71,6 @@ public class Category {
    * Get name
    * @return name
   **/
-  @NotNull
   @ApiModelProperty(required = true, value = "")
 
   public String getName() {

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -23,9 +23,6 @@ import com.google.gson.stream.JsonWriter;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.io.IOException;
-import javax.validation.constraints.*;
-import javax.validation.Valid;
-import org.hibernate.validator.constraints.*;
 
 /**
  * Model for testing model with \&quot;_class\&quot; property

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Client.java
@@ -23,9 +23,6 @@ import com.google.gson.stream.JsonWriter;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.io.IOException;
-import javax.validation.constraints.*;
-import javax.validation.Valid;
-import org.hibernate.validator.constraints.*;
 
 /**
  * Client

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Dog.java
@@ -25,9 +25,6 @@ import io.swagger.annotations.ApiModelProperty;
 import java.io.IOException;
 import org.openapitools.client.model.Animal;
 import org.openapitools.client.model.DogAllOf;
-import javax.validation.constraints.*;
-import javax.validation.Valid;
-import org.hibernate.validator.constraints.*;
 
 /**
  * Dog

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -23,9 +23,6 @@ import com.google.gson.stream.JsonWriter;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.io.IOException;
-import javax.validation.constraints.*;
-import javax.validation.Valid;
-import org.hibernate.validator.constraints.*;
 
 /**
  * DogAllOf

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -25,9 +25,6 @@ import io.swagger.annotations.ApiModelProperty;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import javax.validation.constraints.*;
-import javax.validation.Valid;
-import org.hibernate.validator.constraints.*;
 
 /**
  * EnumArrays

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/EnumClass.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/EnumClass.java
@@ -16,9 +16,6 @@ package org.openapitools.client.model;
 import java.util.Objects;
 import java.util.Arrays;
 import com.google.gson.annotations.SerializedName;
-import javax.validation.constraints.*;
-import javax.validation.Valid;
-import org.hibernate.validator.constraints.*;
 
 import java.io.IOException;
 import com.google.gson.TypeAdapter;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -24,9 +24,6 @@ import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.io.IOException;
 import org.openapitools.client.model.OuterEnum;
-import javax.validation.constraints.*;
-import javax.validation.Valid;
-import org.hibernate.validator.constraints.*;
 
 /**
  * EnumTest
@@ -279,7 +276,6 @@ public class EnumTest {
    * Get enumStringRequired
    * @return enumStringRequired
   **/
-  @NotNull
   @ApiModelProperty(required = true, value = "")
 
   public EnumStringRequiredEnum getEnumStringRequired() {
@@ -349,7 +345,6 @@ public class EnumTest {
    * @return outerEnum
   **/
   @javax.annotation.Nullable
-  @Valid
   @ApiModelProperty(value = "")
 
   public OuterEnum getOuterEnum() {

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -25,9 +25,6 @@ import io.swagger.annotations.ApiModelProperty;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import javax.validation.constraints.*;
-import javax.validation.Valid;
-import org.hibernate.validator.constraints.*;
 
 /**
  * FileSchemaTestClass
@@ -54,7 +51,6 @@ public class FileSchemaTestClass {
    * @return file
   **/
   @javax.annotation.Nullable
-  @Valid
   @ApiModelProperty(value = "")
 
   public java.io.File getFile() {
@@ -86,7 +82,6 @@ public class FileSchemaTestClass {
    * @return files
   **/
   @javax.annotation.Nullable
-  @Valid
   @ApiModelProperty(value = "")
 
   public List<java.io.File> getFiles() {

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -28,9 +28,6 @@ import java.math.BigDecimal;
 import java.util.UUID;
 import org.threeten.bp.LocalDate;
 import org.threeten.bp.OffsetDateTime;
-import javax.validation.constraints.*;
-import javax.validation.Valid;
-import org.hibernate.validator.constraints.*;
 
 /**
  * FormatTest
@@ -107,7 +104,7 @@ public class FormatTest {
    * @return integer
   **/
   @javax.annotation.Nullable
- @Min(10) @Max(100)  @ApiModelProperty(value = "")
+  @ApiModelProperty(value = "")
 
   public Integer getInteger() {
     return integer;
@@ -132,7 +129,7 @@ public class FormatTest {
    * @return int32
   **/
   @javax.annotation.Nullable
- @Min(20) @Max(200)  @ApiModelProperty(value = "")
+  @ApiModelProperty(value = "")
 
   public Integer getInt32() {
     return int32;
@@ -179,9 +176,7 @@ public class FormatTest {
    * maximum: 543.2
    * @return number
   **/
-  @NotNull
-  @Valid
- @DecimalMin("32.1") @DecimalMax("543.2")  @ApiModelProperty(required = true, value = "")
+  @ApiModelProperty(required = true, value = "")
 
   public BigDecimal getNumber() {
     return number;
@@ -206,7 +201,7 @@ public class FormatTest {
    * @return _float
   **/
   @javax.annotation.Nullable
- @DecimalMin("54.3") @DecimalMax("987.6")  @ApiModelProperty(value = "")
+  @ApiModelProperty(value = "")
 
   public Float getFloat() {
     return _float;
@@ -231,7 +226,7 @@ public class FormatTest {
    * @return _double
   **/
   @javax.annotation.Nullable
- @DecimalMin("67.8") @DecimalMax("123.4")  @ApiModelProperty(value = "")
+  @ApiModelProperty(value = "")
 
   public Double getDouble() {
     return _double;
@@ -254,7 +249,7 @@ public class FormatTest {
    * @return string
   **/
   @javax.annotation.Nullable
- @Pattern(regexp="/[a-z]/i")  @ApiModelProperty(value = "")
+  @ApiModelProperty(value = "")
 
   public String getString() {
     return string;
@@ -276,8 +271,7 @@ public class FormatTest {
    * Get _byte
    * @return _byte
   **/
-  @NotNull
- @Pattern(regexp="^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$")  @ApiModelProperty(required = true, value = "")
+  @ApiModelProperty(required = true, value = "")
 
   public byte[] getByte() {
     return _byte;
@@ -300,7 +294,6 @@ public class FormatTest {
    * @return binary
   **/
   @javax.annotation.Nullable
-  @Valid
   @ApiModelProperty(value = "")
 
   public File getBinary() {
@@ -323,8 +316,6 @@ public class FormatTest {
    * Get date
    * @return date
   **/
-  @NotNull
-  @Valid
   @ApiModelProperty(required = true, value = "")
 
   public LocalDate getDate() {
@@ -348,7 +339,6 @@ public class FormatTest {
    * @return dateTime
   **/
   @javax.annotation.Nullable
-  @Valid
   @ApiModelProperty(value = "")
 
   public OffsetDateTime getDateTime() {
@@ -372,7 +362,6 @@ public class FormatTest {
    * @return uuid
   **/
   @javax.annotation.Nullable
-  @Valid
   @ApiModelProperty(example = "72f98069-206d-4f12-9f12-3d1e525a8e84", value = "")
 
   public UUID getUuid() {
@@ -395,8 +384,7 @@ public class FormatTest {
    * Get password
    * @return password
   **/
-  @NotNull
- @Size(min=10,max=64)  @ApiModelProperty(required = true, value = "")
+  @ApiModelProperty(required = true, value = "")
 
   public String getPassword() {
     return password;
@@ -419,7 +407,6 @@ public class FormatTest {
    * @return bigDecimal
   **/
   @javax.annotation.Nullable
-  @Valid
   @ApiModelProperty(value = "")
 
   public BigDecimal getBigDecimal() {

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
@@ -23,9 +23,6 @@ import com.google.gson.stream.JsonWriter;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.io.IOException;
-import javax.validation.constraints.*;
-import javax.validation.Valid;
-import org.hibernate.validator.constraints.*;
 
 /**
  * HasOnlyReadOnly

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/MapTest.java
@@ -26,9 +26,6 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import javax.validation.constraints.*;
-import javax.validation.Valid;
-import org.hibernate.validator.constraints.*;
 
 /**
  * MapTest
@@ -118,7 +115,6 @@ public class MapTest {
    * @return mapMapOfString
   **/
   @javax.annotation.Nullable
-  @Valid
   @ApiModelProperty(value = "")
 
   public Map<String, Map<String, String>> getMapMapOfString() {

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -29,9 +29,6 @@ import java.util.Map;
 import java.util.UUID;
 import org.openapitools.client.model.Animal;
 import org.threeten.bp.OffsetDateTime;
-import javax.validation.constraints.*;
-import javax.validation.Valid;
-import org.hibernate.validator.constraints.*;
 
 /**
  * MixedPropertiesAndAdditionalPropertiesClass
@@ -62,7 +59,6 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
    * @return uuid
   **/
   @javax.annotation.Nullable
-  @Valid
   @ApiModelProperty(value = "")
 
   public UUID getUuid() {
@@ -86,7 +82,6 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
    * @return dateTime
   **/
   @javax.annotation.Nullable
-  @Valid
   @ApiModelProperty(value = "")
 
   public OffsetDateTime getDateTime() {
@@ -118,7 +113,6 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
    * @return map
   **/
   @javax.annotation.Nullable
-  @Valid
   @ApiModelProperty(value = "")
 
   public Map<String, Animal> getMap() {

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -23,9 +23,6 @@ import com.google.gson.stream.JsonWriter;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.io.IOException;
-import javax.validation.constraints.*;
-import javax.validation.Valid;
-import org.hibernate.validator.constraints.*;
 
 /**
  * Model for testing model name starting with number

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -23,9 +23,6 @@ import com.google.gson.stream.JsonWriter;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.io.IOException;
-import javax.validation.constraints.*;
-import javax.validation.Valid;
-import org.hibernate.validator.constraints.*;
 
 /**
  * ModelApiResponse

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -23,9 +23,6 @@ import com.google.gson.stream.JsonWriter;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.io.IOException;
-import javax.validation.constraints.*;
-import javax.validation.Valid;
-import org.hibernate.validator.constraints.*;
 
 /**
  * Model for testing reserved words

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Name.java
@@ -23,9 +23,6 @@ import com.google.gson.stream.JsonWriter;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.io.IOException;
-import javax.validation.constraints.*;
-import javax.validation.Valid;
-import org.hibernate.validator.constraints.*;
 
 /**
  * Model for testing model name same as property name
@@ -60,7 +57,6 @@ public class Name {
    * Get name
    * @return name
   **/
-  @NotNull
   @ApiModelProperty(required = true, value = "")
 
   public Integer getName() {

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -24,9 +24,6 @@ import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.io.IOException;
 import java.math.BigDecimal;
-import javax.validation.constraints.*;
-import javax.validation.Valid;
-import org.hibernate.validator.constraints.*;
 
 /**
  * NumberOnly
@@ -49,7 +46,6 @@ public class NumberOnly {
    * @return justNumber
   **/
   @javax.annotation.Nullable
-  @Valid
   @ApiModelProperty(value = "")
 
   public BigDecimal getJustNumber() {

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Order.java
@@ -24,9 +24,6 @@ import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.io.IOException;
 import org.threeten.bp.OffsetDateTime;
-import javax.validation.constraints.*;
-import javax.validation.Valid;
-import org.hibernate.validator.constraints.*;
 
 /**
  * Order
@@ -187,7 +184,6 @@ public class Order {
    * @return shipDate
   **/
   @javax.annotation.Nullable
-  @Valid
   @ApiModelProperty(value = "")
 
   public OffsetDateTime getShipDate() {

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -24,9 +24,6 @@ import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.io.IOException;
 import java.math.BigDecimal;
-import javax.validation.constraints.*;
-import javax.validation.Valid;
-import org.hibernate.validator.constraints.*;
 
 /**
  * OuterComposite
@@ -57,7 +54,6 @@ public class OuterComposite {
    * @return myNumber
   **/
   @javax.annotation.Nullable
-  @Valid
   @ApiModelProperty(value = "")
 
   public BigDecimal getMyNumber() {

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/OuterEnum.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/OuterEnum.java
@@ -16,9 +16,6 @@ package org.openapitools.client.model;
 import java.util.Objects;
 import java.util.Arrays;
 import com.google.gson.annotations.SerializedName;
-import javax.validation.constraints.*;
-import javax.validation.Valid;
-import org.hibernate.validator.constraints.*;
 
 import java.io.IOException;
 import com.google.gson.TypeAdapter;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Pet.java
@@ -27,9 +27,6 @@ import java.util.ArrayList;
 import java.util.List;
 import org.openapitools.client.model.Category;
 import org.openapitools.client.model.Tag;
-import javax.validation.constraints.*;
-import javax.validation.Valid;
-import org.hibernate.validator.constraints.*;
 
 /**
  * Pet
@@ -144,7 +141,6 @@ public class Pet {
    * @return category
   **/
   @javax.annotation.Nullable
-  @Valid
   @ApiModelProperty(value = "")
 
   public Category getCategory() {
@@ -167,7 +163,6 @@ public class Pet {
    * Get name
    * @return name
   **/
-  @NotNull
   @ApiModelProperty(example = "doggie", required = true, value = "")
 
   public String getName() {
@@ -195,7 +190,6 @@ public class Pet {
    * Get photoUrls
    * @return photoUrls
   **/
-  @NotNull
   @ApiModelProperty(required = true, value = "")
 
   public List<String> getPhotoUrls() {
@@ -227,7 +221,6 @@ public class Pet {
    * @return tags
   **/
   @javax.annotation.Nullable
-  @Valid
   @ApiModelProperty(value = "")
 
   public List<Tag> getTags() {

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -23,9 +23,6 @@ import com.google.gson.stream.JsonWriter;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.io.IOException;
-import javax.validation.constraints.*;
-import javax.validation.Valid;
-import org.hibernate.validator.constraints.*;
 
 /**
  * ReadOnlyFirst

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -23,9 +23,6 @@ import com.google.gson.stream.JsonWriter;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.io.IOException;
-import javax.validation.constraints.*;
-import javax.validation.Valid;
-import org.hibernate.validator.constraints.*;
 
 /**
  * SpecialModelName

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Tag.java
@@ -23,9 +23,6 @@ import com.google.gson.stream.JsonWriter;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.io.IOException;
-import javax.validation.constraints.*;
-import javax.validation.Valid;
-import org.hibernate.validator.constraints.*;
 
 /**
  * Tag

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -26,9 +26,6 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
-import javax.validation.constraints.*;
-import javax.validation.Valid;
-import org.hibernate.validator.constraints.*;
 
 /**
  * TypeHolderDefault
@@ -66,7 +63,6 @@ public class TypeHolderDefault {
    * Get stringItem
    * @return stringItem
   **/
-  @NotNull
   @ApiModelProperty(required = true, value = "")
 
   public String getStringItem() {
@@ -89,8 +85,6 @@ public class TypeHolderDefault {
    * Get numberItem
    * @return numberItem
   **/
-  @NotNull
-  @Valid
   @ApiModelProperty(required = true, value = "")
 
   public BigDecimal getNumberItem() {
@@ -113,7 +107,6 @@ public class TypeHolderDefault {
    * Get integerItem
    * @return integerItem
   **/
-  @NotNull
   @ApiModelProperty(required = true, value = "")
 
   public Integer getIntegerItem() {
@@ -136,7 +129,6 @@ public class TypeHolderDefault {
    * Get boolItem
    * @return boolItem
   **/
-  @NotNull
   @ApiModelProperty(required = true, value = "")
 
   public Boolean isBoolItem() {
@@ -164,7 +156,6 @@ public class TypeHolderDefault {
    * Get arrayItem
    * @return arrayItem
   **/
-  @NotNull
   @ApiModelProperty(required = true, value = "")
 
   public List<Integer> getArrayItem() {

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -26,9 +26,6 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
-import javax.validation.constraints.*;
-import javax.validation.Valid;
-import org.hibernate.validator.constraints.*;
 
 /**
  * TypeHolderExample
@@ -70,7 +67,6 @@ public class TypeHolderExample {
    * Get stringItem
    * @return stringItem
   **/
-  @NotNull
   @ApiModelProperty(example = "what", required = true, value = "")
 
   public String getStringItem() {
@@ -93,8 +89,6 @@ public class TypeHolderExample {
    * Get numberItem
    * @return numberItem
   **/
-  @NotNull
-  @Valid
   @ApiModelProperty(example = "1.234", required = true, value = "")
 
   public BigDecimal getNumberItem() {
@@ -117,7 +111,6 @@ public class TypeHolderExample {
    * Get floatItem
    * @return floatItem
   **/
-  @NotNull
   @ApiModelProperty(example = "1.234", required = true, value = "")
 
   public Float getFloatItem() {
@@ -140,7 +133,6 @@ public class TypeHolderExample {
    * Get integerItem
    * @return integerItem
   **/
-  @NotNull
   @ApiModelProperty(example = "-2", required = true, value = "")
 
   public Integer getIntegerItem() {
@@ -163,7 +155,6 @@ public class TypeHolderExample {
    * Get boolItem
    * @return boolItem
   **/
-  @NotNull
   @ApiModelProperty(example = "true", required = true, value = "")
 
   public Boolean isBoolItem() {
@@ -191,7 +182,6 @@ public class TypeHolderExample {
    * Get arrayItem
    * @return arrayItem
   **/
-  @NotNull
   @ApiModelProperty(example = "[0, 1, 2, 3]", required = true, value = "")
 
   public List<Integer> getArrayItem() {

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/User.java
@@ -23,9 +23,6 @@ import com.google.gson.stream.JsonWriter;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.io.IOException;
-import javax.validation.constraints.*;
-import javax.validation.Valid;
-import org.hibernate.validator.constraints.*;
 
 /**
  * User

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -26,9 +26,6 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
-import javax.validation.constraints.*;
-import javax.validation.Valid;
-import org.hibernate.validator.constraints.*;
 
 /**
  * XmlItem
@@ -186,7 +183,6 @@ public class XmlItem {
    * @return attributeNumber
   **/
   @javax.annotation.Nullable
-  @Valid
   @ApiModelProperty(example = "1.234", value = "")
 
   public BigDecimal getAttributeNumber() {
@@ -310,7 +306,6 @@ public class XmlItem {
    * @return nameNumber
   **/
   @javax.annotation.Nullable
-  @Valid
   @ApiModelProperty(example = "1.234", value = "")
 
   public BigDecimal getNameNumber() {
@@ -465,7 +460,6 @@ public class XmlItem {
    * @return prefixNumber
   **/
   @javax.annotation.Nullable
-  @Valid
   @ApiModelProperty(example = "1.234", value = "")
 
   public BigDecimal getPrefixNumber() {
@@ -620,7 +614,6 @@ public class XmlItem {
    * @return namespaceNumber
   **/
   @javax.annotation.Nullable
-  @Valid
   @ApiModelProperty(example = "1.234", value = "")
 
   public BigDecimal getNamespaceNumber() {
@@ -775,7 +768,6 @@ public class XmlItem {
    * @return prefixNsNumber
   **/
   @javax.annotation.Nullable
-  @Valid
   @ApiModelProperty(example = "1.234", value = "")
 
   public BigDecimal getPrefixNsNumber() {

--- a/samples/client/petstore/python-asyncio/docs/Animal.md
+++ b/samples/client/petstore/python-asyncio/docs/Animal.md
@@ -4,7 +4,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **class_name** | **str** |  | 
-**color** | **str** |  | [optional] [default to 'red']
+**color** | **str** |  | [optional] [default to "red"]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/python-asyncio/docs/Category.md
+++ b/samples/client/petstore/python-asyncio/docs/Category.md
@@ -4,7 +4,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **id** | **int** |  | [optional] 
-**name** | **str** |  | [default to 'default-name']
+**name** | **str** |  | [default to "default-name"]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/python-asyncio/docs/FakeApi.md
+++ b/samples/client/petstore/python-asyncio/docs/FakeApi.md
@@ -633,13 +633,13 @@ with petstore_api.ApiClient() as api_client:
     # Create an instance of the API class
     api_instance = petstore_api.FakeApi(api_client)
     enum_header_string_array = ['enum_header_string_array_example'] # list[str] | Header parameter enum test (string array) (optional)
-enum_header_string = '-efg' # str | Header parameter enum test (string) (optional) (default to '-efg')
+enum_header_string = "-efg" # str | Header parameter enum test (string) (optional) (default to "-efg")
 enum_query_string_array = ['enum_query_string_array_example'] # list[str] | Query parameter enum test (string array) (optional)
-enum_query_string = '-efg' # str | Query parameter enum test (string) (optional) (default to '-efg')
+enum_query_string = "-efg" # str | Query parameter enum test (string) (optional) (default to "-efg")
 enum_query_integer = 56 # int | Query parameter enum test (double) (optional)
 enum_query_double = 3.4 # float | Query parameter enum test (double) (optional)
-enum_form_string_array = '$' # list[str] | Form parameter enum test (string array) (optional) (default to '$')
-enum_form_string = '-efg' # str | Form parameter enum test (string) (optional) (default to '-efg')
+enum_form_string_array = "$" # list[str] | Form parameter enum test (string array) (optional) (default to "$")
+enum_form_string = "-efg" # str | Form parameter enum test (string) (optional) (default to "-efg")
 
     try:
         # To test enum parameters
@@ -653,13 +653,13 @@ enum_form_string = '-efg' # str | Form parameter enum test (string) (optional) (
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **enum_header_string_array** | [**list[str]**](str.md)| Header parameter enum test (string array) | [optional] 
- **enum_header_string** | **str**| Header parameter enum test (string) | [optional] [default to &#39;-efg&#39;]
+ **enum_header_string** | **str**| Header parameter enum test (string) | [optional] [default to &quot;-efg&quot;]
  **enum_query_string_array** | [**list[str]**](str.md)| Query parameter enum test (string array) | [optional] 
- **enum_query_string** | **str**| Query parameter enum test (string) | [optional] [default to &#39;-efg&#39;]
+ **enum_query_string** | **str**| Query parameter enum test (string) | [optional] [default to &quot;-efg&quot;]
  **enum_query_integer** | **int**| Query parameter enum test (double) | [optional] 
  **enum_query_double** | **float**| Query parameter enum test (double) | [optional] 
- **enum_form_string_array** | [**list[str]**](str.md)| Form parameter enum test (string array) | [optional] [default to &#39;$&#39;]
- **enum_form_string** | **str**| Form parameter enum test (string) | [optional] [default to &#39;-efg&#39;]
+ **enum_form_string_array** | [**list[str]**](str.md)| Form parameter enum test (string array) | [optional] [default to &quot;$&quot;]
+ **enum_form_string** | **str**| Form parameter enum test (string) | [optional] [default to &quot;-efg&quot;]
 
 ### Return type
 

--- a/samples/client/petstore/python-asyncio/docs/TypeHolderDefault.md
+++ b/samples/client/petstore/python-asyncio/docs/TypeHolderDefault.md
@@ -3,7 +3,7 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**string_item** | **str** |  | [default to 'what']
+**string_item** | **str** |  | [default to "what"]
 **number_item** | **float** |  | 
 **integer_item** | **int** |  | 
 **bool_item** | **bool** |  | [default to True]

--- a/samples/client/petstore/python-asyncio/petstore_api/models/animal.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/models/animal.py
@@ -48,7 +48,7 @@ class Animal(object):
         'BigCat': 'BigCat'
     }
 
-    def __init__(self, class_name=None, color='red', local_vars_configuration=None):  # noqa: E501
+    def __init__(self, class_name=None, color="red", local_vars_configuration=None):  # noqa: E501
         """Animal - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
             local_vars_configuration = Configuration()

--- a/samples/client/petstore/python-asyncio/petstore_api/models/category.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/models/category.py
@@ -42,7 +42,7 @@ class Category(object):
         'name': 'name'
     }
 
-    def __init__(self, id=None, name='default-name', local_vars_configuration=None):  # noqa: E501
+    def __init__(self, id=None, name="default-name", local_vars_configuration=None):  # noqa: E501
         """Category - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
             local_vars_configuration = Configuration()

--- a/samples/client/petstore/python-asyncio/petstore_api/models/type_holder_default.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/models/type_holder_default.py
@@ -48,7 +48,7 @@ class TypeHolderDefault(object):
         'array_item': 'array_item'
     }
 
-    def __init__(self, string_item='what', number_item=None, integer_item=None, bool_item=True, array_item=None, local_vars_configuration=None):  # noqa: E501
+    def __init__(self, string_item="what", number_item=None, integer_item=None, bool_item=True, array_item=None, local_vars_configuration=None):  # noqa: E501
         """TypeHolderDefault - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
             local_vars_configuration = Configuration()

--- a/samples/client/petstore/python-tornado/docs/Animal.md
+++ b/samples/client/petstore/python-tornado/docs/Animal.md
@@ -4,7 +4,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **class_name** | **str** |  | 
-**color** | **str** |  | [optional] [default to 'red']
+**color** | **str** |  | [optional] [default to "red"]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/python-tornado/docs/Category.md
+++ b/samples/client/petstore/python-tornado/docs/Category.md
@@ -4,7 +4,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **id** | **int** |  | [optional] 
-**name** | **str** |  | [default to 'default-name']
+**name** | **str** |  | [default to "default-name"]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/python-tornado/docs/FakeApi.md
+++ b/samples/client/petstore/python-tornado/docs/FakeApi.md
@@ -633,13 +633,13 @@ with petstore_api.ApiClient() as api_client:
     # Create an instance of the API class
     api_instance = petstore_api.FakeApi(api_client)
     enum_header_string_array = ['enum_header_string_array_example'] # list[str] | Header parameter enum test (string array) (optional)
-enum_header_string = '-efg' # str | Header parameter enum test (string) (optional) (default to '-efg')
+enum_header_string = "-efg" # str | Header parameter enum test (string) (optional) (default to "-efg")
 enum_query_string_array = ['enum_query_string_array_example'] # list[str] | Query parameter enum test (string array) (optional)
-enum_query_string = '-efg' # str | Query parameter enum test (string) (optional) (default to '-efg')
+enum_query_string = "-efg" # str | Query parameter enum test (string) (optional) (default to "-efg")
 enum_query_integer = 56 # int | Query parameter enum test (double) (optional)
 enum_query_double = 3.4 # float | Query parameter enum test (double) (optional)
-enum_form_string_array = '$' # list[str] | Form parameter enum test (string array) (optional) (default to '$')
-enum_form_string = '-efg' # str | Form parameter enum test (string) (optional) (default to '-efg')
+enum_form_string_array = "$" # list[str] | Form parameter enum test (string array) (optional) (default to "$")
+enum_form_string = "-efg" # str | Form parameter enum test (string) (optional) (default to "-efg")
 
     try:
         # To test enum parameters
@@ -653,13 +653,13 @@ enum_form_string = '-efg' # str | Form parameter enum test (string) (optional) (
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **enum_header_string_array** | [**list[str]**](str.md)| Header parameter enum test (string array) | [optional] 
- **enum_header_string** | **str**| Header parameter enum test (string) | [optional] [default to &#39;-efg&#39;]
+ **enum_header_string** | **str**| Header parameter enum test (string) | [optional] [default to &quot;-efg&quot;]
  **enum_query_string_array** | [**list[str]**](str.md)| Query parameter enum test (string array) | [optional] 
- **enum_query_string** | **str**| Query parameter enum test (string) | [optional] [default to &#39;-efg&#39;]
+ **enum_query_string** | **str**| Query parameter enum test (string) | [optional] [default to &quot;-efg&quot;]
  **enum_query_integer** | **int**| Query parameter enum test (double) | [optional] 
  **enum_query_double** | **float**| Query parameter enum test (double) | [optional] 
- **enum_form_string_array** | [**list[str]**](str.md)| Form parameter enum test (string array) | [optional] [default to &#39;$&#39;]
- **enum_form_string** | **str**| Form parameter enum test (string) | [optional] [default to &#39;-efg&#39;]
+ **enum_form_string_array** | [**list[str]**](str.md)| Form parameter enum test (string array) | [optional] [default to &quot;$&quot;]
+ **enum_form_string** | **str**| Form parameter enum test (string) | [optional] [default to &quot;-efg&quot;]
 
 ### Return type
 

--- a/samples/client/petstore/python-tornado/docs/TypeHolderDefault.md
+++ b/samples/client/petstore/python-tornado/docs/TypeHolderDefault.md
@@ -3,7 +3,7 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**string_item** | **str** |  | [default to 'what']
+**string_item** | **str** |  | [default to "what"]
 **number_item** | **float** |  | 
 **integer_item** | **int** |  | 
 **bool_item** | **bool** |  | [default to True]

--- a/samples/client/petstore/python-tornado/petstore_api/models/animal.py
+++ b/samples/client/petstore/python-tornado/petstore_api/models/animal.py
@@ -48,7 +48,7 @@ class Animal(object):
         'BigCat': 'BigCat'
     }
 
-    def __init__(self, class_name=None, color='red', local_vars_configuration=None):  # noqa: E501
+    def __init__(self, class_name=None, color="red", local_vars_configuration=None):  # noqa: E501
         """Animal - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
             local_vars_configuration = Configuration()

--- a/samples/client/petstore/python-tornado/petstore_api/models/category.py
+++ b/samples/client/petstore/python-tornado/petstore_api/models/category.py
@@ -42,7 +42,7 @@ class Category(object):
         'name': 'name'
     }
 
-    def __init__(self, id=None, name='default-name', local_vars_configuration=None):  # noqa: E501
+    def __init__(self, id=None, name="default-name", local_vars_configuration=None):  # noqa: E501
         """Category - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
             local_vars_configuration = Configuration()

--- a/samples/client/petstore/python-tornado/petstore_api/models/type_holder_default.py
+++ b/samples/client/petstore/python-tornado/petstore_api/models/type_holder_default.py
@@ -48,7 +48,7 @@ class TypeHolderDefault(object):
         'array_item': 'array_item'
     }
 
-    def __init__(self, string_item='what', number_item=None, integer_item=None, bool_item=True, array_item=None, local_vars_configuration=None):  # noqa: E501
+    def __init__(self, string_item="what", number_item=None, integer_item=None, bool_item=True, array_item=None, local_vars_configuration=None):  # noqa: E501
         """TypeHolderDefault - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
             local_vars_configuration = Configuration()

--- a/samples/client/petstore/python/docs/Animal.md
+++ b/samples/client/petstore/python/docs/Animal.md
@@ -4,7 +4,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **class_name** | **str** |  | 
-**color** | **str** |  | [optional] [default to 'red']
+**color** | **str** |  | [optional] [default to "red"]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/python/docs/Category.md
+++ b/samples/client/petstore/python/docs/Category.md
@@ -4,7 +4,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **id** | **int** |  | [optional] 
-**name** | **str** |  | [default to 'default-name']
+**name** | **str** |  | [default to "default-name"]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/python/docs/FakeApi.md
+++ b/samples/client/petstore/python/docs/FakeApi.md
@@ -633,13 +633,13 @@ with petstore_api.ApiClient() as api_client:
     # Create an instance of the API class
     api_instance = petstore_api.FakeApi(api_client)
     enum_header_string_array = ['enum_header_string_array_example'] # list[str] | Header parameter enum test (string array) (optional)
-enum_header_string = '-efg' # str | Header parameter enum test (string) (optional) (default to '-efg')
+enum_header_string = "-efg" # str | Header parameter enum test (string) (optional) (default to "-efg")
 enum_query_string_array = ['enum_query_string_array_example'] # list[str] | Query parameter enum test (string array) (optional)
-enum_query_string = '-efg' # str | Query parameter enum test (string) (optional) (default to '-efg')
+enum_query_string = "-efg" # str | Query parameter enum test (string) (optional) (default to "-efg")
 enum_query_integer = 56 # int | Query parameter enum test (double) (optional)
 enum_query_double = 3.4 # float | Query parameter enum test (double) (optional)
-enum_form_string_array = '$' # list[str] | Form parameter enum test (string array) (optional) (default to '$')
-enum_form_string = '-efg' # str | Form parameter enum test (string) (optional) (default to '-efg')
+enum_form_string_array = "$" # list[str] | Form parameter enum test (string array) (optional) (default to "$")
+enum_form_string = "-efg" # str | Form parameter enum test (string) (optional) (default to "-efg")
 
     try:
         # To test enum parameters
@@ -653,13 +653,13 @@ enum_form_string = '-efg' # str | Form parameter enum test (string) (optional) (
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **enum_header_string_array** | [**list[str]**](str.md)| Header parameter enum test (string array) | [optional] 
- **enum_header_string** | **str**| Header parameter enum test (string) | [optional] [default to &#39;-efg&#39;]
+ **enum_header_string** | **str**| Header parameter enum test (string) | [optional] [default to &quot;-efg&quot;]
  **enum_query_string_array** | [**list[str]**](str.md)| Query parameter enum test (string array) | [optional] 
- **enum_query_string** | **str**| Query parameter enum test (string) | [optional] [default to &#39;-efg&#39;]
+ **enum_query_string** | **str**| Query parameter enum test (string) | [optional] [default to &quot;-efg&quot;]
  **enum_query_integer** | **int**| Query parameter enum test (double) | [optional] 
  **enum_query_double** | **float**| Query parameter enum test (double) | [optional] 
- **enum_form_string_array** | [**list[str]**](str.md)| Form parameter enum test (string array) | [optional] [default to &#39;$&#39;]
- **enum_form_string** | **str**| Form parameter enum test (string) | [optional] [default to &#39;-efg&#39;]
+ **enum_form_string_array** | [**list[str]**](str.md)| Form parameter enum test (string array) | [optional] [default to &quot;$&quot;]
+ **enum_form_string** | **str**| Form parameter enum test (string) | [optional] [default to &quot;-efg&quot;]
 
 ### Return type
 

--- a/samples/client/petstore/python/docs/TypeHolderDefault.md
+++ b/samples/client/petstore/python/docs/TypeHolderDefault.md
@@ -3,7 +3,7 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**string_item** | **str** |  | [default to 'what']
+**string_item** | **str** |  | [default to "what"]
 **number_item** | **float** |  | 
 **integer_item** | **int** |  | 
 **bool_item** | **bool** |  | [default to True]

--- a/samples/client/petstore/python/petstore_api/models/animal.py
+++ b/samples/client/petstore/python/petstore_api/models/animal.py
@@ -48,7 +48,7 @@ class Animal(object):
         'BigCat': 'BigCat'
     }
 
-    def __init__(self, class_name=None, color='red', local_vars_configuration=None):  # noqa: E501
+    def __init__(self, class_name=None, color="red", local_vars_configuration=None):  # noqa: E501
         """Animal - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
             local_vars_configuration = Configuration()

--- a/samples/client/petstore/python/petstore_api/models/category.py
+++ b/samples/client/petstore/python/petstore_api/models/category.py
@@ -42,7 +42,7 @@ class Category(object):
         'name': 'name'
     }
 
-    def __init__(self, id=None, name='default-name', local_vars_configuration=None):  # noqa: E501
+    def __init__(self, id=None, name="default-name", local_vars_configuration=None):  # noqa: E501
         """Category - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
             local_vars_configuration = Configuration()

--- a/samples/client/petstore/python/petstore_api/models/type_holder_default.py
+++ b/samples/client/petstore/python/petstore_api/models/type_holder_default.py
@@ -48,7 +48,7 @@ class TypeHolderDefault(object):
         'array_item': 'array_item'
     }
 
-    def __init__(self, string_item='what', number_item=None, integer_item=None, bool_item=True, array_item=None, local_vars_configuration=None):  # noqa: E501
+    def __init__(self, string_item="what", number_item=None, integer_item=None, bool_item=True, array_item=None, local_vars_configuration=None):  # noqa: E501
         """TypeHolderDefault - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
             local_vars_configuration = Configuration()

--- a/samples/openapi3/client/petstore/python/docs/Animal.md
+++ b/samples/openapi3/client/petstore/python/docs/Animal.md
@@ -4,7 +4,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **class_name** | **str** |  | 
-**color** | **str** |  | [optional] [default to 'red']
+**color** | **str** |  | [optional] [default to "red"]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/openapi3/client/petstore/python/docs/Category.md
+++ b/samples/openapi3/client/petstore/python/docs/Category.md
@@ -4,7 +4,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **id** | **int** |  | [optional] 
-**name** | **str** |  | [default to 'default-name']
+**name** | **str** |  | [default to "default-name"]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/openapi3/client/petstore/python/docs/FakeApi.md
+++ b/samples/openapi3/client/petstore/python/docs/FakeApi.md
@@ -756,13 +756,13 @@ with petstore_api.ApiClient() as api_client:
     # Create an instance of the API class
     api_instance = petstore_api.FakeApi(api_client)
     enum_header_string_array = ['enum_header_string_array_example'] # list[str] | Header parameter enum test (string array) (optional)
-enum_header_string = '-efg' # str | Header parameter enum test (string) (optional) (default to '-efg')
+enum_header_string = "-efg" # str | Header parameter enum test (string) (optional) (default to "-efg")
 enum_query_string_array = ['enum_query_string_array_example'] # list[str] | Query parameter enum test (string array) (optional)
-enum_query_string = '-efg' # str | Query parameter enum test (string) (optional) (default to '-efg')
+enum_query_string = "-efg" # str | Query parameter enum test (string) (optional) (default to "-efg")
 enum_query_integer = 56 # int | Query parameter enum test (double) (optional)
 enum_query_double = 3.4 # float | Query parameter enum test (double) (optional)
-enum_form_string_array = '$' # list[str] | Form parameter enum test (string array) (optional) (default to '$')
-enum_form_string = '-efg' # str | Form parameter enum test (string) (optional) (default to '-efg')
+enum_form_string_array = "$" # list[str] | Form parameter enum test (string array) (optional) (default to "$")
+enum_form_string = "-efg" # str | Form parameter enum test (string) (optional) (default to "-efg")
 
     try:
         # To test enum parameters
@@ -776,13 +776,13 @@ enum_form_string = '-efg' # str | Form parameter enum test (string) (optional) (
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **enum_header_string_array** | [**list[str]**](str.md)| Header parameter enum test (string array) | [optional] 
- **enum_header_string** | **str**| Header parameter enum test (string) | [optional] [default to &#39;-efg&#39;]
+ **enum_header_string** | **str**| Header parameter enum test (string) | [optional] [default to &quot;-efg&quot;]
  **enum_query_string_array** | [**list[str]**](str.md)| Query parameter enum test (string array) | [optional] 
- **enum_query_string** | **str**| Query parameter enum test (string) | [optional] [default to &#39;-efg&#39;]
+ **enum_query_string** | **str**| Query parameter enum test (string) | [optional] [default to &quot;-efg&quot;]
  **enum_query_integer** | **int**| Query parameter enum test (double) | [optional] 
  **enum_query_double** | **float**| Query parameter enum test (double) | [optional] 
- **enum_form_string_array** | [**list[str]**](str.md)| Form parameter enum test (string array) | [optional] [default to &#39;$&#39;]
- **enum_form_string** | **str**| Form parameter enum test (string) | [optional] [default to &#39;-efg&#39;]
+ **enum_form_string_array** | [**list[str]**](str.md)| Form parameter enum test (string array) | [optional] [default to &quot;$&quot;]
+ **enum_form_string** | **str**| Form parameter enum test (string) | [optional] [default to &quot;-efg&quot;]
 
 ### Return type
 

--- a/samples/openapi3/client/petstore/python/docs/Foo.md
+++ b/samples/openapi3/client/petstore/python/docs/Foo.md
@@ -3,7 +3,7 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**bar** | **str** |  | [optional] [default to 'bar']
+**bar** | **str** |  | [optional] [default to "bar"]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/openapi3/client/petstore/python/docs/InlineObject2.md
+++ b/samples/openapi3/client/petstore/python/docs/InlineObject2.md
@@ -4,7 +4,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **enum_form_string_array** | **list[str]** | Form parameter enum test (string array) | [optional] 
-**enum_form_string** | **str** | Form parameter enum test (string) | [optional] [default to '-efg']
+**enum_form_string** | **str** | Form parameter enum test (string) | [optional] [default to Enum_form_stringEnum._EFG]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/openapi3/client/petstore/python/petstore_api/models/animal.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/animal.py
@@ -47,7 +47,7 @@ class Animal(object):
         'Cat': 'Cat'
     }
 
-    def __init__(self, class_name=None, color='red', local_vars_configuration=None):  # noqa: E501
+    def __init__(self, class_name=None, color="red", local_vars_configuration=None):  # noqa: E501
         """Animal - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
             local_vars_configuration = Configuration()

--- a/samples/openapi3/client/petstore/python/petstore_api/models/category.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/category.py
@@ -42,7 +42,7 @@ class Category(object):
         'name': 'name'
     }
 
-    def __init__(self, id=None, name='default-name', local_vars_configuration=None):  # noqa: E501
+    def __init__(self, id=None, name="default-name", local_vars_configuration=None):  # noqa: E501
         """Category - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
             local_vars_configuration = Configuration()

--- a/samples/openapi3/client/petstore/python/petstore_api/models/foo.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/foo.py
@@ -40,7 +40,7 @@ class Foo(object):
         'bar': 'bar'
     }
 
-    def __init__(self, bar='bar', local_vars_configuration=None):  # noqa: E501
+    def __init__(self, bar="bar", local_vars_configuration=None):  # noqa: E501
         """Foo - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
             local_vars_configuration = Configuration()

--- a/samples/openapi3/client/petstore/python/petstore_api/models/inline_object2.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/inline_object2.py
@@ -42,7 +42,7 @@ class InlineObject2(object):
         'enum_form_string': 'enum_form_string'
     }
 
-    def __init__(self, enum_form_string_array=None, enum_form_string='-efg', local_vars_configuration=None):  # noqa: E501
+    def __init__(self, enum_form_string_array=None, enum_form_string=Enum_form_stringEnum._EFG, local_vars_configuration=None):  # noqa: E501
         """InlineObject2 - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
             local_vars_configuration = Configuration()

--- a/samples/server/petstore/php-slim4/lib/Model/EnumClass.php
+++ b/samples/server/petstore/php-slim4/lib/Model/EnumClass.php
@@ -30,8 +30,8 @@ class EnumClass implements ModelInterface
     private const MODEL_SCHEMA = <<<'SCHEMA'
 {
   "type" : "string",
-  "enum" : [ "_abc", "-efg", "(xyz)" ],
-  "default" : "-efg"
+  "default" : "-efg",
+  "enum" : [ "_abc", "-efg", "(xyz)" ]
 }
 SCHEMA;
 


### PR DESCRIPTION
Wrap the default and example value string literals using double quotes (instead of single quote) to avoid the need to escape any embedded single quotes and also to avoid any invalid syntax errors due to delimiter collision in the generated test code.

Also:
- Modified 1 test.
- Added 1 test.

### Open Issues

If merged, this will resolve #5981 

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
@taxpon (2017/07) @frol (2017/07) @mbohlool (2017/07) @cbornet (2017/09) @kenjones-cisco (2017/11) @tomplus (2018/10) @Jyhess (2019/01) @slash-arun (2019/11) @spacether (2019/11)
