### PR TITLE
typescript-fetch: Make "Index" a reserved word

### DIFF
--- a/docs/generators/typescript-fetch.md
+++ b/docs/generators/typescript-fetch.md
@@ -76,6 +76,7 @@ sidebar_label: typescript-fetch
 <li>HTTPHeaders</li>
 <li>HTTPMethod</li>
 <li>HTTPQuery</li>
+<li>Index</li>
 <li>JSONApiResponse</li>
 <li>Middleware</li>
 <li>ModelPropertyNaming</li>

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptFetchClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptFetchClientCodegen.java
@@ -312,6 +312,9 @@ public class TypeScriptFetchClientCodegen extends AbstractTypeScriptClientCodege
         this.reservedWords.add("VoidApiResponse");
         this.reservedWords.add("BlobApiResponse");
         this.reservedWords.add("TextApiResponse");
+        // "Index" would create a file "Index.ts" which on case insensitive filesystems
+        // would override our "index.js" file
+        this.reservedWords.add("Index");
     }
 
     private boolean getUseSingleRequestParameter() {


### PR DESCRIPTION
Some APIs have a model called "Index" which would create a file
"Index.ts" which would override "index.ts" on case-insensitive file
systems (e.g. macOS, some Windows versions). Make "Index" a reserved
word to prevent this clash.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist

- [ X ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ X ] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [ X ] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [ X ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [ X ] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
