### PR TITLE
[cpp][Qt5] Add the ability to pass QNetworkAccessManager as a parameter 

### DIFF
--- a/modules/openapi-generator/src/main/resources/cpp-qt5-client/HttpRequest.cpp.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-client/HttpRequest.cpp.mustache
@@ -44,12 +44,13 @@ void {{prefix}}HttpRequestInput::add_file(QString variable_name, QString local_f
     files.append(file);
 }
 
-{{prefix}}HttpRequestWorker::{{prefix}}HttpRequestWorker(QObject *parent)
-    : QObject(parent), manager(nullptr), timeOutTimer(this), isResponseCompressionEnabled(false), isRequestCompressionEnabled(false), httpResponseCode(-1) {
+{{prefix}}HttpRequestWorker::{{prefix}}HttpRequestWorker(QObject *parent, QNetworkAccessManager *_manager)
+    : QObject(parent), manager(_manager), timeOutTimer(this), isResponseCompressionEnabled(false), isRequestCompressionEnabled(false), httpResponseCode(-1) {
     qsrand(QDateTime::currentDateTime().toTime_t());
-    manager = new QNetworkAccessManager(this);
+    if (manager == nullptr) {
+        manager = new QNetworkAccessManager(this);
+    }
     workingDirectory = QDir::currentPath();
-    connect(manager, &QNetworkAccessManager::finished, this, &{{prefix}}HttpRequestWorker::on_manager_finished);
     timeOutTimer.setSingleShot(true);
 }
 
@@ -347,7 +348,7 @@ void {{prefix}}HttpRequestWorker::execute({{prefix}}HttpRequestInput *input) {
         reply = manager->deleteResource(request);
     } else {
 #if (QT_VERSION >= 0x050800)
-        manager->sendCustomRequest(request, input->http_method.toLatin1(), request_content);
+        reply = manager->sendCustomRequest(request, input->http_method.toLatin1(), request_content);
 #else
         QBuffer *buffer = new QBuffer;
         buffer->setData(request_content);
@@ -356,6 +357,12 @@ void {{prefix}}HttpRequestWorker::execute({{prefix}}HttpRequestInput *input) {
         reply = manager->sendCustomRequest(request, input->http_method.toLatin1(), buffer);
         buffer->setParent(reply);
 #endif
+    }
+    if (reply != nullptr) {
+        reply->setParent(this);
+        connect(reply, &QNetworkReply::finished, [this, reply] {
+            on_manager_finished(reply);
+        });
     }
     if (timeOutTimer.interval() > 0) {
         QObject::connect(&timeOutTimer, &QTimer::timeout, [=]() { on_manager_timeout(reply); });

--- a/modules/openapi-generator/src/main/resources/cpp-qt5-client/HttpRequest.cpp.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-client/HttpRequest.cpp.mustache
@@ -361,16 +361,18 @@ void {{prefix}}HttpRequestWorker::execute({{prefix}}HttpRequestInput *input) {
     if (reply != nullptr) {
         reply->setParent(this);
         connect(reply, &QNetworkReply::finished, [this, reply] {
-            on_manager_finished(reply);
+            on_reply_finished(reply);
         });
     }
     if (timeOutTimer.interval() > 0) {
-        QObject::connect(&timeOutTimer, &QTimer::timeout, [=]() { on_manager_timeout(reply); });
+        QObject::connect(&timeOutTimer, &QTimer::timeout, [this, reply] {
+            on_reply_timeout(reply);
+        });
         timeOutTimer.start();
     }
 }
 
-void {{prefix}}HttpRequestWorker::on_manager_finished(QNetworkReply *reply) {
+void {{prefix}}HttpRequestWorker::on_reply_finished(QNetworkReply *reply) {
     bool codeSts = false;
     if(timeOutTimer.isActive()) {
         QObject::disconnect(&timeOutTimer, &QTimer::timeout, nullptr, nullptr);
@@ -394,11 +396,11 @@ void {{prefix}}HttpRequestWorker::on_manager_finished(QNetworkReply *reply) {
     emit on_execution_finished(this);
 }
 
-void {{prefix}}HttpRequestWorker::on_manager_timeout(QNetworkReply *reply) {
+void {{prefix}}HttpRequestWorker::on_reply_timeout(QNetworkReply *reply) {
     error_type = QNetworkReply::TimeoutError;
     response = "";
     error_str = "Timed out waiting for response";
-    disconnect(manager, nullptr, nullptr, nullptr);
+    disconnect(reply, nullptr, nullptr, nullptr);
     reply->abort();
     reply->deleteLater();
     emit on_execution_finished(this);

--- a/modules/openapi-generator/src/main/resources/cpp-qt5-client/HttpRequest.h.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-client/HttpRequest.h.mustache
@@ -87,13 +87,11 @@ private:
     bool isRequestCompressionEnabled;
     int  httpResponseCode;
 
-    void on_manager_timeout(QNetworkReply *reply);
+    void on_reply_timeout(QNetworkReply *reply);
+    void on_reply_finished(QNetworkReply *reply);
     void process_response(QNetworkReply *reply);
     QByteArray decompress(const QByteArray& data);
     QByteArray compress(const QByteArray& input, int level, {{prefix}}CompressionType compressType);
- 
-private slots:
-    void on_manager_finished(QNetworkReply *reply);
 };
 
 {{#cppNamespaceDeclarations}}

--- a/modules/openapi-generator/src/main/resources/cpp-qt5-client/HttpRequest.h.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-client/HttpRequest.h.mustache
@@ -50,7 +50,7 @@ class {{prefix}}HttpRequestWorker : public QObject {
     Q_OBJECT
 
 public:
-    explicit {{prefix}}HttpRequestWorker(QObject *parent = nullptr);
+    explicit {{prefix}}HttpRequestWorker(QObject *parent = nullptr, QNetworkAccessManager *manager = nullptr);
     virtual ~{{prefix}}HttpRequestWorker();
 
     QByteArray response;

--- a/modules/openapi-generator/src/main/resources/cpp-qt5-client/api-body.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-client/api-body.mustache
@@ -15,6 +15,7 @@ namespace {{this}} {
       _port(port),
       _basePath(basePath),
       _timeOut(timeOut),
+      _manager(nullptr),
       isResponseCompressionEnabled(false),
       isRequestCompressionEnabled(false) {}
 
@@ -43,6 +44,10 @@ void {{classname}}::setTimeOut(const int timeOut) {
 
 void {{classname}}::setWorkingDirectory(const QString &path) {
     _workingDirectory = path;
+}
+
+void {{classname}}::setNetworkAccessManager(QNetworkAccessManager* manager) {
+    _manager = manager;  
 }
 
 void {{classname}}::addHeaders(const QString &key, const QString &value) {
@@ -120,7 +125,7 @@ void {{classname}}::{{nickname}}({{#allParams}}const {{{dataType}}} &{{paramName
         }
     }
 {{/collectionFormat}}{{/queryParams}}
-    {{prefix}}HttpRequestWorker *worker = new {{prefix}}HttpRequestWorker(this);
+    {{prefix}}HttpRequestWorker *worker = new {{prefix}}HttpRequestWorker(this, _manager);
     worker->setTimeOut(_timeOut);
     worker->setWorkingDirectory(_workingDirectory);{{#contentCompression}}
     worker->setResponseCompressionEnabled(isResponseCompressionEnabled);

--- a/modules/openapi-generator/src/main/resources/cpp-qt5-client/api-header.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-client/api-header.mustache
@@ -8,6 +8,7 @@
 {{/imports}}
 
 #include <QObject>
+#include <QNetworkAccessManager>
 
 {{#cppNamespaceDeclarations}}
 namespace {{this}} {
@@ -26,6 +27,7 @@ public:
     void setBasePath(const QString &basePath);
     void setTimeOut(const int timeOut);
     void setWorkingDirectory(const QString &path);
+    void setNetworkAccessManager(QNetworkAccessManager* manager);
     void addHeaders(const QString &key, const QString &value);
     void enableRequestCompression();
     void enableResponseCompression();
@@ -39,6 +41,7 @@ private:
     QString _basePath;
     int _timeOut;
     QString _workingDirectory;
+    QNetworkAccessManager* _manager;
     QMap<QString, QString> defaultHeaders;
     bool isResponseCompressionEnabled;
     bool isRequestCompressionEnabled;

--- a/samples/client/petstore/cpp-qt5/client/PFXHttpRequest.h
+++ b/samples/client/petstore/cpp-qt5/client/PFXHttpRequest.h
@@ -58,7 +58,7 @@ class PFXHttpRequestWorker : public QObject {
     Q_OBJECT
 
 public:
-    explicit PFXHttpRequestWorker(QObject *parent = nullptr);
+    explicit PFXHttpRequestWorker(QObject *parent = nullptr, QNetworkAccessManager *manager = nullptr);
     virtual ~PFXHttpRequestWorker();
 
     QByteArray response;

--- a/samples/client/petstore/cpp-qt5/client/PFXHttpRequest.h
+++ b/samples/client/petstore/cpp-qt5/client/PFXHttpRequest.h
@@ -95,13 +95,11 @@ private:
     bool isRequestCompressionEnabled;
     int  httpResponseCode;
 
-    void on_manager_timeout(QNetworkReply *reply);
+    void on_reply_timeout(QNetworkReply *reply);
+    void on_reply_finished(QNetworkReply *reply);
     void process_response(QNetworkReply *reply);
     QByteArray decompress(const QByteArray& data);
     QByteArray compress(const QByteArray& input, int level, PFXCompressionType compressType);
- 
-private slots:
-    void on_manager_finished(QNetworkReply *reply);
 };
 
 } // namespace test_namespace

--- a/samples/client/petstore/cpp-qt5/client/PFXPetApi.cpp
+++ b/samples/client/petstore/cpp-qt5/client/PFXPetApi.cpp
@@ -23,6 +23,7 @@ PFXPetApi::PFXPetApi(const QString &scheme, const QString &host, int port, const
       _port(port),
       _basePath(basePath),
       _timeOut(timeOut),
+      _manager(nullptr),
       isResponseCompressionEnabled(false),
       isRequestCompressionEnabled(false) {}
 
@@ -53,6 +54,10 @@ void PFXPetApi::setWorkingDirectory(const QString &path) {
     _workingDirectory = path;
 }
 
+void PFXPetApi::setNetworkAccessManager(QNetworkAccessManager* manager) {
+    _manager = manager;  
+}
+
 void PFXPetApi::addHeaders(const QString &key, const QString &value) {
     defaultHeaders.insert(key, value);
 }
@@ -77,7 +82,7 @@ void PFXPetApi::addPet(const PFXPet &body) {
                            .arg(_basePath)
                            .arg("/pet");
 
-    PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this);
+    PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this, _manager);
     worker->setTimeOut(_timeOut);
     worker->setWorkingDirectory(_workingDirectory);
     PFXHttpRequestInput input(fullPath, "POST");
@@ -125,7 +130,7 @@ void PFXPetApi::deletePet(const qint64 &pet_id, const QString &api_key) {
     pet_idPathParam.append("petId").append("}");
     fullPath.replace(pet_idPathParam, QUrl::toPercentEncoding(::test_namespace::toStringValue(pet_id)));
 
-    PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this);
+    PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this, _manager);
     worker->setTimeOut(_timeOut);
     worker->setWorkingDirectory(_workingDirectory);
     PFXHttpRequestInput input(fullPath, "DELETE");
@@ -209,7 +214,7 @@ void PFXPetApi::findPetsByStatus(const QList<QString> &status) {
         }
     }
 
-    PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this);
+    PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this, _manager);
     worker->setTimeOut(_timeOut);
     worker->setWorkingDirectory(_workingDirectory);
     PFXHttpRequestInput input(fullPath, "GET");
@@ -299,7 +304,7 @@ void PFXPetApi::findPetsByTags(const QList<QString> &tags) {
         }
     }
 
-    PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this);
+    PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this, _manager);
     worker->setTimeOut(_timeOut);
     worker->setWorkingDirectory(_workingDirectory);
     PFXHttpRequestInput input(fullPath, "GET");
@@ -354,7 +359,7 @@ void PFXPetApi::getPetById(const qint64 &pet_id) {
     pet_idPathParam.append("petId").append("}");
     fullPath.replace(pet_idPathParam, QUrl::toPercentEncoding(::test_namespace::toStringValue(pet_id)));
 
-    PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this);
+    PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this, _manager);
     worker->setTimeOut(_timeOut);
     worker->setWorkingDirectory(_workingDirectory);
     PFXHttpRequestInput input(fullPath, "GET");
@@ -397,7 +402,7 @@ void PFXPetApi::updatePet(const PFXPet &body) {
                            .arg(_basePath)
                            .arg("/pet");
 
-    PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this);
+    PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this, _manager);
     worker->setTimeOut(_timeOut);
     worker->setWorkingDirectory(_workingDirectory);
     PFXHttpRequestInput input(fullPath, "PUT");
@@ -445,7 +450,7 @@ void PFXPetApi::updatePetWithForm(const qint64 &pet_id, const QString &name, con
     pet_idPathParam.append("petId").append("}");
     fullPath.replace(pet_idPathParam, QUrl::toPercentEncoding(::test_namespace::toStringValue(pet_id)));
 
-    PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this);
+    PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this, _manager);
     worker->setTimeOut(_timeOut);
     worker->setWorkingDirectory(_workingDirectory);
     PFXHttpRequestInput input(fullPath, "POST");
@@ -492,7 +497,7 @@ void PFXPetApi::uploadFile(const qint64 &pet_id, const QString &additional_metad
     pet_idPathParam.append("petId").append("}");
     fullPath.replace(pet_idPathParam, QUrl::toPercentEncoding(::test_namespace::toStringValue(pet_id)));
 
-    PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this);
+    PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this, _manager);
     worker->setTimeOut(_timeOut);
     worker->setWorkingDirectory(_workingDirectory);
     PFXHttpRequestInput input(fullPath, "POST");

--- a/samples/client/petstore/cpp-qt5/client/PFXPetApi.h
+++ b/samples/client/petstore/cpp-qt5/client/PFXPetApi.h
@@ -20,6 +20,7 @@
 #include <QString>
 
 #include <QObject>
+#include <QNetworkAccessManager>
 
 namespace test_namespace {
 
@@ -36,6 +37,7 @@ public:
     void setBasePath(const QString &basePath);
     void setTimeOut(const int timeOut);
     void setWorkingDirectory(const QString &path);
+    void setNetworkAccessManager(QNetworkAccessManager* manager);
     void addHeaders(const QString &key, const QString &value);
     void enableRequestCompression();
     void enableResponseCompression();
@@ -56,6 +58,7 @@ private:
     QString _basePath;
     int _timeOut;
     QString _workingDirectory;
+    QNetworkAccessManager* _manager;
     QMap<QString, QString> defaultHeaders;
     bool isResponseCompressionEnabled;
     bool isRequestCompressionEnabled;

--- a/samples/client/petstore/cpp-qt5/client/PFXStoreApi.cpp
+++ b/samples/client/petstore/cpp-qt5/client/PFXStoreApi.cpp
@@ -23,6 +23,7 @@ PFXStoreApi::PFXStoreApi(const QString &scheme, const QString &host, int port, c
       _port(port),
       _basePath(basePath),
       _timeOut(timeOut),
+      _manager(nullptr),
       isResponseCompressionEnabled(false),
       isRequestCompressionEnabled(false) {}
 
@@ -53,6 +54,10 @@ void PFXStoreApi::setWorkingDirectory(const QString &path) {
     _workingDirectory = path;
 }
 
+void PFXStoreApi::setNetworkAccessManager(QNetworkAccessManager* manager) {
+    _manager = manager;  
+}
+
 void PFXStoreApi::addHeaders(const QString &key, const QString &value) {
     defaultHeaders.insert(key, value);
 }
@@ -80,7 +85,7 @@ void PFXStoreApi::deleteOrder(const QString &order_id) {
     order_idPathParam.append("orderId").append("}");
     fullPath.replace(order_idPathParam, QUrl::toPercentEncoding(::test_namespace::toStringValue(order_id)));
 
-    PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this);
+    PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this, _manager);
     worker->setTimeOut(_timeOut);
     worker->setWorkingDirectory(_workingDirectory);
     PFXHttpRequestInput input(fullPath, "DELETE");
@@ -122,7 +127,7 @@ void PFXStoreApi::getInventory() {
                            .arg(_basePath)
                            .arg("/store/inventory");
 
-    PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this);
+    PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this, _manager);
     worker->setTimeOut(_timeOut);
     worker->setWorkingDirectory(_workingDirectory);
     PFXHttpRequestInput input(fullPath, "GET");
@@ -177,7 +182,7 @@ void PFXStoreApi::getOrderById(const qint64 &order_id) {
     order_idPathParam.append("orderId").append("}");
     fullPath.replace(order_idPathParam, QUrl::toPercentEncoding(::test_namespace::toStringValue(order_id)));
 
-    PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this);
+    PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this, _manager);
     worker->setTimeOut(_timeOut);
     worker->setWorkingDirectory(_workingDirectory);
     PFXHttpRequestInput input(fullPath, "GET");
@@ -220,7 +225,7 @@ void PFXStoreApi::placeOrder(const PFXOrder &body) {
                            .arg(_basePath)
                            .arg("/store/order");
 
-    PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this);
+    PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this, _manager);
     worker->setTimeOut(_timeOut);
     worker->setWorkingDirectory(_workingDirectory);
     PFXHttpRequestInput input(fullPath, "POST");

--- a/samples/client/petstore/cpp-qt5/client/PFXStoreApi.h
+++ b/samples/client/petstore/cpp-qt5/client/PFXStoreApi.h
@@ -19,6 +19,7 @@
 #include <QString>
 
 #include <QObject>
+#include <QNetworkAccessManager>
 
 namespace test_namespace {
 
@@ -35,6 +36,7 @@ public:
     void setBasePath(const QString &basePath);
     void setTimeOut(const int timeOut);
     void setWorkingDirectory(const QString &path);
+    void setNetworkAccessManager(QNetworkAccessManager* manager);
     void addHeaders(const QString &key, const QString &value);
     void enableRequestCompression();
     void enableResponseCompression();
@@ -51,6 +53,7 @@ private:
     QString _basePath;
     int _timeOut;
     QString _workingDirectory;
+    QNetworkAccessManager* _manager;
     QMap<QString, QString> defaultHeaders;
     bool isResponseCompressionEnabled;
     bool isRequestCompressionEnabled;

--- a/samples/client/petstore/cpp-qt5/client/PFXUserApi.cpp
+++ b/samples/client/petstore/cpp-qt5/client/PFXUserApi.cpp
@@ -23,6 +23,7 @@ PFXUserApi::PFXUserApi(const QString &scheme, const QString &host, int port, con
       _port(port),
       _basePath(basePath),
       _timeOut(timeOut),
+      _manager(nullptr),
       isResponseCompressionEnabled(false),
       isRequestCompressionEnabled(false) {}
 
@@ -53,6 +54,10 @@ void PFXUserApi::setWorkingDirectory(const QString &path) {
     _workingDirectory = path;
 }
 
+void PFXUserApi::setNetworkAccessManager(QNetworkAccessManager* manager) {
+    _manager = manager;  
+}
+
 void PFXUserApi::addHeaders(const QString &key, const QString &value) {
     defaultHeaders.insert(key, value);
 }
@@ -77,7 +82,7 @@ void PFXUserApi::createUser(const PFXUser &body) {
                            .arg(_basePath)
                            .arg("/user");
 
-    PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this);
+    PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this, _manager);
     worker->setTimeOut(_timeOut);
     worker->setWorkingDirectory(_workingDirectory);
     PFXHttpRequestInput input(fullPath, "POST");
@@ -122,7 +127,7 @@ void PFXUserApi::createUsersWithArrayInput(const QList<PFXUser> &body) {
                            .arg(_basePath)
                            .arg("/user/createWithArray");
 
-    PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this);
+    PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this, _manager);
     worker->setTimeOut(_timeOut);
     worker->setWorkingDirectory(_workingDirectory);
     PFXHttpRequestInput input(fullPath, "POST");
@@ -168,7 +173,7 @@ void PFXUserApi::createUsersWithListInput(const QList<PFXUser> &body) {
                            .arg(_basePath)
                            .arg("/user/createWithList");
 
-    PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this);
+    PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this, _manager);
     worker->setTimeOut(_timeOut);
     worker->setWorkingDirectory(_workingDirectory);
     PFXHttpRequestInput input(fullPath, "POST");
@@ -217,7 +222,7 @@ void PFXUserApi::deleteUser(const QString &username) {
     usernamePathParam.append("username").append("}");
     fullPath.replace(usernamePathParam, QUrl::toPercentEncoding(::test_namespace::toStringValue(username)));
 
-    PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this);
+    PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this, _manager);
     worker->setTimeOut(_timeOut);
     worker->setWorkingDirectory(_workingDirectory);
     PFXHttpRequestInput input(fullPath, "DELETE");
@@ -262,7 +267,7 @@ void PFXUserApi::getUserByName(const QString &username) {
     usernamePathParam.append("username").append("}");
     fullPath.replace(usernamePathParam, QUrl::toPercentEncoding(::test_namespace::toStringValue(username)));
 
-    PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this);
+    PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this, _manager);
     worker->setTimeOut(_timeOut);
     worker->setWorkingDirectory(_workingDirectory);
     PFXHttpRequestInput input(fullPath, "GET");
@@ -317,7 +322,7 @@ void PFXUserApi::loginUser(const QString &username, const QString &password) {
         fullPath.append("?");
     fullPath.append(QUrl::toPercentEncoding("password")).append("=").append(QUrl::toPercentEncoding(::test_namespace::toStringValue(password)));
 
-    PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this);
+    PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this, _manager);
     worker->setTimeOut(_timeOut);
     worker->setWorkingDirectory(_workingDirectory);
     PFXHttpRequestInput input(fullPath, "GET");
@@ -361,7 +366,7 @@ void PFXUserApi::logoutUser() {
                            .arg(_basePath)
                            .arg("/user/logout");
 
-    PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this);
+    PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this, _manager);
     worker->setTimeOut(_timeOut);
     worker->setWorkingDirectory(_workingDirectory);
     PFXHttpRequestInput input(fullPath, "GET");
@@ -406,7 +411,7 @@ void PFXUserApi::updateUser(const QString &username, const PFXUser &body) {
     usernamePathParam.append("username").append("}");
     fullPath.replace(usernamePathParam, QUrl::toPercentEncoding(::test_namespace::toStringValue(username)));
 
-    PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this);
+    PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this, _manager);
     worker->setTimeOut(_timeOut);
     worker->setWorkingDirectory(_workingDirectory);
     PFXHttpRequestInput input(fullPath, "PUT");

--- a/samples/client/petstore/cpp-qt5/client/PFXUserApi.h
+++ b/samples/client/petstore/cpp-qt5/client/PFXUserApi.h
@@ -19,6 +19,7 @@
 #include <QString>
 
 #include <QObject>
+#include <QNetworkAccessManager>
 
 namespace test_namespace {
 
@@ -35,6 +36,7 @@ public:
     void setBasePath(const QString &basePath);
     void setTimeOut(const int timeOut);
     void setWorkingDirectory(const QString &path);
+    void setNetworkAccessManager(QNetworkAccessManager* manager);
     void addHeaders(const QString &key, const QString &value);
     void enableRequestCompression();
     void enableResponseCompression();
@@ -55,6 +57,7 @@ private:
     QString _basePath;
     int _timeOut;
     QString _workingDirectory;
+    QNetworkAccessManager* _manager;
     QMap<QString, QString> defaultHeaders;
     bool isResponseCompressionEnabled;
     bool isRequestCompressionEnabled;


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

Problem:
Every api call created new connection to server. It happens because _OAIHttpRequestWorker_ creates new _QNetworkAccessManager_ every time.

Solution:
Passing _QNetworkAccessManager_ as parameter. It allows QT reusing an opened early connection if it possible (if server support keep alive connections and if there is no active request).
This change is optional and should not affect existing code.
Also I change connect to signal _QNetworkReply::finished_ instead of _QNetworkAccessManager::finished_. 


@ravinikam  @stkrwork @etherealjoy  @martindelille  @muttleyxd 

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
