### PR TITLE
[scala][akka-http] fix non-default packages for api, model and invoker

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractScalaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractScalaCodegen.java
@@ -563,4 +563,8 @@ public abstract class AbstractScalaCodegen extends DefaultCodegen {
         return operationId;
     }
 
+    public void setInvokerPackage(String invokerPackage) {
+        this.invokerPackage = invokerPackage;
+    }
+
 }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ScalaAkkaClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ScalaAkkaClientCodegen.java
@@ -112,7 +112,6 @@ public class ScalaAkkaClientCodegen extends AbstractScalaCodegen implements Code
         additionalProperties.put("fnCapitalize", new CapitalizeLambda());
         additionalProperties.put("fnCamelize", new CamelizeLambda(false));
         additionalProperties.put("fnEnumEntry", new EnumEntryLambda());
-        additionalProperties.put("mainPackage", mainPackage);
 
         importMapping.remove("Seq");
         importMapping.remove("List");
@@ -146,15 +145,24 @@ public class ScalaAkkaClientCodegen extends AbstractScalaCodegen implements Code
     @Override
     public void processOpts() {
         super.processOpts();
+        if (additionalProperties.containsKey(CodegenConstants.INVOKER_PACKAGE)) {
+            this.setInvokerPackage((String) additionalProperties.get(CodegenConstants.INVOKER_PACKAGE));
+        }
         if (additionalProperties.containsKey("mainPackage")) {
             setMainPackage((String) additionalProperties.get("mainPackage"));
             additionalProperties.replace("configKeyPath", this.configKeyPath);
-            apiPackage = mainPackage + ".api";
-            modelPackage = mainPackage + ".model";
-            invokerPackage = mainPackage + ".core";
-            additionalProperties.put("apiPackage", apiPackage);
-            additionalProperties.put("modelPackage", modelPackage);
-            additionalProperties.put("invokerPackage", invokerPackage);
+            if (!additionalProperties.containsKey(CodegenConstants.INVOKER_PACKAGE)){
+                invokerPackage = mainPackage + ".core";
+                additionalProperties.put(CodegenConstants.INVOKER_PACKAGE, invokerPackage);
+            }
+            if (!additionalProperties.containsKey(CodegenConstants.API_PACKAGE)){
+                apiPackage = mainPackage + ".api";
+                additionalProperties.put(CodegenConstants.API_PACKAGE, apiPackage);
+            }
+            if (!additionalProperties.containsKey(CodegenConstants.MODEL_PACKAGE)){
+                modelPackage = mainPackage + ".model";
+                additionalProperties.put(CodegenConstants.MODEL_PACKAGE, modelPackage);
+            }
         }
 
         supportingFiles.add(new SupportingFile("README.mustache", "", "README.md"));

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ScalaAkkaClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ScalaAkkaClientCodegen.java
@@ -99,7 +99,6 @@ public class ScalaAkkaClientCodegen extends AbstractScalaCodegen implements Code
                         "trait", "try", "true", "type", "val", "var", "while", "with", "yield")
         );
 
-        additionalProperties.put(CodegenConstants.INVOKER_PACKAGE, invokerPackage);
         additionalProperties.put(CodegenConstants.GROUP_ID, groupId);
         additionalProperties.put(CodegenConstants.ARTIFACT_ID, artifactId);
         additionalProperties.put(CodegenConstants.ARTIFACT_VERSION, artifactVersion);

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ScalaAkkaClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ScalaAkkaClientCodegen.java
@@ -150,10 +150,6 @@ public class ScalaAkkaClientCodegen extends AbstractScalaCodegen implements Code
         if (additionalProperties.containsKey("mainPackage")) {
             setMainPackage((String) additionalProperties.get("mainPackage"));
             additionalProperties.replace("configKeyPath", this.configKeyPath);
-            if (!additionalProperties.containsKey(CodegenConstants.INVOKER_PACKAGE)){
-                invokerPackage = mainPackage + ".core";
-                additionalProperties.put(CodegenConstants.INVOKER_PACKAGE, invokerPackage);
-            }
             if (!additionalProperties.containsKey(CodegenConstants.API_PACKAGE)){
                 apiPackage = mainPackage + ".api";
                 additionalProperties.put(CodegenConstants.API_PACKAGE, apiPackage);
@@ -162,7 +158,11 @@ public class ScalaAkkaClientCodegen extends AbstractScalaCodegen implements Code
                 modelPackage = mainPackage + ".model";
                 additionalProperties.put(CodegenConstants.MODEL_PACKAGE, modelPackage);
             }
+            if (!additionalProperties.containsKey(CodegenConstants.INVOKER_PACKAGE)){
+                invokerPackage = mainPackage + ".core";
+            }
         }
+        additionalProperties.put(CodegenConstants.INVOKER_PACKAGE, invokerPackage);
 
         supportingFiles.add(new SupportingFile("README.mustache", "", "README.md"));
         supportingFiles.add(new SupportingFile("pom.mustache", "", "pom.xml"));

--- a/modules/openapi-generator/src/main/resources/scala-akka-client/api.mustache
+++ b/modules/openapi-generator/src/main/resources/scala-akka-client/api.mustache
@@ -4,9 +4,9 @@ package {{package}}
 {{#imports}}
 import {{import}}
 {{/imports}}
-import {{mainPackage}}.core._
-import {{mainPackage}}.core.CollectionFormats._
-import {{mainPackage}}.core.ApiKeyLocations._
+import {{invokerPackage}}._
+import {{invokerPackage}}.CollectionFormats._
+import {{invokerPackage}}.ApiKeyLocations._
 
 {{#operations}}
 object {{classname}} {

--- a/modules/openapi-generator/src/main/resources/scala-akka-client/apiInvoker.mustache
+++ b/modules/openapi-generator/src/main/resources/scala-akka-client/apiInvoker.mustache
@@ -72,8 +72,8 @@ trait UnitJSONSupport {
 
 class ApiInvoker(formats: Formats)(implicit system: ActorSystem) extends CustomContentTypes with Json4sSupport {
 
-  import {{{mainPackage}}}.core.ApiInvoker._
-  import {{{mainPackage}}}.core.ParametersMap._
+  import {{{invokerPackage}}}.ApiInvoker._
+  import {{{invokerPackage}}}.ParametersMap._
 
   implicit val ec: ExecutionContextExecutor = system.dispatcher
   implicit val jsonFormats: Formats = formats

--- a/modules/openapi-generator/src/main/resources/scala-akka-client/apiInvoker.mustache
+++ b/modules/openapi-generator/src/main/resources/scala-akka-client/apiInvoker.mustache
@@ -1,5 +1,5 @@
 {{>licenseInfo}}
-package {{{mainPackage}}}.core
+package {{invokerPackage}}
 
 import java.io.File
 

--- a/modules/openapi-generator/src/main/resources/scala-akka-client/apiRequest.mustache
+++ b/modules/openapi-generator/src/main/resources/scala-akka-client/apiRequest.mustache
@@ -1,5 +1,5 @@
 {{>licenseInfo}}
-package {{{mainPackage}}}.core
+package {{invokerPackage}}
 
 sealed trait ResponseState
 

--- a/modules/openapi-generator/src/main/resources/scala-akka-client/apiSettings.mustache
+++ b/modules/openapi-generator/src/main/resources/scala-akka-client/apiSettings.mustache
@@ -14,7 +14,7 @@ import scala.concurrent.duration.FiniteDuration
 class ApiSettings(config: Config) extends Extension {
   def this(system: ExtendedActorSystem) = this(system.settings.config)
 
-  private def cfg = config.getConfig("{{{mainPackage}}}.apiRequest")
+  private def cfg = config.getConfig("{{configKeyPath}}.{{configKey}}")
 
   val alwaysTrustCertificates: Boolean = cfg.getBoolean("trust-certificates")
   val defaultHeaders: List[RawHeader] = cfg.getConfig("default-headers").entrySet.asScala.toList.map(c => RawHeader(c.getKey, c.getValue.render))

--- a/modules/openapi-generator/src/main/resources/scala-akka-client/apiSettings.mustache
+++ b/modules/openapi-generator/src/main/resources/scala-akka-client/apiSettings.mustache
@@ -1,5 +1,5 @@
 {{>licenseInfo}}
-package {{{mainPackage}}}.core
+package {{invokerPackage}}
 
 import java.util.concurrent.TimeUnit
 

--- a/modules/openapi-generator/src/main/resources/scala-akka-client/model.mustache
+++ b/modules/openapi-generator/src/main/resources/scala-akka-client/model.mustache
@@ -4,7 +4,7 @@ package {{package}}
 {{#imports}}
 import {{import}}
 {{/imports}}
-import {{mainPackage}}.core.ApiModel
+import {{invokerPackage}}.ApiModel
 
 {{#models}}
 {{#model}}

--- a/modules/openapi-generator/src/main/resources/scala-akka-client/requests.mustache
+++ b/modules/openapi-generator/src/main/resources/scala-akka-client/requests.mustache
@@ -1,5 +1,5 @@
 {{>licenseInfo}}
-package {{mainPackage}}.core
+package {{invokerPackage}}
 
 import java.io.File
 import java.net.URLEncoder

--- a/modules/openapi-generator/src/main/resources/scala-sttp/api.mustache
+++ b/modules/openapi-generator/src/main/resources/scala-sttp/api.mustache
@@ -4,7 +4,7 @@ package {{package}}
 {{#imports}}
 import {{import}}
 {{/imports}}
-import {{mainPackage}}.core._
+import {{invokerPackage}}._
 import alias._
 import sttp.client._
 import sttp.model.Method

--- a/modules/openapi-generator/src/main/resources/scala-sttp/apiInvoker.mustache
+++ b/modules/openapi-generator/src/main/resources/scala-sttp/apiInvoker.mustache
@@ -1,5 +1,5 @@
 {{>licenseInfo}}
-package {{{mainPackage}}}.core
+package {{invokerPackage}}
 
 import org.json4s._
 import sttp.client._

--- a/modules/openapi-generator/src/main/resources/scala-sttp/model.mustache
+++ b/modules/openapi-generator/src/main/resources/scala-sttp/model.mustache
@@ -4,7 +4,7 @@ package {{package}}
 {{#imports}}
 import {{import}}
 {{/imports}}
-import {{mainPackage}}.core.ApiModel
+import {{invokerPackage}}.ApiModel
 
 {{#models}}
 {{#model}}

--- a/modules/openapi-generator/src/main/resources/scala-sttp/requests.mustache
+++ b/modules/openapi-generator/src/main/resources/scala-sttp/requests.mustache
@@ -1,5 +1,5 @@
 {{>licenseInfo}}
-package {{mainPackage}}.core
+package {{invokerPackage}}
 
 import sttp.client.{Identity, RequestT, ResponseError}
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/scalaakka/ScalaAkkaClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/scalaakka/ScalaAkkaClientCodegenTest.java
@@ -473,16 +473,10 @@ public class ScalaAkkaClientCodegenTest {
         Map<String, String> generatedFiles = generator.getFiles();
         Assert.assertEquals(generatedFiles.size(), 14);
 
-        for (Map.Entry<String,String> entry : generatedFiles.entrySet()) {
-            System.out.println(entry.getKey());
-        }
+        String outputPath = output.getAbsolutePath().replace("\\", "/");
 
-        System.out.println("Expected: " + output + "/src/main/scala/hello/world/model/package/SomeObj.scala");
-        System.out.println("Expected: " + output + "/src/main/scala/hello/world/package/invoker/ApiSettings.scala");
-        System.out.println("Expected: " + output + "/src/main/scala/hello/world/api/package/PingApi.scala");
-
-        Assert.assertTrue(generatedFiles.containsKey(output + "/src/main/scala/hello/world/model/package/SomeObj.scala".replace("/", File.separator)), "Model package is correct");
-        Assert.assertTrue(generatedFiles.containsKey(output + "/src/main/scala/hello/world/package/invoker/ApiSettings.scala".replace("/", File.separator)), "Invoker package is correct");
-        Assert.assertTrue(generatedFiles.containsKey(output + "/src/main/scala/hello/world/api/package/PingApi.scala".replace("/", File.separator)), "Api package is correct");
+        Assert.assertTrue(generatedFiles.containsKey(outputPath + "/src/main/scala/hello/world/model/package/SomeObj.scala"), "Model package is correct");
+        Assert.assertTrue(generatedFiles.containsKey(outputPath + "/src/main/scala/hello/world/package/invoker/ApiSettings.scala"), "Invoker package is correct");
+        Assert.assertTrue(generatedFiles.containsKey(outputPath + "/src/main/scala/hello/world/api/package/PingApi.scala"), "Api package is correct");
     }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/scalaakka/ScalaAkkaClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/scalaakka/ScalaAkkaClientCodegenTest.java
@@ -442,9 +442,12 @@ public class ScalaAkkaClientCodegenTest {
 
         Map<String, String> generatedFiles = generator.getFiles();
         Assert.assertEquals(generatedFiles.size(), 14);
-        Assert.assertTrue(generatedFiles.containsKey(output + "/src/main/scala/hello/world/model/SomeObj.scala".replace("/", File.separator)));
-        Assert.assertTrue(generatedFiles.containsKey(output + "/src/main/scala/hello/world/core/ApiSettings.scala".replace("/", File.separator)));
-        Assert.assertTrue(generatedFiles.containsKey(output + "/src/main/scala/hello/world/api/PingApi.scala".replace("/", File.separator)));
+
+        String outputPath = output.getAbsolutePath().replace("\\", "/");
+
+        Assert.assertTrue(generatedFiles.containsKey(outputPath + "/src/main/scala/hello/world/model/SomeObj.scala"));
+        Assert.assertTrue(generatedFiles.containsKey(outputPath + "/src/main/scala/hello/world/core/ApiSettings.scala"));
+        Assert.assertTrue(generatedFiles.containsKey(outputPath + "/src/main/scala/hello/world/api/PingApi.scala"));
     }
 
     @Test(description = "override api packages")

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/scalaakka/ScalaAkkaClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/scalaakka/ScalaAkkaClientCodegenTest.java
@@ -442,9 +442,9 @@ public class ScalaAkkaClientCodegenTest {
 
         Map<String, String> generatedFiles = generator.getFiles();
         Assert.assertEquals(generatedFiles.size(), 14);
-        Assert.assertTrue(generatedFiles.containsKey(output + "/src/main/scala/hello/world/model/SomeObj.scala"));
-        Assert.assertTrue(generatedFiles.containsKey(output + "/src/main/scala/hello/world/core/ApiSettings.scala"));
-        Assert.assertTrue(generatedFiles.containsKey(output + "/src/main/scala/hello/world/api/PingApi.scala"));
+        Assert.assertTrue(generatedFiles.containsKey(output + "/src/main/scala/hello/world/model/SomeObj.scala".replace("/", File.separator)));
+        Assert.assertTrue(generatedFiles.containsKey(output + "/src/main/scala/hello/world/core/ApiSettings.scala".replace("/", File.separator)));
+        Assert.assertTrue(generatedFiles.containsKey(output + "/src/main/scala/hello/world/api/PingApi.scala".replace("/", File.separator)));
     }
 
     @Test(description = "override api packages")
@@ -472,8 +472,8 @@ public class ScalaAkkaClientCodegenTest {
 
         Map<String, String> generatedFiles = generator.getFiles();
         Assert.assertEquals(generatedFiles.size(), 14);
-        Assert.assertTrue(generatedFiles.containsKey(output + "/src/main/scala/hello/world/model/package/SomeObj.scala"), "Model package is correct");
-        Assert.assertTrue(generatedFiles.containsKey(output + "/src/main/scala/hello/world/package/invoker/ApiSettings.scala"), "Invoker package is correct");
-        Assert.assertTrue(generatedFiles.containsKey(output + "/src/main/scala/hello/world/api/package/PingApi.scala"), "Api package is correct");
+        Assert.assertTrue(generatedFiles.containsKey(output + "/src/main/scala/hello/world/model/package/SomeObj.scala".replace("/", File.separator)), "Model package is correct");
+        Assert.assertTrue(generatedFiles.containsKey(output + "/src/main/scala/hello/world/package/invoker/ApiSettings.scala".replace("/", File.separator)), "Invoker package is correct");
+        Assert.assertTrue(generatedFiles.containsKey(output + "/src/main/scala/hello/world/api/package/PingApi.scala".replace("/", File.separator)), "Api package is correct");
     }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/scalaakka/ScalaAkkaClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/scalaakka/ScalaAkkaClientCodegenTest.java
@@ -472,6 +472,11 @@ public class ScalaAkkaClientCodegenTest {
 
         Map<String, String> generatedFiles = generator.getFiles();
         Assert.assertEquals(generatedFiles.size(), 14);
+
+        for (Map.Entry<String,String> entry : generatedFiles.entrySet()) {
+            System.out.println(entry.getKey());
+        }
+
         Assert.assertTrue(generatedFiles.containsKey(output + "/src/main/scala/hello/world/model/package/SomeObj.scala".replace("/", File.separator)), "Model package is correct");
         Assert.assertTrue(generatedFiles.containsKey(output + "/src/main/scala/hello/world/package/invoker/ApiSettings.scala".replace("/", File.separator)), "Invoker package is correct");
         Assert.assertTrue(generatedFiles.containsKey(output + "/src/main/scala/hello/world/api/package/PingApi.scala".replace("/", File.separator)), "Api package is correct");

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/scalaakka/ScalaAkkaClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/scalaakka/ScalaAkkaClientCodegenTest.java
@@ -419,4 +419,61 @@ public class ScalaAkkaClientCodegenTest {
         Assert.assertEquals(cm.classFilename, "NonStrippedModelName");
 
     }
+
+    @Test(description = "override only mainPackage")
+    public void mainPackageTest() throws Exception {
+        Map<String, Object> properties = new HashMap<>();
+        properties.put("mainPackage", "hello.world");
+
+        File output = Files.createTempDirectory("test").toFile();
+        output.deleteOnExit();
+
+        final DefaultCodegen codegen = new ScalaAkkaClientCodegen();
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName(codegen.getName())
+                .setAdditionalProperties(properties)
+                .setInputSpec("src/test/resources/3_0/scala_reserved_words.yaml")
+                .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
+
+        final ClientOptInput clientOptInput = configurator.toClientOptInput();
+        MockDefaultGenerator generator = new MockDefaultGenerator();
+        Generator gen = generator.opts(clientOptInput);
+        gen.generate();
+
+        Map<String, String> generatedFiles = generator.getFiles();
+        Assert.assertEquals(generatedFiles.size(), 14);
+        Assert.assertTrue(generatedFiles.containsKey(output + "/src/main/scala/hello/world/model/SomeObj.scala"));
+        Assert.assertTrue(generatedFiles.containsKey(output + "/src/main/scala/hello/world/core/ApiSettings.scala"));
+        Assert.assertTrue(generatedFiles.containsKey(output + "/src/main/scala/hello/world/api/PingApi.scala"));
+    }
+
+    @Test(description = "override api packages")
+    public void overridePackagesTest() throws Exception {
+        Map<String, Object> properties = new HashMap<>();
+        properties.put("mainPackage", "hello.world");
+        properties.put("apiPackage", "hello.world.api.package");
+        properties.put("modelPackage", "hello.world.model.package");
+        properties.put("invokerPackage", "hello.world.package.invoker");
+
+        File output = Files.createTempDirectory("test").toFile();
+        output.deleteOnExit();
+
+        final DefaultCodegen codegen = new ScalaAkkaClientCodegen();
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName(codegen.getName())
+                .setAdditionalProperties(properties)
+                .setInputSpec("src/test/resources/3_0/scala_reserved_words.yaml")
+                .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
+
+        final ClientOptInput clientOptInput = configurator.toClientOptInput();
+        MockDefaultGenerator generator = new MockDefaultGenerator();
+        Generator gen = generator.opts(clientOptInput);
+        gen.generate();
+
+        Map<String, String> generatedFiles = generator.getFiles();
+        Assert.assertEquals(generatedFiles.size(), 14);
+        Assert.assertTrue(generatedFiles.containsKey(output + "/src/main/scala/hello/world/model/package/SomeObj.scala"), "Model package is correct");
+        Assert.assertTrue(generatedFiles.containsKey(output + "/src/main/scala/hello/world/package/invoker/ApiSettings.scala"), "Invoker package is correct");
+        Assert.assertTrue(generatedFiles.containsKey(output + "/src/main/scala/hello/world/api/package/PingApi.scala"), "Api package is correct");
+    }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/scalaakka/ScalaAkkaClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/scalaakka/ScalaAkkaClientCodegenTest.java
@@ -477,6 +477,10 @@ public class ScalaAkkaClientCodegenTest {
             System.out.println(entry.getKey());
         }
 
+        System.out.println("Expected: " + output + "/src/main/scala/hello/world/model/package/SomeObj.scala");
+        System.out.println("Expected: " + output + "/src/main/scala/hello/world/package/invoker/ApiSettings.scala");
+        System.out.println("Expected: " + output + "/src/main/scala/hello/world/api/package/PingApi.scala");
+
         Assert.assertTrue(generatedFiles.containsKey(output + "/src/main/scala/hello/world/model/package/SomeObj.scala".replace("/", File.separator)), "Model package is correct");
         Assert.assertTrue(generatedFiles.containsKey(output + "/src/main/scala/hello/world/package/invoker/ApiSettings.scala".replace("/", File.separator)), "Invoker package is correct");
         Assert.assertTrue(generatedFiles.containsKey(output + "/src/main/scala/hello/world/api/package/PingApi.scala".replace("/", File.separator)), "Api package is correct");


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

Default setting for mainPackage is `org.openapitools.client`  and it will be always next values for:
`api = mainPackage + .api`
`invoker = mainPackage + .invoker`
`model = mainPackage + .model`

There is a cases when i want to define all of 3 properties explicitly ( sbt-plugin / gradle-plugin ) or to have custom values. 

This fix allows to apply explicitly every property and combine with `mainPackage` when applicable

https://github.com/OpenAPITools/openapi-generator/issues/6128

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@clasnake (2017/07), @jimschubert (2017/09) ❤️, @shijinkui (2018/01), @ramzimaalej (2018/03), @chameleon82 (2020/03), @Bouillie (2020/04)