### PR TITLE
[Java][MicroProfile] Use jsonb imports for serializing  and deserializing enum

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/microprofile/enumClass.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/microprofile/enumClass.mustache
@@ -1,13 +1,24 @@
+{{#withXml}}
 @XmlType(name="{{datatypeWithEnum}}")
 @XmlEnum({{dataType}}.class)
+{{/withXml}}
+{{^withXml}}
+@JsonbTypeSerializer({{datatypeWithEnum}}.Serializer.class)
+@JsonbTypeDeserializer({{datatypeWithEnum}}.Deserializer.class)
+{{/withXml}}
 public enum {{datatypeWithEnum}} {
 
     {{#allowableValues}}
+    {{#withXml}}
 {{#enumVars}}@XmlEnumValue({{#isInteger}}"{{/isInteger}}{{#isDouble}}"{{/isDouble}}{{#isLong}}"{{/isLong}}{{#isFloat}}"{{/isFloat}}{{{value}}}{{#isInteger}}"{{/isInteger}}{{#isDouble}}"{{/isDouble}}{{#isLong}}"{{/isLong}}{{#isFloat}}"{{/isFloat}}) {{name}}({{dataType}}.valueOf({{{value}}})){{^-last}}, {{/-last}}{{#-last}};{{/-last}}{{/enumVars}}
+	{{/withXml}}
+	{{^withXml}}
+{{#enumVars}}{{name}}({{dataType}}.valueOf({{{value}}})){{^-last}}, {{/-last}}{{#-last}};{{/-last}}{{/enumVars}}	
+	{{/withXml}}
     {{/allowableValues}}
 
 
-    private {{dataType}} value;
+    {{dataType}} value;
 
     {{datatypeWithEnum}} ({{dataType}} v) {
         value = v;
@@ -22,6 +33,7 @@ public enum {{datatypeWithEnum}} {
         return String.valueOf(value);
     }
 
+    {{#withXml}}
     public static {{datatypeWithEnum}} fromValue(String v) {
         for ({{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} b : {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}}.values()) {
             if (String.valueOf(b.value).equals(v)) {
@@ -30,4 +42,25 @@ public enum {{datatypeWithEnum}} {
         }
         {{#useNullForUnknownEnumValue}}return null;{{/useNullForUnknownEnumValue}}{{^useNullForUnknownEnumValue}}throw new IllegalArgumentException("Unexpected value '" + v + "'");{{/useNullForUnknownEnumValue}}
     }
+    {{/withXml}}
+    {{^withXml}}
+    public static final class Deserializer implements JsonbDeserializer<{{datatypeWithEnum}}> {
+        @Override
+        public {{datatypeWithEnum}} deserialize(JsonParser parser, DeserializationContext ctx, Type rtType) {
+            for ({{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} b : {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}}.values()) {
+                if (String.valueOf(b.value).equals(parser.getString())) {
+                    return b;
+                }
+            }
+            {{#useNullForUnknownEnumValue}}return null;{{/useNullForUnknownEnumValue}}{{^useNullForUnknownEnumValue}}throw new IllegalArgumentException("Unexpected value '" + parser.getString() + "'");{{/useNullForUnknownEnumValue}}
+        }
+    }
+
+    public static final class Serializer implements JsonbSerializer<{{datatypeWithEnum}}> {
+        @Override
+        public void serialize({{datatypeWithEnum}} obj, JsonGenerator generator, SerializationContext ctx) {
+            generator.write(obj.value);
+        }
+    }
+    {{/withXml}}
 }

--- a/modules/openapi-generator/src/main/resources/Java/libraries/microprofile/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/microprofile/pojo.mustache
@@ -1,3 +1,4 @@
+{{#withXml}}
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlAccessType;
@@ -5,7 +6,19 @@ import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.XmlEnum;
 import javax.xml.bind.annotation.XmlEnumValue;
+{{/withXml}}
+{{^withXml}}
+import java.lang.reflect.Type;
+import javax.json.bind.annotation.JsonbTypeDeserializer;
+import javax.json.bind.annotation.JsonbTypeSerializer;
+import javax.json.bind.serializer.DeserializationContext;
+import javax.json.bind.serializer.JsonbDeserializer;
+import javax.json.bind.serializer.JsonbSerializer;
+import javax.json.bind.serializer.SerializationContext;
+import javax.json.stream.JsonGenerator;
+import javax.json.stream.JsonParser;
 import javax.json.bind.annotation.JsonbProperty;
+{{/withXml}}
 
 {{#withXml}}
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/modules/openapi-generator/src/main/resources/Java/libraries/microprofile/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/microprofile/pojo.mustache
@@ -69,7 +69,9 @@ public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}}{{#serializ
   {{/maximum}}
    * @return {{name}}
   **/
+  {{^withXml}}
   @JsonbProperty("{{baseName}}")
+  {{/withXml}}
 {{#vendorExtensions.x-extra-annotation}}
   {{{vendorExtensions.x-extra-annotation}}}
 {{/vendorExtensions.x-extra-annotation}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/microprofile/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/microprofile/pom.mustache
@@ -103,6 +103,11 @@
       <version>1.0</version>
     </dependency>
     <dependency>
+        <groupId>javax.json</groupId>
+        <artifactId>javax.json-api</artifactId>
+        <version>1.1.4</version>
+    </dependency>
+    <dependency>
         <groupId>javax.xml.bind</groupId>
         <artifactId>jaxb-api</artifactId>
         <version>2.2.11</version>

--- a/samples/client/petstore/java/microprofile-rest-client/pom.xml
+++ b/samples/client/petstore/java/microprofile-rest-client/pom.xml
@@ -90,6 +90,11 @@
       <version>1.0</version>
     </dependency>
     <dependency>
+        <groupId>javax.json</groupId>
+        <artifactId>javax.json-api</artifactId>
+        <version>1.1.4</version>
+    </dependency>
+    <dependency>
         <groupId>javax.xml.bind</groupId>
         <artifactId>jaxb-api</artifactId>
         <version>2.2.11</version>

--- a/samples/client/petstore/java/microprofile-rest-client/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/microprofile-rest-client/src/main/java/org/openapitools/client/model/Category.java
@@ -25,13 +25,15 @@
 package org.openapitools.client.model;
 
 
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlType;
-import javax.xml.bind.annotation.XmlEnum;
-import javax.xml.bind.annotation.XmlEnumValue;
+import java.lang.reflect.Type;
+import javax.json.bind.annotation.JsonbTypeDeserializer;
+import javax.json.bind.annotation.JsonbTypeSerializer;
+import javax.json.bind.serializer.DeserializationContext;
+import javax.json.bind.serializer.JsonbDeserializer;
+import javax.json.bind.serializer.JsonbSerializer;
+import javax.json.bind.serializer.SerializationContext;
+import javax.json.stream.JsonGenerator;
+import javax.json.stream.JsonParser;
 import javax.json.bind.annotation.JsonbProperty;
 
 /**

--- a/samples/client/petstore/java/microprofile-rest-client/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/microprofile-rest-client/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -25,13 +25,15 @@
 package org.openapitools.client.model;
 
 
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlType;
-import javax.xml.bind.annotation.XmlEnum;
-import javax.xml.bind.annotation.XmlEnumValue;
+import java.lang.reflect.Type;
+import javax.json.bind.annotation.JsonbTypeDeserializer;
+import javax.json.bind.annotation.JsonbTypeSerializer;
+import javax.json.bind.serializer.DeserializationContext;
+import javax.json.bind.serializer.JsonbDeserializer;
+import javax.json.bind.serializer.JsonbSerializer;
+import javax.json.bind.serializer.SerializationContext;
+import javax.json.stream.JsonGenerator;
+import javax.json.stream.JsonParser;
 import javax.json.bind.annotation.JsonbProperty;
 
 /**

--- a/samples/client/petstore/java/microprofile-rest-client/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/microprofile-rest-client/src/main/java/org/openapitools/client/model/Order.java
@@ -26,13 +26,15 @@ package org.openapitools.client.model;
 
 import java.util.Date;
 
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlType;
-import javax.xml.bind.annotation.XmlEnum;
-import javax.xml.bind.annotation.XmlEnumValue;
+import java.lang.reflect.Type;
+import javax.json.bind.annotation.JsonbTypeDeserializer;
+import javax.json.bind.annotation.JsonbTypeSerializer;
+import javax.json.bind.serializer.DeserializationContext;
+import javax.json.bind.serializer.JsonbDeserializer;
+import javax.json.bind.serializer.JsonbSerializer;
+import javax.json.bind.serializer.SerializationContext;
+import javax.json.stream.JsonGenerator;
+import javax.json.stream.JsonParser;
 import javax.json.bind.annotation.JsonbProperty;
 
 /**
@@ -48,14 +50,14 @@ public class Order  {
 
   private Date shipDate;
 
-@XmlType(name="StatusEnum")
-@XmlEnum(String.class)
+@JsonbTypeSerializer(StatusEnum.Serializer.class)
+@JsonbTypeDeserializer(StatusEnum.Deserializer.class)
 public enum StatusEnum {
 
-@XmlEnumValue("placed") PLACED(String.valueOf("placed")), @XmlEnumValue("approved") APPROVED(String.valueOf("approved")), @XmlEnumValue("delivered") DELIVERED(String.valueOf("delivered"));
+PLACED(String.valueOf("placed")), APPROVED(String.valueOf("approved")), DELIVERED(String.valueOf("delivered"));	
 
 
-    private String value;
+    String value;
 
     StatusEnum (String v) {
         value = v;
@@ -70,13 +72,23 @@ public enum StatusEnum {
         return String.valueOf(value);
     }
 
-    public static StatusEnum fromValue(String v) {
-        for (StatusEnum b : StatusEnum.values()) {
-            if (String.valueOf(b.value).equals(v)) {
-                return b;
+    public static final class Deserializer implements JsonbDeserializer<StatusEnum> {
+        @Override
+        public StatusEnum deserialize(JsonParser parser, DeserializationContext ctx, Type rtType) {
+            for (StatusEnum b : StatusEnum.values()) {
+                if (String.valueOf(b.value).equals(parser.getString())) {
+                    return b;
+                }
             }
+            throw new IllegalArgumentException("Unexpected value '" + parser.getString() + "'");
         }
-        throw new IllegalArgumentException("Unexpected value '" + v + "'");
+    }
+
+    public static final class Serializer implements JsonbSerializer<StatusEnum> {
+        @Override
+        public void serialize(StatusEnum obj, JsonGenerator generator, SerializationContext ctx) {
+            generator.write(obj.value);
+        }
     }
 }
 

--- a/samples/client/petstore/java/microprofile-rest-client/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/microprofile-rest-client/src/main/java/org/openapitools/client/model/Pet.java
@@ -29,13 +29,15 @@ import java.util.List;
 import org.openapitools.client.model.Category;
 import org.openapitools.client.model.Tag;
 
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlType;
-import javax.xml.bind.annotation.XmlEnum;
-import javax.xml.bind.annotation.XmlEnumValue;
+import java.lang.reflect.Type;
+import javax.json.bind.annotation.JsonbTypeDeserializer;
+import javax.json.bind.annotation.JsonbTypeSerializer;
+import javax.json.bind.serializer.DeserializationContext;
+import javax.json.bind.serializer.JsonbDeserializer;
+import javax.json.bind.serializer.JsonbSerializer;
+import javax.json.bind.serializer.SerializationContext;
+import javax.json.stream.JsonGenerator;
+import javax.json.stream.JsonParser;
 import javax.json.bind.annotation.JsonbProperty;
 
 /**
@@ -53,14 +55,14 @@ public class Pet  {
 
   private List<Tag> tags = null;
 
-@XmlType(name="StatusEnum")
-@XmlEnum(String.class)
+@JsonbTypeSerializer(StatusEnum.Serializer.class)
+@JsonbTypeDeserializer(StatusEnum.Deserializer.class)
 public enum StatusEnum {
 
-@XmlEnumValue("available") AVAILABLE(String.valueOf("available")), @XmlEnumValue("pending") PENDING(String.valueOf("pending")), @XmlEnumValue("sold") SOLD(String.valueOf("sold"));
+AVAILABLE(String.valueOf("available")), PENDING(String.valueOf("pending")), SOLD(String.valueOf("sold"));	
 
 
-    private String value;
+    String value;
 
     StatusEnum (String v) {
         value = v;
@@ -75,13 +77,23 @@ public enum StatusEnum {
         return String.valueOf(value);
     }
 
-    public static StatusEnum fromValue(String v) {
-        for (StatusEnum b : StatusEnum.values()) {
-            if (String.valueOf(b.value).equals(v)) {
-                return b;
+    public static final class Deserializer implements JsonbDeserializer<StatusEnum> {
+        @Override
+        public StatusEnum deserialize(JsonParser parser, DeserializationContext ctx, Type rtType) {
+            for (StatusEnum b : StatusEnum.values()) {
+                if (String.valueOf(b.value).equals(parser.getString())) {
+                    return b;
+                }
             }
+            throw new IllegalArgumentException("Unexpected value '" + parser.getString() + "'");
         }
-        throw new IllegalArgumentException("Unexpected value '" + v + "'");
+    }
+
+    public static final class Serializer implements JsonbSerializer<StatusEnum> {
+        @Override
+        public void serialize(StatusEnum obj, JsonGenerator generator, SerializationContext ctx) {
+            generator.write(obj.value);
+        }
     }
 }
 

--- a/samples/client/petstore/java/microprofile-rest-client/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/microprofile-rest-client/src/main/java/org/openapitools/client/model/Tag.java
@@ -25,13 +25,15 @@
 package org.openapitools.client.model;
 
 
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlType;
-import javax.xml.bind.annotation.XmlEnum;
-import javax.xml.bind.annotation.XmlEnumValue;
+import java.lang.reflect.Type;
+import javax.json.bind.annotation.JsonbTypeDeserializer;
+import javax.json.bind.annotation.JsonbTypeSerializer;
+import javax.json.bind.serializer.DeserializationContext;
+import javax.json.bind.serializer.JsonbDeserializer;
+import javax.json.bind.serializer.JsonbSerializer;
+import javax.json.bind.serializer.SerializationContext;
+import javax.json.stream.JsonGenerator;
+import javax.json.stream.JsonParser;
 import javax.json.bind.annotation.JsonbProperty;
 
 /**

--- a/samples/client/petstore/java/microprofile-rest-client/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/microprofile-rest-client/src/main/java/org/openapitools/client/model/User.java
@@ -25,13 +25,15 @@
 package org.openapitools.client.model;
 
 
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlType;
-import javax.xml.bind.annotation.XmlEnum;
-import javax.xml.bind.annotation.XmlEnumValue;
+import java.lang.reflect.Type;
+import javax.json.bind.annotation.JsonbTypeDeserializer;
+import javax.json.bind.annotation.JsonbTypeSerializer;
+import javax.json.bind.serializer.DeserializationContext;
+import javax.json.bind.serializer.JsonbDeserializer;
+import javax.json.bind.serializer.JsonbSerializer;
+import javax.json.bind.serializer.SerializationContext;
+import javax.json.stream.JsonGenerator;
+import javax.json.stream.JsonParser;
 import javax.json.bind.annotation.JsonbProperty;
 
 /**


### PR DESCRIPTION
Fixes the issue no: 2 reported in the issue https://github.com/OpenAPITools/openapi-generator/issues/6028

The pull request removes all jaxb (xml) imports when withXml=false also it uses JsonbTypeSerializer & JsonbTypeDeserializer to deal with enum data types.