### PR TITLE
Support media types other than json

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript/api/api.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/api/api.mustache
@@ -157,10 +157,15 @@ export class {{classname}}ResponseProcessor {
         {{#responses}}
         if (isCodeInRange("{{code}}", response.httpStatusCode)) {
             {{#dataType}}
-            const body: {{{dataType}}} = ObjectSerializer.deserialize(
-                ObjectSerializer.parse(response.body, contentType),
-                "{{{dataType}}}", "{{returnFormat}}"
-            ) as {{{dataType}}};
+            let body: {{{dataType}}};
+            if ("{{{dataType}}}" as string === "HttpFile" as string) {
+                body = response.getBodyAsFile() as any as {{{returnType}}};
+            } else {
+                body = ObjectSerializer.deserialize(
+                    ObjectSerializer.parse(response.body, contentType),
+                    "{{{dataType}}}", "{{returnFormat}}"
+                ) as {{{dataType}}};
+            }
             {{#isSuccessCode}}
             return body;
             {{/isSuccessCode}}
@@ -179,13 +184,18 @@ export class {{classname}}ResponseProcessor {
         }
         {{/responses}}
 
-        // Work around for incorrect api specification in petstore.yaml
+        // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
             {{#returnType}}
-            const body: {{{returnType}}} = ObjectSerializer.deserialize(
-                ObjectSerializer.parse(response.body, contentType),
-                "{{{returnType}}}", "{{returnFormat}}"
-            ) as {{{returnType}}};
+            let body: {{{returnType}}};
+            if ("{{{returnType}}}" as string === "HttpFile" as string) {
+                body = response.getBodyAsFile() as any as {{{returnType}}};
+            } else {
+                body = ObjectSerializer.deserialize(
+                    ObjectSerializer.parse(response.body, contentType),
+                    "{{{returnType}}}", "{{returnFormat}}"
+                ) as {{{returnType}}};
+            }
             return body;
             {{/returnType}}
             {{^returnType}}

--- a/modules/openapi-generator/src/main/resources/typescript/api/api.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/api/api.mustache
@@ -110,12 +110,10 @@ export class {{classname}}RequestFactory extends BaseAPIRequestFactory {
 
 		// Body Params
 	    {{#bodyParam}}
-        {{^consumes}}
-        requestContext.setHeaderParam("Content-Type", "application/json");
-        {{/consumes}}
-        {{#consumes.0}}
-        requestContext.setHeaderParam("Content-Type", "{{{mediaType}}}");
-        {{/consumes.0}}
+        const contentType = ObjectSerializer.getPreferredMediaType([{{#consumes}}
+            "{{{mediaType}}}"{{#hasMore}},{{/hasMore}}
+        {{/consumes}}]);
+        requestContext.setHeaderParam("Content-Type", contentType);
 		// TODO: Should this be handled by ObjectSerializer? imo yes => confidential information included in local object should not be sent
         const needsSerialization = (<any>"{{dataType}}" !== "string") || requestContext.getHeaders()['Content-Type'] === 'application/json';
         const serializedBody = needsSerialization ? JSON.stringify({{paramName}} || {}) : ({{paramName}} || "").toString(); // TODO: `toString` call is unnecessary

--- a/modules/openapi-generator/src/main/resources/typescript/api/api.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/api/api.mustache
@@ -114,9 +114,10 @@ export class {{classname}}RequestFactory extends BaseAPIRequestFactory {
             "{{{mediaType}}}"{{#hasMore}},{{/hasMore}}
         {{/consumes}}]);
         requestContext.setHeaderParam("Content-Type", contentType);
-		// TODO: Should this be handled by ObjectSerializer? imo yes => confidential information included in local object should not be sent
-        const needsSerialization = (<any>"{{dataType}}" !== "string") || requestContext.getHeaders()['Content-Type'] === 'application/json';
-        const serializedBody = needsSerialization ? JSON.stringify({{paramName}} || {}) : ({{paramName}} || "").toString(); // TODO: `toString` call is unnecessary
+        const serializedBody = ObjectSerializer.stringify(
+            ObjectSerializer.serialize({{paramName}}, "{{{dataType}}}", "{{dataFormat}}"),
+            contentType
+        );
         requestContext.setBody(serializedBody);
 	    {{/bodyParam}}
 		

--- a/modules/openapi-generator/src/main/resources/typescript/api/api.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/api/api.mustache
@@ -52,7 +52,7 @@ export class {{classname}}RequestFactory extends BaseAPIRequestFactory {
 
 		// Make Request Context
     	const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.{{httpMethod}});
-        requestContext.setHeaderParam("Accept", "application/json")
+        requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
 		{{#queryParams}}

--- a/modules/openapi-generator/src/main/resources/typescript/api/api.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/api/api.mustache
@@ -153,11 +153,14 @@ export class {{classname}}ResponseProcessor {
      * @throws ApiException if the response code was not in [200, 299]
      */
     public {{nickname}}(response: ResponseContext): {{#returnType}} {{{returnType}}}{{/returnType}} {{^returnType}} void {{/returnType}} {      
+        const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         {{#responses}}
         if (isCodeInRange("{{code}}", response.httpStatusCode)) {
             {{#dataType}}
-            const jsonBody = JSON.parse(response.body);
-            const body: {{{dataType}}} = ObjectSerializer.deserialize(jsonBody, "{{{dataType}}}", "{{returnFormat}}") as {{{dataType}}};            
+            const body: {{{dataType}}} = ObjectSerializer.deserialize(
+                ObjectSerializer.parse(response.body, contentType),
+                "{{{dataType}}}", "{{returnFormat}}"
+            ) as {{{dataType}}};
             {{#isSuccessCode}}
             return body;
             {{/isSuccessCode}}
@@ -172,21 +175,24 @@ export class {{classname}}ResponseProcessor {
             {{^isSuccessCode}}
             throw new ApiException<string>(response.httpStatusCode, "{{message}}");
             {{/isSuccessCode}}
-            {{/dataType}}                        
+            {{/dataType}}
         }
         {{/responses}}
-        
+
         // Work around for incorrect api specification in petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-        	{{#returnType}}
-            const jsonBody = JSON.parse(response.body);
-            const body: {{{returnType}}} = ObjectSerializer.deserialize(jsonBody, "{{{returnType}}}", "{{returnFormat}}") as {{{returnType}}};            
-			return body;        		
-        	{{/returnType}}
-        	{{^returnType}}
-        	return;
-        	{{/returnType}}
+            {{#returnType}}
+            const body: {{{returnType}}} = ObjectSerializer.deserialize(
+                ObjectSerializer.parse(response.body, contentType),
+                "{{{returnType}}}", "{{returnFormat}}"
+            ) as {{{returnType}}};
+            return body;
+            {{/returnType}}
+            {{^returnType}}
+            return;
+            {{/returnType}}
         }
+
         let body = response.body || "";
     	throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
     }

--- a/modules/openapi-generator/src/main/resources/typescript/api/api.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/api/api.mustache
@@ -96,9 +96,9 @@ export class {{classname}}RequestFactory extends BaseAPIRequestFactory {
              {{#node}}
              localVarFormParams.append('{{baseName}}', {{paramName}}.data, {{paramName}}.name);
              {{/node}}
-             {{^node}}
+             {{#browser}}
              localVarFormParams.append('{{baseName}}', {{paramName}}, {{paramName}}.name);
-             {{/node}}
+             {{/browser}}
              {{/platforms}}
              {{/isFile}}
         }
@@ -152,20 +152,20 @@ export class {{classname}}ResponseProcessor {
      * @params response Response returned by the server for a request to {{nickname}}
      * @throws ApiException if the response code was not in [200, 299]
      */
-    public {{nickname}}(response: ResponseContext): {{#returnType}} {{{returnType}}}{{/returnType}} {{^returnType}} void {{/returnType}} {      
+     public async {{nickname}}(response: ResponseContext): Promise<{{#returnType}}{{{returnType}}}{{/returnType}} {{^returnType}}void{{/returnType}}> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         {{#responses}}
         if (isCodeInRange("{{code}}", response.httpStatusCode)) {
             {{#dataType}}
-            let body: {{{dataType}}};
-            if ("{{{dataType}}}" as string === "HttpFile" as string) {
-                body = response.getBodyAsFile() as any as {{{returnType}}};
-            } else {
-                body = ObjectSerializer.deserialize(
-                    ObjectSerializer.parse(response.body, contentType),
-                    "{{{dataType}}}", "{{returnFormat}}"
-                ) as {{{dataType}}};
-            }
+            {{#isBinary}}
+            const body: {{{dataType}}} = await response.getBodyAsFile() as any as {{{returnType}}};
+            {{/isBinary}}
+            {{^isBinary}}
+            const body: {{{dataType}}} = ObjectSerializer.deserialize(
+                ObjectSerializer.parse(await response.body.text(), contentType),
+                "{{{dataType}}}", "{{returnFormat}}"
+            ) as {{{dataType}}};
+            {{/isBinary}}
             {{#isSuccessCode}}
             return body;
             {{/isSuccessCode}}
@@ -187,15 +187,15 @@ export class {{classname}}ResponseProcessor {
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
             {{#returnType}}
-            let body: {{{returnType}}};
-            if ("{{{returnType}}}" as string === "HttpFile" as string) {
-                body = response.getBodyAsFile() as any as {{{returnType}}};
-            } else {
-                body = ObjectSerializer.deserialize(
-                    ObjectSerializer.parse(response.body, contentType),
-                    "{{{returnType}}}", "{{returnFormat}}"
-                ) as {{{returnType}}};
-            }
+            {{#isBinary}}
+            const body: {{{returnType}}} = await response.getBodyAsFile() as any as {{{returnType}}};
+            {{/isBinary}}
+            {{^isBinary}}
+            const body: {{{returnType}}} = ObjectSerializer.deserialize(
+                ObjectSerializer.parse(await response.body.text(), contentType),
+                "{{{returnType}}}", "{{returnFormat}}"
+            ) as {{{returnType}}};
+            {{/isBinary}}
             return body;
             {{/returnType}}
             {{^returnType}}

--- a/modules/openapi-generator/src/main/resources/typescript/http/http.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/http/http.mustache
@@ -142,11 +142,56 @@ export class RequestContext {
 }
 
 export class ResponseContext {
+    public constructor(
+        public httpStatusCode: number,
+        public headers: { [key: string]: string },
+        public body: string
+    ) {}
 
-    public constructor(public httpStatusCode: number, 
-        public headers: { [key: string]: string }, public body: string) {
+    /**
+     * Parse header value in the form `value; param1="value1"`
+     *
+     * E.g. for Content-Type or Content-Disposition
+     * Parameter names are converted to lower case
+     * The first parameter is returned with the key `""`
+     */
+    public getParsedHeader(headerName: string): { [parameter: string]: string } {
+        const result: { [parameter: string]: string } = {};
+        if (!this.headers[headerName]) {
+            return result;
+        }
+
+        const parameters = this.headers[headerName].split(";");
+        for (const parameter of parameters) {
+            let [key, value] = parameter.split("=", 2);
+            key = key.toLowerCase().trim();
+            if (value === undefined) {
+                result[""] = key;
+            } else {
+                value = value.trim();
+                if (value.startsWith('"') && value.endsWith('"')) {
+                    value = value.substring(1, value.length - 1);
+                }
+                result[key] = value;
+            }
+        }
+        return result;
     }
-    
+
+    public getBodyAsFile(): HttpFile {
+        const contentDisposition = this.getParsedHeader("content-disposition");
+        {{#platforms}}
+        {{#node}}
+        return {
+            data: new {{{fileContentDataType}}}(this.body),
+            name: contentDisposition["filename"] || ""
+        };
+        {{/node}}
+        {{^node}}
+        return new File([this.body], contentDisposition["filename"] || "");
+        {{/node}}
+        {{/platforms}}
+    }
 }
 
 export interface HttpLibrary {

--- a/modules/openapi-generator/src/main/resources/typescript/http/http.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/http/http.mustache
@@ -43,9 +43,9 @@ export type HttpFile = {
     name: string
 };
 {{/node}}
-{{^node}}
+{{#browser}}
 export type HttpFile = {{{fileContentDataType}}} & { readonly name: string };
-{{/node}}
+{{/browser}}
 {{/platforms}}
 
 
@@ -141,11 +141,51 @@ export class RequestContext {
     }
 }
 
+export interface ResponseBody {
+    text(): Promise<string>;
+    binary(): Promise<{{{fileContentDataType}}}>;
+}
+
+
+/**
+ * Helper class to generate a `ResponseBody` from binary data
+ */
+export class SelfDecodingBody implements ResponseBody {
+    constructor(private dataSource: Promise<{{{fileContentDataType}}}>) {}
+
+    binary(): Promise<{{{fileContentDataType}}}> {
+        return this.dataSource;
+    }
+
+    async text(): Promise<string> {
+        const data: {{{fileContentDataType}}} = await this.dataSource;
+        {{#platforms}}
+        {{#node}}
+        return data.toString();
+        {{/node}}
+        {{#browser}}
+        // @ts-ignore
+        if (data.text) {
+            // @ts-ignore
+            return data.text();
+        }
+
+        return new Promise<string>((resolve, reject) => {
+            const reader = new FileReader();
+            reader.addEventListener("load", () => resolve(reader.result));
+            reader.addEventListener("error", () => reject(reader.error));
+            reader.readAsText(data);
+        });
+        {{/browser}}
+        {{/platforms}}
+    }
+}
+
 export class ResponseContext {
     public constructor(
         public httpStatusCode: number,
         public headers: { [key: string]: string },
-        public body: string
+        public body: ResponseBody
     ) {}
 
     /**
@@ -178,18 +218,25 @@ export class ResponseContext {
         return result;
     }
 
-    public getBodyAsFile(): HttpFile {
-        const contentDisposition = this.getParsedHeader("content-disposition");
+    public async getBodyAsFile(): Promise<HttpFile> {
+        const data = await this.body.binary();
+        const fileName = this.getParsedHeader("content-disposition")["filename"] || "";
         {{#platforms}}
         {{#node}}
-        return {
-            data: new {{{fileContentDataType}}}(this.body),
-            name: contentDisposition["filename"] || ""
-        };
+        return { data, name: fileName };
         {{/node}}
-        {{^node}}
-        return new File([this.body], contentDisposition["filename"] || "");
-        {{/node}}
+        {{#browser}}
+        const contentType = this.headers["content-type"] || "";
+        try {
+            return new File([data], fileName, { type: contentType });
+        } catch (error) {
+            /** Fallback for when the File constructor is not available */
+            return Object.assign(data, {
+                name: fileName,
+                type: contentType
+            });
+        }
+        {{/browser}}
         {{/platforms}}
     }
 }

--- a/modules/openapi-generator/src/main/resources/typescript/http/isomorphic-fetch.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/http/isomorphic-fetch.mustache
@@ -10,24 +10,23 @@ export class IsomorphicFetchHttpLibrary implements HttpLibrary {
     public send(request: RequestContext): Observable<ResponseContext> {
         let method = request.getHttpMethod().toString();
         let body = request.getBody();
-        
+
         const resultPromise = fetch(request.getUrl(), {
             method: method,
             body: body as any,
             headers: request.getHeaders(),
             credentials: "same-origin"
         }).then((resp: any) => {
-            // hack
-            let headers = (resp.headers as any)._headers;
-            for (let key in headers) {
-                headers[key] = (headers[key] as Array<string>).join("; ");
-            }
+            const headers: { [name: string]: string } = {};
+            resp.headers.forEach((value: string, name: string) => {
+              headers[name] = value;
+            });
 
             return resp.text().then((body: string) => {
                 return new ResponseContext(resp.status, headers, body)
             });
         });
-        
+
         return from<Promise<ResponseContext>>(resultPromise);
 
     }

--- a/modules/openapi-generator/src/main/resources/typescript/http/isomorphic-fetch.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/http/isomorphic-fetch.mustache
@@ -22,9 +22,21 @@ export class IsomorphicFetchHttpLibrary implements HttpLibrary {
               headers[name] = value;
             });
 
-            return resp.text().then((body: string) => {
-                return new ResponseContext(resp.status, headers, body)
-            });
+            {{#platforms}}
+            {{#node}}
+            const body = {
+              text: () => resp.text(),
+              binary: () => resp.buffer()
+            };
+            {{/node}}
+            {{^node}}
+            const body = {
+              text: () => resp.text(),
+              binary: () => resp.blob()
+            };
+            {{/node}}
+            {{/platforms}}
+            return new ResponseContext(resp.status, headers, body);
         });
 
         return from<Promise<ResponseContext>>(resultPromise);

--- a/modules/openapi-generator/src/main/resources/typescript/http/isomorphic-fetch.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/http/isomorphic-fetch.mustache
@@ -1,9 +1,13 @@
-declare var fetch: any;
-
 import {HttpLibrary, RequestContext, ResponseContext} from './http';
-import 'es6-promise/auto';
 import { from, Observable } from {{#useRxJS}}'rxjs'{{/useRxJS}}{{^useRxJS}}'../rxjsStub'{{/useRxJS}};
-import 'isomorphic-fetch';
+{{#platforms}}
+{{#node}}
+import fetch from "node-fetch";
+{{/node}}
+{{#browser}}
+import "whatwg-fetch";
+{{/browser}}
+{{/platforms}}
 
 export class IsomorphicFetchHttpLibrary implements HttpLibrary {
 
@@ -15,7 +19,11 @@ export class IsomorphicFetchHttpLibrary implements HttpLibrary {
             method: method,
             body: body as any,
             headers: request.getHeaders(),
+            {{#platforms}}
+            {{#browser}}
             credentials: "same-origin"
+            {{/browser}}
+            {{/platforms}}
         }).then((resp: any) => {
             const headers: { [name: string]: string } = {};
             resp.headers.forEach((value: string, name: string) => {

--- a/modules/openapi-generator/src/main/resources/typescript/http/jquery.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/http/jquery.mustache
@@ -1,13 +1,9 @@
-import {HttpLibrary, RequestContext, ResponseContext, HttpException} from './http';
+import { HttpLibrary, RequestContext, ResponseContext, HttpException, SelfDecodingBody } from './http';
 import * as e6p from 'es6-promise'
 import { from, Observable } from {{#useRxJS}}'rxjs'{{/useRxJS}}{{^useRxJS}}'../rxjsStub'{{/useRxJS}};
 e6p.polyfill();
 import * as $ from 'jquery';
-{{#platforms}}
-{{#node}}
-import * as FormData from "form-data";
-{{/node}}
-{{/platforms}}
+
 
 export class JQueryHttpLibrary implements HttpLibrary {
 
@@ -21,9 +17,19 @@ export class JQueryHttpLibrary implements HttpLibrary {
             type: method,
             headers: request.getHeaders(),
             processData: false,
-            xhrFields: { withCredentials: true }, 
+            xhrFields: { withCredentials: true },
             data: body
         };
+
+        /**
+         * Allow receiving binary data with jquery ajax
+         *
+         * Source: https://keyangxiang.com/2017/09/01/HTML5-XHR-download-binary-content-as-Blob/
+         */
+         requestOptions.beforeSend = (jqXHR: any, settings: any) => {
+             settings.xhr().responseType = "blob";
+         };
+
 
         if (request.getHeaders()['Content-Type']) {
             requestOptions.contentType = headerParams['Content-Type'];
@@ -48,9 +54,12 @@ export class JQueryHttpLibrary implements HttpLibrary {
         const sentRequest = $.ajax(requestOptions);
         
         const resultPromise = new Promise<ResponseContext>((resolve, reject) => {
-            sentRequest.done((resp, _, jqXHR) => {
-                const headers = this.getResponseHeaders(jqXHR)
-                const result = new ResponseContext(jqXHR.status, headers, JSON.stringify(resp));
+            sentRequest.done((data, _, jqXHR) => {
+                const result = new ResponseContext(
+                    jqXHR.status,
+                    this.getResponseHeaders(jqXHR),
+                    new SelfDecodingBody(Promise.resolve(data))
+                );
                 resolve(result);
             })
             sentRequest.fail((jqXHR: any) => {

--- a/modules/openapi-generator/src/main/resources/typescript/index.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/index.mustache
@@ -1,3 +1,5 @@
+import 'es6-promise/auto';
+
 export * from './http/http';
 export * from './auth/auth';
 export * from './models/all';

--- a/modules/openapi-generator/src/main/resources/typescript/model/ObjectSerializer.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/model/ObjectSerializer.mustache
@@ -21,6 +21,12 @@ let primitives = [
                     "number",
                     "any"
                  ];
+
+const supportedMediaTypes: { [mediaType: string]: number } = {
+  "application/json": Infinity,
+  "application/octet-stream": 0
+}
+
                  
 let enumsMap: Set<string> = new Set<string>([
     {{#models}}
@@ -161,5 +167,71 @@ export class ObjectSerializer {
             }
             return instance;
         }
+    }
+
+
+    /**
+     * Normalize media type
+     *
+     * We currently do not handle any media types attributes, i.e. anything
+     * after a semicolon. All content is assumed to be UTF-8 compatible.
+     */
+    public static normalizeMediaType(mediaType: string): string {
+        return mediaType.split(";")[0].trim().toLowerCase();
+    }
+
+    /**
+     * From a list of possible media types, choose the one we can handle best.
+     *
+     * The order of the given media types does not have any impact on the choice
+     * made.
+     */
+    public static getPreferredMediaType(mediaTypes: Array<string>): string {
+        /** According to OAS 3 we should default to json */
+        if (!mediaTypes) {
+            return "application/json";
+        }
+
+        const normalMediaTypes = mediaTypes.map(this.normalizeMediaType);
+        let selectedMediaType: string | undefined = undefined;
+        let selectedRank: number = -Infinity;
+        for (const mediaType of normalMediaTypes) {
+            if (supportedMediaTypes[mediaType] > selectedRank) {
+                selectedMediaType = mediaType;
+                selectedRank = supportedMediaTypes[mediaType];
+            }
+        }
+
+        if (selectedMediaType === undefined) {
+            throw new Error("None of the given media types are supported: " + mediaTypes.join(", "));
+        }
+
+        return selectedMediaType!;
+    }
+
+    /**
+     * Convert data to a string according the given media type
+     *
+     * TODO: Add support for
+     *    - json
+     *    - binary fallback
+     *    - xml (togglable in generator config)
+     *    - yaml (togglable in generator config)
+     */
+    public static stringify(data: any, mediaType: string): string {
+        return "";
+    }
+
+    /**
+     * Parse data from a string according to the given media type
+     *
+     * TODO: Add support for
+     *    - json
+     *    - binary fallback
+     *    - xml (togglable in generator config)
+     *    - yaml (togglable in generator config)
+     *    - multipart (togglabel in generator config)
+     */
+    public static parse(rawData: string, mediaType: string) {
     }
 }

--- a/modules/openapi-generator/src/main/resources/typescript/model/ObjectSerializer.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/model/ObjectSerializer.mustache
@@ -176,7 +176,10 @@ export class ObjectSerializer {
      * We currently do not handle any media types attributes, i.e. anything
      * after a semicolon. All content is assumed to be UTF-8 compatible.
      */
-    public static normalizeMediaType(mediaType: string): string {
+    public static normalizeMediaType(mediaType: string | undefined): string | undefined {
+        if (mediaType === undefined) {
+            return undefined;
+        }
         return mediaType.split(";")[0].trim().toLowerCase();
     }
 
@@ -196,9 +199,9 @@ export class ObjectSerializer {
         let selectedMediaType: string | undefined = undefined;
         let selectedRank: number = -Infinity;
         for (const mediaType of normalMediaTypes) {
-            if (supportedMediaTypes[mediaType] > selectedRank) {
+            if (supportedMediaTypes[mediaType!] > selectedRank) {
                 selectedMediaType = mediaType;
-                selectedRank = supportedMediaTypes[mediaType];
+                selectedRank = supportedMediaTypes[mediaType!];
             }
         }
 
@@ -223,7 +226,11 @@ export class ObjectSerializer {
     /**
      * Parse data from a string according to the given media type
      */
-    public static parse(rawData: string, mediaType: string) {
+    public static parse(rawData: string, mediaType: string | undefined) {
+        if (mediaType === undefined) {
+            throw new Error("Cannot parse content. No Content-Type defined.");
+        }
+
         if (mediaType === "application/json") {
             return JSON.parse(rawData);
         }

--- a/modules/openapi-generator/src/main/resources/typescript/model/ObjectSerializer.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/model/ObjectSerializer.mustache
@@ -211,27 +211,23 @@ export class ObjectSerializer {
 
     /**
      * Convert data to a string according the given media type
-     *
-     * TODO: Add support for
-     *    - json
-     *    - binary fallback
-     *    - xml (togglable in generator config)
-     *    - yaml (togglable in generator config)
      */
     public static stringify(data: any, mediaType: string): string {
-        return "";
+        if (mediaType === "application/json") {
+            return JSON.stringify(data);
+        }
+
+        throw new Error("The mediaType " + mediaType + " is not supported by ObjectSerializer.stringify.");
     }
 
     /**
      * Parse data from a string according to the given media type
-     *
-     * TODO: Add support for
-     *    - json
-     *    - binary fallback
-     *    - xml (togglable in generator config)
-     *    - yaml (togglable in generator config)
-     *    - multipart (togglabel in generator config)
      */
     public static parse(rawData: string, mediaType: string) {
+        if (mediaType === "application/json") {
+            return JSON.parse(rawData);
+        }
+
+        throw new Error("The mediaType " + mediaType + " is not supported by ObjectSerializer.parse.");
     }
 }

--- a/modules/openapi-generator/src/main/resources/typescript/package.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/package.mustache
@@ -19,8 +19,15 @@
   "dependencies": {
     {{#frameworks}}
     {{#fetch-api}}
-    "isomorphic-fetch": "^2.2.1",
-    "@types/isomorphic-fetch": "0.0.34",
+    {{#platforms}}
+    {{#node}}
+    "node-fetch": "^2.6.0",
+    "@types/node-fetch": "^2.5.7",
+    {{/node}}
+    {{#browser}}
+    "whatwg-fetch": "^3.0.0",
+    {{/browser}}
+    {{/platforms}}
     {{/fetch-api}}
     {{#jquery}}
     "@types/jquery": "^3.3.29",

--- a/modules/openapi-generator/src/main/resources/typescript/tsconfig.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/tsconfig.mustache
@@ -16,7 +16,14 @@
     "sourceMap": true,
     "outDir": "./dist",
     "noLib": false,
+    {{#platforms}}
+    {{#node}}
+    "lib": [ "es6" ]
+    {{/node}}
+    {{#browser}}
     "lib": [ "es6", "dom" ]
+    {{/browser}}
+    {{/platforms}}
   },
   "exclude": [
   	"dist",

--- a/samples/client/petstore/typescript/builds/default/apis/PetApi.ts
+++ b/samples/client/petstore/typescript/builds/default/apis/PetApi.ts
@@ -49,9 +49,10 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
             "application/xml"
         ]);
         requestContext.setHeaderParam("Content-Type", contentType);
-		// TODO: Should this be handled by ObjectSerializer? imo yes => confidential information included in local object should not be sent
-        const needsSerialization = (<any>"Pet" !== "string") || requestContext.getHeaders()['Content-Type'] === 'application/json';
-        const serializedBody = needsSerialization ? JSON.stringify(body || {}) : (body || "").toString(); // TODO: `toString` call is unnecessary
+        const serializedBody = ObjectSerializer.stringify(
+            ObjectSerializer.serialize(body, "Pet", ""),
+            contentType
+        );
         requestContext.setBody(serializedBody);
 		
 		let authMethod = null;
@@ -268,9 +269,10 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
             "application/xml"
         ]);
         requestContext.setHeaderParam("Content-Type", contentType);
-		// TODO: Should this be handled by ObjectSerializer? imo yes => confidential information included in local object should not be sent
-        const needsSerialization = (<any>"Pet" !== "string") || requestContext.getHeaders()['Content-Type'] === 'application/json';
-        const serializedBody = needsSerialization ? JSON.stringify(body || {}) : (body || "").toString(); // TODO: `toString` call is unnecessary
+        const serializedBody = ObjectSerializer.stringify(
+            ObjectSerializer.serialize(body, "Pet", ""),
+            contentType
+        );
         requestContext.setBody(serializedBody);
 		
 		let authMethod = null;

--- a/samples/client/petstore/typescript/builds/default/apis/PetApi.ts
+++ b/samples/client/petstore/typescript/builds/default/apis/PetApi.ts
@@ -412,7 +412,7 @@ export class PetApiResponseProcessor {
             throw new ApiException<string>(response.httpStatusCode, "Invalid input");
         }
 
-        // Work around for incorrect api specification in petstore.yaml
+        // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
             return;
         }
@@ -434,7 +434,7 @@ export class PetApiResponseProcessor {
             throw new ApiException<string>(response.httpStatusCode, "Invalid pet value");
         }
 
-        // Work around for incorrect api specification in petstore.yaml
+        // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
             return;
         }
@@ -453,22 +453,32 @@ export class PetApiResponseProcessor {
     public findPetsByStatus(response: ResponseContext):  Array<Pet>  {      
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
-            const body: Array<Pet> = ObjectSerializer.deserialize(
-                ObjectSerializer.parse(response.body, contentType),
-                "Array<Pet>", ""
-            ) as Array<Pet>;
+            let body: Array<Pet>;
+            if ("Array<Pet>" as string === "HttpFile" as string) {
+                body = response.getBodyAsFile() as any as Array<Pet>;
+            } else {
+                body = ObjectSerializer.deserialize(
+                    ObjectSerializer.parse(response.body, contentType),
+                    "Array<Pet>", ""
+                ) as Array<Pet>;
+            }
             return body;
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<string>(response.httpStatusCode, "Invalid status value");
         }
 
-        // Work around for incorrect api specification in petstore.yaml
+        // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            const body: Array<Pet> = ObjectSerializer.deserialize(
-                ObjectSerializer.parse(response.body, contentType),
-                "Array<Pet>", ""
-            ) as Array<Pet>;
+            let body: Array<Pet>;
+            if ("Array<Pet>" as string === "HttpFile" as string) {
+                body = response.getBodyAsFile() as any as Array<Pet>;
+            } else {
+                body = ObjectSerializer.deserialize(
+                    ObjectSerializer.parse(response.body, contentType),
+                    "Array<Pet>", ""
+                ) as Array<Pet>;
+            }
             return body;
         }
 
@@ -486,22 +496,32 @@ export class PetApiResponseProcessor {
     public findPetsByTags(response: ResponseContext):  Array<Pet>  {      
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
-            const body: Array<Pet> = ObjectSerializer.deserialize(
-                ObjectSerializer.parse(response.body, contentType),
-                "Array<Pet>", ""
-            ) as Array<Pet>;
+            let body: Array<Pet>;
+            if ("Array<Pet>" as string === "HttpFile" as string) {
+                body = response.getBodyAsFile() as any as Array<Pet>;
+            } else {
+                body = ObjectSerializer.deserialize(
+                    ObjectSerializer.parse(response.body, contentType),
+                    "Array<Pet>", ""
+                ) as Array<Pet>;
+            }
             return body;
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<string>(response.httpStatusCode, "Invalid tag value");
         }
 
-        // Work around for incorrect api specification in petstore.yaml
+        // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            const body: Array<Pet> = ObjectSerializer.deserialize(
-                ObjectSerializer.parse(response.body, contentType),
-                "Array<Pet>", ""
-            ) as Array<Pet>;
+            let body: Array<Pet>;
+            if ("Array<Pet>" as string === "HttpFile" as string) {
+                body = response.getBodyAsFile() as any as Array<Pet>;
+            } else {
+                body = ObjectSerializer.deserialize(
+                    ObjectSerializer.parse(response.body, contentType),
+                    "Array<Pet>", ""
+                ) as Array<Pet>;
+            }
             return body;
         }
 
@@ -519,10 +539,15 @@ export class PetApiResponseProcessor {
     public getPetById(response: ResponseContext):  Pet  {      
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
-            const body: Pet = ObjectSerializer.deserialize(
-                ObjectSerializer.parse(response.body, contentType),
-                "Pet", ""
-            ) as Pet;
+            let body: Pet;
+            if ("Pet" as string === "HttpFile" as string) {
+                body = response.getBodyAsFile() as any as Pet;
+            } else {
+                body = ObjectSerializer.deserialize(
+                    ObjectSerializer.parse(response.body, contentType),
+                    "Pet", ""
+                ) as Pet;
+            }
             return body;
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
@@ -532,12 +557,17 @@ export class PetApiResponseProcessor {
             throw new ApiException<string>(response.httpStatusCode, "Pet not found");
         }
 
-        // Work around for incorrect api specification in petstore.yaml
+        // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            const body: Pet = ObjectSerializer.deserialize(
-                ObjectSerializer.parse(response.body, contentType),
-                "Pet", ""
-            ) as Pet;
+            let body: Pet;
+            if ("Pet" as string === "HttpFile" as string) {
+                body = response.getBodyAsFile() as any as Pet;
+            } else {
+                body = ObjectSerializer.deserialize(
+                    ObjectSerializer.parse(response.body, contentType),
+                    "Pet", ""
+                ) as Pet;
+            }
             return body;
         }
 
@@ -564,7 +594,7 @@ export class PetApiResponseProcessor {
             throw new ApiException<string>(response.httpStatusCode, "Validation exception");
         }
 
-        // Work around for incorrect api specification in petstore.yaml
+        // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
             return;
         }
@@ -586,7 +616,7 @@ export class PetApiResponseProcessor {
             throw new ApiException<string>(response.httpStatusCode, "Invalid input");
         }
 
-        // Work around for incorrect api specification in petstore.yaml
+        // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
             return;
         }
@@ -605,19 +635,29 @@ export class PetApiResponseProcessor {
     public uploadFile(response: ResponseContext):  ApiResponse  {      
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
-            const body: ApiResponse = ObjectSerializer.deserialize(
-                ObjectSerializer.parse(response.body, contentType),
-                "ApiResponse", ""
-            ) as ApiResponse;
+            let body: ApiResponse;
+            if ("ApiResponse" as string === "HttpFile" as string) {
+                body = response.getBodyAsFile() as any as ApiResponse;
+            } else {
+                body = ObjectSerializer.deserialize(
+                    ObjectSerializer.parse(response.body, contentType),
+                    "ApiResponse", ""
+                ) as ApiResponse;
+            }
             return body;
         }
 
-        // Work around for incorrect api specification in petstore.yaml
+        // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            const body: ApiResponse = ObjectSerializer.deserialize(
-                ObjectSerializer.parse(response.body, contentType),
-                "ApiResponse", ""
-            ) as ApiResponse;
+            let body: ApiResponse;
+            if ("ApiResponse" as string === "HttpFile" as string) {
+                body = response.getBodyAsFile() as any as ApiResponse;
+            } else {
+                body = ObjectSerializer.deserialize(
+                    ObjectSerializer.parse(response.body, contentType),
+                    "ApiResponse", ""
+                ) as ApiResponse;
+            }
             return body;
         }
 

--- a/samples/client/petstore/typescript/builds/default/apis/PetApi.ts
+++ b/samples/client/petstore/typescript/builds/default/apis/PetApi.ts
@@ -407,14 +407,16 @@ export class PetApiResponseProcessor {
      * @throws ApiException if the response code was not in [200, 299]
      */
     public addPet(response: ResponseContext):   void  {      
+        const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("405", response.httpStatusCode)) {
             throw new ApiException<string>(response.httpStatusCode, "Invalid input");
         }
-        
+
         // Work around for incorrect api specification in petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-        	return;
+            return;
         }
+
         let body = response.body || "";
     	throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
     }
@@ -427,14 +429,16 @@ export class PetApiResponseProcessor {
      * @throws ApiException if the response code was not in [200, 299]
      */
     public deletePet(response: ResponseContext):   void  {      
+        const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<string>(response.httpStatusCode, "Invalid pet value");
         }
-        
+
         // Work around for incorrect api specification in petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-        	return;
+            return;
         }
+
         let body = response.body || "";
     	throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
     }
@@ -447,21 +451,27 @@ export class PetApiResponseProcessor {
      * @throws ApiException if the response code was not in [200, 299]
      */
     public findPetsByStatus(response: ResponseContext):  Array<Pet>  {      
+        const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
-            const jsonBody = JSON.parse(response.body);
-            const body: Array<Pet> = ObjectSerializer.deserialize(jsonBody, "Array<Pet>", "") as Array<Pet>;            
+            const body: Array<Pet> = ObjectSerializer.deserialize(
+                ObjectSerializer.parse(response.body, contentType),
+                "Array<Pet>", ""
+            ) as Array<Pet>;
             return body;
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<string>(response.httpStatusCode, "Invalid status value");
         }
-        
+
         // Work around for incorrect api specification in petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            const jsonBody = JSON.parse(response.body);
-            const body: Array<Pet> = ObjectSerializer.deserialize(jsonBody, "Array<Pet>", "") as Array<Pet>;            
-			return body;        		
+            const body: Array<Pet> = ObjectSerializer.deserialize(
+                ObjectSerializer.parse(response.body, contentType),
+                "Array<Pet>", ""
+            ) as Array<Pet>;
+            return body;
         }
+
         let body = response.body || "";
     	throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
     }
@@ -474,21 +484,27 @@ export class PetApiResponseProcessor {
      * @throws ApiException if the response code was not in [200, 299]
      */
     public findPetsByTags(response: ResponseContext):  Array<Pet>  {      
+        const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
-            const jsonBody = JSON.parse(response.body);
-            const body: Array<Pet> = ObjectSerializer.deserialize(jsonBody, "Array<Pet>", "") as Array<Pet>;            
+            const body: Array<Pet> = ObjectSerializer.deserialize(
+                ObjectSerializer.parse(response.body, contentType),
+                "Array<Pet>", ""
+            ) as Array<Pet>;
             return body;
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<string>(response.httpStatusCode, "Invalid tag value");
         }
-        
+
         // Work around for incorrect api specification in petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            const jsonBody = JSON.parse(response.body);
-            const body: Array<Pet> = ObjectSerializer.deserialize(jsonBody, "Array<Pet>", "") as Array<Pet>;            
-			return body;        		
+            const body: Array<Pet> = ObjectSerializer.deserialize(
+                ObjectSerializer.parse(response.body, contentType),
+                "Array<Pet>", ""
+            ) as Array<Pet>;
+            return body;
         }
+
         let body = response.body || "";
     	throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
     }
@@ -501,9 +517,12 @@ export class PetApiResponseProcessor {
      * @throws ApiException if the response code was not in [200, 299]
      */
     public getPetById(response: ResponseContext):  Pet  {      
+        const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
-            const jsonBody = JSON.parse(response.body);
-            const body: Pet = ObjectSerializer.deserialize(jsonBody, "Pet", "") as Pet;            
+            const body: Pet = ObjectSerializer.deserialize(
+                ObjectSerializer.parse(response.body, contentType),
+                "Pet", ""
+            ) as Pet;
             return body;
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
@@ -512,13 +531,16 @@ export class PetApiResponseProcessor {
         if (isCodeInRange("404", response.httpStatusCode)) {
             throw new ApiException<string>(response.httpStatusCode, "Pet not found");
         }
-        
+
         // Work around for incorrect api specification in petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            const jsonBody = JSON.parse(response.body);
-            const body: Pet = ObjectSerializer.deserialize(jsonBody, "Pet", "") as Pet;            
-			return body;        		
+            const body: Pet = ObjectSerializer.deserialize(
+                ObjectSerializer.parse(response.body, contentType),
+                "Pet", ""
+            ) as Pet;
+            return body;
         }
+
         let body = response.body || "";
     	throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
     }
@@ -531,6 +553,7 @@ export class PetApiResponseProcessor {
      * @throws ApiException if the response code was not in [200, 299]
      */
     public updatePet(response: ResponseContext):   void  {      
+        const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<string>(response.httpStatusCode, "Invalid ID supplied");
         }
@@ -540,11 +563,12 @@ export class PetApiResponseProcessor {
         if (isCodeInRange("405", response.httpStatusCode)) {
             throw new ApiException<string>(response.httpStatusCode, "Validation exception");
         }
-        
+
         // Work around for incorrect api specification in petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-        	return;
+            return;
         }
+
         let body = response.body || "";
     	throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
     }
@@ -557,14 +581,16 @@ export class PetApiResponseProcessor {
      * @throws ApiException if the response code was not in [200, 299]
      */
     public updatePetWithForm(response: ResponseContext):   void  {      
+        const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("405", response.httpStatusCode)) {
             throw new ApiException<string>(response.httpStatusCode, "Invalid input");
         }
-        
+
         // Work around for incorrect api specification in petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-        	return;
+            return;
         }
+
         let body = response.body || "";
     	throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
     }
@@ -577,18 +603,24 @@ export class PetApiResponseProcessor {
      * @throws ApiException if the response code was not in [200, 299]
      */
     public uploadFile(response: ResponseContext):  ApiResponse  {      
+        const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
-            const jsonBody = JSON.parse(response.body);
-            const body: ApiResponse = ObjectSerializer.deserialize(jsonBody, "ApiResponse", "") as ApiResponse;            
+            const body: ApiResponse = ObjectSerializer.deserialize(
+                ObjectSerializer.parse(response.body, contentType),
+                "ApiResponse", ""
+            ) as ApiResponse;
             return body;
         }
-        
+
         // Work around for incorrect api specification in petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            const jsonBody = JSON.parse(response.body);
-            const body: ApiResponse = ObjectSerializer.deserialize(jsonBody, "ApiResponse", "") as ApiResponse;            
-			return body;        		
+            const body: ApiResponse = ObjectSerializer.deserialize(
+                ObjectSerializer.parse(response.body, contentType),
+                "ApiResponse", ""
+            ) as ApiResponse;
+            return body;
         }
+
         let body = response.body || "";
     	throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
     }

--- a/samples/client/petstore/typescript/builds/default/apis/PetApi.ts
+++ b/samples/client/petstore/typescript/builds/default/apis/PetApi.ts
@@ -406,7 +406,7 @@ export class PetApiResponseProcessor {
      * @params response Response returned by the server for a request to addPet
      * @throws ApiException if the response code was not in [200, 299]
      */
-    public addPet(response: ResponseContext):   void  {      
+     public async addPet(response: ResponseContext): Promise< void> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("405", response.httpStatusCode)) {
             throw new ApiException<string>(response.httpStatusCode, "Invalid input");
@@ -428,7 +428,7 @@ export class PetApiResponseProcessor {
      * @params response Response returned by the server for a request to deletePet
      * @throws ApiException if the response code was not in [200, 299]
      */
-    public deletePet(response: ResponseContext):   void  {      
+     public async deletePet(response: ResponseContext): Promise< void> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<string>(response.httpStatusCode, "Invalid pet value");
@@ -450,18 +450,13 @@ export class PetApiResponseProcessor {
      * @params response Response returned by the server for a request to findPetsByStatus
      * @throws ApiException if the response code was not in [200, 299]
      */
-    public findPetsByStatus(response: ResponseContext):  Array<Pet>  {      
+     public async findPetsByStatus(response: ResponseContext): Promise<Array<Pet> > {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
-            let body: Array<Pet>;
-            if ("Array<Pet>" as string === "HttpFile" as string) {
-                body = response.getBodyAsFile() as any as Array<Pet>;
-            } else {
-                body = ObjectSerializer.deserialize(
-                    ObjectSerializer.parse(response.body, contentType),
-                    "Array<Pet>", ""
-                ) as Array<Pet>;
-            }
+            const body: Array<Pet> = ObjectSerializer.deserialize(
+                ObjectSerializer.parse(await response.body.text(), contentType),
+                "Array<Pet>", ""
+            ) as Array<Pet>;
             return body;
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
@@ -470,15 +465,10 @@ export class PetApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            let body: Array<Pet>;
-            if ("Array<Pet>" as string === "HttpFile" as string) {
-                body = response.getBodyAsFile() as any as Array<Pet>;
-            } else {
-                body = ObjectSerializer.deserialize(
-                    ObjectSerializer.parse(response.body, contentType),
-                    "Array<Pet>", ""
-                ) as Array<Pet>;
-            }
+            const body: Array<Pet> = ObjectSerializer.deserialize(
+                ObjectSerializer.parse(await response.body.text(), contentType),
+                "Array<Pet>", ""
+            ) as Array<Pet>;
             return body;
         }
 
@@ -493,18 +483,13 @@ export class PetApiResponseProcessor {
      * @params response Response returned by the server for a request to findPetsByTags
      * @throws ApiException if the response code was not in [200, 299]
      */
-    public findPetsByTags(response: ResponseContext):  Array<Pet>  {      
+     public async findPetsByTags(response: ResponseContext): Promise<Array<Pet> > {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
-            let body: Array<Pet>;
-            if ("Array<Pet>" as string === "HttpFile" as string) {
-                body = response.getBodyAsFile() as any as Array<Pet>;
-            } else {
-                body = ObjectSerializer.deserialize(
-                    ObjectSerializer.parse(response.body, contentType),
-                    "Array<Pet>", ""
-                ) as Array<Pet>;
-            }
+            const body: Array<Pet> = ObjectSerializer.deserialize(
+                ObjectSerializer.parse(await response.body.text(), contentType),
+                "Array<Pet>", ""
+            ) as Array<Pet>;
             return body;
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
@@ -513,15 +498,10 @@ export class PetApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            let body: Array<Pet>;
-            if ("Array<Pet>" as string === "HttpFile" as string) {
-                body = response.getBodyAsFile() as any as Array<Pet>;
-            } else {
-                body = ObjectSerializer.deserialize(
-                    ObjectSerializer.parse(response.body, contentType),
-                    "Array<Pet>", ""
-                ) as Array<Pet>;
-            }
+            const body: Array<Pet> = ObjectSerializer.deserialize(
+                ObjectSerializer.parse(await response.body.text(), contentType),
+                "Array<Pet>", ""
+            ) as Array<Pet>;
             return body;
         }
 
@@ -536,18 +516,13 @@ export class PetApiResponseProcessor {
      * @params response Response returned by the server for a request to getPetById
      * @throws ApiException if the response code was not in [200, 299]
      */
-    public getPetById(response: ResponseContext):  Pet  {      
+     public async getPetById(response: ResponseContext): Promise<Pet > {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
-            let body: Pet;
-            if ("Pet" as string === "HttpFile" as string) {
-                body = response.getBodyAsFile() as any as Pet;
-            } else {
-                body = ObjectSerializer.deserialize(
-                    ObjectSerializer.parse(response.body, contentType),
-                    "Pet", ""
-                ) as Pet;
-            }
+            const body: Pet = ObjectSerializer.deserialize(
+                ObjectSerializer.parse(await response.body.text(), contentType),
+                "Pet", ""
+            ) as Pet;
             return body;
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
@@ -559,15 +534,10 @@ export class PetApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            let body: Pet;
-            if ("Pet" as string === "HttpFile" as string) {
-                body = response.getBodyAsFile() as any as Pet;
-            } else {
-                body = ObjectSerializer.deserialize(
-                    ObjectSerializer.parse(response.body, contentType),
-                    "Pet", ""
-                ) as Pet;
-            }
+            const body: Pet = ObjectSerializer.deserialize(
+                ObjectSerializer.parse(await response.body.text(), contentType),
+                "Pet", ""
+            ) as Pet;
             return body;
         }
 
@@ -582,7 +552,7 @@ export class PetApiResponseProcessor {
      * @params response Response returned by the server for a request to updatePet
      * @throws ApiException if the response code was not in [200, 299]
      */
-    public updatePet(response: ResponseContext):   void  {      
+     public async updatePet(response: ResponseContext): Promise< void> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<string>(response.httpStatusCode, "Invalid ID supplied");
@@ -610,7 +580,7 @@ export class PetApiResponseProcessor {
      * @params response Response returned by the server for a request to updatePetWithForm
      * @throws ApiException if the response code was not in [200, 299]
      */
-    public updatePetWithForm(response: ResponseContext):   void  {      
+     public async updatePetWithForm(response: ResponseContext): Promise< void> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("405", response.httpStatusCode)) {
             throw new ApiException<string>(response.httpStatusCode, "Invalid input");
@@ -632,32 +602,22 @@ export class PetApiResponseProcessor {
      * @params response Response returned by the server for a request to uploadFile
      * @throws ApiException if the response code was not in [200, 299]
      */
-    public uploadFile(response: ResponseContext):  ApiResponse  {      
+     public async uploadFile(response: ResponseContext): Promise<ApiResponse > {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
-            let body: ApiResponse;
-            if ("ApiResponse" as string === "HttpFile" as string) {
-                body = response.getBodyAsFile() as any as ApiResponse;
-            } else {
-                body = ObjectSerializer.deserialize(
-                    ObjectSerializer.parse(response.body, contentType),
-                    "ApiResponse", ""
-                ) as ApiResponse;
-            }
+            const body: ApiResponse = ObjectSerializer.deserialize(
+                ObjectSerializer.parse(await response.body.text(), contentType),
+                "ApiResponse", ""
+            ) as ApiResponse;
             return body;
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            let body: ApiResponse;
-            if ("ApiResponse" as string === "HttpFile" as string) {
-                body = response.getBodyAsFile() as any as ApiResponse;
-            } else {
-                body = ObjectSerializer.deserialize(
-                    ObjectSerializer.parse(response.body, contentType),
-                    "ApiResponse", ""
-                ) as ApiResponse;
-            }
+            const body: ApiResponse = ObjectSerializer.deserialize(
+                ObjectSerializer.parse(await response.body.text(), contentType),
+                "ApiResponse", ""
+            ) as ApiResponse;
             return body;
         }
 

--- a/samples/client/petstore/typescript/builds/default/apis/PetApi.ts
+++ b/samples/client/petstore/typescript/builds/default/apis/PetApi.ts
@@ -33,7 +33,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
 
 		// Make Request Context
     	const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
-        requestContext.setHeaderParam("Accept", "application/json")
+        requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
 	
@@ -80,7 +80,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
 
 		// Make Request Context
     	const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.DELETE);
-        requestContext.setHeaderParam("Accept", "application/json")
+        requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
 	
@@ -121,7 +121,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
 
 		// Make Request Context
     	const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
-        requestContext.setHeaderParam("Accept", "application/json")
+        requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
         if (status !== undefined) {
@@ -164,7 +164,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
 
 		// Make Request Context
     	const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
-        requestContext.setHeaderParam("Accept", "application/json")
+        requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
         if (tags !== undefined) {
@@ -208,7 +208,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
 
 		// Make Request Context
     	const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
-        requestContext.setHeaderParam("Accept", "application/json")
+        requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
 	
@@ -247,7 +247,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
 
 		// Make Request Context
     	const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.PUT);
-        requestContext.setHeaderParam("Accept", "application/json")
+        requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
 	
@@ -296,7 +296,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
 
 		// Make Request Context
     	const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
-        requestContext.setHeaderParam("Accept", "application/json")
+        requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
 	
@@ -350,7 +350,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
 
 		// Make Request Context
     	const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
-        requestContext.setHeaderParam("Accept", "application/json")
+        requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
 	

--- a/samples/client/petstore/typescript/builds/default/apis/PetApi.ts
+++ b/samples/client/petstore/typescript/builds/default/apis/PetApi.ts
@@ -43,7 +43,12 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
 
 
 		// Body Params
-        requestContext.setHeaderParam("Content-Type", "application/json");
+        const contentType = ObjectSerializer.getPreferredMediaType([
+            "application/json",
+        
+            "application/xml"
+        ]);
+        requestContext.setHeaderParam("Content-Type", contentType);
 		// TODO: Should this be handled by ObjectSerializer? imo yes => confidential information included in local object should not be sent
         const needsSerialization = (<any>"Pet" !== "string") || requestContext.getHeaders()['Content-Type'] === 'application/json';
         const serializedBody = needsSerialization ? JSON.stringify(body || {}) : (body || "").toString(); // TODO: `toString` call is unnecessary
@@ -257,7 +262,12 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
 
 
 		// Body Params
-        requestContext.setHeaderParam("Content-Type", "application/json");
+        const contentType = ObjectSerializer.getPreferredMediaType([
+            "application/json",
+        
+            "application/xml"
+        ]);
+        requestContext.setHeaderParam("Content-Type", contentType);
 		// TODO: Should this be handled by ObjectSerializer? imo yes => confidential information included in local object should not be sent
         const needsSerialization = (<any>"Pet" !== "string") || requestContext.getHeaders()['Content-Type'] === 'application/json';
         const serializedBody = needsSerialization ? JSON.stringify(body || {}) : (body || "").toString(); // TODO: `toString` call is unnecessary

--- a/samples/client/petstore/typescript/builds/default/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript/builds/default/apis/StoreApi.ts
@@ -149,9 +149,10 @@ export class StoreApiRequestFactory extends BaseAPIRequestFactory {
 		// Body Params
         const contentType = ObjectSerializer.getPreferredMediaType([]);
         requestContext.setHeaderParam("Content-Type", contentType);
-		// TODO: Should this be handled by ObjectSerializer? imo yes => confidential information included in local object should not be sent
-        const needsSerialization = (<any>"Order" !== "string") || requestContext.getHeaders()['Content-Type'] === 'application/json';
-        const serializedBody = needsSerialization ? JSON.stringify(body || {}) : (body || "").toString(); // TODO: `toString` call is unnecessary
+        const serializedBody = ObjectSerializer.stringify(
+            ObjectSerializer.serialize(body, "Order", ""),
+            contentType
+        );
         requestContext.setBody(serializedBody);
 		
     	// Apply auth methods

--- a/samples/client/petstore/typescript/builds/default/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript/builds/default/apis/StoreApi.ts
@@ -173,7 +173,7 @@ export class StoreApiResponseProcessor {
      * @params response Response returned by the server for a request to deleteOrder
      * @throws ApiException if the response code was not in [200, 299]
      */
-    public deleteOrder(response: ResponseContext):   void  {      
+     public async deleteOrder(response: ResponseContext): Promise< void> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<string>(response.httpStatusCode, "Invalid ID supplied");
@@ -198,32 +198,22 @@ export class StoreApiResponseProcessor {
      * @params response Response returned by the server for a request to getInventory
      * @throws ApiException if the response code was not in [200, 299]
      */
-    public getInventory(response: ResponseContext):  { [key: string]: number; }  {      
+     public async getInventory(response: ResponseContext): Promise<{ [key: string]: number; } > {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
-            let body: { [key: string]: number; };
-            if ("{ [key: string]: number; }" as string === "HttpFile" as string) {
-                body = response.getBodyAsFile() as any as { [key: string]: number; };
-            } else {
-                body = ObjectSerializer.deserialize(
-                    ObjectSerializer.parse(response.body, contentType),
-                    "{ [key: string]: number; }", "int32"
-                ) as { [key: string]: number; };
-            }
+            const body: { [key: string]: number; } = ObjectSerializer.deserialize(
+                ObjectSerializer.parse(await response.body.text(), contentType),
+                "{ [key: string]: number; }", "int32"
+            ) as { [key: string]: number; };
             return body;
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            let body: { [key: string]: number; };
-            if ("{ [key: string]: number; }" as string === "HttpFile" as string) {
-                body = response.getBodyAsFile() as any as { [key: string]: number; };
-            } else {
-                body = ObjectSerializer.deserialize(
-                    ObjectSerializer.parse(response.body, contentType),
-                    "{ [key: string]: number; }", "int32"
-                ) as { [key: string]: number; };
-            }
+            const body: { [key: string]: number; } = ObjectSerializer.deserialize(
+                ObjectSerializer.parse(await response.body.text(), contentType),
+                "{ [key: string]: number; }", "int32"
+            ) as { [key: string]: number; };
             return body;
         }
 
@@ -238,18 +228,13 @@ export class StoreApiResponseProcessor {
      * @params response Response returned by the server for a request to getOrderById
      * @throws ApiException if the response code was not in [200, 299]
      */
-    public getOrderById(response: ResponseContext):  Order  {      
+     public async getOrderById(response: ResponseContext): Promise<Order > {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
-            let body: Order;
-            if ("Order" as string === "HttpFile" as string) {
-                body = response.getBodyAsFile() as any as Order;
-            } else {
-                body = ObjectSerializer.deserialize(
-                    ObjectSerializer.parse(response.body, contentType),
-                    "Order", ""
-                ) as Order;
-            }
+            const body: Order = ObjectSerializer.deserialize(
+                ObjectSerializer.parse(await response.body.text(), contentType),
+                "Order", ""
+            ) as Order;
             return body;
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
@@ -261,15 +246,10 @@ export class StoreApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            let body: Order;
-            if ("Order" as string === "HttpFile" as string) {
-                body = response.getBodyAsFile() as any as Order;
-            } else {
-                body = ObjectSerializer.deserialize(
-                    ObjectSerializer.parse(response.body, contentType),
-                    "Order", ""
-                ) as Order;
-            }
+            const body: Order = ObjectSerializer.deserialize(
+                ObjectSerializer.parse(await response.body.text(), contentType),
+                "Order", ""
+            ) as Order;
             return body;
         }
 
@@ -284,18 +264,13 @@ export class StoreApiResponseProcessor {
      * @params response Response returned by the server for a request to placeOrder
      * @throws ApiException if the response code was not in [200, 299]
      */
-    public placeOrder(response: ResponseContext):  Order  {      
+     public async placeOrder(response: ResponseContext): Promise<Order > {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
-            let body: Order;
-            if ("Order" as string === "HttpFile" as string) {
-                body = response.getBodyAsFile() as any as Order;
-            } else {
-                body = ObjectSerializer.deserialize(
-                    ObjectSerializer.parse(response.body, contentType),
-                    "Order", ""
-                ) as Order;
-            }
+            const body: Order = ObjectSerializer.deserialize(
+                ObjectSerializer.parse(await response.body.text(), contentType),
+                "Order", ""
+            ) as Order;
             return body;
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
@@ -304,15 +279,10 @@ export class StoreApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            let body: Order;
-            if ("Order" as string === "HttpFile" as string) {
-                body = response.getBodyAsFile() as any as Order;
-            } else {
-                body = ObjectSerializer.deserialize(
-                    ObjectSerializer.parse(response.body, contentType),
-                    "Order", ""
-                ) as Order;
-            }
+            const body: Order = ObjectSerializer.deserialize(
+                ObjectSerializer.parse(await response.body.text(), contentType),
+                "Order", ""
+            ) as Order;
             return body;
         }
 

--- a/samples/client/petstore/typescript/builds/default/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript/builds/default/apis/StoreApi.ts
@@ -174,17 +174,19 @@ export class StoreApiResponseProcessor {
      * @throws ApiException if the response code was not in [200, 299]
      */
     public deleteOrder(response: ResponseContext):   void  {      
+        const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<string>(response.httpStatusCode, "Invalid ID supplied");
         }
         if (isCodeInRange("404", response.httpStatusCode)) {
             throw new ApiException<string>(response.httpStatusCode, "Order not found");
         }
-        
+
         // Work around for incorrect api specification in petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-        	return;
+            return;
         }
+
         let body = response.body || "";
     	throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
     }
@@ -197,18 +199,24 @@ export class StoreApiResponseProcessor {
      * @throws ApiException if the response code was not in [200, 299]
      */
     public getInventory(response: ResponseContext):  { [key: string]: number; }  {      
+        const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
-            const jsonBody = JSON.parse(response.body);
-            const body: { [key: string]: number; } = ObjectSerializer.deserialize(jsonBody, "{ [key: string]: number; }", "int32") as { [key: string]: number; };            
+            const body: { [key: string]: number; } = ObjectSerializer.deserialize(
+                ObjectSerializer.parse(response.body, contentType),
+                "{ [key: string]: number; }", "int32"
+            ) as { [key: string]: number; };
             return body;
         }
-        
+
         // Work around for incorrect api specification in petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            const jsonBody = JSON.parse(response.body);
-            const body: { [key: string]: number; } = ObjectSerializer.deserialize(jsonBody, "{ [key: string]: number; }", "int32") as { [key: string]: number; };            
-			return body;        		
+            const body: { [key: string]: number; } = ObjectSerializer.deserialize(
+                ObjectSerializer.parse(response.body, contentType),
+                "{ [key: string]: number; }", "int32"
+            ) as { [key: string]: number; };
+            return body;
         }
+
         let body = response.body || "";
     	throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
     }
@@ -221,9 +229,12 @@ export class StoreApiResponseProcessor {
      * @throws ApiException if the response code was not in [200, 299]
      */
     public getOrderById(response: ResponseContext):  Order  {      
+        const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
-            const jsonBody = JSON.parse(response.body);
-            const body: Order = ObjectSerializer.deserialize(jsonBody, "Order", "") as Order;            
+            const body: Order = ObjectSerializer.deserialize(
+                ObjectSerializer.parse(response.body, contentType),
+                "Order", ""
+            ) as Order;
             return body;
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
@@ -232,13 +243,16 @@ export class StoreApiResponseProcessor {
         if (isCodeInRange("404", response.httpStatusCode)) {
             throw new ApiException<string>(response.httpStatusCode, "Order not found");
         }
-        
+
         // Work around for incorrect api specification in petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            const jsonBody = JSON.parse(response.body);
-            const body: Order = ObjectSerializer.deserialize(jsonBody, "Order", "") as Order;            
-			return body;        		
+            const body: Order = ObjectSerializer.deserialize(
+                ObjectSerializer.parse(response.body, contentType),
+                "Order", ""
+            ) as Order;
+            return body;
         }
+
         let body = response.body || "";
     	throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
     }
@@ -251,21 +265,27 @@ export class StoreApiResponseProcessor {
      * @throws ApiException if the response code was not in [200, 299]
      */
     public placeOrder(response: ResponseContext):  Order  {      
+        const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
-            const jsonBody = JSON.parse(response.body);
-            const body: Order = ObjectSerializer.deserialize(jsonBody, "Order", "") as Order;            
+            const body: Order = ObjectSerializer.deserialize(
+                ObjectSerializer.parse(response.body, contentType),
+                "Order", ""
+            ) as Order;
             return body;
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<string>(response.httpStatusCode, "Invalid Order");
         }
-        
+
         // Work around for incorrect api specification in petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            const jsonBody = JSON.parse(response.body);
-            const body: Order = ObjectSerializer.deserialize(jsonBody, "Order", "") as Order;            
-			return body;        		
+            const body: Order = ObjectSerializer.deserialize(
+                ObjectSerializer.parse(response.body, contentType),
+                "Order", ""
+            ) as Order;
+            return body;
         }
+
         let body = response.body || "";
     	throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
     }

--- a/samples/client/petstore/typescript/builds/default/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript/builds/default/apis/StoreApi.ts
@@ -147,7 +147,8 @@ export class StoreApiRequestFactory extends BaseAPIRequestFactory {
 
 
 		// Body Params
-        requestContext.setHeaderParam("Content-Type", "application/json");
+        const contentType = ObjectSerializer.getPreferredMediaType([]);
+        requestContext.setHeaderParam("Content-Type", contentType);
 		// TODO: Should this be handled by ObjectSerializer? imo yes => confidential information included in local object should not be sent
         const needsSerialization = (<any>"Order" !== "string") || requestContext.getHeaders()['Content-Type'] === 'application/json';
         const serializedBody = needsSerialization ? JSON.stringify(body || {}) : (body || "").toString(); // TODO: `toString` call is unnecessary

--- a/samples/client/petstore/typescript/builds/default/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript/builds/default/apis/StoreApi.ts
@@ -182,7 +182,7 @@ export class StoreApiResponseProcessor {
             throw new ApiException<string>(response.httpStatusCode, "Order not found");
         }
 
-        // Work around for incorrect api specification in petstore.yaml
+        // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
             return;
         }
@@ -201,19 +201,29 @@ export class StoreApiResponseProcessor {
     public getInventory(response: ResponseContext):  { [key: string]: number; }  {      
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
-            const body: { [key: string]: number; } = ObjectSerializer.deserialize(
-                ObjectSerializer.parse(response.body, contentType),
-                "{ [key: string]: number; }", "int32"
-            ) as { [key: string]: number; };
+            let body: { [key: string]: number; };
+            if ("{ [key: string]: number; }" as string === "HttpFile" as string) {
+                body = response.getBodyAsFile() as any as { [key: string]: number; };
+            } else {
+                body = ObjectSerializer.deserialize(
+                    ObjectSerializer.parse(response.body, contentType),
+                    "{ [key: string]: number; }", "int32"
+                ) as { [key: string]: number; };
+            }
             return body;
         }
 
-        // Work around for incorrect api specification in petstore.yaml
+        // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            const body: { [key: string]: number; } = ObjectSerializer.deserialize(
-                ObjectSerializer.parse(response.body, contentType),
-                "{ [key: string]: number; }", "int32"
-            ) as { [key: string]: number; };
+            let body: { [key: string]: number; };
+            if ("{ [key: string]: number; }" as string === "HttpFile" as string) {
+                body = response.getBodyAsFile() as any as { [key: string]: number; };
+            } else {
+                body = ObjectSerializer.deserialize(
+                    ObjectSerializer.parse(response.body, contentType),
+                    "{ [key: string]: number; }", "int32"
+                ) as { [key: string]: number; };
+            }
             return body;
         }
 
@@ -231,10 +241,15 @@ export class StoreApiResponseProcessor {
     public getOrderById(response: ResponseContext):  Order  {      
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
-            const body: Order = ObjectSerializer.deserialize(
-                ObjectSerializer.parse(response.body, contentType),
-                "Order", ""
-            ) as Order;
+            let body: Order;
+            if ("Order" as string === "HttpFile" as string) {
+                body = response.getBodyAsFile() as any as Order;
+            } else {
+                body = ObjectSerializer.deserialize(
+                    ObjectSerializer.parse(response.body, contentType),
+                    "Order", ""
+                ) as Order;
+            }
             return body;
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
@@ -244,12 +259,17 @@ export class StoreApiResponseProcessor {
             throw new ApiException<string>(response.httpStatusCode, "Order not found");
         }
 
-        // Work around for incorrect api specification in petstore.yaml
+        // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            const body: Order = ObjectSerializer.deserialize(
-                ObjectSerializer.parse(response.body, contentType),
-                "Order", ""
-            ) as Order;
+            let body: Order;
+            if ("Order" as string === "HttpFile" as string) {
+                body = response.getBodyAsFile() as any as Order;
+            } else {
+                body = ObjectSerializer.deserialize(
+                    ObjectSerializer.parse(response.body, contentType),
+                    "Order", ""
+                ) as Order;
+            }
             return body;
         }
 
@@ -267,22 +287,32 @@ export class StoreApiResponseProcessor {
     public placeOrder(response: ResponseContext):  Order  {      
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
-            const body: Order = ObjectSerializer.deserialize(
-                ObjectSerializer.parse(response.body, contentType),
-                "Order", ""
-            ) as Order;
+            let body: Order;
+            if ("Order" as string === "HttpFile" as string) {
+                body = response.getBodyAsFile() as any as Order;
+            } else {
+                body = ObjectSerializer.deserialize(
+                    ObjectSerializer.parse(response.body, contentType),
+                    "Order", ""
+                ) as Order;
+            }
             return body;
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<string>(response.httpStatusCode, "Invalid Order");
         }
 
-        // Work around for incorrect api specification in petstore.yaml
+        // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            const body: Order = ObjectSerializer.deserialize(
-                ObjectSerializer.parse(response.body, contentType),
-                "Order", ""
-            ) as Order;
+            let body: Order;
+            if ("Order" as string === "HttpFile" as string) {
+                body = response.getBodyAsFile() as any as Order;
+            } else {
+                body = ObjectSerializer.deserialize(
+                    ObjectSerializer.parse(response.body, contentType),
+                    "Order", ""
+                ) as Order;
+            }
             return body;
         }
 

--- a/samples/client/petstore/typescript/builds/default/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript/builds/default/apis/StoreApi.ts
@@ -34,7 +34,7 @@ export class StoreApiRequestFactory extends BaseAPIRequestFactory {
 
 		// Make Request Context
     	const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.DELETE);
-        requestContext.setHeaderParam("Accept", "application/json")
+        requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
 	
@@ -62,7 +62,7 @@ export class StoreApiRequestFactory extends BaseAPIRequestFactory {
 
 		// Make Request Context
     	const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
-        requestContext.setHeaderParam("Accept", "application/json")
+        requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
 	
@@ -103,7 +103,7 @@ export class StoreApiRequestFactory extends BaseAPIRequestFactory {
 
 		// Make Request Context
     	const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
-        requestContext.setHeaderParam("Accept", "application/json")
+        requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
 	
@@ -137,7 +137,7 @@ export class StoreApiRequestFactory extends BaseAPIRequestFactory {
 
 		// Make Request Context
     	const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
-        requestContext.setHeaderParam("Accept", "application/json")
+        requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
 	

--- a/samples/client/petstore/typescript/builds/default/apis/UserApi.ts
+++ b/samples/client/petstore/typescript/builds/default/apis/UserApi.ts
@@ -43,7 +43,8 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
 
 
 		// Body Params
-        requestContext.setHeaderParam("Content-Type", "application/json");
+        const contentType = ObjectSerializer.getPreferredMediaType([]);
+        requestContext.setHeaderParam("Content-Type", contentType);
 		// TODO: Should this be handled by ObjectSerializer? imo yes => confidential information included in local object should not be sent
         const needsSerialization = (<any>"User" !== "string") || requestContext.getHeaders()['Content-Type'] === 'application/json';
         const serializedBody = needsSerialization ? JSON.stringify(body || {}) : (body || "").toString(); // TODO: `toString` call is unnecessary
@@ -82,7 +83,8 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
 
 
 		// Body Params
-        requestContext.setHeaderParam("Content-Type", "application/json");
+        const contentType = ObjectSerializer.getPreferredMediaType([]);
+        requestContext.setHeaderParam("Content-Type", contentType);
 		// TODO: Should this be handled by ObjectSerializer? imo yes => confidential information included in local object should not be sent
         const needsSerialization = (<any>"Array&lt;User&gt;" !== "string") || requestContext.getHeaders()['Content-Type'] === 'application/json';
         const serializedBody = needsSerialization ? JSON.stringify(body || {}) : (body || "").toString(); // TODO: `toString` call is unnecessary
@@ -121,7 +123,8 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
 
 
 		// Body Params
-        requestContext.setHeaderParam("Content-Type", "application/json");
+        const contentType = ObjectSerializer.getPreferredMediaType([]);
+        requestContext.setHeaderParam("Content-Type", contentType);
 		// TODO: Should this be handled by ObjectSerializer? imo yes => confidential information included in local object should not be sent
         const needsSerialization = (<any>"Array&lt;User&gt;" !== "string") || requestContext.getHeaders()['Content-Type'] === 'application/json';
         const serializedBody = needsSerialization ? JSON.stringify(body || {}) : (body || "").toString(); // TODO: `toString` call is unnecessary
@@ -314,7 +317,8 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
 
 
 		// Body Params
-        requestContext.setHeaderParam("Content-Type", "application/json");
+        const contentType = ObjectSerializer.getPreferredMediaType([]);
+        requestContext.setHeaderParam("Content-Type", contentType);
 		// TODO: Should this be handled by ObjectSerializer? imo yes => confidential information included in local object should not be sent
         const needsSerialization = (<any>"User" !== "string") || requestContext.getHeaders()['Content-Type'] === 'application/json';
         const serializedBody = needsSerialization ? JSON.stringify(body || {}) : (body || "").toString(); // TODO: `toString` call is unnecessary

--- a/samples/client/petstore/typescript/builds/default/apis/UserApi.ts
+++ b/samples/client/petstore/typescript/builds/default/apis/UserApi.ts
@@ -45,9 +45,10 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
 		// Body Params
         const contentType = ObjectSerializer.getPreferredMediaType([]);
         requestContext.setHeaderParam("Content-Type", contentType);
-		// TODO: Should this be handled by ObjectSerializer? imo yes => confidential information included in local object should not be sent
-        const needsSerialization = (<any>"User" !== "string") || requestContext.getHeaders()['Content-Type'] === 'application/json';
-        const serializedBody = needsSerialization ? JSON.stringify(body || {}) : (body || "").toString(); // TODO: `toString` call is unnecessary
+        const serializedBody = ObjectSerializer.stringify(
+            ObjectSerializer.serialize(body, "User", ""),
+            contentType
+        );
         requestContext.setBody(serializedBody);
 		
     	// Apply auth methods
@@ -85,9 +86,10 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
 		// Body Params
         const contentType = ObjectSerializer.getPreferredMediaType([]);
         requestContext.setHeaderParam("Content-Type", contentType);
-		// TODO: Should this be handled by ObjectSerializer? imo yes => confidential information included in local object should not be sent
-        const needsSerialization = (<any>"Array&lt;User&gt;" !== "string") || requestContext.getHeaders()['Content-Type'] === 'application/json';
-        const serializedBody = needsSerialization ? JSON.stringify(body || {}) : (body || "").toString(); // TODO: `toString` call is unnecessary
+        const serializedBody = ObjectSerializer.stringify(
+            ObjectSerializer.serialize(body, "Array<User>", ""),
+            contentType
+        );
         requestContext.setBody(serializedBody);
 		
     	// Apply auth methods
@@ -125,9 +127,10 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
 		// Body Params
         const contentType = ObjectSerializer.getPreferredMediaType([]);
         requestContext.setHeaderParam("Content-Type", contentType);
-		// TODO: Should this be handled by ObjectSerializer? imo yes => confidential information included in local object should not be sent
-        const needsSerialization = (<any>"Array&lt;User&gt;" !== "string") || requestContext.getHeaders()['Content-Type'] === 'application/json';
-        const serializedBody = needsSerialization ? JSON.stringify(body || {}) : (body || "").toString(); // TODO: `toString` call is unnecessary
+        const serializedBody = ObjectSerializer.stringify(
+            ObjectSerializer.serialize(body, "Array<User>", ""),
+            contentType
+        );
         requestContext.setBody(serializedBody);
 		
     	// Apply auth methods
@@ -319,9 +322,10 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
 		// Body Params
         const contentType = ObjectSerializer.getPreferredMediaType([]);
         requestContext.setHeaderParam("Content-Type", contentType);
-		// TODO: Should this be handled by ObjectSerializer? imo yes => confidential information included in local object should not be sent
-        const needsSerialization = (<any>"User" !== "string") || requestContext.getHeaders()['Content-Type'] === 'application/json';
-        const serializedBody = needsSerialization ? JSON.stringify(body || {}) : (body || "").toString(); // TODO: `toString` call is unnecessary
+        const serializedBody = ObjectSerializer.stringify(
+            ObjectSerializer.serialize(body, "User", ""),
+            contentType
+        );
         requestContext.setBody(serializedBody);
 		
     	// Apply auth methods

--- a/samples/client/petstore/typescript/builds/default/apis/UserApi.ts
+++ b/samples/client/petstore/typescript/builds/default/apis/UserApi.ts
@@ -346,7 +346,7 @@ export class UserApiResponseProcessor {
      * @params response Response returned by the server for a request to createUser
      * @throws ApiException if the response code was not in [200, 299]
      */
-    public createUser(response: ResponseContext):   void  {      
+     public async createUser(response: ResponseContext): Promise< void> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("0", response.httpStatusCode)) {
             throw new ApiException<string>(response.httpStatusCode, "successful operation");
@@ -368,7 +368,7 @@ export class UserApiResponseProcessor {
      * @params response Response returned by the server for a request to createUsersWithArrayInput
      * @throws ApiException if the response code was not in [200, 299]
      */
-    public createUsersWithArrayInput(response: ResponseContext):   void  {      
+     public async createUsersWithArrayInput(response: ResponseContext): Promise< void> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("0", response.httpStatusCode)) {
             throw new ApiException<string>(response.httpStatusCode, "successful operation");
@@ -390,7 +390,7 @@ export class UserApiResponseProcessor {
      * @params response Response returned by the server for a request to createUsersWithListInput
      * @throws ApiException if the response code was not in [200, 299]
      */
-    public createUsersWithListInput(response: ResponseContext):   void  {      
+     public async createUsersWithListInput(response: ResponseContext): Promise< void> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("0", response.httpStatusCode)) {
             throw new ApiException<string>(response.httpStatusCode, "successful operation");
@@ -412,7 +412,7 @@ export class UserApiResponseProcessor {
      * @params response Response returned by the server for a request to deleteUser
      * @throws ApiException if the response code was not in [200, 299]
      */
-    public deleteUser(response: ResponseContext):   void  {      
+     public async deleteUser(response: ResponseContext): Promise< void> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<string>(response.httpStatusCode, "Invalid username supplied");
@@ -437,18 +437,13 @@ export class UserApiResponseProcessor {
      * @params response Response returned by the server for a request to getUserByName
      * @throws ApiException if the response code was not in [200, 299]
      */
-    public getUserByName(response: ResponseContext):  User  {      
+     public async getUserByName(response: ResponseContext): Promise<User > {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
-            let body: User;
-            if ("User" as string === "HttpFile" as string) {
-                body = response.getBodyAsFile() as any as User;
-            } else {
-                body = ObjectSerializer.deserialize(
-                    ObjectSerializer.parse(response.body, contentType),
-                    "User", ""
-                ) as User;
-            }
+            const body: User = ObjectSerializer.deserialize(
+                ObjectSerializer.parse(await response.body.text(), contentType),
+                "User", ""
+            ) as User;
             return body;
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
@@ -460,15 +455,10 @@ export class UserApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            let body: User;
-            if ("User" as string === "HttpFile" as string) {
-                body = response.getBodyAsFile() as any as User;
-            } else {
-                body = ObjectSerializer.deserialize(
-                    ObjectSerializer.parse(response.body, contentType),
-                    "User", ""
-                ) as User;
-            }
+            const body: User = ObjectSerializer.deserialize(
+                ObjectSerializer.parse(await response.body.text(), contentType),
+                "User", ""
+            ) as User;
             return body;
         }
 
@@ -483,18 +473,13 @@ export class UserApiResponseProcessor {
      * @params response Response returned by the server for a request to loginUser
      * @throws ApiException if the response code was not in [200, 299]
      */
-    public loginUser(response: ResponseContext):  string  {      
+     public async loginUser(response: ResponseContext): Promise<string > {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
-            let body: string;
-            if ("string" as string === "HttpFile" as string) {
-                body = response.getBodyAsFile() as any as string;
-            } else {
-                body = ObjectSerializer.deserialize(
-                    ObjectSerializer.parse(response.body, contentType),
-                    "string", ""
-                ) as string;
-            }
+            const body: string = ObjectSerializer.deserialize(
+                ObjectSerializer.parse(await response.body.text(), contentType),
+                "string", ""
+            ) as string;
             return body;
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
@@ -503,15 +488,10 @@ export class UserApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            let body: string;
-            if ("string" as string === "HttpFile" as string) {
-                body = response.getBodyAsFile() as any as string;
-            } else {
-                body = ObjectSerializer.deserialize(
-                    ObjectSerializer.parse(response.body, contentType),
-                    "string", ""
-                ) as string;
-            }
+            const body: string = ObjectSerializer.deserialize(
+                ObjectSerializer.parse(await response.body.text(), contentType),
+                "string", ""
+            ) as string;
             return body;
         }
 
@@ -526,7 +506,7 @@ export class UserApiResponseProcessor {
      * @params response Response returned by the server for a request to logoutUser
      * @throws ApiException if the response code was not in [200, 299]
      */
-    public logoutUser(response: ResponseContext):   void  {      
+     public async logoutUser(response: ResponseContext): Promise< void> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("0", response.httpStatusCode)) {
             throw new ApiException<string>(response.httpStatusCode, "successful operation");
@@ -548,7 +528,7 @@ export class UserApiResponseProcessor {
      * @params response Response returned by the server for a request to updateUser
      * @throws ApiException if the response code was not in [200, 299]
      */
-    public updateUser(response: ResponseContext):   void  {      
+     public async updateUser(response: ResponseContext): Promise< void> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<string>(response.httpStatusCode, "Invalid user supplied");

--- a/samples/client/petstore/typescript/builds/default/apis/UserApi.ts
+++ b/samples/client/petstore/typescript/builds/default/apis/UserApi.ts
@@ -347,14 +347,16 @@ export class UserApiResponseProcessor {
      * @throws ApiException if the response code was not in [200, 299]
      */
     public createUser(response: ResponseContext):   void  {      
+        const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("0", response.httpStatusCode)) {
             throw new ApiException<string>(response.httpStatusCode, "successful operation");
         }
-        
+
         // Work around for incorrect api specification in petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-        	return;
+            return;
         }
+
         let body = response.body || "";
     	throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
     }
@@ -367,14 +369,16 @@ export class UserApiResponseProcessor {
      * @throws ApiException if the response code was not in [200, 299]
      */
     public createUsersWithArrayInput(response: ResponseContext):   void  {      
+        const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("0", response.httpStatusCode)) {
             throw new ApiException<string>(response.httpStatusCode, "successful operation");
         }
-        
+
         // Work around for incorrect api specification in petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-        	return;
+            return;
         }
+
         let body = response.body || "";
     	throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
     }
@@ -387,14 +391,16 @@ export class UserApiResponseProcessor {
      * @throws ApiException if the response code was not in [200, 299]
      */
     public createUsersWithListInput(response: ResponseContext):   void  {      
+        const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("0", response.httpStatusCode)) {
             throw new ApiException<string>(response.httpStatusCode, "successful operation");
         }
-        
+
         // Work around for incorrect api specification in petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-        	return;
+            return;
         }
+
         let body = response.body || "";
     	throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
     }
@@ -407,17 +413,19 @@ export class UserApiResponseProcessor {
      * @throws ApiException if the response code was not in [200, 299]
      */
     public deleteUser(response: ResponseContext):   void  {      
+        const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<string>(response.httpStatusCode, "Invalid username supplied");
         }
         if (isCodeInRange("404", response.httpStatusCode)) {
             throw new ApiException<string>(response.httpStatusCode, "User not found");
         }
-        
+
         // Work around for incorrect api specification in petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-        	return;
+            return;
         }
+
         let body = response.body || "";
     	throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
     }
@@ -430,9 +438,12 @@ export class UserApiResponseProcessor {
      * @throws ApiException if the response code was not in [200, 299]
      */
     public getUserByName(response: ResponseContext):  User  {      
+        const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
-            const jsonBody = JSON.parse(response.body);
-            const body: User = ObjectSerializer.deserialize(jsonBody, "User", "") as User;            
+            const body: User = ObjectSerializer.deserialize(
+                ObjectSerializer.parse(response.body, contentType),
+                "User", ""
+            ) as User;
             return body;
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
@@ -441,13 +452,16 @@ export class UserApiResponseProcessor {
         if (isCodeInRange("404", response.httpStatusCode)) {
             throw new ApiException<string>(response.httpStatusCode, "User not found");
         }
-        
+
         // Work around for incorrect api specification in petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            const jsonBody = JSON.parse(response.body);
-            const body: User = ObjectSerializer.deserialize(jsonBody, "User", "") as User;            
-			return body;        		
+            const body: User = ObjectSerializer.deserialize(
+                ObjectSerializer.parse(response.body, contentType),
+                "User", ""
+            ) as User;
+            return body;
         }
+
         let body = response.body || "";
     	throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
     }
@@ -460,21 +474,27 @@ export class UserApiResponseProcessor {
      * @throws ApiException if the response code was not in [200, 299]
      */
     public loginUser(response: ResponseContext):  string  {      
+        const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
-            const jsonBody = JSON.parse(response.body);
-            const body: string = ObjectSerializer.deserialize(jsonBody, "string", "") as string;            
+            const body: string = ObjectSerializer.deserialize(
+                ObjectSerializer.parse(response.body, contentType),
+                "string", ""
+            ) as string;
             return body;
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<string>(response.httpStatusCode, "Invalid username/password supplied");
         }
-        
+
         // Work around for incorrect api specification in petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            const jsonBody = JSON.parse(response.body);
-            const body: string = ObjectSerializer.deserialize(jsonBody, "string", "") as string;            
-			return body;        		
+            const body: string = ObjectSerializer.deserialize(
+                ObjectSerializer.parse(response.body, contentType),
+                "string", ""
+            ) as string;
+            return body;
         }
+
         let body = response.body || "";
     	throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
     }
@@ -487,14 +507,16 @@ export class UserApiResponseProcessor {
      * @throws ApiException if the response code was not in [200, 299]
      */
     public logoutUser(response: ResponseContext):   void  {      
+        const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("0", response.httpStatusCode)) {
             throw new ApiException<string>(response.httpStatusCode, "successful operation");
         }
-        
+
         // Work around for incorrect api specification in petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-        	return;
+            return;
         }
+
         let body = response.body || "";
     	throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
     }
@@ -507,17 +529,19 @@ export class UserApiResponseProcessor {
      * @throws ApiException if the response code was not in [200, 299]
      */
     public updateUser(response: ResponseContext):   void  {      
+        const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<string>(response.httpStatusCode, "Invalid user supplied");
         }
         if (isCodeInRange("404", response.httpStatusCode)) {
             throw new ApiException<string>(response.httpStatusCode, "User not found");
         }
-        
+
         // Work around for incorrect api specification in petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-        	return;
+            return;
         }
+
         let body = response.body || "";
     	throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
     }

--- a/samples/client/petstore/typescript/builds/default/apis/UserApi.ts
+++ b/samples/client/petstore/typescript/builds/default/apis/UserApi.ts
@@ -33,7 +33,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
 
 		// Make Request Context
     	const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
-        requestContext.setHeaderParam("Accept", "application/json")
+        requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
 	
@@ -72,7 +72,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
 
 		// Make Request Context
     	const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
-        requestContext.setHeaderParam("Accept", "application/json")
+        requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
 	
@@ -111,7 +111,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
 
 		// Make Request Context
     	const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
-        requestContext.setHeaderParam("Accept", "application/json")
+        requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
 	
@@ -152,7 +152,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
 
 		// Make Request Context
     	const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.DELETE);
-        requestContext.setHeaderParam("Accept", "application/json")
+        requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
 	
@@ -187,7 +187,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
 
 		// Make Request Context
     	const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
-        requestContext.setHeaderParam("Accept", "application/json")
+        requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
 	
@@ -228,7 +228,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
 
 		// Make Request Context
     	const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
-        requestContext.setHeaderParam("Accept", "application/json")
+        requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
         if (username !== undefined) {
@@ -261,7 +261,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
 
 		// Make Request Context
     	const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
-        requestContext.setHeaderParam("Accept", "application/json")
+        requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
 	
@@ -304,7 +304,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
 
 		// Make Request Context
     	const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.PUT);
-        requestContext.setHeaderParam("Accept", "application/json")
+        requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
 	

--- a/samples/client/petstore/typescript/builds/default/apis/UserApi.ts
+++ b/samples/client/petstore/typescript/builds/default/apis/UserApi.ts
@@ -352,7 +352,7 @@ export class UserApiResponseProcessor {
             throw new ApiException<string>(response.httpStatusCode, "successful operation");
         }
 
-        // Work around for incorrect api specification in petstore.yaml
+        // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
             return;
         }
@@ -374,7 +374,7 @@ export class UserApiResponseProcessor {
             throw new ApiException<string>(response.httpStatusCode, "successful operation");
         }
 
-        // Work around for incorrect api specification in petstore.yaml
+        // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
             return;
         }
@@ -396,7 +396,7 @@ export class UserApiResponseProcessor {
             throw new ApiException<string>(response.httpStatusCode, "successful operation");
         }
 
-        // Work around for incorrect api specification in petstore.yaml
+        // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
             return;
         }
@@ -421,7 +421,7 @@ export class UserApiResponseProcessor {
             throw new ApiException<string>(response.httpStatusCode, "User not found");
         }
 
-        // Work around for incorrect api specification in petstore.yaml
+        // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
             return;
         }
@@ -440,10 +440,15 @@ export class UserApiResponseProcessor {
     public getUserByName(response: ResponseContext):  User  {      
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
-            const body: User = ObjectSerializer.deserialize(
-                ObjectSerializer.parse(response.body, contentType),
-                "User", ""
-            ) as User;
+            let body: User;
+            if ("User" as string === "HttpFile" as string) {
+                body = response.getBodyAsFile() as any as User;
+            } else {
+                body = ObjectSerializer.deserialize(
+                    ObjectSerializer.parse(response.body, contentType),
+                    "User", ""
+                ) as User;
+            }
             return body;
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
@@ -453,12 +458,17 @@ export class UserApiResponseProcessor {
             throw new ApiException<string>(response.httpStatusCode, "User not found");
         }
 
-        // Work around for incorrect api specification in petstore.yaml
+        // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            const body: User = ObjectSerializer.deserialize(
-                ObjectSerializer.parse(response.body, contentType),
-                "User", ""
-            ) as User;
+            let body: User;
+            if ("User" as string === "HttpFile" as string) {
+                body = response.getBodyAsFile() as any as User;
+            } else {
+                body = ObjectSerializer.deserialize(
+                    ObjectSerializer.parse(response.body, contentType),
+                    "User", ""
+                ) as User;
+            }
             return body;
         }
 
@@ -476,22 +486,32 @@ export class UserApiResponseProcessor {
     public loginUser(response: ResponseContext):  string  {      
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
-            const body: string = ObjectSerializer.deserialize(
-                ObjectSerializer.parse(response.body, contentType),
-                "string", ""
-            ) as string;
+            let body: string;
+            if ("string" as string === "HttpFile" as string) {
+                body = response.getBodyAsFile() as any as string;
+            } else {
+                body = ObjectSerializer.deserialize(
+                    ObjectSerializer.parse(response.body, contentType),
+                    "string", ""
+                ) as string;
+            }
             return body;
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<string>(response.httpStatusCode, "Invalid username/password supplied");
         }
 
-        // Work around for incorrect api specification in petstore.yaml
+        // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            const body: string = ObjectSerializer.deserialize(
-                ObjectSerializer.parse(response.body, contentType),
-                "string", ""
-            ) as string;
+            let body: string;
+            if ("string" as string === "HttpFile" as string) {
+                body = response.getBodyAsFile() as any as string;
+            } else {
+                body = ObjectSerializer.deserialize(
+                    ObjectSerializer.parse(response.body, contentType),
+                    "string", ""
+                ) as string;
+            }
             return body;
         }
 
@@ -512,7 +532,7 @@ export class UserApiResponseProcessor {
             throw new ApiException<string>(response.httpStatusCode, "successful operation");
         }
 
-        // Work around for incorrect api specification in petstore.yaml
+        // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
             return;
         }
@@ -537,7 +557,7 @@ export class UserApiResponseProcessor {
             throw new ApiException<string>(response.httpStatusCode, "User not found");
         }
 
-        // Work around for incorrect api specification in petstore.yaml
+        // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
             return;
         }

--- a/samples/client/petstore/typescript/builds/default/http/http.ts
+++ b/samples/client/petstore/typescript/builds/default/http/http.ts
@@ -124,11 +124,49 @@ export class RequestContext {
 }
 
 export class ResponseContext {
+    public constructor(
+        public httpStatusCode: number,
+        public headers: { [key: string]: string },
+        public body: string
+    ) {}
 
-    public constructor(public httpStatusCode: number, 
-        public headers: { [key: string]: string }, public body: string) {
+    /**
+     * Parse header value in the form `value; param1="value1"`
+     *
+     * E.g. for Content-Type or Content-Disposition
+     * Parameter names are converted to lower case
+     * The first parameter is returned with the key `""`
+     */
+    public getParsedHeader(headerName: string): { [parameter: string]: string } {
+        const result: { [parameter: string]: string } = {};
+        if (!this.headers[headerName]) {
+            return result;
+        }
+
+        const parameters = this.headers[headerName].split(";");
+        for (const parameter of parameters) {
+            let [key, value] = parameter.split("=", 2);
+            key = key.toLowerCase().trim();
+            if (value === undefined) {
+                result[""] = key;
+            } else {
+                value = value.trim();
+                if (value.startsWith('"') && value.endsWith('"')) {
+                    value = value.substring(1, value.length - 1);
+                }
+                result[key] = value;
+            }
+        }
+        return result;
     }
-    
+
+    public getBodyAsFile(): HttpFile {
+        const contentDisposition = this.getParsedHeader("content-disposition");
+        return {
+            data: new Buffer(this.body),
+            name: contentDisposition["filename"] || ""
+        };
+    }
 }
 
 export interface HttpLibrary {

--- a/samples/client/petstore/typescript/builds/default/http/isomorphic-fetch.ts
+++ b/samples/client/petstore/typescript/builds/default/http/isomorphic-fetch.ts
@@ -22,9 +22,11 @@ export class IsomorphicFetchHttpLibrary implements HttpLibrary {
               headers[name] = value;
             });
 
-            return resp.text().then((body: string) => {
-                return new ResponseContext(resp.status, headers, body)
-            });
+            const body = {
+              text: () => resp.text(),
+              binary: () => resp.buffer()
+            };
+            return new ResponseContext(resp.status, headers, body);
         });
 
         return from<Promise<ResponseContext>>(resultPromise);

--- a/samples/client/petstore/typescript/builds/default/http/isomorphic-fetch.ts
+++ b/samples/client/petstore/typescript/builds/default/http/isomorphic-fetch.ts
@@ -10,24 +10,23 @@ export class IsomorphicFetchHttpLibrary implements HttpLibrary {
     public send(request: RequestContext): Observable<ResponseContext> {
         let method = request.getHttpMethod().toString();
         let body = request.getBody();
-        
+
         const resultPromise = fetch(request.getUrl(), {
             method: method,
             body: body as any,
             headers: request.getHeaders(),
             credentials: "same-origin"
         }).then((resp: any) => {
-            // hack
-            let headers = (resp.headers as any)._headers;
-            for (let key in headers) {
-                headers[key] = (headers[key] as Array<string>).join("; ");
-            }
+            const headers: { [name: string]: string } = {};
+            resp.headers.forEach((value: string, name: string) => {
+              headers[name] = value;
+            });
 
             return resp.text().then((body: string) => {
                 return new ResponseContext(resp.status, headers, body)
             });
         });
-        
+
         return from<Promise<ResponseContext>>(resultPromise);
 
     }

--- a/samples/client/petstore/typescript/builds/default/http/isomorphic-fetch.ts
+++ b/samples/client/petstore/typescript/builds/default/http/isomorphic-fetch.ts
@@ -1,9 +1,6 @@
-declare var fetch: any;
-
 import {HttpLibrary, RequestContext, ResponseContext} from './http';
-import 'es6-promise/auto';
 import { from, Observable } from '../rxjsStub';
-import 'isomorphic-fetch';
+import fetch from "node-fetch";
 
 export class IsomorphicFetchHttpLibrary implements HttpLibrary {
 
@@ -15,7 +12,6 @@ export class IsomorphicFetchHttpLibrary implements HttpLibrary {
             method: method,
             body: body as any,
             headers: request.getHeaders(),
-            credentials: "same-origin"
         }).then((resp: any) => {
             const headers: { [name: string]: string } = {};
             resp.headers.forEach((value: string, name: string) => {

--- a/samples/client/petstore/typescript/builds/default/index.ts
+++ b/samples/client/petstore/typescript/builds/default/index.ts
@@ -1,3 +1,5 @@
+import 'es6-promise/auto';
+
 export * from './http/http';
 export * from './auth/auth';
 export * from './models/all';

--- a/samples/client/petstore/typescript/builds/default/models/ObjectSerializer.ts
+++ b/samples/client/petstore/typescript/builds/default/models/ObjectSerializer.ts
@@ -170,7 +170,10 @@ export class ObjectSerializer {
      * We currently do not handle any media types attributes, i.e. anything
      * after a semicolon. All content is assumed to be UTF-8 compatible.
      */
-    public static normalizeMediaType(mediaType: string): string {
+    public static normalizeMediaType(mediaType: string | undefined): string | undefined {
+        if (mediaType === undefined) {
+            return undefined;
+        }
         return mediaType.split(";")[0].trim().toLowerCase();
     }
 
@@ -190,9 +193,9 @@ export class ObjectSerializer {
         let selectedMediaType: string | undefined = undefined;
         let selectedRank: number = -Infinity;
         for (const mediaType of normalMediaTypes) {
-            if (supportedMediaTypes[mediaType] > selectedRank) {
+            if (supportedMediaTypes[mediaType!] > selectedRank) {
                 selectedMediaType = mediaType;
-                selectedRank = supportedMediaTypes[mediaType];
+                selectedRank = supportedMediaTypes[mediaType!];
             }
         }
 
@@ -217,7 +220,11 @@ export class ObjectSerializer {
     /**
      * Parse data from a string according to the given media type
      */
-    public static parse(rawData: string, mediaType: string) {
+    public static parse(rawData: string, mediaType: string | undefined) {
+        if (mediaType === undefined) {
+            throw new Error("Cannot parse content. No Content-Type defined.");
+        }
+
         if (mediaType === "application/json") {
             return JSON.parse(rawData);
         }

--- a/samples/client/petstore/typescript/builds/default/models/ObjectSerializer.ts
+++ b/samples/client/petstore/typescript/builds/default/models/ObjectSerializer.ts
@@ -205,27 +205,23 @@ export class ObjectSerializer {
 
     /**
      * Convert data to a string according the given media type
-     *
-     * TODO: Add support for
-     *    - json
-     *    - binary fallback
-     *    - xml (togglable in generator config)
-     *    - yaml (togglable in generator config)
      */
     public static stringify(data: any, mediaType: string): string {
-        return "";
+        if (mediaType === "application/json") {
+            return JSON.stringify(data);
+        }
+
+        throw new Error("The mediaType " + mediaType + " is not supported by ObjectSerializer.stringify.");
     }
 
     /**
      * Parse data from a string according to the given media type
-     *
-     * TODO: Add support for
-     *    - json
-     *    - binary fallback
-     *    - xml (togglable in generator config)
-     *    - yaml (togglable in generator config)
-     *    - multipart (togglabel in generator config)
      */
     public static parse(rawData: string, mediaType: string) {
+        if (mediaType === "application/json") {
+            return JSON.parse(rawData);
+        }
+
+        throw new Error("The mediaType " + mediaType + " is not supported by ObjectSerializer.parse.");
     }
 }

--- a/samples/client/petstore/typescript/builds/default/models/ObjectSerializer.ts
+++ b/samples/client/petstore/typescript/builds/default/models/ObjectSerializer.ts
@@ -23,6 +23,12 @@ let primitives = [
                     "number",
                     "any"
                  ];
+
+const supportedMediaTypes: { [mediaType: string]: number } = {
+  "application/json": Infinity,
+  "application/octet-stream": 0
+}
+
                  
 let enumsMap: Set<string> = new Set<string>([
 					"OrderStatusEnum",
@@ -155,5 +161,71 @@ export class ObjectSerializer {
             }
             return instance;
         }
+    }
+
+
+    /**
+     * Normalize media type
+     *
+     * We currently do not handle any media types attributes, i.e. anything
+     * after a semicolon. All content is assumed to be UTF-8 compatible.
+     */
+    public static normalizeMediaType(mediaType: string): string {
+        return mediaType.split(";")[0].trim().toLowerCase();
+    }
+
+    /**
+     * From a list of possible media types, choose the one we can handle best.
+     *
+     * The order of the given media types does not have any impact on the choice
+     * made.
+     */
+    public static getPreferredMediaType(mediaTypes: Array<string>): string {
+        /** According to OAS 3 we should default to json */
+        if (!mediaTypes) {
+            return "application/json";
+        }
+
+        const normalMediaTypes = mediaTypes.map(this.normalizeMediaType);
+        let selectedMediaType: string | undefined = undefined;
+        let selectedRank: number = -Infinity;
+        for (const mediaType of normalMediaTypes) {
+            if (supportedMediaTypes[mediaType] > selectedRank) {
+                selectedMediaType = mediaType;
+                selectedRank = supportedMediaTypes[mediaType];
+            }
+        }
+
+        if (selectedMediaType === undefined) {
+            throw new Error("None of the given media types are supported: " + mediaTypes.join(", "));
+        }
+
+        return selectedMediaType!;
+    }
+
+    /**
+     * Convert data to a string according the given media type
+     *
+     * TODO: Add support for
+     *    - json
+     *    - binary fallback
+     *    - xml (togglable in generator config)
+     *    - yaml (togglable in generator config)
+     */
+    public static stringify(data: any, mediaType: string): string {
+        return "";
+    }
+
+    /**
+     * Parse data from a string according to the given media type
+     *
+     * TODO: Add support for
+     *    - json
+     *    - binary fallback
+     *    - xml (togglable in generator config)
+     *    - yaml (togglable in generator config)
+     *    - multipart (togglabel in generator config)
+     */
+    public static parse(rawData: string, mediaType: string) {
     }
 }

--- a/samples/client/petstore/typescript/builds/default/package-lock.json
+++ b/samples/client/petstore/typescript/builds/default/package-lock.json
@@ -4,15 +4,31 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@types/isomorphic-fetch": {
-      "version": "0.0.34",
-      "resolved": "https://registry.npmjs.org/@types/isomorphic-fetch/-/isomorphic-fetch-0.0.34.tgz",
-      "integrity": "sha1-PDSD5gbAQTeEOOlRRk8A5OYHBtY="
-    },
     "@types/node": {
       "version": "12.12.7",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.7.tgz",
       "integrity": "sha512-E6Zn0rffhgd130zbCbAr/JdXfXkoOUFAKNs/rF8qnafSJ8KYaA/j3oz7dcwal+lYjLA7xvdd5J4wdYpCTlP8+w=="
+    },
+    "@types/node-fetch": {
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.7.tgz",
+      "integrity": "sha512-o2WVNf5UhWRkxlf6eq+jMZDu7kjgpgJfl4xVNlvryc95O/6F2ld8ztKX+qu+Rjyet93WAWm5LjeX9H5FGkODvw==",
+      "requires": {
+        "@types/node": "*",
+        "form-data": "^3.0.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
+          "integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
+      }
     },
     "asynckit": {
       "version": "0.4.0",
@@ -37,14 +53,6 @@
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
-    "encoding": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
-      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
-      "requires": {
-        "iconv-lite": "~0.4.13"
-      }
-    },
     "es6-promise": {
       "version": "4.2.5",
       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.5.tgz",
@@ -58,28 +66,6 @@
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.6",
         "mime-types": "^2.1.12"
-      }
-    },
-    "iconv-lite": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "requires": {
-        "safer-buffer": ">= 2.1.2 < 3"
-      }
-    },
-    "is-stream": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
-    },
-    "isomorphic-fetch": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
-      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
-      "requires": {
-        "node-fetch": "^1.0.1",
-        "whatwg-fetch": ">=0.10.0"
       }
     },
     "mime-db": {
@@ -96,13 +82,9 @@
       }
     },
     "node-fetch": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
-      "requires": {
-        "encoding": "^0.1.11",
-        "is-stream": "^1.0.1"
-      }
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
     },
     "querystringify": {
       "version": "2.1.0",
@@ -114,14 +96,9 @@
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
     },
-    "safer-buffer": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
-    },
     "typescript": {
       "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.9.2.tgz",
+      "resolved": false,
       "integrity": "sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==",
       "dev": true
     },
@@ -133,11 +110,6 @@
         "querystringify": "^2.0.0",
         "requires-port": "^1.0.0"
       }
-    },
-    "whatwg-fetch": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
-      "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q=="
     }
   }
 }

--- a/samples/client/petstore/typescript/builds/default/package.json
+++ b/samples/client/petstore/typescript/builds/default/package.json
@@ -17,8 +17,8 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "isomorphic-fetch": "^2.2.1",
-    "@types/isomorphic-fetch": "0.0.34",
+    "node-fetch": "^2.6.0",
+    "@types/node-fetch": "^2.5.7",
     "@types/node": "*",
     "form-data": "^2.5.0",
     "btoa": "^1.2.1",

--- a/samples/client/petstore/typescript/builds/default/tsconfig.json
+++ b/samples/client/petstore/typescript/builds/default/tsconfig.json
@@ -16,7 +16,7 @@
     "sourceMap": true,
     "outDir": "./dist",
     "noLib": false,
-    "lib": [ "es6", "dom" ]
+    "lib": [ "es6" ]
   },
   "exclude": [
   	"dist",

--- a/samples/client/petstore/typescript/builds/jquery/apis/PetApi.ts
+++ b/samples/client/petstore/typescript/builds/jquery/apis/PetApi.ts
@@ -48,9 +48,10 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
             "application/xml"
         ]);
         requestContext.setHeaderParam("Content-Type", contentType);
-		// TODO: Should this be handled by ObjectSerializer? imo yes => confidential information included in local object should not be sent
-        const needsSerialization = (<any>"Pet" !== "string") || requestContext.getHeaders()['Content-Type'] === 'application/json';
-        const serializedBody = needsSerialization ? JSON.stringify(body || {}) : (body || "").toString(); // TODO: `toString` call is unnecessary
+        const serializedBody = ObjectSerializer.stringify(
+            ObjectSerializer.serialize(body, "Pet", ""),
+            contentType
+        );
         requestContext.setBody(serializedBody);
 		
 		let authMethod = null;
@@ -267,9 +268,10 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
             "application/xml"
         ]);
         requestContext.setHeaderParam("Content-Type", contentType);
-		// TODO: Should this be handled by ObjectSerializer? imo yes => confidential information included in local object should not be sent
-        const needsSerialization = (<any>"Pet" !== "string") || requestContext.getHeaders()['Content-Type'] === 'application/json';
-        const serializedBody = needsSerialization ? JSON.stringify(body || {}) : (body || "").toString(); // TODO: `toString` call is unnecessary
+        const serializedBody = ObjectSerializer.stringify(
+            ObjectSerializer.serialize(body, "Pet", ""),
+            contentType
+        );
         requestContext.setBody(serializedBody);
 		
 		let authMethod = null;

--- a/samples/client/petstore/typescript/builds/jquery/apis/PetApi.ts
+++ b/samples/client/petstore/typescript/builds/jquery/apis/PetApi.ts
@@ -406,14 +406,16 @@ export class PetApiResponseProcessor {
      * @throws ApiException if the response code was not in [200, 299]
      */
     public addPet(response: ResponseContext):   void  {      
+        const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("405", response.httpStatusCode)) {
             throw new ApiException<string>(response.httpStatusCode, "Invalid input");
         }
-        
+
         // Work around for incorrect api specification in petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-        	return;
+            return;
         }
+
         let body = response.body || "";
     	throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
     }
@@ -426,14 +428,16 @@ export class PetApiResponseProcessor {
      * @throws ApiException if the response code was not in [200, 299]
      */
     public deletePet(response: ResponseContext):   void  {      
+        const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<string>(response.httpStatusCode, "Invalid pet value");
         }
-        
+
         // Work around for incorrect api specification in petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-        	return;
+            return;
         }
+
         let body = response.body || "";
     	throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
     }
@@ -446,21 +450,27 @@ export class PetApiResponseProcessor {
      * @throws ApiException if the response code was not in [200, 299]
      */
     public findPetsByStatus(response: ResponseContext):  Array<Pet>  {      
+        const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
-            const jsonBody = JSON.parse(response.body);
-            const body: Array<Pet> = ObjectSerializer.deserialize(jsonBody, "Array<Pet>", "") as Array<Pet>;            
+            const body: Array<Pet> = ObjectSerializer.deserialize(
+                ObjectSerializer.parse(response.body, contentType),
+                "Array<Pet>", ""
+            ) as Array<Pet>;
             return body;
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<string>(response.httpStatusCode, "Invalid status value");
         }
-        
+
         // Work around for incorrect api specification in petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            const jsonBody = JSON.parse(response.body);
-            const body: Array<Pet> = ObjectSerializer.deserialize(jsonBody, "Array<Pet>", "") as Array<Pet>;            
-			return body;        		
+            const body: Array<Pet> = ObjectSerializer.deserialize(
+                ObjectSerializer.parse(response.body, contentType),
+                "Array<Pet>", ""
+            ) as Array<Pet>;
+            return body;
         }
+
         let body = response.body || "";
     	throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
     }
@@ -473,21 +483,27 @@ export class PetApiResponseProcessor {
      * @throws ApiException if the response code was not in [200, 299]
      */
     public findPetsByTags(response: ResponseContext):  Array<Pet>  {      
+        const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
-            const jsonBody = JSON.parse(response.body);
-            const body: Array<Pet> = ObjectSerializer.deserialize(jsonBody, "Array<Pet>", "") as Array<Pet>;            
+            const body: Array<Pet> = ObjectSerializer.deserialize(
+                ObjectSerializer.parse(response.body, contentType),
+                "Array<Pet>", ""
+            ) as Array<Pet>;
             return body;
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<string>(response.httpStatusCode, "Invalid tag value");
         }
-        
+
         // Work around for incorrect api specification in petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            const jsonBody = JSON.parse(response.body);
-            const body: Array<Pet> = ObjectSerializer.deserialize(jsonBody, "Array<Pet>", "") as Array<Pet>;            
-			return body;        		
+            const body: Array<Pet> = ObjectSerializer.deserialize(
+                ObjectSerializer.parse(response.body, contentType),
+                "Array<Pet>", ""
+            ) as Array<Pet>;
+            return body;
         }
+
         let body = response.body || "";
     	throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
     }
@@ -500,9 +516,12 @@ export class PetApiResponseProcessor {
      * @throws ApiException if the response code was not in [200, 299]
      */
     public getPetById(response: ResponseContext):  Pet  {      
+        const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
-            const jsonBody = JSON.parse(response.body);
-            const body: Pet = ObjectSerializer.deserialize(jsonBody, "Pet", "") as Pet;            
+            const body: Pet = ObjectSerializer.deserialize(
+                ObjectSerializer.parse(response.body, contentType),
+                "Pet", ""
+            ) as Pet;
             return body;
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
@@ -511,13 +530,16 @@ export class PetApiResponseProcessor {
         if (isCodeInRange("404", response.httpStatusCode)) {
             throw new ApiException<string>(response.httpStatusCode, "Pet not found");
         }
-        
+
         // Work around for incorrect api specification in petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            const jsonBody = JSON.parse(response.body);
-            const body: Pet = ObjectSerializer.deserialize(jsonBody, "Pet", "") as Pet;            
-			return body;        		
+            const body: Pet = ObjectSerializer.deserialize(
+                ObjectSerializer.parse(response.body, contentType),
+                "Pet", ""
+            ) as Pet;
+            return body;
         }
+
         let body = response.body || "";
     	throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
     }
@@ -530,6 +552,7 @@ export class PetApiResponseProcessor {
      * @throws ApiException if the response code was not in [200, 299]
      */
     public updatePet(response: ResponseContext):   void  {      
+        const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<string>(response.httpStatusCode, "Invalid ID supplied");
         }
@@ -539,11 +562,12 @@ export class PetApiResponseProcessor {
         if (isCodeInRange("405", response.httpStatusCode)) {
             throw new ApiException<string>(response.httpStatusCode, "Validation exception");
         }
-        
+
         // Work around for incorrect api specification in petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-        	return;
+            return;
         }
+
         let body = response.body || "";
     	throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
     }
@@ -556,14 +580,16 @@ export class PetApiResponseProcessor {
      * @throws ApiException if the response code was not in [200, 299]
      */
     public updatePetWithForm(response: ResponseContext):   void  {      
+        const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("405", response.httpStatusCode)) {
             throw new ApiException<string>(response.httpStatusCode, "Invalid input");
         }
-        
+
         // Work around for incorrect api specification in petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-        	return;
+            return;
         }
+
         let body = response.body || "";
     	throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
     }
@@ -576,18 +602,24 @@ export class PetApiResponseProcessor {
      * @throws ApiException if the response code was not in [200, 299]
      */
     public uploadFile(response: ResponseContext):  ApiResponse  {      
+        const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
-            const jsonBody = JSON.parse(response.body);
-            const body: ApiResponse = ObjectSerializer.deserialize(jsonBody, "ApiResponse", "") as ApiResponse;            
+            const body: ApiResponse = ObjectSerializer.deserialize(
+                ObjectSerializer.parse(response.body, contentType),
+                "ApiResponse", ""
+            ) as ApiResponse;
             return body;
         }
-        
+
         // Work around for incorrect api specification in petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            const jsonBody = JSON.parse(response.body);
-            const body: ApiResponse = ObjectSerializer.deserialize(jsonBody, "ApiResponse", "") as ApiResponse;            
-			return body;        		
+            const body: ApiResponse = ObjectSerializer.deserialize(
+                ObjectSerializer.parse(response.body, contentType),
+                "ApiResponse", ""
+            ) as ApiResponse;
+            return body;
         }
+
         let body = response.body || "";
     	throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
     }

--- a/samples/client/petstore/typescript/builds/jquery/apis/PetApi.ts
+++ b/samples/client/petstore/typescript/builds/jquery/apis/PetApi.ts
@@ -42,7 +42,12 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
 
 
 		// Body Params
-        requestContext.setHeaderParam("Content-Type", "application/json");
+        const contentType = ObjectSerializer.getPreferredMediaType([
+            "application/json",
+        
+            "application/xml"
+        ]);
+        requestContext.setHeaderParam("Content-Type", contentType);
 		// TODO: Should this be handled by ObjectSerializer? imo yes => confidential information included in local object should not be sent
         const needsSerialization = (<any>"Pet" !== "string") || requestContext.getHeaders()['Content-Type'] === 'application/json';
         const serializedBody = needsSerialization ? JSON.stringify(body || {}) : (body || "").toString(); // TODO: `toString` call is unnecessary
@@ -256,7 +261,12 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
 
 
 		// Body Params
-        requestContext.setHeaderParam("Content-Type", "application/json");
+        const contentType = ObjectSerializer.getPreferredMediaType([
+            "application/json",
+        
+            "application/xml"
+        ]);
+        requestContext.setHeaderParam("Content-Type", contentType);
 		// TODO: Should this be handled by ObjectSerializer? imo yes => confidential information included in local object should not be sent
         const needsSerialization = (<any>"Pet" !== "string") || requestContext.getHeaders()['Content-Type'] === 'application/json';
         const serializedBody = needsSerialization ? JSON.stringify(body || {}) : (body || "").toString(); // TODO: `toString` call is unnecessary

--- a/samples/client/petstore/typescript/builds/jquery/apis/PetApi.ts
+++ b/samples/client/petstore/typescript/builds/jquery/apis/PetApi.ts
@@ -32,7 +32,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
 
 		// Make Request Context
     	const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
-        requestContext.setHeaderParam("Accept", "application/json")
+        requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
 	
@@ -79,7 +79,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
 
 		// Make Request Context
     	const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.DELETE);
-        requestContext.setHeaderParam("Accept", "application/json")
+        requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
 	
@@ -120,7 +120,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
 
 		// Make Request Context
     	const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
-        requestContext.setHeaderParam("Accept", "application/json")
+        requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
         if (status !== undefined) {
@@ -163,7 +163,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
 
 		// Make Request Context
     	const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
-        requestContext.setHeaderParam("Accept", "application/json")
+        requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
         if (tags !== undefined) {
@@ -207,7 +207,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
 
 		// Make Request Context
     	const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
-        requestContext.setHeaderParam("Accept", "application/json")
+        requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
 	
@@ -246,7 +246,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
 
 		// Make Request Context
     	const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.PUT);
-        requestContext.setHeaderParam("Accept", "application/json")
+        requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
 	
@@ -295,7 +295,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
 
 		// Make Request Context
     	const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
-        requestContext.setHeaderParam("Accept", "application/json")
+        requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
 	
@@ -349,7 +349,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
 
 		// Make Request Context
     	const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
-        requestContext.setHeaderParam("Accept", "application/json")
+        requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
 	

--- a/samples/client/petstore/typescript/builds/jquery/apis/PetApi.ts
+++ b/samples/client/petstore/typescript/builds/jquery/apis/PetApi.ts
@@ -405,7 +405,7 @@ export class PetApiResponseProcessor {
      * @params response Response returned by the server for a request to addPet
      * @throws ApiException if the response code was not in [200, 299]
      */
-    public addPet(response: ResponseContext):   void  {      
+     public async addPet(response: ResponseContext): Promise< void> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("405", response.httpStatusCode)) {
             throw new ApiException<string>(response.httpStatusCode, "Invalid input");
@@ -427,7 +427,7 @@ export class PetApiResponseProcessor {
      * @params response Response returned by the server for a request to deletePet
      * @throws ApiException if the response code was not in [200, 299]
      */
-    public deletePet(response: ResponseContext):   void  {      
+     public async deletePet(response: ResponseContext): Promise< void> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<string>(response.httpStatusCode, "Invalid pet value");
@@ -449,18 +449,13 @@ export class PetApiResponseProcessor {
      * @params response Response returned by the server for a request to findPetsByStatus
      * @throws ApiException if the response code was not in [200, 299]
      */
-    public findPetsByStatus(response: ResponseContext):  Array<Pet>  {      
+     public async findPetsByStatus(response: ResponseContext): Promise<Array<Pet> > {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
-            let body: Array<Pet>;
-            if ("Array<Pet>" as string === "HttpFile" as string) {
-                body = response.getBodyAsFile() as any as Array<Pet>;
-            } else {
-                body = ObjectSerializer.deserialize(
-                    ObjectSerializer.parse(response.body, contentType),
-                    "Array<Pet>", ""
-                ) as Array<Pet>;
-            }
+            const body: Array<Pet> = ObjectSerializer.deserialize(
+                ObjectSerializer.parse(await response.body.text(), contentType),
+                "Array<Pet>", ""
+            ) as Array<Pet>;
             return body;
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
@@ -469,15 +464,10 @@ export class PetApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            let body: Array<Pet>;
-            if ("Array<Pet>" as string === "HttpFile" as string) {
-                body = response.getBodyAsFile() as any as Array<Pet>;
-            } else {
-                body = ObjectSerializer.deserialize(
-                    ObjectSerializer.parse(response.body, contentType),
-                    "Array<Pet>", ""
-                ) as Array<Pet>;
-            }
+            const body: Array<Pet> = ObjectSerializer.deserialize(
+                ObjectSerializer.parse(await response.body.text(), contentType),
+                "Array<Pet>", ""
+            ) as Array<Pet>;
             return body;
         }
 
@@ -492,18 +482,13 @@ export class PetApiResponseProcessor {
      * @params response Response returned by the server for a request to findPetsByTags
      * @throws ApiException if the response code was not in [200, 299]
      */
-    public findPetsByTags(response: ResponseContext):  Array<Pet>  {      
+     public async findPetsByTags(response: ResponseContext): Promise<Array<Pet> > {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
-            let body: Array<Pet>;
-            if ("Array<Pet>" as string === "HttpFile" as string) {
-                body = response.getBodyAsFile() as any as Array<Pet>;
-            } else {
-                body = ObjectSerializer.deserialize(
-                    ObjectSerializer.parse(response.body, contentType),
-                    "Array<Pet>", ""
-                ) as Array<Pet>;
-            }
+            const body: Array<Pet> = ObjectSerializer.deserialize(
+                ObjectSerializer.parse(await response.body.text(), contentType),
+                "Array<Pet>", ""
+            ) as Array<Pet>;
             return body;
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
@@ -512,15 +497,10 @@ export class PetApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            let body: Array<Pet>;
-            if ("Array<Pet>" as string === "HttpFile" as string) {
-                body = response.getBodyAsFile() as any as Array<Pet>;
-            } else {
-                body = ObjectSerializer.deserialize(
-                    ObjectSerializer.parse(response.body, contentType),
-                    "Array<Pet>", ""
-                ) as Array<Pet>;
-            }
+            const body: Array<Pet> = ObjectSerializer.deserialize(
+                ObjectSerializer.parse(await response.body.text(), contentType),
+                "Array<Pet>", ""
+            ) as Array<Pet>;
             return body;
         }
 
@@ -535,18 +515,13 @@ export class PetApiResponseProcessor {
      * @params response Response returned by the server for a request to getPetById
      * @throws ApiException if the response code was not in [200, 299]
      */
-    public getPetById(response: ResponseContext):  Pet  {      
+     public async getPetById(response: ResponseContext): Promise<Pet > {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
-            let body: Pet;
-            if ("Pet" as string === "HttpFile" as string) {
-                body = response.getBodyAsFile() as any as Pet;
-            } else {
-                body = ObjectSerializer.deserialize(
-                    ObjectSerializer.parse(response.body, contentType),
-                    "Pet", ""
-                ) as Pet;
-            }
+            const body: Pet = ObjectSerializer.deserialize(
+                ObjectSerializer.parse(await response.body.text(), contentType),
+                "Pet", ""
+            ) as Pet;
             return body;
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
@@ -558,15 +533,10 @@ export class PetApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            let body: Pet;
-            if ("Pet" as string === "HttpFile" as string) {
-                body = response.getBodyAsFile() as any as Pet;
-            } else {
-                body = ObjectSerializer.deserialize(
-                    ObjectSerializer.parse(response.body, contentType),
-                    "Pet", ""
-                ) as Pet;
-            }
+            const body: Pet = ObjectSerializer.deserialize(
+                ObjectSerializer.parse(await response.body.text(), contentType),
+                "Pet", ""
+            ) as Pet;
             return body;
         }
 
@@ -581,7 +551,7 @@ export class PetApiResponseProcessor {
      * @params response Response returned by the server for a request to updatePet
      * @throws ApiException if the response code was not in [200, 299]
      */
-    public updatePet(response: ResponseContext):   void  {      
+     public async updatePet(response: ResponseContext): Promise< void> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<string>(response.httpStatusCode, "Invalid ID supplied");
@@ -609,7 +579,7 @@ export class PetApiResponseProcessor {
      * @params response Response returned by the server for a request to updatePetWithForm
      * @throws ApiException if the response code was not in [200, 299]
      */
-    public updatePetWithForm(response: ResponseContext):   void  {      
+     public async updatePetWithForm(response: ResponseContext): Promise< void> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("405", response.httpStatusCode)) {
             throw new ApiException<string>(response.httpStatusCode, "Invalid input");
@@ -631,32 +601,22 @@ export class PetApiResponseProcessor {
      * @params response Response returned by the server for a request to uploadFile
      * @throws ApiException if the response code was not in [200, 299]
      */
-    public uploadFile(response: ResponseContext):  ApiResponse  {      
+     public async uploadFile(response: ResponseContext): Promise<ApiResponse > {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
-            let body: ApiResponse;
-            if ("ApiResponse" as string === "HttpFile" as string) {
-                body = response.getBodyAsFile() as any as ApiResponse;
-            } else {
-                body = ObjectSerializer.deserialize(
-                    ObjectSerializer.parse(response.body, contentType),
-                    "ApiResponse", ""
-                ) as ApiResponse;
-            }
+            const body: ApiResponse = ObjectSerializer.deserialize(
+                ObjectSerializer.parse(await response.body.text(), contentType),
+                "ApiResponse", ""
+            ) as ApiResponse;
             return body;
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            let body: ApiResponse;
-            if ("ApiResponse" as string === "HttpFile" as string) {
-                body = response.getBodyAsFile() as any as ApiResponse;
-            } else {
-                body = ObjectSerializer.deserialize(
-                    ObjectSerializer.parse(response.body, contentType),
-                    "ApiResponse", ""
-                ) as ApiResponse;
-            }
+            const body: ApiResponse = ObjectSerializer.deserialize(
+                ObjectSerializer.parse(await response.body.text(), contentType),
+                "ApiResponse", ""
+            ) as ApiResponse;
             return body;
         }
 

--- a/samples/client/petstore/typescript/builds/jquery/apis/PetApi.ts
+++ b/samples/client/petstore/typescript/builds/jquery/apis/PetApi.ts
@@ -411,7 +411,7 @@ export class PetApiResponseProcessor {
             throw new ApiException<string>(response.httpStatusCode, "Invalid input");
         }
 
-        // Work around for incorrect api specification in petstore.yaml
+        // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
             return;
         }
@@ -433,7 +433,7 @@ export class PetApiResponseProcessor {
             throw new ApiException<string>(response.httpStatusCode, "Invalid pet value");
         }
 
-        // Work around for incorrect api specification in petstore.yaml
+        // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
             return;
         }
@@ -452,22 +452,32 @@ export class PetApiResponseProcessor {
     public findPetsByStatus(response: ResponseContext):  Array<Pet>  {      
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
-            const body: Array<Pet> = ObjectSerializer.deserialize(
-                ObjectSerializer.parse(response.body, contentType),
-                "Array<Pet>", ""
-            ) as Array<Pet>;
+            let body: Array<Pet>;
+            if ("Array<Pet>" as string === "HttpFile" as string) {
+                body = response.getBodyAsFile() as any as Array<Pet>;
+            } else {
+                body = ObjectSerializer.deserialize(
+                    ObjectSerializer.parse(response.body, contentType),
+                    "Array<Pet>", ""
+                ) as Array<Pet>;
+            }
             return body;
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<string>(response.httpStatusCode, "Invalid status value");
         }
 
-        // Work around for incorrect api specification in petstore.yaml
+        // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            const body: Array<Pet> = ObjectSerializer.deserialize(
-                ObjectSerializer.parse(response.body, contentType),
-                "Array<Pet>", ""
-            ) as Array<Pet>;
+            let body: Array<Pet>;
+            if ("Array<Pet>" as string === "HttpFile" as string) {
+                body = response.getBodyAsFile() as any as Array<Pet>;
+            } else {
+                body = ObjectSerializer.deserialize(
+                    ObjectSerializer.parse(response.body, contentType),
+                    "Array<Pet>", ""
+                ) as Array<Pet>;
+            }
             return body;
         }
 
@@ -485,22 +495,32 @@ export class PetApiResponseProcessor {
     public findPetsByTags(response: ResponseContext):  Array<Pet>  {      
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
-            const body: Array<Pet> = ObjectSerializer.deserialize(
-                ObjectSerializer.parse(response.body, contentType),
-                "Array<Pet>", ""
-            ) as Array<Pet>;
+            let body: Array<Pet>;
+            if ("Array<Pet>" as string === "HttpFile" as string) {
+                body = response.getBodyAsFile() as any as Array<Pet>;
+            } else {
+                body = ObjectSerializer.deserialize(
+                    ObjectSerializer.parse(response.body, contentType),
+                    "Array<Pet>", ""
+                ) as Array<Pet>;
+            }
             return body;
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<string>(response.httpStatusCode, "Invalid tag value");
         }
 
-        // Work around for incorrect api specification in petstore.yaml
+        // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            const body: Array<Pet> = ObjectSerializer.deserialize(
-                ObjectSerializer.parse(response.body, contentType),
-                "Array<Pet>", ""
-            ) as Array<Pet>;
+            let body: Array<Pet>;
+            if ("Array<Pet>" as string === "HttpFile" as string) {
+                body = response.getBodyAsFile() as any as Array<Pet>;
+            } else {
+                body = ObjectSerializer.deserialize(
+                    ObjectSerializer.parse(response.body, contentType),
+                    "Array<Pet>", ""
+                ) as Array<Pet>;
+            }
             return body;
         }
 
@@ -518,10 +538,15 @@ export class PetApiResponseProcessor {
     public getPetById(response: ResponseContext):  Pet  {      
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
-            const body: Pet = ObjectSerializer.deserialize(
-                ObjectSerializer.parse(response.body, contentType),
-                "Pet", ""
-            ) as Pet;
+            let body: Pet;
+            if ("Pet" as string === "HttpFile" as string) {
+                body = response.getBodyAsFile() as any as Pet;
+            } else {
+                body = ObjectSerializer.deserialize(
+                    ObjectSerializer.parse(response.body, contentType),
+                    "Pet", ""
+                ) as Pet;
+            }
             return body;
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
@@ -531,12 +556,17 @@ export class PetApiResponseProcessor {
             throw new ApiException<string>(response.httpStatusCode, "Pet not found");
         }
 
-        // Work around for incorrect api specification in petstore.yaml
+        // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            const body: Pet = ObjectSerializer.deserialize(
-                ObjectSerializer.parse(response.body, contentType),
-                "Pet", ""
-            ) as Pet;
+            let body: Pet;
+            if ("Pet" as string === "HttpFile" as string) {
+                body = response.getBodyAsFile() as any as Pet;
+            } else {
+                body = ObjectSerializer.deserialize(
+                    ObjectSerializer.parse(response.body, contentType),
+                    "Pet", ""
+                ) as Pet;
+            }
             return body;
         }
 
@@ -563,7 +593,7 @@ export class PetApiResponseProcessor {
             throw new ApiException<string>(response.httpStatusCode, "Validation exception");
         }
 
-        // Work around for incorrect api specification in petstore.yaml
+        // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
             return;
         }
@@ -585,7 +615,7 @@ export class PetApiResponseProcessor {
             throw new ApiException<string>(response.httpStatusCode, "Invalid input");
         }
 
-        // Work around for incorrect api specification in petstore.yaml
+        // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
             return;
         }
@@ -604,19 +634,29 @@ export class PetApiResponseProcessor {
     public uploadFile(response: ResponseContext):  ApiResponse  {      
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
-            const body: ApiResponse = ObjectSerializer.deserialize(
-                ObjectSerializer.parse(response.body, contentType),
-                "ApiResponse", ""
-            ) as ApiResponse;
+            let body: ApiResponse;
+            if ("ApiResponse" as string === "HttpFile" as string) {
+                body = response.getBodyAsFile() as any as ApiResponse;
+            } else {
+                body = ObjectSerializer.deserialize(
+                    ObjectSerializer.parse(response.body, contentType),
+                    "ApiResponse", ""
+                ) as ApiResponse;
+            }
             return body;
         }
 
-        // Work around for incorrect api specification in petstore.yaml
+        // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            const body: ApiResponse = ObjectSerializer.deserialize(
-                ObjectSerializer.parse(response.body, contentType),
-                "ApiResponse", ""
-            ) as ApiResponse;
+            let body: ApiResponse;
+            if ("ApiResponse" as string === "HttpFile" as string) {
+                body = response.getBodyAsFile() as any as ApiResponse;
+            } else {
+                body = ObjectSerializer.deserialize(
+                    ObjectSerializer.parse(response.body, contentType),
+                    "ApiResponse", ""
+                ) as ApiResponse;
+            }
             return body;
         }
 

--- a/samples/client/petstore/typescript/builds/jquery/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript/builds/jquery/apis/StoreApi.ts
@@ -33,7 +33,7 @@ export class StoreApiRequestFactory extends BaseAPIRequestFactory {
 
 		// Make Request Context
     	const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.DELETE);
-        requestContext.setHeaderParam("Accept", "application/json")
+        requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
 	
@@ -61,7 +61,7 @@ export class StoreApiRequestFactory extends BaseAPIRequestFactory {
 
 		// Make Request Context
     	const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
-        requestContext.setHeaderParam("Accept", "application/json")
+        requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
 	
@@ -102,7 +102,7 @@ export class StoreApiRequestFactory extends BaseAPIRequestFactory {
 
 		// Make Request Context
     	const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
-        requestContext.setHeaderParam("Accept", "application/json")
+        requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
 	
@@ -136,7 +136,7 @@ export class StoreApiRequestFactory extends BaseAPIRequestFactory {
 
 		// Make Request Context
     	const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
-        requestContext.setHeaderParam("Accept", "application/json")
+        requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
 	

--- a/samples/client/petstore/typescript/builds/jquery/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript/builds/jquery/apis/StoreApi.ts
@@ -172,7 +172,7 @@ export class StoreApiResponseProcessor {
      * @params response Response returned by the server for a request to deleteOrder
      * @throws ApiException if the response code was not in [200, 299]
      */
-    public deleteOrder(response: ResponseContext):   void  {      
+     public async deleteOrder(response: ResponseContext): Promise< void> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<string>(response.httpStatusCode, "Invalid ID supplied");
@@ -197,32 +197,22 @@ export class StoreApiResponseProcessor {
      * @params response Response returned by the server for a request to getInventory
      * @throws ApiException if the response code was not in [200, 299]
      */
-    public getInventory(response: ResponseContext):  { [key: string]: number; }  {      
+     public async getInventory(response: ResponseContext): Promise<{ [key: string]: number; } > {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
-            let body: { [key: string]: number; };
-            if ("{ [key: string]: number; }" as string === "HttpFile" as string) {
-                body = response.getBodyAsFile() as any as { [key: string]: number; };
-            } else {
-                body = ObjectSerializer.deserialize(
-                    ObjectSerializer.parse(response.body, contentType),
-                    "{ [key: string]: number; }", "int32"
-                ) as { [key: string]: number; };
-            }
+            const body: { [key: string]: number; } = ObjectSerializer.deserialize(
+                ObjectSerializer.parse(await response.body.text(), contentType),
+                "{ [key: string]: number; }", "int32"
+            ) as { [key: string]: number; };
             return body;
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            let body: { [key: string]: number; };
-            if ("{ [key: string]: number; }" as string === "HttpFile" as string) {
-                body = response.getBodyAsFile() as any as { [key: string]: number; };
-            } else {
-                body = ObjectSerializer.deserialize(
-                    ObjectSerializer.parse(response.body, contentType),
-                    "{ [key: string]: number; }", "int32"
-                ) as { [key: string]: number; };
-            }
+            const body: { [key: string]: number; } = ObjectSerializer.deserialize(
+                ObjectSerializer.parse(await response.body.text(), contentType),
+                "{ [key: string]: number; }", "int32"
+            ) as { [key: string]: number; };
             return body;
         }
 
@@ -237,18 +227,13 @@ export class StoreApiResponseProcessor {
      * @params response Response returned by the server for a request to getOrderById
      * @throws ApiException if the response code was not in [200, 299]
      */
-    public getOrderById(response: ResponseContext):  Order  {      
+     public async getOrderById(response: ResponseContext): Promise<Order > {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
-            let body: Order;
-            if ("Order" as string === "HttpFile" as string) {
-                body = response.getBodyAsFile() as any as Order;
-            } else {
-                body = ObjectSerializer.deserialize(
-                    ObjectSerializer.parse(response.body, contentType),
-                    "Order", ""
-                ) as Order;
-            }
+            const body: Order = ObjectSerializer.deserialize(
+                ObjectSerializer.parse(await response.body.text(), contentType),
+                "Order", ""
+            ) as Order;
             return body;
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
@@ -260,15 +245,10 @@ export class StoreApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            let body: Order;
-            if ("Order" as string === "HttpFile" as string) {
-                body = response.getBodyAsFile() as any as Order;
-            } else {
-                body = ObjectSerializer.deserialize(
-                    ObjectSerializer.parse(response.body, contentType),
-                    "Order", ""
-                ) as Order;
-            }
+            const body: Order = ObjectSerializer.deserialize(
+                ObjectSerializer.parse(await response.body.text(), contentType),
+                "Order", ""
+            ) as Order;
             return body;
         }
 
@@ -283,18 +263,13 @@ export class StoreApiResponseProcessor {
      * @params response Response returned by the server for a request to placeOrder
      * @throws ApiException if the response code was not in [200, 299]
      */
-    public placeOrder(response: ResponseContext):  Order  {      
+     public async placeOrder(response: ResponseContext): Promise<Order > {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
-            let body: Order;
-            if ("Order" as string === "HttpFile" as string) {
-                body = response.getBodyAsFile() as any as Order;
-            } else {
-                body = ObjectSerializer.deserialize(
-                    ObjectSerializer.parse(response.body, contentType),
-                    "Order", ""
-                ) as Order;
-            }
+            const body: Order = ObjectSerializer.deserialize(
+                ObjectSerializer.parse(await response.body.text(), contentType),
+                "Order", ""
+            ) as Order;
             return body;
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
@@ -303,15 +278,10 @@ export class StoreApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            let body: Order;
-            if ("Order" as string === "HttpFile" as string) {
-                body = response.getBodyAsFile() as any as Order;
-            } else {
-                body = ObjectSerializer.deserialize(
-                    ObjectSerializer.parse(response.body, contentType),
-                    "Order", ""
-                ) as Order;
-            }
+            const body: Order = ObjectSerializer.deserialize(
+                ObjectSerializer.parse(await response.body.text(), contentType),
+                "Order", ""
+            ) as Order;
             return body;
         }
 

--- a/samples/client/petstore/typescript/builds/jquery/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript/builds/jquery/apis/StoreApi.ts
@@ -181,7 +181,7 @@ export class StoreApiResponseProcessor {
             throw new ApiException<string>(response.httpStatusCode, "Order not found");
         }
 
-        // Work around for incorrect api specification in petstore.yaml
+        // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
             return;
         }
@@ -200,19 +200,29 @@ export class StoreApiResponseProcessor {
     public getInventory(response: ResponseContext):  { [key: string]: number; }  {      
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
-            const body: { [key: string]: number; } = ObjectSerializer.deserialize(
-                ObjectSerializer.parse(response.body, contentType),
-                "{ [key: string]: number; }", "int32"
-            ) as { [key: string]: number; };
+            let body: { [key: string]: number; };
+            if ("{ [key: string]: number; }" as string === "HttpFile" as string) {
+                body = response.getBodyAsFile() as any as { [key: string]: number; };
+            } else {
+                body = ObjectSerializer.deserialize(
+                    ObjectSerializer.parse(response.body, contentType),
+                    "{ [key: string]: number; }", "int32"
+                ) as { [key: string]: number; };
+            }
             return body;
         }
 
-        // Work around for incorrect api specification in petstore.yaml
+        // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            const body: { [key: string]: number; } = ObjectSerializer.deserialize(
-                ObjectSerializer.parse(response.body, contentType),
-                "{ [key: string]: number; }", "int32"
-            ) as { [key: string]: number; };
+            let body: { [key: string]: number; };
+            if ("{ [key: string]: number; }" as string === "HttpFile" as string) {
+                body = response.getBodyAsFile() as any as { [key: string]: number; };
+            } else {
+                body = ObjectSerializer.deserialize(
+                    ObjectSerializer.parse(response.body, contentType),
+                    "{ [key: string]: number; }", "int32"
+                ) as { [key: string]: number; };
+            }
             return body;
         }
 
@@ -230,10 +240,15 @@ export class StoreApiResponseProcessor {
     public getOrderById(response: ResponseContext):  Order  {      
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
-            const body: Order = ObjectSerializer.deserialize(
-                ObjectSerializer.parse(response.body, contentType),
-                "Order", ""
-            ) as Order;
+            let body: Order;
+            if ("Order" as string === "HttpFile" as string) {
+                body = response.getBodyAsFile() as any as Order;
+            } else {
+                body = ObjectSerializer.deserialize(
+                    ObjectSerializer.parse(response.body, contentType),
+                    "Order", ""
+                ) as Order;
+            }
             return body;
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
@@ -243,12 +258,17 @@ export class StoreApiResponseProcessor {
             throw new ApiException<string>(response.httpStatusCode, "Order not found");
         }
 
-        // Work around for incorrect api specification in petstore.yaml
+        // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            const body: Order = ObjectSerializer.deserialize(
-                ObjectSerializer.parse(response.body, contentType),
-                "Order", ""
-            ) as Order;
+            let body: Order;
+            if ("Order" as string === "HttpFile" as string) {
+                body = response.getBodyAsFile() as any as Order;
+            } else {
+                body = ObjectSerializer.deserialize(
+                    ObjectSerializer.parse(response.body, contentType),
+                    "Order", ""
+                ) as Order;
+            }
             return body;
         }
 
@@ -266,22 +286,32 @@ export class StoreApiResponseProcessor {
     public placeOrder(response: ResponseContext):  Order  {      
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
-            const body: Order = ObjectSerializer.deserialize(
-                ObjectSerializer.parse(response.body, contentType),
-                "Order", ""
-            ) as Order;
+            let body: Order;
+            if ("Order" as string === "HttpFile" as string) {
+                body = response.getBodyAsFile() as any as Order;
+            } else {
+                body = ObjectSerializer.deserialize(
+                    ObjectSerializer.parse(response.body, contentType),
+                    "Order", ""
+                ) as Order;
+            }
             return body;
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<string>(response.httpStatusCode, "Invalid Order");
         }
 
-        // Work around for incorrect api specification in petstore.yaml
+        // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            const body: Order = ObjectSerializer.deserialize(
-                ObjectSerializer.parse(response.body, contentType),
-                "Order", ""
-            ) as Order;
+            let body: Order;
+            if ("Order" as string === "HttpFile" as string) {
+                body = response.getBodyAsFile() as any as Order;
+            } else {
+                body = ObjectSerializer.deserialize(
+                    ObjectSerializer.parse(response.body, contentType),
+                    "Order", ""
+                ) as Order;
+            }
             return body;
         }
 

--- a/samples/client/petstore/typescript/builds/jquery/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript/builds/jquery/apis/StoreApi.ts
@@ -148,9 +148,10 @@ export class StoreApiRequestFactory extends BaseAPIRequestFactory {
 		// Body Params
         const contentType = ObjectSerializer.getPreferredMediaType([]);
         requestContext.setHeaderParam("Content-Type", contentType);
-		// TODO: Should this be handled by ObjectSerializer? imo yes => confidential information included in local object should not be sent
-        const needsSerialization = (<any>"Order" !== "string") || requestContext.getHeaders()['Content-Type'] === 'application/json';
-        const serializedBody = needsSerialization ? JSON.stringify(body || {}) : (body || "").toString(); // TODO: `toString` call is unnecessary
+        const serializedBody = ObjectSerializer.stringify(
+            ObjectSerializer.serialize(body, "Order", ""),
+            contentType
+        );
         requestContext.setBody(serializedBody);
 		
     	// Apply auth methods

--- a/samples/client/petstore/typescript/builds/jquery/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript/builds/jquery/apis/StoreApi.ts
@@ -146,7 +146,8 @@ export class StoreApiRequestFactory extends BaseAPIRequestFactory {
 
 
 		// Body Params
-        requestContext.setHeaderParam("Content-Type", "application/json");
+        const contentType = ObjectSerializer.getPreferredMediaType([]);
+        requestContext.setHeaderParam("Content-Type", contentType);
 		// TODO: Should this be handled by ObjectSerializer? imo yes => confidential information included in local object should not be sent
         const needsSerialization = (<any>"Order" !== "string") || requestContext.getHeaders()['Content-Type'] === 'application/json';
         const serializedBody = needsSerialization ? JSON.stringify(body || {}) : (body || "").toString(); // TODO: `toString` call is unnecessary

--- a/samples/client/petstore/typescript/builds/jquery/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript/builds/jquery/apis/StoreApi.ts
@@ -173,17 +173,19 @@ export class StoreApiResponseProcessor {
      * @throws ApiException if the response code was not in [200, 299]
      */
     public deleteOrder(response: ResponseContext):   void  {      
+        const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<string>(response.httpStatusCode, "Invalid ID supplied");
         }
         if (isCodeInRange("404", response.httpStatusCode)) {
             throw new ApiException<string>(response.httpStatusCode, "Order not found");
         }
-        
+
         // Work around for incorrect api specification in petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-        	return;
+            return;
         }
+
         let body = response.body || "";
     	throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
     }
@@ -196,18 +198,24 @@ export class StoreApiResponseProcessor {
      * @throws ApiException if the response code was not in [200, 299]
      */
     public getInventory(response: ResponseContext):  { [key: string]: number; }  {      
+        const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
-            const jsonBody = JSON.parse(response.body);
-            const body: { [key: string]: number; } = ObjectSerializer.deserialize(jsonBody, "{ [key: string]: number; }", "int32") as { [key: string]: number; };            
+            const body: { [key: string]: number; } = ObjectSerializer.deserialize(
+                ObjectSerializer.parse(response.body, contentType),
+                "{ [key: string]: number; }", "int32"
+            ) as { [key: string]: number; };
             return body;
         }
-        
+
         // Work around for incorrect api specification in petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            const jsonBody = JSON.parse(response.body);
-            const body: { [key: string]: number; } = ObjectSerializer.deserialize(jsonBody, "{ [key: string]: number; }", "int32") as { [key: string]: number; };            
-			return body;        		
+            const body: { [key: string]: number; } = ObjectSerializer.deserialize(
+                ObjectSerializer.parse(response.body, contentType),
+                "{ [key: string]: number; }", "int32"
+            ) as { [key: string]: number; };
+            return body;
         }
+
         let body = response.body || "";
     	throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
     }
@@ -220,9 +228,12 @@ export class StoreApiResponseProcessor {
      * @throws ApiException if the response code was not in [200, 299]
      */
     public getOrderById(response: ResponseContext):  Order  {      
+        const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
-            const jsonBody = JSON.parse(response.body);
-            const body: Order = ObjectSerializer.deserialize(jsonBody, "Order", "") as Order;            
+            const body: Order = ObjectSerializer.deserialize(
+                ObjectSerializer.parse(response.body, contentType),
+                "Order", ""
+            ) as Order;
             return body;
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
@@ -231,13 +242,16 @@ export class StoreApiResponseProcessor {
         if (isCodeInRange("404", response.httpStatusCode)) {
             throw new ApiException<string>(response.httpStatusCode, "Order not found");
         }
-        
+
         // Work around for incorrect api specification in petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            const jsonBody = JSON.parse(response.body);
-            const body: Order = ObjectSerializer.deserialize(jsonBody, "Order", "") as Order;            
-			return body;        		
+            const body: Order = ObjectSerializer.deserialize(
+                ObjectSerializer.parse(response.body, contentType),
+                "Order", ""
+            ) as Order;
+            return body;
         }
+
         let body = response.body || "";
     	throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
     }
@@ -250,21 +264,27 @@ export class StoreApiResponseProcessor {
      * @throws ApiException if the response code was not in [200, 299]
      */
     public placeOrder(response: ResponseContext):  Order  {      
+        const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
-            const jsonBody = JSON.parse(response.body);
-            const body: Order = ObjectSerializer.deserialize(jsonBody, "Order", "") as Order;            
+            const body: Order = ObjectSerializer.deserialize(
+                ObjectSerializer.parse(response.body, contentType),
+                "Order", ""
+            ) as Order;
             return body;
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<string>(response.httpStatusCode, "Invalid Order");
         }
-        
+
         // Work around for incorrect api specification in petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            const jsonBody = JSON.parse(response.body);
-            const body: Order = ObjectSerializer.deserialize(jsonBody, "Order", "") as Order;            
-			return body;        		
+            const body: Order = ObjectSerializer.deserialize(
+                ObjectSerializer.parse(response.body, contentType),
+                "Order", ""
+            ) as Order;
+            return body;
         }
+
         let body = response.body || "";
     	throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
     }

--- a/samples/client/petstore/typescript/builds/jquery/apis/UserApi.ts
+++ b/samples/client/petstore/typescript/builds/jquery/apis/UserApi.ts
@@ -44,9 +44,10 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
 		// Body Params
         const contentType = ObjectSerializer.getPreferredMediaType([]);
         requestContext.setHeaderParam("Content-Type", contentType);
-		// TODO: Should this be handled by ObjectSerializer? imo yes => confidential information included in local object should not be sent
-        const needsSerialization = (<any>"User" !== "string") || requestContext.getHeaders()['Content-Type'] === 'application/json';
-        const serializedBody = needsSerialization ? JSON.stringify(body || {}) : (body || "").toString(); // TODO: `toString` call is unnecessary
+        const serializedBody = ObjectSerializer.stringify(
+            ObjectSerializer.serialize(body, "User", ""),
+            contentType
+        );
         requestContext.setBody(serializedBody);
 		
     	// Apply auth methods
@@ -84,9 +85,10 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
 		// Body Params
         const contentType = ObjectSerializer.getPreferredMediaType([]);
         requestContext.setHeaderParam("Content-Type", contentType);
-		// TODO: Should this be handled by ObjectSerializer? imo yes => confidential information included in local object should not be sent
-        const needsSerialization = (<any>"Array&lt;User&gt;" !== "string") || requestContext.getHeaders()['Content-Type'] === 'application/json';
-        const serializedBody = needsSerialization ? JSON.stringify(body || {}) : (body || "").toString(); // TODO: `toString` call is unnecessary
+        const serializedBody = ObjectSerializer.stringify(
+            ObjectSerializer.serialize(body, "Array<User>", ""),
+            contentType
+        );
         requestContext.setBody(serializedBody);
 		
     	// Apply auth methods
@@ -124,9 +126,10 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
 		// Body Params
         const contentType = ObjectSerializer.getPreferredMediaType([]);
         requestContext.setHeaderParam("Content-Type", contentType);
-		// TODO: Should this be handled by ObjectSerializer? imo yes => confidential information included in local object should not be sent
-        const needsSerialization = (<any>"Array&lt;User&gt;" !== "string") || requestContext.getHeaders()['Content-Type'] === 'application/json';
-        const serializedBody = needsSerialization ? JSON.stringify(body || {}) : (body || "").toString(); // TODO: `toString` call is unnecessary
+        const serializedBody = ObjectSerializer.stringify(
+            ObjectSerializer.serialize(body, "Array<User>", ""),
+            contentType
+        );
         requestContext.setBody(serializedBody);
 		
     	// Apply auth methods
@@ -318,9 +321,10 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
 		// Body Params
         const contentType = ObjectSerializer.getPreferredMediaType([]);
         requestContext.setHeaderParam("Content-Type", contentType);
-		// TODO: Should this be handled by ObjectSerializer? imo yes => confidential information included in local object should not be sent
-        const needsSerialization = (<any>"User" !== "string") || requestContext.getHeaders()['Content-Type'] === 'application/json';
-        const serializedBody = needsSerialization ? JSON.stringify(body || {}) : (body || "").toString(); // TODO: `toString` call is unnecessary
+        const serializedBody = ObjectSerializer.stringify(
+            ObjectSerializer.serialize(body, "User", ""),
+            contentType
+        );
         requestContext.setBody(serializedBody);
 		
     	// Apply auth methods

--- a/samples/client/petstore/typescript/builds/jquery/apis/UserApi.ts
+++ b/samples/client/petstore/typescript/builds/jquery/apis/UserApi.ts
@@ -32,7 +32,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
 
 		// Make Request Context
     	const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
-        requestContext.setHeaderParam("Accept", "application/json")
+        requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
 	
@@ -71,7 +71,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
 
 		// Make Request Context
     	const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
-        requestContext.setHeaderParam("Accept", "application/json")
+        requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
 	
@@ -110,7 +110,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
 
 		// Make Request Context
     	const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
-        requestContext.setHeaderParam("Accept", "application/json")
+        requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
 	
@@ -151,7 +151,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
 
 		// Make Request Context
     	const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.DELETE);
-        requestContext.setHeaderParam("Accept", "application/json")
+        requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
 	
@@ -186,7 +186,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
 
 		// Make Request Context
     	const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
-        requestContext.setHeaderParam("Accept", "application/json")
+        requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
 	
@@ -227,7 +227,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
 
 		// Make Request Context
     	const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
-        requestContext.setHeaderParam("Accept", "application/json")
+        requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
         if (username !== undefined) {
@@ -260,7 +260,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
 
 		// Make Request Context
     	const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
-        requestContext.setHeaderParam("Accept", "application/json")
+        requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
 	
@@ -303,7 +303,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
 
 		// Make Request Context
     	const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.PUT);
-        requestContext.setHeaderParam("Accept", "application/json")
+        requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
 	

--- a/samples/client/petstore/typescript/builds/jquery/apis/UserApi.ts
+++ b/samples/client/petstore/typescript/builds/jquery/apis/UserApi.ts
@@ -345,7 +345,7 @@ export class UserApiResponseProcessor {
      * @params response Response returned by the server for a request to createUser
      * @throws ApiException if the response code was not in [200, 299]
      */
-    public createUser(response: ResponseContext):   void  {      
+     public async createUser(response: ResponseContext): Promise< void> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("0", response.httpStatusCode)) {
             throw new ApiException<string>(response.httpStatusCode, "successful operation");
@@ -367,7 +367,7 @@ export class UserApiResponseProcessor {
      * @params response Response returned by the server for a request to createUsersWithArrayInput
      * @throws ApiException if the response code was not in [200, 299]
      */
-    public createUsersWithArrayInput(response: ResponseContext):   void  {      
+     public async createUsersWithArrayInput(response: ResponseContext): Promise< void> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("0", response.httpStatusCode)) {
             throw new ApiException<string>(response.httpStatusCode, "successful operation");
@@ -389,7 +389,7 @@ export class UserApiResponseProcessor {
      * @params response Response returned by the server for a request to createUsersWithListInput
      * @throws ApiException if the response code was not in [200, 299]
      */
-    public createUsersWithListInput(response: ResponseContext):   void  {      
+     public async createUsersWithListInput(response: ResponseContext): Promise< void> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("0", response.httpStatusCode)) {
             throw new ApiException<string>(response.httpStatusCode, "successful operation");
@@ -411,7 +411,7 @@ export class UserApiResponseProcessor {
      * @params response Response returned by the server for a request to deleteUser
      * @throws ApiException if the response code was not in [200, 299]
      */
-    public deleteUser(response: ResponseContext):   void  {      
+     public async deleteUser(response: ResponseContext): Promise< void> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<string>(response.httpStatusCode, "Invalid username supplied");
@@ -436,18 +436,13 @@ export class UserApiResponseProcessor {
      * @params response Response returned by the server for a request to getUserByName
      * @throws ApiException if the response code was not in [200, 299]
      */
-    public getUserByName(response: ResponseContext):  User  {      
+     public async getUserByName(response: ResponseContext): Promise<User > {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
-            let body: User;
-            if ("User" as string === "HttpFile" as string) {
-                body = response.getBodyAsFile() as any as User;
-            } else {
-                body = ObjectSerializer.deserialize(
-                    ObjectSerializer.parse(response.body, contentType),
-                    "User", ""
-                ) as User;
-            }
+            const body: User = ObjectSerializer.deserialize(
+                ObjectSerializer.parse(await response.body.text(), contentType),
+                "User", ""
+            ) as User;
             return body;
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
@@ -459,15 +454,10 @@ export class UserApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            let body: User;
-            if ("User" as string === "HttpFile" as string) {
-                body = response.getBodyAsFile() as any as User;
-            } else {
-                body = ObjectSerializer.deserialize(
-                    ObjectSerializer.parse(response.body, contentType),
-                    "User", ""
-                ) as User;
-            }
+            const body: User = ObjectSerializer.deserialize(
+                ObjectSerializer.parse(await response.body.text(), contentType),
+                "User", ""
+            ) as User;
             return body;
         }
 
@@ -482,18 +472,13 @@ export class UserApiResponseProcessor {
      * @params response Response returned by the server for a request to loginUser
      * @throws ApiException if the response code was not in [200, 299]
      */
-    public loginUser(response: ResponseContext):  string  {      
+     public async loginUser(response: ResponseContext): Promise<string > {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
-            let body: string;
-            if ("string" as string === "HttpFile" as string) {
-                body = response.getBodyAsFile() as any as string;
-            } else {
-                body = ObjectSerializer.deserialize(
-                    ObjectSerializer.parse(response.body, contentType),
-                    "string", ""
-                ) as string;
-            }
+            const body: string = ObjectSerializer.deserialize(
+                ObjectSerializer.parse(await response.body.text(), contentType),
+                "string", ""
+            ) as string;
             return body;
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
@@ -502,15 +487,10 @@ export class UserApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            let body: string;
-            if ("string" as string === "HttpFile" as string) {
-                body = response.getBodyAsFile() as any as string;
-            } else {
-                body = ObjectSerializer.deserialize(
-                    ObjectSerializer.parse(response.body, contentType),
-                    "string", ""
-                ) as string;
-            }
+            const body: string = ObjectSerializer.deserialize(
+                ObjectSerializer.parse(await response.body.text(), contentType),
+                "string", ""
+            ) as string;
             return body;
         }
 
@@ -525,7 +505,7 @@ export class UserApiResponseProcessor {
      * @params response Response returned by the server for a request to logoutUser
      * @throws ApiException if the response code was not in [200, 299]
      */
-    public logoutUser(response: ResponseContext):   void  {      
+     public async logoutUser(response: ResponseContext): Promise< void> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("0", response.httpStatusCode)) {
             throw new ApiException<string>(response.httpStatusCode, "successful operation");
@@ -547,7 +527,7 @@ export class UserApiResponseProcessor {
      * @params response Response returned by the server for a request to updateUser
      * @throws ApiException if the response code was not in [200, 299]
      */
-    public updateUser(response: ResponseContext):   void  {      
+     public async updateUser(response: ResponseContext): Promise< void> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<string>(response.httpStatusCode, "Invalid user supplied");

--- a/samples/client/petstore/typescript/builds/jquery/apis/UserApi.ts
+++ b/samples/client/petstore/typescript/builds/jquery/apis/UserApi.ts
@@ -351,7 +351,7 @@ export class UserApiResponseProcessor {
             throw new ApiException<string>(response.httpStatusCode, "successful operation");
         }
 
-        // Work around for incorrect api specification in petstore.yaml
+        // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
             return;
         }
@@ -373,7 +373,7 @@ export class UserApiResponseProcessor {
             throw new ApiException<string>(response.httpStatusCode, "successful operation");
         }
 
-        // Work around for incorrect api specification in petstore.yaml
+        // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
             return;
         }
@@ -395,7 +395,7 @@ export class UserApiResponseProcessor {
             throw new ApiException<string>(response.httpStatusCode, "successful operation");
         }
 
-        // Work around for incorrect api specification in petstore.yaml
+        // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
             return;
         }
@@ -420,7 +420,7 @@ export class UserApiResponseProcessor {
             throw new ApiException<string>(response.httpStatusCode, "User not found");
         }
 
-        // Work around for incorrect api specification in petstore.yaml
+        // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
             return;
         }
@@ -439,10 +439,15 @@ export class UserApiResponseProcessor {
     public getUserByName(response: ResponseContext):  User  {      
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
-            const body: User = ObjectSerializer.deserialize(
-                ObjectSerializer.parse(response.body, contentType),
-                "User", ""
-            ) as User;
+            let body: User;
+            if ("User" as string === "HttpFile" as string) {
+                body = response.getBodyAsFile() as any as User;
+            } else {
+                body = ObjectSerializer.deserialize(
+                    ObjectSerializer.parse(response.body, contentType),
+                    "User", ""
+                ) as User;
+            }
             return body;
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
@@ -452,12 +457,17 @@ export class UserApiResponseProcessor {
             throw new ApiException<string>(response.httpStatusCode, "User not found");
         }
 
-        // Work around for incorrect api specification in petstore.yaml
+        // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            const body: User = ObjectSerializer.deserialize(
-                ObjectSerializer.parse(response.body, contentType),
-                "User", ""
-            ) as User;
+            let body: User;
+            if ("User" as string === "HttpFile" as string) {
+                body = response.getBodyAsFile() as any as User;
+            } else {
+                body = ObjectSerializer.deserialize(
+                    ObjectSerializer.parse(response.body, contentType),
+                    "User", ""
+                ) as User;
+            }
             return body;
         }
 
@@ -475,22 +485,32 @@ export class UserApiResponseProcessor {
     public loginUser(response: ResponseContext):  string  {      
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
-            const body: string = ObjectSerializer.deserialize(
-                ObjectSerializer.parse(response.body, contentType),
-                "string", ""
-            ) as string;
+            let body: string;
+            if ("string" as string === "HttpFile" as string) {
+                body = response.getBodyAsFile() as any as string;
+            } else {
+                body = ObjectSerializer.deserialize(
+                    ObjectSerializer.parse(response.body, contentType),
+                    "string", ""
+                ) as string;
+            }
             return body;
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<string>(response.httpStatusCode, "Invalid username/password supplied");
         }
 
-        // Work around for incorrect api specification in petstore.yaml
+        // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            const body: string = ObjectSerializer.deserialize(
-                ObjectSerializer.parse(response.body, contentType),
-                "string", ""
-            ) as string;
+            let body: string;
+            if ("string" as string === "HttpFile" as string) {
+                body = response.getBodyAsFile() as any as string;
+            } else {
+                body = ObjectSerializer.deserialize(
+                    ObjectSerializer.parse(response.body, contentType),
+                    "string", ""
+                ) as string;
+            }
             return body;
         }
 
@@ -511,7 +531,7 @@ export class UserApiResponseProcessor {
             throw new ApiException<string>(response.httpStatusCode, "successful operation");
         }
 
-        // Work around for incorrect api specification in petstore.yaml
+        // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
             return;
         }
@@ -536,7 +556,7 @@ export class UserApiResponseProcessor {
             throw new ApiException<string>(response.httpStatusCode, "User not found");
         }
 
-        // Work around for incorrect api specification in petstore.yaml
+        // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
             return;
         }

--- a/samples/client/petstore/typescript/builds/jquery/apis/UserApi.ts
+++ b/samples/client/petstore/typescript/builds/jquery/apis/UserApi.ts
@@ -42,7 +42,8 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
 
 
 		// Body Params
-        requestContext.setHeaderParam("Content-Type", "application/json");
+        const contentType = ObjectSerializer.getPreferredMediaType([]);
+        requestContext.setHeaderParam("Content-Type", contentType);
 		// TODO: Should this be handled by ObjectSerializer? imo yes => confidential information included in local object should not be sent
         const needsSerialization = (<any>"User" !== "string") || requestContext.getHeaders()['Content-Type'] === 'application/json';
         const serializedBody = needsSerialization ? JSON.stringify(body || {}) : (body || "").toString(); // TODO: `toString` call is unnecessary
@@ -81,7 +82,8 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
 
 
 		// Body Params
-        requestContext.setHeaderParam("Content-Type", "application/json");
+        const contentType = ObjectSerializer.getPreferredMediaType([]);
+        requestContext.setHeaderParam("Content-Type", contentType);
 		// TODO: Should this be handled by ObjectSerializer? imo yes => confidential information included in local object should not be sent
         const needsSerialization = (<any>"Array&lt;User&gt;" !== "string") || requestContext.getHeaders()['Content-Type'] === 'application/json';
         const serializedBody = needsSerialization ? JSON.stringify(body || {}) : (body || "").toString(); // TODO: `toString` call is unnecessary
@@ -120,7 +122,8 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
 
 
 		// Body Params
-        requestContext.setHeaderParam("Content-Type", "application/json");
+        const contentType = ObjectSerializer.getPreferredMediaType([]);
+        requestContext.setHeaderParam("Content-Type", contentType);
 		// TODO: Should this be handled by ObjectSerializer? imo yes => confidential information included in local object should not be sent
         const needsSerialization = (<any>"Array&lt;User&gt;" !== "string") || requestContext.getHeaders()['Content-Type'] === 'application/json';
         const serializedBody = needsSerialization ? JSON.stringify(body || {}) : (body || "").toString(); // TODO: `toString` call is unnecessary
@@ -313,7 +316,8 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
 
 
 		// Body Params
-        requestContext.setHeaderParam("Content-Type", "application/json");
+        const contentType = ObjectSerializer.getPreferredMediaType([]);
+        requestContext.setHeaderParam("Content-Type", contentType);
 		// TODO: Should this be handled by ObjectSerializer? imo yes => confidential information included in local object should not be sent
         const needsSerialization = (<any>"User" !== "string") || requestContext.getHeaders()['Content-Type'] === 'application/json';
         const serializedBody = needsSerialization ? JSON.stringify(body || {}) : (body || "").toString(); // TODO: `toString` call is unnecessary

--- a/samples/client/petstore/typescript/builds/jquery/apis/UserApi.ts
+++ b/samples/client/petstore/typescript/builds/jquery/apis/UserApi.ts
@@ -346,14 +346,16 @@ export class UserApiResponseProcessor {
      * @throws ApiException if the response code was not in [200, 299]
      */
     public createUser(response: ResponseContext):   void  {      
+        const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("0", response.httpStatusCode)) {
             throw new ApiException<string>(response.httpStatusCode, "successful operation");
         }
-        
+
         // Work around for incorrect api specification in petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-        	return;
+            return;
         }
+
         let body = response.body || "";
     	throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
     }
@@ -366,14 +368,16 @@ export class UserApiResponseProcessor {
      * @throws ApiException if the response code was not in [200, 299]
      */
     public createUsersWithArrayInput(response: ResponseContext):   void  {      
+        const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("0", response.httpStatusCode)) {
             throw new ApiException<string>(response.httpStatusCode, "successful operation");
         }
-        
+
         // Work around for incorrect api specification in petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-        	return;
+            return;
         }
+
         let body = response.body || "";
     	throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
     }
@@ -386,14 +390,16 @@ export class UserApiResponseProcessor {
      * @throws ApiException if the response code was not in [200, 299]
      */
     public createUsersWithListInput(response: ResponseContext):   void  {      
+        const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("0", response.httpStatusCode)) {
             throw new ApiException<string>(response.httpStatusCode, "successful operation");
         }
-        
+
         // Work around for incorrect api specification in petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-        	return;
+            return;
         }
+
         let body = response.body || "";
     	throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
     }
@@ -406,17 +412,19 @@ export class UserApiResponseProcessor {
      * @throws ApiException if the response code was not in [200, 299]
      */
     public deleteUser(response: ResponseContext):   void  {      
+        const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<string>(response.httpStatusCode, "Invalid username supplied");
         }
         if (isCodeInRange("404", response.httpStatusCode)) {
             throw new ApiException<string>(response.httpStatusCode, "User not found");
         }
-        
+
         // Work around for incorrect api specification in petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-        	return;
+            return;
         }
+
         let body = response.body || "";
     	throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
     }
@@ -429,9 +437,12 @@ export class UserApiResponseProcessor {
      * @throws ApiException if the response code was not in [200, 299]
      */
     public getUserByName(response: ResponseContext):  User  {      
+        const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
-            const jsonBody = JSON.parse(response.body);
-            const body: User = ObjectSerializer.deserialize(jsonBody, "User", "") as User;            
+            const body: User = ObjectSerializer.deserialize(
+                ObjectSerializer.parse(response.body, contentType),
+                "User", ""
+            ) as User;
             return body;
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
@@ -440,13 +451,16 @@ export class UserApiResponseProcessor {
         if (isCodeInRange("404", response.httpStatusCode)) {
             throw new ApiException<string>(response.httpStatusCode, "User not found");
         }
-        
+
         // Work around for incorrect api specification in petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            const jsonBody = JSON.parse(response.body);
-            const body: User = ObjectSerializer.deserialize(jsonBody, "User", "") as User;            
-			return body;        		
+            const body: User = ObjectSerializer.deserialize(
+                ObjectSerializer.parse(response.body, contentType),
+                "User", ""
+            ) as User;
+            return body;
         }
+
         let body = response.body || "";
     	throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
     }
@@ -459,21 +473,27 @@ export class UserApiResponseProcessor {
      * @throws ApiException if the response code was not in [200, 299]
      */
     public loginUser(response: ResponseContext):  string  {      
+        const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
-            const jsonBody = JSON.parse(response.body);
-            const body: string = ObjectSerializer.deserialize(jsonBody, "string", "") as string;            
+            const body: string = ObjectSerializer.deserialize(
+                ObjectSerializer.parse(response.body, contentType),
+                "string", ""
+            ) as string;
             return body;
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<string>(response.httpStatusCode, "Invalid username/password supplied");
         }
-        
+
         // Work around for incorrect api specification in petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            const jsonBody = JSON.parse(response.body);
-            const body: string = ObjectSerializer.deserialize(jsonBody, "string", "") as string;            
-			return body;        		
+            const body: string = ObjectSerializer.deserialize(
+                ObjectSerializer.parse(response.body, contentType),
+                "string", ""
+            ) as string;
+            return body;
         }
+
         let body = response.body || "";
     	throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
     }
@@ -486,14 +506,16 @@ export class UserApiResponseProcessor {
      * @throws ApiException if the response code was not in [200, 299]
      */
     public logoutUser(response: ResponseContext):   void  {      
+        const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("0", response.httpStatusCode)) {
             throw new ApiException<string>(response.httpStatusCode, "successful operation");
         }
-        
+
         // Work around for incorrect api specification in petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-        	return;
+            return;
         }
+
         let body = response.body || "";
     	throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
     }
@@ -506,17 +528,19 @@ export class UserApiResponseProcessor {
      * @throws ApiException if the response code was not in [200, 299]
      */
     public updateUser(response: ResponseContext):   void  {      
+        const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<string>(response.httpStatusCode, "Invalid user supplied");
         }
         if (isCodeInRange("404", response.httpStatusCode)) {
             throw new ApiException<string>(response.httpStatusCode, "User not found");
         }
-        
+
         // Work around for incorrect api specification in petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-        	return;
+            return;
         }
+
         let body = response.body || "";
     	throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
     }

--- a/samples/client/petstore/typescript/builds/jquery/http/http.ts
+++ b/samples/client/petstore/typescript/builds/jquery/http/http.ts
@@ -119,11 +119,46 @@ export class RequestContext {
 }
 
 export class ResponseContext {
+    public constructor(
+        public httpStatusCode: number,
+        public headers: { [key: string]: string },
+        public body: string
+    ) {}
 
-    public constructor(public httpStatusCode: number, 
-        public headers: { [key: string]: string }, public body: string) {
+    /**
+     * Parse header value in the form `value; param1="value1"`
+     *
+     * E.g. for Content-Type or Content-Disposition
+     * Parameter names are converted to lower case
+     * The first parameter is returned with the key `""`
+     */
+    public getParsedHeader(headerName: string): { [parameter: string]: string } {
+        const result: { [parameter: string]: string } = {};
+        if (!this.headers[headerName]) {
+            return result;
+        }
+
+        const parameters = this.headers[headerName].split(";");
+        for (const parameter of parameters) {
+            let [key, value] = parameter.split("=", 2);
+            key = key.toLowerCase().trim();
+            if (value === undefined) {
+                result[""] = key;
+            } else {
+                value = value.trim();
+                if (value.startsWith('"') && value.endsWith('"')) {
+                    value = value.substring(1, value.length - 1);
+                }
+                result[key] = value;
+            }
+        }
+        return result;
     }
-    
+
+    public getBodyAsFile(): HttpFile {
+        const contentDisposition = this.getParsedHeader("content-disposition");
+        return new File([this.body], contentDisposition["filename"] || "");
+    }
 }
 
 export interface HttpLibrary {

--- a/samples/client/petstore/typescript/builds/jquery/http/jquery.ts
+++ b/samples/client/petstore/typescript/builds/jquery/http/jquery.ts
@@ -1,8 +1,9 @@
-import {HttpLibrary, RequestContext, ResponseContext, HttpException} from './http';
+import { HttpLibrary, RequestContext, ResponseContext, HttpException, SelfDecodingBody } from './http';
 import * as e6p from 'es6-promise'
 import { from, Observable } from '../rxjsStub';
 e6p.polyfill();
 import * as $ from 'jquery';
+
 
 export class JQueryHttpLibrary implements HttpLibrary {
 
@@ -16,9 +17,19 @@ export class JQueryHttpLibrary implements HttpLibrary {
             type: method,
             headers: request.getHeaders(),
             processData: false,
-            xhrFields: { withCredentials: true }, 
+            xhrFields: { withCredentials: true },
             data: body
         };
+
+        /**
+         * Allow receiving binary data with jquery ajax
+         *
+         * Source: https://keyangxiang.com/2017/09/01/HTML5-XHR-download-binary-content-as-Blob/
+         */
+         requestOptions.beforeSend = (jqXHR: any, settings: any) => {
+             settings.xhr().responseType = "blob";
+         };
+
 
         if (request.getHeaders()['Content-Type']) {
             requestOptions.contentType = headerParams['Content-Type'];
@@ -43,9 +54,12 @@ export class JQueryHttpLibrary implements HttpLibrary {
         const sentRequest = $.ajax(requestOptions);
         
         const resultPromise = new Promise<ResponseContext>((resolve, reject) => {
-            sentRequest.done((resp, _, jqXHR) => {
-                const headers = this.getResponseHeaders(jqXHR)
-                const result = new ResponseContext(jqXHR.status, headers, JSON.stringify(resp));
+            sentRequest.done((data, _, jqXHR) => {
+                const result = new ResponseContext(
+                    jqXHR.status,
+                    this.getResponseHeaders(jqXHR),
+                    new SelfDecodingBody(Promise.resolve(data))
+                );
                 resolve(result);
             })
             sentRequest.fail((jqXHR: any) => {

--- a/samples/client/petstore/typescript/builds/jquery/index.ts
+++ b/samples/client/petstore/typescript/builds/jquery/index.ts
@@ -1,3 +1,5 @@
+import 'es6-promise/auto';
+
 export * from './http/http';
 export * from './auth/auth';
 export * from './models/all';

--- a/samples/client/petstore/typescript/builds/jquery/models/ObjectSerializer.ts
+++ b/samples/client/petstore/typescript/builds/jquery/models/ObjectSerializer.ts
@@ -170,7 +170,10 @@ export class ObjectSerializer {
      * We currently do not handle any media types attributes, i.e. anything
      * after a semicolon. All content is assumed to be UTF-8 compatible.
      */
-    public static normalizeMediaType(mediaType: string): string {
+    public static normalizeMediaType(mediaType: string | undefined): string | undefined {
+        if (mediaType === undefined) {
+            return undefined;
+        }
         return mediaType.split(";")[0].trim().toLowerCase();
     }
 
@@ -190,9 +193,9 @@ export class ObjectSerializer {
         let selectedMediaType: string | undefined = undefined;
         let selectedRank: number = -Infinity;
         for (const mediaType of normalMediaTypes) {
-            if (supportedMediaTypes[mediaType] > selectedRank) {
+            if (supportedMediaTypes[mediaType!] > selectedRank) {
                 selectedMediaType = mediaType;
-                selectedRank = supportedMediaTypes[mediaType];
+                selectedRank = supportedMediaTypes[mediaType!];
             }
         }
 
@@ -217,7 +220,11 @@ export class ObjectSerializer {
     /**
      * Parse data from a string according to the given media type
      */
-    public static parse(rawData: string, mediaType: string) {
+    public static parse(rawData: string, mediaType: string | undefined) {
+        if (mediaType === undefined) {
+            throw new Error("Cannot parse content. No Content-Type defined.");
+        }
+
         if (mediaType === "application/json") {
             return JSON.parse(rawData);
         }

--- a/samples/client/petstore/typescript/builds/jquery/models/ObjectSerializer.ts
+++ b/samples/client/petstore/typescript/builds/jquery/models/ObjectSerializer.ts
@@ -205,27 +205,23 @@ export class ObjectSerializer {
 
     /**
      * Convert data to a string according the given media type
-     *
-     * TODO: Add support for
-     *    - json
-     *    - binary fallback
-     *    - xml (togglable in generator config)
-     *    - yaml (togglable in generator config)
      */
     public static stringify(data: any, mediaType: string): string {
-        return "";
+        if (mediaType === "application/json") {
+            return JSON.stringify(data);
+        }
+
+        throw new Error("The mediaType " + mediaType + " is not supported by ObjectSerializer.stringify.");
     }
 
     /**
      * Parse data from a string according to the given media type
-     *
-     * TODO: Add support for
-     *    - json
-     *    - binary fallback
-     *    - xml (togglable in generator config)
-     *    - yaml (togglable in generator config)
-     *    - multipart (togglabel in generator config)
      */
     public static parse(rawData: string, mediaType: string) {
+        if (mediaType === "application/json") {
+            return JSON.parse(rawData);
+        }
+
+        throw new Error("The mediaType " + mediaType + " is not supported by ObjectSerializer.parse.");
     }
 }

--- a/samples/client/petstore/typescript/builds/jquery/models/ObjectSerializer.ts
+++ b/samples/client/petstore/typescript/builds/jquery/models/ObjectSerializer.ts
@@ -23,6 +23,12 @@ let primitives = [
                     "number",
                     "any"
                  ];
+
+const supportedMediaTypes: { [mediaType: string]: number } = {
+  "application/json": Infinity,
+  "application/octet-stream": 0
+}
+
                  
 let enumsMap: Set<string> = new Set<string>([
 					"OrderStatusEnum",
@@ -155,5 +161,71 @@ export class ObjectSerializer {
             }
             return instance;
         }
+    }
+
+
+    /**
+     * Normalize media type
+     *
+     * We currently do not handle any media types attributes, i.e. anything
+     * after a semicolon. All content is assumed to be UTF-8 compatible.
+     */
+    public static normalizeMediaType(mediaType: string): string {
+        return mediaType.split(";")[0].trim().toLowerCase();
+    }
+
+    /**
+     * From a list of possible media types, choose the one we can handle best.
+     *
+     * The order of the given media types does not have any impact on the choice
+     * made.
+     */
+    public static getPreferredMediaType(mediaTypes: Array<string>): string {
+        /** According to OAS 3 we should default to json */
+        if (!mediaTypes) {
+            return "application/json";
+        }
+
+        const normalMediaTypes = mediaTypes.map(this.normalizeMediaType);
+        let selectedMediaType: string | undefined = undefined;
+        let selectedRank: number = -Infinity;
+        for (const mediaType of normalMediaTypes) {
+            if (supportedMediaTypes[mediaType] > selectedRank) {
+                selectedMediaType = mediaType;
+                selectedRank = supportedMediaTypes[mediaType];
+            }
+        }
+
+        if (selectedMediaType === undefined) {
+            throw new Error("None of the given media types are supported: " + mediaTypes.join(", "));
+        }
+
+        return selectedMediaType!;
+    }
+
+    /**
+     * Convert data to a string according the given media type
+     *
+     * TODO: Add support for
+     *    - json
+     *    - binary fallback
+     *    - xml (togglable in generator config)
+     *    - yaml (togglable in generator config)
+     */
+    public static stringify(data: any, mediaType: string): string {
+        return "";
+    }
+
+    /**
+     * Parse data from a string according to the given media type
+     *
+     * TODO: Add support for
+     *    - json
+     *    - binary fallback
+     *    - xml (togglable in generator config)
+     *    - yaml (togglable in generator config)
+     *    - multipart (togglabel in generator config)
+     */
+    public static parse(rawData: string, mediaType: string) {
     }
 }

--- a/samples/client/petstore/typescript/builds/jquery/package-lock.json
+++ b/samples/client/petstore/typescript/builds/jquery/package-lock.json
@@ -28,9 +28,9 @@
       "integrity": "sha512-aRVgGdnmW2OiySVPUC9e6m+plolMAJKjZnQlCwNSuK5yQ0JN61DZSO1X1Ufd1foqWRAlig0rhduTCHe7sVtK5Q=="
     },
     "jquery": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.4.1.tgz",
-      "integrity": "sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw=="
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.5.1.tgz",
+      "integrity": "sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg=="
     },
     "querystringify": {
       "version": "2.1.1",

--- a/samples/client/petstore/typescript/tests/default/package-lock.json
+++ b/samples/client/petstore/typescript/tests/default/package-lock.json
@@ -34,9 +34,9 @@
       "integrity": "sha512-uD0j/AQOa5le7afuK+u+woi8jNKF1vf3DN0H7LCJhft/lNNibUr7VcAesdgtWfEKveZol3ZG1CJqwx2Bhrnl8w=="
     },
     "acorn": {
-      "version": "5.7.3",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
-      "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw=="
+      "version": "5.7.4",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
+      "integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg=="
     },
     "acorn-jsx": {
       "version": "3.0.1",
@@ -748,9 +748,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "lru-cache": {
       "version": "4.1.5",
@@ -803,23 +803,16 @@
       }
     },
     "minimist": {
-      "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "mkdirp": {
-      "version": "0.5.1",
-      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
       "requires": {
-        "minimist": "0.0.8"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "0.0.8",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
-        }
+        "minimist": "^1.2.5"
       }
     },
     "mocha": {
@@ -841,6 +834,21 @@
         "supports-color": "5.4.0"
       },
       "dependencies": {
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
         "supports-color": {
           "version": "5.4.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
@@ -1215,12 +1223,11 @@
     "ts-petstore-client": {
       "version": "file:../../builds/default",
       "requires": {
-        "@types/isomorphic-fetch": "0.0.34",
         "@types/node": "*",
         "btoa": "^1.2.1",
         "es6-promise": "^4.2.4",
         "form-data": "^2.5.0",
-        "isomorphic-fetch": "^2.2.1",
+        "node-fetch": "^2.6.0",
         "url-parse": "^1.4.3"
       },
       "dependencies": {
@@ -1257,14 +1264,6 @@
           "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
           "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
         },
-        "encoding": {
-          "version": "0.1.12",
-          "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
-          "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
-          "requires": {
-            "iconv-lite": "~0.4.13"
-          }
-        },
         "es6-promise": {
           "version": "4.2.5",
           "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.5.tgz",
@@ -1280,25 +1279,11 @@
             "mime-types": "^2.1.12"
           }
         },
-        "iconv-lite": {
-          "version": "0.4.24",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-          "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-          "requires": {
-            "safer-buffer": ">= 2.1.2 < 3"
-          }
-        },
-        "is-stream": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
-        },
         "isomorphic-fetch": {
           "version": "2.2.1",
           "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
           "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
           "requires": {
-            "node-fetch": "^1.0.1",
             "whatwg-fetch": ">=0.10.0"
           }
         },
@@ -1316,13 +1301,9 @@
           }
         },
         "node-fetch": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-          "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
-          "requires": {
-            "encoding": "^0.1.11",
-            "is-stream": "^1.0.1"
-          }
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+          "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
         },
         "querystringify": {
           "version": "2.1.0",
@@ -1333,11 +1314,6 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
           "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
-        },
-        "safer-buffer": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-          "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
         },
         "typescript": {
           "version": "2.9.2",

--- a/samples/client/petstore/typescript/tests/default/test/http/isomorphic-fetch.test.ts
+++ b/samples/client/petstore/typescript/tests/default/test/http/isomorphic-fetch.test.ts
@@ -18,17 +18,15 @@ for (let libName in libs) {
             requestContext.addCookie("test-cookie", "cookie-value");
             lib.send(requestContext).toPromise().then((resp: petstore.ResponseContext) => {
                     expect(resp.httpStatusCode, "Expected status code to be 200").to.eq(200);
-                    let body = JSON.parse(resp.body);
+                    return resp.body.text();
+            }).then((bodyText: string) => {
+                    let body = JSON.parse(bodyText);
                     expect(body["headers"]).to.exist;
                     expect(body["headers"]["X-Test-Token"]).to.equal("Test-Token");
                     expect(body["headers"]["Cookie"]).to.equal("test-cookie=cookie-value;");
                     done();
-                },
-                (e: any) => {
-                    done(e);
-                }
-                )
-        })
+            }).catch(done)
+        });
 
         it("POST-Request", (done) => {
             let requestContext = new petstore.RequestContext("http://httpbin.org/post", petstore.HttpMethod.POST);
@@ -42,17 +40,16 @@ for (let libName in libs) {
             lib.send(requestContext).toPromise().then(
                     (resp: petstore.ResponseContext) => {
                     expect(resp.httpStatusCode, "Expected status code to be 200").to.eq(200);
-                    let body = JSON.parse(resp.body);
+                    return resp.body.text();
+            }).then((bodyText: string) => {
+                    let body = JSON.parse(bodyText);
                     expect(body["headers"]).to.exist;
                     expect(body["headers"]["X-Test-Token"]).to.equal("Test-Token");
                     expect(body["headers"]["Cookie"]).to.equal("test-cookie=cookie-value;");
                     expect(body["files"]["testFile"]).to.equal("abc");
                     expect(body["form"]["test"]).to.equal("test2");
                     done();
-                },
-                (e: any) => {
-                    done(e);
-                })            
+            }).catch(done)
         });
 
         it("Cookies-Request", (done) => {
@@ -62,13 +59,12 @@ for (let libName in libs) {
             lib.send(requestContext).toPromise().then(
                 (resp: petstore.ResponseContext) => {
                     expect(resp.httpStatusCode, "Expected status code to be 200").to.eq(200);
-                    let body = JSON.parse(resp.body);
+                    return resp.body.text();
+            }).then((bodyText: string) => {
+                    let body = JSON.parse(bodyText);
                     expect(body["cookies"]["test-cookie"]).to.equal("cookie-value");
                     done();
-                },
-                (e: any) => {
-                    done(e);
-                })            
+            }).catch(done)
         })
     })
 }

--- a/samples/client/petstore/typescript/tests/jquery/package-lock.json
+++ b/samples/client/petstore/typescript/tests/jquery/package-lock.json
@@ -216,9 +216,9 @@
       "integrity": "sha512-sY5AXXVZv4Y1VACTtR11UJCPHHudgY5i26Qj5TypE6DKlIApbwb5uqhXcJ5UUGbvZNRh7EeIoW+LrJumBsKp7w=="
     },
     "acorn": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.1.tgz",
-      "integrity": "sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA=="
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
+      "integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA=="
     },
     "acorn-globals": {
       "version": "4.3.2",
@@ -250,9 +250,9 @@
       "integrity": "sha512-OtUw6JUTgxA2QoqqmrmQ7F2NYqiBPi/L2jqHyFtllhOUvXYQXf0Z1CYUinIfyT4bTCGmrA7gX9FvHA81uzCoVw=="
     },
     "agent-base": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz",
-      "integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
+      "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
       "requires": {
         "es6-promisify": "^5.0.0"
       }
@@ -294,22 +294,13 @@
       "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
     },
     "anymatch": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
-      "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
+      "integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
+      "optional": true,
       "requires": {
-        "micromatch": "^3.1.4",
-        "normalize-path": "^2.1.1"
-      },
-      "dependencies": {
-        "normalize-path": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-          "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-          "requires": {
-            "remove-trailing-separator": "^1.0.1"
-          }
-        }
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
       }
     },
     "aproba": {
@@ -410,7 +401,8 @@
     "async-each": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
-      "integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ=="
+      "integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==",
+      "optional": true
     },
     "async-limiter": {
       "version": "1.0.0",
@@ -543,14 +535,15 @@
       "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ=="
     },
     "binary-extensions": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
-      "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",
+      "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==",
+      "optional": true
     },
     "bluebird": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.1.tgz",
-      "integrity": "sha512-DdmyoGCleJnkbp3nkbxTLJ18rjDsE4yCggEwKNXkeV123sPNfOCYeDoeuOY+F2FrSjO1YXcTU+dsy96KMy+gcg=="
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
     },
     "bn.js": {
       "version": "4.11.8",
@@ -678,6 +671,11 @@
         "isarray": "^1.0.0"
       }
     },
+    "buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
+    },
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
@@ -694,9 +692,9 @@
       "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug="
     },
     "cacache": {
-      "version": "12.0.3",
-      "resolved": "https://registry.npmjs.org/cacache/-/cacache-12.0.3.tgz",
-      "integrity": "sha512-kqdmfXEGFepesTuROHMs3MpFLWrPkSSpRqOw80RCflZXy/khxaArvFrQ7uJxSUduzAufc6G0g1VUCOZXxWavPw==",
+      "version": "12.0.4",
+      "resolved": "https://registry.npmjs.org/cacache/-/cacache-12.0.4.tgz",
+      "integrity": "sha512-a0tMB40oefvuInr4Cwb3GerbL9xTj1D5yg0T5xrjGCGyfvbxseIXX7BAO/u/hIXdafzOI5JC3wDwHyf24buOAQ==",
       "requires": {
         "bluebird": "^3.5.5",
         "chownr": "^1.1.1",
@@ -816,28 +814,60 @@
       "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I="
     },
     "chokidar": {
-      "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
-      "integrity": "sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.0.tgz",
+      "integrity": "sha512-aXAaho2VJtisB/1fg1+3nlLJqGOuewTzQpd/Tz0yTg2R0e4IGtshYvtjowyEumcBv2z+y4+kc75Mz7j5xJskcQ==",
+      "optional": true,
       "requires": {
-        "anymatch": "^2.0.0",
-        "async-each": "^1.0.1",
-        "braces": "^2.3.2",
-        "fsevents": "^1.2.7",
-        "glob-parent": "^3.1.0",
-        "inherits": "^2.0.3",
-        "is-binary-path": "^1.0.0",
-        "is-glob": "^4.0.0",
-        "normalize-path": "^3.0.0",
-        "path-is-absolute": "^1.0.0",
-        "readdirp": "^2.2.1",
-        "upath": "^1.1.1"
+        "anymatch": "~3.1.1",
+        "braces": "~3.0.2",
+        "fsevents": "~2.1.2",
+        "glob-parent": "~5.1.0",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.4.0"
+      },
+      "dependencies": {
+        "braces": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+          "optional": true,
+          "requires": {
+            "fill-range": "^7.0.1"
+          }
+        },
+        "fill-range": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+          "optional": true,
+          "requires": {
+            "to-regex-range": "^5.0.1"
+          }
+        },
+        "is-number": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+          "optional": true
+        },
+        "to-regex-range": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+          "optional": true,
+          "requires": {
+            "is-number": "^7.0.0"
+          }
+        }
       }
     },
     "chownr": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.3.tgz",
-      "integrity": "sha512-i70fVHhmV3DtTl6nqvZOnIjbY0Pe4kAUjwHj8z0zAdgBtYrJyYwLKCCuRBQ5ppkyL0AkN7HKRnETdmdp1zqNXw=="
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
     },
     "chrome-trace-event": {
       "version": "1.0.2",
@@ -1318,9 +1348,9 @@
       }
     },
     "es6-promise": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.6.tgz",
-      "integrity": "sha512-aRVgGdnmW2OiySVPUC9e6m+plolMAJKjZnQlCwNSuK5yQ0JN61DZSO1X1Ufd1foqWRAlig0rhduTCHe7sVtK5Q=="
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
     },
     "es6-promisify": {
       "version": "5.0.0",
@@ -1447,9 +1477,9 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "5.7.3",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
-          "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw=="
+          "version": "5.7.4",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
+          "integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg=="
         }
       }
     },
@@ -1673,14 +1703,14 @@
       }
     },
     "extract-zip": {
-      "version": "1.6.7",
-      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.7.tgz",
-      "integrity": "sha1-qEC0uK9kAyZMjbV/Txp0Mz74H+k=",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.7.0.tgz",
+      "integrity": "sha512-xoh5G1W/PB0/27lXgMQyIhP5DSY/LhoCsOyZgb+6iMmRtCwVBo55uKaMoEYrDCKQhWvqEip5ZPKAc6eFNyf/MA==",
       "requires": {
-        "concat-stream": "1.6.2",
-        "debug": "2.6.9",
-        "mkdirp": "0.5.1",
-        "yauzl": "2.4.1"
+        "concat-stream": "^1.6.2",
+        "debug": "^2.6.9",
+        "mkdirp": "^0.5.4",
+        "yauzl": "^2.10.0"
       },
       "dependencies": {
         "debug": {
@@ -1719,17 +1749,17 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
     },
     "fd-slicer": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
-      "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
       "requires": {
         "pend": "~1.2.0"
       }
     },
     "figgy-pudding": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.1.tgz",
-      "integrity": "sha512-vNKxJHTEKNThjfrdJwHc7brvM6eVevuO5nTj6ez8ZQ1qbXTvGthucRF7S4vf2cr71QVnT70V34v0S1DyQsti0w=="
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.2.tgz",
+      "integrity": "sha512-0btnI/H8f2pavGMN8w40mlSKOfTK2SVJmBfBeVIj3kNw0swwgzyRq0d5TJVOwodFmtvpPeWPN/MCcfuWF0Ezbw=="
     },
     "figures": {
       "version": "2.0.0",
@@ -1872,485 +1902,10 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fsevents": {
-      "version": "1.2.9",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.9.tgz",
-      "integrity": "sha512-oeyj2H3EjjonWcFjD5NvZNE9Rqe4UW+nQBU2HNeKw0koVLEFIhtyETyAakeAM3de7Z/SW5kcA+fZUait9EApnw==",
-      "optional": true,
-      "requires": {
-        "nan": "^2.12.1",
-        "node-pre-gyp": "^0.12.0"
-      },
-      "dependencies": {
-        "abbrev": {
-          "version": "1.1.1",
-          "bundled": true,
-          "optional": true
-        },
-        "ansi-regex": {
-          "version": "2.1.1",
-          "bundled": true,
-          "optional": true
-        },
-        "aproba": {
-          "version": "1.2.0",
-          "bundled": true,
-          "optional": true
-        },
-        "are-we-there-yet": {
-          "version": "1.1.5",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "delegates": "^1.0.0",
-            "readable-stream": "^2.0.6"
-          }
-        },
-        "balanced-match": {
-          "version": "1.0.0",
-          "bundled": true,
-          "optional": true
-        },
-        "brace-expansion": {
-          "version": "1.1.11",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "balanced-match": "^1.0.0",
-            "concat-map": "0.0.1"
-          }
-        },
-        "chownr": {
-          "version": "1.1.1",
-          "bundled": true,
-          "optional": true
-        },
-        "code-point-at": {
-          "version": "1.1.0",
-          "bundled": true,
-          "optional": true
-        },
-        "concat-map": {
-          "version": "0.0.1",
-          "bundled": true,
-          "optional": true
-        },
-        "console-control-strings": {
-          "version": "1.1.0",
-          "bundled": true,
-          "optional": true
-        },
-        "core-util-is": {
-          "version": "1.0.2",
-          "bundled": true,
-          "optional": true
-        },
-        "debug": {
-          "version": "4.1.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "deep-extend": {
-          "version": "0.6.0",
-          "bundled": true,
-          "optional": true
-        },
-        "delegates": {
-          "version": "1.0.0",
-          "bundled": true,
-          "optional": true
-        },
-        "detect-libc": {
-          "version": "1.0.3",
-          "bundled": true,
-          "optional": true
-        },
-        "fs-minipass": {
-          "version": "1.2.5",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "minipass": "^2.2.1"
-          }
-        },
-        "fs.realpath": {
-          "version": "1.0.0",
-          "bundled": true,
-          "optional": true
-        },
-        "gauge": {
-          "version": "2.7.4",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "aproba": "^1.0.3",
-            "console-control-strings": "^1.0.0",
-            "has-unicode": "^2.0.0",
-            "object-assign": "^4.1.0",
-            "signal-exit": "^3.0.0",
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wide-align": "^1.1.0"
-          }
-        },
-        "glob": {
-          "version": "7.1.3",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
-        "has-unicode": {
-          "version": "2.0.1",
-          "bundled": true,
-          "optional": true
-        },
-        "iconv-lite": {
-          "version": "0.4.24",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "safer-buffer": ">= 2.1.2 < 3"
-          }
-        },
-        "ignore-walk": {
-          "version": "3.0.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "minimatch": "^3.0.4"
-          }
-        },
-        "inflight": {
-          "version": "1.0.6",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "once": "^1.3.0",
-            "wrappy": "1"
-          }
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "bundled": true,
-          "optional": true
-        },
-        "ini": {
-          "version": "1.3.5",
-          "bundled": true,
-          "optional": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "number-is-nan": "^1.0.0"
-          }
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "bundled": true,
-          "optional": true
-        },
-        "minimatch": {
-          "version": "3.0.4",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "brace-expansion": "^1.1.7"
-          }
-        },
-        "minimist": {
-          "version": "0.0.8",
-          "bundled": true,
-          "optional": true
-        },
-        "minipass": {
-          "version": "2.3.5",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "safe-buffer": "^5.1.2",
-            "yallist": "^3.0.0"
-          }
-        },
-        "minizlib": {
-          "version": "1.2.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "minipass": "^2.2.1"
-          }
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "minimist": "0.0.8"
-          }
-        },
-        "ms": {
-          "version": "2.1.1",
-          "bundled": true,
-          "optional": true
-        },
-        "needle": {
-          "version": "2.3.0",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "debug": "^4.1.0",
-            "iconv-lite": "^0.4.4",
-            "sax": "^1.2.4"
-          }
-        },
-        "node-pre-gyp": {
-          "version": "0.12.0",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "detect-libc": "^1.0.2",
-            "mkdirp": "^0.5.1",
-            "needle": "^2.2.1",
-            "nopt": "^4.0.1",
-            "npm-packlist": "^1.1.6",
-            "npmlog": "^4.0.2",
-            "rc": "^1.2.7",
-            "rimraf": "^2.6.1",
-            "semver": "^5.3.0",
-            "tar": "^4"
-          }
-        },
-        "nopt": {
-          "version": "4.0.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "abbrev": "1",
-            "osenv": "^0.1.4"
-          }
-        },
-        "npm-bundled": {
-          "version": "1.0.6",
-          "bundled": true,
-          "optional": true
-        },
-        "npm-packlist": {
-          "version": "1.4.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "ignore-walk": "^3.0.1",
-            "npm-bundled": "^1.0.1"
-          }
-        },
-        "npmlog": {
-          "version": "4.1.2",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "are-we-there-yet": "~1.1.2",
-            "console-control-strings": "~1.1.0",
-            "gauge": "~2.7.3",
-            "set-blocking": "~2.0.0"
-          }
-        },
-        "number-is-nan": {
-          "version": "1.0.1",
-          "bundled": true,
-          "optional": true
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true,
-          "optional": true
-        },
-        "once": {
-          "version": "1.4.0",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "wrappy": "1"
-          }
-        },
-        "os-homedir": {
-          "version": "1.0.2",
-          "bundled": true,
-          "optional": true
-        },
-        "os-tmpdir": {
-          "version": "1.0.2",
-          "bundled": true,
-          "optional": true
-        },
-        "osenv": {
-          "version": "0.1.5",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "os-homedir": "^1.0.0",
-            "os-tmpdir": "^1.0.0"
-          }
-        },
-        "path-is-absolute": {
-          "version": "1.0.1",
-          "bundled": true,
-          "optional": true
-        },
-        "process-nextick-args": {
-          "version": "2.0.0",
-          "bundled": true,
-          "optional": true
-        },
-        "rc": {
-          "version": "1.2.8",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "deep-extend": "^0.6.0",
-            "ini": "~1.3.0",
-            "minimist": "^1.2.0",
-            "strip-json-comments": "~2.0.1"
-          },
-          "dependencies": {
-            "minimist": {
-              "version": "1.2.0",
-              "bundled": true,
-              "optional": true
-            }
-          }
-        },
-        "readable-stream": {
-          "version": "2.3.6",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "rimraf": {
-          "version": "2.6.3",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "glob": "^7.1.3"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "bundled": true,
-          "optional": true
-        },
-        "safer-buffer": {
-          "version": "2.1.2",
-          "bundled": true,
-          "optional": true
-        },
-        "sax": {
-          "version": "1.2.4",
-          "bundled": true,
-          "optional": true
-        },
-        "semver": {
-          "version": "5.7.0",
-          "bundled": true,
-          "optional": true
-        },
-        "set-blocking": {
-          "version": "2.0.0",
-          "bundled": true,
-          "optional": true
-        },
-        "signal-exit": {
-          "version": "3.0.2",
-          "bundled": true,
-          "optional": true
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        },
-        "strip-json-comments": {
-          "version": "2.0.1",
-          "bundled": true,
-          "optional": true
-        },
-        "tar": {
-          "version": "4.4.8",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "chownr": "^1.1.1",
-            "fs-minipass": "^1.2.5",
-            "minipass": "^2.3.4",
-            "minizlib": "^1.1.1",
-            "mkdirp": "^0.5.0",
-            "safe-buffer": "^5.1.2",
-            "yallist": "^3.0.2"
-          }
-        },
-        "util-deprecate": {
-          "version": "1.0.2",
-          "bundled": true,
-          "optional": true
-        },
-        "wide-align": {
-          "version": "1.1.3",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "string-width": "^1.0.2 || 2"
-          }
-        },
-        "wrappy": {
-          "version": "1.0.2",
-          "bundled": true,
-          "optional": true
-        },
-        "yallist": {
-          "version": "3.0.3",
-          "bundled": true,
-          "optional": true
-        }
-      }
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
+      "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+      "optional": true
     },
     "functional-red-black-tree": {
       "version": "1.0.1",
@@ -2397,22 +1952,12 @@
       }
     },
     "glob-parent": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
-      "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
+      "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+      "optional": true,
       "requires": {
-        "is-glob": "^3.1.0",
-        "path-dirname": "^1.0.0"
-      },
-      "dependencies": {
-        "is-glob": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
-          "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-          "requires": {
-            "is-extglob": "^2.1.0"
-          }
-        }
+        "is-glob": "^4.0.1"
       }
     },
     "global-modules": {
@@ -2573,11 +2118,11 @@
       "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM="
     },
     "https-proxy-agent": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
-      "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
+      "integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
       "requires": {
-        "agent-base": "^4.1.0",
+        "agent-base": "^4.3.0",
         "debug": "^3.1.0"
       },
       "dependencies": {
@@ -2702,11 +2247,12 @@
       }
     },
     "is-binary-path": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
-      "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "optional": true,
       "requires": {
-        "binary-extensions": "^1.0.0"
+        "binary-extensions": "^2.0.0"
       }
     },
     "is-buffer": {
@@ -2953,9 +2499,9 @@
       },
       "dependencies": {
         "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
         }
       }
     },
@@ -2971,9 +2517,9 @@
       }
     },
     "kind-of": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-      "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
     },
     "lcid": {
       "version": "2.0.0",
@@ -3017,9 +2563,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "lodash.sortby": {
       "version": "4.7.0",
@@ -3141,9 +2687,9 @@
       }
     },
     "mime": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.2.tgz",
-      "integrity": "sha512-zJBfZDkwRu+j3Pdd2aHsR5GfH2jIWhmL1ZzBoc+X+3JEti2hbArWcyJ+1laC1D2/U/W1a/+Cegj0/OnEU2ybjg=="
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.5.tgz",
+      "integrity": "sha512-3hQhEUF027BuxZjQA3s7rIv/7VCQPa27hN9u9g87sEkWaKwQPuXOkVKtOeiyUrnWqTDiOs8Ed2rwg733mB0R5w=="
     },
     "mime-db": {
       "version": "1.40.0",
@@ -3182,9 +2728,9 @@
       }
     },
     "minimist": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "mississippi": {
       "version": "3.0.0",
@@ -3204,9 +2750,9 @@
       }
     },
     "mixin-deep": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
-      "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
+      "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
       "requires": {
         "for-in": "^1.0.2",
         "is-extendable": "^1.0.1"
@@ -3223,11 +2769,11 @@
       }
     },
     "mkdirp": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
       "requires": {
-        "minimist": "0.0.8"
+        "minimist": "^1.2.5"
       }
     },
     "move-concurrently": {
@@ -3252,12 +2798,6 @@
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
-    },
-    "nan": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
-      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
-      "optional": true
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -3346,7 +2886,8 @@
     "normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "optional": true
     },
     "npm-run-path": {
       "version": "2.0.2",
@@ -3551,7 +3092,8 @@
     "path-dirname": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
-      "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA="
+      "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
+      "optional": true
     },
     "path-exists": {
       "version": "3.0.0",
@@ -3599,6 +3141,12 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+    },
+    "picomatch": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
+      "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
+      "optional": true
     },
     "pify": {
       "version": "4.0.1",
@@ -3654,9 +3202,9 @@
       "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM="
     },
     "proxy-from-env": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.0.0.tgz",
-      "integrity": "sha1-M8UDmPcOp+uW0h97gXYwpVeRx+4="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "prr": {
       "version": "1.0.1",
@@ -3722,9 +3270,9 @@
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "puppeteer": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-1.15.0.tgz",
-      "integrity": "sha512-D2y5kwA9SsYkNUmcBzu9WZ4V1SGHiQTmgvDZSx6sRYFsgV25IebL4V6FaHjF6MbwLK9C6f3G3pmck9qmwM8H3w==",
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-1.20.0.tgz",
+      "integrity": "sha512-bt48RDBy2eIwZPrkgbcwHtb51mj2nKvHOPMaSH2IsWiv7lOG9k9zhaRzpDZafrk05ajMc3cu+lSQYYOfH2DkVQ==",
       "requires": {
         "debug": "^4.1.0",
         "extract-zip": "^1.6.6",
@@ -3841,13 +3389,12 @@
       }
     },
     "readdirp": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
-      "integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.4.0.tgz",
+      "integrity": "sha512-0xe001vZBnJEK+uKcj8qOhyAKPzIT+gStxWr3LCB0DwcXR5NZJ3IaC+yGnHCYzB/S7ov3m3EEbZI2zeNvX+hGQ==",
+      "optional": true,
       "requires": {
-        "graceful-fs": "^4.1.11",
-        "micromatch": "^3.1.10",
-        "readable-stream": "^2.0.2"
+        "picomatch": "^2.2.1"
       }
     },
     "regex-not": {
@@ -3867,7 +3414,8 @@
     "remove-trailing-separator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
+      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+      "optional": true
     },
     "repeat-element": {
       "version": "1.1.3",
@@ -4145,9 +3693,9 @@
       "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
     },
     "serialize-javascript": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.9.1.tgz",
-      "integrity": "sha512-0Vb/54WJ6k5v8sSWN09S0ora+Hnr+cX40r9F170nT+mSkaxltoE/7R3OrIdBSUv1OoiobH1QoWQbCnAO+e8J1A=="
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-2.1.2.tgz",
+      "integrity": "sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ=="
     },
     "set-blocking": {
       "version": "2.0.0",
@@ -4155,9 +3703,9 @@
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
     },
     "set-value": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
-      "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
+      "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
       "requires": {
         "extend-shallow": "^2.0.1",
         "is-extendable": "^0.1.1",
@@ -4464,9 +4012,9 @@
       }
     },
     "stream-shift": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
-      "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
+      "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ=="
     },
     "string-width": {
       "version": "2.1.1",
@@ -4567,9 +4115,9 @@
       "integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA=="
     },
     "terser": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-4.4.0.tgz",
-      "integrity": "sha512-oDG16n2WKm27JO8h4y/w3iqBGAOSCtq7k8dRmrn4Wf9NouL0b2WpMHGChFGZq4nFAQy1FsNJrVQHfurXOSTmOA==",
+      "version": "4.6.13",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-4.6.13.tgz",
+      "integrity": "sha512-wMvqukYgVpQlymbnNbabVZbtM6PN63AzqexpwJL8tbh/mRT9LE5o+ruVduAGL7D6Fpjl+Q+06U5I9Ul82odAhw==",
       "requires": {
         "commander": "^2.20.0",
         "source-map": "~0.6.1",
@@ -4582,9 +4130,9 @@
           "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
         },
         "source-map-support": {
-          "version": "0.5.16",
-          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.16.tgz",
-          "integrity": "sha512-efyLRJDr68D9hBBNIPWFjhpFzURh+KJykQwvMyW5UiZzYwoF6l4YMMDIJJEyFWxWCqfyxLzz6tSfUFR+kXXsVQ==",
+          "version": "0.5.19",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
+          "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
           "requires": {
             "buffer-from": "^1.0.0",
             "source-map": "^0.6.0"
@@ -4593,15 +4141,15 @@
       }
     },
     "terser-webpack-plugin": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.1.tgz",
-      "integrity": "sha512-ZXmmfiwtCLfz8WKZyYUuuHf3dMYEjg8NrjHMb0JqHVHVOSkzp3cW2/XG1fP3tRhqEqSzMwzzRQGtAPbs4Cncxg==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.3.tgz",
+      "integrity": "sha512-QMxecFz/gHQwteWwSo5nTc6UaICqN1bMedC5sMtUc7y3Ha3Q8y6ZO0iCR8pq4RJC8Hjf0FEPEHZqcMB/+DFCrA==",
       "requires": {
         "cacache": "^12.0.2",
         "find-cache-dir": "^2.1.0",
         "is-wsl": "^1.1.0",
         "schema-utils": "^1.0.0",
-        "serialize-javascript": "^1.7.0",
+        "serialize-javascript": "^2.1.2",
         "source-map": "^0.6.1",
         "terser": "^4.1.2",
         "webpack-sources": "^1.4.0",
@@ -4734,9 +4282,9 @@
       },
       "dependencies": {
         "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
         }
       }
     },
@@ -4746,7 +4294,7 @@
         "@types/jquery": "^3.3.29",
         "btoa": "^1.2.1",
         "es6-promise": "^4.2.4",
-        "jquery": "^3.4.1",
+        "jquery": "^3.5.1",
         "url-parse": "^1.4.3"
       },
       "dependencies": {
@@ -4928,9 +4476,9 @@
           }
         },
         "jquery": {
-          "version": "3.4.1",
-          "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.4.1.tgz",
-          "integrity": "sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw=="
+          "version": "3.5.1",
+          "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.5.1.tgz",
+          "integrity": "sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg=="
         },
         "mime-db": {
           "version": "1.40.0",
@@ -5036,35 +4584,14 @@
       "dev": true
     },
     "union-value": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
-      "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
+      "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
       "requires": {
         "arr-union": "^3.1.0",
         "get-value": "^2.0.6",
         "is-extendable": "^0.1.1",
-        "set-value": "^0.4.3"
-      },
-      "dependencies": {
-        "extend-shallow": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-          "requires": {
-            "is-extendable": "^0.1.0"
-          }
-        },
-        "set-value": {
-          "version": "0.4.3",
-          "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
-          "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
-          "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-extendable": "^0.1.1",
-            "is-plain-object": "^2.0.1",
-            "to-object-path": "^0.3.0"
-          }
-        }
+        "set-value": "^2.0.1"
       }
     },
     "unique-filename": {
@@ -5122,7 +4649,8 @@
     "upath": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
-      "integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg=="
+      "integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==",
+      "optional": true
     },
     "uri-js": {
       "version": "4.2.2",
@@ -5223,13 +4751,119 @@
       }
     },
     "watchpack": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.6.0.tgz",
-      "integrity": "sha512-i6dHe3EyLjMmDlU1/bGQpEw25XSjkJULPuAVKCbNRefQVq48yXKUpwg538F7AZTf9kyr57zj++pQFltUa5H7yA==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.7.2.tgz",
+      "integrity": "sha512-ymVbbQP40MFTp+cNMvpyBpBtygHnPzPkHqoIwRRj/0B8KhqQwV8LaKjtbaxF2lK4vl8zN9wCxS46IFCU5K4W0g==",
       "requires": {
-        "chokidar": "^2.0.2",
+        "chokidar": "^3.4.0",
         "graceful-fs": "^4.1.2",
-        "neo-async": "^2.5.0"
+        "neo-async": "^2.5.0",
+        "watchpack-chokidar2": "^2.0.0"
+      }
+    },
+    "watchpack-chokidar2": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/watchpack-chokidar2/-/watchpack-chokidar2-2.0.0.tgz",
+      "integrity": "sha512-9TyfOyN/zLUbA288wZ8IsMZ+6cbzvsNyEzSBp6e/zkifi6xxbl8SmQ/CxQq32k8NNqrdVEVUVSEf56L4rQ/ZxA==",
+      "optional": true,
+      "requires": {
+        "chokidar": "^2.1.8"
+      },
+      "dependencies": {
+        "anymatch": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
+          "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+          "optional": true,
+          "requires": {
+            "micromatch": "^3.1.4",
+            "normalize-path": "^2.1.1"
+          },
+          "dependencies": {
+            "normalize-path": {
+              "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+              "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+              "optional": true,
+              "requires": {
+                "remove-trailing-separator": "^1.0.1"
+              }
+            }
+          }
+        },
+        "binary-extensions": {
+          "version": "1.13.1",
+          "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
+          "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
+          "optional": true
+        },
+        "chokidar": {
+          "version": "2.1.8",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
+          "integrity": "sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==",
+          "optional": true,
+          "requires": {
+            "anymatch": "^2.0.0",
+            "async-each": "^1.0.1",
+            "braces": "^2.3.2",
+            "fsevents": "^1.2.7",
+            "glob-parent": "^3.1.0",
+            "inherits": "^2.0.3",
+            "is-binary-path": "^1.0.0",
+            "is-glob": "^4.0.0",
+            "normalize-path": "^3.0.0",
+            "path-is-absolute": "^1.0.0",
+            "readdirp": "^2.2.1",
+            "upath": "^1.1.1"
+          }
+        },
+        "fsevents": {
+          "version": "1.2.13",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
+          "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
+          "optional": true
+        },
+        "glob-parent": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+          "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+          "optional": true,
+          "requires": {
+            "is-glob": "^3.1.0",
+            "path-dirname": "^1.0.0"
+          },
+          "dependencies": {
+            "is-glob": {
+              "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+              "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+              "optional": true,
+              "requires": {
+                "is-extglob": "^2.1.0"
+              }
+            }
+          }
+        },
+        "is-binary-path": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+          "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+          "optional": true,
+          "requires": {
+            "binary-extensions": "^1.0.0"
+          }
+        },
+        "readdirp": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
+          "integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
+          "optional": true,
+          "requires": {
+            "graceful-fs": "^4.1.11",
+            "micromatch": "^3.1.10",
+            "readable-stream": "^2.0.2"
+          }
+        }
       }
     },
     "webidl-conversions": {
@@ -5268,9 +4902,9 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.3.0.tgz",
-          "integrity": "sha512-/czfa8BwS88b9gWQVhc8eknunSA2DoJpJyTQkhheIf5E48u1N0R4q/YxxsAeqRrmK9TQ/uYfgLDfZo91UlANIA=="
+          "version": "6.4.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
+          "integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA=="
         },
         "ajv": {
           "version": "6.10.2",
@@ -5530,20 +5164,21 @@
       }
     },
     "yargs-parser": {
-      "version": "13.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
-      "integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
+      "version": "13.1.2",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+      "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
       "requires": {
         "camelcase": "^5.0.0",
         "decamelize": "^1.2.0"
       }
     },
     "yauzl": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
-      "integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
       "requires": {
-        "fd-slicer": "~1.0.1"
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
       }
     },
     "yn": {


### PR DESCRIPTION
Currently the new typescript generator only supports receiving http responses with `Content-Type: application/json`. This is an approach to support other media types as well.
In particular the first goal is to allow parsing arbitrary binary files as `HttpFile`.
Later other media types, like xml could be added (possibly togglable with an config option to not always pull in the relevant parser library)

Please have a look, when you find the time @TiFu. The file download is not quite finished though.

Cf. #802