### PR TITLE
[csharp-netcore] Fix for issue 5442. Use if/else instead of ??

### DIFF
--- a/modules/openapi-generator/src/main/resources/csharp-netcore/modelGeneric.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/modelGeneric.mustache
@@ -63,7 +63,14 @@
             {{#required}}
             {{^vendorExtensions.x-csharp-value-type}}
             // to ensure "{{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}}" is required (not null)
-            this.{{name}} = {{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}} ?? throw new ArgumentNullException("{{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}} is a required property for {{classname}} and cannot be null");
+            if ({{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}} == null)
+            {
+                throw new InvalidDataException("{{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}} is a required property for {{classname}} and cannot be null");
+            }
+            else
+            {
+                this.{{name}} = {{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}};
+            }
             {{/vendorExtensions.x-csharp-value-type}}
             {{#vendorExtensions.x-csharp-value-type}}
             this.{{name}} = {{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}};

--- a/modules/openapi-generator/src/main/resources/csharp-netcore/modelGeneric.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/modelGeneric.mustache
@@ -65,7 +65,7 @@
             // to ensure "{{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}}" is required (not null)
             if ({{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}} == null)
             {
-                throw new InvalidDataException("{{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}} is a required property for {{classname}} and cannot be null");
+                throw new ArgumentNullException("{{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}} is a required property for {{classname}} and cannot be null");
             }
             else
             {

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Animal.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Animal.cs
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
             // to ensure "className" is required (not null)
             if (className == null)
             {
-                throw new InvalidDataException("className is a required property for Animal and cannot be null");
+                throw new ArgumentNullException("className is a required property for Animal and cannot be null");
             }
             else
             {

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Animal.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Animal.cs
@@ -53,7 +53,14 @@ namespace Org.OpenAPITools.Model
         public Animal(string className = default(string), string color = "red")
         {
             // to ensure "className" is required (not null)
-            this.ClassName = className ?? throw new ArgumentNullException("className is a required property for Animal and cannot be null");
+            if (className == null)
+            {
+                throw new InvalidDataException("className is a required property for Animal and cannot be null");
+            }
+            else
+            {
+                this.ClassName = className;
+            }
             // use default value if no "color" provided
             this.Color = color ?? "red";
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Category.cs
@@ -45,7 +45,14 @@ namespace Org.OpenAPITools.Model
         public Category(long id = default(long), string name = "default-name")
         {
             // to ensure "name" is required (not null)
-            this.Name = name ?? throw new ArgumentNullException("name is a required property for Category and cannot be null");
+            if (name == null)
+            {
+                throw new InvalidDataException("name is a required property for Category and cannot be null");
+            }
+            else
+            {
+                this.Name = name;
+            }
             this.Id = id;
         }
         

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Category.cs
@@ -47,7 +47,7 @@ namespace Org.OpenAPITools.Model
             // to ensure "name" is required (not null)
             if (name == null)
             {
-                throw new InvalidDataException("name is a required property for Category and cannot be null");
+                throw new ArgumentNullException("name is a required property for Category and cannot be null");
             }
             else
             {

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -60,7 +60,7 @@ namespace Org.OpenAPITools.Model
             // to ensure "_byte" is required (not null)
             if (_byte == null)
             {
-                throw new InvalidDataException("_byte is a required property for FormatTest and cannot be null");
+                throw new ArgumentNullException("_byte is a required property for FormatTest and cannot be null");
             }
             else
             {
@@ -70,7 +70,7 @@ namespace Org.OpenAPITools.Model
             // to ensure "password" is required (not null)
             if (password == null)
             {
-                throw new InvalidDataException("password is a required property for FormatTest and cannot be null");
+                throw new ArgumentNullException("password is a required property for FormatTest and cannot be null");
             }
             else
             {

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -58,10 +58,24 @@ namespace Org.OpenAPITools.Model
         {
             this.Number = number;
             // to ensure "_byte" is required (not null)
-            this.Byte = _byte ?? throw new ArgumentNullException("_byte is a required property for FormatTest and cannot be null");
+            if (_byte == null)
+            {
+                throw new InvalidDataException("_byte is a required property for FormatTest and cannot be null");
+            }
+            else
+            {
+                this.Byte = _byte;
+            }
             this.Date = date;
             // to ensure "password" is required (not null)
-            this.Password = password ?? throw new ArgumentNullException("password is a required property for FormatTest and cannot be null");
+            if (password == null)
+            {
+                throw new InvalidDataException("password is a required property for FormatTest and cannot be null");
+            }
+            else
+            {
+                this.Password = password;
+            }
             this.Integer = integer;
             this.Int32 = int32;
             this.Int64 = int64;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Pet.cs
@@ -82,9 +82,23 @@ namespace Org.OpenAPITools.Model
         public Pet(long id = default(long), Category category = default(Category), string name = default(string), List<string> photoUrls = default(List<string>), List<Tag> tags = default(List<Tag>), StatusEnum? status = default(StatusEnum?))
         {
             // to ensure "name" is required (not null)
-            this.Name = name ?? throw new ArgumentNullException("name is a required property for Pet and cannot be null");
+            if (name == null)
+            {
+                throw new InvalidDataException("name is a required property for Pet and cannot be null");
+            }
+            else
+            {
+                this.Name = name;
+            }
             // to ensure "photoUrls" is required (not null)
-            this.PhotoUrls = photoUrls ?? throw new ArgumentNullException("photoUrls is a required property for Pet and cannot be null");
+            if (photoUrls == null)
+            {
+                throw new InvalidDataException("photoUrls is a required property for Pet and cannot be null");
+            }
+            else
+            {
+                this.PhotoUrls = photoUrls;
+            }
             this.Id = id;
             this.Category = category;
             this.Tags = tags;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Pet.cs
@@ -84,7 +84,7 @@ namespace Org.OpenAPITools.Model
             // to ensure "name" is required (not null)
             if (name == null)
             {
-                throw new InvalidDataException("name is a required property for Pet and cannot be null");
+                throw new ArgumentNullException("name is a required property for Pet and cannot be null");
             }
             else
             {
@@ -93,7 +93,7 @@ namespace Org.OpenAPITools.Model
             // to ensure "photoUrls" is required (not null)
             if (photoUrls == null)
             {
-                throw new InvalidDataException("photoUrls is a required property for Pet and cannot be null");
+                throw new ArgumentNullException("photoUrls is a required property for Pet and cannot be null");
             }
             else
             {

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/TypeHolderDefault.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/TypeHolderDefault.cs
@@ -50,7 +50,7 @@ namespace Org.OpenAPITools.Model
             // to ensure "stringItem" is required (not null)
             if (stringItem == null)
             {
-                throw new InvalidDataException("stringItem is a required property for TypeHolderDefault and cannot be null");
+                throw new ArgumentNullException("stringItem is a required property for TypeHolderDefault and cannot be null");
             }
             else
             {
@@ -62,7 +62,7 @@ namespace Org.OpenAPITools.Model
             // to ensure "arrayItem" is required (not null)
             if (arrayItem == null)
             {
-                throw new InvalidDataException("arrayItem is a required property for TypeHolderDefault and cannot be null");
+                throw new ArgumentNullException("arrayItem is a required property for TypeHolderDefault and cannot be null");
             }
             else
             {

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/TypeHolderDefault.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/TypeHolderDefault.cs
@@ -48,12 +48,26 @@ namespace Org.OpenAPITools.Model
         public TypeHolderDefault(string stringItem = "what", decimal numberItem = default(decimal), int integerItem = default(int), bool boolItem = true, List<int> arrayItem = default(List<int>))
         {
             // to ensure "stringItem" is required (not null)
-            this.StringItem = stringItem ?? throw new ArgumentNullException("stringItem is a required property for TypeHolderDefault and cannot be null");
+            if (stringItem == null)
+            {
+                throw new InvalidDataException("stringItem is a required property for TypeHolderDefault and cannot be null");
+            }
+            else
+            {
+                this.StringItem = stringItem;
+            }
             this.NumberItem = numberItem;
             this.IntegerItem = integerItem;
             this.BoolItem = boolItem;
             // to ensure "arrayItem" is required (not null)
-            this.ArrayItem = arrayItem ?? throw new ArgumentNullException("arrayItem is a required property for TypeHolderDefault and cannot be null");
+            if (arrayItem == null)
+            {
+                throw new InvalidDataException("arrayItem is a required property for TypeHolderDefault and cannot be null");
+            }
+            else
+            {
+                this.ArrayItem = arrayItem;
+            }
         }
         
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/TypeHolderExample.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/TypeHolderExample.cs
@@ -51,7 +51,7 @@ namespace Org.OpenAPITools.Model
             // to ensure "stringItem" is required (not null)
             if (stringItem == null)
             {
-                throw new InvalidDataException("stringItem is a required property for TypeHolderExample and cannot be null");
+                throw new ArgumentNullException("stringItem is a required property for TypeHolderExample and cannot be null");
             }
             else
             {
@@ -64,7 +64,7 @@ namespace Org.OpenAPITools.Model
             // to ensure "arrayItem" is required (not null)
             if (arrayItem == null)
             {
-                throw new InvalidDataException("arrayItem is a required property for TypeHolderExample and cannot be null");
+                throw new ArgumentNullException("arrayItem is a required property for TypeHolderExample and cannot be null");
             }
             else
             {

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/TypeHolderExample.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/TypeHolderExample.cs
@@ -49,13 +49,27 @@ namespace Org.OpenAPITools.Model
         public TypeHolderExample(string stringItem = default(string), decimal numberItem = default(decimal), float floatItem = default(float), int integerItem = default(int), bool boolItem = default(bool), List<int> arrayItem = default(List<int>))
         {
             // to ensure "stringItem" is required (not null)
-            this.StringItem = stringItem ?? throw new ArgumentNullException("stringItem is a required property for TypeHolderExample and cannot be null");
+            if (stringItem == null)
+            {
+                throw new InvalidDataException("stringItem is a required property for TypeHolderExample and cannot be null");
+            }
+            else
+            {
+                this.StringItem = stringItem;
+            }
             this.NumberItem = numberItem;
             this.FloatItem = floatItem;
             this.IntegerItem = integerItem;
             this.BoolItem = boolItem;
             // to ensure "arrayItem" is required (not null)
-            this.ArrayItem = arrayItem ?? throw new ArgumentNullException("arrayItem is a required property for TypeHolderExample and cannot be null");
+            if (arrayItem == null)
+            {
+                throw new InvalidDataException("arrayItem is a required property for TypeHolderExample and cannot be null");
+            }
+            else
+            {
+                this.ArrayItem = arrayItem;
+            }
         }
         
         /// <summary>


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
Fix invalid C# code being generated on required parameters. Use if/else instead of ?? operator.
<!-- Please check the completed items below -->
### PR checklist

- [X ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X ] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [X ] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [X ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [ X] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@mandrean @jimschubert @frankyjuang @shibayan 