### PR TITLE
[typescript-rxjs] restore prototype inheritance for clone & its clients

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-rxjs/runtime.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-rxjs/runtime.mustache
@@ -61,7 +61,7 @@ export class BaseAPI {
         this.middleware = configuration.middleware;
     }
 
-    withMiddleware = (middlewares: Middleware[]) => {
+    withMiddleware = (middlewares: Middleware[]): this => {
         const next = this.clone();
         next.middleware = next.middleware.concat(middlewares);
         return next;
@@ -121,7 +121,7 @@ export class BaseAPI {
      * Create a shallow clone of `this` by constructing a new instance
      * and then shallow cloning data members.
      */
-    private clone = (): BaseAPI =>
+    private clone = (): this =>
         Object.assign(Object.create(Object.getPrototypeOf(this)), this);
 }
 

--- a/modules/openapi-generator/src/main/resources/typescript-rxjs/runtime.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-rxjs/runtime.mustache
@@ -35,7 +35,7 @@ export class Configuration {
     }
 
     get apiKey(): ((name: string) => string) | undefined {
-        const apiKey = this.configuration.apiKey;
+        const { apiKey } = this.configuration;
         if (!apiKey) {
             return undefined;
         }
@@ -43,7 +43,7 @@ export class Configuration {
     }
 
     get accessToken(): ((name: string, scopes?: string[]) => string) | undefined {
-        const accessToken = this.configuration.accessToken;
+        const { accessToken } = this.configuration;
         if (!accessToken) {
             return undefined;
         }

--- a/samples/client/petstore/typescript-rxjs/builds/default/runtime.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/default/runtime.ts
@@ -46,7 +46,7 @@ export class Configuration {
     }
 
     get apiKey(): ((name: string) => string) | undefined {
-        const apiKey = this.configuration.apiKey;
+        const { apiKey } = this.configuration;
         if (!apiKey) {
             return undefined;
         }
@@ -54,7 +54,7 @@ export class Configuration {
     }
 
     get accessToken(): ((name: string, scopes?: string[]) => string) | undefined {
-        const accessToken = this.configuration.accessToken;
+        const { accessToken } = this.configuration;
         if (!accessToken) {
             return undefined;
         }

--- a/samples/client/petstore/typescript-rxjs/builds/default/runtime.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/default/runtime.ts
@@ -72,7 +72,7 @@ export class BaseAPI {
         this.middleware = configuration.middleware;
     }
 
-    withMiddleware = (middlewares: Middleware[]) => {
+    withMiddleware = (middlewares: Middleware[]): this => {
         const next = this.clone();
         next.middleware = next.middleware.concat(middlewares);
         return next;
@@ -132,7 +132,7 @@ export class BaseAPI {
      * Create a shallow clone of `this` by constructing a new instance
      * and then shallow cloning data members.
      */
-    private clone = (): BaseAPI =>
+    private clone = (): this =>
         Object.assign(Object.create(Object.getPrototypeOf(this)), this);
 }
 

--- a/samples/client/petstore/typescript-rxjs/builds/es6-target/runtime.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/es6-target/runtime.ts
@@ -46,7 +46,7 @@ export class Configuration {
     }
 
     get apiKey(): ((name: string) => string) | undefined {
-        const apiKey = this.configuration.apiKey;
+        const { apiKey } = this.configuration;
         if (!apiKey) {
             return undefined;
         }
@@ -54,7 +54,7 @@ export class Configuration {
     }
 
     get accessToken(): ((name: string, scopes?: string[]) => string) | undefined {
-        const accessToken = this.configuration.accessToken;
+        const { accessToken } = this.configuration;
         if (!accessToken) {
             return undefined;
         }

--- a/samples/client/petstore/typescript-rxjs/builds/es6-target/runtime.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/es6-target/runtime.ts
@@ -72,7 +72,7 @@ export class BaseAPI {
         this.middleware = configuration.middleware;
     }
 
-    withMiddleware = (middlewares: Middleware[]) => {
+    withMiddleware = (middlewares: Middleware[]): this => {
         const next = this.clone();
         next.middleware = next.middleware.concat(middlewares);
         return next;
@@ -132,7 +132,7 @@ export class BaseAPI {
      * Create a shallow clone of `this` by constructing a new instance
      * and then shallow cloning data members.
      */
-    private clone = (): BaseAPI =>
+    private clone = (): this =>
         Object.assign(Object.create(Object.getPrototypeOf(this)), this);
 }
 

--- a/samples/client/petstore/typescript-rxjs/builds/with-interfaces/runtime.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/with-interfaces/runtime.ts
@@ -46,7 +46,7 @@ export class Configuration {
     }
 
     get apiKey(): ((name: string) => string) | undefined {
-        const apiKey = this.configuration.apiKey;
+        const { apiKey } = this.configuration;
         if (!apiKey) {
             return undefined;
         }
@@ -54,7 +54,7 @@ export class Configuration {
     }
 
     get accessToken(): ((name: string, scopes?: string[]) => string) | undefined {
-        const accessToken = this.configuration.accessToken;
+        const { accessToken } = this.configuration;
         if (!accessToken) {
             return undefined;
         }

--- a/samples/client/petstore/typescript-rxjs/builds/with-interfaces/runtime.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/with-interfaces/runtime.ts
@@ -72,7 +72,7 @@ export class BaseAPI {
         this.middleware = configuration.middleware;
     }
 
-    withMiddleware = (middlewares: Middleware[]) => {
+    withMiddleware = (middlewares: Middleware[]): this => {
         const next = this.clone();
         next.middleware = next.middleware.concat(middlewares);
         return next;
@@ -132,7 +132,7 @@ export class BaseAPI {
      * Create a shallow clone of `this` by constructing a new instance
      * and then shallow cloning data members.
      */
-    private clone = (): BaseAPI =>
+    private clone = (): this =>
         Object.assign(Object.create(Object.getPrototypeOf(this)), this);
 }
 

--- a/samples/client/petstore/typescript-rxjs/builds/with-npm-version/runtime.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/with-npm-version/runtime.ts
@@ -46,7 +46,7 @@ export class Configuration {
     }
 
     get apiKey(): ((name: string) => string) | undefined {
-        const apiKey = this.configuration.apiKey;
+        const { apiKey } = this.configuration;
         if (!apiKey) {
             return undefined;
         }
@@ -54,7 +54,7 @@ export class Configuration {
     }
 
     get accessToken(): ((name: string, scopes?: string[]) => string) | undefined {
-        const accessToken = this.configuration.accessToken;
+        const { accessToken } = this.configuration;
         if (!accessToken) {
             return undefined;
         }

--- a/samples/client/petstore/typescript-rxjs/builds/with-npm-version/runtime.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/with-npm-version/runtime.ts
@@ -72,7 +72,7 @@ export class BaseAPI {
         this.middleware = configuration.middleware;
     }
 
-    withMiddleware = (middlewares: Middleware[]) => {
+    withMiddleware = (middlewares: Middleware[]): this => {
         const next = this.clone();
         next.middleware = next.middleware.concat(middlewares);
         return next;
@@ -132,7 +132,7 @@ export class BaseAPI {
      * Create a shallow clone of `this` by constructing a new instance
      * and then shallow cloning data members.
      */
-    private clone = (): BaseAPI =>
+    private clone = (): this =>
         Object.assign(Object.create(Object.getPrototypeOf(this)), this);
 }
 


### PR DESCRIPTION
This reverts (by improving) a change by @denyo in #4250, which I spoke to him in [the review comment](https://github.com/OpenAPITools/openapi-generator/pull/4250#pullrequestreview-395647328). In my opinion, if this change is accepted, it should be adopted by the rest of typescript templates.

- previously clone() and its clients in the BaseAPI class were generic
- with removal of the generic argument, these methods became unavailable
  to the API classes inheriting from BaseAPI
- original generic was imprecise, as these are not statics
- return type of `this` is the correct notation

Additionally, @denyo [requested](https://github.com/OpenAPITools/openapi-generator/pull/6001#discussion_r412200918) I add some of the changes he has PRed in #5465 to avoid future conflict. I agree with the destructuring change and have included it. I've [left a couple of comments](https://github.com/OpenAPITools/openapi-generator/pull/5465#pullrequestreview-398535535) in his PR with my take on the ternary usage.

NB: Apologies for force pushes, the local environment has created a flawed starting point.
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

cc @TiFu (2017/07) @taxpon (2017/07) @sebastianhaas (2017/07) @kenisteward (2017/07) @Vrolijkx (2017/09) @macjohnny (2018/01) @topce (2018/10) @akehir (2019/07) @petejohansonxo (2019/11) @amakhrov (2020/02)