### PR TITLE
Fix locale issue for numeric string conversions

### DIFF
--- a/modules/openapi-generator/src/main/resources/csharp-netcore/ClientUtils.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/ClientUtils.mustache
@@ -97,7 +97,7 @@ namespace {{packageName}}.Client
             if (obj is ICollection collection)
                 return string.Join(",", collection.Cast<object>());
 
-            return Convert.ToString(obj);
+            return Convert.ToString(obj, CultureInfo.InvariantCulture);
         }
 
         /// <summary>

--- a/modules/openapi-generator/src/main/resources/csharp-netcore/ClientUtils.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/ClientUtils.mustache
@@ -1,6 +1,7 @@
 {{>partial_header}}
 
 using System;
+using System.Globalization;
 using System.Collections;
 using System.IO;
 using System.Linq;

--- a/modules/openapi-generator/src/main/resources/csharp-netcore/ClientUtils.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/ClientUtils.mustache
@@ -1,8 +1,8 @@
 {{>partial_header}}
 
 using System;
-using System.Globalization;
 using System.Collections;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;


### PR DESCRIPTION
Using a generated .NET Core client from an application with a locale that formats numbers with a comma as a decimal separator will make the client send invalid numeric parameters to the API. Any numeric parameter with decimals will added to the URL with a comma ('0,15' instead of '0.15'), potentially breaking the API integration.
In my specific use case, the API interpreted '0,15' as '15', resulting in pretty funky errors.

This commit ensures that parameters are parsed with the invariant culture, fixing the mentioned error.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [ ] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
