### PR TITLE
Propagate deprecated property through $ref's

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -2845,6 +2845,9 @@ public class DefaultCodegen implements CodegenConfig {
         if (p.getDeprecated() != null) {
             property.deprecated = p.getDeprecated();
         } else if (p.get$ref() != null) {
+            // Since $ref should be replaced with the model it refers
+            // to, $ref'ing a model with 'deprecated' set should cause
+            // the property to reflect the model's 'deprecated' value.
             String ref = ModelUtils.getSimpleRef(p.get$ref());
             if (ref != null) {
                 Schema referencedSchema = ModelUtils.getSchemas(this.openAPI).get(ref);

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -2844,6 +2844,14 @@ public class DefaultCodegen implements CodegenConfig {
 
         if (p.getDeprecated() != null) {
             property.deprecated = p.getDeprecated();
+        } else if (p.get$ref() != null) {
+            String ref = ModelUtils.getSimpleRef(p.get$ref());
+            if (ref != null) {
+                Schema referencedSchema = ModelUtils.getSchemas(this.openAPI).get(ref);
+                if (referencedSchema != null && referencedSchema.getDeprecated() != null) {
+                    property.deprecated = referencedSchema.getDeprecated();
+                }
+            }
         }
         if (p.getReadOnly() != null) {
             property.isReadOnly = p.getReadOnly();

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
@@ -1410,6 +1410,19 @@ public class DefaultCodegenTest {
     }
 
     @Test
+    public void testDeprecatedRef() {
+        final OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/model-deprecated.yaml");
+        new InlineModelResolver().flatten(openAPI);
+        final DefaultCodegen codegen = new DefaultCodegen();
+        codegen.setOpenAPI(openAPI);
+
+        final Map requestProperties = Collections.unmodifiableMap(openAPI.getComponents().getSchemas().get("complex").getProperties());
+
+        Assert.assertTrue(codegen.fromProperty("deprecated", (Schema)requestProperties.get("deprecated")).deprecated);
+        Assert.assertFalse(codegen.fromProperty("current", (Schema)requestProperties.get("current")).deprecated);
+    }
+
+    @Test
     public void integerSchemaPropertyAndModelTest() {
         OpenAPI openAPI = TestUtils.createOpenAPI();
         final Schema schema = new IntegerSchema().format("int32");

--- a/modules/openapi-generator/src/test/resources/3_0/model-deprecated.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/model-deprecated.yaml
@@ -1,0 +1,36 @@
+openapi: 3.0.1
+info:
+  version: 1.0.0
+  title: Example
+  license:
+    name: MIT
+servers:
+  - url: http://api.example.xyz/v1
+
+components:
+  schemas:
+    deprecated:
+      type: object
+      deprecated: true
+      properties:
+        customerCode:
+          type: string
+          example: '0001'
+        firstName:
+          type: string
+          example: 'first'
+    current:
+      type: object
+      properties:
+        customerCode:
+          type: string
+          example: '0001'
+        firstName:
+          type: string
+          example: 'first'
+    complex:
+      properties:
+        deprecated:
+          $ref: "#/components/schemas/deprecated"
+        current:
+          type: boolean


### PR DESCRIPTION
As $ref is supposed to completely replace the definition of a property,
make sure we also include the 'deprecated' property when generating the
type of a $ref property.

This makes a property $ref'ing a deprecated schema also become deprecated.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
