### PR TITLE
Fix  #4157 dart enum toJson method 

### DIFF
--- a/modules/openapi-generator/src/main/resources/dart2/enum.mustache
+++ b/modules/openapi-generator/src/main/resources/dart2/enum.mustache
@@ -12,6 +12,10 @@ class {{classname}} {
   static const {{classname}} {{{name}}} = const {{classname}}._internal({{{value}}});
     {{/enumVars}}
   {{/allowableValues}}
+  
+  {{dataType}} toJson (){
+    return this.value;
+  }
 
   static {{classname}} fromJson({{dataType}} value) {
     return new {{classname}}TypeTransformer().decode(value);


### PR DESCRIPTION
Just create a toJson method for enum serialization. As you can see on: https://github.com/OpenAPITools/openapi-generator/issues/4157#issuecomment-621370059 :

On the version 4.3.1 the serialize function delegate on dart convert library json.encode(). It return an error because serializing this enums because the enum is not "encodable" (is not a number, boolean, string, null, list or a map), so the encode() method looks for a toJson() on the Object passed:

```dart
  /// If [toEncodable] is omitted, it defaults to a function that returns the
  /// result of calling `.toJson()` on the unencodable object.
```

So I implemented this method on the template.