### PR TITLE
Add generator cli to docker-compose stack

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,3 +16,21 @@ services:
       - ./website/sidebars.json:/app/website/sidebars.json
       - ./website/siteConfig.js:/app/website/siteConfig.js
     working_dir: /app/website
+
+  generator:
+    image: maven:3-jdk-8
+    environment:
+        - GEN_UID=1000
+        - GEN_GID=1000
+        - GEN_DIR=/openapi-generator
+        - MAVEN_CONFIG=/var/maven/.m2
+        - 'MAVEN_OPTS=-Dhttps.protocols=TLSv1.2 -Dmaven.repo.local=/var/maven/.m2/repository -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=WARN -Dorg.slf4j.simpleLogger.showDateTime=true -Djava.awt.headless=true'
+    volumes:
+      - .:/openapi-generator
+      - ./CI/run-in-docker-settings.xml:/var/maven/.m2/settings.xml
+      - mvndata:/var/maven/.m2/repository/
+    entrypoint: /openapi-generator/docker-entrypoint.sh
+    working_dir: /openapi-generator
+
+volumes:
+  mvndata:


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

This is mainly for the development process, otherwise you can use the generator from the official docker image.
The usage of the script `run-in-docker.sh` can be done via docker-compose.
```
docker-compose run generator mvn package
docker-compose run generator generate \
            -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml \
            -g typescript-server \
            -o /openapi-generator/out
```
Additionally, there is some permission management so that generated projects can have appropriate permissions and also maven repository directory can be written.

<!-- Please check the completed items below -->
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [ ] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [ ] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
