### PR TITLE
[typescript-rxjs] Prints out the parameter name in throwIfNullOrUndefined

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-rxjs/apis.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-rxjs/apis.mustache
@@ -41,7 +41,7 @@ export class {{classname}} extends BaseAPI {
         {{#hasParams}}
         {{#allParams}}
         {{#required}}
-        throwIfNullOrUndefined({{> paramNamePartial}}, '{{nickname}}');
+        throwIfNullOrUndefined({{> paramNamePartial}}, '{{> paramNamePartial}}', '{{nickname}}');
         {{/required}}
         {{/allParams}}
 

--- a/modules/openapi-generator/src/main/resources/typescript-rxjs/runtime.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-rxjs/runtime.mustache
@@ -178,9 +178,9 @@ export const throwIfRequired = (params: {[key: string]: any}, key: string, nickn
     }
 };
 
-export const throwIfNullOrUndefined = (value: any, nickname?: string) => {
+export const throwIfNullOrUndefined = (value: any, pramName: string, nickname: string) => {
     if (value == null) {
-        throw new Error(`Parameter "${value}" was null or undefined when calling "${nickname}".`);
+        throw new Error(`Parameter "${paramName}" was null or undefined when calling "${nickname}".`);
     }
 };
 

--- a/modules/openapi-generator/src/main/resources/typescript-rxjs/runtime.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-rxjs/runtime.mustache
@@ -178,7 +178,7 @@ export const throwIfRequired = (params: {[key: string]: any}, key: string, nickn
     }
 };
 
-export const throwIfNullOrUndefined = (value: any, pramName: string, nickname: string) => {
+export const throwIfNullOrUndefined = (value: any, paramName: string, nickname: string) => {
     if (value == null) {
         throw new Error(`Parameter "${paramName}" was null or undefined when calling "${nickname}".`);
     }

--- a/samples/client/petstore/typescript-rxjs/builds/default/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/default/apis/PetApi.ts
@@ -64,7 +64,7 @@ export class PetApi extends BaseAPI {
      * Add a new pet to the store
      */
     addPet = ({ body }: AddPetRequest): Observable<void> => {
-        throwIfNullOrUndefined(body, 'addPet');
+        throwIfNullOrUndefined(body, 'body', 'addPet');
 
         const headers: HttpHeaders = {
             'Content-Type': 'application/json',
@@ -89,7 +89,7 @@ export class PetApi extends BaseAPI {
      * Deletes a pet
      */
     deletePet = ({ petId, apiKey }: DeletePetRequest): Observable<void> => {
-        throwIfNullOrUndefined(petId, 'deletePet');
+        throwIfNullOrUndefined(petId, 'petId', 'deletePet');
 
         const headers: HttpHeaders = {
             ...(apiKey != null ? { 'api_key': String(apiKey) } : undefined),
@@ -114,7 +114,7 @@ export class PetApi extends BaseAPI {
      * Finds Pets by status
      */
     findPetsByStatus = ({ status }: FindPetsByStatusRequest): Observable<Array<Pet>> => {
-        throwIfNullOrUndefined(status, 'findPetsByStatus');
+        throwIfNullOrUndefined(status, 'status', 'findPetsByStatus');
 
         const headers: HttpHeaders = {
             // oauth required
@@ -143,7 +143,7 @@ export class PetApi extends BaseAPI {
      * Finds Pets by tags
      */
     findPetsByTags = ({ tags }: FindPetsByTagsRequest): Observable<Array<Pet>> => {
-        throwIfNullOrUndefined(tags, 'findPetsByTags');
+        throwIfNullOrUndefined(tags, 'tags', 'findPetsByTags');
 
         const headers: HttpHeaders = {
             // oauth required
@@ -172,7 +172,7 @@ export class PetApi extends BaseAPI {
      * Find pet by ID
      */
     getPetById = ({ petId }: GetPetByIdRequest): Observable<Pet> => {
-        throwIfNullOrUndefined(petId, 'getPetById');
+        throwIfNullOrUndefined(petId, 'petId', 'getPetById');
 
         const headers: HttpHeaders = {
             ...(this.configuration.apiKey && { 'api_key': this.configuration.apiKey('api_key') }), // api_key authentication
@@ -189,7 +189,7 @@ export class PetApi extends BaseAPI {
      * Update an existing pet
      */
     updatePet = ({ body }: UpdatePetRequest): Observable<void> => {
-        throwIfNullOrUndefined(body, 'updatePet');
+        throwIfNullOrUndefined(body, 'body', 'updatePet');
 
         const headers: HttpHeaders = {
             'Content-Type': 'application/json',
@@ -214,7 +214,7 @@ export class PetApi extends BaseAPI {
      * Updates a pet in the store with form data
      */
     updatePetWithForm = ({ petId, name, status }: UpdatePetWithFormRequest): Observable<void> => {
-        throwIfNullOrUndefined(petId, 'updatePetWithForm');
+        throwIfNullOrUndefined(petId, 'petId', 'updatePetWithForm');
 
         const headers: HttpHeaders = {
             // oauth required
@@ -242,7 +242,7 @@ export class PetApi extends BaseAPI {
      * uploads an image
      */
     uploadFile = ({ petId, additionalMetadata, file }: UploadFileRequest): Observable<ApiResponse> => {
-        throwIfNullOrUndefined(petId, 'uploadFile');
+        throwIfNullOrUndefined(petId, 'petId', 'uploadFile');
 
         const headers: HttpHeaders = {
             // oauth required

--- a/samples/client/petstore/typescript-rxjs/builds/default/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/default/apis/StoreApi.ts
@@ -39,7 +39,7 @@ export class StoreApi extends BaseAPI {
      * Delete purchase order by ID
      */
     deleteOrder = ({ orderId }: DeleteOrderRequest): Observable<void> => {
-        throwIfNullOrUndefined(orderId, 'deleteOrder');
+        throwIfNullOrUndefined(orderId, 'orderId', 'deleteOrder');
 
         return this.request<void>({
             path: '/store/order/{orderId}'.replace('{orderId}', encodeURI(orderId)),
@@ -68,7 +68,7 @@ export class StoreApi extends BaseAPI {
      * Find purchase order by ID
      */
     getOrderById = ({ orderId }: GetOrderByIdRequest): Observable<Order> => {
-        throwIfNullOrUndefined(orderId, 'getOrderById');
+        throwIfNullOrUndefined(orderId, 'orderId', 'getOrderById');
 
         return this.request<Order>({
             path: '/store/order/{orderId}'.replace('{orderId}', encodeURI(orderId)),
@@ -80,7 +80,7 @@ export class StoreApi extends BaseAPI {
      * Place an order for a pet
      */
     placeOrder = ({ body }: PlaceOrderRequest): Observable<Order> => {
-        throwIfNullOrUndefined(body, 'placeOrder');
+        throwIfNullOrUndefined(body, 'body', 'placeOrder');
 
         const headers: HttpHeaders = {
             'Content-Type': 'application/json',

--- a/samples/client/petstore/typescript-rxjs/builds/default/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/default/apis/UserApi.ts
@@ -57,7 +57,7 @@ export class UserApi extends BaseAPI {
      * Create user
      */
     createUser = ({ body }: CreateUserRequest): Observable<void> => {
-        throwIfNullOrUndefined(body, 'createUser');
+        throwIfNullOrUndefined(body, 'body', 'createUser');
 
         const headers: HttpHeaders = {
             'Content-Type': 'application/json',
@@ -75,7 +75,7 @@ export class UserApi extends BaseAPI {
      * Creates list of users with given input array
      */
     createUsersWithArrayInput = ({ body }: CreateUsersWithArrayInputRequest): Observable<void> => {
-        throwIfNullOrUndefined(body, 'createUsersWithArrayInput');
+        throwIfNullOrUndefined(body, 'body', 'createUsersWithArrayInput');
 
         const headers: HttpHeaders = {
             'Content-Type': 'application/json',
@@ -93,7 +93,7 @@ export class UserApi extends BaseAPI {
      * Creates list of users with given input array
      */
     createUsersWithListInput = ({ body }: CreateUsersWithListInputRequest): Observable<void> => {
-        throwIfNullOrUndefined(body, 'createUsersWithListInput');
+        throwIfNullOrUndefined(body, 'body', 'createUsersWithListInput');
 
         const headers: HttpHeaders = {
             'Content-Type': 'application/json',
@@ -112,7 +112,7 @@ export class UserApi extends BaseAPI {
      * Delete user
      */
     deleteUser = ({ username }: DeleteUserRequest): Observable<void> => {
-        throwIfNullOrUndefined(username, 'deleteUser');
+        throwIfNullOrUndefined(username, 'username', 'deleteUser');
 
         return this.request<void>({
             path: '/user/{username}'.replace('{username}', encodeURI(username)),
@@ -124,7 +124,7 @@ export class UserApi extends BaseAPI {
      * Get user by user name
      */
     getUserByName = ({ username }: GetUserByNameRequest): Observable<User> => {
-        throwIfNullOrUndefined(username, 'getUserByName');
+        throwIfNullOrUndefined(username, 'username', 'getUserByName');
 
         return this.request<User>({
             path: '/user/{username}'.replace('{username}', encodeURI(username)),
@@ -136,8 +136,8 @@ export class UserApi extends BaseAPI {
      * Logs user into the system
      */
     loginUser = ({ username, password }: LoginUserRequest): Observable<string> => {
-        throwIfNullOrUndefined(username, 'loginUser');
-        throwIfNullOrUndefined(password, 'loginUser');
+        throwIfNullOrUndefined(username, 'username', 'loginUser');
+        throwIfNullOrUndefined(password, 'password', 'loginUser');
 
         const query: HttpQuery = { // required parameters are used directly since they are already checked by throwIfNullOrUndefined
             'username': username,
@@ -166,8 +166,8 @@ export class UserApi extends BaseAPI {
      * Updated user
      */
     updateUser = ({ username, body }: UpdateUserRequest): Observable<void> => {
-        throwIfNullOrUndefined(username, 'updateUser');
-        throwIfNullOrUndefined(body, 'updateUser');
+        throwIfNullOrUndefined(username, 'username', 'updateUser');
+        throwIfNullOrUndefined(body, 'body', 'updateUser');
 
         const headers: HttpHeaders = {
             'Content-Type': 'application/json',

--- a/samples/client/petstore/typescript-rxjs/builds/default/runtime.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/default/runtime.ts
@@ -189,7 +189,7 @@ export const throwIfRequired = (params: {[key: string]: any}, key: string, nickn
     }
 };
 
-export const throwIfNullOrUndefined = (value: any, pramName: string, nickname: string) => {
+export const throwIfNullOrUndefined = (value: any, paramName: string, nickname: string) => {
     if (value == null) {
         throw new Error(`Parameter "${paramName}" was null or undefined when calling "${nickname}".`);
     }

--- a/samples/client/petstore/typescript-rxjs/builds/default/runtime.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/default/runtime.ts
@@ -189,9 +189,9 @@ export const throwIfRequired = (params: {[key: string]: any}, key: string, nickn
     }
 };
 
-export const throwIfNullOrUndefined = (value: any, nickname?: string) => {
+export const throwIfNullOrUndefined = (value: any, pramName: string, nickname: string) => {
     if (value == null) {
-        throw new Error(`Parameter "${value}" was null or undefined when calling "${nickname}".`);
+        throw new Error(`Parameter "${paramName}" was null or undefined when calling "${nickname}".`);
     }
 };
 

--- a/samples/client/petstore/typescript-rxjs/builds/es6-target/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/es6-target/apis/PetApi.ts
@@ -64,7 +64,7 @@ export class PetApi extends BaseAPI {
      * Add a new pet to the store
      */
     addPet = ({ body }: AddPetRequest): Observable<void> => {
-        throwIfNullOrUndefined(body, 'addPet');
+        throwIfNullOrUndefined(body, 'body', 'addPet');
 
         const headers: HttpHeaders = {
             'Content-Type': 'application/json',
@@ -89,7 +89,7 @@ export class PetApi extends BaseAPI {
      * Deletes a pet
      */
     deletePet = ({ petId, apiKey }: DeletePetRequest): Observable<void> => {
-        throwIfNullOrUndefined(petId, 'deletePet');
+        throwIfNullOrUndefined(petId, 'petId', 'deletePet');
 
         const headers: HttpHeaders = {
             ...(apiKey != null ? { 'api_key': String(apiKey) } : undefined),
@@ -114,7 +114,7 @@ export class PetApi extends BaseAPI {
      * Finds Pets by status
      */
     findPetsByStatus = ({ status }: FindPetsByStatusRequest): Observable<Array<Pet>> => {
-        throwIfNullOrUndefined(status, 'findPetsByStatus');
+        throwIfNullOrUndefined(status, 'status', 'findPetsByStatus');
 
         const headers: HttpHeaders = {
             // oauth required
@@ -143,7 +143,7 @@ export class PetApi extends BaseAPI {
      * Finds Pets by tags
      */
     findPetsByTags = ({ tags }: FindPetsByTagsRequest): Observable<Array<Pet>> => {
-        throwIfNullOrUndefined(tags, 'findPetsByTags');
+        throwIfNullOrUndefined(tags, 'tags', 'findPetsByTags');
 
         const headers: HttpHeaders = {
             // oauth required
@@ -172,7 +172,7 @@ export class PetApi extends BaseAPI {
      * Find pet by ID
      */
     getPetById = ({ petId }: GetPetByIdRequest): Observable<Pet> => {
-        throwIfNullOrUndefined(petId, 'getPetById');
+        throwIfNullOrUndefined(petId, 'petId', 'getPetById');
 
         const headers: HttpHeaders = {
             ...(this.configuration.apiKey && { 'api_key': this.configuration.apiKey('api_key') }), // api_key authentication
@@ -189,7 +189,7 @@ export class PetApi extends BaseAPI {
      * Update an existing pet
      */
     updatePet = ({ body }: UpdatePetRequest): Observable<void> => {
-        throwIfNullOrUndefined(body, 'updatePet');
+        throwIfNullOrUndefined(body, 'body', 'updatePet');
 
         const headers: HttpHeaders = {
             'Content-Type': 'application/json',
@@ -214,7 +214,7 @@ export class PetApi extends BaseAPI {
      * Updates a pet in the store with form data
      */
     updatePetWithForm = ({ petId, name, status }: UpdatePetWithFormRequest): Observable<void> => {
-        throwIfNullOrUndefined(petId, 'updatePetWithForm');
+        throwIfNullOrUndefined(petId, 'petId', 'updatePetWithForm');
 
         const headers: HttpHeaders = {
             // oauth required
@@ -242,7 +242,7 @@ export class PetApi extends BaseAPI {
      * uploads an image
      */
     uploadFile = ({ petId, additionalMetadata, file }: UploadFileRequest): Observable<ApiResponse> => {
-        throwIfNullOrUndefined(petId, 'uploadFile');
+        throwIfNullOrUndefined(petId, 'petId', 'uploadFile');
 
         const headers: HttpHeaders = {
             // oauth required

--- a/samples/client/petstore/typescript-rxjs/builds/es6-target/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/es6-target/apis/StoreApi.ts
@@ -39,7 +39,7 @@ export class StoreApi extends BaseAPI {
      * Delete purchase order by ID
      */
     deleteOrder = ({ orderId }: DeleteOrderRequest): Observable<void> => {
-        throwIfNullOrUndefined(orderId, 'deleteOrder');
+        throwIfNullOrUndefined(orderId, 'orderId', 'deleteOrder');
 
         return this.request<void>({
             path: '/store/order/{orderId}'.replace('{orderId}', encodeURI(orderId)),
@@ -68,7 +68,7 @@ export class StoreApi extends BaseAPI {
      * Find purchase order by ID
      */
     getOrderById = ({ orderId }: GetOrderByIdRequest): Observable<Order> => {
-        throwIfNullOrUndefined(orderId, 'getOrderById');
+        throwIfNullOrUndefined(orderId, 'orderId', 'getOrderById');
 
         return this.request<Order>({
             path: '/store/order/{orderId}'.replace('{orderId}', encodeURI(orderId)),
@@ -80,7 +80,7 @@ export class StoreApi extends BaseAPI {
      * Place an order for a pet
      */
     placeOrder = ({ body }: PlaceOrderRequest): Observable<Order> => {
-        throwIfNullOrUndefined(body, 'placeOrder');
+        throwIfNullOrUndefined(body, 'body', 'placeOrder');
 
         const headers: HttpHeaders = {
             'Content-Type': 'application/json',

--- a/samples/client/petstore/typescript-rxjs/builds/es6-target/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/es6-target/apis/UserApi.ts
@@ -57,7 +57,7 @@ export class UserApi extends BaseAPI {
      * Create user
      */
     createUser = ({ body }: CreateUserRequest): Observable<void> => {
-        throwIfNullOrUndefined(body, 'createUser');
+        throwIfNullOrUndefined(body, 'body', 'createUser');
 
         const headers: HttpHeaders = {
             'Content-Type': 'application/json',
@@ -75,7 +75,7 @@ export class UserApi extends BaseAPI {
      * Creates list of users with given input array
      */
     createUsersWithArrayInput = ({ body }: CreateUsersWithArrayInputRequest): Observable<void> => {
-        throwIfNullOrUndefined(body, 'createUsersWithArrayInput');
+        throwIfNullOrUndefined(body, 'body', 'createUsersWithArrayInput');
 
         const headers: HttpHeaders = {
             'Content-Type': 'application/json',
@@ -93,7 +93,7 @@ export class UserApi extends BaseAPI {
      * Creates list of users with given input array
      */
     createUsersWithListInput = ({ body }: CreateUsersWithListInputRequest): Observable<void> => {
-        throwIfNullOrUndefined(body, 'createUsersWithListInput');
+        throwIfNullOrUndefined(body, 'body', 'createUsersWithListInput');
 
         const headers: HttpHeaders = {
             'Content-Type': 'application/json',
@@ -112,7 +112,7 @@ export class UserApi extends BaseAPI {
      * Delete user
      */
     deleteUser = ({ username }: DeleteUserRequest): Observable<void> => {
-        throwIfNullOrUndefined(username, 'deleteUser');
+        throwIfNullOrUndefined(username, 'username', 'deleteUser');
 
         return this.request<void>({
             path: '/user/{username}'.replace('{username}', encodeURI(username)),
@@ -124,7 +124,7 @@ export class UserApi extends BaseAPI {
      * Get user by user name
      */
     getUserByName = ({ username }: GetUserByNameRequest): Observable<User> => {
-        throwIfNullOrUndefined(username, 'getUserByName');
+        throwIfNullOrUndefined(username, 'username', 'getUserByName');
 
         return this.request<User>({
             path: '/user/{username}'.replace('{username}', encodeURI(username)),
@@ -136,8 +136,8 @@ export class UserApi extends BaseAPI {
      * Logs user into the system
      */
     loginUser = ({ username, password }: LoginUserRequest): Observable<string> => {
-        throwIfNullOrUndefined(username, 'loginUser');
-        throwIfNullOrUndefined(password, 'loginUser');
+        throwIfNullOrUndefined(username, 'username', 'loginUser');
+        throwIfNullOrUndefined(password, 'password', 'loginUser');
 
         const query: HttpQuery = { // required parameters are used directly since they are already checked by throwIfNullOrUndefined
             'username': username,
@@ -166,8 +166,8 @@ export class UserApi extends BaseAPI {
      * Updated user
      */
     updateUser = ({ username, body }: UpdateUserRequest): Observable<void> => {
-        throwIfNullOrUndefined(username, 'updateUser');
-        throwIfNullOrUndefined(body, 'updateUser');
+        throwIfNullOrUndefined(username, 'username', 'updateUser');
+        throwIfNullOrUndefined(body, 'body', 'updateUser');
 
         const headers: HttpHeaders = {
             'Content-Type': 'application/json',

--- a/samples/client/petstore/typescript-rxjs/builds/es6-target/runtime.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/es6-target/runtime.ts
@@ -189,7 +189,7 @@ export const throwIfRequired = (params: {[key: string]: any}, key: string, nickn
     }
 };
 
-export const throwIfNullOrUndefined = (value: any, pramName: string, nickname: string) => {
+export const throwIfNullOrUndefined = (value: any, paramName: string, nickname: string) => {
     if (value == null) {
         throw new Error(`Parameter "${paramName}" was null or undefined when calling "${nickname}".`);
     }

--- a/samples/client/petstore/typescript-rxjs/builds/es6-target/runtime.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/es6-target/runtime.ts
@@ -189,9 +189,9 @@ export const throwIfRequired = (params: {[key: string]: any}, key: string, nickn
     }
 };
 
-export const throwIfNullOrUndefined = (value: any, nickname?: string) => {
+export const throwIfNullOrUndefined = (value: any, pramName: string, nickname: string) => {
     if (value == null) {
-        throw new Error(`Parameter "${value}" was null or undefined when calling "${nickname}".`);
+        throw new Error(`Parameter "${paramName}" was null or undefined when calling "${nickname}".`);
     }
 };
 

--- a/samples/client/petstore/typescript-rxjs/builds/with-interfaces/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/with-interfaces/apis/PetApi.ts
@@ -64,7 +64,7 @@ export class PetApi extends BaseAPI {
      * Add a new pet to the store
      */
     addPet = ({ body }: AddPetRequest): Observable<void> => {
-        throwIfNullOrUndefined(body, 'addPet');
+        throwIfNullOrUndefined(body, 'body', 'addPet');
 
         const headers: HttpHeaders = {
             'Content-Type': 'application/json',
@@ -89,7 +89,7 @@ export class PetApi extends BaseAPI {
      * Deletes a pet
      */
     deletePet = ({ petId, apiKey }: DeletePetRequest): Observable<void> => {
-        throwIfNullOrUndefined(petId, 'deletePet');
+        throwIfNullOrUndefined(petId, 'petId', 'deletePet');
 
         const headers: HttpHeaders = {
             ...(apiKey != null ? { 'api_key': String(apiKey) } : undefined),
@@ -114,7 +114,7 @@ export class PetApi extends BaseAPI {
      * Finds Pets by status
      */
     findPetsByStatus = ({ status }: FindPetsByStatusRequest): Observable<Array<Pet>> => {
-        throwIfNullOrUndefined(status, 'findPetsByStatus');
+        throwIfNullOrUndefined(status, 'status', 'findPetsByStatus');
 
         const headers: HttpHeaders = {
             // oauth required
@@ -143,7 +143,7 @@ export class PetApi extends BaseAPI {
      * Finds Pets by tags
      */
     findPetsByTags = ({ tags }: FindPetsByTagsRequest): Observable<Array<Pet>> => {
-        throwIfNullOrUndefined(tags, 'findPetsByTags');
+        throwIfNullOrUndefined(tags, 'tags', 'findPetsByTags');
 
         const headers: HttpHeaders = {
             // oauth required
@@ -172,7 +172,7 @@ export class PetApi extends BaseAPI {
      * Find pet by ID
      */
     getPetById = ({ petId }: GetPetByIdRequest): Observable<Pet> => {
-        throwIfNullOrUndefined(petId, 'getPetById');
+        throwIfNullOrUndefined(petId, 'petId', 'getPetById');
 
         const headers: HttpHeaders = {
             ...(this.configuration.apiKey && { 'api_key': this.configuration.apiKey('api_key') }), // api_key authentication
@@ -189,7 +189,7 @@ export class PetApi extends BaseAPI {
      * Update an existing pet
      */
     updatePet = ({ body }: UpdatePetRequest): Observable<void> => {
-        throwIfNullOrUndefined(body, 'updatePet');
+        throwIfNullOrUndefined(body, 'body', 'updatePet');
 
         const headers: HttpHeaders = {
             'Content-Type': 'application/json',
@@ -214,7 +214,7 @@ export class PetApi extends BaseAPI {
      * Updates a pet in the store with form data
      */
     updatePetWithForm = ({ petId, name, status }: UpdatePetWithFormRequest): Observable<void> => {
-        throwIfNullOrUndefined(petId, 'updatePetWithForm');
+        throwIfNullOrUndefined(petId, 'petId', 'updatePetWithForm');
 
         const headers: HttpHeaders = {
             // oauth required
@@ -242,7 +242,7 @@ export class PetApi extends BaseAPI {
      * uploads an image
      */
     uploadFile = ({ petId, additionalMetadata, file }: UploadFileRequest): Observable<ApiResponse> => {
-        throwIfNullOrUndefined(petId, 'uploadFile');
+        throwIfNullOrUndefined(petId, 'petId', 'uploadFile');
 
         const headers: HttpHeaders = {
             // oauth required

--- a/samples/client/petstore/typescript-rxjs/builds/with-interfaces/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/with-interfaces/apis/StoreApi.ts
@@ -39,7 +39,7 @@ export class StoreApi extends BaseAPI {
      * Delete purchase order by ID
      */
     deleteOrder = ({ orderId }: DeleteOrderRequest): Observable<void> => {
-        throwIfNullOrUndefined(orderId, 'deleteOrder');
+        throwIfNullOrUndefined(orderId, 'orderId', 'deleteOrder');
 
         return this.request<void>({
             path: '/store/order/{orderId}'.replace('{orderId}', encodeURI(orderId)),
@@ -68,7 +68,7 @@ export class StoreApi extends BaseAPI {
      * Find purchase order by ID
      */
     getOrderById = ({ orderId }: GetOrderByIdRequest): Observable<Order> => {
-        throwIfNullOrUndefined(orderId, 'getOrderById');
+        throwIfNullOrUndefined(orderId, 'orderId', 'getOrderById');
 
         return this.request<Order>({
             path: '/store/order/{orderId}'.replace('{orderId}', encodeURI(orderId)),
@@ -80,7 +80,7 @@ export class StoreApi extends BaseAPI {
      * Place an order for a pet
      */
     placeOrder = ({ body }: PlaceOrderRequest): Observable<Order> => {
-        throwIfNullOrUndefined(body, 'placeOrder');
+        throwIfNullOrUndefined(body, 'body', 'placeOrder');
 
         const headers: HttpHeaders = {
             'Content-Type': 'application/json',

--- a/samples/client/petstore/typescript-rxjs/builds/with-interfaces/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/with-interfaces/apis/UserApi.ts
@@ -57,7 +57,7 @@ export class UserApi extends BaseAPI {
      * Create user
      */
     createUser = ({ body }: CreateUserRequest): Observable<void> => {
-        throwIfNullOrUndefined(body, 'createUser');
+        throwIfNullOrUndefined(body, 'body', 'createUser');
 
         const headers: HttpHeaders = {
             'Content-Type': 'application/json',
@@ -75,7 +75,7 @@ export class UserApi extends BaseAPI {
      * Creates list of users with given input array
      */
     createUsersWithArrayInput = ({ body }: CreateUsersWithArrayInputRequest): Observable<void> => {
-        throwIfNullOrUndefined(body, 'createUsersWithArrayInput');
+        throwIfNullOrUndefined(body, 'body', 'createUsersWithArrayInput');
 
         const headers: HttpHeaders = {
             'Content-Type': 'application/json',
@@ -93,7 +93,7 @@ export class UserApi extends BaseAPI {
      * Creates list of users with given input array
      */
     createUsersWithListInput = ({ body }: CreateUsersWithListInputRequest): Observable<void> => {
-        throwIfNullOrUndefined(body, 'createUsersWithListInput');
+        throwIfNullOrUndefined(body, 'body', 'createUsersWithListInput');
 
         const headers: HttpHeaders = {
             'Content-Type': 'application/json',
@@ -112,7 +112,7 @@ export class UserApi extends BaseAPI {
      * Delete user
      */
     deleteUser = ({ username }: DeleteUserRequest): Observable<void> => {
-        throwIfNullOrUndefined(username, 'deleteUser');
+        throwIfNullOrUndefined(username, 'username', 'deleteUser');
 
         return this.request<void>({
             path: '/user/{username}'.replace('{username}', encodeURI(username)),
@@ -124,7 +124,7 @@ export class UserApi extends BaseAPI {
      * Get user by user name
      */
     getUserByName = ({ username }: GetUserByNameRequest): Observable<User> => {
-        throwIfNullOrUndefined(username, 'getUserByName');
+        throwIfNullOrUndefined(username, 'username', 'getUserByName');
 
         return this.request<User>({
             path: '/user/{username}'.replace('{username}', encodeURI(username)),
@@ -136,8 +136,8 @@ export class UserApi extends BaseAPI {
      * Logs user into the system
      */
     loginUser = ({ username, password }: LoginUserRequest): Observable<string> => {
-        throwIfNullOrUndefined(username, 'loginUser');
-        throwIfNullOrUndefined(password, 'loginUser');
+        throwIfNullOrUndefined(username, 'username', 'loginUser');
+        throwIfNullOrUndefined(password, 'password', 'loginUser');
 
         const query: HttpQuery = { // required parameters are used directly since they are already checked by throwIfNullOrUndefined
             'username': username,
@@ -166,8 +166,8 @@ export class UserApi extends BaseAPI {
      * Updated user
      */
     updateUser = ({ username, body }: UpdateUserRequest): Observable<void> => {
-        throwIfNullOrUndefined(username, 'updateUser');
-        throwIfNullOrUndefined(body, 'updateUser');
+        throwIfNullOrUndefined(username, 'username', 'updateUser');
+        throwIfNullOrUndefined(body, 'body', 'updateUser');
 
         const headers: HttpHeaders = {
             'Content-Type': 'application/json',

--- a/samples/client/petstore/typescript-rxjs/builds/with-interfaces/runtime.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/with-interfaces/runtime.ts
@@ -189,7 +189,7 @@ export const throwIfRequired = (params: {[key: string]: any}, key: string, nickn
     }
 };
 
-export const throwIfNullOrUndefined = (value: any, pramName: string, nickname: string) => {
+export const throwIfNullOrUndefined = (value: any, paramName: string, nickname: string) => {
     if (value == null) {
         throw new Error(`Parameter "${paramName}" was null or undefined when calling "${nickname}".`);
     }

--- a/samples/client/petstore/typescript-rxjs/builds/with-interfaces/runtime.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/with-interfaces/runtime.ts
@@ -189,9 +189,9 @@ export const throwIfRequired = (params: {[key: string]: any}, key: string, nickn
     }
 };
 
-export const throwIfNullOrUndefined = (value: any, nickname?: string) => {
+export const throwIfNullOrUndefined = (value: any, pramName: string, nickname: string) => {
     if (value == null) {
-        throw new Error(`Parameter "${value}" was null or undefined when calling "${nickname}".`);
+        throw new Error(`Parameter "${paramName}" was null or undefined when calling "${nickname}".`);
     }
 };
 

--- a/samples/client/petstore/typescript-rxjs/builds/with-npm-version/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/with-npm-version/apis/PetApi.ts
@@ -64,7 +64,7 @@ export class PetApi extends BaseAPI {
      * Add a new pet to the store
      */
     addPet = ({ body }: AddPetRequest): Observable<void> => {
-        throwIfNullOrUndefined(body, 'addPet');
+        throwIfNullOrUndefined(body, 'body', 'addPet');
 
         const headers: HttpHeaders = {
             'Content-Type': 'application/json',
@@ -89,7 +89,7 @@ export class PetApi extends BaseAPI {
      * Deletes a pet
      */
     deletePet = ({ petId, apiKey }: DeletePetRequest): Observable<void> => {
-        throwIfNullOrUndefined(petId, 'deletePet');
+        throwIfNullOrUndefined(petId, 'petId', 'deletePet');
 
         const headers: HttpHeaders = {
             ...(apiKey != null ? { 'api_key': String(apiKey) } : undefined),
@@ -114,7 +114,7 @@ export class PetApi extends BaseAPI {
      * Finds Pets by status
      */
     findPetsByStatus = ({ status }: FindPetsByStatusRequest): Observable<Array<Pet>> => {
-        throwIfNullOrUndefined(status, 'findPetsByStatus');
+        throwIfNullOrUndefined(status, 'status', 'findPetsByStatus');
 
         const headers: HttpHeaders = {
             // oauth required
@@ -143,7 +143,7 @@ export class PetApi extends BaseAPI {
      * Finds Pets by tags
      */
     findPetsByTags = ({ tags }: FindPetsByTagsRequest): Observable<Array<Pet>> => {
-        throwIfNullOrUndefined(tags, 'findPetsByTags');
+        throwIfNullOrUndefined(tags, 'tags', 'findPetsByTags');
 
         const headers: HttpHeaders = {
             // oauth required
@@ -172,7 +172,7 @@ export class PetApi extends BaseAPI {
      * Find pet by ID
      */
     getPetById = ({ petId }: GetPetByIdRequest): Observable<Pet> => {
-        throwIfNullOrUndefined(petId, 'getPetById');
+        throwIfNullOrUndefined(petId, 'petId', 'getPetById');
 
         const headers: HttpHeaders = {
             ...(this.configuration.apiKey && { 'api_key': this.configuration.apiKey('api_key') }), // api_key authentication
@@ -189,7 +189,7 @@ export class PetApi extends BaseAPI {
      * Update an existing pet
      */
     updatePet = ({ body }: UpdatePetRequest): Observable<void> => {
-        throwIfNullOrUndefined(body, 'updatePet');
+        throwIfNullOrUndefined(body, 'body', 'updatePet');
 
         const headers: HttpHeaders = {
             'Content-Type': 'application/json',
@@ -214,7 +214,7 @@ export class PetApi extends BaseAPI {
      * Updates a pet in the store with form data
      */
     updatePetWithForm = ({ petId, name, status }: UpdatePetWithFormRequest): Observable<void> => {
-        throwIfNullOrUndefined(petId, 'updatePetWithForm');
+        throwIfNullOrUndefined(petId, 'petId', 'updatePetWithForm');
 
         const headers: HttpHeaders = {
             // oauth required
@@ -242,7 +242,7 @@ export class PetApi extends BaseAPI {
      * uploads an image
      */
     uploadFile = ({ petId, additionalMetadata, file }: UploadFileRequest): Observable<ApiResponse> => {
-        throwIfNullOrUndefined(petId, 'uploadFile');
+        throwIfNullOrUndefined(petId, 'petId', 'uploadFile');
 
         const headers: HttpHeaders = {
             // oauth required

--- a/samples/client/petstore/typescript-rxjs/builds/with-npm-version/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/with-npm-version/apis/StoreApi.ts
@@ -39,7 +39,7 @@ export class StoreApi extends BaseAPI {
      * Delete purchase order by ID
      */
     deleteOrder = ({ orderId }: DeleteOrderRequest): Observable<void> => {
-        throwIfNullOrUndefined(orderId, 'deleteOrder');
+        throwIfNullOrUndefined(orderId, 'orderId', 'deleteOrder');
 
         return this.request<void>({
             path: '/store/order/{orderId}'.replace('{orderId}', encodeURI(orderId)),
@@ -68,7 +68,7 @@ export class StoreApi extends BaseAPI {
      * Find purchase order by ID
      */
     getOrderById = ({ orderId }: GetOrderByIdRequest): Observable<Order> => {
-        throwIfNullOrUndefined(orderId, 'getOrderById');
+        throwIfNullOrUndefined(orderId, 'orderId', 'getOrderById');
 
         return this.request<Order>({
             path: '/store/order/{orderId}'.replace('{orderId}', encodeURI(orderId)),
@@ -80,7 +80,7 @@ export class StoreApi extends BaseAPI {
      * Place an order for a pet
      */
     placeOrder = ({ body }: PlaceOrderRequest): Observable<Order> => {
-        throwIfNullOrUndefined(body, 'placeOrder');
+        throwIfNullOrUndefined(body, 'body', 'placeOrder');
 
         const headers: HttpHeaders = {
             'Content-Type': 'application/json',

--- a/samples/client/petstore/typescript-rxjs/builds/with-npm-version/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/with-npm-version/apis/UserApi.ts
@@ -57,7 +57,7 @@ export class UserApi extends BaseAPI {
      * Create user
      */
     createUser = ({ body }: CreateUserRequest): Observable<void> => {
-        throwIfNullOrUndefined(body, 'createUser');
+        throwIfNullOrUndefined(body, 'body', 'createUser');
 
         const headers: HttpHeaders = {
             'Content-Type': 'application/json',
@@ -75,7 +75,7 @@ export class UserApi extends BaseAPI {
      * Creates list of users with given input array
      */
     createUsersWithArrayInput = ({ body }: CreateUsersWithArrayInputRequest): Observable<void> => {
-        throwIfNullOrUndefined(body, 'createUsersWithArrayInput');
+        throwIfNullOrUndefined(body, 'body', 'createUsersWithArrayInput');
 
         const headers: HttpHeaders = {
             'Content-Type': 'application/json',
@@ -93,7 +93,7 @@ export class UserApi extends BaseAPI {
      * Creates list of users with given input array
      */
     createUsersWithListInput = ({ body }: CreateUsersWithListInputRequest): Observable<void> => {
-        throwIfNullOrUndefined(body, 'createUsersWithListInput');
+        throwIfNullOrUndefined(body, 'body', 'createUsersWithListInput');
 
         const headers: HttpHeaders = {
             'Content-Type': 'application/json',
@@ -112,7 +112,7 @@ export class UserApi extends BaseAPI {
      * Delete user
      */
     deleteUser = ({ username }: DeleteUserRequest): Observable<void> => {
-        throwIfNullOrUndefined(username, 'deleteUser');
+        throwIfNullOrUndefined(username, 'username', 'deleteUser');
 
         return this.request<void>({
             path: '/user/{username}'.replace('{username}', encodeURI(username)),
@@ -124,7 +124,7 @@ export class UserApi extends BaseAPI {
      * Get user by user name
      */
     getUserByName = ({ username }: GetUserByNameRequest): Observable<User> => {
-        throwIfNullOrUndefined(username, 'getUserByName');
+        throwIfNullOrUndefined(username, 'username', 'getUserByName');
 
         return this.request<User>({
             path: '/user/{username}'.replace('{username}', encodeURI(username)),
@@ -136,8 +136,8 @@ export class UserApi extends BaseAPI {
      * Logs user into the system
      */
     loginUser = ({ username, password }: LoginUserRequest): Observable<string> => {
-        throwIfNullOrUndefined(username, 'loginUser');
-        throwIfNullOrUndefined(password, 'loginUser');
+        throwIfNullOrUndefined(username, 'username', 'loginUser');
+        throwIfNullOrUndefined(password, 'password', 'loginUser');
 
         const query: HttpQuery = { // required parameters are used directly since they are already checked by throwIfNullOrUndefined
             'username': username,
@@ -166,8 +166,8 @@ export class UserApi extends BaseAPI {
      * Updated user
      */
     updateUser = ({ username, body }: UpdateUserRequest): Observable<void> => {
-        throwIfNullOrUndefined(username, 'updateUser');
-        throwIfNullOrUndefined(body, 'updateUser');
+        throwIfNullOrUndefined(username, 'username', 'updateUser');
+        throwIfNullOrUndefined(body, 'body', 'updateUser');
 
         const headers: HttpHeaders = {
             'Content-Type': 'application/json',

--- a/samples/client/petstore/typescript-rxjs/builds/with-npm-version/runtime.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/with-npm-version/runtime.ts
@@ -189,7 +189,7 @@ export const throwIfRequired = (params: {[key: string]: any}, key: string, nickn
     }
 };
 
-export const throwIfNullOrUndefined = (value: any, pramName: string, nickname: string) => {
+export const throwIfNullOrUndefined = (value: any, paramName: string, nickname: string) => {
     if (value == null) {
         throw new Error(`Parameter "${paramName}" was null or undefined when calling "${nickname}".`);
     }

--- a/samples/client/petstore/typescript-rxjs/builds/with-npm-version/runtime.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/with-npm-version/runtime.ts
@@ -189,9 +189,9 @@ export const throwIfRequired = (params: {[key: string]: any}, key: string, nickn
     }
 };
 
-export const throwIfNullOrUndefined = (value: any, nickname?: string) => {
+export const throwIfNullOrUndefined = (value: any, pramName: string, nickname: string) => {
     if (value == null) {
-        throw new Error(`Parameter "${value}" was null or undefined when calling "${nickname}".`);
+        throw new Error(`Parameter "${paramName}" was null or undefined when calling "${nickname}".`);
     }
 };
 


### PR DESCRIPTION
This updates `throwIfNullOrUndefined` to take in & print the name of the parameter being checked. This PR in response to this comment [here](https://github.com/OpenAPITools/openapi-generator/pull/4250#discussion_r415219054).

The signature of `throwIfNulllOrUndefined` was changed to make `nickname` non-optional, but based on `apis.mustache` the param will never be undefined. Granted, the change is breaking, but this is also merging into 5.0.x. I considered removing the other deprecated exports in `runtime.mustache` (since this is merging into 5.0.x), but I figured I would not in this PR and ask for opinions about that here. 

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@TiFu (2017/07) @taxpon (2017/07) @sebastianhaas (2017/07) @kenisteward (2017/07) @Vrolijkx (2017/09) @macjohnny (2018/01) @topce (2018/10) @akehir (2019/07) @petejohansonxo (2019/11) @amakhrov (2020/02)
