### PR TITLE
[typescript-fetch] Allow multiline documentation

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptFetchClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptFetchClientCodegen.java
@@ -17,11 +17,14 @@
 
 package org.openapitools.codegen.languages;
 
+import com.google.common.collect.ImmutableMap;
+import com.samskivert.mustache.Mustache;
 import io.swagger.v3.oas.models.media.ArraySchema;
 import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.parser.util.SchemaTypeUtil;
 import org.openapitools.codegen.*;
 import org.openapitools.codegen.meta.features.DocumentationFeature;
+import org.openapitools.codegen.templating.mustache.IndentedLambda;
 import org.openapitools.codegen.utils.ModelUtils;
 
 import java.io.File;
@@ -132,6 +135,14 @@ public class TypeScriptFetchClientCodegen extends AbstractTypeScriptClientCodege
         if (additionalProperties.containsKey(TYPESCRIPT_THREE_PLUS)) {
             this.setTypescriptThreePlus(convertPropertyToBoolean(TYPESCRIPT_THREE_PLUS));
         }
+    }
+
+    @Override
+    protected ImmutableMap.Builder<String, Mustache.Lambda> addMustacheLambdas() {
+        ImmutableMap.Builder<String, Mustache.Lambda> lambdas = super.addMustacheLambdas();
+        lambdas.put("indented_star_1", new IndentedLambda(1, " ", "* "));
+        lambdas.put("indented_star_4", new IndentedLambda(5, " ", "* "));
+        return lambdas;
     }
 
     @Override

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/apis.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/apis.mustache
@@ -28,8 +28,8 @@ export interface {{#prefixParameterInterfaces}}{{classname}}{{/prefixParameterIn
 {{#withInterfaces}}
 {{#operations}}
 /**
- * {{classname}} - interface{{#description}}
- * {{&description}}{{/description}}
+ * {{classname}} - interface
+ * {{#lambda.indented_1}}{{{unescapedDescription}}}{{/lambda.indented_1}}
  * @export
  * @interface {{classname}}Interface
  */
@@ -71,7 +71,7 @@ export interface {{classname}}Interface {
 {{/withInterfaces}}
 {{#operations}}
 /**
- * {{#description}}{{{description}}}{{/description}}{{^description}}no description{{/description}}
+ * {{#lambda.indented_star_1}}{{{unescapedDescription}}}{{/lambda.indented_star_1}}
  */
 {{#withInterfaces}}
 export class {{classname}} extends runtime.BaseAPI implements {{classname}}Interface {

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/modelEnum.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/modelEnum.mustache
@@ -1,5 +1,5 @@
 /**
- * {{{description}}}
+ * {{#lambda.indented_star_1}}{{{unescapedDescription}}}{{/lambda.indented_star_1}}
  * @export
  * @enum {string}
  */

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/modelGeneric.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/modelGeneric.mustache
@@ -19,7 +19,7 @@ import {
 
 {{/discriminator}}
 /**
- * {{{description}}}
+ * {{#lambda.indented_star_1}}{{{unescapedDescription}}}{{/lambda.indented_star_1}}
  * @export
  * @interface {{classname}}
  */
@@ -29,7 +29,7 @@ export interface {{classname}} {{#parent}}extends {{{parent}}} {{/parent}}{
 {{/additionalPropertiesType}}
 {{#vars}}
     /**
-     * {{{description}}}
+     * {{#lambda.indented_star_4}}{{{unescapedDescription}}}{{/lambda.indented_star_4}}
      * @type {{=<% %>=}}{<%&datatype%>}<%={{ }}=%>
      * @memberof {{classname}}
      */

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/modelOneOf.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/modelOneOf.mustache
@@ -11,8 +11,8 @@ import {
 
 {{/hasImports}}
 /**
- * @type {{classname}}{{#description}}
- * {{{description}}}{{/description}}
+ * @type {{classname}}
+ * {{#lambda.indented_star_1}}{{{unescapedDescription}}}{{/lambda.indented_star_1}}
  * @export
  */
 export type {{classname}} = {{#discriminator}}{{#mappedModels}}{ {{discriminator.propertyName}}: '{{mappingName}}' } & {{modelName}}{{^-last}} | {{/-last}}{{/mappedModels}}{{/discriminator}}{{^discriminator}}{{#oneOf}}{{{.}}}{{^-last}} | {{/-last}}{{/oneOf}}{{/discriminator}};

--- a/samples/client/petstore/typescript-fetch/builds/default/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/apis/PetApi.ts
@@ -61,7 +61,7 @@ export interface UploadFileRequest {
 }
 
 /**
- * no description
+ * 
  */
 export class PetApi extends runtime.BaseAPI {
 

--- a/samples/client/petstore/typescript-fetch/builds/default/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/apis/StoreApi.ts
@@ -33,7 +33,7 @@ export interface PlaceOrderRequest {
 }
 
 /**
- * no description
+ * 
  */
 export class StoreApi extends runtime.BaseAPI {
 

--- a/samples/client/petstore/typescript-fetch/builds/default/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/apis/UserApi.ts
@@ -51,7 +51,7 @@ export interface UpdateUserRequest {
 }
 
 /**
- * no description
+ * 
  */
 export class UserApi extends runtime.BaseAPI {
 

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/apis/PetApi.ts
@@ -61,7 +61,7 @@ export interface UploadFileRequest {
 }
 
 /**
- * no description
+ * 
  */
 export class PetApi extends runtime.BaseAPI {
 

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/apis/StoreApi.ts
@@ -33,7 +33,7 @@ export interface PlaceOrderRequest {
 }
 
 /**
- * no description
+ * 
  */
 export class StoreApi extends runtime.BaseAPI {
 

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/apis/UserApi.ts
@@ -51,7 +51,7 @@ export interface UpdateUserRequest {
 }
 
 /**
- * no description
+ * 
  */
 export class UserApi extends runtime.BaseAPI {
 

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/apis/PetApi.ts
@@ -61,7 +61,7 @@ export interface UploadFileRequest {
 }
 
 /**
- * no description
+ * 
  */
 export class PetApi extends runtime.BaseAPI {
 

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/apis/StoreApi.ts
@@ -33,7 +33,7 @@ export interface PlaceOrderRequest {
 }
 
 /**
- * no description
+ * 
  */
 export class StoreApi extends runtime.BaseAPI {
 

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/apis/UserApi.ts
@@ -51,7 +51,7 @@ export interface UpdateUserRequest {
 }
 
 /**
- * no description
+ * 
  */
 export class UserApi extends runtime.BaseAPI {
 

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/apis/PetApi.ts
@@ -61,7 +61,7 @@ export interface PetApiUploadFileRequest {
 }
 
 /**
- * no description
+ * 
  */
 export class PetApi extends runtime.BaseAPI {
 

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/apis/StoreApi.ts
@@ -33,7 +33,7 @@ export interface StoreApiPlaceOrderRequest {
 }
 
 /**
- * no description
+ * 
  */
 export class StoreApi extends runtime.BaseAPI {
 

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/apis/UserApi.ts
@@ -51,7 +51,7 @@ export interface UserApiUpdateUserRequest {
 }
 
 /**
- * no description
+ * 
  */
 export class UserApi extends runtime.BaseAPI {
 

--- a/samples/client/petstore/typescript-fetch/builds/typescript-three-plus/src/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/typescript-three-plus/src/apis/PetApi.ts
@@ -61,7 +61,7 @@ export interface UploadFileRequest {
 }
 
 /**
- * no description
+ * 
  */
 export class PetApi extends runtime.BaseAPI {
 

--- a/samples/client/petstore/typescript-fetch/builds/typescript-three-plus/src/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/typescript-three-plus/src/apis/StoreApi.ts
@@ -33,7 +33,7 @@ export interface PlaceOrderRequest {
 }
 
 /**
- * no description
+ * 
  */
 export class StoreApi extends runtime.BaseAPI {
 

--- a/samples/client/petstore/typescript-fetch/builds/typescript-three-plus/src/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/typescript-three-plus/src/apis/UserApi.ts
@@ -51,7 +51,7 @@ export interface UpdateUserRequest {
 }
 
 /**
- * no description
+ * 
  */
 export class UserApi extends runtime.BaseAPI {
 

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/apis/PetApi.ts
@@ -62,6 +62,7 @@ export interface UploadFileRequest {
 
 /**
  * PetApi - interface
+ * 
  * @export
  * @interface PetApiInterface
  */
@@ -197,7 +198,7 @@ export interface PetApiInterface {
 }
 
 /**
- * no description
+ * 
  */
 export class PetApi extends runtime.BaseAPI implements PetApiInterface {
 

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/apis/StoreApi.ts
@@ -34,6 +34,7 @@ export interface PlaceOrderRequest {
 
 /**
  * StoreApi - interface
+ * 
  * @export
  * @interface StoreApiInterface
  */
@@ -103,7 +104,7 @@ export interface StoreApiInterface {
 }
 
 /**
- * no description
+ * 
  */
 export class StoreApi extends runtime.BaseAPI implements StoreApiInterface {
 

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/apis/UserApi.ts
@@ -52,6 +52,7 @@ export interface UpdateUserRequest {
 
 /**
  * UserApi - interface
+ * 
  * @export
  * @interface UserApiInterface
  */
@@ -183,7 +184,7 @@ export interface UserApiInterface {
 }
 
 /**
- * no description
+ * 
  */
 export class UserApi extends runtime.BaseAPI implements UserApiInterface {
 

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/apis/PetApi.ts
@@ -61,7 +61,7 @@ export interface UploadFileRequest {
 }
 
 /**
- * no description
+ * 
  */
 export class PetApi extends runtime.BaseAPI {
 

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/apis/StoreApi.ts
@@ -33,7 +33,7 @@ export interface PlaceOrderRequest {
 }
 
 /**
- * no description
+ * 
  */
 export class StoreApi extends runtime.BaseAPI {
 

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/apis/UserApi.ts
@@ -51,7 +51,7 @@ export interface UpdateUserRequest {
 }
 
 /**
- * no description
+ * 
  */
 export class UserApi extends runtime.BaseAPI {
 


### PR DESCRIPTION
Add a lambda that formats the documentation correctly even if it
contains newlines. The generated docs with typedoc looks a lot better
and also renders Markdown correctly.

Also remove the "no description" fallback for APIs because we don't have
it anywhere else, other generators don't generate a default fallback and
I'd rather have no documentation than a "no description" string.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist

- [ X ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ X ] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [ X ] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [ X ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [ X ] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
