### PR TITLE
[kotlin][spring] Fix ApiUtil compilation

### DIFF
--- a/modules/openapi-generator/src/main/resources/kotlin-spring/apiUtil.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/apiUtil.mustache
@@ -12,9 +12,9 @@ object ApiUtil {
     fun setExampleResponse(req: NativeWebRequest, contentType: String, example: String) {
         try {
             val res = req.getNativeResponse(HttpServletResponse::class.java)
-            res.setCharacterEncoding("UTF-8")
-            res.addHeader("Content-Type", contentType)
-            res.getWriter().print(example)
+            res?.characterEncoding = "UTF-8"
+            res?.addHeader("Content-Type", contentType)
+            res?.writer?.print(example)
         } catch (e: IOException) {
             throw RuntimeException(e)
         }

--- a/samples/server/petstore/kotlin-springboot-modelMutable/src/main/kotlin/org/openapitools/api/ApiUtil.kt
+++ b/samples/server/petstore/kotlin-springboot-modelMutable/src/main/kotlin/org/openapitools/api/ApiUtil.kt
@@ -9,9 +9,9 @@ object ApiUtil {
     fun setExampleResponse(req: NativeWebRequest, contentType: String, example: String) {
         try {
             val res = req.getNativeResponse(HttpServletResponse::class.java)
-            res.setCharacterEncoding("UTF-8")
-            res.addHeader("Content-Type", contentType)
-            res.getWriter().print(example)
+            res?.characterEncoding = "UTF-8"
+            res?.addHeader("Content-Type", contentType)
+            res?.writer?.print(example)
         } catch (e: IOException) {
             throw RuntimeException(e)
         }

--- a/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/api/ApiUtil.kt
+++ b/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/api/ApiUtil.kt
@@ -9,9 +9,9 @@ object ApiUtil {
     fun setExampleResponse(req: NativeWebRequest, contentType: String, example: String) {
         try {
             val res = req.getNativeResponse(HttpServletResponse::class.java)
-            res.setCharacterEncoding("UTF-8")
-            res.addHeader("Content-Type", contentType)
-            res.getWriter().print(example)
+            res?.characterEncoding = "UTF-8"
+            res?.addHeader("Content-Type", contentType)
+            res?.writer?.print(example)
         } catch (e: IOException) {
             throw RuntimeException(e)
         }


### PR DESCRIPTION
fixes #5476 The kotlin-spring generator ApiUtil object doesn't compile, by adding null safe accessor


### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
