### PR TITLE
Fix #6157: Updated native template to fix null async return

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/native/api.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/native/api.mustache
@@ -9,7 +9,6 @@ import {{invokerPackage}}.Pair;
 import {{import}};
 {{/imports}}
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 

--- a/modules/openapi-generator/src/main/resources/Java/libraries/native/api.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/native/api.mustache
@@ -181,12 +181,12 @@ public class {{classname}} {
               );
           } else {
               return CompletableFuture.completedFuture(
-                  {{#returnValue}}
+                  {{#returnType}}
                       memberVarObjectMapper.readValue(localVarResponse.body(), new TypeReference<{{{returnType}}}>() {})
-                  {{/returnValue}}
-                  {{^returnValue}}
+                  {{/returnType}}
+                  {{^returnType}}
                       null
-                  {{/returnValue}}
+                  {{/returnType}}
               );
           }
       });

--- a/modules/openapi-generator/src/main/resources/Java/libraries/native/api.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/native/api.mustache
@@ -9,6 +9,7 @@ import {{invokerPackage}}.Pair;
 import {{import}};
 {{/imports}}
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -180,14 +181,18 @@ public class {{classname}} {
                   localVarResponse.body())
               );
           } else {
-              return CompletableFuture.completedFuture(
-                  {{#returnType}}
-                      memberVarObjectMapper.readValue(localVarResponse.body(), new TypeReference<{{{returnType}}}>() {})
-                  {{/returnType}}
-                  {{^returnType}}
-                      null
-                  {{/returnType}}
-              );
+               try {
+                  return CompletableFuture.completedFuture(
+                      {{#returnType}}
+                          memberVarObjectMapper.readValue(localVarResponse.body(), new TypeReference<{{{returnType}}}>() {})
+                      {{/returnType}}
+                      {{^returnType}}
+                          null
+                      {{/returnType}}
+                  );
+              } catch (IOException e) {
+                  return CompletableFuture.failedFuture(new ApiException(e));
+              }
           }
       });
       {{/asyncNative}}


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

Fixes issue: https://github.com/OpenAPITools/openapi-generator/issues/6157
@wing328 @UkonnRa @joerg-wille

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
