### PR TITLE
Added Allianz Technolgy

### DIFF
--- a/README.md
+++ b/README.md
@@ -567,6 +567,7 @@ Here are some companies/projects (alphabetical order) using OpenAPI Generator in
 
 - [Adaptant Solutions AG](https://www.adaptant.io/)
 - [Agoda](https://www.agoda.com/)
+- [Allianz](https://www.allianz.com)
 - [Angular.Schule](https://angular.schule/)
 - [Australia and New Zealand Banking Group (ANZ)](http://www.anz.com/)
 - [ASKUL](https://www.askul.co.jp)


### PR DESCRIPTION
Adding Allianz Technology, the service provider subsidiary of Allianz SE, as company who is using OpenAPI generator.

