### PR TITLE
[Rust Server] Support boolean headers, and fix panic handling headers

### DIFF
--- a/modules/openapi-generator/src/main/resources/rust-server/client-imports.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/client-imports.mustache
@@ -8,6 +8,7 @@ use hyper::{Body, Uri, Response};
 use hyper_openssl::HttpsConnector;
 use serde_json;
 use std::borrow::Cow;
+use std::convert::TryInto;
 use std::io::{Read, Error, ErrorKind};
 use std::error;
 use std::fmt;

--- a/modules/openapi-generator/src/main/resources/rust-server/client-operation.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/client-operation.mustache
@@ -332,15 +332,23 @@
         // Header parameters
 {{/-first}}
 {{^isMapContainer}}
-{{#required}}
+{{^required}}
+        match param_{{{paramName}}} {
+            Some(param_{{{paramName}}}) => {
+{{/required}}
         request.headers_mut().append(
             HeaderName::from_static("{{{nameInLowerCase}}}"),
-            header::IntoHeaderValue(param_{{{paramName}}}.clone()).into());
-{{/required}}
+            match header::IntoHeaderValue(param_{{{paramName}}}.clone()).try_into() {
+                Ok(header) => header,
+                Err(e) => {
+                    return Box::new(future::err(ApiError(format!(
+                        "Invalid header {{{paramName}}} - {}", e)))) as Box<dyn Future<Item=_, Error=_> + Send>;
+                },
+            });
 {{^required}}
-        param_{{{paramName}}}.map(|value| request.headers_mut().append(
-            HeaderName::from_static("{{{nameInLowerCase}}}"),
-            header::IntoHeaderValue(value.clone()).into()));
+            },
+            None => {}
+        }
 {{/required}}
 {{/isMapContainer}}
 {{#isMapContainer}}
@@ -359,6 +367,14 @@
                         Some(response_{{{name}}}) => response_{{{name}}}.clone(),
                         None => return Box::new(future::err(ApiError(String::from("Required response header {{{baseName}}} for response {{{code}}} was not found.")))) as Box<dyn Future<Item=_, Error=_> + Send>,
                     };
+                    let response_{{{name}}} = match TryInto::<header::IntoHeaderValue<{{{dataType}}}>>::try_into(response_{{{name}}}) {
+                        Ok(value) => value,
+                        Err(e) => {
+                            return Box::new(future::err(ApiError(format!("Invalid response header {{baseName}} for response {{code}} - {}", e)))) as Box<dyn Future<Item=_, Error=_> + Send>;
+                        },
+                    };
+                    let response_{{{name}}} = response_{{{name}}}.0;
+
 {{/headers}}
                     let body = response.into_body();
                     Box::new(
@@ -402,7 +418,7 @@
                             {
                                 body: body,
   {{/-first}}
-                                {{{name}}}: (*Into::<header::IntoHeaderValue<{{{dataType}}}>>::into(response_{{{name}}})).clone(),
+                                {{{name}}}: response_{{name}},
   {{#-last}}
                             }
   {{/-last}}
@@ -416,7 +432,7 @@
   {{#-first}}
                             {
   {{/-first}}
-                              {{{name}}}: (*Into::<header::IntoHeaderValue<{{{dataType}}}>>::into(response_{{{name}}})).clone(),
+                                {{{name}}}: response_{{name}},
   {{#-last}}
                             }
   {{/-last}}

--- a/modules/openapi-generator/src/main/resources/rust-server/header.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/header.mustache
@@ -82,6 +82,18 @@ impl From<IntoHeaderValue<String>> for HeaderValue {
     }
 }
 
+impl From<HeaderValue> for IntoHeaderValue<bool> {
+    fn from(hdr_value: HeaderValue) -> Self {
+        IntoHeaderValue(hdr_value.to_str().unwrap().parse().unwrap())
+    }
+}
+
+impl From<IntoHeaderValue<bool>> for HeaderValue {
+    fn from(hdr_value: IntoHeaderValue<bool>) -> Self {
+        HeaderValue::from_str(&hdr_value.0.to_string()).unwrap()
+    }
+}
+
 impl From<HeaderValue> for IntoHeaderValue<DateTime<Utc>> {
     fn from(hdr_value: HeaderValue) -> Self {
         IntoHeaderValue(

--- a/modules/openapi-generator/src/main/resources/rust-server/header.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/header.mustache
@@ -1,5 +1,6 @@
 use chrono::{DateTime, Utc};
 use hyper::header::HeaderValue;
+use std::convert::TryFrom;
 use std::fmt;
 use std::ops::Deref;
 
@@ -19,19 +20,31 @@ impl<T> Deref for IntoHeaderValue<T> {
     }
 }
 
-// Derive for each From<T> in hyper::header::HeaderValue
+// Derive for each TryFrom<T> in hyper::header::HeaderValue
 
 macro_rules! ihv_generate {
     ($t:ident) => {
-        impl From<HeaderValue> for IntoHeaderValue<$t> {
-            fn from(hdr_value: HeaderValue) -> Self {
-                IntoHeaderValue(hdr_value.to_str().unwrap().parse::<$t>().unwrap())
+        impl TryFrom<HeaderValue> for IntoHeaderValue<$t> {
+            type Error = String;
+
+            fn try_from(hdr_value: HeaderValue) -> Result<Self, Self::Error> {
+                match hdr_value.to_str() {
+                    Ok(hdr_value) => match hdr_value.parse::<$t>() {
+                        Ok(hdr_value) => Ok(IntoHeaderValue(hdr_value)),
+                        Err(e) => Err(format!("Unable to parse {} as a string: {}",
+                            stringify!($t), e)),
+                    },
+                    Err(e) => Err(format!("Unable to parse header {:?} as a string - {}",
+                        hdr_value, e)),
+                }
             }
         }
 
-        impl From<IntoHeaderValue<$t>> for HeaderValue {
-            fn from(hdr_value: IntoHeaderValue<$t>) -> Self {
-                hdr_value.0.into()
+        impl TryFrom<IntoHeaderValue<$t>> for HeaderValue {
+            type Error = String;
+
+            fn try_from(hdr_value: IntoHeaderValue<$t>) -> Result<Self, Self::Error> {
+                Ok(hdr_value.0.into())
             }
         }
     };
@@ -48,64 +61,120 @@ ihv_generate!(i32);
 
 // Custom derivations
 
-impl From<HeaderValue> for IntoHeaderValue<Vec<String>> {
-    fn from(hdr_value: HeaderValue) -> Self {
-        IntoHeaderValue(
-            hdr_value
-                .to_str()
-                .unwrap()
+// Vec<String>
+
+impl TryFrom<HeaderValue> for IntoHeaderValue<Vec<String>> {
+    type Error = String;
+
+    fn try_from(hdr_value: HeaderValue) -> Result<Self, Self::Error> {
+        match hdr_value.to_str() {
+            Ok(hdr_value) => Ok(IntoHeaderValue(
+                hdr_value
                 .split(',')
                 .filter_map(|x| match x.trim() {
                     "" => None,
                     y => Some(y.to_string()),
                 })
-                .collect(),
-        )
+                .collect())),
+            Err(e) => Err(format!("Unable to parse header: {:?} as a string - {}",
+                hdr_value, e)),
+        }
     }
 }
 
-impl From<IntoHeaderValue<Vec<String>>> for HeaderValue {
-    fn from(hdr_value: IntoHeaderValue<Vec<String>>) -> Self {
-        HeaderValue::from_str(&hdr_value.0.join(", ")).unwrap()
+impl TryFrom<IntoHeaderValue<Vec<String>>> for HeaderValue {
+    type Error = String;
+
+    fn try_from(hdr_value: IntoHeaderValue<Vec<String>>) -> Result<Self, Self::Error> {
+       match HeaderValue::from_str(&hdr_value.0.join(", ")) {
+           Ok(hdr_value) => Ok(hdr_value),
+           Err(e) => Err(format!("Unable to convert {:?} into a header - {}",
+               hdr_value, e))
+       }
     }
 }
 
-impl From<HeaderValue> for IntoHeaderValue<String> {
-    fn from(hdr_value: HeaderValue) -> Self {
-        IntoHeaderValue(hdr_value.to_str().unwrap().to_string())
+// String
+
+impl TryFrom<HeaderValue> for IntoHeaderValue<String> {
+    type Error = String;
+
+    fn try_from(hdr_value: HeaderValue) -> Result<Self, Self::Error> {
+        match hdr_value.to_str() {
+            Ok(hdr_value) => Ok(IntoHeaderValue(hdr_value.to_string())),
+            Err(e) => Err(format!("Unable to convert header {:?} to {}",
+                hdr_value, e)),
+        }
     }
 }
 
-impl From<IntoHeaderValue<String>> for HeaderValue {
-    fn from(hdr_value: IntoHeaderValue<String>) -> Self {
-        HeaderValue::from_str(&hdr_value.0).unwrap()
+impl TryFrom<IntoHeaderValue<String>> for HeaderValue {
+    type Error = String;
+
+    fn try_from(hdr_value: IntoHeaderValue<String>) -> Result<Self, Self::Error> {
+        match HeaderValue::from_str(&hdr_value.0) {
+            Ok(hdr_value) => Ok(hdr_value),
+            Err(e) => Err(format!("Unable to convert {:?} from a header {}",
+                hdr_value, e))
+        }
     }
 }
 
-impl From<HeaderValue> for IntoHeaderValue<bool> {
-    fn from(hdr_value: HeaderValue) -> Self {
-        IntoHeaderValue(hdr_value.to_str().unwrap().parse().unwrap())
+// bool
+impl TryFrom<HeaderValue> for IntoHeaderValue<bool> {
+    type Error = String;
+
+    fn try_from(hdr_value: HeaderValue) -> Result<Self, Self::Error> {
+        match hdr_value.to_str() {
+            Ok(hdr_value) => match hdr_value.parse() {
+                Ok(hdr_value) => Ok(IntoHeaderValue(hdr_value)),
+                Err(e) => Err(format!("Unable to parse bool from {} - {}",
+                    hdr_value, e)),
+            },
+            Err(e) => Err(format!("Unable to convert {:?} from a header {}",
+                hdr_value, e)),
+        }
     }
 }
 
-impl From<IntoHeaderValue<bool>> for HeaderValue {
-    fn from(hdr_value: IntoHeaderValue<bool>) -> Self {
-        HeaderValue::from_str(&hdr_value.0.to_string()).unwrap()
+impl TryFrom<IntoHeaderValue<bool>> for HeaderValue {
+    type Error = String;
+
+    fn try_from(hdr_value: IntoHeaderValue<bool>) -> Result<Self, Self::Error> {
+        match HeaderValue::from_str(&hdr_value.0.to_string()) {
+            Ok(hdr_value) => Ok(hdr_value),
+            Err(e) => Err(format!("Unable to convert: {:?} into a header: {}",
+                hdr_value, e))
+        }
     }
 }
 
-impl From<HeaderValue> for IntoHeaderValue<DateTime<Utc>> {
-    fn from(hdr_value: HeaderValue) -> Self {
-        IntoHeaderValue(
-            DateTime::parse_from_rfc3339(hdr_value.to_str().unwrap())
-                .unwrap()
-                .with_timezone(&Utc),
-        )
+// DateTime
+
+impl TryFrom<HeaderValue> for IntoHeaderValue<DateTime<Utc>> {
+    type Error = String;
+
+    fn try_from(hdr_value: HeaderValue) -> Result<Self, Self::Error> {
+        match hdr_value.to_str() {
+            Ok(hdr_value) => match DateTime::parse_from_rfc3339(hdr_value) {
+                Ok(date) => Ok(IntoHeaderValue(date.with_timezone(&Utc))),
+                Err(e) => Err(format!("Unable to parse: {} as date - {}",
+                    hdr_value, e)),
+            },
+            Err(e) => Err(format!("Unable to convert header {:?} to string {}",
+                    hdr_value, e)),
+        }
     }
 }
 
-impl From<IntoHeaderValue<DateTime<Utc>>> for HeaderValue {
-    fn from(hdr_value: IntoHeaderValue<DateTime<Utc>>) -> Self {
-        HeaderValue::from_str(hdr_value.0.to_rfc3339().as_str()).unwrap()
+impl TryFrom<IntoHeaderValue<DateTime<Utc>>> for HeaderValue {
+    type Error = String;
+
+    fn try_from(hdr_value: IntoHeaderValue<DateTime<Utc>>) -> Result<Self, Self::Error> {
+        match HeaderValue::from_str(hdr_value.0.to_rfc3339().as_str()) {
+            Ok(hdr_value) => Ok(hdr_value),
+            Err(e) => Err(format!("Unable to convert {:?} to a header: {}",
+                hdr_value, e)),
+        }
     }
 }

--- a/modules/openapi-generator/src/main/resources/rust-server/models.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/models.mustache
@@ -127,12 +127,13 @@ impl ::std::str::FromStr for {{{classname}}} {
 impl std::convert::TryFrom<header::IntoHeaderValue<{{{classname}}}>> for hyper::header::HeaderValue {
     type Error = String;
 
-    fn try_from(hdr_value: header::IntoHeaderValue<{{{classname}}}>) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<{{{classname}}}>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match hyper::header::HeaderValue::from_str(&hdr_value) {
-             Ok(value) => Ok(value),
-             Err(e) => Err(format!("Invalid header value for {{classname}} - value: {} is invalid {}",
-                 hdr_value, e))
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for {{classname}} - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -141,17 +142,19 @@ impl std::convert::TryFrom<header::IntoHeaderValue<{{{classname}}}>> for hyper::
 impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<{{{classname}}}> {
     type Error = String;
 
-    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-             Ok(value) => {
+             std::result::Result::Ok(value) => {
                     match <{{{classname}}} as std::str::FromStr>::from_str(value) {
-                        Ok(value) => Ok(header::IntoHeaderValue(value)),
-                        Err(err) => Err(format!("Unable to convert header value '{}' into {{classname}} - {}",
-                            value, err))
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into {{classname}} - {}",
+                                value, err))
                     }
              },
-             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
-                 hdr_value, e))
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }

--- a/modules/openapi-generator/src/main/resources/rust-server/models.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/models.mustache
@@ -124,16 +124,35 @@ impl ::std::str::FromStr for {{{classname}}} {
 // Methods for converting between header::IntoHeaderValue<{{{classname}}}> and hyper::header::HeaderValue
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<header::IntoHeaderValue<{{{classname}}}>> for hyper::header::HeaderValue {
-    fn from(hdr_value: header::IntoHeaderValue<{{{classname}}}>) -> Self {
-        hyper::header::HeaderValue::from_str(&hdr_value.to_string()).unwrap()
+impl std::convert::TryFrom<header::IntoHeaderValue<{{{classname}}}>> for hyper::header::HeaderValue {
+    type Error = String;
+
+    fn try_from(hdr_value: header::IntoHeaderValue<{{{classname}}}>) -> Result<Self, Self::Error> {
+        let hdr_value = hdr_value.to_string();
+        match hyper::header::HeaderValue::from_str(&hdr_value) {
+             Ok(value) => Ok(value),
+             Err(e) => Err(format!("Invalid header value for {{classname}} - value: {} is invalid {}",
+                 hdr_value, e))
+        }
     }
 }
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<hyper::header::HeaderValue> for header::IntoHeaderValue<{{{classname}}}> {
-    fn from(hdr_value: hyper::header::HeaderValue) -> Self {
-        header::IntoHeaderValue(<{{{classname}}} as std::str::FromStr>::from_str(hdr_value.to_str().unwrap()).unwrap())
+impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<{{{classname}}}> {
+    type Error = String;
+
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+        match hdr_value.to_str() {
+             Ok(value) => {
+                    match <{{{classname}}} as std::str::FromStr>::from_str(value) {
+                        Ok(value) => Ok(header::IntoHeaderValue(value)),
+                        Err(err) => Err(format!("Unable to convert header value '{}' into {{classname}} - {}",
+                            value, err))
+                    }
+             },
+             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
+                 hdr_value, e))
+        }
     }
 }
 

--- a/modules/openapi-generator/src/main/resources/rust-server/server-imports.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/server-imports.mustache
@@ -5,6 +5,8 @@ use hyper::{Request, Response, Error, StatusCode, Body, HeaderMap};
 use hyper::header::{HeaderName, HeaderValue, CONTENT_TYPE};
 use log::warn;
 use serde_json;
+#[allow(unused_imports)]
+use std::convert::{TryFrom, TryInto};
 use std::io;
 use url::form_urlencoded;
 #[allow(unused_imports)]

--- a/modules/openapi-generator/src/main/resources/rust-server/server-operation.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/server-operation.mustache
@@ -87,20 +87,35 @@
   {{/-first}}
                 let param_{{{paramName}}} = headers.get(HeaderName::from_static("{{{nameInLowerCase}}}"));
 
-{{#required}}
                 let param_{{{paramName}}} = match param_{{{paramName}}} {
-                    Some(v) => header::IntoHeaderValue::<{{{dataType}}}>::from((*v).clone()).0,
-                    None => return Box::new(future::ok(Response::builder()
-                                        .status(StatusCode::BAD_REQUEST)
-                                        .body(Body::from("Missing or invalid required header {{{baseName}}}"))
-                                        .expect("Unable to create Bad Request response for missing required header {{{baseName}}}"))),
-                };
+                    Some(v) => match header::IntoHeaderValue::<{{{dataType}}}>::try_from((*v).clone()) {
+                        Ok(result) =>
+{{#required}}
+                            result.0,
 {{/required}}
 {{^required}}
-                let param_{{{paramName}}} = param_{{{paramName}}}.map(|p| {
-                        header::IntoHeaderValue::<{{{dataType}}}>::from((*p).clone()).0
-                });
+                            Some(result.0),
 {{/required}}
+                        Err(err) => {
+                            return Box::new(future::ok(Response::builder()
+                                        .status(StatusCode::BAD_REQUEST)
+                                        .body(Body::from(format!("Invalid header {{{baseName}}} - {}", err)))
+                                        .expect("Unable to create Bad Request response for invalid header {{{baseName}}}")));
+
+                        },
+                    },
+                    None => {
+{{#required}}
+                        return Box::new(future::ok(Response::builder()
+                                        .status(StatusCode::BAD_REQUEST)
+                                        .body(Body::from("Missing required header {{{baseName}}}"))
+                                        .expect("Unable to create Bad Request response for missing required header {{{baseName}}}")));
+{{/required}}
+{{^required}}
+                        None
+{{/required}}
+                    }
+                };
   {{#-last}}
 
   {{/-last}}
@@ -486,11 +501,23 @@
 {{/headers}}
 {{/dataType}}
                                                 => {
+{{#headers}}
+                                                    let {{{name}}} = match header::IntoHeaderValue({{{name}}}).try_into() {
+                                                        Ok(val) => val,
+                                                        Err(e) => {
+                                                            return future::ok(Response::builder()
+                                                                    .status(StatusCode::INTERNAL_SERVER_ERROR)
+                                                                    .body(Body::from(format!("An internal server error occurred handling {{name}} header - {}", e)))
+                                                                    .expect("Unable to create Internal Server Error for invalid response header"))
+                                                        }
+                                                    };
+
+{{/headers}}
                                                     *response.status_mut() = StatusCode::from_u16({{{code}}}).expect("Unable to turn {{{code}}} into a StatusCode");
 {{#headers}}
                                                     response.headers_mut().insert(
                                                         HeaderName::from_static("{{{nameInLowerCase}}}"),
-                                                        header::IntoHeaderValue({{name}}).into()
+                                                        {{name}}
                                                     );
 {{/headers}}
 {{#produces}}

--- a/modules/openapi-generator/src/test/resources/3_0/rust-server/openapi-v3.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/rust-server/openapi-v3.yaml
@@ -227,6 +227,9 @@ paths:
             Success-Info:
               schema:
                 type: String
+            Bool-Header:
+              schema:
+                type: bool
             Object-Header:
               schema:
                 $ref: "#/components/schemas/ObjectHeader"

--- a/samples/server/petstore/rust-server/output/multipart-v3/src/client/mod.rs
+++ b/samples/server/petstore/rust-server/output/multipart-v3/src/client/mod.rs
@@ -8,6 +8,7 @@ use hyper::{Body, Uri, Response};
 use hyper_openssl::HttpsConnector;
 use serde_json;
 use std::borrow::Cow;
+use std::convert::TryInto;
 use std::io::{Read, Error, ErrorKind};
 use std::error;
 use std::fmt;

--- a/samples/server/petstore/rust-server/output/multipart-v3/src/models.rs
+++ b/samples/server/petstore/rust-server/output/multipart-v3/src/models.rs
@@ -8,16 +8,35 @@ use crate::header;
 // Methods for converting between header::IntoHeaderValue<InlineObject> and hyper::header::HeaderValue
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<header::IntoHeaderValue<InlineObject>> for hyper::header::HeaderValue {
-    fn from(hdr_value: header::IntoHeaderValue<InlineObject>) -> Self {
-        hyper::header::HeaderValue::from_str(&hdr_value.to_string()).unwrap()
+impl std::convert::TryFrom<header::IntoHeaderValue<InlineObject>> for hyper::header::HeaderValue {
+    type Error = String;
+
+    fn try_from(hdr_value: header::IntoHeaderValue<InlineObject>) -> Result<Self, Self::Error> {
+        let hdr_value = hdr_value.to_string();
+        match hyper::header::HeaderValue::from_str(&hdr_value) {
+             Ok(value) => Ok(value),
+             Err(e) => Err(format!("Invalid header value for InlineObject - value: {} is invalid {}",
+                 hdr_value, e))
+        }
     }
 }
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<hyper::header::HeaderValue> for header::IntoHeaderValue<InlineObject> {
-    fn from(hdr_value: hyper::header::HeaderValue) -> Self {
-        header::IntoHeaderValue(<InlineObject as std::str::FromStr>::from_str(hdr_value.to_str().unwrap()).unwrap())
+impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<InlineObject> {
+    type Error = String;
+
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+        match hdr_value.to_str() {
+             Ok(value) => {
+                    match <InlineObject as std::str::FromStr>::from_str(value) {
+                        Ok(value) => Ok(header::IntoHeaderValue(value)),
+                        Err(err) => Err(format!("Unable to convert header value '{}' into InlineObject - {}",
+                            value, err))
+                    }
+             },
+             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
+                 hdr_value, e))
+        }
     }
 }
 
@@ -111,16 +130,35 @@ impl std::str::FromStr for InlineObject {
 // Methods for converting between header::IntoHeaderValue<MultipartRelatedRequest> and hyper::header::HeaderValue
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<header::IntoHeaderValue<MultipartRelatedRequest>> for hyper::header::HeaderValue {
-    fn from(hdr_value: header::IntoHeaderValue<MultipartRelatedRequest>) -> Self {
-        hyper::header::HeaderValue::from_str(&hdr_value.to_string()).unwrap()
+impl std::convert::TryFrom<header::IntoHeaderValue<MultipartRelatedRequest>> for hyper::header::HeaderValue {
+    type Error = String;
+
+    fn try_from(hdr_value: header::IntoHeaderValue<MultipartRelatedRequest>) -> Result<Self, Self::Error> {
+        let hdr_value = hdr_value.to_string();
+        match hyper::header::HeaderValue::from_str(&hdr_value) {
+             Ok(value) => Ok(value),
+             Err(e) => Err(format!("Invalid header value for MultipartRelatedRequest - value: {} is invalid {}",
+                 hdr_value, e))
+        }
     }
 }
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<hyper::header::HeaderValue> for header::IntoHeaderValue<MultipartRelatedRequest> {
-    fn from(hdr_value: hyper::header::HeaderValue) -> Self {
-        header::IntoHeaderValue(<MultipartRelatedRequest as std::str::FromStr>::from_str(hdr_value.to_str().unwrap()).unwrap())
+impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<MultipartRelatedRequest> {
+    type Error = String;
+
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+        match hdr_value.to_str() {
+             Ok(value) => {
+                    match <MultipartRelatedRequest as std::str::FromStr>::from_str(value) {
+                        Ok(value) => Ok(header::IntoHeaderValue(value)),
+                        Err(err) => Err(format!("Unable to convert header value '{}' into MultipartRelatedRequest - {}",
+                            value, err))
+                    }
+             },
+             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
+                 hdr_value, e))
+        }
     }
 }
 
@@ -223,16 +261,35 @@ impl std::str::FromStr for MultipartRelatedRequest {
 // Methods for converting between header::IntoHeaderValue<MultipartRequest> and hyper::header::HeaderValue
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<header::IntoHeaderValue<MultipartRequest>> for hyper::header::HeaderValue {
-    fn from(hdr_value: header::IntoHeaderValue<MultipartRequest>) -> Self {
-        hyper::header::HeaderValue::from_str(&hdr_value.to_string()).unwrap()
+impl std::convert::TryFrom<header::IntoHeaderValue<MultipartRequest>> for hyper::header::HeaderValue {
+    type Error = String;
+
+    fn try_from(hdr_value: header::IntoHeaderValue<MultipartRequest>) -> Result<Self, Self::Error> {
+        let hdr_value = hdr_value.to_string();
+        match hyper::header::HeaderValue::from_str(&hdr_value) {
+             Ok(value) => Ok(value),
+             Err(e) => Err(format!("Invalid header value for MultipartRequest - value: {} is invalid {}",
+                 hdr_value, e))
+        }
     }
 }
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<hyper::header::HeaderValue> for header::IntoHeaderValue<MultipartRequest> {
-    fn from(hdr_value: hyper::header::HeaderValue) -> Self {
-        header::IntoHeaderValue(<MultipartRequest as std::str::FromStr>::from_str(hdr_value.to_str().unwrap()).unwrap())
+impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<MultipartRequest> {
+    type Error = String;
+
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+        match hdr_value.to_str() {
+             Ok(value) => {
+                    match <MultipartRequest as std::str::FromStr>::from_str(value) {
+                        Ok(value) => Ok(header::IntoHeaderValue(value)),
+                        Err(err) => Err(format!("Unable to convert header value '{}' into MultipartRequest - {}",
+                            value, err))
+                    }
+             },
+             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
+                 hdr_value, e))
+        }
     }
 }
 
@@ -349,16 +406,35 @@ impl std::str::FromStr for MultipartRequest {
 // Methods for converting between header::IntoHeaderValue<MultipartRequestObjectField> and hyper::header::HeaderValue
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<header::IntoHeaderValue<MultipartRequestObjectField>> for hyper::header::HeaderValue {
-    fn from(hdr_value: header::IntoHeaderValue<MultipartRequestObjectField>) -> Self {
-        hyper::header::HeaderValue::from_str(&hdr_value.to_string()).unwrap()
+impl std::convert::TryFrom<header::IntoHeaderValue<MultipartRequestObjectField>> for hyper::header::HeaderValue {
+    type Error = String;
+
+    fn try_from(hdr_value: header::IntoHeaderValue<MultipartRequestObjectField>) -> Result<Self, Self::Error> {
+        let hdr_value = hdr_value.to_string();
+        match hyper::header::HeaderValue::from_str(&hdr_value) {
+             Ok(value) => Ok(value),
+             Err(e) => Err(format!("Invalid header value for MultipartRequestObjectField - value: {} is invalid {}",
+                 hdr_value, e))
+        }
     }
 }
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<hyper::header::HeaderValue> for header::IntoHeaderValue<MultipartRequestObjectField> {
-    fn from(hdr_value: hyper::header::HeaderValue) -> Self {
-        header::IntoHeaderValue(<MultipartRequestObjectField as std::str::FromStr>::from_str(hdr_value.to_str().unwrap()).unwrap())
+impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<MultipartRequestObjectField> {
+    type Error = String;
+
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+        match hdr_value.to_str() {
+             Ok(value) => {
+                    match <MultipartRequestObjectField as std::str::FromStr>::from_str(value) {
+                        Ok(value) => Ok(header::IntoHeaderValue(value)),
+                        Err(err) => Err(format!("Unable to convert header value '{}' into MultipartRequestObjectField - {}",
+                            value, err))
+                    }
+             },
+             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
+                 hdr_value, e))
+        }
     }
 }
 

--- a/samples/server/petstore/rust-server/output/multipart-v3/src/models.rs
+++ b/samples/server/petstore/rust-server/output/multipart-v3/src/models.rs
@@ -11,12 +11,13 @@ use crate::header;
 impl std::convert::TryFrom<header::IntoHeaderValue<InlineObject>> for hyper::header::HeaderValue {
     type Error = String;
 
-    fn try_from(hdr_value: header::IntoHeaderValue<InlineObject>) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<InlineObject>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match hyper::header::HeaderValue::from_str(&hdr_value) {
-             Ok(value) => Ok(value),
-             Err(e) => Err(format!("Invalid header value for InlineObject - value: {} is invalid {}",
-                 hdr_value, e))
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for InlineObject - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -25,17 +26,19 @@ impl std::convert::TryFrom<header::IntoHeaderValue<InlineObject>> for hyper::hea
 impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<InlineObject> {
     type Error = String;
 
-    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-             Ok(value) => {
+             std::result::Result::Ok(value) => {
                     match <InlineObject as std::str::FromStr>::from_str(value) {
-                        Ok(value) => Ok(header::IntoHeaderValue(value)),
-                        Err(err) => Err(format!("Unable to convert header value '{}' into InlineObject - {}",
-                            value, err))
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into InlineObject - {}",
+                                value, err))
                     }
              },
-             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
-                 hdr_value, e))
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
@@ -133,12 +136,13 @@ impl std::str::FromStr for InlineObject {
 impl std::convert::TryFrom<header::IntoHeaderValue<MultipartRelatedRequest>> for hyper::header::HeaderValue {
     type Error = String;
 
-    fn try_from(hdr_value: header::IntoHeaderValue<MultipartRelatedRequest>) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<MultipartRelatedRequest>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match hyper::header::HeaderValue::from_str(&hdr_value) {
-             Ok(value) => Ok(value),
-             Err(e) => Err(format!("Invalid header value for MultipartRelatedRequest - value: {} is invalid {}",
-                 hdr_value, e))
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for MultipartRelatedRequest - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -147,17 +151,19 @@ impl std::convert::TryFrom<header::IntoHeaderValue<MultipartRelatedRequest>> for
 impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<MultipartRelatedRequest> {
     type Error = String;
 
-    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-             Ok(value) => {
+             std::result::Result::Ok(value) => {
                     match <MultipartRelatedRequest as std::str::FromStr>::from_str(value) {
-                        Ok(value) => Ok(header::IntoHeaderValue(value)),
-                        Err(err) => Err(format!("Unable to convert header value '{}' into MultipartRelatedRequest - {}",
-                            value, err))
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into MultipartRelatedRequest - {}",
+                                value, err))
                     }
              },
-             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
-                 hdr_value, e))
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
@@ -264,12 +270,13 @@ impl std::str::FromStr for MultipartRelatedRequest {
 impl std::convert::TryFrom<header::IntoHeaderValue<MultipartRequest>> for hyper::header::HeaderValue {
     type Error = String;
 
-    fn try_from(hdr_value: header::IntoHeaderValue<MultipartRequest>) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<MultipartRequest>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match hyper::header::HeaderValue::from_str(&hdr_value) {
-             Ok(value) => Ok(value),
-             Err(e) => Err(format!("Invalid header value for MultipartRequest - value: {} is invalid {}",
-                 hdr_value, e))
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for MultipartRequest - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -278,17 +285,19 @@ impl std::convert::TryFrom<header::IntoHeaderValue<MultipartRequest>> for hyper:
 impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<MultipartRequest> {
     type Error = String;
 
-    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-             Ok(value) => {
+             std::result::Result::Ok(value) => {
                     match <MultipartRequest as std::str::FromStr>::from_str(value) {
-                        Ok(value) => Ok(header::IntoHeaderValue(value)),
-                        Err(err) => Err(format!("Unable to convert header value '{}' into MultipartRequest - {}",
-                            value, err))
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into MultipartRequest - {}",
+                                value, err))
                     }
              },
-             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
-                 hdr_value, e))
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
@@ -409,12 +418,13 @@ impl std::str::FromStr for MultipartRequest {
 impl std::convert::TryFrom<header::IntoHeaderValue<MultipartRequestObjectField>> for hyper::header::HeaderValue {
     type Error = String;
 
-    fn try_from(hdr_value: header::IntoHeaderValue<MultipartRequestObjectField>) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<MultipartRequestObjectField>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match hyper::header::HeaderValue::from_str(&hdr_value) {
-             Ok(value) => Ok(value),
-             Err(e) => Err(format!("Invalid header value for MultipartRequestObjectField - value: {} is invalid {}",
-                 hdr_value, e))
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for MultipartRequestObjectField - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -423,17 +433,19 @@ impl std::convert::TryFrom<header::IntoHeaderValue<MultipartRequestObjectField>>
 impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<MultipartRequestObjectField> {
     type Error = String;
 
-    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-             Ok(value) => {
+             std::result::Result::Ok(value) => {
                     match <MultipartRequestObjectField as std::str::FromStr>::from_str(value) {
-                        Ok(value) => Ok(header::IntoHeaderValue(value)),
-                        Err(err) => Err(format!("Unable to convert header value '{}' into MultipartRequestObjectField - {}",
-                            value, err))
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into MultipartRequestObjectField - {}",
+                                value, err))
                     }
              },
-             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
-                 hdr_value, e))
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }

--- a/samples/server/petstore/rust-server/output/multipart-v3/src/server/mod.rs
+++ b/samples/server/petstore/rust-server/output/multipart-v3/src/server/mod.rs
@@ -5,6 +5,8 @@ use hyper::{Request, Response, Error, StatusCode, Body, HeaderMap};
 use hyper::header::{HeaderName, HeaderValue, CONTENT_TYPE};
 use log::warn;
 use serde_json;
+#[allow(unused_imports)]
+use std::convert::{TryFrom, TryInto};
 use std::io;
 use url::form_urlencoded;
 #[allow(unused_imports)]

--- a/samples/server/petstore/rust-server/output/no-example-v3/src/client/mod.rs
+++ b/samples/server/petstore/rust-server/output/no-example-v3/src/client/mod.rs
@@ -8,6 +8,7 @@ use hyper::{Body, Uri, Response};
 use hyper_openssl::HttpsConnector;
 use serde_json;
 use std::borrow::Cow;
+use std::convert::TryInto;
 use std::io::{Read, Error, ErrorKind};
 use std::error;
 use std::fmt;

--- a/samples/server/petstore/rust-server/output/no-example-v3/src/models.rs
+++ b/samples/server/petstore/rust-server/output/no-example-v3/src/models.rs
@@ -8,16 +8,35 @@ use crate::header;
 // Methods for converting between header::IntoHeaderValue<InlineObject> and hyper::header::HeaderValue
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<header::IntoHeaderValue<InlineObject>> for hyper::header::HeaderValue {
-    fn from(hdr_value: header::IntoHeaderValue<InlineObject>) -> Self {
-        hyper::header::HeaderValue::from_str(&hdr_value.to_string()).unwrap()
+impl std::convert::TryFrom<header::IntoHeaderValue<InlineObject>> for hyper::header::HeaderValue {
+    type Error = String;
+
+    fn try_from(hdr_value: header::IntoHeaderValue<InlineObject>) -> Result<Self, Self::Error> {
+        let hdr_value = hdr_value.to_string();
+        match hyper::header::HeaderValue::from_str(&hdr_value) {
+             Ok(value) => Ok(value),
+             Err(e) => Err(format!("Invalid header value for InlineObject - value: {} is invalid {}",
+                 hdr_value, e))
+        }
     }
 }
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<hyper::header::HeaderValue> for header::IntoHeaderValue<InlineObject> {
-    fn from(hdr_value: hyper::header::HeaderValue) -> Self {
-        header::IntoHeaderValue(<InlineObject as std::str::FromStr>::from_str(hdr_value.to_str().unwrap()).unwrap())
+impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<InlineObject> {
+    type Error = String;
+
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+        match hdr_value.to_str() {
+             Ok(value) => {
+                    match <InlineObject as std::str::FromStr>::from_str(value) {
+                        Ok(value) => Ok(header::IntoHeaderValue(value)),
+                        Err(err) => Err(format!("Unable to convert header value '{}' into InlineObject - {}",
+                            value, err))
+                    }
+             },
+             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
+                 hdr_value, e))
+        }
     }
 }
 

--- a/samples/server/petstore/rust-server/output/no-example-v3/src/models.rs
+++ b/samples/server/petstore/rust-server/output/no-example-v3/src/models.rs
@@ -11,12 +11,13 @@ use crate::header;
 impl std::convert::TryFrom<header::IntoHeaderValue<InlineObject>> for hyper::header::HeaderValue {
     type Error = String;
 
-    fn try_from(hdr_value: header::IntoHeaderValue<InlineObject>) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<InlineObject>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match hyper::header::HeaderValue::from_str(&hdr_value) {
-             Ok(value) => Ok(value),
-             Err(e) => Err(format!("Invalid header value for InlineObject - value: {} is invalid {}",
-                 hdr_value, e))
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for InlineObject - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -25,17 +26,19 @@ impl std::convert::TryFrom<header::IntoHeaderValue<InlineObject>> for hyper::hea
 impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<InlineObject> {
     type Error = String;
 
-    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-             Ok(value) => {
+             std::result::Result::Ok(value) => {
                     match <InlineObject as std::str::FromStr>::from_str(value) {
-                        Ok(value) => Ok(header::IntoHeaderValue(value)),
-                        Err(err) => Err(format!("Unable to convert header value '{}' into InlineObject - {}",
-                            value, err))
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into InlineObject - {}",
+                                value, err))
                     }
              },
-             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
-                 hdr_value, e))
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }

--- a/samples/server/petstore/rust-server/output/no-example-v3/src/server/mod.rs
+++ b/samples/server/petstore/rust-server/output/no-example-v3/src/server/mod.rs
@@ -5,6 +5,8 @@ use hyper::{Request, Response, Error, StatusCode, Body, HeaderMap};
 use hyper::header::{HeaderName, HeaderValue, CONTENT_TYPE};
 use log::warn;
 use serde_json;
+#[allow(unused_imports)]
+use std::convert::{TryFrom, TryInto};
 use std::io;
 use url::form_urlencoded;
 #[allow(unused_imports)]

--- a/samples/server/petstore/rust-server/output/openapi-v3/api/openapi.yaml
+++ b/samples/server/petstore/rust-server/output/openapi-v3/api/openapi.yaml
@@ -214,6 +214,11 @@ paths:
               schema:
                 type: String
               style: simple
+            Bool-Header:
+              explode: false
+              schema:
+                type: bool
+              style: simple
             Object-Header:
               explode: false
               schema:

--- a/samples/server/petstore/rust-server/output/openapi-v3/src/lib.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/src/lib.rs
@@ -119,6 +119,7 @@ pub enum ResponsesWithHeadersGetResponse {
     {
         body: String,
         success_info: String,
+        bool_header: bool,
         object_header: models::ObjectHeader
     }
     ,

--- a/samples/server/petstore/rust-server/output/openapi-v3/src/models.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/src/models.rs
@@ -8,16 +8,35 @@ use crate::header;
 // Methods for converting between header::IntoHeaderValue<AnotherXmlArray> and hyper::header::HeaderValue
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<header::IntoHeaderValue<AnotherXmlArray>> for hyper::header::HeaderValue {
-    fn from(hdr_value: header::IntoHeaderValue<AnotherXmlArray>) -> Self {
-        hyper::header::HeaderValue::from_str(&hdr_value.to_string()).unwrap()
+impl std::convert::TryFrom<header::IntoHeaderValue<AnotherXmlArray>> for hyper::header::HeaderValue {
+    type Error = String;
+
+    fn try_from(hdr_value: header::IntoHeaderValue<AnotherXmlArray>) -> Result<Self, Self::Error> {
+        let hdr_value = hdr_value.to_string();
+        match hyper::header::HeaderValue::from_str(&hdr_value) {
+             Ok(value) => Ok(value),
+             Err(e) => Err(format!("Invalid header value for AnotherXmlArray - value: {} is invalid {}",
+                 hdr_value, e))
+        }
     }
 }
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<hyper::header::HeaderValue> for header::IntoHeaderValue<AnotherXmlArray> {
-    fn from(hdr_value: hyper::header::HeaderValue) -> Self {
-        header::IntoHeaderValue(<AnotherXmlArray as std::str::FromStr>::from_str(hdr_value.to_str().unwrap()).unwrap())
+impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<AnotherXmlArray> {
+    type Error = String;
+
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+        match hdr_value.to_str() {
+             Ok(value) => {
+                    match <AnotherXmlArray as std::str::FromStr>::from_str(value) {
+                        Ok(value) => Ok(header::IntoHeaderValue(value)),
+                        Err(err) => Err(format!("Unable to convert header value '{}' into AnotherXmlArray - {}",
+                            value, err))
+                    }
+             },
+             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
+                 hdr_value, e))
+        }
     }
 }
 
@@ -187,16 +206,35 @@ impl AnotherXmlInner {
 // Methods for converting between header::IntoHeaderValue<AnotherXmlObject> and hyper::header::HeaderValue
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<header::IntoHeaderValue<AnotherXmlObject>> for hyper::header::HeaderValue {
-    fn from(hdr_value: header::IntoHeaderValue<AnotherXmlObject>) -> Self {
-        hyper::header::HeaderValue::from_str(&hdr_value.to_string()).unwrap()
+impl std::convert::TryFrom<header::IntoHeaderValue<AnotherXmlObject>> for hyper::header::HeaderValue {
+    type Error = String;
+
+    fn try_from(hdr_value: header::IntoHeaderValue<AnotherXmlObject>) -> Result<Self, Self::Error> {
+        let hdr_value = hdr_value.to_string();
+        match hyper::header::HeaderValue::from_str(&hdr_value) {
+             Ok(value) => Ok(value),
+             Err(e) => Err(format!("Invalid header value for AnotherXmlObject - value: {} is invalid {}",
+                 hdr_value, e))
+        }
     }
 }
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<hyper::header::HeaderValue> for header::IntoHeaderValue<AnotherXmlObject> {
-    fn from(hdr_value: hyper::header::HeaderValue) -> Self {
-        header::IntoHeaderValue(<AnotherXmlObject as std::str::FromStr>::from_str(hdr_value.to_str().unwrap()).unwrap())
+impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<AnotherXmlObject> {
+    type Error = String;
+
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+        match hdr_value.to_str() {
+             Ok(value) => {
+                    match <AnotherXmlObject as std::str::FromStr>::from_str(value) {
+                        Ok(value) => Ok(header::IntoHeaderValue(value)),
+                        Err(err) => Err(format!("Unable to convert header value '{}' into AnotherXmlObject - {}",
+                            value, err))
+                    }
+             },
+             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
+                 hdr_value, e))
+        }
     }
 }
 
@@ -301,16 +339,35 @@ impl AnotherXmlObject {
 // Methods for converting between header::IntoHeaderValue<DuplicateXmlObject> and hyper::header::HeaderValue
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<header::IntoHeaderValue<DuplicateXmlObject>> for hyper::header::HeaderValue {
-    fn from(hdr_value: header::IntoHeaderValue<DuplicateXmlObject>) -> Self {
-        hyper::header::HeaderValue::from_str(&hdr_value.to_string()).unwrap()
+impl std::convert::TryFrom<header::IntoHeaderValue<DuplicateXmlObject>> for hyper::header::HeaderValue {
+    type Error = String;
+
+    fn try_from(hdr_value: header::IntoHeaderValue<DuplicateXmlObject>) -> Result<Self, Self::Error> {
+        let hdr_value = hdr_value.to_string();
+        match hyper::header::HeaderValue::from_str(&hdr_value) {
+             Ok(value) => Ok(value),
+             Err(e) => Err(format!("Invalid header value for DuplicateXmlObject - value: {} is invalid {}",
+                 hdr_value, e))
+        }
     }
 }
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<hyper::header::HeaderValue> for header::IntoHeaderValue<DuplicateXmlObject> {
-    fn from(hdr_value: hyper::header::HeaderValue) -> Self {
-        header::IntoHeaderValue(<DuplicateXmlObject as std::str::FromStr>::from_str(hdr_value.to_str().unwrap()).unwrap())
+impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<DuplicateXmlObject> {
+    type Error = String;
+
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+        match hdr_value.to_str() {
+             Ok(value) => {
+                    match <DuplicateXmlObject as std::str::FromStr>::from_str(value) {
+                        Ok(value) => Ok(header::IntoHeaderValue(value)),
+                        Err(err) => Err(format!("Unable to convert header value '{}' into DuplicateXmlObject - {}",
+                            value, err))
+                    }
+             },
+             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
+                 hdr_value, e))
+        }
     }
 }
 
@@ -577,16 +634,35 @@ impl Error {
 // Methods for converting between header::IntoHeaderValue<InlineResponse201> and hyper::header::HeaderValue
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<header::IntoHeaderValue<InlineResponse201>> for hyper::header::HeaderValue {
-    fn from(hdr_value: header::IntoHeaderValue<InlineResponse201>) -> Self {
-        hyper::header::HeaderValue::from_str(&hdr_value.to_string()).unwrap()
+impl std::convert::TryFrom<header::IntoHeaderValue<InlineResponse201>> for hyper::header::HeaderValue {
+    type Error = String;
+
+    fn try_from(hdr_value: header::IntoHeaderValue<InlineResponse201>) -> Result<Self, Self::Error> {
+        let hdr_value = hdr_value.to_string();
+        match hyper::header::HeaderValue::from_str(&hdr_value) {
+             Ok(value) => Ok(value),
+             Err(e) => Err(format!("Invalid header value for InlineResponse201 - value: {} is invalid {}",
+                 hdr_value, e))
+        }
     }
 }
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<hyper::header::HeaderValue> for header::IntoHeaderValue<InlineResponse201> {
-    fn from(hdr_value: hyper::header::HeaderValue) -> Self {
-        header::IntoHeaderValue(<InlineResponse201 as std::str::FromStr>::from_str(hdr_value.to_str().unwrap()).unwrap())
+impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<InlineResponse201> {
+    type Error = String;
+
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+        match hdr_value.to_str() {
+             Ok(value) => {
+                    match <InlineResponse201 as std::str::FromStr>::from_str(value) {
+                        Ok(value) => Ok(header::IntoHeaderValue(value)),
+                        Err(err) => Err(format!("Unable to convert header value '{}' into InlineResponse201 - {}",
+                            value, err))
+                    }
+             },
+             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
+                 hdr_value, e))
+        }
     }
 }
 
@@ -720,16 +796,35 @@ impl MyId {
 // Methods for converting between header::IntoHeaderValue<MyIdList> and hyper::header::HeaderValue
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<header::IntoHeaderValue<MyIdList>> for hyper::header::HeaderValue {
-    fn from(hdr_value: header::IntoHeaderValue<MyIdList>) -> Self {
-        hyper::header::HeaderValue::from_str(&hdr_value.to_string()).unwrap()
+impl std::convert::TryFrom<header::IntoHeaderValue<MyIdList>> for hyper::header::HeaderValue {
+    type Error = String;
+
+    fn try_from(hdr_value: header::IntoHeaderValue<MyIdList>) -> Result<Self, Self::Error> {
+        let hdr_value = hdr_value.to_string();
+        match hyper::header::HeaderValue::from_str(&hdr_value) {
+             Ok(value) => Ok(value),
+             Err(e) => Err(format!("Invalid header value for MyIdList - value: {} is invalid {}",
+                 hdr_value, e))
+        }
     }
 }
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<hyper::header::HeaderValue> for header::IntoHeaderValue<MyIdList> {
-    fn from(hdr_value: hyper::header::HeaderValue) -> Self {
-        header::IntoHeaderValue(<MyIdList as std::str::FromStr>::from_str(hdr_value.to_str().unwrap()).unwrap())
+impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<MyIdList> {
+    type Error = String;
+
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+        match hdr_value.to_str() {
+             Ok(value) => {
+                    match <MyIdList as std::str::FromStr>::from_str(value) {
+                        Ok(value) => Ok(header::IntoHeaderValue(value)),
+                        Err(err) => Err(format!("Unable to convert header value '{}' into MyIdList - {}",
+                            value, err))
+                    }
+             },
+             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
+                 hdr_value, e))
+        }
     }
 }
 
@@ -835,16 +930,35 @@ impl MyIdList {
 // Methods for converting between header::IntoHeaderValue<NullableTest> and hyper::header::HeaderValue
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<header::IntoHeaderValue<NullableTest>> for hyper::header::HeaderValue {
-    fn from(hdr_value: header::IntoHeaderValue<NullableTest>) -> Self {
-        hyper::header::HeaderValue::from_str(&hdr_value.to_string()).unwrap()
+impl std::convert::TryFrom<header::IntoHeaderValue<NullableTest>> for hyper::header::HeaderValue {
+    type Error = String;
+
+    fn try_from(hdr_value: header::IntoHeaderValue<NullableTest>) -> Result<Self, Self::Error> {
+        let hdr_value = hdr_value.to_string();
+        match hyper::header::HeaderValue::from_str(&hdr_value) {
+             Ok(value) => Ok(value),
+             Err(e) => Err(format!("Invalid header value for NullableTest - value: {} is invalid {}",
+                 hdr_value, e))
+        }
     }
 }
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<hyper::header::HeaderValue> for header::IntoHeaderValue<NullableTest> {
-    fn from(hdr_value: hyper::header::HeaderValue) -> Self {
-        header::IntoHeaderValue(<NullableTest as std::str::FromStr>::from_str(hdr_value.to_str().unwrap()).unwrap())
+impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<NullableTest> {
+    type Error = String;
+
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+        match hdr_value.to_str() {
+             Ok(value) => {
+                    match <NullableTest as std::str::FromStr>::from_str(value) {
+                        Ok(value) => Ok(header::IntoHeaderValue(value)),
+                        Err(err) => Err(format!("Unable to convert header value '{}' into NullableTest - {}",
+                            value, err))
+                    }
+             },
+             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
+                 hdr_value, e))
+        }
     }
 }
 
@@ -999,16 +1113,35 @@ impl NullableTest {
 // Methods for converting between header::IntoHeaderValue<ObjectHeader> and hyper::header::HeaderValue
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<header::IntoHeaderValue<ObjectHeader>> for hyper::header::HeaderValue {
-    fn from(hdr_value: header::IntoHeaderValue<ObjectHeader>) -> Self {
-        hyper::header::HeaderValue::from_str(&hdr_value.to_string()).unwrap()
+impl std::convert::TryFrom<header::IntoHeaderValue<ObjectHeader>> for hyper::header::HeaderValue {
+    type Error = String;
+
+    fn try_from(hdr_value: header::IntoHeaderValue<ObjectHeader>) -> Result<Self, Self::Error> {
+        let hdr_value = hdr_value.to_string();
+        match hyper::header::HeaderValue::from_str(&hdr_value) {
+             Ok(value) => Ok(value),
+             Err(e) => Err(format!("Invalid header value for ObjectHeader - value: {} is invalid {}",
+                 hdr_value, e))
+        }
     }
 }
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<hyper::header::HeaderValue> for header::IntoHeaderValue<ObjectHeader> {
-    fn from(hdr_value: hyper::header::HeaderValue) -> Self {
-        header::IntoHeaderValue(<ObjectHeader as std::str::FromStr>::from_str(hdr_value.to_str().unwrap()).unwrap())
+impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<ObjectHeader> {
+    type Error = String;
+
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+        match hdr_value.to_str() {
+             Ok(value) => {
+                    match <ObjectHeader as std::str::FromStr>::from_str(value) {
+                        Ok(value) => Ok(header::IntoHeaderValue(value)),
+                        Err(err) => Err(format!("Unable to convert header value '{}' into ObjectHeader - {}",
+                            value, err))
+                    }
+             },
+             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
+                 hdr_value, e))
+        }
     }
 }
 
@@ -1113,16 +1246,35 @@ impl ObjectHeader {
 // Methods for converting between header::IntoHeaderValue<ObjectParam> and hyper::header::HeaderValue
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<header::IntoHeaderValue<ObjectParam>> for hyper::header::HeaderValue {
-    fn from(hdr_value: header::IntoHeaderValue<ObjectParam>) -> Self {
-        hyper::header::HeaderValue::from_str(&hdr_value.to_string()).unwrap()
+impl std::convert::TryFrom<header::IntoHeaderValue<ObjectParam>> for hyper::header::HeaderValue {
+    type Error = String;
+
+    fn try_from(hdr_value: header::IntoHeaderValue<ObjectParam>) -> Result<Self, Self::Error> {
+        let hdr_value = hdr_value.to_string();
+        match hyper::header::HeaderValue::from_str(&hdr_value) {
+             Ok(value) => Ok(value),
+             Err(e) => Err(format!("Invalid header value for ObjectParam - value: {} is invalid {}",
+                 hdr_value, e))
+        }
     }
 }
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<hyper::header::HeaderValue> for header::IntoHeaderValue<ObjectParam> {
-    fn from(hdr_value: hyper::header::HeaderValue) -> Self {
-        header::IntoHeaderValue(<ObjectParam as std::str::FromStr>::from_str(hdr_value.to_str().unwrap()).unwrap())
+impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<ObjectParam> {
+    type Error = String;
+
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+        match hdr_value.to_str() {
+             Ok(value) => {
+                    match <ObjectParam as std::str::FromStr>::from_str(value) {
+                        Ok(value) => Ok(header::IntoHeaderValue(value)),
+                        Err(err) => Err(format!("Unable to convert header value '{}' into ObjectParam - {}",
+                            value, err))
+                    }
+             },
+             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
+                 hdr_value, e))
+        }
     }
 }
 
@@ -1227,16 +1379,35 @@ impl ObjectParam {
 // Methods for converting between header::IntoHeaderValue<ObjectUntypedProps> and hyper::header::HeaderValue
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<header::IntoHeaderValue<ObjectUntypedProps>> for hyper::header::HeaderValue {
-    fn from(hdr_value: header::IntoHeaderValue<ObjectUntypedProps>) -> Self {
-        hyper::header::HeaderValue::from_str(&hdr_value.to_string()).unwrap()
+impl std::convert::TryFrom<header::IntoHeaderValue<ObjectUntypedProps>> for hyper::header::HeaderValue {
+    type Error = String;
+
+    fn try_from(hdr_value: header::IntoHeaderValue<ObjectUntypedProps>) -> Result<Self, Self::Error> {
+        let hdr_value = hdr_value.to_string();
+        match hyper::header::HeaderValue::from_str(&hdr_value) {
+             Ok(value) => Ok(value),
+             Err(e) => Err(format!("Invalid header value for ObjectUntypedProps - value: {} is invalid {}",
+                 hdr_value, e))
+        }
     }
 }
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<hyper::header::HeaderValue> for header::IntoHeaderValue<ObjectUntypedProps> {
-    fn from(hdr_value: hyper::header::HeaderValue) -> Self {
-        header::IntoHeaderValue(<ObjectUntypedProps as std::str::FromStr>::from_str(hdr_value.to_str().unwrap()).unwrap())
+impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<ObjectUntypedProps> {
+    type Error = String;
+
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+        match hdr_value.to_str() {
+             Ok(value) => {
+                    match <ObjectUntypedProps as std::str::FromStr>::from_str(value) {
+                        Ok(value) => Ok(header::IntoHeaderValue(value)),
+                        Err(err) => Err(format!("Unable to convert header value '{}' into ObjectUntypedProps - {}",
+                            value, err))
+                    }
+             },
+             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
+                 hdr_value, e))
+        }
     }
 }
 
@@ -1354,16 +1525,35 @@ impl ObjectUntypedProps {
 // Methods for converting between header::IntoHeaderValue<ObjectWithArrayOfObjects> and hyper::header::HeaderValue
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<header::IntoHeaderValue<ObjectWithArrayOfObjects>> for hyper::header::HeaderValue {
-    fn from(hdr_value: header::IntoHeaderValue<ObjectWithArrayOfObjects>) -> Self {
-        hyper::header::HeaderValue::from_str(&hdr_value.to_string()).unwrap()
+impl std::convert::TryFrom<header::IntoHeaderValue<ObjectWithArrayOfObjects>> for hyper::header::HeaderValue {
+    type Error = String;
+
+    fn try_from(hdr_value: header::IntoHeaderValue<ObjectWithArrayOfObjects>) -> Result<Self, Self::Error> {
+        let hdr_value = hdr_value.to_string();
+        match hyper::header::HeaderValue::from_str(&hdr_value) {
+             Ok(value) => Ok(value),
+             Err(e) => Err(format!("Invalid header value for ObjectWithArrayOfObjects - value: {} is invalid {}",
+                 hdr_value, e))
+        }
     }
 }
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<hyper::header::HeaderValue> for header::IntoHeaderValue<ObjectWithArrayOfObjects> {
-    fn from(hdr_value: hyper::header::HeaderValue) -> Self {
-        header::IntoHeaderValue(<ObjectWithArrayOfObjects as std::str::FromStr>::from_str(hdr_value.to_str().unwrap()).unwrap())
+impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<ObjectWithArrayOfObjects> {
+    type Error = String;
+
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+        match hdr_value.to_str() {
+             Ok(value) => {
+                    match <ObjectWithArrayOfObjects as std::str::FromStr>::from_str(value) {
+                        Ok(value) => Ok(header::IntoHeaderValue(value)),
+                        Err(err) => Err(format!("Unable to convert header value '{}' into ObjectWithArrayOfObjects - {}",
+                            value, err))
+                    }
+             },
+             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
+                 hdr_value, e))
+        }
     }
 }
 
@@ -1778,16 +1968,35 @@ impl UuidObject {
 // Methods for converting between header::IntoHeaderValue<XmlArray> and hyper::header::HeaderValue
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<header::IntoHeaderValue<XmlArray>> for hyper::header::HeaderValue {
-    fn from(hdr_value: header::IntoHeaderValue<XmlArray>) -> Self {
-        hyper::header::HeaderValue::from_str(&hdr_value.to_string()).unwrap()
+impl std::convert::TryFrom<header::IntoHeaderValue<XmlArray>> for hyper::header::HeaderValue {
+    type Error = String;
+
+    fn try_from(hdr_value: header::IntoHeaderValue<XmlArray>) -> Result<Self, Self::Error> {
+        let hdr_value = hdr_value.to_string();
+        match hyper::header::HeaderValue::from_str(&hdr_value) {
+             Ok(value) => Ok(value),
+             Err(e) => Err(format!("Invalid header value for XmlArray - value: {} is invalid {}",
+                 hdr_value, e))
+        }
     }
 }
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<hyper::header::HeaderValue> for header::IntoHeaderValue<XmlArray> {
-    fn from(hdr_value: hyper::header::HeaderValue) -> Self {
-        header::IntoHeaderValue(<XmlArray as std::str::FromStr>::from_str(hdr_value.to_str().unwrap()).unwrap())
+impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<XmlArray> {
+    type Error = String;
+
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+        match hdr_value.to_str() {
+             Ok(value) => {
+                    match <XmlArray as std::str::FromStr>::from_str(value) {
+                        Ok(value) => Ok(header::IntoHeaderValue(value)),
+                        Err(err) => Err(format!("Unable to convert header value '{}' into XmlArray - {}",
+                            value, err))
+                    }
+             },
+             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
+                 hdr_value, e))
+        }
     }
 }
 
@@ -1957,16 +2166,35 @@ impl XmlInner {
 // Methods for converting between header::IntoHeaderValue<XmlObject> and hyper::header::HeaderValue
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<header::IntoHeaderValue<XmlObject>> for hyper::header::HeaderValue {
-    fn from(hdr_value: header::IntoHeaderValue<XmlObject>) -> Self {
-        hyper::header::HeaderValue::from_str(&hdr_value.to_string()).unwrap()
+impl std::convert::TryFrom<header::IntoHeaderValue<XmlObject>> for hyper::header::HeaderValue {
+    type Error = String;
+
+    fn try_from(hdr_value: header::IntoHeaderValue<XmlObject>) -> Result<Self, Self::Error> {
+        let hdr_value = hdr_value.to_string();
+        match hyper::header::HeaderValue::from_str(&hdr_value) {
+             Ok(value) => Ok(value),
+             Err(e) => Err(format!("Invalid header value for XmlObject - value: {} is invalid {}",
+                 hdr_value, e))
+        }
     }
 }
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<hyper::header::HeaderValue> for header::IntoHeaderValue<XmlObject> {
-    fn from(hdr_value: hyper::header::HeaderValue) -> Self {
-        header::IntoHeaderValue(<XmlObject as std::str::FromStr>::from_str(hdr_value.to_str().unwrap()).unwrap())
+impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<XmlObject> {
+    type Error = String;
+
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+        match hdr_value.to_str() {
+             Ok(value) => {
+                    match <XmlObject as std::str::FromStr>::from_str(value) {
+                        Ok(value) => Ok(header::IntoHeaderValue(value)),
+                        Err(err) => Err(format!("Unable to convert header value '{}' into XmlObject - {}",
+                            value, err))
+                    }
+             },
+             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
+                 hdr_value, e))
+        }
     }
 }
 

--- a/samples/server/petstore/rust-server/output/openapi-v3/src/models.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/src/models.rs
@@ -11,12 +11,13 @@ use crate::header;
 impl std::convert::TryFrom<header::IntoHeaderValue<AnotherXmlArray>> for hyper::header::HeaderValue {
     type Error = String;
 
-    fn try_from(hdr_value: header::IntoHeaderValue<AnotherXmlArray>) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<AnotherXmlArray>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match hyper::header::HeaderValue::from_str(&hdr_value) {
-             Ok(value) => Ok(value),
-             Err(e) => Err(format!("Invalid header value for AnotherXmlArray - value: {} is invalid {}",
-                 hdr_value, e))
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for AnotherXmlArray - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -25,17 +26,19 @@ impl std::convert::TryFrom<header::IntoHeaderValue<AnotherXmlArray>> for hyper::
 impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<AnotherXmlArray> {
     type Error = String;
 
-    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-             Ok(value) => {
+             std::result::Result::Ok(value) => {
                     match <AnotherXmlArray as std::str::FromStr>::from_str(value) {
-                        Ok(value) => Ok(header::IntoHeaderValue(value)),
-                        Err(err) => Err(format!("Unable to convert header value '{}' into AnotherXmlArray - {}",
-                            value, err))
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into AnotherXmlArray - {}",
+                                value, err))
                     }
              },
-             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
-                 hdr_value, e))
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
@@ -209,12 +212,13 @@ impl AnotherXmlInner {
 impl std::convert::TryFrom<header::IntoHeaderValue<AnotherXmlObject>> for hyper::header::HeaderValue {
     type Error = String;
 
-    fn try_from(hdr_value: header::IntoHeaderValue<AnotherXmlObject>) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<AnotherXmlObject>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match hyper::header::HeaderValue::from_str(&hdr_value) {
-             Ok(value) => Ok(value),
-             Err(e) => Err(format!("Invalid header value for AnotherXmlObject - value: {} is invalid {}",
-                 hdr_value, e))
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for AnotherXmlObject - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -223,17 +227,19 @@ impl std::convert::TryFrom<header::IntoHeaderValue<AnotherXmlObject>> for hyper:
 impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<AnotherXmlObject> {
     type Error = String;
 
-    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-             Ok(value) => {
+             std::result::Result::Ok(value) => {
                     match <AnotherXmlObject as std::str::FromStr>::from_str(value) {
-                        Ok(value) => Ok(header::IntoHeaderValue(value)),
-                        Err(err) => Err(format!("Unable to convert header value '{}' into AnotherXmlObject - {}",
-                            value, err))
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into AnotherXmlObject - {}",
+                                value, err))
                     }
              },
-             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
-                 hdr_value, e))
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
@@ -342,12 +348,13 @@ impl AnotherXmlObject {
 impl std::convert::TryFrom<header::IntoHeaderValue<DuplicateXmlObject>> for hyper::header::HeaderValue {
     type Error = String;
 
-    fn try_from(hdr_value: header::IntoHeaderValue<DuplicateXmlObject>) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<DuplicateXmlObject>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match hyper::header::HeaderValue::from_str(&hdr_value) {
-             Ok(value) => Ok(value),
-             Err(e) => Err(format!("Invalid header value for DuplicateXmlObject - value: {} is invalid {}",
-                 hdr_value, e))
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for DuplicateXmlObject - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -356,17 +363,19 @@ impl std::convert::TryFrom<header::IntoHeaderValue<DuplicateXmlObject>> for hype
 impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<DuplicateXmlObject> {
     type Error = String;
 
-    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-             Ok(value) => {
+             std::result::Result::Ok(value) => {
                     match <DuplicateXmlObject as std::str::FromStr>::from_str(value) {
-                        Ok(value) => Ok(header::IntoHeaderValue(value)),
-                        Err(err) => Err(format!("Unable to convert header value '{}' into DuplicateXmlObject - {}",
-                            value, err))
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into DuplicateXmlObject - {}",
+                                value, err))
                     }
              },
-             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
-                 hdr_value, e))
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
@@ -637,12 +646,13 @@ impl Error {
 impl std::convert::TryFrom<header::IntoHeaderValue<InlineResponse201>> for hyper::header::HeaderValue {
     type Error = String;
 
-    fn try_from(hdr_value: header::IntoHeaderValue<InlineResponse201>) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<InlineResponse201>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match hyper::header::HeaderValue::from_str(&hdr_value) {
-             Ok(value) => Ok(value),
-             Err(e) => Err(format!("Invalid header value for InlineResponse201 - value: {} is invalid {}",
-                 hdr_value, e))
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for InlineResponse201 - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -651,17 +661,19 @@ impl std::convert::TryFrom<header::IntoHeaderValue<InlineResponse201>> for hyper
 impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<InlineResponse201> {
     type Error = String;
 
-    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-             Ok(value) => {
+             std::result::Result::Ok(value) => {
                     match <InlineResponse201 as std::str::FromStr>::from_str(value) {
-                        Ok(value) => Ok(header::IntoHeaderValue(value)),
-                        Err(err) => Err(format!("Unable to convert header value '{}' into InlineResponse201 - {}",
-                            value, err))
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into InlineResponse201 - {}",
+                                value, err))
                     }
              },
-             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
-                 hdr_value, e))
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
@@ -799,12 +811,13 @@ impl MyId {
 impl std::convert::TryFrom<header::IntoHeaderValue<MyIdList>> for hyper::header::HeaderValue {
     type Error = String;
 
-    fn try_from(hdr_value: header::IntoHeaderValue<MyIdList>) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<MyIdList>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match hyper::header::HeaderValue::from_str(&hdr_value) {
-             Ok(value) => Ok(value),
-             Err(e) => Err(format!("Invalid header value for MyIdList - value: {} is invalid {}",
-                 hdr_value, e))
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for MyIdList - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -813,17 +826,19 @@ impl std::convert::TryFrom<header::IntoHeaderValue<MyIdList>> for hyper::header:
 impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<MyIdList> {
     type Error = String;
 
-    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-             Ok(value) => {
+             std::result::Result::Ok(value) => {
                     match <MyIdList as std::str::FromStr>::from_str(value) {
-                        Ok(value) => Ok(header::IntoHeaderValue(value)),
-                        Err(err) => Err(format!("Unable to convert header value '{}' into MyIdList - {}",
-                            value, err))
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into MyIdList - {}",
+                                value, err))
                     }
              },
-             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
-                 hdr_value, e))
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
@@ -933,12 +948,13 @@ impl MyIdList {
 impl std::convert::TryFrom<header::IntoHeaderValue<NullableTest>> for hyper::header::HeaderValue {
     type Error = String;
 
-    fn try_from(hdr_value: header::IntoHeaderValue<NullableTest>) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<NullableTest>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match hyper::header::HeaderValue::from_str(&hdr_value) {
-             Ok(value) => Ok(value),
-             Err(e) => Err(format!("Invalid header value for NullableTest - value: {} is invalid {}",
-                 hdr_value, e))
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for NullableTest - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -947,17 +963,19 @@ impl std::convert::TryFrom<header::IntoHeaderValue<NullableTest>> for hyper::hea
 impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<NullableTest> {
     type Error = String;
 
-    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-             Ok(value) => {
+             std::result::Result::Ok(value) => {
                     match <NullableTest as std::str::FromStr>::from_str(value) {
-                        Ok(value) => Ok(header::IntoHeaderValue(value)),
-                        Err(err) => Err(format!("Unable to convert header value '{}' into NullableTest - {}",
-                            value, err))
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into NullableTest - {}",
+                                value, err))
                     }
              },
-             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
-                 hdr_value, e))
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
@@ -1116,12 +1134,13 @@ impl NullableTest {
 impl std::convert::TryFrom<header::IntoHeaderValue<ObjectHeader>> for hyper::header::HeaderValue {
     type Error = String;
 
-    fn try_from(hdr_value: header::IntoHeaderValue<ObjectHeader>) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<ObjectHeader>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match hyper::header::HeaderValue::from_str(&hdr_value) {
-             Ok(value) => Ok(value),
-             Err(e) => Err(format!("Invalid header value for ObjectHeader - value: {} is invalid {}",
-                 hdr_value, e))
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for ObjectHeader - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -1130,17 +1149,19 @@ impl std::convert::TryFrom<header::IntoHeaderValue<ObjectHeader>> for hyper::hea
 impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<ObjectHeader> {
     type Error = String;
 
-    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-             Ok(value) => {
+             std::result::Result::Ok(value) => {
                     match <ObjectHeader as std::str::FromStr>::from_str(value) {
-                        Ok(value) => Ok(header::IntoHeaderValue(value)),
-                        Err(err) => Err(format!("Unable to convert header value '{}' into ObjectHeader - {}",
-                            value, err))
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into ObjectHeader - {}",
+                                value, err))
                     }
              },
-             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
-                 hdr_value, e))
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
@@ -1249,12 +1270,13 @@ impl ObjectHeader {
 impl std::convert::TryFrom<header::IntoHeaderValue<ObjectParam>> for hyper::header::HeaderValue {
     type Error = String;
 
-    fn try_from(hdr_value: header::IntoHeaderValue<ObjectParam>) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<ObjectParam>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match hyper::header::HeaderValue::from_str(&hdr_value) {
-             Ok(value) => Ok(value),
-             Err(e) => Err(format!("Invalid header value for ObjectParam - value: {} is invalid {}",
-                 hdr_value, e))
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for ObjectParam - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -1263,17 +1285,19 @@ impl std::convert::TryFrom<header::IntoHeaderValue<ObjectParam>> for hyper::head
 impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<ObjectParam> {
     type Error = String;
 
-    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-             Ok(value) => {
+             std::result::Result::Ok(value) => {
                     match <ObjectParam as std::str::FromStr>::from_str(value) {
-                        Ok(value) => Ok(header::IntoHeaderValue(value)),
-                        Err(err) => Err(format!("Unable to convert header value '{}' into ObjectParam - {}",
-                            value, err))
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into ObjectParam - {}",
+                                value, err))
                     }
              },
-             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
-                 hdr_value, e))
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
@@ -1382,12 +1406,13 @@ impl ObjectParam {
 impl std::convert::TryFrom<header::IntoHeaderValue<ObjectUntypedProps>> for hyper::header::HeaderValue {
     type Error = String;
 
-    fn try_from(hdr_value: header::IntoHeaderValue<ObjectUntypedProps>) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<ObjectUntypedProps>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match hyper::header::HeaderValue::from_str(&hdr_value) {
-             Ok(value) => Ok(value),
-             Err(e) => Err(format!("Invalid header value for ObjectUntypedProps - value: {} is invalid {}",
-                 hdr_value, e))
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for ObjectUntypedProps - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -1396,17 +1421,19 @@ impl std::convert::TryFrom<header::IntoHeaderValue<ObjectUntypedProps>> for hype
 impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<ObjectUntypedProps> {
     type Error = String;
 
-    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-             Ok(value) => {
+             std::result::Result::Ok(value) => {
                     match <ObjectUntypedProps as std::str::FromStr>::from_str(value) {
-                        Ok(value) => Ok(header::IntoHeaderValue(value)),
-                        Err(err) => Err(format!("Unable to convert header value '{}' into ObjectUntypedProps - {}",
-                            value, err))
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into ObjectUntypedProps - {}",
+                                value, err))
                     }
              },
-             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
-                 hdr_value, e))
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
@@ -1528,12 +1555,13 @@ impl ObjectUntypedProps {
 impl std::convert::TryFrom<header::IntoHeaderValue<ObjectWithArrayOfObjects>> for hyper::header::HeaderValue {
     type Error = String;
 
-    fn try_from(hdr_value: header::IntoHeaderValue<ObjectWithArrayOfObjects>) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<ObjectWithArrayOfObjects>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match hyper::header::HeaderValue::from_str(&hdr_value) {
-             Ok(value) => Ok(value),
-             Err(e) => Err(format!("Invalid header value for ObjectWithArrayOfObjects - value: {} is invalid {}",
-                 hdr_value, e))
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for ObjectWithArrayOfObjects - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -1542,17 +1570,19 @@ impl std::convert::TryFrom<header::IntoHeaderValue<ObjectWithArrayOfObjects>> fo
 impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<ObjectWithArrayOfObjects> {
     type Error = String;
 
-    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-             Ok(value) => {
+             std::result::Result::Ok(value) => {
                     match <ObjectWithArrayOfObjects as std::str::FromStr>::from_str(value) {
-                        Ok(value) => Ok(header::IntoHeaderValue(value)),
-                        Err(err) => Err(format!("Unable to convert header value '{}' into ObjectWithArrayOfObjects - {}",
-                            value, err))
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into ObjectWithArrayOfObjects - {}",
+                                value, err))
                     }
              },
-             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
-                 hdr_value, e))
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
@@ -1971,12 +2001,13 @@ impl UuidObject {
 impl std::convert::TryFrom<header::IntoHeaderValue<XmlArray>> for hyper::header::HeaderValue {
     type Error = String;
 
-    fn try_from(hdr_value: header::IntoHeaderValue<XmlArray>) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<XmlArray>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match hyper::header::HeaderValue::from_str(&hdr_value) {
-             Ok(value) => Ok(value),
-             Err(e) => Err(format!("Invalid header value for XmlArray - value: {} is invalid {}",
-                 hdr_value, e))
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for XmlArray - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -1985,17 +2016,19 @@ impl std::convert::TryFrom<header::IntoHeaderValue<XmlArray>> for hyper::header:
 impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<XmlArray> {
     type Error = String;
 
-    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-             Ok(value) => {
+             std::result::Result::Ok(value) => {
                     match <XmlArray as std::str::FromStr>::from_str(value) {
-                        Ok(value) => Ok(header::IntoHeaderValue(value)),
-                        Err(err) => Err(format!("Unable to convert header value '{}' into XmlArray - {}",
-                            value, err))
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into XmlArray - {}",
+                                value, err))
                     }
              },
-             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
-                 hdr_value, e))
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
@@ -2169,12 +2202,13 @@ impl XmlInner {
 impl std::convert::TryFrom<header::IntoHeaderValue<XmlObject>> for hyper::header::HeaderValue {
     type Error = String;
 
-    fn try_from(hdr_value: header::IntoHeaderValue<XmlObject>) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<XmlObject>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match hyper::header::HeaderValue::from_str(&hdr_value) {
-             Ok(value) => Ok(value),
-             Err(e) => Err(format!("Invalid header value for XmlObject - value: {} is invalid {}",
-                 hdr_value, e))
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for XmlObject - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -2183,17 +2217,19 @@ impl std::convert::TryFrom<header::IntoHeaderValue<XmlObject>> for hyper::header
 impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<XmlObject> {
     type Error = String;
 
-    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-             Ok(value) => {
+             std::result::Result::Ok(value) => {
                     match <XmlObject as std::str::FromStr>::from_str(value) {
-                        Ok(value) => Ok(header::IntoHeaderValue(value)),
-                        Err(err) => Err(format!("Unable to convert header value '{}' into XmlObject - {}",
-                            value, err))
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into XmlObject - {}",
+                                value, err))
                     }
              },
-             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
-                 hdr_value, e))
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }

--- a/samples/server/petstore/rust-server/output/ops-v3/src/client/mod.rs
+++ b/samples/server/petstore/rust-server/output/ops-v3/src/client/mod.rs
@@ -8,6 +8,7 @@ use hyper::{Body, Uri, Response};
 use hyper_openssl::HttpsConnector;
 use serde_json;
 use std::borrow::Cow;
+use std::convert::TryInto;
 use std::io::{Read, Error, ErrorKind};
 use std::error;
 use std::fmt;

--- a/samples/server/petstore/rust-server/output/ops-v3/src/server/mod.rs
+++ b/samples/server/petstore/rust-server/output/ops-v3/src/server/mod.rs
@@ -5,6 +5,8 @@ use hyper::{Request, Response, Error, StatusCode, Body, HeaderMap};
 use hyper::header::{HeaderName, HeaderValue, CONTENT_TYPE};
 use log::warn;
 use serde_json;
+#[allow(unused_imports)]
+use std::convert::{TryFrom, TryInto};
 use std::io;
 use url::form_urlencoded;
 #[allow(unused_imports)]

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/src/models.rs
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/src/models.rs
@@ -11,12 +11,13 @@ use crate::header;
 impl std::convert::TryFrom<header::IntoHeaderValue<AdditionalPropertiesClass>> for hyper::header::HeaderValue {
     type Error = String;
 
-    fn try_from(hdr_value: header::IntoHeaderValue<AdditionalPropertiesClass>) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<AdditionalPropertiesClass>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match hyper::header::HeaderValue::from_str(&hdr_value) {
-             Ok(value) => Ok(value),
-             Err(e) => Err(format!("Invalid header value for AdditionalPropertiesClass - value: {} is invalid {}",
-                 hdr_value, e))
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for AdditionalPropertiesClass - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -25,17 +26,19 @@ impl std::convert::TryFrom<header::IntoHeaderValue<AdditionalPropertiesClass>> f
 impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<AdditionalPropertiesClass> {
     type Error = String;
 
-    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-             Ok(value) => {
+             std::result::Result::Ok(value) => {
                     match <AdditionalPropertiesClass as std::str::FromStr>::from_str(value) {
-                        Ok(value) => Ok(header::IntoHeaderValue(value)),
-                        Err(err) => Err(format!("Unable to convert header value '{}' into AdditionalPropertiesClass - {}",
-                            value, err))
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into AdditionalPropertiesClass - {}",
+                                value, err))
                     }
              },
-             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
-                 hdr_value, e))
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
@@ -140,12 +143,13 @@ impl AdditionalPropertiesClass {
 impl std::convert::TryFrom<header::IntoHeaderValue<Animal>> for hyper::header::HeaderValue {
     type Error = String;
 
-    fn try_from(hdr_value: header::IntoHeaderValue<Animal>) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<Animal>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match hyper::header::HeaderValue::from_str(&hdr_value) {
-             Ok(value) => Ok(value),
-             Err(e) => Err(format!("Invalid header value for Animal - value: {} is invalid {}",
-                 hdr_value, e))
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for Animal - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -154,17 +158,19 @@ impl std::convert::TryFrom<header::IntoHeaderValue<Animal>> for hyper::header::H
 impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<Animal> {
     type Error = String;
 
-    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-             Ok(value) => {
+             std::result::Result::Ok(value) => {
                     match <Animal as std::str::FromStr>::from_str(value) {
-                        Ok(value) => Ok(header::IntoHeaderValue(value)),
-                        Err(err) => Err(format!("Unable to convert header value '{}' into Animal - {}",
-                            value, err))
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into Animal - {}",
+                                value, err))
                     }
              },
-             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
-                 hdr_value, e))
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
@@ -273,12 +279,13 @@ impl Animal {
 impl std::convert::TryFrom<header::IntoHeaderValue<AnimalFarm>> for hyper::header::HeaderValue {
     type Error = String;
 
-    fn try_from(hdr_value: header::IntoHeaderValue<AnimalFarm>) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<AnimalFarm>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match hyper::header::HeaderValue::from_str(&hdr_value) {
-             Ok(value) => Ok(value),
-             Err(e) => Err(format!("Invalid header value for AnimalFarm - value: {} is invalid {}",
-                 hdr_value, e))
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for AnimalFarm - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -287,17 +294,19 @@ impl std::convert::TryFrom<header::IntoHeaderValue<AnimalFarm>> for hyper::heade
 impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<AnimalFarm> {
     type Error = String;
 
-    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-             Ok(value) => {
+             std::result::Result::Ok(value) => {
                     match <AnimalFarm as std::str::FromStr>::from_str(value) {
-                        Ok(value) => Ok(header::IntoHeaderValue(value)),
-                        Err(err) => Err(format!("Unable to convert header value '{}' into AnimalFarm - {}",
-                            value, err))
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into AnimalFarm - {}",
+                                value, err))
                     }
              },
-             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
-                 hdr_value, e))
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
@@ -407,12 +416,13 @@ impl AnimalFarm {
 impl std::convert::TryFrom<header::IntoHeaderValue<ApiResponse>> for hyper::header::HeaderValue {
     type Error = String;
 
-    fn try_from(hdr_value: header::IntoHeaderValue<ApiResponse>) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<ApiResponse>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match hyper::header::HeaderValue::from_str(&hdr_value) {
-             Ok(value) => Ok(value),
-             Err(e) => Err(format!("Invalid header value for ApiResponse - value: {} is invalid {}",
-                 hdr_value, e))
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for ApiResponse - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -421,17 +431,19 @@ impl std::convert::TryFrom<header::IntoHeaderValue<ApiResponse>> for hyper::head
 impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<ApiResponse> {
     type Error = String;
 
-    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-             Ok(value) => {
+             std::result::Result::Ok(value) => {
                     match <ApiResponse as std::str::FromStr>::from_str(value) {
-                        Ok(value) => Ok(header::IntoHeaderValue(value)),
-                        Err(err) => Err(format!("Unable to convert header value '{}' into ApiResponse - {}",
-                            value, err))
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into ApiResponse - {}",
+                                value, err))
                     }
              },
-             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
-                 hdr_value, e))
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
@@ -557,12 +569,13 @@ impl ApiResponse {
 impl std::convert::TryFrom<header::IntoHeaderValue<ArrayOfArrayOfNumberOnly>> for hyper::header::HeaderValue {
     type Error = String;
 
-    fn try_from(hdr_value: header::IntoHeaderValue<ArrayOfArrayOfNumberOnly>) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<ArrayOfArrayOfNumberOnly>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match hyper::header::HeaderValue::from_str(&hdr_value) {
-             Ok(value) => Ok(value),
-             Err(e) => Err(format!("Invalid header value for ArrayOfArrayOfNumberOnly - value: {} is invalid {}",
-                 hdr_value, e))
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for ArrayOfArrayOfNumberOnly - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -571,17 +584,19 @@ impl std::convert::TryFrom<header::IntoHeaderValue<ArrayOfArrayOfNumberOnly>> fo
 impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<ArrayOfArrayOfNumberOnly> {
     type Error = String;
 
-    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-             Ok(value) => {
+             std::result::Result::Ok(value) => {
                     match <ArrayOfArrayOfNumberOnly as std::str::FromStr>::from_str(value) {
-                        Ok(value) => Ok(header::IntoHeaderValue(value)),
-                        Err(err) => Err(format!("Unable to convert header value '{}' into ArrayOfArrayOfNumberOnly - {}",
-                            value, err))
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into ArrayOfArrayOfNumberOnly - {}",
+                                value, err))
                     }
              },
-             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
-                 hdr_value, e))
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
@@ -675,12 +690,13 @@ impl ArrayOfArrayOfNumberOnly {
 impl std::convert::TryFrom<header::IntoHeaderValue<ArrayOfNumberOnly>> for hyper::header::HeaderValue {
     type Error = String;
 
-    fn try_from(hdr_value: header::IntoHeaderValue<ArrayOfNumberOnly>) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<ArrayOfNumberOnly>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match hyper::header::HeaderValue::from_str(&hdr_value) {
-             Ok(value) => Ok(value),
-             Err(e) => Err(format!("Invalid header value for ArrayOfNumberOnly - value: {} is invalid {}",
-                 hdr_value, e))
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for ArrayOfNumberOnly - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -689,17 +705,19 @@ impl std::convert::TryFrom<header::IntoHeaderValue<ArrayOfNumberOnly>> for hyper
 impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<ArrayOfNumberOnly> {
     type Error = String;
 
-    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-             Ok(value) => {
+             std::result::Result::Ok(value) => {
                     match <ArrayOfNumberOnly as std::str::FromStr>::from_str(value) {
-                        Ok(value) => Ok(header::IntoHeaderValue(value)),
-                        Err(err) => Err(format!("Unable to convert header value '{}' into ArrayOfNumberOnly - {}",
-                            value, err))
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into ArrayOfNumberOnly - {}",
+                                value, err))
                     }
              },
-             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
-                 hdr_value, e))
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
@@ -797,12 +815,13 @@ impl ArrayOfNumberOnly {
 impl std::convert::TryFrom<header::IntoHeaderValue<ArrayTest>> for hyper::header::HeaderValue {
     type Error = String;
 
-    fn try_from(hdr_value: header::IntoHeaderValue<ArrayTest>) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<ArrayTest>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match hyper::header::HeaderValue::from_str(&hdr_value) {
-             Ok(value) => Ok(value),
-             Err(e) => Err(format!("Invalid header value for ArrayTest - value: {} is invalid {}",
-                 hdr_value, e))
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for ArrayTest - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -811,17 +830,19 @@ impl std::convert::TryFrom<header::IntoHeaderValue<ArrayTest>> for hyper::header
 impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<ArrayTest> {
     type Error = String;
 
-    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-             Ok(value) => {
+             std::result::Result::Ok(value) => {
                     match <ArrayTest as std::str::FromStr>::from_str(value) {
-                        Ok(value) => Ok(header::IntoHeaderValue(value)),
-                        Err(err) => Err(format!("Unable to convert header value '{}' into ArrayTest - {}",
-                            value, err))
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into ArrayTest - {}",
+                                value, err))
                     }
              },
-             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
-                 hdr_value, e))
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
@@ -954,12 +975,13 @@ impl ArrayTest {
 impl std::convert::TryFrom<header::IntoHeaderValue<Capitalization>> for hyper::header::HeaderValue {
     type Error = String;
 
-    fn try_from(hdr_value: header::IntoHeaderValue<Capitalization>) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<Capitalization>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match hyper::header::HeaderValue::from_str(&hdr_value) {
-             Ok(value) => Ok(value),
-             Err(e) => Err(format!("Invalid header value for Capitalization - value: {} is invalid {}",
-                 hdr_value, e))
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for Capitalization - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -968,17 +990,19 @@ impl std::convert::TryFrom<header::IntoHeaderValue<Capitalization>> for hyper::h
 impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<Capitalization> {
     type Error = String;
 
-    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-             Ok(value) => {
+             std::result::Result::Ok(value) => {
                     match <Capitalization as std::str::FromStr>::from_str(value) {
-                        Ok(value) => Ok(header::IntoHeaderValue(value)),
-                        Err(err) => Err(format!("Unable to convert header value '{}' into Capitalization - {}",
-                            value, err))
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into Capitalization - {}",
+                                value, err))
                     }
              },
-             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
-                 hdr_value, e))
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
@@ -1147,12 +1171,13 @@ impl Capitalization {
 impl std::convert::TryFrom<header::IntoHeaderValue<Cat>> for hyper::header::HeaderValue {
     type Error = String;
 
-    fn try_from(hdr_value: header::IntoHeaderValue<Cat>) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<Cat>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match hyper::header::HeaderValue::from_str(&hdr_value) {
-             Ok(value) => Ok(value),
-             Err(e) => Err(format!("Invalid header value for Cat - value: {} is invalid {}",
-                 hdr_value, e))
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for Cat - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -1161,17 +1186,19 @@ impl std::convert::TryFrom<header::IntoHeaderValue<Cat>> for hyper::header::Head
 impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<Cat> {
     type Error = String;
 
-    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-             Ok(value) => {
+             std::result::Result::Ok(value) => {
                     match <Cat as std::str::FromStr>::from_str(value) {
-                        Ok(value) => Ok(header::IntoHeaderValue(value)),
-                        Err(err) => Err(format!("Unable to convert header value '{}' into Cat - {}",
-                            value, err))
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into Cat - {}",
+                                value, err))
                     }
              },
-             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
-                 hdr_value, e))
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
@@ -1294,12 +1321,13 @@ impl Cat {
 impl std::convert::TryFrom<header::IntoHeaderValue<CatAllOf>> for hyper::header::HeaderValue {
     type Error = String;
 
-    fn try_from(hdr_value: header::IntoHeaderValue<CatAllOf>) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<CatAllOf>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match hyper::header::HeaderValue::from_str(&hdr_value) {
-             Ok(value) => Ok(value),
-             Err(e) => Err(format!("Invalid header value for CatAllOf - value: {} is invalid {}",
-                 hdr_value, e))
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for CatAllOf - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -1308,17 +1336,19 @@ impl std::convert::TryFrom<header::IntoHeaderValue<CatAllOf>> for hyper::header:
 impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<CatAllOf> {
     type Error = String;
 
-    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-             Ok(value) => {
+             std::result::Result::Ok(value) => {
                     match <CatAllOf as std::str::FromStr>::from_str(value) {
-                        Ok(value) => Ok(header::IntoHeaderValue(value)),
-                        Err(err) => Err(format!("Unable to convert header value '{}' into CatAllOf - {}",
-                            value, err))
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into CatAllOf - {}",
+                                value, err))
                     }
              },
-             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
-                 hdr_value, e))
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
@@ -1416,12 +1446,13 @@ impl CatAllOf {
 impl std::convert::TryFrom<header::IntoHeaderValue<Category>> for hyper::header::HeaderValue {
     type Error = String;
 
-    fn try_from(hdr_value: header::IntoHeaderValue<Category>) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<Category>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match hyper::header::HeaderValue::from_str(&hdr_value) {
-             Ok(value) => Ok(value),
-             Err(e) => Err(format!("Invalid header value for Category - value: {} is invalid {}",
-                 hdr_value, e))
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for Category - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -1430,17 +1461,19 @@ impl std::convert::TryFrom<header::IntoHeaderValue<Category>> for hyper::header:
 impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<Category> {
     type Error = String;
 
-    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-             Ok(value) => {
+             std::result::Result::Ok(value) => {
                     match <Category as std::str::FromStr>::from_str(value) {
-                        Ok(value) => Ok(header::IntoHeaderValue(value)),
-                        Err(err) => Err(format!("Unable to convert header value '{}' into Category - {}",
-                            value, err))
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into Category - {}",
+                                value, err))
                     }
              },
-             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
-                 hdr_value, e))
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
@@ -1554,12 +1587,13 @@ impl Category {
 impl std::convert::TryFrom<header::IntoHeaderValue<ClassModel>> for hyper::header::HeaderValue {
     type Error = String;
 
-    fn try_from(hdr_value: header::IntoHeaderValue<ClassModel>) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<ClassModel>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match hyper::header::HeaderValue::from_str(&hdr_value) {
-             Ok(value) => Ok(value),
-             Err(e) => Err(format!("Invalid header value for ClassModel - value: {} is invalid {}",
-                 hdr_value, e))
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for ClassModel - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -1568,17 +1602,19 @@ impl std::convert::TryFrom<header::IntoHeaderValue<ClassModel>> for hyper::heade
 impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<ClassModel> {
     type Error = String;
 
-    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-             Ok(value) => {
+             std::result::Result::Ok(value) => {
                     match <ClassModel as std::str::FromStr>::from_str(value) {
-                        Ok(value) => Ok(header::IntoHeaderValue(value)),
-                        Err(err) => Err(format!("Unable to convert header value '{}' into ClassModel - {}",
-                            value, err))
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into ClassModel - {}",
+                                value, err))
                     }
              },
-             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
-                 hdr_value, e))
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
@@ -1676,12 +1712,13 @@ impl ClassModel {
 impl std::convert::TryFrom<header::IntoHeaderValue<Client>> for hyper::header::HeaderValue {
     type Error = String;
 
-    fn try_from(hdr_value: header::IntoHeaderValue<Client>) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<Client>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match hyper::header::HeaderValue::from_str(&hdr_value) {
-             Ok(value) => Ok(value),
-             Err(e) => Err(format!("Invalid header value for Client - value: {} is invalid {}",
-                 hdr_value, e))
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for Client - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -1690,17 +1727,19 @@ impl std::convert::TryFrom<header::IntoHeaderValue<Client>> for hyper::header::H
 impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<Client> {
     type Error = String;
 
-    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-             Ok(value) => {
+             std::result::Result::Ok(value) => {
                     match <Client as std::str::FromStr>::from_str(value) {
-                        Ok(value) => Ok(header::IntoHeaderValue(value)),
-                        Err(err) => Err(format!("Unable to convert header value '{}' into Client - {}",
-                            value, err))
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into Client - {}",
+                                value, err))
                     }
              },
-             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
-                 hdr_value, e))
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
@@ -1798,12 +1837,13 @@ impl Client {
 impl std::convert::TryFrom<header::IntoHeaderValue<Dog>> for hyper::header::HeaderValue {
     type Error = String;
 
-    fn try_from(hdr_value: header::IntoHeaderValue<Dog>) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<Dog>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match hyper::header::HeaderValue::from_str(&hdr_value) {
-             Ok(value) => Ok(value),
-             Err(e) => Err(format!("Invalid header value for Dog - value: {} is invalid {}",
-                 hdr_value, e))
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for Dog - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -1812,17 +1852,19 @@ impl std::convert::TryFrom<header::IntoHeaderValue<Dog>> for hyper::header::Head
 impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<Dog> {
     type Error = String;
 
-    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-             Ok(value) => {
+             std::result::Result::Ok(value) => {
                     match <Dog as std::str::FromStr>::from_str(value) {
-                        Ok(value) => Ok(header::IntoHeaderValue(value)),
-                        Err(err) => Err(format!("Unable to convert header value '{}' into Dog - {}",
-                            value, err))
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into Dog - {}",
+                                value, err))
                     }
              },
-             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
-                 hdr_value, e))
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
@@ -1945,12 +1987,13 @@ impl Dog {
 impl std::convert::TryFrom<header::IntoHeaderValue<DogAllOf>> for hyper::header::HeaderValue {
     type Error = String;
 
-    fn try_from(hdr_value: header::IntoHeaderValue<DogAllOf>) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<DogAllOf>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match hyper::header::HeaderValue::from_str(&hdr_value) {
-             Ok(value) => Ok(value),
-             Err(e) => Err(format!("Invalid header value for DogAllOf - value: {} is invalid {}",
-                 hdr_value, e))
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for DogAllOf - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -1959,17 +2002,19 @@ impl std::convert::TryFrom<header::IntoHeaderValue<DogAllOf>> for hyper::header:
 impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<DogAllOf> {
     type Error = String;
 
-    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-             Ok(value) => {
+             std::result::Result::Ok(value) => {
                     match <DogAllOf as std::str::FromStr>::from_str(value) {
-                        Ok(value) => Ok(header::IntoHeaderValue(value)),
-                        Err(err) => Err(format!("Unable to convert header value '{}' into DogAllOf - {}",
-                            value, err))
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into DogAllOf - {}",
+                                value, err))
                     }
              },
-             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
-                 hdr_value, e))
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
@@ -2067,12 +2112,13 @@ impl DogAllOf {
 impl std::convert::TryFrom<header::IntoHeaderValue<EnumArrays>> for hyper::header::HeaderValue {
     type Error = String;
 
-    fn try_from(hdr_value: header::IntoHeaderValue<EnumArrays>) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<EnumArrays>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match hyper::header::HeaderValue::from_str(&hdr_value) {
-             Ok(value) => Ok(value),
-             Err(e) => Err(format!("Invalid header value for EnumArrays - value: {} is invalid {}",
-                 hdr_value, e))
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for EnumArrays - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -2081,17 +2127,19 @@ impl std::convert::TryFrom<header::IntoHeaderValue<EnumArrays>> for hyper::heade
 impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<EnumArrays> {
     type Error = String;
 
-    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-             Ok(value) => {
+             std::result::Result::Ok(value) => {
                     match <EnumArrays as std::str::FromStr>::from_str(value) {
-                        Ok(value) => Ok(header::IntoHeaderValue(value)),
-                        Err(err) => Err(format!("Unable to convert header value '{}' into EnumArrays - {}",
-                            value, err))
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into EnumArrays - {}",
+                                value, err))
                     }
              },
-             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
-                 hdr_value, e))
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
@@ -2264,12 +2312,13 @@ impl EnumClass {
 impl std::convert::TryFrom<header::IntoHeaderValue<EnumTest>> for hyper::header::HeaderValue {
     type Error = String;
 
-    fn try_from(hdr_value: header::IntoHeaderValue<EnumTest>) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<EnumTest>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match hyper::header::HeaderValue::from_str(&hdr_value) {
-             Ok(value) => Ok(value),
-             Err(e) => Err(format!("Invalid header value for EnumTest - value: {} is invalid {}",
-                 hdr_value, e))
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for EnumTest - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -2278,17 +2327,19 @@ impl std::convert::TryFrom<header::IntoHeaderValue<EnumTest>> for hyper::header:
 impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<EnumTest> {
     type Error = String;
 
-    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-             Ok(value) => {
+             std::result::Result::Ok(value) => {
                     match <EnumTest as std::str::FromStr>::from_str(value) {
-                        Ok(value) => Ok(header::IntoHeaderValue(value)),
-                        Err(err) => Err(format!("Unable to convert header value '{}' into EnumTest - {}",
-                            value, err))
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into EnumTest - {}",
+                                value, err))
                     }
              },
-             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
-                 hdr_value, e))
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
@@ -2439,12 +2490,13 @@ impl EnumTest {
 impl std::convert::TryFrom<header::IntoHeaderValue<FormatTest>> for hyper::header::HeaderValue {
     type Error = String;
 
-    fn try_from(hdr_value: header::IntoHeaderValue<FormatTest>) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<FormatTest>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match hyper::header::HeaderValue::from_str(&hdr_value) {
-             Ok(value) => Ok(value),
-             Err(e) => Err(format!("Invalid header value for FormatTest - value: {} is invalid {}",
-                 hdr_value, e))
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for FormatTest - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -2453,17 +2505,19 @@ impl std::convert::TryFrom<header::IntoHeaderValue<FormatTest>> for hyper::heade
 impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<FormatTest> {
     type Error = String;
 
-    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-             Ok(value) => {
+             std::result::Result::Ok(value) => {
                     match <FormatTest as std::str::FromStr>::from_str(value) {
-                        Ok(value) => Ok(header::IntoHeaderValue(value)),
-                        Err(err) => Err(format!("Unable to convert header value '{}' into FormatTest - {}",
-                            value, err))
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into FormatTest - {}",
+                                value, err))
                     }
              },
-             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
-                 hdr_value, e))
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
@@ -2703,12 +2757,13 @@ impl FormatTest {
 impl std::convert::TryFrom<header::IntoHeaderValue<HasOnlyReadOnly>> for hyper::header::HeaderValue {
     type Error = String;
 
-    fn try_from(hdr_value: header::IntoHeaderValue<HasOnlyReadOnly>) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<HasOnlyReadOnly>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match hyper::header::HeaderValue::from_str(&hdr_value) {
-             Ok(value) => Ok(value),
-             Err(e) => Err(format!("Invalid header value for HasOnlyReadOnly - value: {} is invalid {}",
-                 hdr_value, e))
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for HasOnlyReadOnly - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -2717,17 +2772,19 @@ impl std::convert::TryFrom<header::IntoHeaderValue<HasOnlyReadOnly>> for hyper::
 impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<HasOnlyReadOnly> {
     type Error = String;
 
-    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-             Ok(value) => {
+             std::result::Result::Ok(value) => {
                     match <HasOnlyReadOnly as std::str::FromStr>::from_str(value) {
-                        Ok(value) => Ok(header::IntoHeaderValue(value)),
-                        Err(err) => Err(format!("Unable to convert header value '{}' into HasOnlyReadOnly - {}",
-                            value, err))
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into HasOnlyReadOnly - {}",
+                                value, err))
                     }
              },
-             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
-                 hdr_value, e))
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
@@ -2839,12 +2896,13 @@ impl HasOnlyReadOnly {
 impl std::convert::TryFrom<header::IntoHeaderValue<List>> for hyper::header::HeaderValue {
     type Error = String;
 
-    fn try_from(hdr_value: header::IntoHeaderValue<List>) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<List>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match hyper::header::HeaderValue::from_str(&hdr_value) {
-             Ok(value) => Ok(value),
-             Err(e) => Err(format!("Invalid header value for List - value: {} is invalid {}",
-                 hdr_value, e))
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for List - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -2853,17 +2911,19 @@ impl std::convert::TryFrom<header::IntoHeaderValue<List>> for hyper::header::Hea
 impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<List> {
     type Error = String;
 
-    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-             Ok(value) => {
+             std::result::Result::Ok(value) => {
                     match <List as std::str::FromStr>::from_str(value) {
-                        Ok(value) => Ok(header::IntoHeaderValue(value)),
-                        Err(err) => Err(format!("Unable to convert header value '{}' into List - {}",
-                            value, err))
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into List - {}",
+                                value, err))
                     }
              },
-             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
-                 hdr_value, e))
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
@@ -2961,12 +3021,13 @@ impl List {
 impl std::convert::TryFrom<header::IntoHeaderValue<MapTest>> for hyper::header::HeaderValue {
     type Error = String;
 
-    fn try_from(hdr_value: header::IntoHeaderValue<MapTest>) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<MapTest>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match hyper::header::HeaderValue::from_str(&hdr_value) {
-             Ok(value) => Ok(value),
-             Err(e) => Err(format!("Invalid header value for MapTest - value: {} is invalid {}",
-                 hdr_value, e))
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for MapTest - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -2975,17 +3036,19 @@ impl std::convert::TryFrom<header::IntoHeaderValue<MapTest>> for hyper::header::
 impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<MapTest> {
     type Error = String;
 
-    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-             Ok(value) => {
+             std::result::Result::Ok(value) => {
                     match <MapTest as std::str::FromStr>::from_str(value) {
-                        Ok(value) => Ok(header::IntoHeaderValue(value)),
-                        Err(err) => Err(format!("Unable to convert header value '{}' into MapTest - {}",
-                            value, err))
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into MapTest - {}",
+                                value, err))
                     }
              },
-             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
-                 hdr_value, e))
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
@@ -3103,12 +3166,13 @@ impl MapTest {
 impl std::convert::TryFrom<header::IntoHeaderValue<MixedPropertiesAndAdditionalPropertiesClass>> for hyper::header::HeaderValue {
     type Error = String;
 
-    fn try_from(hdr_value: header::IntoHeaderValue<MixedPropertiesAndAdditionalPropertiesClass>) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<MixedPropertiesAndAdditionalPropertiesClass>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match hyper::header::HeaderValue::from_str(&hdr_value) {
-             Ok(value) => Ok(value),
-             Err(e) => Err(format!("Invalid header value for MixedPropertiesAndAdditionalPropertiesClass - value: {} is invalid {}",
-                 hdr_value, e))
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for MixedPropertiesAndAdditionalPropertiesClass - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -3117,17 +3181,19 @@ impl std::convert::TryFrom<header::IntoHeaderValue<MixedPropertiesAndAdditionalP
 impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<MixedPropertiesAndAdditionalPropertiesClass> {
     type Error = String;
 
-    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-             Ok(value) => {
+             std::result::Result::Ok(value) => {
                     match <MixedPropertiesAndAdditionalPropertiesClass as std::str::FromStr>::from_str(value) {
-                        Ok(value) => Ok(header::IntoHeaderValue(value)),
-                        Err(err) => Err(format!("Unable to convert header value '{}' into MixedPropertiesAndAdditionalPropertiesClass - {}",
-                            value, err))
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into MixedPropertiesAndAdditionalPropertiesClass - {}",
+                                value, err))
                     }
              },
-             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
-                 hdr_value, e))
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
@@ -3243,12 +3309,13 @@ impl MixedPropertiesAndAdditionalPropertiesClass {
 impl std::convert::TryFrom<header::IntoHeaderValue<Model200Response>> for hyper::header::HeaderValue {
     type Error = String;
 
-    fn try_from(hdr_value: header::IntoHeaderValue<Model200Response>) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<Model200Response>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match hyper::header::HeaderValue::from_str(&hdr_value) {
-             Ok(value) => Ok(value),
-             Err(e) => Err(format!("Invalid header value for Model200Response - value: {} is invalid {}",
-                 hdr_value, e))
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for Model200Response - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -3257,17 +3324,19 @@ impl std::convert::TryFrom<header::IntoHeaderValue<Model200Response>> for hyper:
 impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<Model200Response> {
     type Error = String;
 
-    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-             Ok(value) => {
+             std::result::Result::Ok(value) => {
                     match <Model200Response as std::str::FromStr>::from_str(value) {
-                        Ok(value) => Ok(header::IntoHeaderValue(value)),
-                        Err(err) => Err(format!("Unable to convert header value '{}' into Model200Response - {}",
-                            value, err))
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into Model200Response - {}",
+                                value, err))
                     }
              },
-             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
-                 hdr_value, e))
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
@@ -3381,12 +3450,13 @@ impl Model200Response {
 impl std::convert::TryFrom<header::IntoHeaderValue<ModelReturn>> for hyper::header::HeaderValue {
     type Error = String;
 
-    fn try_from(hdr_value: header::IntoHeaderValue<ModelReturn>) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<ModelReturn>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match hyper::header::HeaderValue::from_str(&hdr_value) {
-             Ok(value) => Ok(value),
-             Err(e) => Err(format!("Invalid header value for ModelReturn - value: {} is invalid {}",
-                 hdr_value, e))
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for ModelReturn - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -3395,17 +3465,19 @@ impl std::convert::TryFrom<header::IntoHeaderValue<ModelReturn>> for hyper::head
 impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<ModelReturn> {
     type Error = String;
 
-    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-             Ok(value) => {
+             std::result::Result::Ok(value) => {
                     match <ModelReturn as std::str::FromStr>::from_str(value) {
-                        Ok(value) => Ok(header::IntoHeaderValue(value)),
-                        Err(err) => Err(format!("Unable to convert header value '{}' into ModelReturn - {}",
-                            value, err))
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into ModelReturn - {}",
+                                value, err))
                     }
              },
-             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
-                 hdr_value, e))
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
@@ -3505,12 +3577,13 @@ impl ModelReturn {
 impl std::convert::TryFrom<header::IntoHeaderValue<Name>> for hyper::header::HeaderValue {
     type Error = String;
 
-    fn try_from(hdr_value: header::IntoHeaderValue<Name>) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<Name>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match hyper::header::HeaderValue::from_str(&hdr_value) {
-             Ok(value) => Ok(value),
-             Err(e) => Err(format!("Invalid header value for Name - value: {} is invalid {}",
-                 hdr_value, e))
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for Name - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -3519,17 +3592,19 @@ impl std::convert::TryFrom<header::IntoHeaderValue<Name>> for hyper::header::Hea
 impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<Name> {
     type Error = String;
 
-    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-             Ok(value) => {
+             std::result::Result::Ok(value) => {
                     match <Name as std::str::FromStr>::from_str(value) {
-                        Ok(value) => Ok(header::IntoHeaderValue(value)),
-                        Err(err) => Err(format!("Unable to convert header value '{}' into Name - {}",
-                            value, err))
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into Name - {}",
+                                value, err))
                     }
              },
-             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
-                 hdr_value, e))
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
@@ -3667,12 +3742,13 @@ impl Name {
 impl std::convert::TryFrom<header::IntoHeaderValue<NumberOnly>> for hyper::header::HeaderValue {
     type Error = String;
 
-    fn try_from(hdr_value: header::IntoHeaderValue<NumberOnly>) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<NumberOnly>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match hyper::header::HeaderValue::from_str(&hdr_value) {
-             Ok(value) => Ok(value),
-             Err(e) => Err(format!("Invalid header value for NumberOnly - value: {} is invalid {}",
-                 hdr_value, e))
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for NumberOnly - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -3681,17 +3757,19 @@ impl std::convert::TryFrom<header::IntoHeaderValue<NumberOnly>> for hyper::heade
 impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<NumberOnly> {
     type Error = String;
 
-    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-             Ok(value) => {
+             std::result::Result::Ok(value) => {
                     match <NumberOnly as std::str::FromStr>::from_str(value) {
-                        Ok(value) => Ok(header::IntoHeaderValue(value)),
-                        Err(err) => Err(format!("Unable to convert header value '{}' into NumberOnly - {}",
-                            value, err))
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into NumberOnly - {}",
+                                value, err))
                     }
              },
-             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
-                 hdr_value, e))
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
@@ -3789,12 +3867,13 @@ impl NumberOnly {
 impl std::convert::TryFrom<header::IntoHeaderValue<ObjectContainingObjectWithOnlyAdditionalProperties>> for hyper::header::HeaderValue {
     type Error = String;
 
-    fn try_from(hdr_value: header::IntoHeaderValue<ObjectContainingObjectWithOnlyAdditionalProperties>) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<ObjectContainingObjectWithOnlyAdditionalProperties>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match hyper::header::HeaderValue::from_str(&hdr_value) {
-             Ok(value) => Ok(value),
-             Err(e) => Err(format!("Invalid header value for ObjectContainingObjectWithOnlyAdditionalProperties - value: {} is invalid {}",
-                 hdr_value, e))
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for ObjectContainingObjectWithOnlyAdditionalProperties - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -3803,17 +3882,19 @@ impl std::convert::TryFrom<header::IntoHeaderValue<ObjectContainingObjectWithOnl
 impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<ObjectContainingObjectWithOnlyAdditionalProperties> {
     type Error = String;
 
-    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-             Ok(value) => {
+             std::result::Result::Ok(value) => {
                     match <ObjectContainingObjectWithOnlyAdditionalProperties as std::str::FromStr>::from_str(value) {
-                        Ok(value) => Ok(header::IntoHeaderValue(value)),
-                        Err(err) => Err(format!("Unable to convert header value '{}' into ObjectContainingObjectWithOnlyAdditionalProperties - {}",
-                            value, err))
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into ObjectContainingObjectWithOnlyAdditionalProperties - {}",
+                                value, err))
                     }
              },
-             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
-                 hdr_value, e))
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
@@ -3967,12 +4048,13 @@ impl ObjectWithOnlyAdditionalProperties {
 impl std::convert::TryFrom<header::IntoHeaderValue<Order>> for hyper::header::HeaderValue {
     type Error = String;
 
-    fn try_from(hdr_value: header::IntoHeaderValue<Order>) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<Order>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match hyper::header::HeaderValue::from_str(&hdr_value) {
-             Ok(value) => Ok(value),
-             Err(e) => Err(format!("Invalid header value for Order - value: {} is invalid {}",
-                 hdr_value, e))
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for Order - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -3981,17 +4063,19 @@ impl std::convert::TryFrom<header::IntoHeaderValue<Order>> for hyper::header::He
 impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<Order> {
     type Error = String;
 
-    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-             Ok(value) => {
+             std::result::Result::Ok(value) => {
                     match <Order as std::str::FromStr>::from_str(value) {
-                        Ok(value) => Ok(header::IntoHeaderValue(value)),
-                        Err(err) => Err(format!("Unable to convert header value '{}' into Order - {}",
-                            value, err))
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into Order - {}",
+                                value, err))
                     }
              },
-             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
-                 hdr_value, e))
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
@@ -4198,12 +4282,13 @@ impl OuterBoolean {
 impl std::convert::TryFrom<header::IntoHeaderValue<OuterComposite>> for hyper::header::HeaderValue {
     type Error = String;
 
-    fn try_from(hdr_value: header::IntoHeaderValue<OuterComposite>) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<OuterComposite>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match hyper::header::HeaderValue::from_str(&hdr_value) {
-             Ok(value) => Ok(value),
-             Err(e) => Err(format!("Invalid header value for OuterComposite - value: {} is invalid {}",
-                 hdr_value, e))
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for OuterComposite - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -4212,17 +4297,19 @@ impl std::convert::TryFrom<header::IntoHeaderValue<OuterComposite>> for hyper::h
 impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<OuterComposite> {
     type Error = String;
 
-    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-             Ok(value) => {
+             std::result::Result::Ok(value) => {
                     match <OuterComposite as std::str::FromStr>::from_str(value) {
-                        Ok(value) => Ok(header::IntoHeaderValue(value)),
-                        Err(err) => Err(format!("Unable to convert header value '{}' into OuterComposite - {}",
-                            value, err))
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into OuterComposite - {}",
+                                value, err))
                     }
              },
-             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
-                 hdr_value, e))
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
@@ -4488,12 +4575,13 @@ impl OuterString {
 impl std::convert::TryFrom<header::IntoHeaderValue<Pet>> for hyper::header::HeaderValue {
     type Error = String;
 
-    fn try_from(hdr_value: header::IntoHeaderValue<Pet>) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<Pet>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match hyper::header::HeaderValue::from_str(&hdr_value) {
-             Ok(value) => Ok(value),
-             Err(e) => Err(format!("Invalid header value for Pet - value: {} is invalid {}",
-                 hdr_value, e))
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for Pet - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -4502,17 +4590,19 @@ impl std::convert::TryFrom<header::IntoHeaderValue<Pet>> for hyper::header::Head
 impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<Pet> {
     type Error = String;
 
-    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-             Ok(value) => {
+             std::result::Result::Ok(value) => {
                     match <Pet as std::str::FromStr>::from_str(value) {
-                        Ok(value) => Ok(header::IntoHeaderValue(value)),
-                        Err(err) => Err(format!("Unable to convert header value '{}' into Pet - {}",
-                            value, err))
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into Pet - {}",
+                                value, err))
                     }
              },
-             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
-                 hdr_value, e))
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
@@ -4669,12 +4759,13 @@ impl Pet {
 impl std::convert::TryFrom<header::IntoHeaderValue<ReadOnlyFirst>> for hyper::header::HeaderValue {
     type Error = String;
 
-    fn try_from(hdr_value: header::IntoHeaderValue<ReadOnlyFirst>) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<ReadOnlyFirst>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match hyper::header::HeaderValue::from_str(&hdr_value) {
-             Ok(value) => Ok(value),
-             Err(e) => Err(format!("Invalid header value for ReadOnlyFirst - value: {} is invalid {}",
-                 hdr_value, e))
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for ReadOnlyFirst - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -4683,17 +4774,19 @@ impl std::convert::TryFrom<header::IntoHeaderValue<ReadOnlyFirst>> for hyper::he
 impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<ReadOnlyFirst> {
     type Error = String;
 
-    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-             Ok(value) => {
+             std::result::Result::Ok(value) => {
                     match <ReadOnlyFirst as std::str::FromStr>::from_str(value) {
-                        Ok(value) => Ok(header::IntoHeaderValue(value)),
-                        Err(err) => Err(format!("Unable to convert header value '{}' into ReadOnlyFirst - {}",
-                            value, err))
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into ReadOnlyFirst - {}",
+                                value, err))
                     }
              },
-             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
-                 hdr_value, e))
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
@@ -4805,12 +4898,13 @@ impl ReadOnlyFirst {
 impl std::convert::TryFrom<header::IntoHeaderValue<SpecialModelName>> for hyper::header::HeaderValue {
     type Error = String;
 
-    fn try_from(hdr_value: header::IntoHeaderValue<SpecialModelName>) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<SpecialModelName>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match hyper::header::HeaderValue::from_str(&hdr_value) {
-             Ok(value) => Ok(value),
-             Err(e) => Err(format!("Invalid header value for SpecialModelName - value: {} is invalid {}",
-                 hdr_value, e))
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for SpecialModelName - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -4819,17 +4913,19 @@ impl std::convert::TryFrom<header::IntoHeaderValue<SpecialModelName>> for hyper:
 impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<SpecialModelName> {
     type Error = String;
 
-    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-             Ok(value) => {
+             std::result::Result::Ok(value) => {
                     match <SpecialModelName as std::str::FromStr>::from_str(value) {
-                        Ok(value) => Ok(header::IntoHeaderValue(value)),
-                        Err(err) => Err(format!("Unable to convert header value '{}' into SpecialModelName - {}",
-                            value, err))
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into SpecialModelName - {}",
+                                value, err))
                     }
              },
-             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
-                 hdr_value, e))
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
@@ -4928,12 +5024,13 @@ impl SpecialModelName {
 impl std::convert::TryFrom<header::IntoHeaderValue<Tag>> for hyper::header::HeaderValue {
     type Error = String;
 
-    fn try_from(hdr_value: header::IntoHeaderValue<Tag>) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<Tag>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match hyper::header::HeaderValue::from_str(&hdr_value) {
-             Ok(value) => Ok(value),
-             Err(e) => Err(format!("Invalid header value for Tag - value: {} is invalid {}",
-                 hdr_value, e))
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for Tag - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -4942,17 +5039,19 @@ impl std::convert::TryFrom<header::IntoHeaderValue<Tag>> for hyper::header::Head
 impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<Tag> {
     type Error = String;
 
-    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-             Ok(value) => {
+             std::result::Result::Ok(value) => {
                     match <Tag as std::str::FromStr>::from_str(value) {
-                        Ok(value) => Ok(header::IntoHeaderValue(value)),
-                        Err(err) => Err(format!("Unable to convert header value '{}' into Tag - {}",
-                            value, err))
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into Tag - {}",
+                                value, err))
                     }
              },
-             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
-                 hdr_value, e))
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
@@ -5065,12 +5164,13 @@ impl Tag {
 impl std::convert::TryFrom<header::IntoHeaderValue<User>> for hyper::header::HeaderValue {
     type Error = String;
 
-    fn try_from(hdr_value: header::IntoHeaderValue<User>) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<User>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match hyper::header::HeaderValue::from_str(&hdr_value) {
-             Ok(value) => Ok(value),
-             Err(e) => Err(format!("Invalid header value for User - value: {} is invalid {}",
-                 hdr_value, e))
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for User - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -5079,17 +5179,19 @@ impl std::convert::TryFrom<header::IntoHeaderValue<User>> for hyper::header::Hea
 impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<User> {
     type Error = String;
 
-    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-             Ok(value) => {
+             std::result::Result::Ok(value) => {
                     match <User as std::str::FromStr>::from_str(value) {
-                        Ok(value) => Ok(header::IntoHeaderValue(value)),
-                        Err(err) => Err(format!("Unable to convert header value '{}' into User - {}",
-                            value, err))
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into User - {}",
+                                value, err))
                     }
              },
-             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
-                 hdr_value, e))
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/src/models.rs
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/src/models.rs
@@ -8,16 +8,35 @@ use crate::header;
 // Methods for converting between header::IntoHeaderValue<AdditionalPropertiesClass> and hyper::header::HeaderValue
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<header::IntoHeaderValue<AdditionalPropertiesClass>> for hyper::header::HeaderValue {
-    fn from(hdr_value: header::IntoHeaderValue<AdditionalPropertiesClass>) -> Self {
-        hyper::header::HeaderValue::from_str(&hdr_value.to_string()).unwrap()
+impl std::convert::TryFrom<header::IntoHeaderValue<AdditionalPropertiesClass>> for hyper::header::HeaderValue {
+    type Error = String;
+
+    fn try_from(hdr_value: header::IntoHeaderValue<AdditionalPropertiesClass>) -> Result<Self, Self::Error> {
+        let hdr_value = hdr_value.to_string();
+        match hyper::header::HeaderValue::from_str(&hdr_value) {
+             Ok(value) => Ok(value),
+             Err(e) => Err(format!("Invalid header value for AdditionalPropertiesClass - value: {} is invalid {}",
+                 hdr_value, e))
+        }
     }
 }
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<hyper::header::HeaderValue> for header::IntoHeaderValue<AdditionalPropertiesClass> {
-    fn from(hdr_value: hyper::header::HeaderValue) -> Self {
-        header::IntoHeaderValue(<AdditionalPropertiesClass as std::str::FromStr>::from_str(hdr_value.to_str().unwrap()).unwrap())
+impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<AdditionalPropertiesClass> {
+    type Error = String;
+
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+        match hdr_value.to_str() {
+             Ok(value) => {
+                    match <AdditionalPropertiesClass as std::str::FromStr>::from_str(value) {
+                        Ok(value) => Ok(header::IntoHeaderValue(value)),
+                        Err(err) => Err(format!("Unable to convert header value '{}' into AdditionalPropertiesClass - {}",
+                            value, err))
+                    }
+             },
+             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
+                 hdr_value, e))
+        }
     }
 }
 
@@ -118,16 +137,35 @@ impl AdditionalPropertiesClass {
 // Methods for converting between header::IntoHeaderValue<Animal> and hyper::header::HeaderValue
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<header::IntoHeaderValue<Animal>> for hyper::header::HeaderValue {
-    fn from(hdr_value: header::IntoHeaderValue<Animal>) -> Self {
-        hyper::header::HeaderValue::from_str(&hdr_value.to_string()).unwrap()
+impl std::convert::TryFrom<header::IntoHeaderValue<Animal>> for hyper::header::HeaderValue {
+    type Error = String;
+
+    fn try_from(hdr_value: header::IntoHeaderValue<Animal>) -> Result<Self, Self::Error> {
+        let hdr_value = hdr_value.to_string();
+        match hyper::header::HeaderValue::from_str(&hdr_value) {
+             Ok(value) => Ok(value),
+             Err(e) => Err(format!("Invalid header value for Animal - value: {} is invalid {}",
+                 hdr_value, e))
+        }
     }
 }
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<hyper::header::HeaderValue> for header::IntoHeaderValue<Animal> {
-    fn from(hdr_value: hyper::header::HeaderValue) -> Self {
-        header::IntoHeaderValue(<Animal as std::str::FromStr>::from_str(hdr_value.to_str().unwrap()).unwrap())
+impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<Animal> {
+    type Error = String;
+
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+        match hdr_value.to_str() {
+             Ok(value) => {
+                    match <Animal as std::str::FromStr>::from_str(value) {
+                        Ok(value) => Ok(header::IntoHeaderValue(value)),
+                        Err(err) => Err(format!("Unable to convert header value '{}' into Animal - {}",
+                            value, err))
+                    }
+             },
+             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
+                 hdr_value, e))
+        }
     }
 }
 
@@ -232,16 +270,35 @@ impl Animal {
 // Methods for converting between header::IntoHeaderValue<AnimalFarm> and hyper::header::HeaderValue
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<header::IntoHeaderValue<AnimalFarm>> for hyper::header::HeaderValue {
-    fn from(hdr_value: header::IntoHeaderValue<AnimalFarm>) -> Self {
-        hyper::header::HeaderValue::from_str(&hdr_value.to_string()).unwrap()
+impl std::convert::TryFrom<header::IntoHeaderValue<AnimalFarm>> for hyper::header::HeaderValue {
+    type Error = String;
+
+    fn try_from(hdr_value: header::IntoHeaderValue<AnimalFarm>) -> Result<Self, Self::Error> {
+        let hdr_value = hdr_value.to_string();
+        match hyper::header::HeaderValue::from_str(&hdr_value) {
+             Ok(value) => Ok(value),
+             Err(e) => Err(format!("Invalid header value for AnimalFarm - value: {} is invalid {}",
+                 hdr_value, e))
+        }
     }
 }
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<hyper::header::HeaderValue> for header::IntoHeaderValue<AnimalFarm> {
-    fn from(hdr_value: hyper::header::HeaderValue) -> Self {
-        header::IntoHeaderValue(<AnimalFarm as std::str::FromStr>::from_str(hdr_value.to_str().unwrap()).unwrap())
+impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<AnimalFarm> {
+    type Error = String;
+
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+        match hdr_value.to_str() {
+             Ok(value) => {
+                    match <AnimalFarm as std::str::FromStr>::from_str(value) {
+                        Ok(value) => Ok(header::IntoHeaderValue(value)),
+                        Err(err) => Err(format!("Unable to convert header value '{}' into AnimalFarm - {}",
+                            value, err))
+                    }
+             },
+             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
+                 hdr_value, e))
+        }
     }
 }
 
@@ -347,16 +404,35 @@ impl AnimalFarm {
 // Methods for converting between header::IntoHeaderValue<ApiResponse> and hyper::header::HeaderValue
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<header::IntoHeaderValue<ApiResponse>> for hyper::header::HeaderValue {
-    fn from(hdr_value: header::IntoHeaderValue<ApiResponse>) -> Self {
-        hyper::header::HeaderValue::from_str(&hdr_value.to_string()).unwrap()
+impl std::convert::TryFrom<header::IntoHeaderValue<ApiResponse>> for hyper::header::HeaderValue {
+    type Error = String;
+
+    fn try_from(hdr_value: header::IntoHeaderValue<ApiResponse>) -> Result<Self, Self::Error> {
+        let hdr_value = hdr_value.to_string();
+        match hyper::header::HeaderValue::from_str(&hdr_value) {
+             Ok(value) => Ok(value),
+             Err(e) => Err(format!("Invalid header value for ApiResponse - value: {} is invalid {}",
+                 hdr_value, e))
+        }
     }
 }
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<hyper::header::HeaderValue> for header::IntoHeaderValue<ApiResponse> {
-    fn from(hdr_value: hyper::header::HeaderValue) -> Self {
-        header::IntoHeaderValue(<ApiResponse as std::str::FromStr>::from_str(hdr_value.to_str().unwrap()).unwrap())
+impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<ApiResponse> {
+    type Error = String;
+
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+        match hdr_value.to_str() {
+             Ok(value) => {
+                    match <ApiResponse as std::str::FromStr>::from_str(value) {
+                        Ok(value) => Ok(header::IntoHeaderValue(value)),
+                        Err(err) => Err(format!("Unable to convert header value '{}' into ApiResponse - {}",
+                            value, err))
+                    }
+             },
+             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
+                 hdr_value, e))
+        }
     }
 }
 
@@ -478,16 +554,35 @@ impl ApiResponse {
 // Methods for converting between header::IntoHeaderValue<ArrayOfArrayOfNumberOnly> and hyper::header::HeaderValue
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<header::IntoHeaderValue<ArrayOfArrayOfNumberOnly>> for hyper::header::HeaderValue {
-    fn from(hdr_value: header::IntoHeaderValue<ArrayOfArrayOfNumberOnly>) -> Self {
-        hyper::header::HeaderValue::from_str(&hdr_value.to_string()).unwrap()
+impl std::convert::TryFrom<header::IntoHeaderValue<ArrayOfArrayOfNumberOnly>> for hyper::header::HeaderValue {
+    type Error = String;
+
+    fn try_from(hdr_value: header::IntoHeaderValue<ArrayOfArrayOfNumberOnly>) -> Result<Self, Self::Error> {
+        let hdr_value = hdr_value.to_string();
+        match hyper::header::HeaderValue::from_str(&hdr_value) {
+             Ok(value) => Ok(value),
+             Err(e) => Err(format!("Invalid header value for ArrayOfArrayOfNumberOnly - value: {} is invalid {}",
+                 hdr_value, e))
+        }
     }
 }
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<hyper::header::HeaderValue> for header::IntoHeaderValue<ArrayOfArrayOfNumberOnly> {
-    fn from(hdr_value: hyper::header::HeaderValue) -> Self {
-        header::IntoHeaderValue(<ArrayOfArrayOfNumberOnly as std::str::FromStr>::from_str(hdr_value.to_str().unwrap()).unwrap())
+impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<ArrayOfArrayOfNumberOnly> {
+    type Error = String;
+
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+        match hdr_value.to_str() {
+             Ok(value) => {
+                    match <ArrayOfArrayOfNumberOnly as std::str::FromStr>::from_str(value) {
+                        Ok(value) => Ok(header::IntoHeaderValue(value)),
+                        Err(err) => Err(format!("Unable to convert header value '{}' into ArrayOfArrayOfNumberOnly - {}",
+                            value, err))
+                    }
+             },
+             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
+                 hdr_value, e))
+        }
     }
 }
 
@@ -577,16 +672,35 @@ impl ArrayOfArrayOfNumberOnly {
 // Methods for converting between header::IntoHeaderValue<ArrayOfNumberOnly> and hyper::header::HeaderValue
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<header::IntoHeaderValue<ArrayOfNumberOnly>> for hyper::header::HeaderValue {
-    fn from(hdr_value: header::IntoHeaderValue<ArrayOfNumberOnly>) -> Self {
-        hyper::header::HeaderValue::from_str(&hdr_value.to_string()).unwrap()
+impl std::convert::TryFrom<header::IntoHeaderValue<ArrayOfNumberOnly>> for hyper::header::HeaderValue {
+    type Error = String;
+
+    fn try_from(hdr_value: header::IntoHeaderValue<ArrayOfNumberOnly>) -> Result<Self, Self::Error> {
+        let hdr_value = hdr_value.to_string();
+        match hyper::header::HeaderValue::from_str(&hdr_value) {
+             Ok(value) => Ok(value),
+             Err(e) => Err(format!("Invalid header value for ArrayOfNumberOnly - value: {} is invalid {}",
+                 hdr_value, e))
+        }
     }
 }
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<hyper::header::HeaderValue> for header::IntoHeaderValue<ArrayOfNumberOnly> {
-    fn from(hdr_value: hyper::header::HeaderValue) -> Self {
-        header::IntoHeaderValue(<ArrayOfNumberOnly as std::str::FromStr>::from_str(hdr_value.to_str().unwrap()).unwrap())
+impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<ArrayOfNumberOnly> {
+    type Error = String;
+
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+        match hdr_value.to_str() {
+             Ok(value) => {
+                    match <ArrayOfNumberOnly as std::str::FromStr>::from_str(value) {
+                        Ok(value) => Ok(header::IntoHeaderValue(value)),
+                        Err(err) => Err(format!("Unable to convert header value '{}' into ArrayOfNumberOnly - {}",
+                            value, err))
+                    }
+             },
+             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
+                 hdr_value, e))
+        }
     }
 }
 
@@ -680,16 +794,35 @@ impl ArrayOfNumberOnly {
 // Methods for converting between header::IntoHeaderValue<ArrayTest> and hyper::header::HeaderValue
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<header::IntoHeaderValue<ArrayTest>> for hyper::header::HeaderValue {
-    fn from(hdr_value: header::IntoHeaderValue<ArrayTest>) -> Self {
-        hyper::header::HeaderValue::from_str(&hdr_value.to_string()).unwrap()
+impl std::convert::TryFrom<header::IntoHeaderValue<ArrayTest>> for hyper::header::HeaderValue {
+    type Error = String;
+
+    fn try_from(hdr_value: header::IntoHeaderValue<ArrayTest>) -> Result<Self, Self::Error> {
+        let hdr_value = hdr_value.to_string();
+        match hyper::header::HeaderValue::from_str(&hdr_value) {
+             Ok(value) => Ok(value),
+             Err(e) => Err(format!("Invalid header value for ArrayTest - value: {} is invalid {}",
+                 hdr_value, e))
+        }
     }
 }
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<hyper::header::HeaderValue> for header::IntoHeaderValue<ArrayTest> {
-    fn from(hdr_value: hyper::header::HeaderValue) -> Self {
-        header::IntoHeaderValue(<ArrayTest as std::str::FromStr>::from_str(hdr_value.to_str().unwrap()).unwrap())
+impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<ArrayTest> {
+    type Error = String;
+
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+        match hdr_value.to_str() {
+             Ok(value) => {
+                    match <ArrayTest as std::str::FromStr>::from_str(value) {
+                        Ok(value) => Ok(header::IntoHeaderValue(value)),
+                        Err(err) => Err(format!("Unable to convert header value '{}' into ArrayTest - {}",
+                            value, err))
+                    }
+             },
+             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
+                 hdr_value, e))
+        }
     }
 }
 
@@ -818,16 +951,35 @@ impl ArrayTest {
 // Methods for converting between header::IntoHeaderValue<Capitalization> and hyper::header::HeaderValue
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<header::IntoHeaderValue<Capitalization>> for hyper::header::HeaderValue {
-    fn from(hdr_value: header::IntoHeaderValue<Capitalization>) -> Self {
-        hyper::header::HeaderValue::from_str(&hdr_value.to_string()).unwrap()
+impl std::convert::TryFrom<header::IntoHeaderValue<Capitalization>> for hyper::header::HeaderValue {
+    type Error = String;
+
+    fn try_from(hdr_value: header::IntoHeaderValue<Capitalization>) -> Result<Self, Self::Error> {
+        let hdr_value = hdr_value.to_string();
+        match hyper::header::HeaderValue::from_str(&hdr_value) {
+             Ok(value) => Ok(value),
+             Err(e) => Err(format!("Invalid header value for Capitalization - value: {} is invalid {}",
+                 hdr_value, e))
+        }
     }
 }
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<hyper::header::HeaderValue> for header::IntoHeaderValue<Capitalization> {
-    fn from(hdr_value: hyper::header::HeaderValue) -> Self {
-        header::IntoHeaderValue(<Capitalization as std::str::FromStr>::from_str(hdr_value.to_str().unwrap()).unwrap())
+impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<Capitalization> {
+    type Error = String;
+
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+        match hdr_value.to_str() {
+             Ok(value) => {
+                    match <Capitalization as std::str::FromStr>::from_str(value) {
+                        Ok(value) => Ok(header::IntoHeaderValue(value)),
+                        Err(err) => Err(format!("Unable to convert header value '{}' into Capitalization - {}",
+                            value, err))
+                    }
+             },
+             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
+                 hdr_value, e))
+        }
     }
 }
 
@@ -992,16 +1144,35 @@ impl Capitalization {
 // Methods for converting between header::IntoHeaderValue<Cat> and hyper::header::HeaderValue
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<header::IntoHeaderValue<Cat>> for hyper::header::HeaderValue {
-    fn from(hdr_value: header::IntoHeaderValue<Cat>) -> Self {
-        hyper::header::HeaderValue::from_str(&hdr_value.to_string()).unwrap()
+impl std::convert::TryFrom<header::IntoHeaderValue<Cat>> for hyper::header::HeaderValue {
+    type Error = String;
+
+    fn try_from(hdr_value: header::IntoHeaderValue<Cat>) -> Result<Self, Self::Error> {
+        let hdr_value = hdr_value.to_string();
+        match hyper::header::HeaderValue::from_str(&hdr_value) {
+             Ok(value) => Ok(value),
+             Err(e) => Err(format!("Invalid header value for Cat - value: {} is invalid {}",
+                 hdr_value, e))
+        }
     }
 }
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<hyper::header::HeaderValue> for header::IntoHeaderValue<Cat> {
-    fn from(hdr_value: hyper::header::HeaderValue) -> Self {
-        header::IntoHeaderValue(<Cat as std::str::FromStr>::from_str(hdr_value.to_str().unwrap()).unwrap())
+impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<Cat> {
+    type Error = String;
+
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+        match hdr_value.to_str() {
+             Ok(value) => {
+                    match <Cat as std::str::FromStr>::from_str(value) {
+                        Ok(value) => Ok(header::IntoHeaderValue(value)),
+                        Err(err) => Err(format!("Unable to convert header value '{}' into Cat - {}",
+                            value, err))
+                    }
+             },
+             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
+                 hdr_value, e))
+        }
     }
 }
 
@@ -1120,16 +1291,35 @@ impl Cat {
 // Methods for converting between header::IntoHeaderValue<CatAllOf> and hyper::header::HeaderValue
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<header::IntoHeaderValue<CatAllOf>> for hyper::header::HeaderValue {
-    fn from(hdr_value: header::IntoHeaderValue<CatAllOf>) -> Self {
-        hyper::header::HeaderValue::from_str(&hdr_value.to_string()).unwrap()
+impl std::convert::TryFrom<header::IntoHeaderValue<CatAllOf>> for hyper::header::HeaderValue {
+    type Error = String;
+
+    fn try_from(hdr_value: header::IntoHeaderValue<CatAllOf>) -> Result<Self, Self::Error> {
+        let hdr_value = hdr_value.to_string();
+        match hyper::header::HeaderValue::from_str(&hdr_value) {
+             Ok(value) => Ok(value),
+             Err(e) => Err(format!("Invalid header value for CatAllOf - value: {} is invalid {}",
+                 hdr_value, e))
+        }
     }
 }
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<hyper::header::HeaderValue> for header::IntoHeaderValue<CatAllOf> {
-    fn from(hdr_value: hyper::header::HeaderValue) -> Self {
-        header::IntoHeaderValue(<CatAllOf as std::str::FromStr>::from_str(hdr_value.to_str().unwrap()).unwrap())
+impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<CatAllOf> {
+    type Error = String;
+
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+        match hdr_value.to_str() {
+             Ok(value) => {
+                    match <CatAllOf as std::str::FromStr>::from_str(value) {
+                        Ok(value) => Ok(header::IntoHeaderValue(value)),
+                        Err(err) => Err(format!("Unable to convert header value '{}' into CatAllOf - {}",
+                            value, err))
+                    }
+             },
+             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
+                 hdr_value, e))
+        }
     }
 }
 
@@ -1223,16 +1413,35 @@ impl CatAllOf {
 // Methods for converting between header::IntoHeaderValue<Category> and hyper::header::HeaderValue
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<header::IntoHeaderValue<Category>> for hyper::header::HeaderValue {
-    fn from(hdr_value: header::IntoHeaderValue<Category>) -> Self {
-        hyper::header::HeaderValue::from_str(&hdr_value.to_string()).unwrap()
+impl std::convert::TryFrom<header::IntoHeaderValue<Category>> for hyper::header::HeaderValue {
+    type Error = String;
+
+    fn try_from(hdr_value: header::IntoHeaderValue<Category>) -> Result<Self, Self::Error> {
+        let hdr_value = hdr_value.to_string();
+        match hyper::header::HeaderValue::from_str(&hdr_value) {
+             Ok(value) => Ok(value),
+             Err(e) => Err(format!("Invalid header value for Category - value: {} is invalid {}",
+                 hdr_value, e))
+        }
     }
 }
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<hyper::header::HeaderValue> for header::IntoHeaderValue<Category> {
-    fn from(hdr_value: hyper::header::HeaderValue) -> Self {
-        header::IntoHeaderValue(<Category as std::str::FromStr>::from_str(hdr_value.to_str().unwrap()).unwrap())
+impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<Category> {
+    type Error = String;
+
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+        match hdr_value.to_str() {
+             Ok(value) => {
+                    match <Category as std::str::FromStr>::from_str(value) {
+                        Ok(value) => Ok(header::IntoHeaderValue(value)),
+                        Err(err) => Err(format!("Unable to convert header value '{}' into Category - {}",
+                            value, err))
+                    }
+             },
+             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
+                 hdr_value, e))
+        }
     }
 }
 
@@ -1342,16 +1551,35 @@ impl Category {
 // Methods for converting between header::IntoHeaderValue<ClassModel> and hyper::header::HeaderValue
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<header::IntoHeaderValue<ClassModel>> for hyper::header::HeaderValue {
-    fn from(hdr_value: header::IntoHeaderValue<ClassModel>) -> Self {
-        hyper::header::HeaderValue::from_str(&hdr_value.to_string()).unwrap()
+impl std::convert::TryFrom<header::IntoHeaderValue<ClassModel>> for hyper::header::HeaderValue {
+    type Error = String;
+
+    fn try_from(hdr_value: header::IntoHeaderValue<ClassModel>) -> Result<Self, Self::Error> {
+        let hdr_value = hdr_value.to_string();
+        match hyper::header::HeaderValue::from_str(&hdr_value) {
+             Ok(value) => Ok(value),
+             Err(e) => Err(format!("Invalid header value for ClassModel - value: {} is invalid {}",
+                 hdr_value, e))
+        }
     }
 }
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<hyper::header::HeaderValue> for header::IntoHeaderValue<ClassModel> {
-    fn from(hdr_value: hyper::header::HeaderValue) -> Self {
-        header::IntoHeaderValue(<ClassModel as std::str::FromStr>::from_str(hdr_value.to_str().unwrap()).unwrap())
+impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<ClassModel> {
+    type Error = String;
+
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+        match hdr_value.to_str() {
+             Ok(value) => {
+                    match <ClassModel as std::str::FromStr>::from_str(value) {
+                        Ok(value) => Ok(header::IntoHeaderValue(value)),
+                        Err(err) => Err(format!("Unable to convert header value '{}' into ClassModel - {}",
+                            value, err))
+                    }
+             },
+             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
+                 hdr_value, e))
+        }
     }
 }
 
@@ -1445,16 +1673,35 @@ impl ClassModel {
 // Methods for converting between header::IntoHeaderValue<Client> and hyper::header::HeaderValue
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<header::IntoHeaderValue<Client>> for hyper::header::HeaderValue {
-    fn from(hdr_value: header::IntoHeaderValue<Client>) -> Self {
-        hyper::header::HeaderValue::from_str(&hdr_value.to_string()).unwrap()
+impl std::convert::TryFrom<header::IntoHeaderValue<Client>> for hyper::header::HeaderValue {
+    type Error = String;
+
+    fn try_from(hdr_value: header::IntoHeaderValue<Client>) -> Result<Self, Self::Error> {
+        let hdr_value = hdr_value.to_string();
+        match hyper::header::HeaderValue::from_str(&hdr_value) {
+             Ok(value) => Ok(value),
+             Err(e) => Err(format!("Invalid header value for Client - value: {} is invalid {}",
+                 hdr_value, e))
+        }
     }
 }
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<hyper::header::HeaderValue> for header::IntoHeaderValue<Client> {
-    fn from(hdr_value: hyper::header::HeaderValue) -> Self {
-        header::IntoHeaderValue(<Client as std::str::FromStr>::from_str(hdr_value.to_str().unwrap()).unwrap())
+impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<Client> {
+    type Error = String;
+
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+        match hdr_value.to_str() {
+             Ok(value) => {
+                    match <Client as std::str::FromStr>::from_str(value) {
+                        Ok(value) => Ok(header::IntoHeaderValue(value)),
+                        Err(err) => Err(format!("Unable to convert header value '{}' into Client - {}",
+                            value, err))
+                    }
+             },
+             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
+                 hdr_value, e))
+        }
     }
 }
 
@@ -1548,16 +1795,35 @@ impl Client {
 // Methods for converting between header::IntoHeaderValue<Dog> and hyper::header::HeaderValue
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<header::IntoHeaderValue<Dog>> for hyper::header::HeaderValue {
-    fn from(hdr_value: header::IntoHeaderValue<Dog>) -> Self {
-        hyper::header::HeaderValue::from_str(&hdr_value.to_string()).unwrap()
+impl std::convert::TryFrom<header::IntoHeaderValue<Dog>> for hyper::header::HeaderValue {
+    type Error = String;
+
+    fn try_from(hdr_value: header::IntoHeaderValue<Dog>) -> Result<Self, Self::Error> {
+        let hdr_value = hdr_value.to_string();
+        match hyper::header::HeaderValue::from_str(&hdr_value) {
+             Ok(value) => Ok(value),
+             Err(e) => Err(format!("Invalid header value for Dog - value: {} is invalid {}",
+                 hdr_value, e))
+        }
     }
 }
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<hyper::header::HeaderValue> for header::IntoHeaderValue<Dog> {
-    fn from(hdr_value: hyper::header::HeaderValue) -> Self {
-        header::IntoHeaderValue(<Dog as std::str::FromStr>::from_str(hdr_value.to_str().unwrap()).unwrap())
+impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<Dog> {
+    type Error = String;
+
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+        match hdr_value.to_str() {
+             Ok(value) => {
+                    match <Dog as std::str::FromStr>::from_str(value) {
+                        Ok(value) => Ok(header::IntoHeaderValue(value)),
+                        Err(err) => Err(format!("Unable to convert header value '{}' into Dog - {}",
+                            value, err))
+                    }
+             },
+             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
+                 hdr_value, e))
+        }
     }
 }
 
@@ -1676,16 +1942,35 @@ impl Dog {
 // Methods for converting between header::IntoHeaderValue<DogAllOf> and hyper::header::HeaderValue
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<header::IntoHeaderValue<DogAllOf>> for hyper::header::HeaderValue {
-    fn from(hdr_value: header::IntoHeaderValue<DogAllOf>) -> Self {
-        hyper::header::HeaderValue::from_str(&hdr_value.to_string()).unwrap()
+impl std::convert::TryFrom<header::IntoHeaderValue<DogAllOf>> for hyper::header::HeaderValue {
+    type Error = String;
+
+    fn try_from(hdr_value: header::IntoHeaderValue<DogAllOf>) -> Result<Self, Self::Error> {
+        let hdr_value = hdr_value.to_string();
+        match hyper::header::HeaderValue::from_str(&hdr_value) {
+             Ok(value) => Ok(value),
+             Err(e) => Err(format!("Invalid header value for DogAllOf - value: {} is invalid {}",
+                 hdr_value, e))
+        }
     }
 }
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<hyper::header::HeaderValue> for header::IntoHeaderValue<DogAllOf> {
-    fn from(hdr_value: hyper::header::HeaderValue) -> Self {
-        header::IntoHeaderValue(<DogAllOf as std::str::FromStr>::from_str(hdr_value.to_str().unwrap()).unwrap())
+impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<DogAllOf> {
+    type Error = String;
+
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+        match hdr_value.to_str() {
+             Ok(value) => {
+                    match <DogAllOf as std::str::FromStr>::from_str(value) {
+                        Ok(value) => Ok(header::IntoHeaderValue(value)),
+                        Err(err) => Err(format!("Unable to convert header value '{}' into DogAllOf - {}",
+                            value, err))
+                    }
+             },
+             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
+                 hdr_value, e))
+        }
     }
 }
 
@@ -1779,16 +2064,35 @@ impl DogAllOf {
 // Methods for converting between header::IntoHeaderValue<EnumArrays> and hyper::header::HeaderValue
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<header::IntoHeaderValue<EnumArrays>> for hyper::header::HeaderValue {
-    fn from(hdr_value: header::IntoHeaderValue<EnumArrays>) -> Self {
-        hyper::header::HeaderValue::from_str(&hdr_value.to_string()).unwrap()
+impl std::convert::TryFrom<header::IntoHeaderValue<EnumArrays>> for hyper::header::HeaderValue {
+    type Error = String;
+
+    fn try_from(hdr_value: header::IntoHeaderValue<EnumArrays>) -> Result<Self, Self::Error> {
+        let hdr_value = hdr_value.to_string();
+        match hyper::header::HeaderValue::from_str(&hdr_value) {
+             Ok(value) => Ok(value),
+             Err(e) => Err(format!("Invalid header value for EnumArrays - value: {} is invalid {}",
+                 hdr_value, e))
+        }
     }
 }
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<hyper::header::HeaderValue> for header::IntoHeaderValue<EnumArrays> {
-    fn from(hdr_value: hyper::header::HeaderValue) -> Self {
-        header::IntoHeaderValue(<EnumArrays as std::str::FromStr>::from_str(hdr_value.to_str().unwrap()).unwrap())
+impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<EnumArrays> {
+    type Error = String;
+
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+        match hdr_value.to_str() {
+             Ok(value) => {
+                    match <EnumArrays as std::str::FromStr>::from_str(value) {
+                        Ok(value) => Ok(header::IntoHeaderValue(value)),
+                        Err(err) => Err(format!("Unable to convert header value '{}' into EnumArrays - {}",
+                            value, err))
+                    }
+             },
+             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
+                 hdr_value, e))
+        }
     }
 }
 
@@ -1957,16 +2261,35 @@ impl EnumClass {
 // Methods for converting between header::IntoHeaderValue<EnumTest> and hyper::header::HeaderValue
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<header::IntoHeaderValue<EnumTest>> for hyper::header::HeaderValue {
-    fn from(hdr_value: header::IntoHeaderValue<EnumTest>) -> Self {
-        hyper::header::HeaderValue::from_str(&hdr_value.to_string()).unwrap()
+impl std::convert::TryFrom<header::IntoHeaderValue<EnumTest>> for hyper::header::HeaderValue {
+    type Error = String;
+
+    fn try_from(hdr_value: header::IntoHeaderValue<EnumTest>) -> Result<Self, Self::Error> {
+        let hdr_value = hdr_value.to_string();
+        match hyper::header::HeaderValue::from_str(&hdr_value) {
+             Ok(value) => Ok(value),
+             Err(e) => Err(format!("Invalid header value for EnumTest - value: {} is invalid {}",
+                 hdr_value, e))
+        }
     }
 }
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<hyper::header::HeaderValue> for header::IntoHeaderValue<EnumTest> {
-    fn from(hdr_value: hyper::header::HeaderValue) -> Self {
-        header::IntoHeaderValue(<EnumTest as std::str::FromStr>::from_str(hdr_value.to_str().unwrap()).unwrap())
+impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<EnumTest> {
+    type Error = String;
+
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+        match hdr_value.to_str() {
+             Ok(value) => {
+                    match <EnumTest as std::str::FromStr>::from_str(value) {
+                        Ok(value) => Ok(header::IntoHeaderValue(value)),
+                        Err(err) => Err(format!("Unable to convert header value '{}' into EnumTest - {}",
+                            value, err))
+                    }
+             },
+             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
+                 hdr_value, e))
+        }
     }
 }
 
@@ -2113,16 +2436,35 @@ impl EnumTest {
 // Methods for converting between header::IntoHeaderValue<FormatTest> and hyper::header::HeaderValue
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<header::IntoHeaderValue<FormatTest>> for hyper::header::HeaderValue {
-    fn from(hdr_value: header::IntoHeaderValue<FormatTest>) -> Self {
-        hyper::header::HeaderValue::from_str(&hdr_value.to_string()).unwrap()
+impl std::convert::TryFrom<header::IntoHeaderValue<FormatTest>> for hyper::header::HeaderValue {
+    type Error = String;
+
+    fn try_from(hdr_value: header::IntoHeaderValue<FormatTest>) -> Result<Self, Self::Error> {
+        let hdr_value = hdr_value.to_string();
+        match hyper::header::HeaderValue::from_str(&hdr_value) {
+             Ok(value) => Ok(value),
+             Err(e) => Err(format!("Invalid header value for FormatTest - value: {} is invalid {}",
+                 hdr_value, e))
+        }
     }
 }
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<hyper::header::HeaderValue> for header::IntoHeaderValue<FormatTest> {
-    fn from(hdr_value: hyper::header::HeaderValue) -> Self {
-        header::IntoHeaderValue(<FormatTest as std::str::FromStr>::from_str(hdr_value.to_str().unwrap()).unwrap())
+impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<FormatTest> {
+    type Error = String;
+
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+        match hdr_value.to_str() {
+             Ok(value) => {
+                    match <FormatTest as std::str::FromStr>::from_str(value) {
+                        Ok(value) => Ok(header::IntoHeaderValue(value)),
+                        Err(err) => Err(format!("Unable to convert header value '{}' into FormatTest - {}",
+                            value, err))
+                    }
+             },
+             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
+                 hdr_value, e))
+        }
     }
 }
 
@@ -2358,16 +2700,35 @@ impl FormatTest {
 // Methods for converting between header::IntoHeaderValue<HasOnlyReadOnly> and hyper::header::HeaderValue
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<header::IntoHeaderValue<HasOnlyReadOnly>> for hyper::header::HeaderValue {
-    fn from(hdr_value: header::IntoHeaderValue<HasOnlyReadOnly>) -> Self {
-        hyper::header::HeaderValue::from_str(&hdr_value.to_string()).unwrap()
+impl std::convert::TryFrom<header::IntoHeaderValue<HasOnlyReadOnly>> for hyper::header::HeaderValue {
+    type Error = String;
+
+    fn try_from(hdr_value: header::IntoHeaderValue<HasOnlyReadOnly>) -> Result<Self, Self::Error> {
+        let hdr_value = hdr_value.to_string();
+        match hyper::header::HeaderValue::from_str(&hdr_value) {
+             Ok(value) => Ok(value),
+             Err(e) => Err(format!("Invalid header value for HasOnlyReadOnly - value: {} is invalid {}",
+                 hdr_value, e))
+        }
     }
 }
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<hyper::header::HeaderValue> for header::IntoHeaderValue<HasOnlyReadOnly> {
-    fn from(hdr_value: hyper::header::HeaderValue) -> Self {
-        header::IntoHeaderValue(<HasOnlyReadOnly as std::str::FromStr>::from_str(hdr_value.to_str().unwrap()).unwrap())
+impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<HasOnlyReadOnly> {
+    type Error = String;
+
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+        match hdr_value.to_str() {
+             Ok(value) => {
+                    match <HasOnlyReadOnly as std::str::FromStr>::from_str(value) {
+                        Ok(value) => Ok(header::IntoHeaderValue(value)),
+                        Err(err) => Err(format!("Unable to convert header value '{}' into HasOnlyReadOnly - {}",
+                            value, err))
+                    }
+             },
+             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
+                 hdr_value, e))
+        }
     }
 }
 
@@ -2475,16 +2836,35 @@ impl HasOnlyReadOnly {
 // Methods for converting between header::IntoHeaderValue<List> and hyper::header::HeaderValue
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<header::IntoHeaderValue<List>> for hyper::header::HeaderValue {
-    fn from(hdr_value: header::IntoHeaderValue<List>) -> Self {
-        hyper::header::HeaderValue::from_str(&hdr_value.to_string()).unwrap()
+impl std::convert::TryFrom<header::IntoHeaderValue<List>> for hyper::header::HeaderValue {
+    type Error = String;
+
+    fn try_from(hdr_value: header::IntoHeaderValue<List>) -> Result<Self, Self::Error> {
+        let hdr_value = hdr_value.to_string();
+        match hyper::header::HeaderValue::from_str(&hdr_value) {
+             Ok(value) => Ok(value),
+             Err(e) => Err(format!("Invalid header value for List - value: {} is invalid {}",
+                 hdr_value, e))
+        }
     }
 }
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<hyper::header::HeaderValue> for header::IntoHeaderValue<List> {
-    fn from(hdr_value: hyper::header::HeaderValue) -> Self {
-        header::IntoHeaderValue(<List as std::str::FromStr>::from_str(hdr_value.to_str().unwrap()).unwrap())
+impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<List> {
+    type Error = String;
+
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+        match hdr_value.to_str() {
+             Ok(value) => {
+                    match <List as std::str::FromStr>::from_str(value) {
+                        Ok(value) => Ok(header::IntoHeaderValue(value)),
+                        Err(err) => Err(format!("Unable to convert header value '{}' into List - {}",
+                            value, err))
+                    }
+             },
+             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
+                 hdr_value, e))
+        }
     }
 }
 
@@ -2578,16 +2958,35 @@ impl List {
 // Methods for converting between header::IntoHeaderValue<MapTest> and hyper::header::HeaderValue
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<header::IntoHeaderValue<MapTest>> for hyper::header::HeaderValue {
-    fn from(hdr_value: header::IntoHeaderValue<MapTest>) -> Self {
-        hyper::header::HeaderValue::from_str(&hdr_value.to_string()).unwrap()
+impl std::convert::TryFrom<header::IntoHeaderValue<MapTest>> for hyper::header::HeaderValue {
+    type Error = String;
+
+    fn try_from(hdr_value: header::IntoHeaderValue<MapTest>) -> Result<Self, Self::Error> {
+        let hdr_value = hdr_value.to_string();
+        match hyper::header::HeaderValue::from_str(&hdr_value) {
+             Ok(value) => Ok(value),
+             Err(e) => Err(format!("Invalid header value for MapTest - value: {} is invalid {}",
+                 hdr_value, e))
+        }
     }
 }
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<hyper::header::HeaderValue> for header::IntoHeaderValue<MapTest> {
-    fn from(hdr_value: hyper::header::HeaderValue) -> Self {
-        header::IntoHeaderValue(<MapTest as std::str::FromStr>::from_str(hdr_value.to_str().unwrap()).unwrap())
+impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<MapTest> {
+    type Error = String;
+
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+        match hdr_value.to_str() {
+             Ok(value) => {
+                    match <MapTest as std::str::FromStr>::from_str(value) {
+                        Ok(value) => Ok(header::IntoHeaderValue(value)),
+                        Err(err) => Err(format!("Unable to convert header value '{}' into MapTest - {}",
+                            value, err))
+                    }
+             },
+             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
+                 hdr_value, e))
+        }
     }
 }
 
@@ -2701,16 +3100,35 @@ impl MapTest {
 // Methods for converting between header::IntoHeaderValue<MixedPropertiesAndAdditionalPropertiesClass> and hyper::header::HeaderValue
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<header::IntoHeaderValue<MixedPropertiesAndAdditionalPropertiesClass>> for hyper::header::HeaderValue {
-    fn from(hdr_value: header::IntoHeaderValue<MixedPropertiesAndAdditionalPropertiesClass>) -> Self {
-        hyper::header::HeaderValue::from_str(&hdr_value.to_string()).unwrap()
+impl std::convert::TryFrom<header::IntoHeaderValue<MixedPropertiesAndAdditionalPropertiesClass>> for hyper::header::HeaderValue {
+    type Error = String;
+
+    fn try_from(hdr_value: header::IntoHeaderValue<MixedPropertiesAndAdditionalPropertiesClass>) -> Result<Self, Self::Error> {
+        let hdr_value = hdr_value.to_string();
+        match hyper::header::HeaderValue::from_str(&hdr_value) {
+             Ok(value) => Ok(value),
+             Err(e) => Err(format!("Invalid header value for MixedPropertiesAndAdditionalPropertiesClass - value: {} is invalid {}",
+                 hdr_value, e))
+        }
     }
 }
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<hyper::header::HeaderValue> for header::IntoHeaderValue<MixedPropertiesAndAdditionalPropertiesClass> {
-    fn from(hdr_value: hyper::header::HeaderValue) -> Self {
-        header::IntoHeaderValue(<MixedPropertiesAndAdditionalPropertiesClass as std::str::FromStr>::from_str(hdr_value.to_str().unwrap()).unwrap())
+impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<MixedPropertiesAndAdditionalPropertiesClass> {
+    type Error = String;
+
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+        match hdr_value.to_str() {
+             Ok(value) => {
+                    match <MixedPropertiesAndAdditionalPropertiesClass as std::str::FromStr>::from_str(value) {
+                        Ok(value) => Ok(header::IntoHeaderValue(value)),
+                        Err(err) => Err(format!("Unable to convert header value '{}' into MixedPropertiesAndAdditionalPropertiesClass - {}",
+                            value, err))
+                    }
+             },
+             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
+                 hdr_value, e))
+        }
     }
 }
 
@@ -2822,16 +3240,35 @@ impl MixedPropertiesAndAdditionalPropertiesClass {
 // Methods for converting between header::IntoHeaderValue<Model200Response> and hyper::header::HeaderValue
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<header::IntoHeaderValue<Model200Response>> for hyper::header::HeaderValue {
-    fn from(hdr_value: header::IntoHeaderValue<Model200Response>) -> Self {
-        hyper::header::HeaderValue::from_str(&hdr_value.to_string()).unwrap()
+impl std::convert::TryFrom<header::IntoHeaderValue<Model200Response>> for hyper::header::HeaderValue {
+    type Error = String;
+
+    fn try_from(hdr_value: header::IntoHeaderValue<Model200Response>) -> Result<Self, Self::Error> {
+        let hdr_value = hdr_value.to_string();
+        match hyper::header::HeaderValue::from_str(&hdr_value) {
+             Ok(value) => Ok(value),
+             Err(e) => Err(format!("Invalid header value for Model200Response - value: {} is invalid {}",
+                 hdr_value, e))
+        }
     }
 }
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<hyper::header::HeaderValue> for header::IntoHeaderValue<Model200Response> {
-    fn from(hdr_value: hyper::header::HeaderValue) -> Self {
-        header::IntoHeaderValue(<Model200Response as std::str::FromStr>::from_str(hdr_value.to_str().unwrap()).unwrap())
+impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<Model200Response> {
+    type Error = String;
+
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+        match hdr_value.to_str() {
+             Ok(value) => {
+                    match <Model200Response as std::str::FromStr>::from_str(value) {
+                        Ok(value) => Ok(header::IntoHeaderValue(value)),
+                        Err(err) => Err(format!("Unable to convert header value '{}' into Model200Response - {}",
+                            value, err))
+                    }
+             },
+             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
+                 hdr_value, e))
+        }
     }
 }
 
@@ -2941,16 +3378,35 @@ impl Model200Response {
 // Methods for converting between header::IntoHeaderValue<ModelReturn> and hyper::header::HeaderValue
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<header::IntoHeaderValue<ModelReturn>> for hyper::header::HeaderValue {
-    fn from(hdr_value: header::IntoHeaderValue<ModelReturn>) -> Self {
-        hyper::header::HeaderValue::from_str(&hdr_value.to_string()).unwrap()
+impl std::convert::TryFrom<header::IntoHeaderValue<ModelReturn>> for hyper::header::HeaderValue {
+    type Error = String;
+
+    fn try_from(hdr_value: header::IntoHeaderValue<ModelReturn>) -> Result<Self, Self::Error> {
+        let hdr_value = hdr_value.to_string();
+        match hyper::header::HeaderValue::from_str(&hdr_value) {
+             Ok(value) => Ok(value),
+             Err(e) => Err(format!("Invalid header value for ModelReturn - value: {} is invalid {}",
+                 hdr_value, e))
+        }
     }
 }
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<hyper::header::HeaderValue> for header::IntoHeaderValue<ModelReturn> {
-    fn from(hdr_value: hyper::header::HeaderValue) -> Self {
-        header::IntoHeaderValue(<ModelReturn as std::str::FromStr>::from_str(hdr_value.to_str().unwrap()).unwrap())
+impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<ModelReturn> {
+    type Error = String;
+
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+        match hdr_value.to_str() {
+             Ok(value) => {
+                    match <ModelReturn as std::str::FromStr>::from_str(value) {
+                        Ok(value) => Ok(header::IntoHeaderValue(value)),
+                        Err(err) => Err(format!("Unable to convert header value '{}' into ModelReturn - {}",
+                            value, err))
+                    }
+             },
+             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
+                 hdr_value, e))
+        }
     }
 }
 
@@ -3046,16 +3502,35 @@ impl ModelReturn {
 // Methods for converting between header::IntoHeaderValue<Name> and hyper::header::HeaderValue
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<header::IntoHeaderValue<Name>> for hyper::header::HeaderValue {
-    fn from(hdr_value: header::IntoHeaderValue<Name>) -> Self {
-        hyper::header::HeaderValue::from_str(&hdr_value.to_string()).unwrap()
+impl std::convert::TryFrom<header::IntoHeaderValue<Name>> for hyper::header::HeaderValue {
+    type Error = String;
+
+    fn try_from(hdr_value: header::IntoHeaderValue<Name>) -> Result<Self, Self::Error> {
+        let hdr_value = hdr_value.to_string();
+        match hyper::header::HeaderValue::from_str(&hdr_value) {
+             Ok(value) => Ok(value),
+             Err(e) => Err(format!("Invalid header value for Name - value: {} is invalid {}",
+                 hdr_value, e))
+        }
     }
 }
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<hyper::header::HeaderValue> for header::IntoHeaderValue<Name> {
-    fn from(hdr_value: hyper::header::HeaderValue) -> Self {
-        header::IntoHeaderValue(<Name as std::str::FromStr>::from_str(hdr_value.to_str().unwrap()).unwrap())
+impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<Name> {
+    type Error = String;
+
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+        match hdr_value.to_str() {
+             Ok(value) => {
+                    match <Name as std::str::FromStr>::from_str(value) {
+                        Ok(value) => Ok(header::IntoHeaderValue(value)),
+                        Err(err) => Err(format!("Unable to convert header value '{}' into Name - {}",
+                            value, err))
+                    }
+             },
+             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
+                 hdr_value, e))
+        }
     }
 }
 
@@ -3189,16 +3664,35 @@ impl Name {
 // Methods for converting between header::IntoHeaderValue<NumberOnly> and hyper::header::HeaderValue
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<header::IntoHeaderValue<NumberOnly>> for hyper::header::HeaderValue {
-    fn from(hdr_value: header::IntoHeaderValue<NumberOnly>) -> Self {
-        hyper::header::HeaderValue::from_str(&hdr_value.to_string()).unwrap()
+impl std::convert::TryFrom<header::IntoHeaderValue<NumberOnly>> for hyper::header::HeaderValue {
+    type Error = String;
+
+    fn try_from(hdr_value: header::IntoHeaderValue<NumberOnly>) -> Result<Self, Self::Error> {
+        let hdr_value = hdr_value.to_string();
+        match hyper::header::HeaderValue::from_str(&hdr_value) {
+             Ok(value) => Ok(value),
+             Err(e) => Err(format!("Invalid header value for NumberOnly - value: {} is invalid {}",
+                 hdr_value, e))
+        }
     }
 }
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<hyper::header::HeaderValue> for header::IntoHeaderValue<NumberOnly> {
-    fn from(hdr_value: hyper::header::HeaderValue) -> Self {
-        header::IntoHeaderValue(<NumberOnly as std::str::FromStr>::from_str(hdr_value.to_str().unwrap()).unwrap())
+impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<NumberOnly> {
+    type Error = String;
+
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+        match hdr_value.to_str() {
+             Ok(value) => {
+                    match <NumberOnly as std::str::FromStr>::from_str(value) {
+                        Ok(value) => Ok(header::IntoHeaderValue(value)),
+                        Err(err) => Err(format!("Unable to convert header value '{}' into NumberOnly - {}",
+                            value, err))
+                    }
+             },
+             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
+                 hdr_value, e))
+        }
     }
 }
 
@@ -3292,16 +3786,35 @@ impl NumberOnly {
 // Methods for converting between header::IntoHeaderValue<ObjectContainingObjectWithOnlyAdditionalProperties> and hyper::header::HeaderValue
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<header::IntoHeaderValue<ObjectContainingObjectWithOnlyAdditionalProperties>> for hyper::header::HeaderValue {
-    fn from(hdr_value: header::IntoHeaderValue<ObjectContainingObjectWithOnlyAdditionalProperties>) -> Self {
-        hyper::header::HeaderValue::from_str(&hdr_value.to_string()).unwrap()
+impl std::convert::TryFrom<header::IntoHeaderValue<ObjectContainingObjectWithOnlyAdditionalProperties>> for hyper::header::HeaderValue {
+    type Error = String;
+
+    fn try_from(hdr_value: header::IntoHeaderValue<ObjectContainingObjectWithOnlyAdditionalProperties>) -> Result<Self, Self::Error> {
+        let hdr_value = hdr_value.to_string();
+        match hyper::header::HeaderValue::from_str(&hdr_value) {
+             Ok(value) => Ok(value),
+             Err(e) => Err(format!("Invalid header value for ObjectContainingObjectWithOnlyAdditionalProperties - value: {} is invalid {}",
+                 hdr_value, e))
+        }
     }
 }
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<hyper::header::HeaderValue> for header::IntoHeaderValue<ObjectContainingObjectWithOnlyAdditionalProperties> {
-    fn from(hdr_value: hyper::header::HeaderValue) -> Self {
-        header::IntoHeaderValue(<ObjectContainingObjectWithOnlyAdditionalProperties as std::str::FromStr>::from_str(hdr_value.to_str().unwrap()).unwrap())
+impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<ObjectContainingObjectWithOnlyAdditionalProperties> {
+    type Error = String;
+
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+        match hdr_value.to_str() {
+             Ok(value) => {
+                    match <ObjectContainingObjectWithOnlyAdditionalProperties as std::str::FromStr>::from_str(value) {
+                        Ok(value) => Ok(header::IntoHeaderValue(value)),
+                        Err(err) => Err(format!("Unable to convert header value '{}' into ObjectContainingObjectWithOnlyAdditionalProperties - {}",
+                            value, err))
+                    }
+             },
+             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
+                 hdr_value, e))
+        }
     }
 }
 
@@ -3451,16 +3964,35 @@ impl ObjectWithOnlyAdditionalProperties {
 // Methods for converting between header::IntoHeaderValue<Order> and hyper::header::HeaderValue
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<header::IntoHeaderValue<Order>> for hyper::header::HeaderValue {
-    fn from(hdr_value: header::IntoHeaderValue<Order>) -> Self {
-        hyper::header::HeaderValue::from_str(&hdr_value.to_string()).unwrap()
+impl std::convert::TryFrom<header::IntoHeaderValue<Order>> for hyper::header::HeaderValue {
+    type Error = String;
+
+    fn try_from(hdr_value: header::IntoHeaderValue<Order>) -> Result<Self, Self::Error> {
+        let hdr_value = hdr_value.to_string();
+        match hyper::header::HeaderValue::from_str(&hdr_value) {
+             Ok(value) => Ok(value),
+             Err(e) => Err(format!("Invalid header value for Order - value: {} is invalid {}",
+                 hdr_value, e))
+        }
     }
 }
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<hyper::header::HeaderValue> for header::IntoHeaderValue<Order> {
-    fn from(hdr_value: hyper::header::HeaderValue) -> Self {
-        header::IntoHeaderValue(<Order as std::str::FromStr>::from_str(hdr_value.to_str().unwrap()).unwrap())
+impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<Order> {
+    type Error = String;
+
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+        match hdr_value.to_str() {
+             Ok(value) => {
+                    match <Order as std::str::FromStr>::from_str(value) {
+                        Ok(value) => Ok(header::IntoHeaderValue(value)),
+                        Err(err) => Err(format!("Unable to convert header value '{}' into Order - {}",
+                            value, err))
+                    }
+             },
+             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
+                 hdr_value, e))
+        }
     }
 }
 
@@ -3663,16 +4195,35 @@ impl OuterBoolean {
 // Methods for converting between header::IntoHeaderValue<OuterComposite> and hyper::header::HeaderValue
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<header::IntoHeaderValue<OuterComposite>> for hyper::header::HeaderValue {
-    fn from(hdr_value: header::IntoHeaderValue<OuterComposite>) -> Self {
-        hyper::header::HeaderValue::from_str(&hdr_value.to_string()).unwrap()
+impl std::convert::TryFrom<header::IntoHeaderValue<OuterComposite>> for hyper::header::HeaderValue {
+    type Error = String;
+
+    fn try_from(hdr_value: header::IntoHeaderValue<OuterComposite>) -> Result<Self, Self::Error> {
+        let hdr_value = hdr_value.to_string();
+        match hyper::header::HeaderValue::from_str(&hdr_value) {
+             Ok(value) => Ok(value),
+             Err(e) => Err(format!("Invalid header value for OuterComposite - value: {} is invalid {}",
+                 hdr_value, e))
+        }
     }
 }
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<hyper::header::HeaderValue> for header::IntoHeaderValue<OuterComposite> {
-    fn from(hdr_value: hyper::header::HeaderValue) -> Self {
-        header::IntoHeaderValue(<OuterComposite as std::str::FromStr>::from_str(hdr_value.to_str().unwrap()).unwrap())
+impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<OuterComposite> {
+    type Error = String;
+
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+        match hdr_value.to_str() {
+             Ok(value) => {
+                    match <OuterComposite as std::str::FromStr>::from_str(value) {
+                        Ok(value) => Ok(header::IntoHeaderValue(value)),
+                        Err(err) => Err(format!("Unable to convert header value '{}' into OuterComposite - {}",
+                            value, err))
+                    }
+             },
+             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
+                 hdr_value, e))
+        }
     }
 }
 
@@ -3934,16 +4485,35 @@ impl OuterString {
 // Methods for converting between header::IntoHeaderValue<Pet> and hyper::header::HeaderValue
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<header::IntoHeaderValue<Pet>> for hyper::header::HeaderValue {
-    fn from(hdr_value: header::IntoHeaderValue<Pet>) -> Self {
-        hyper::header::HeaderValue::from_str(&hdr_value.to_string()).unwrap()
+impl std::convert::TryFrom<header::IntoHeaderValue<Pet>> for hyper::header::HeaderValue {
+    type Error = String;
+
+    fn try_from(hdr_value: header::IntoHeaderValue<Pet>) -> Result<Self, Self::Error> {
+        let hdr_value = hdr_value.to_string();
+        match hyper::header::HeaderValue::from_str(&hdr_value) {
+             Ok(value) => Ok(value),
+             Err(e) => Err(format!("Invalid header value for Pet - value: {} is invalid {}",
+                 hdr_value, e))
+        }
     }
 }
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<hyper::header::HeaderValue> for header::IntoHeaderValue<Pet> {
-    fn from(hdr_value: hyper::header::HeaderValue) -> Self {
-        header::IntoHeaderValue(<Pet as std::str::FromStr>::from_str(hdr_value.to_str().unwrap()).unwrap())
+impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<Pet> {
+    type Error = String;
+
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+        match hdr_value.to_str() {
+             Ok(value) => {
+                    match <Pet as std::str::FromStr>::from_str(value) {
+                        Ok(value) => Ok(header::IntoHeaderValue(value)),
+                        Err(err) => Err(format!("Unable to convert header value '{}' into Pet - {}",
+                            value, err))
+                    }
+             },
+             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
+                 hdr_value, e))
+        }
     }
 }
 
@@ -4096,16 +4666,35 @@ impl Pet {
 // Methods for converting between header::IntoHeaderValue<ReadOnlyFirst> and hyper::header::HeaderValue
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<header::IntoHeaderValue<ReadOnlyFirst>> for hyper::header::HeaderValue {
-    fn from(hdr_value: header::IntoHeaderValue<ReadOnlyFirst>) -> Self {
-        hyper::header::HeaderValue::from_str(&hdr_value.to_string()).unwrap()
+impl std::convert::TryFrom<header::IntoHeaderValue<ReadOnlyFirst>> for hyper::header::HeaderValue {
+    type Error = String;
+
+    fn try_from(hdr_value: header::IntoHeaderValue<ReadOnlyFirst>) -> Result<Self, Self::Error> {
+        let hdr_value = hdr_value.to_string();
+        match hyper::header::HeaderValue::from_str(&hdr_value) {
+             Ok(value) => Ok(value),
+             Err(e) => Err(format!("Invalid header value for ReadOnlyFirst - value: {} is invalid {}",
+                 hdr_value, e))
+        }
     }
 }
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<hyper::header::HeaderValue> for header::IntoHeaderValue<ReadOnlyFirst> {
-    fn from(hdr_value: hyper::header::HeaderValue) -> Self {
-        header::IntoHeaderValue(<ReadOnlyFirst as std::str::FromStr>::from_str(hdr_value.to_str().unwrap()).unwrap())
+impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<ReadOnlyFirst> {
+    type Error = String;
+
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+        match hdr_value.to_str() {
+             Ok(value) => {
+                    match <ReadOnlyFirst as std::str::FromStr>::from_str(value) {
+                        Ok(value) => Ok(header::IntoHeaderValue(value)),
+                        Err(err) => Err(format!("Unable to convert header value '{}' into ReadOnlyFirst - {}",
+                            value, err))
+                    }
+             },
+             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
+                 hdr_value, e))
+        }
     }
 }
 
@@ -4213,16 +4802,35 @@ impl ReadOnlyFirst {
 // Methods for converting between header::IntoHeaderValue<SpecialModelName> and hyper::header::HeaderValue
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<header::IntoHeaderValue<SpecialModelName>> for hyper::header::HeaderValue {
-    fn from(hdr_value: header::IntoHeaderValue<SpecialModelName>) -> Self {
-        hyper::header::HeaderValue::from_str(&hdr_value.to_string()).unwrap()
+impl std::convert::TryFrom<header::IntoHeaderValue<SpecialModelName>> for hyper::header::HeaderValue {
+    type Error = String;
+
+    fn try_from(hdr_value: header::IntoHeaderValue<SpecialModelName>) -> Result<Self, Self::Error> {
+        let hdr_value = hdr_value.to_string();
+        match hyper::header::HeaderValue::from_str(&hdr_value) {
+             Ok(value) => Ok(value),
+             Err(e) => Err(format!("Invalid header value for SpecialModelName - value: {} is invalid {}",
+                 hdr_value, e))
+        }
     }
 }
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<hyper::header::HeaderValue> for header::IntoHeaderValue<SpecialModelName> {
-    fn from(hdr_value: hyper::header::HeaderValue) -> Self {
-        header::IntoHeaderValue(<SpecialModelName as std::str::FromStr>::from_str(hdr_value.to_str().unwrap()).unwrap())
+impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<SpecialModelName> {
+    type Error = String;
+
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+        match hdr_value.to_str() {
+             Ok(value) => {
+                    match <SpecialModelName as std::str::FromStr>::from_str(value) {
+                        Ok(value) => Ok(header::IntoHeaderValue(value)),
+                        Err(err) => Err(format!("Unable to convert header value '{}' into SpecialModelName - {}",
+                            value, err))
+                    }
+             },
+             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
+                 hdr_value, e))
+        }
     }
 }
 
@@ -4317,16 +4925,35 @@ impl SpecialModelName {
 // Methods for converting between header::IntoHeaderValue<Tag> and hyper::header::HeaderValue
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<header::IntoHeaderValue<Tag>> for hyper::header::HeaderValue {
-    fn from(hdr_value: header::IntoHeaderValue<Tag>) -> Self {
-        hyper::header::HeaderValue::from_str(&hdr_value.to_string()).unwrap()
+impl std::convert::TryFrom<header::IntoHeaderValue<Tag>> for hyper::header::HeaderValue {
+    type Error = String;
+
+    fn try_from(hdr_value: header::IntoHeaderValue<Tag>) -> Result<Self, Self::Error> {
+        let hdr_value = hdr_value.to_string();
+        match hyper::header::HeaderValue::from_str(&hdr_value) {
+             Ok(value) => Ok(value),
+             Err(e) => Err(format!("Invalid header value for Tag - value: {} is invalid {}",
+                 hdr_value, e))
+        }
     }
 }
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<hyper::header::HeaderValue> for header::IntoHeaderValue<Tag> {
-    fn from(hdr_value: hyper::header::HeaderValue) -> Self {
-        header::IntoHeaderValue(<Tag as std::str::FromStr>::from_str(hdr_value.to_str().unwrap()).unwrap())
+impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<Tag> {
+    type Error = String;
+
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+        match hdr_value.to_str() {
+             Ok(value) => {
+                    match <Tag as std::str::FromStr>::from_str(value) {
+                        Ok(value) => Ok(header::IntoHeaderValue(value)),
+                        Err(err) => Err(format!("Unable to convert header value '{}' into Tag - {}",
+                            value, err))
+                    }
+             },
+             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
+                 hdr_value, e))
+        }
     }
 }
 
@@ -4435,16 +5062,35 @@ impl Tag {
 // Methods for converting between header::IntoHeaderValue<User> and hyper::header::HeaderValue
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<header::IntoHeaderValue<User>> for hyper::header::HeaderValue {
-    fn from(hdr_value: header::IntoHeaderValue<User>) -> Self {
-        hyper::header::HeaderValue::from_str(&hdr_value.to_string()).unwrap()
+impl std::convert::TryFrom<header::IntoHeaderValue<User>> for hyper::header::HeaderValue {
+    type Error = String;
+
+    fn try_from(hdr_value: header::IntoHeaderValue<User>) -> Result<Self, Self::Error> {
+        let hdr_value = hdr_value.to_string();
+        match hyper::header::HeaderValue::from_str(&hdr_value) {
+             Ok(value) => Ok(value),
+             Err(e) => Err(format!("Invalid header value for User - value: {} is invalid {}",
+                 hdr_value, e))
+        }
     }
 }
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<hyper::header::HeaderValue> for header::IntoHeaderValue<User> {
-    fn from(hdr_value: hyper::header::HeaderValue) -> Self {
-        header::IntoHeaderValue(<User as std::str::FromStr>::from_str(hdr_value.to_str().unwrap()).unwrap())
+impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<User> {
+    type Error = String;
+
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+        match hdr_value.to_str() {
+             Ok(value) => {
+                    match <User as std::str::FromStr>::from_str(value) {
+                        Ok(value) => Ok(header::IntoHeaderValue(value)),
+                        Err(err) => Err(format!("Unable to convert header value '{}' into User - {}",
+                            value, err))
+                    }
+             },
+             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
+                 hdr_value, e))
+        }
     }
 }
 

--- a/samples/server/petstore/rust-server/output/rust-server-test/src/client/mod.rs
+++ b/samples/server/petstore/rust-server/output/rust-server-test/src/client/mod.rs
@@ -8,6 +8,7 @@ use hyper::{Body, Uri, Response};
 use hyper_openssl::HttpsConnector;
 use serde_json;
 use std::borrow::Cow;
+use std::convert::TryInto;
 use std::io::{Read, Error, ErrorKind};
 use std::error;
 use std::fmt;

--- a/samples/server/petstore/rust-server/output/rust-server-test/src/models.rs
+++ b/samples/server/petstore/rust-server/output/rust-server-test/src/models.rs
@@ -8,16 +8,35 @@ use crate::header;
 // Methods for converting between header::IntoHeaderValue<ANullableContainer> and hyper::header::HeaderValue
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<header::IntoHeaderValue<ANullableContainer>> for hyper::header::HeaderValue {
-    fn from(hdr_value: header::IntoHeaderValue<ANullableContainer>) -> Self {
-        hyper::header::HeaderValue::from_str(&hdr_value.to_string()).unwrap()
+impl std::convert::TryFrom<header::IntoHeaderValue<ANullableContainer>> for hyper::header::HeaderValue {
+    type Error = String;
+
+    fn try_from(hdr_value: header::IntoHeaderValue<ANullableContainer>) -> Result<Self, Self::Error> {
+        let hdr_value = hdr_value.to_string();
+        match hyper::header::HeaderValue::from_str(&hdr_value) {
+             Ok(value) => Ok(value),
+             Err(e) => Err(format!("Invalid header value for ANullableContainer - value: {} is invalid {}",
+                 hdr_value, e))
+        }
     }
 }
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<hyper::header::HeaderValue> for header::IntoHeaderValue<ANullableContainer> {
-    fn from(hdr_value: hyper::header::HeaderValue) -> Self {
-        header::IntoHeaderValue(<ANullableContainer as std::str::FromStr>::from_str(hdr_value.to_str().unwrap()).unwrap())
+impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<ANullableContainer> {
+    type Error = String;
+
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+        match hdr_value.to_str() {
+             Ok(value) => {
+                    match <ANullableContainer as std::str::FromStr>::from_str(value) {
+                        Ok(value) => Ok(header::IntoHeaderValue(value)),
+                        Err(err) => Err(format!("Unable to convert header value '{}' into ANullableContainer - {}",
+                            value, err))
+                    }
+             },
+             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
+                 hdr_value, e))
+        }
     }
 }
 
@@ -169,16 +188,35 @@ impl ::std::str::FromStr for AdditionalPropertiesObject {
 // Methods for converting between header::IntoHeaderValue<AllOfObject> and hyper::header::HeaderValue
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<header::IntoHeaderValue<AllOfObject>> for hyper::header::HeaderValue {
-    fn from(hdr_value: header::IntoHeaderValue<AllOfObject>) -> Self {
-        hyper::header::HeaderValue::from_str(&hdr_value.to_string()).unwrap()
+impl std::convert::TryFrom<header::IntoHeaderValue<AllOfObject>> for hyper::header::HeaderValue {
+    type Error = String;
+
+    fn try_from(hdr_value: header::IntoHeaderValue<AllOfObject>) -> Result<Self, Self::Error> {
+        let hdr_value = hdr_value.to_string();
+        match hyper::header::HeaderValue::from_str(&hdr_value) {
+             Ok(value) => Ok(value),
+             Err(e) => Err(format!("Invalid header value for AllOfObject - value: {} is invalid {}",
+                 hdr_value, e))
+        }
     }
 }
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<hyper::header::HeaderValue> for header::IntoHeaderValue<AllOfObject> {
-    fn from(hdr_value: hyper::header::HeaderValue) -> Self {
-        header::IntoHeaderValue(<AllOfObject as std::str::FromStr>::from_str(hdr_value.to_str().unwrap()).unwrap())
+impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<AllOfObject> {
+    type Error = String;
+
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+        match hdr_value.to_str() {
+             Ok(value) => {
+                    match <AllOfObject as std::str::FromStr>::from_str(value) {
+                        Ok(value) => Ok(header::IntoHeaderValue(value)),
+                        Err(err) => Err(format!("Unable to convert header value '{}' into AllOfObject - {}",
+                            value, err))
+                    }
+             },
+             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
+                 hdr_value, e))
+        }
     }
 }
 
@@ -278,16 +316,35 @@ impl std::str::FromStr for AllOfObject {
 // Methods for converting between header::IntoHeaderValue<BaseAllOf> and hyper::header::HeaderValue
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<header::IntoHeaderValue<BaseAllOf>> for hyper::header::HeaderValue {
-    fn from(hdr_value: header::IntoHeaderValue<BaseAllOf>) -> Self {
-        hyper::header::HeaderValue::from_str(&hdr_value.to_string()).unwrap()
+impl std::convert::TryFrom<header::IntoHeaderValue<BaseAllOf>> for hyper::header::HeaderValue {
+    type Error = String;
+
+    fn try_from(hdr_value: header::IntoHeaderValue<BaseAllOf>) -> Result<Self, Self::Error> {
+        let hdr_value = hdr_value.to_string();
+        match hyper::header::HeaderValue::from_str(&hdr_value) {
+             Ok(value) => Ok(value),
+             Err(e) => Err(format!("Invalid header value for BaseAllOf - value: {} is invalid {}",
+                 hdr_value, e))
+        }
     }
 }
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<hyper::header::HeaderValue> for header::IntoHeaderValue<BaseAllOf> {
-    fn from(hdr_value: hyper::header::HeaderValue) -> Self {
-        header::IntoHeaderValue(<BaseAllOf as std::str::FromStr>::from_str(hdr_value.to_str().unwrap()).unwrap())
+impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<BaseAllOf> {
+    type Error = String;
+
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+        match hdr_value.to_str() {
+             Ok(value) => {
+                    match <BaseAllOf as std::str::FromStr>::from_str(value) {
+                        Ok(value) => Ok(header::IntoHeaderValue(value)),
+                        Err(err) => Err(format!("Unable to convert header value '{}' into BaseAllOf - {}",
+                            value, err))
+                    }
+             },
+             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
+                 hdr_value, e))
+        }
     }
 }
 
@@ -374,16 +431,35 @@ impl std::str::FromStr for BaseAllOf {
 // Methods for converting between header::IntoHeaderValue<GetYamlResponse> and hyper::header::HeaderValue
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<header::IntoHeaderValue<GetYamlResponse>> for hyper::header::HeaderValue {
-    fn from(hdr_value: header::IntoHeaderValue<GetYamlResponse>) -> Self {
-        hyper::header::HeaderValue::from_str(&hdr_value.to_string()).unwrap()
+impl std::convert::TryFrom<header::IntoHeaderValue<GetYamlResponse>> for hyper::header::HeaderValue {
+    type Error = String;
+
+    fn try_from(hdr_value: header::IntoHeaderValue<GetYamlResponse>) -> Result<Self, Self::Error> {
+        let hdr_value = hdr_value.to_string();
+        match hyper::header::HeaderValue::from_str(&hdr_value) {
+             Ok(value) => Ok(value),
+             Err(e) => Err(format!("Invalid header value for GetYamlResponse - value: {} is invalid {}",
+                 hdr_value, e))
+        }
     }
 }
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<hyper::header::HeaderValue> for header::IntoHeaderValue<GetYamlResponse> {
-    fn from(hdr_value: hyper::header::HeaderValue) -> Self {
-        header::IntoHeaderValue(<GetYamlResponse as std::str::FromStr>::from_str(hdr_value.to_str().unwrap()).unwrap())
+impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<GetYamlResponse> {
+    type Error = String;
+
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+        match hdr_value.to_str() {
+             Ok(value) => {
+                    match <GetYamlResponse as std::str::FromStr>::from_str(value) {
+                        Ok(value) => Ok(header::IntoHeaderValue(value)),
+                        Err(err) => Err(format!("Unable to convert header value '{}' into GetYamlResponse - {}",
+                            value, err))
+                    }
+             },
+             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
+                 hdr_value, e))
+        }
     }
 }
 
@@ -470,16 +546,35 @@ impl std::str::FromStr for GetYamlResponse {
 // Methods for converting between header::IntoHeaderValue<InlineObject> and hyper::header::HeaderValue
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<header::IntoHeaderValue<InlineObject>> for hyper::header::HeaderValue {
-    fn from(hdr_value: header::IntoHeaderValue<InlineObject>) -> Self {
-        hyper::header::HeaderValue::from_str(&hdr_value.to_string()).unwrap()
+impl std::convert::TryFrom<header::IntoHeaderValue<InlineObject>> for hyper::header::HeaderValue {
+    type Error = String;
+
+    fn try_from(hdr_value: header::IntoHeaderValue<InlineObject>) -> Result<Self, Self::Error> {
+        let hdr_value = hdr_value.to_string();
+        match hyper::header::HeaderValue::from_str(&hdr_value) {
+             Ok(value) => Ok(value),
+             Err(e) => Err(format!("Invalid header value for InlineObject - value: {} is invalid {}",
+                 hdr_value, e))
+        }
     }
 }
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<hyper::header::HeaderValue> for header::IntoHeaderValue<InlineObject> {
-    fn from(hdr_value: hyper::header::HeaderValue) -> Self {
-        header::IntoHeaderValue(<InlineObject as std::str::FromStr>::from_str(hdr_value.to_str().unwrap()).unwrap())
+impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<InlineObject> {
+    type Error = String;
+
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+        match hdr_value.to_str() {
+             Ok(value) => {
+                    match <InlineObject as std::str::FromStr>::from_str(value) {
+                        Ok(value) => Ok(header::IntoHeaderValue(value)),
+                        Err(err) => Err(format!("Unable to convert header value '{}' into InlineObject - {}",
+                            value, err))
+                    }
+             },
+             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
+                 hdr_value, e))
+        }
     }
 }
 
@@ -577,16 +672,35 @@ impl std::str::FromStr for InlineObject {
 // Methods for converting between header::IntoHeaderValue<ObjectOfObjects> and hyper::header::HeaderValue
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<header::IntoHeaderValue<ObjectOfObjects>> for hyper::header::HeaderValue {
-    fn from(hdr_value: header::IntoHeaderValue<ObjectOfObjects>) -> Self {
-        hyper::header::HeaderValue::from_str(&hdr_value.to_string()).unwrap()
+impl std::convert::TryFrom<header::IntoHeaderValue<ObjectOfObjects>> for hyper::header::HeaderValue {
+    type Error = String;
+
+    fn try_from(hdr_value: header::IntoHeaderValue<ObjectOfObjects>) -> Result<Self, Self::Error> {
+        let hdr_value = hdr_value.to_string();
+        match hyper::header::HeaderValue::from_str(&hdr_value) {
+             Ok(value) => Ok(value),
+             Err(e) => Err(format!("Invalid header value for ObjectOfObjects - value: {} is invalid {}",
+                 hdr_value, e))
+        }
     }
 }
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<hyper::header::HeaderValue> for header::IntoHeaderValue<ObjectOfObjects> {
-    fn from(hdr_value: hyper::header::HeaderValue) -> Self {
-        header::IntoHeaderValue(<ObjectOfObjects as std::str::FromStr>::from_str(hdr_value.to_str().unwrap()).unwrap())
+impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<ObjectOfObjects> {
+    type Error = String;
+
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+        match hdr_value.to_str() {
+             Ok(value) => {
+                    match <ObjectOfObjects as std::str::FromStr>::from_str(value) {
+                        Ok(value) => Ok(header::IntoHeaderValue(value)),
+                        Err(err) => Err(format!("Unable to convert header value '{}' into ObjectOfObjects - {}",
+                            value, err))
+                    }
+             },
+             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
+                 hdr_value, e))
+        }
     }
 }
 
@@ -668,16 +782,35 @@ impl std::str::FromStr for ObjectOfObjects {
 // Methods for converting between header::IntoHeaderValue<ObjectOfObjectsInner> and hyper::header::HeaderValue
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<header::IntoHeaderValue<ObjectOfObjectsInner>> for hyper::header::HeaderValue {
-    fn from(hdr_value: header::IntoHeaderValue<ObjectOfObjectsInner>) -> Self {
-        hyper::header::HeaderValue::from_str(&hdr_value.to_string()).unwrap()
+impl std::convert::TryFrom<header::IntoHeaderValue<ObjectOfObjectsInner>> for hyper::header::HeaderValue {
+    type Error = String;
+
+    fn try_from(hdr_value: header::IntoHeaderValue<ObjectOfObjectsInner>) -> Result<Self, Self::Error> {
+        let hdr_value = hdr_value.to_string();
+        match hyper::header::HeaderValue::from_str(&hdr_value) {
+             Ok(value) => Ok(value),
+             Err(e) => Err(format!("Invalid header value for ObjectOfObjectsInner - value: {} is invalid {}",
+                 hdr_value, e))
+        }
     }
 }
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl From<hyper::header::HeaderValue> for header::IntoHeaderValue<ObjectOfObjectsInner> {
-    fn from(hdr_value: hyper::header::HeaderValue) -> Self {
-        header::IntoHeaderValue(<ObjectOfObjectsInner as std::str::FromStr>::from_str(hdr_value.to_str().unwrap()).unwrap())
+impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<ObjectOfObjectsInner> {
+    type Error = String;
+
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+        match hdr_value.to_str() {
+             Ok(value) => {
+                    match <ObjectOfObjectsInner as std::str::FromStr>::from_str(value) {
+                        Ok(value) => Ok(header::IntoHeaderValue(value)),
+                        Err(err) => Err(format!("Unable to convert header value '{}' into ObjectOfObjectsInner - {}",
+                            value, err))
+                    }
+             },
+             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
+                 hdr_value, e))
+        }
     }
 }
 

--- a/samples/server/petstore/rust-server/output/rust-server-test/src/models.rs
+++ b/samples/server/petstore/rust-server/output/rust-server-test/src/models.rs
@@ -11,12 +11,13 @@ use crate::header;
 impl std::convert::TryFrom<header::IntoHeaderValue<ANullableContainer>> for hyper::header::HeaderValue {
     type Error = String;
 
-    fn try_from(hdr_value: header::IntoHeaderValue<ANullableContainer>) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<ANullableContainer>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match hyper::header::HeaderValue::from_str(&hdr_value) {
-             Ok(value) => Ok(value),
-             Err(e) => Err(format!("Invalid header value for ANullableContainer - value: {} is invalid {}",
-                 hdr_value, e))
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for ANullableContainer - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -25,17 +26,19 @@ impl std::convert::TryFrom<header::IntoHeaderValue<ANullableContainer>> for hype
 impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<ANullableContainer> {
     type Error = String;
 
-    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-             Ok(value) => {
+             std::result::Result::Ok(value) => {
                     match <ANullableContainer as std::str::FromStr>::from_str(value) {
-                        Ok(value) => Ok(header::IntoHeaderValue(value)),
-                        Err(err) => Err(format!("Unable to convert header value '{}' into ANullableContainer - {}",
-                            value, err))
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into ANullableContainer - {}",
+                                value, err))
                     }
              },
-             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
-                 hdr_value, e))
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
@@ -191,12 +194,13 @@ impl ::std::str::FromStr for AdditionalPropertiesObject {
 impl std::convert::TryFrom<header::IntoHeaderValue<AllOfObject>> for hyper::header::HeaderValue {
     type Error = String;
 
-    fn try_from(hdr_value: header::IntoHeaderValue<AllOfObject>) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<AllOfObject>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match hyper::header::HeaderValue::from_str(&hdr_value) {
-             Ok(value) => Ok(value),
-             Err(e) => Err(format!("Invalid header value for AllOfObject - value: {} is invalid {}",
-                 hdr_value, e))
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for AllOfObject - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -205,17 +209,19 @@ impl std::convert::TryFrom<header::IntoHeaderValue<AllOfObject>> for hyper::head
 impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<AllOfObject> {
     type Error = String;
 
-    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-             Ok(value) => {
+             std::result::Result::Ok(value) => {
                     match <AllOfObject as std::str::FromStr>::from_str(value) {
-                        Ok(value) => Ok(header::IntoHeaderValue(value)),
-                        Err(err) => Err(format!("Unable to convert header value '{}' into AllOfObject - {}",
-                            value, err))
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into AllOfObject - {}",
+                                value, err))
                     }
              },
-             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
-                 hdr_value, e))
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
@@ -319,12 +325,13 @@ impl std::str::FromStr for AllOfObject {
 impl std::convert::TryFrom<header::IntoHeaderValue<BaseAllOf>> for hyper::header::HeaderValue {
     type Error = String;
 
-    fn try_from(hdr_value: header::IntoHeaderValue<BaseAllOf>) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<BaseAllOf>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match hyper::header::HeaderValue::from_str(&hdr_value) {
-             Ok(value) => Ok(value),
-             Err(e) => Err(format!("Invalid header value for BaseAllOf - value: {} is invalid {}",
-                 hdr_value, e))
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for BaseAllOf - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -333,17 +340,19 @@ impl std::convert::TryFrom<header::IntoHeaderValue<BaseAllOf>> for hyper::header
 impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<BaseAllOf> {
     type Error = String;
 
-    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-             Ok(value) => {
+             std::result::Result::Ok(value) => {
                     match <BaseAllOf as std::str::FromStr>::from_str(value) {
-                        Ok(value) => Ok(header::IntoHeaderValue(value)),
-                        Err(err) => Err(format!("Unable to convert header value '{}' into BaseAllOf - {}",
-                            value, err))
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into BaseAllOf - {}",
+                                value, err))
                     }
              },
-             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
-                 hdr_value, e))
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
@@ -434,12 +443,13 @@ impl std::str::FromStr for BaseAllOf {
 impl std::convert::TryFrom<header::IntoHeaderValue<GetYamlResponse>> for hyper::header::HeaderValue {
     type Error = String;
 
-    fn try_from(hdr_value: header::IntoHeaderValue<GetYamlResponse>) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<GetYamlResponse>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match hyper::header::HeaderValue::from_str(&hdr_value) {
-             Ok(value) => Ok(value),
-             Err(e) => Err(format!("Invalid header value for GetYamlResponse - value: {} is invalid {}",
-                 hdr_value, e))
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for GetYamlResponse - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -448,17 +458,19 @@ impl std::convert::TryFrom<header::IntoHeaderValue<GetYamlResponse>> for hyper::
 impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<GetYamlResponse> {
     type Error = String;
 
-    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-             Ok(value) => {
+             std::result::Result::Ok(value) => {
                     match <GetYamlResponse as std::str::FromStr>::from_str(value) {
-                        Ok(value) => Ok(header::IntoHeaderValue(value)),
-                        Err(err) => Err(format!("Unable to convert header value '{}' into GetYamlResponse - {}",
-                            value, err))
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into GetYamlResponse - {}",
+                                value, err))
                     }
              },
-             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
-                 hdr_value, e))
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
@@ -549,12 +561,13 @@ impl std::str::FromStr for GetYamlResponse {
 impl std::convert::TryFrom<header::IntoHeaderValue<InlineObject>> for hyper::header::HeaderValue {
     type Error = String;
 
-    fn try_from(hdr_value: header::IntoHeaderValue<InlineObject>) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<InlineObject>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match hyper::header::HeaderValue::from_str(&hdr_value) {
-             Ok(value) => Ok(value),
-             Err(e) => Err(format!("Invalid header value for InlineObject - value: {} is invalid {}",
-                 hdr_value, e))
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for InlineObject - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -563,17 +576,19 @@ impl std::convert::TryFrom<header::IntoHeaderValue<InlineObject>> for hyper::hea
 impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<InlineObject> {
     type Error = String;
 
-    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-             Ok(value) => {
+             std::result::Result::Ok(value) => {
                     match <InlineObject as std::str::FromStr>::from_str(value) {
-                        Ok(value) => Ok(header::IntoHeaderValue(value)),
-                        Err(err) => Err(format!("Unable to convert header value '{}' into InlineObject - {}",
-                            value, err))
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into InlineObject - {}",
+                                value, err))
                     }
              },
-             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
-                 hdr_value, e))
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
@@ -675,12 +690,13 @@ impl std::str::FromStr for InlineObject {
 impl std::convert::TryFrom<header::IntoHeaderValue<ObjectOfObjects>> for hyper::header::HeaderValue {
     type Error = String;
 
-    fn try_from(hdr_value: header::IntoHeaderValue<ObjectOfObjects>) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<ObjectOfObjects>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match hyper::header::HeaderValue::from_str(&hdr_value) {
-             Ok(value) => Ok(value),
-             Err(e) => Err(format!("Invalid header value for ObjectOfObjects - value: {} is invalid {}",
-                 hdr_value, e))
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for ObjectOfObjects - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -689,17 +705,19 @@ impl std::convert::TryFrom<header::IntoHeaderValue<ObjectOfObjects>> for hyper::
 impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<ObjectOfObjects> {
     type Error = String;
 
-    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-             Ok(value) => {
+             std::result::Result::Ok(value) => {
                     match <ObjectOfObjects as std::str::FromStr>::from_str(value) {
-                        Ok(value) => Ok(header::IntoHeaderValue(value)),
-                        Err(err) => Err(format!("Unable to convert header value '{}' into ObjectOfObjects - {}",
-                            value, err))
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into ObjectOfObjects - {}",
+                                value, err))
                     }
              },
-             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
-                 hdr_value, e))
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }
@@ -785,12 +803,13 @@ impl std::str::FromStr for ObjectOfObjects {
 impl std::convert::TryFrom<header::IntoHeaderValue<ObjectOfObjectsInner>> for hyper::header::HeaderValue {
     type Error = String;
 
-    fn try_from(hdr_value: header::IntoHeaderValue<ObjectOfObjectsInner>) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<ObjectOfObjectsInner>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match hyper::header::HeaderValue::from_str(&hdr_value) {
-             Ok(value) => Ok(value),
-             Err(e) => Err(format!("Invalid header value for ObjectOfObjectsInner - value: {} is invalid {}",
-                 hdr_value, e))
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for ObjectOfObjectsInner - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
@@ -799,17 +818,19 @@ impl std::convert::TryFrom<header::IntoHeaderValue<ObjectOfObjectsInner>> for hy
 impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<ObjectOfObjectsInner> {
     type Error = String;
 
-    fn try_from(hdr_value: hyper::header::HeaderValue) -> Result<Self, Self::Error> {
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
-             Ok(value) => {
+             std::result::Result::Ok(value) => {
                     match <ObjectOfObjectsInner as std::str::FromStr>::from_str(value) {
-                        Ok(value) => Ok(header::IntoHeaderValue(value)),
-                        Err(err) => Err(format!("Unable to convert header value '{}' into ObjectOfObjectsInner - {}",
-                            value, err))
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{}' into ObjectOfObjectsInner - {}",
+                                value, err))
                     }
              },
-             Err(e) => Err(format!("Unable to convert header: {:?} to string: {}",
-                 hdr_value, e))
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {:?} to string: {}",
+                     hdr_value, e))
         }
     }
 }

--- a/samples/server/petstore/rust-server/output/rust-server-test/src/server/mod.rs
+++ b/samples/server/petstore/rust-server/output/rust-server-test/src/server/mod.rs
@@ -5,6 +5,8 @@ use hyper::{Request, Response, Error, StatusCode, Body, HeaderMap};
 use hyper::header::{HeaderName, HeaderValue, CONTENT_TYPE};
 use log::warn;
 use serde_json;
+#[allow(unused_imports)]
+use std::convert::{TryFrom, TryInto};
 use std::io;
 use url::form_urlencoded;
 #[allow(unused_imports)]


### PR DESCRIPTION
Handle headers containing a boolean

Fix panic if a header doesn't represent a valid value.

### Rust Server Technical Committee

- @frol
- @farcaller 
- @bjgill

### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [X] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [X] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.