### PR TITLE
typescript-fetch: Escape operation-id if clashing with model names

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptFetchClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptFetchClientCodegen.java
@@ -235,7 +235,22 @@ public class TypeScriptFetchClientCodegen extends AbstractTypeScriptClientCodege
         this.updateOperationParameterEnumInformation(operations);
         this.addOperationObjectResponseInformation(operations);
         this.addOperationPrefixParameterInterfacesInformation(operations);
+        this.escapeOperationIds(operations);
         return operations;
+    }
+
+    private void escapeOperationIds(Map<String, Object> operations) {
+        Map<String, Object> _operations = (Map<String, Object>) operations.get("operations");
+        List<CodegenOperation> operationList = (List<CodegenOperation>) _operations.get("operation");
+        for (CodegenOperation op : operationList) {
+            String param = op.operationIdCamelCase + "Request";
+            if (op.imports.contains(param)) {
+                // we import a model with the same name as the generated operation, escape it
+                op.operationIdCamelCase += "Operation";
+                op.operationIdLowerCase += "operation";
+                op.operationIdSnakeCase += "_operation";
+            }
+        }
     }
 
     private void addOperationModelImportInfomation(Map<String, Object> operations) {


### PR DESCRIPTION
A model import might clash with an operation when badly named. Append a "Operation" to the name to disambiguate and make the code compil.e

Closes #6002

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist

- [ X ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ X ] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [ X ] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [ X ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [ X ] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
