### PR TITLE
[Python experimental] Add __setattr__ function to ensure signing_info.host is the same as configuration.host when the user assigns signing info

### DIFF
--- a/modules/openapi-generator/src/main/resources/python/configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/python/configuration.mustache
@@ -272,7 +272,7 @@ class Configuration(object):
         return result
 
     def __setattr__(self, name, value):
-        self.__dict__[name] = value
+        object.__setattr__(self, name, value)
 {{#hasHttpSignatureMethods}}
         if name == "signing_info" and value is not None:
             # Ensure the host paramater from signing info is the same as

--- a/modules/openapi-generator/src/main/resources/python/configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/python/configuration.mustache
@@ -271,6 +271,15 @@ class Configuration(object):
         result.debug = self.debug
         return result
 
+    def __setattr__(self, name, value):
+        self.__dict__[name] = value
+{{#hasHttpSignatureMethods}}
+        if name == "signing_info" and value is not None:
+            # Ensure the host paramater from signing info is the same as
+            # Configuration.host.
+            value.host = self.host
+{{/hasHttpSignatureMethods}}
+
     @classmethod
     def set_default(cls, default):
         """Set default instance of configuration.

--- a/samples/client/petstore/python-asyncio/petstore_api/configuration.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/configuration.py
@@ -195,6 +195,9 @@ class Configuration(object):
         result.debug = self.debug
         return result
 
+    def __setattr__(self, name, value):
+        object.__setattr__(self, name, value)
+
     @classmethod
     def set_default(cls, default):
         """Set default instance of configuration.

--- a/samples/client/petstore/python-experimental/petstore_api/configuration.py
+++ b/samples/client/petstore/python-experimental/petstore_api/configuration.py
@@ -200,7 +200,7 @@ class Configuration(object):
         return result
 
     def __setattr__(self, name, value):
-        self.__dict__[name] = value
+        object.__setattr__(self, name, value)
 
     @classmethod
     def set_default(cls, default):

--- a/samples/client/petstore/python-experimental/petstore_api/configuration.py
+++ b/samples/client/petstore/python-experimental/petstore_api/configuration.py
@@ -199,6 +199,9 @@ class Configuration(object):
         result.debug = self.debug
         return result
 
+    def __setattr__(self, name, value):
+        self.__dict__[name] = value
+
     @classmethod
     def set_default(cls, default):
         """Set default instance of configuration.

--- a/samples/client/petstore/python-tornado/petstore_api/configuration.py
+++ b/samples/client/petstore/python-tornado/petstore_api/configuration.py
@@ -199,6 +199,9 @@ class Configuration(object):
         result.debug = self.debug
         return result
 
+    def __setattr__(self, name, value):
+        object.__setattr__(self, name, value)
+
     @classmethod
     def set_default(cls, default):
         """Set default instance of configuration.

--- a/samples/client/petstore/python/petstore_api/configuration.py
+++ b/samples/client/petstore/python/petstore_api/configuration.py
@@ -199,6 +199,9 @@ class Configuration(object):
         result.debug = self.debug
         return result
 
+    def __setattr__(self, name, value):
+        object.__setattr__(self, name, value)
+
     @classmethod
     def set_default(cls, default):
         """Set default instance of configuration.

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/configuration.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/configuration.py
@@ -246,6 +246,13 @@ class Configuration(object):
         result.debug = self.debug
         return result
 
+    def __setattr__(self, name, value):
+        self.__dict__[name] = value
+        if name == "signing_info" and value is not None:
+            # Ensure the host paramater from signing info is the same as
+            # Configuration.host.
+            value.host = self.host
+
     @classmethod
     def set_default(cls, default):
         """Set default instance of configuration.

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/configuration.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/configuration.py
@@ -247,7 +247,7 @@ class Configuration(object):
         return result
 
     def __setattr__(self, name, value):
-        self.__dict__[name] = value
+        object.__setattr__(self, name, value)
         if name == "signing_info" and value is not None:
             # Ensure the host paramater from signing info is the same as
             # Configuration.host.

--- a/samples/openapi3/client/petstore/python/petstore_api/configuration.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/configuration.py
@@ -199,6 +199,9 @@ class Configuration(object):
         result.debug = self.debug
         return result
 
+    def __setattr__(self, name, value):
+        object.__setattr__(self, name, value)
+
     @classmethod
     def set_default(cls, default):
         """Set default instance of configuration.


### PR DESCRIPTION
To initialize the configuration, developers can write the following code:
```python
configuration = Configuration(
   host = "http://example.com",
   configuration.signing_info = openapi.HttpSigningConfiguration(
     signing_scheme = intersight.signing.SCHEME_RSA_SHA256,
     ...
   )
)
```

Or, for whatever reason, they can first create the config object, then assign the signing info:
```python
configuration = Configuration(
   host = "http://example.com"
)
...
configuration.signing_info = openapi.HttpSigningConfiguration(
   signing_scheme = intersight.signing.SCHEME_RSA_SHA256,
   ...
)
```

In the first case, the host parameter is automatically passed from the Configuration object to the HttpSigningConfiguration. In the second case, the HttpSigningConfiguration.host was None. This PR fixes the problem for the second case, i.e. the developer should not have to set the parameter twice.

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
