### PR TITLE
[csharp-netcore] adds support for specifying cookies in the configuration object

### DIFF
--- a/modules/openapi-generator/src/main/resources/csharp-netcore/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/ApiClient.mustache
@@ -271,7 +271,7 @@ namespace {{packageName}}.Client
             {
                 foreach (var headerParam in configuration.DefaultHeaders)
                 {
-                   if (String.Equals(headerParam.Key, "cookie", StringComparison.OrdinalIgnoreCase))
+                    if (String.Equals(headerParam.Key, "cookie", StringComparison.OrdinalIgnoreCase))
                     {
                         string[] cookieSeparators = new string[] {";"};
                         string[] EqualSeparator = new string[] {"="};

--- a/modules/openapi-generator/src/main/resources/csharp-netcore/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/ApiClient.mustache
@@ -271,6 +271,21 @@ namespace {{packageName}}.Client
             {
                 foreach (var headerParam in configuration.DefaultHeaders)
                 {
+                   if (String.Equals(headerParam.Key, "cookie", StringComparison.OrdinalIgnoreCase))
+                    {
+                        string[] cookieSeparators = new string[] {";"};
+                        string[] EqualSeparator = new string[] {"="};
+                        string[] rawCookieParams = headerParam.Value.Split(cookieSeparators, StringSplitOptions.None);
+                        foreach (string paramset in rawCookieParams)
+                        {
+                            String[] param = paramset.Split(EqualSeparator, StringSplitOptions.None);
+                            if (param.Length == 2)
+                            {
+                                request.AddCookie(param[0], param[1]);
+                            }
+                        }
+                        continue;
+                    }
                     request.AddHeader(headerParam.Key, headerParam.Value);
                 }
             }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -274,6 +274,21 @@ namespace Org.OpenAPITools.Client
             {
                 foreach (var headerParam in configuration.DefaultHeaders)
                 {
+                    if (String.Equals(headerParam.Key, "cookie", StringComparison.OrdinalIgnoreCase))
+                    {
+                        string[] cookieSeparators = new string[] {";"};
+                        string[] EqualSeparator = new string[] {"="};
+                        string[] rawCookieParams = headerParam.Value.Split(cookieSeparators, StringSplitOptions.None);
+                        foreach (string paramset in rawCookieParams)
+                        {
+                            String[] param = paramset.Split(EqualSeparator, StringSplitOptions.None);
+                            if (param.Length == 2)
+                            {
+                                request.AddCookie(param[0], param[1]);
+                            }
+                        }
+                        continue;
+                    }
                     request.AddHeader(headerParam.Key, headerParam.Value);
                 }
             }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -275,6 +275,21 @@ namespace Org.OpenAPITools.Client
             {
                 foreach (var headerParam in configuration.DefaultHeaders)
                 {
+                    if (String.Equals(headerParam.Key, "cookie", StringComparison.OrdinalIgnoreCase))
+                    {
+                        string[] cookieSeparators = new string[] {";"};
+                        string[] EqualSeparator = new string[] {"="};
+                        string[] rawCookieParams = headerParam.Value.Split(cookieSeparators, StringSplitOptions.None);
+                        foreach (string paramset in rawCookieParams)
+                        {
+                            String[] param = paramset.Split(EqualSeparator, StringSplitOptions.None);
+                            if (param.Length == 2)
+                            {
+                                request.AddCookie(param[0], param[1]);
+                            }
+                        }
+                        continue;
+                    }
                     request.AddHeader(headerParam.Key, headerParam.Value);
                 }
             }


### PR DESCRIPTION
fixes #6191 

Allows to specify cookies in DefaultHeaders. It takes care of specifying multiple `;` separated `Key=Value` cookies.
```
Org.OpenAPITools.Client.Configuration config = new Org.OpenAPITools.Client.Configuration();
var api = new Org.OpenAPITools.Api.NtpApi(config);
var url = endpoint + "ntp/Policies";
var headers = new Dictionary<string, string>()
{
    { "cookie", "k1=v1;k2=v2;v3"},
    { "origin", url }
};
foreach (var h in headers)
{
    api.Configuration.DefaultHeaders.Add(h.Key, h.Value);
}
```

/cc @wing328 @jimschubert 

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [ ] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
