### PR TITLE
Skip web.config generation for aspnetcore 3.x

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AspNetCoreServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AspNetCoreServerCodegen.java
@@ -325,7 +325,7 @@ public class AspNetCoreServerCodegen extends AbstractCSharpCodegen {
         if (!additionalProperties.containsKey(NEWTONSOFT_VERSION)) {
             additionalProperties.put(NEWTONSOFT_VERSION, newtonsoftVersion);
         } else {
-            newtonsoftVersion = (String)additionalProperties.get(NEWTONSOFT_VERSION);
+            newtonsoftVersion = (String) additionalProperties.get(NEWTONSOFT_VERSION);
         }
 
         // CHeck for the modifiers etc.
@@ -383,8 +383,6 @@ public class AspNetCoreServerCodegen extends AbstractCSharpCodegen {
             // wwwroot files.
             supportingFiles.add(new SupportingFile("wwwroot" + File.separator + "README.md", packageFolder + File.separator + "wwwroot", "README.md"));
             supportingFiles.add(new SupportingFile("wwwroot" + File.separator + "index.html", packageFolder + File.separator + "wwwroot", "index.html"));
-            supportingFiles.add(new SupportingFile("wwwroot" + File.separator + "web.config", packageFolder + File.separator + "wwwroot", "web.config"));
-
             supportingFiles.add(new SupportingFile("wwwroot" + File.separator + "openapi-original.mustache",
                     packageFolder + File.separator + "wwwroot", "openapi-original.json"));
         } else {
@@ -398,7 +396,7 @@ public class AspNetCoreServerCodegen extends AbstractCSharpCodegen {
                     packageFolder + File.separator + "Filters", "GeneratePathParamsValidationFilter.cs"));
         }
 
-        supportingFiles.add(new SupportingFile("Authentication" + File.separator + "ApiAuthentication.mustache",packageFolder + File.separator + "Authentication", "ApiAuthentication.cs"));
+        supportingFiles.add(new SupportingFile("Authentication" + File.separator + "ApiAuthentication.mustache", packageFolder + File.separator + "Authentication", "ApiAuthentication.cs"));
     }
 
     public void setPackageGuid(String packageGuid) {
@@ -542,6 +540,8 @@ public class AspNetCoreServerCodegen extends AbstractCSharpCodegen {
         } else if ("2.0".equals(aspnetCoreVersion.getOptValue())) {
             supportingFiles.add(new SupportingFile("web.config", packageFolder, "web.config"));
             compatibilityVersion = null;
+        } else if ("2.2".equals(aspnetCoreVersion.getOptValue()) || "2.1".equals(aspnetCoreVersion.getOptValue())) {
+            supportingFiles.add(new SupportingFile("wwwroot" + File.separator + "web.config", packageFolder + File.separator + "wwwroot", "web.config"));
         } else {
             // default, do nothing
             compatibilityVersion = "Version_" + aspnetCoreVersion.getOptValue().replace(".", "_");


### PR DESCRIPTION
A follow-up PR for https://github.com/OpenAPITools/openapi-generator/pull/6025#discussion_r416632520


<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

cc @jimschubert, @frankyjuang, @shibayan