### PR TITLE
fix issue 5815

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -3015,7 +3015,8 @@ public class DefaultCodegen implements CodegenConfig {
         //Referenced enum case:
         if (referencedSchema.getEnum() != null && !referencedSchema.getEnum().isEmpty()) {
             List<Object> _enum = referencedSchema.getEnum();
-
+            // If referenced schema is enum then property is treated as enum.
+            property.isEnum = true;
             Map<String, Object> allowableValues = new HashMap<String, Object>();
             allowableValues.put("values", _enum);
             if (allowableValues.size() > 0) {

--- a/modules/openapi-generator/src/test/resources/3_0/issue_5815.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/issue_5815.yaml
@@ -1,0 +1,39 @@
+openapi: 3.0.0
+info:
+  title: Test schema for issue 5815
+  version: 1.0.0
+paths:
+  /abc:
+    get:
+      operationId: getABC
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                a:
+                  $ref: '#/components/schemas/ResourceA'
+                b:
+                  $ref: '#/components/schemas/ResourceB'
+      responses:
+        '200':
+          description: successful operation
+components:
+  schemas:
+    ResourceA:
+      type: object
+      properties:
+        status:
+          $ref: '#/components/schemas/ResourceStatus'
+    ResourceB:
+      type: object
+      properties:
+        status:
+          $ref: '#/components/schemas/ResourceStatus'
+    ResourceStatus:
+      type: string
+      enum:
+        - a
+        - b
+        - c


### PR DESCRIPTION
https://github.com/OpenAPITools/openapi-generator/issues/5815

The graphql-schema generator cannot generates enum property properly if the property is referenced enum. 

This fix allows graphql-schema generator to generate enum properly and also fix potential referenced enum problem.

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [ ] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [ ] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
