### PR TITLE
fixes duplicate property generation in Implementing class of OneOf

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/OneOfImplementorAdditionalData.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/OneOfImplementorAdditionalData.java
@@ -79,6 +79,11 @@ public class OneOfImplementorAdditionalData {
             for (CodegenProperty v : m.vars) {
                 omitAdding.add(v.baseName);
             }
+            // also skip the variables inherited from heirarchy of parents
+            for (CodegenProperty v : m.allVars) {
+                omitAdding.add(v.baseName);
+            }
+
         }
         for (CodegenProperty v : toAdd) {
             if (!omitAdding.contains(v.baseName)) {


### PR DESCRIPTION
Fixes a scenario where having `OneOf` in the schema with objects that inherit from hierarchy of parents can cause duplicate properties to be generated when flattening out properties in the struct.
This change also omits the inherited properties.

cc @bkabrda 

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [ ] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
