### PR TITLE
When withXml=false we shouldn't add the jaxb imports

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/microprofile/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/microprofile/pojo.mustache
@@ -1,3 +1,4 @@
+{{#withXml}}
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlAccessType;
@@ -5,6 +6,7 @@ import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.XmlEnum;
 import javax.xml.bind.annotation.XmlEnumValue;
+{{/withXml}}
 import javax.json.bind.annotation.JsonbProperty;
 
 {{#withXml}}

--- a/samples/client/petstore/java/microprofile-rest-client/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/microprofile-rest-client/src/main/java/org/openapitools/client/model/Category.java
@@ -25,13 +25,6 @@
 package org.openapitools.client.model;
 
 
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlType;
-import javax.xml.bind.annotation.XmlEnum;
-import javax.xml.bind.annotation.XmlEnumValue;
 import javax.json.bind.annotation.JsonbProperty;
 
 /**

--- a/samples/client/petstore/java/microprofile-rest-client/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/microprofile-rest-client/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -25,13 +25,6 @@
 package org.openapitools.client.model;
 
 
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlType;
-import javax.xml.bind.annotation.XmlEnum;
-import javax.xml.bind.annotation.XmlEnumValue;
 import javax.json.bind.annotation.JsonbProperty;
 
 /**

--- a/samples/client/petstore/java/microprofile-rest-client/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/microprofile-rest-client/src/main/java/org/openapitools/client/model/Order.java
@@ -26,13 +26,6 @@ package org.openapitools.client.model;
 
 import java.util.Date;
 
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlType;
-import javax.xml.bind.annotation.XmlEnum;
-import javax.xml.bind.annotation.XmlEnumValue;
 import javax.json.bind.annotation.JsonbProperty;
 
 /**

--- a/samples/client/petstore/java/microprofile-rest-client/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/microprofile-rest-client/src/main/java/org/openapitools/client/model/Pet.java
@@ -29,13 +29,6 @@ import java.util.List;
 import org.openapitools.client.model.Category;
 import org.openapitools.client.model.Tag;
 
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlType;
-import javax.xml.bind.annotation.XmlEnum;
-import javax.xml.bind.annotation.XmlEnumValue;
 import javax.json.bind.annotation.JsonbProperty;
 
 /**

--- a/samples/client/petstore/java/microprofile-rest-client/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/microprofile-rest-client/src/main/java/org/openapitools/client/model/Tag.java
@@ -25,13 +25,6 @@
 package org.openapitools.client.model;
 
 
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlType;
-import javax.xml.bind.annotation.XmlEnum;
-import javax.xml.bind.annotation.XmlEnumValue;
 import javax.json.bind.annotation.JsonbProperty;
 
 /**

--- a/samples/client/petstore/java/microprofile-rest-client/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/microprofile-rest-client/src/main/java/org/openapitools/client/model/User.java
@@ -25,13 +25,6 @@
 package org.openapitools.client.model;
 
 
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlType;
-import javax.xml.bind.annotation.XmlEnum;
-import javax.xml.bind.annotation.XmlEnumValue;
 import javax.json.bind.annotation.JsonbProperty;
 
 /**


### PR DESCRIPTION
When users are just dealing with json and set withXml=false jaxb (Java Api XML binding) imports are not needed.