### PR TITLE
Add Http signature authentication test to fake petstore spec

### DIFF
--- a/modules/openapi-generator-maven-plugin/examples/spring.xml
+++ b/modules/openapi-generator-maven-plugin/examples/spring.xml
@@ -20,7 +20,7 @@
 				<groupId>org.openapitools</groupId>
 				<artifactId>openapi-generator-maven-plugin</artifactId>
 				<!-- RELEASE_VERSION -->
-				<version>4.2.2-SNAPSHOT</version>
+				<version>4.3.1-SNAPSHOT</version>
 				<!-- /RELEASE_VERSION -->
 				<executions>
 					<execution>

--- a/modules/openapi-generator/src/test/resources/3_0/petstore-with-fake-endpoints-models-for-testing.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/petstore-with-fake-endpoints-models-for-testing.yaml
@@ -1093,6 +1093,32 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HealthCheckResult'
+  /fake/http-signature-test:
+    get:
+      tags:
+        - fake
+      summary: test http signature authentication
+      operationId: fake-http-signature-test
+      parameters:
+        - name: query_1 
+          in: query
+          description: query parameter
+          required: optional 
+          schema:
+            type: string
+        - name: header_1 
+          in: header 
+          description: header parameter
+          required: optional 
+          schema:
+            type: string
+      security:
+        - http_signature_test
+      requestBody:
+        $ref: '#/components/requestBodies/Pet'
+      responses:
+        200:
+          description: The instance started successfully
 servers:
   - url: 'http://{server}.swagger.io:{port}/v2'
     description: petstore server
@@ -1168,6 +1194,9 @@ components:
       type: http
       scheme: bearer
       bearerFormat: JWT
+    http_signature_test:
+      type: http
+      scheme: signature 
   schemas:
     Foo:
       type: object

--- a/samples/openapi3/client/petstore/go/go-petstore/README.md
+++ b/samples/openapi3/client/petstore/go/go-petstore/README.md
@@ -35,6 +35,7 @@ Class | Method | HTTP request | Description
 *AnotherFakeApi* | [**Call123TestSpecialTags**](docs/AnotherFakeApi.md#call123testspecialtags) | **Patch** /another-fake/dummy | To test special tags
 *DefaultApi* | [**FooGet**](docs/DefaultApi.md#fooget) | **Get** /foo | 
 *FakeApi* | [**FakeHealthGet**](docs/FakeApi.md#fakehealthget) | **Get** /fake/health | Health check endpoint
+*FakeApi* | [**FakeHttpSignatureTest**](docs/FakeApi.md#fakehttpsignaturetest) | **Get** /fake/http-signature-test | test http signature authentication
 *FakeApi* | [**FakeOuterBooleanSerialize**](docs/FakeApi.md#fakeouterbooleanserialize) | **Post** /fake/outer/boolean | 
 *FakeApi* | [**FakeOuterCompositeSerialize**](docs/FakeApi.md#fakeoutercompositeserialize) | **Post** /fake/outer/composite | 
 *FakeApi* | [**FakeOuterNumberSerialize**](docs/FakeApi.md#fakeouternumberserialize) | **Post** /fake/outer/number | 
@@ -175,6 +176,21 @@ r, err := client.Service.Operation(auth, args)
 
 
 ## http_basic_test
+
+- **Type**: HTTP basic authentication
+
+Example
+
+```golang
+auth := context.WithValue(context.Background(), sw.ContextBasicAuth, sw.BasicAuth{
+    UserName: "username",
+    Password: "password",
+})
+r, err := client.Service.Operation(auth, args)
+```
+
+
+## http_signature_test
 
 - **Type**: HTTP basic authentication
 

--- a/samples/openapi3/client/petstore/go/go-petstore/api/openapi.yaml
+++ b/samples/openapi3/client/petstore/go/go-petstore/api/openapi.yaml
@@ -1169,6 +1169,35 @@ paths:
       summary: Health check endpoint
       tags:
       - fake
+  /fake/http-signature-test:
+    get:
+      operationId: fake-http-signature-test
+      parameters:
+      - description: query parameter
+        explode: true
+        in: query
+        name: query_1
+        required: false
+        schema:
+          type: string
+        style: form
+      - description: header parameter
+        explode: false
+        in: header
+        name: header_1
+        required: false
+        schema:
+          type: string
+        style: simple
+      requestBody:
+        $ref: '#/components/requestBodies/Pet'
+      responses:
+        "200":
+          description: The instance started successfully
+      security: []
+      summary: test http signature authentication
+      tags:
+      - fake
 components:
   requestBodies:
     UserArray:
@@ -2056,4 +2085,7 @@ components:
     bearer_test:
       bearerFormat: JWT
       scheme: bearer
+      type: http
+    http_signature_test:
+      scheme: signature
       type: http

--- a/samples/openapi3/client/petstore/go/go-petstore/api_fake.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/api_fake.go
@@ -101,6 +101,87 @@ func (a *FakeApiService) FakeHealthGet(ctx _context.Context) (HealthCheckResult,
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
+// FakeHttpSignatureTestOpts Optional parameters for the method 'FakeHttpSignatureTest'
+type FakeHttpSignatureTestOpts struct {
+    Query1 optional.String
+    Header1 optional.String
+}
+
+/*
+FakeHttpSignatureTest test http signature authentication
+ * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ * @param pet Pet object that needs to be added to the store
+ * @param optional nil or *FakeHttpSignatureTestOpts - Optional Parameters:
+ * @param "Query1" (optional.String) -  query parameter
+ * @param "Header1" (optional.String) -  header parameter
+*/
+func (a *FakeApiService) FakeHttpSignatureTest(ctx _context.Context, pet Pet, localVarOptionals *FakeHttpSignatureTestOpts) (*_nethttp.Response, error) {
+	var (
+		localVarHTTPMethod   = _nethttp.MethodGet
+		localVarPostBody     interface{}
+		localVarFormFileName string
+		localVarFileName     string
+		localVarFileBytes    []byte
+	)
+
+	// create path and map variables
+	localVarPath := a.client.cfg.BasePath + "/fake/http-signature-test"
+	localVarHeaderParams := make(map[string]string)
+	localVarQueryParams := _neturl.Values{}
+	localVarFormParams := _neturl.Values{}
+
+	if localVarOptionals != nil && localVarOptionals.Query1.IsSet() {
+		localVarQueryParams.Add("query_1", parameterToString(localVarOptionals.Query1.Value(), ""))
+	}
+	// to determine the Content-Type header
+	localVarHTTPContentTypes := []string{"application/json", "application/xml"}
+
+	// set Content-Type header
+	localVarHTTPContentType := selectHeaderContentType(localVarHTTPContentTypes)
+	if localVarHTTPContentType != "" {
+		localVarHeaderParams["Content-Type"] = localVarHTTPContentType
+	}
+
+	// to determine the Accept header
+	localVarHTTPHeaderAccepts := []string{}
+
+	// set Accept header
+	localVarHTTPHeaderAccept := selectHeaderAccept(localVarHTTPHeaderAccepts)
+	if localVarHTTPHeaderAccept != "" {
+		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
+	}
+	if localVarOptionals != nil && localVarOptionals.Header1.IsSet() {
+		localVarHeaderParams["header_1"] = parameterToString(localVarOptionals.Header1.Value(), "")
+	}
+	// body params
+	localVarPostBody = &pet
+	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	localVarHTTPResponse, err := a.client.callAPI(r)
+	if err != nil || localVarHTTPResponse == nil {
+		return localVarHTTPResponse, err
+	}
+
+	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarHTTPResponse.Body.Close()
+	if err != nil {
+		return localVarHTTPResponse, err
+	}
+
+	if localVarHTTPResponse.StatusCode >= 300 {
+		newErr := GenericOpenAPIError{
+			body:  localVarBody,
+			error: localVarHTTPResponse.Status,
+		}
+		return localVarHTTPResponse, newErr
+	}
+
+	return localVarHTTPResponse, nil
+}
+
 // FakeOuterBooleanSerializeOpts Optional parameters for the method 'FakeOuterBooleanSerialize'
 type FakeOuterBooleanSerializeOpts struct {
     Body optional.Bool

--- a/samples/openapi3/client/petstore/go/go-petstore/docs/FakeApi.md
+++ b/samples/openapi3/client/petstore/go/go-petstore/docs/FakeApi.md
@@ -5,6 +5,7 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 Method | HTTP request | Description
 ------------- | ------------- | -------------
 [**FakeHealthGet**](FakeApi.md#FakeHealthGet) | **Get** /fake/health | Health check endpoint
+[**FakeHttpSignatureTest**](FakeApi.md#FakeHttpSignatureTest) | **Get** /fake/http-signature-test | test http signature authentication
 [**FakeOuterBooleanSerialize**](FakeApi.md#FakeOuterBooleanSerialize) | **Post** /fake/outer/boolean | 
 [**FakeOuterCompositeSerialize**](FakeApi.md#FakeOuterCompositeSerialize) | **Post** /fake/outer/composite | 
 [**FakeOuterNumberSerialize**](FakeApi.md#FakeOuterNumberSerialize) | **Post** /fake/outer/number | 
@@ -43,6 +44,50 @@ No authorization required
 
 - **Content-Type**: Not defined
 - **Accept**: application/json
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints)
+[[Back to Model list]](../README.md#documentation-for-models)
+[[Back to README]](../README.md)
+
+
+## FakeHttpSignatureTest
+
+> FakeHttpSignatureTest(ctx, pet, optional)
+
+test http signature authentication
+
+### Required Parameters
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+**ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
+**pet** | [**Pet**](Pet.md)| Pet object that needs to be added to the store | 
+ **optional** | ***FakeHttpSignatureTestOpts** | optional parameters | nil if no parameters
+
+### Optional Parameters
+
+Optional parameters are passed through a pointer to a FakeHttpSignatureTestOpts struct
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+
+ **query1** | **optional.String**| query parameter | 
+ **header1** | **optional.String**| header parameter | 
+
+### Return type
+
+ (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: application/json, application/xml
+- **Accept**: Not defined
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints)
 [[Back to Model list]](../README.md#documentation-for-models)

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/README.md
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/README.md
@@ -86,6 +86,7 @@ Class | Method | HTTP request | Description
 *AnotherFakeApi* | [**call123TestSpecialTags**](docs/Api/AnotherFakeApi.md#call123testspecialtags) | **PATCH** /another-fake/dummy | To test special tags
 *DefaultApi* | [**fooGet**](docs/Api/DefaultApi.md#fooget) | **GET** /foo | 
 *FakeApi* | [**fakeHealthGet**](docs/Api/FakeApi.md#fakehealthget) | **GET** /fake/health | Health check endpoint
+*FakeApi* | [**fakeHttpSignatureTest**](docs/Api/FakeApi.md#fakehttpsignaturetest) | **GET** /fake/http-signature-test | test http signature authentication
 *FakeApi* | [**fakeOuterBooleanSerialize**](docs/Api/FakeApi.md#fakeouterbooleanserialize) | **POST** /fake/outer/boolean | 
 *FakeApi* | [**fakeOuterCompositeSerialize**](docs/Api/FakeApi.md#fakeoutercompositeserialize) | **POST** /fake/outer/composite | 
 *FakeApi* | [**fakeOuterNumberSerialize**](docs/Api/FakeApi.md#fakeouternumberserialize) | **POST** /fake/outer/number | 
@@ -211,6 +212,11 @@ Class | Method | HTTP request | Description
 
 
 - **Type**: HTTP basic authentication
+
+
+
+## http_signature_test
+
 
 
 

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/docs/Api/FakeApi.md
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/docs/Api/FakeApi.md
@@ -5,6 +5,7 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 Method | HTTP request | Description
 ------------- | ------------- | -------------
 [**fakeHealthGet**](FakeApi.md#fakeHealthGet) | **GET** /fake/health | Health check endpoint
+[**fakeHttpSignatureTest**](FakeApi.md#fakeHttpSignatureTest) | **GET** /fake/http-signature-test | test http signature authentication
 [**fakeOuterBooleanSerialize**](FakeApi.md#fakeOuterBooleanSerialize) | **POST** /fake/outer/boolean | 
 [**fakeOuterCompositeSerialize**](FakeApi.md#fakeOuterCompositeSerialize) | **POST** /fake/outer/composite | 
 [**fakeOuterNumberSerialize**](FakeApi.md#fakeOuterNumberSerialize) | **POST** /fake/outer/number | 
@@ -65,6 +66,63 @@ No authorization required
 
 - **Content-Type**: Not defined
 - **Accept**: application/json
+
+[[Back to top]](#) [[Back to API list]](../../README.md#documentation-for-api-endpoints)
+[[Back to Model list]](../../README.md#documentation-for-models)
+[[Back to README]](../../README.md)
+
+
+## fakeHttpSignatureTest
+
+> fakeHttpSignatureTest($pet, $query_1, $header_1)
+
+test http signature authentication
+
+### Example
+
+```php
+<?php
+require_once(__DIR__ . '/vendor/autoload.php');
+
+
+$apiInstance = new OpenAPI\Client\Api\FakeApi(
+    // If you want use custom http client, pass your client which implements `GuzzleHttp\ClientInterface`.
+    // This is optional, `GuzzleHttp\Client` will be used as default.
+    new GuzzleHttp\Client()
+);
+$pet = new \OpenAPI\Client\Model\Pet(); // \OpenAPI\Client\Model\Pet | Pet object that needs to be added to the store
+$query_1 = 'query_1_example'; // string | query parameter
+$header_1 = 'header_1_example'; // string | header parameter
+
+try {
+    $apiInstance->fakeHttpSignatureTest($pet, $query_1, $header_1);
+} catch (Exception $e) {
+    echo 'Exception when calling FakeApi->fakeHttpSignatureTest: ', $e->getMessage(), PHP_EOL;
+}
+?>
+```
+
+### Parameters
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **pet** | [**\OpenAPI\Client\Model\Pet**](../Model/Pet.md)| Pet object that needs to be added to the store |
+ **query_1** | **string**| query parameter | [optional]
+ **header_1** | **string**| header parameter | [optional]
+
+### Return type
+
+void (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: application/json, application/xml
+- **Accept**: Not defined
 
 [[Back to top]](#) [[Back to API list]](../../README.md#documentation-for-api-endpoints)
 [[Back to Model list]](../../README.md#documentation-for-models)

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Api/FakeApi.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Api/FakeApi.php
@@ -370,6 +370,251 @@ class FakeApi
     }
 
     /**
+     * Operation fakeHttpSignatureTest
+     *
+     * test http signature authentication
+     *
+     * @param  \OpenAPI\Client\Model\Pet $pet Pet object that needs to be added to the store (required)
+     * @param  string $query_1 query parameter (optional)
+     * @param  string $header_1 header parameter (optional)
+     *
+     * @throws \OpenAPI\Client\ApiException on non-2xx response
+     * @throws \InvalidArgumentException
+     * @return void
+     */
+    public function fakeHttpSignatureTest($pet, $query_1 = null, $header_1 = null)
+    {
+        $this->fakeHttpSignatureTestWithHttpInfo($pet, $query_1, $header_1);
+    }
+
+    /**
+     * Operation fakeHttpSignatureTestWithHttpInfo
+     *
+     * test http signature authentication
+     *
+     * @param  \OpenAPI\Client\Model\Pet $pet Pet object that needs to be added to the store (required)
+     * @param  string $query_1 query parameter (optional)
+     * @param  string $header_1 header parameter (optional)
+     *
+     * @throws \OpenAPI\Client\ApiException on non-2xx response
+     * @throws \InvalidArgumentException
+     * @return array of null, HTTP status code, HTTP response headers (array of strings)
+     */
+    public function fakeHttpSignatureTestWithHttpInfo($pet, $query_1 = null, $header_1 = null)
+    {
+        $request = $this->fakeHttpSignatureTestRequest($pet, $query_1, $header_1);
+
+        try {
+            $options = $this->createHttpClientOption();
+            try {
+                $response = $this->client->send($request, $options);
+            } catch (RequestException $e) {
+                throw new ApiException(
+                    "[{$e->getCode()}] {$e->getMessage()}",
+                    $e->getCode(),
+                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
+                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                );
+            }
+
+            $statusCode = $response->getStatusCode();
+
+            if ($statusCode < 200 || $statusCode > 299) {
+                throw new ApiException(
+                    sprintf(
+                        '[%d] Error connecting to the API (%s)',
+                        $statusCode,
+                        $request->getUri()
+                    ),
+                    $statusCode,
+                    $response->getHeaders(),
+                    $response->getBody()
+                );
+            }
+
+            return [null, $statusCode, $response->getHeaders()];
+
+        } catch (ApiException $e) {
+            switch ($e->getCode()) {
+            }
+            throw $e;
+        }
+    }
+
+    /**
+     * Operation fakeHttpSignatureTestAsync
+     *
+     * test http signature authentication
+     *
+     * @param  \OpenAPI\Client\Model\Pet $pet Pet object that needs to be added to the store (required)
+     * @param  string $query_1 query parameter (optional)
+     * @param  string $header_1 header parameter (optional)
+     *
+     * @throws \InvalidArgumentException
+     * @return \GuzzleHttp\Promise\PromiseInterface
+     */
+    public function fakeHttpSignatureTestAsync($pet, $query_1 = null, $header_1 = null)
+    {
+        return $this->fakeHttpSignatureTestAsyncWithHttpInfo($pet, $query_1, $header_1)
+            ->then(
+                function ($response) {
+                    return $response[0];
+                }
+            );
+    }
+
+    /**
+     * Operation fakeHttpSignatureTestAsyncWithHttpInfo
+     *
+     * test http signature authentication
+     *
+     * @param  \OpenAPI\Client\Model\Pet $pet Pet object that needs to be added to the store (required)
+     * @param  string $query_1 query parameter (optional)
+     * @param  string $header_1 header parameter (optional)
+     *
+     * @throws \InvalidArgumentException
+     * @return \GuzzleHttp\Promise\PromiseInterface
+     */
+    public function fakeHttpSignatureTestAsyncWithHttpInfo($pet, $query_1 = null, $header_1 = null)
+    {
+        $returnType = '';
+        $request = $this->fakeHttpSignatureTestRequest($pet, $query_1, $header_1);
+
+        return $this->client
+            ->sendAsync($request, $this->createHttpClientOption())
+            ->then(
+                function ($response) use ($returnType) {
+                    return [null, $response->getStatusCode(), $response->getHeaders()];
+                },
+                function ($exception) {
+                    $response = $exception->getResponse();
+                    $statusCode = $response->getStatusCode();
+                    throw new ApiException(
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        $response->getBody()
+                    );
+                }
+            );
+    }
+
+    /**
+     * Create request for operation 'fakeHttpSignatureTest'
+     *
+     * @param  \OpenAPI\Client\Model\Pet $pet Pet object that needs to be added to the store (required)
+     * @param  string $query_1 query parameter (optional)
+     * @param  string $header_1 header parameter (optional)
+     *
+     * @throws \InvalidArgumentException
+     * @return \GuzzleHttp\Psr7\Request
+     */
+    protected function fakeHttpSignatureTestRequest($pet, $query_1 = null, $header_1 = null)
+    {
+        // verify the required parameter 'pet' is set
+        if ($pet === null || (is_array($pet) && count($pet) === 0)) {
+            throw new \InvalidArgumentException(
+                'Missing the required parameter $pet when calling fakeHttpSignatureTest'
+            );
+        }
+
+        $resourcePath = '/fake/http-signature-test';
+        $formParams = [];
+        $queryParams = [];
+        $headerParams = [];
+        $httpBody = '';
+        $multipart = false;
+
+        // query params
+        if ($query_1 !== null) {
+            if('form' === 'form' && is_array($query_1)) {
+                foreach($query_1 as $key => $value) {
+                    $queryParams[$key] = $value;
+                }
+            }
+            else {
+                $queryParams['query_1'] = $query_1;
+            }
+        }
+
+        // header params
+        if ($header_1 !== null) {
+            $headerParams['header_1'] = ObjectSerializer::toHeaderValue($header_1);
+        }
+
+
+        // body params
+        $_tempBody = null;
+        if (isset($pet)) {
+            $_tempBody = $pet;
+        }
+
+        if ($multipart) {
+            $headers = $this->headerSelector->selectHeadersForMultipart(
+                []
+            );
+        } else {
+            $headers = $this->headerSelector->selectHeaders(
+                [],
+                ['application/json', 'application/xml']
+            );
+        }
+
+        // for model (json/xml)
+        if (isset($_tempBody)) {
+            // $_tempBody is the method argument, if present
+            if ($headers['Content-Type'] === 'application/json') {
+                $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
+            } else {
+                $httpBody = $_tempBody;
+            }
+        } elseif (count($formParams) > 0) {
+            if ($multipart) {
+                $multipartContents = [];
+                foreach ($formParams as $formParamName => $formParamValue) {
+                    $multipartContents[] = [
+                        'name' => $formParamName,
+                        'contents' => $formParamValue
+                    ];
+                }
+                // for HTTP post (form)
+                $httpBody = new MultipartStream($multipartContents);
+
+            } elseif ($headers['Content-Type'] === 'application/json') {
+                $httpBody = \GuzzleHttp\json_encode($formParams);
+
+            } else {
+                // for HTTP post (form)
+                $httpBody = \GuzzleHttp\Psr7\build_query($formParams);
+            }
+        }
+
+
+        $defaultHeaders = [];
+        if ($this->config->getUserAgent()) {
+            $defaultHeaders['User-Agent'] = $this->config->getUserAgent();
+        }
+
+        $headers = array_merge(
+            $defaultHeaders,
+            $headerParams,
+            $headers
+        );
+
+        $query = \GuzzleHttp\Psr7\build_query($queryParams);
+        return new Request(
+            'GET',
+            $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
+            $headers,
+            $httpBody
+        );
+    }
+
+    /**
      * Operation fakeOuterBooleanSerialize
      *
      * @param  bool $body Input boolean as post body (optional)

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/test/Api/FakeApiTest.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/test/Api/FakeApiTest.php
@@ -83,6 +83,16 @@ class FakeApiTest extends TestCase
     }
 
     /**
+     * Test case for fakeHttpSignatureTest
+     *
+     * test http signature authentication.
+     *
+     */
+    public function testFakeHttpSignatureTest()
+    {
+    }
+
+    /**
      * Test case for fakeOuterBooleanSerialize
      *
      * .

--- a/samples/openapi3/client/petstore/python/README.md
+++ b/samples/openapi3/client/petstore/python/README.md
@@ -46,7 +46,7 @@ Please follow the [installation procedure](#installation--usage) and then run th
 
 ```python
 from __future__ import print_function
-
+import datetime
 import time
 import petstore_api
 from petstore_api.rest import ApiException
@@ -84,6 +84,7 @@ Class | Method | HTTP request | Description
 *AnotherFakeApi* | [**call_123_test_special_tags**](docs/AnotherFakeApi.md#call_123_test_special_tags) | **PATCH** /another-fake/dummy | To test special tags
 *DefaultApi* | [**foo_get**](docs/DefaultApi.md#foo_get) | **GET** /foo | 
 *FakeApi* | [**fake_health_get**](docs/FakeApi.md#fake_health_get) | **GET** /fake/health | Health check endpoint
+*FakeApi* | [**fake_http_signature_test**](docs/FakeApi.md#fake_http_signature_test) | **GET** /fake/http-signature-test | test http signature authentication
 *FakeApi* | [**fake_outer_boolean_serialize**](docs/FakeApi.md#fake_outer_boolean_serialize) | **POST** /fake/outer/boolean | 
 *FakeApi* | [**fake_outer_composite_serialize**](docs/FakeApi.md#fake_outer_composite_serialize) | **POST** /fake/outer/composite | 
 *FakeApi* | [**fake_outer_number_serialize**](docs/FakeApi.md#fake_outer_number_serialize) | **POST** /fake/outer/number | 
@@ -199,6 +200,10 @@ Class | Method | HTTP request | Description
 ## http_basic_test
 
 - **Type**: HTTP basic authentication
+
+
+## http_signature_test
+
 
 
 ## petstore_auth

--- a/samples/openapi3/client/petstore/python/docs/FakeApi.md
+++ b/samples/openapi3/client/petstore/python/docs/FakeApi.md
@@ -5,6 +5,7 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 Method | HTTP request | Description
 ------------- | ------------- | -------------
 [**fake_health_get**](FakeApi.md#fake_health_get) | **GET** /fake/health | Health check endpoint
+[**fake_http_signature_test**](FakeApi.md#fake_http_signature_test) | **GET** /fake/http-signature-test | test http signature authentication
 [**fake_outer_boolean_serialize**](FakeApi.md#fake_outer_boolean_serialize) | **POST** /fake/outer/boolean | 
 [**fake_outer_composite_serialize**](FakeApi.md#fake_outer_composite_serialize) | **POST** /fake/outer/composite | 
 [**fake_outer_number_serialize**](FakeApi.md#fake_outer_number_serialize) | **POST** /fake/outer/number | 
@@ -68,6 +69,69 @@ No authorization required
 
  - **Content-Type**: Not defined
  - **Accept**: application/json
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+**200** | The instance started successfully |  -  |
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+# **fake_http_signature_test**
+> fake_http_signature_test(pet, query_1=query_1, header_1=header_1)
+
+test http signature authentication
+
+### Example
+
+```python
+from __future__ import print_function
+import time
+import petstore_api
+from petstore_api.rest import ApiException
+from pprint import pprint
+# Defining the host is optional and defaults to http://petstore.swagger.io:80/v2
+# See configuration.py for a list of all supported configuration parameters.
+configuration = petstore_api.Configuration(
+    host = "http://petstore.swagger.io:80/v2"
+)
+
+
+# Enter a context with an instance of the API client
+with petstore_api.ApiClient() as api_client:
+    # Create an instance of the API class
+    api_instance = petstore_api.FakeApi(api_client)
+    pet = petstore_api.Pet() # Pet | Pet object that needs to be added to the store
+query_1 = 'query_1_example' # str | query parameter (optional)
+header_1 = 'header_1_example' # str | header parameter (optional)
+
+    try:
+        # test http signature authentication
+        api_instance.fake_http_signature_test(pet, query_1=query_1, header_1=header_1)
+    except ApiException as e:
+        print("Exception when calling FakeApi->fake_http_signature_test: %s\n" % e)
+```
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **pet** | [**Pet**](Pet.md)| Pet object that needs to be added to the store | 
+ **query_1** | **str**| query parameter | [optional] 
+ **header_1** | **str**| header parameter | [optional] 
+
+### Return type
+
+void (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: application/json, application/xml
+ - **Accept**: Not defined
 
 ### HTTP response details
 | Status code | Description | Response headers |

--- a/samples/openapi3/client/petstore/python/petstore_api/api/fake_api.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api/fake_api.py
@@ -139,6 +139,128 @@ class FakeApi(object):
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats)
 
+    def fake_http_signature_test(self, pet, **kwargs):  # noqa: E501
+        """test http signature authentication  # noqa: E501
+
+        This method makes a synchronous HTTP request by default. To make an
+        asynchronous HTTP request, please pass async_req=True
+        >>> thread = api.fake_http_signature_test(pet, async_req=True)
+        >>> result = thread.get()
+
+        :param async_req bool: execute request asynchronously
+        :param Pet pet: Pet object that needs to be added to the store (required)
+        :param str query_1: query parameter
+        :param str header_1: header parameter
+        :param _preload_content: if False, the urllib3.HTTPResponse object will
+                                 be returned without reading/decoding response
+                                 data. Default is True.
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :return: None
+                 If the method is called asynchronously,
+                 returns the request thread.
+        """
+        kwargs['_return_http_data_only'] = True
+        return self.fake_http_signature_test_with_http_info(pet, **kwargs)  # noqa: E501
+
+    def fake_http_signature_test_with_http_info(self, pet, **kwargs):  # noqa: E501
+        """test http signature authentication  # noqa: E501
+
+        This method makes a synchronous HTTP request by default. To make an
+        asynchronous HTTP request, please pass async_req=True
+        >>> thread = api.fake_http_signature_test_with_http_info(pet, async_req=True)
+        >>> result = thread.get()
+
+        :param async_req bool: execute request asynchronously
+        :param Pet pet: Pet object that needs to be added to the store (required)
+        :param str query_1: query parameter
+        :param str header_1: header parameter
+        :param _return_http_data_only: response data without head status code
+                                       and headers
+        :param _preload_content: if False, the urllib3.HTTPResponse object will
+                                 be returned without reading/decoding response
+                                 data. Default is True.
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :return: None
+                 If the method is called asynchronously,
+                 returns the request thread.
+        """
+
+        local_var_params = locals()
+
+        all_params = [
+            'pet',
+            'query_1',
+            'header_1'
+        ]
+        all_params.extend(
+            [
+                'async_req',
+                '_return_http_data_only',
+                '_preload_content',
+                '_request_timeout'
+            ]
+        )
+
+        for key, val in six.iteritems(local_var_params['kwargs']):
+            if key not in all_params:
+                raise ApiTypeError(
+                    "Got an unexpected keyword argument '%s'"
+                    " to method fake_http_signature_test" % key
+                )
+            local_var_params[key] = val
+        del local_var_params['kwargs']
+        # verify the required parameter 'pet' is set
+        if self.api_client.client_side_validation and ('pet' not in local_var_params or  # noqa: E501
+                                                        local_var_params['pet'] is None):  # noqa: E501
+            raise ApiValueError("Missing the required parameter `pet` when calling `fake_http_signature_test`")  # noqa: E501
+
+        collection_formats = {}
+
+        path_params = {}
+
+        query_params = []
+        if 'query_1' in local_var_params and local_var_params['query_1'] is not None:  # noqa: E501
+            query_params.append(('query_1', local_var_params['query_1']))  # noqa: E501
+
+        header_params = {}
+        if 'header_1' in local_var_params:
+            header_params['header_1'] = local_var_params['header_1']  # noqa: E501
+
+        form_params = []
+        local_var_files = {}
+
+        body_params = None
+        if 'pet' in local_var_params:
+            body_params = local_var_params['pet']
+        # HTTP header `Content-Type`
+        header_params['Content-Type'] = self.api_client.select_header_content_type(  # noqa: E501
+            ['application/json', 'application/xml'])  # noqa: E501
+
+        # Authentication setting
+        auth_settings = []  # noqa: E501
+
+        return self.api_client.call_api(
+            '/fake/http-signature-test', 'GET',
+            path_params,
+            query_params,
+            header_params,
+            body=body_params,
+            post_params=form_params,
+            files=local_var_files,
+            response_type=None,  # noqa: E501
+            auth_settings=auth_settings,
+            async_req=local_var_params.get('async_req'),
+            _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
+            _preload_content=local_var_params.get('_preload_content', True),
+            _request_timeout=local_var_params.get('_request_timeout'),
+            collection_formats=collection_formats)
+
     def fake_outer_boolean_serialize(self, **kwargs):  # noqa: E501
         """fake_outer_boolean_serialize  # noqa: E501
 

--- a/samples/openapi3/client/petstore/python/petstore_api/configuration.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/configuration.py
@@ -49,6 +49,8 @@ class Configuration(object):
       then all undeclared properties received by the server are injected into the
       additional properties map. In that case, there are undeclared properties, and
       nothing to discard.
+    :param signing_info: Configuration parameters for the HTTP signature security scheme.
+        Must be an instance of petstore_api.signing.HttpSigningConfiguration
 
     :Example:
 
@@ -86,6 +88,45 @@ conf = petstore_api.Configuration(
     password='the-password',
 )
 
+
+    HTTP Signature Authentication Example.
+    Given the following security scheme in the OpenAPI specification:
+      components:
+        securitySchemes:
+          http_basic_auth:
+            type: http
+            scheme: signature
+
+    Configure API client with HTTP signature authentication. Use the 'hs2019' signature scheme,
+    sign the HTTP requests with the RSA-SSA-PSS signature algorithm, and set the expiration time
+    of the signature to 5 minutes after the signature has been created.
+    Note you can use the constants defined in the petstore_api.signing module, and you can
+    also specify arbitrary HTTP headers to be included in the HTTP signature, except for the
+    'Authorization' header, which is used to carry the signature.
+
+    One may be tempted to sign all headers by default, but in practice it rarely works.
+    This is beccause explicit proxies, transparent proxies, TLS termination endpoints or
+    load balancers may add/modify/remove headers. Include the HTTP headers that you know
+    are not going to be modified in transit.
+
+conf = petstore_api.Configuration(
+    signing_info = petstore_api.signing.HttpSigningConfiguration(
+        key_id =                 'my-key-id',
+        private_key_path =       'rsa.pem',
+        signing_scheme =         petstore_api.signing.SCHEME_HS2019,
+        signing_algorithm =      petstore_api.signing.ALGORITHM_RSASSA_PSS,
+        signed_headers =         [petstore_api.signing.HEADER_REQUEST_TARGET,
+                                    petstore_api.signing.HEADER_CREATED,
+                                    petstore_api.signing.HEADER_EXPIRES,
+                                    petstore_api.signing.HEADER_HOST,
+                                    petstore_api.signing.HEADER_DATE,
+                                    petstore_api.signing.HEADER_DIGEST,
+                                    'Content-Type',
+                                    'User-Agent'
+                                    ],
+        signature_max_validity = datetime.timedelta(minutes=5)
+    )
+)
     """
 
     _default = None
@@ -94,6 +135,7 @@ conf = petstore_api.Configuration(
                  api_key=None, api_key_prefix=None,
                  username=None, password=None,
                  discard_unknown_keys=False,
+                 signing_info=None,
                  ):
         """Constructor
         """
@@ -124,6 +166,11 @@ conf = petstore_api.Configuration(
         """Password for HTTP basic authentication
         """
         self.discard_unknown_keys = discard_unknown_keys
+        if signing_info is not None:
+            signing_info.host = host
+        self.signing_info = signing_info
+        """The HTTP signing configuration
+        """
         self.access_token = None
         """access token for OAuth/Bearer
         """
@@ -205,6 +252,10 @@ conf = petstore_api.Configuration(
 
     def __setattr__(self, name, value):
         object.__setattr__(self, name, value)
+        if name == "signing_info" and value is not None:
+            # Ensure the host paramater from signing info is the same as
+            # Configuration.host.
+            value.host = self.host
 
     @classmethod
     def set_default(cls, default):
@@ -381,6 +432,13 @@ conf = petstore_api.Configuration(
                 'in': 'header',
                 'key': 'Authorization',
                 'value': self.get_basic_auth_token()
+            }
+        if self.signing_info is not None:
+            auth['http_signature_test'] = {
+                'type': 'http-signature',
+                'in': 'header',
+                'key': 'Authorization',
+                'value': None  # Signature headers are calculated for every HTTP request
             }
         if self.access_token is not None:
             auth['petstore_auth'] = {

--- a/samples/openapi3/client/petstore/ruby-faraday/README.md
+++ b/samples/openapi3/client/petstore/ruby-faraday/README.md
@@ -78,6 +78,7 @@ Class | Method | HTTP request | Description
 *Petstore::AnotherFakeApi* | [**call_123_test_special_tags**](docs/AnotherFakeApi.md#call_123_test_special_tags) | **PATCH** /another-fake/dummy | To test special tags
 *Petstore::DefaultApi* | [**foo_get**](docs/DefaultApi.md#foo_get) | **GET** /foo | 
 *Petstore::FakeApi* | [**fake_health_get**](docs/FakeApi.md#fake_health_get) | **GET** /fake/health | Health check endpoint
+*Petstore::FakeApi* | [**fake_http_signature_test**](docs/FakeApi.md#fake_http_signature_test) | **GET** /fake/http-signature-test | test http signature authentication
 *Petstore::FakeApi* | [**fake_outer_boolean_serialize**](docs/FakeApi.md#fake_outer_boolean_serialize) | **POST** /fake/outer/boolean | 
 *Petstore::FakeApi* | [**fake_outer_composite_serialize**](docs/FakeApi.md#fake_outer_composite_serialize) | **POST** /fake/outer/composite | 
 *Petstore::FakeApi* | [**fake_outer_number_serialize**](docs/FakeApi.md#fake_outer_number_serialize) | **POST** /fake/outer/number | 
@@ -192,6 +193,9 @@ Class | Method | HTTP request | Description
 ### http_basic_test
 
 - **Type**: HTTP basic authentication
+
+### http_signature_test
+
 
 ### petstore_auth
 

--- a/samples/openapi3/client/petstore/ruby-faraday/docs/FakeApi.md
+++ b/samples/openapi3/client/petstore/ruby-faraday/docs/FakeApi.md
@@ -5,6 +5,7 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 Method | HTTP request | Description
 ------------- | ------------- | -------------
 [**fake_health_get**](FakeApi.md#fake_health_get) | **GET** /fake/health | Health check endpoint
+[**fake_http_signature_test**](FakeApi.md#fake_http_signature_test) | **GET** /fake/http-signature-test | test http signature authentication
 [**fake_outer_boolean_serialize**](FakeApi.md#fake_outer_boolean_serialize) | **POST** /fake/outer/boolean | 
 [**fake_outer_composite_serialize**](FakeApi.md#fake_outer_composite_serialize) | **POST** /fake/outer/composite | 
 [**fake_outer_number_serialize**](FakeApi.md#fake_outer_number_serialize) | **POST** /fake/outer/number | 
@@ -60,6 +61,56 @@ No authorization required
 
 - **Content-Type**: Not defined
 - **Accept**: application/json
+
+
+## fake_http_signature_test
+
+> fake_http_signature_test(pet, opts)
+
+test http signature authentication
+
+### Example
+
+```ruby
+# load the gem
+require 'petstore'
+
+api_instance = Petstore::FakeApi.new
+pet = Petstore::Pet.new # Pet | Pet object that needs to be added to the store
+opts = {
+  query_1: 'query_1_example', # String | query parameter
+  header_1: 'header_1_example' # String | header parameter
+}
+
+begin
+  #test http signature authentication
+  api_instance.fake_http_signature_test(pet, opts)
+rescue Petstore::ApiError => e
+  puts "Exception when calling FakeApi->fake_http_signature_test: #{e}"
+end
+```
+
+### Parameters
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **pet** | [**Pet**](Pet.md)| Pet object that needs to be added to the store | 
+ **query_1** | **String**| query parameter | [optional] 
+ **header_1** | **String**| header parameter | [optional] 
+
+### Return type
+
+nil (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: application/json, application/xml
+- **Accept**: Not defined
 
 
 ## fake_outer_boolean_serialize

--- a/samples/openapi3/client/petstore/ruby-faraday/lib/petstore/api/fake_api.rb
+++ b/samples/openapi3/client/petstore/ruby-faraday/lib/petstore/api/fake_api.rb
@@ -73,6 +73,72 @@ module Petstore
       return data, status_code, headers
     end
 
+    # test http signature authentication
+    # @param pet [Pet] Pet object that needs to be added to the store
+    # @param [Hash] opts the optional parameters
+    # @option opts [String] :query_1 query parameter
+    # @option opts [String] :header_1 header parameter
+    # @return [nil]
+    def fake_http_signature_test(pet, opts = {})
+      fake_http_signature_test_with_http_info(pet, opts)
+      nil
+    end
+
+    # test http signature authentication
+    # @param pet [Pet] Pet object that needs to be added to the store
+    # @param [Hash] opts the optional parameters
+    # @option opts [String] :query_1 query parameter
+    # @option opts [String] :header_1 header parameter
+    # @return [Array<(nil, Integer, Hash)>] nil, response status code and response headers
+    def fake_http_signature_test_with_http_info(pet, opts = {})
+      if @api_client.config.debugging
+        @api_client.config.logger.debug 'Calling API: FakeApi.fake_http_signature_test ...'
+      end
+      # verify the required parameter 'pet' is set
+      if @api_client.config.client_side_validation && pet.nil?
+        fail ArgumentError, "Missing the required parameter 'pet' when calling FakeApi.fake_http_signature_test"
+      end
+      # resource path
+      local_var_path = '/fake/http-signature-test'
+
+      # query parameters
+      query_params = opts[:query_params] || {}
+      query_params[:'query_1'] = opts[:'query_1'] if !opts[:'query_1'].nil?
+
+      # header parameters
+      header_params = opts[:header_params] || {}
+      # HTTP header 'Content-Type'
+      header_params['Content-Type'] = @api_client.select_header_content_type(['application/json', 'application/xml'])
+      header_params[:'header_1'] = opts[:'header_1'] if !opts[:'header_1'].nil?
+
+      # form parameters
+      form_params = opts[:form_params] || {}
+
+      # http body (model)
+      post_body = opts[:body] || @api_client.object_to_http_body(pet) 
+
+      # return_type
+      return_type = opts[:return_type] 
+
+      # auth_names
+      auth_names = opts[:auth_names] || []
+
+      new_options = opts.merge(
+        :header_params => header_params,
+        :query_params => query_params,
+        :form_params => form_params,
+        :body => post_body,
+        :auth_names => auth_names,
+        :return_type => return_type
+      )
+
+      data, status_code, headers = @api_client.call_api(:GET, local_var_path, new_options)
+      if @api_client.config.debugging
+        @api_client.config.logger.debug "API called: FakeApi#fake_http_signature_test\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
+      end
+      return data, status_code, headers
+    end
+
     # Test serialization of outer boolean types
     # @param [Hash] opts the optional parameters
     # @option opts [Boolean] :body Input boolean as post body

--- a/samples/openapi3/client/petstore/ruby-faraday/spec/api/fake_api_spec.rb
+++ b/samples/openapi3/client/petstore/ruby-faraday/spec/api/fake_api_spec.rb
@@ -42,6 +42,19 @@ describe 'FakeApi' do
     end
   end
 
+  # unit tests for fake_http_signature_test
+  # test http signature authentication
+  # @param pet Pet object that needs to be added to the store
+  # @param [Hash] opts the optional parameters
+  # @option opts [String] :query_1 query parameter
+  # @option opts [String] :header_1 header parameter
+  # @return [nil]
+  describe 'fake_http_signature_test test' do
+    it 'should work' do
+      # assertion here. ref: https://www.relishapp.com/rspec/rspec-expectations/docs/built-in-matchers
+    end
+  end
+
   # unit tests for fake_outer_boolean_serialize
   # Test serialization of outer boolean types
   # @param [Hash] opts the optional parameters

--- a/samples/openapi3/client/petstore/ruby/README.md
+++ b/samples/openapi3/client/petstore/ruby/README.md
@@ -78,6 +78,7 @@ Class | Method | HTTP request | Description
 *Petstore::AnotherFakeApi* | [**call_123_test_special_tags**](docs/AnotherFakeApi.md#call_123_test_special_tags) | **PATCH** /another-fake/dummy | To test special tags
 *Petstore::DefaultApi* | [**foo_get**](docs/DefaultApi.md#foo_get) | **GET** /foo | 
 *Petstore::FakeApi* | [**fake_health_get**](docs/FakeApi.md#fake_health_get) | **GET** /fake/health | Health check endpoint
+*Petstore::FakeApi* | [**fake_http_signature_test**](docs/FakeApi.md#fake_http_signature_test) | **GET** /fake/http-signature-test | test http signature authentication
 *Petstore::FakeApi* | [**fake_outer_boolean_serialize**](docs/FakeApi.md#fake_outer_boolean_serialize) | **POST** /fake/outer/boolean | 
 *Petstore::FakeApi* | [**fake_outer_composite_serialize**](docs/FakeApi.md#fake_outer_composite_serialize) | **POST** /fake/outer/composite | 
 *Petstore::FakeApi* | [**fake_outer_number_serialize**](docs/FakeApi.md#fake_outer_number_serialize) | **POST** /fake/outer/number | 
@@ -192,6 +193,9 @@ Class | Method | HTTP request | Description
 ### http_basic_test
 
 - **Type**: HTTP basic authentication
+
+### http_signature_test
+
 
 ### petstore_auth
 

--- a/samples/openapi3/client/petstore/ruby/docs/FakeApi.md
+++ b/samples/openapi3/client/petstore/ruby/docs/FakeApi.md
@@ -5,6 +5,7 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 Method | HTTP request | Description
 ------------- | ------------- | -------------
 [**fake_health_get**](FakeApi.md#fake_health_get) | **GET** /fake/health | Health check endpoint
+[**fake_http_signature_test**](FakeApi.md#fake_http_signature_test) | **GET** /fake/http-signature-test | test http signature authentication
 [**fake_outer_boolean_serialize**](FakeApi.md#fake_outer_boolean_serialize) | **POST** /fake/outer/boolean | 
 [**fake_outer_composite_serialize**](FakeApi.md#fake_outer_composite_serialize) | **POST** /fake/outer/composite | 
 [**fake_outer_number_serialize**](FakeApi.md#fake_outer_number_serialize) | **POST** /fake/outer/number | 
@@ -60,6 +61,56 @@ No authorization required
 
 - **Content-Type**: Not defined
 - **Accept**: application/json
+
+
+## fake_http_signature_test
+
+> fake_http_signature_test(pet, opts)
+
+test http signature authentication
+
+### Example
+
+```ruby
+# load the gem
+require 'petstore'
+
+api_instance = Petstore::FakeApi.new
+pet = Petstore::Pet.new # Pet | Pet object that needs to be added to the store
+opts = {
+  query_1: 'query_1_example', # String | query parameter
+  header_1: 'header_1_example' # String | header parameter
+}
+
+begin
+  #test http signature authentication
+  api_instance.fake_http_signature_test(pet, opts)
+rescue Petstore::ApiError => e
+  puts "Exception when calling FakeApi->fake_http_signature_test: #{e}"
+end
+```
+
+### Parameters
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **pet** | [**Pet**](Pet.md)| Pet object that needs to be added to the store | 
+ **query_1** | **String**| query parameter | [optional] 
+ **header_1** | **String**| header parameter | [optional] 
+
+### Return type
+
+nil (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: application/json, application/xml
+- **Accept**: Not defined
 
 
 ## fake_outer_boolean_serialize

--- a/samples/openapi3/client/petstore/ruby/lib/petstore/api/fake_api.rb
+++ b/samples/openapi3/client/petstore/ruby/lib/petstore/api/fake_api.rb
@@ -73,6 +73,72 @@ module Petstore
       return data, status_code, headers
     end
 
+    # test http signature authentication
+    # @param pet [Pet] Pet object that needs to be added to the store
+    # @param [Hash] opts the optional parameters
+    # @option opts [String] :query_1 query parameter
+    # @option opts [String] :header_1 header parameter
+    # @return [nil]
+    def fake_http_signature_test(pet, opts = {})
+      fake_http_signature_test_with_http_info(pet, opts)
+      nil
+    end
+
+    # test http signature authentication
+    # @param pet [Pet] Pet object that needs to be added to the store
+    # @param [Hash] opts the optional parameters
+    # @option opts [String] :query_1 query parameter
+    # @option opts [String] :header_1 header parameter
+    # @return [Array<(nil, Integer, Hash)>] nil, response status code and response headers
+    def fake_http_signature_test_with_http_info(pet, opts = {})
+      if @api_client.config.debugging
+        @api_client.config.logger.debug 'Calling API: FakeApi.fake_http_signature_test ...'
+      end
+      # verify the required parameter 'pet' is set
+      if @api_client.config.client_side_validation && pet.nil?
+        fail ArgumentError, "Missing the required parameter 'pet' when calling FakeApi.fake_http_signature_test"
+      end
+      # resource path
+      local_var_path = '/fake/http-signature-test'
+
+      # query parameters
+      query_params = opts[:query_params] || {}
+      query_params[:'query_1'] = opts[:'query_1'] if !opts[:'query_1'].nil?
+
+      # header parameters
+      header_params = opts[:header_params] || {}
+      # HTTP header 'Content-Type'
+      header_params['Content-Type'] = @api_client.select_header_content_type(['application/json', 'application/xml'])
+      header_params[:'header_1'] = opts[:'header_1'] if !opts[:'header_1'].nil?
+
+      # form parameters
+      form_params = opts[:form_params] || {}
+
+      # http body (model)
+      post_body = opts[:body] || @api_client.object_to_http_body(pet) 
+
+      # return_type
+      return_type = opts[:return_type] 
+
+      # auth_names
+      auth_names = opts[:auth_names] || []
+
+      new_options = opts.merge(
+        :header_params => header_params,
+        :query_params => query_params,
+        :form_params => form_params,
+        :body => post_body,
+        :auth_names => auth_names,
+        :return_type => return_type
+      )
+
+      data, status_code, headers = @api_client.call_api(:GET, local_var_path, new_options)
+      if @api_client.config.debugging
+        @api_client.config.logger.debug "API called: FakeApi#fake_http_signature_test\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
+      end
+      return data, status_code, headers
+    end
+
     # Test serialization of outer boolean types
     # @param [Hash] opts the optional parameters
     # @option opts [Boolean] :body Input boolean as post body

--- a/samples/openapi3/client/petstore/ruby/spec/api/fake_api_spec.rb
+++ b/samples/openapi3/client/petstore/ruby/spec/api/fake_api_spec.rb
@@ -42,6 +42,19 @@ describe 'FakeApi' do
     end
   end
 
+  # unit tests for fake_http_signature_test
+  # test http signature authentication
+  # @param pet Pet object that needs to be added to the store
+  # @param [Hash] opts the optional parameters
+  # @option opts [String] :query_1 query parameter
+  # @option opts [String] :header_1 header parameter
+  # @return [nil]
+  describe 'fake_http_signature_test test' do
+    it 'should work' do
+      # assertion here. ref: https://www.relishapp.com/rspec/rspec-expectations/docs/built-in-matchers
+    end
+  end
+
   # unit tests for fake_outer_boolean_serialize
   # Test serialization of outer boolean types
   # @param [Hash] opts the optional parameters

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/api/FakeApi.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/api/FakeApi.java
@@ -16,6 +16,7 @@ import org.openapitools.model.HealthCheckResult;
 import java.util.Map;
 import org.openapitools.model.ModelApiResponse;
 import org.openapitools.model.OuterComposite;
+import org.openapitools.model.Pet;
 import org.openapitools.model.User;
 
 import java.util.Map;
@@ -74,6 +75,20 @@ public class FakeApi  {
     public Response fakeHealthGet(@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.fakeHealthGet(securityContext);
+    }
+    @GET
+    @Path("/http-signature-test")
+    @Consumes({ "application/json", "application/xml" })
+    
+    @io.swagger.annotations.ApiOperation(value = "test http signature authentication", notes = "", response = Void.class, tags={ "fake", })
+    @io.swagger.annotations.ApiResponses(value = { 
+        @io.swagger.annotations.ApiResponse(code = 200, message = "The instance started successfully", response = Void.class) })
+    public Response fakeHttpSignatureTest(@ApiParam(value = "Pet object that needs to be added to the store", required = true) @NotNull @Valid  Pet pet
+,@ApiParam(value = "query parameter") @QueryParam("query_1")  String query1
+,@ApiParam(value = "header parameter" )@HeaderParam("header_1") String header1
+,@Context SecurityContext securityContext)
+    throws NotFoundException {
+        return delegate.fakeHttpSignatureTest(pet, query1, header1, securityContext);
     }
     @POST
     @Path("/outer/boolean")

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/api/FakeApiService.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/api/FakeApiService.java
@@ -14,6 +14,7 @@ import org.openapitools.model.HealthCheckResult;
 import java.util.Map;
 import org.openapitools.model.ModelApiResponse;
 import org.openapitools.model.OuterComposite;
+import org.openapitools.model.Pet;
 import org.openapitools.model.User;
 
 import java.util.List;
@@ -27,6 +28,7 @@ import javax.validation.constraints.*;
 
 public abstract class FakeApiService {
     public abstract Response fakeHealthGet(SecurityContext securityContext) throws NotFoundException;
+    public abstract Response fakeHttpSignatureTest(Pet pet,String query1,String header1,SecurityContext securityContext) throws NotFoundException;
     public abstract Response fakeOuterBooleanSerialize(Boolean body,SecurityContext securityContext) throws NotFoundException;
     public abstract Response fakeOuterCompositeSerialize(OuterComposite outerComposite,SecurityContext securityContext) throws NotFoundException;
     public abstract Response fakeOuterNumberSerialize(BigDecimal body,SecurityContext securityContext) throws NotFoundException;

--- a/samples/server/petstore/jaxrs-jersey/src/main/java/org/openapitools/api/impl/FakeApiServiceImpl.java
+++ b/samples/server/petstore/jaxrs-jersey/src/main/java/org/openapitools/api/impl/FakeApiServiceImpl.java
@@ -12,6 +12,7 @@ import org.openapitools.model.HealthCheckResult;
 import java.util.Map;
 import org.openapitools.model.ModelApiResponse;
 import org.openapitools.model.OuterComposite;
+import org.openapitools.model.Pet;
 import org.openapitools.model.User;
 
 import java.util.List;
@@ -28,6 +29,11 @@ import javax.validation.constraints.*;
 public class FakeApiServiceImpl extends FakeApiService {
     @Override
     public Response fakeHealthGet(SecurityContext securityContext) throws NotFoundException {
+        // do some magic!
+        return Response.ok().entity(new ApiResponseMessage(ApiResponseMessage.OK, "magic!")).build();
+    }
+    @Override
+    public Response fakeHttpSignatureTest(Pet pet, String query1, String header1, SecurityContext securityContext) throws NotFoundException {
         // do some magic!
         return Response.ok().entity(new ApiResponseMessage(ApiResponseMessage.OK, "magic!")).build();
     }


### PR DESCRIPTION
- Add Http signature authentication test to fake petstore spec
- fix plugin version in modules/openapi-generator-maven-plugin/examples/spring.xml

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

FYI @OpenAPITools/generator-core-team 