### PR TITLE
Add test for allOf without object type

### DIFF
--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
@@ -620,6 +620,11 @@ public class DefaultCodegenTest {
         CodegenModel superboyModel = codegen.fromModel("SuperBoy", superboySchema);
         Assert.assertEquals(superboyModel.parent, null);
         Assert.assertEquals(superboyModel.allParents, null);
+
+        Schema superbabySchema = openAPI.getComponents().getSchemas().get("SuperBaby");
+        CodegenModel superbabyModel = codegen.fromModel("SuperBaby", superbabySchema);
+        Assert.assertEquals(superbabyModel.parent, null);
+        Assert.assertEquals(superbabyModel.allParents, null);
     }
 
     @Test

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
@@ -611,16 +611,19 @@ public class DefaultCodegenTest {
 
         codegen.setOpenAPI(openAPI);
 
+        // to test allOf with double refs
         Schema supermanSchema = openAPI.getComponents().getSchemas().get("SuperMan");
         CodegenModel supermanModel = codegen.fromModel("SuperMan", supermanSchema);
         Assert.assertEquals(supermanModel.parent, null);
         Assert.assertEquals(supermanModel.allParents, null);
 
+        // to test allOf with single ref
         Schema superboySchema = openAPI.getComponents().getSchemas().get("SuperBoy");
         CodegenModel superboyModel = codegen.fromModel("SuperBoy", superboySchema);
         Assert.assertEquals(superboyModel.parent, null);
         Assert.assertEquals(superboyModel.allParents, null);
 
+        // to test allOf with single ref and no "type: object" in the (last) inline schema
         Schema superbabySchema = openAPI.getComponents().getSchemas().get("SuperBaby");
         CodegenModel superbabyModel = codegen.fromModel("SuperBaby", superbabySchema);
         Assert.assertEquals(superbabyModel.parent, null);

--- a/modules/openapi-generator/src/test/resources/3_0/allOf_composition.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/allOf_composition.yaml
@@ -26,6 +26,16 @@ paths:
                 $ref: "#/components/schemas/SuperMan"
 components:
   schemas:
+    SuperBaby: # to test single ref (Human) only
+      allOf:
+      - $ref: '#/components/schemas/Human'
+      - required: # without type: object
+          - level
+        properties:
+          gender:
+            type: string
+          age:
+            type: integer 
     SuperBoy: # to test single ref (Human) only
       allOf:
       - $ref: '#/components/schemas/Human'


### PR DESCRIPTION
Add tests for allOf without object type in line schema to ensure there's no inheritance.

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [ ] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
