### PR TITLE
[Docker] Added a check to make sure an argument is passed

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -12,10 +12,14 @@ codegen="${cli}/target/openapi-generator-cli.jar"
 # We code in a list of commands here as source processing is potentially buggy (requires undocumented conventional use of annotations).
 # A list of known commands helps us determine if we should compile CLI. There's an edge-case where a new command not added to this
 # list won't be considered a "real" command. We can get around that a bit by checking CLI completions beforehand if it exists.
-commands="list,generate,meta,help,config-help,validate,version"
+commands="config-help,generate,help,list,meta,validate,version"
 
 if [ $# == 0 ]; then
-	echo "Missing a command"
+	echo "No command specified. Available commands:"
+	for i in $(echo $commands | sed "s/,/ /g")
+	do
+		echo "  $i"
+	done
 	exit
 fi
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -14,6 +14,11 @@ codegen="${cli}/target/openapi-generator-cli.jar"
 # list won't be considered a "real" command. We can get around that a bit by checking CLI completions beforehand if it exists.
 commands="list,generate,meta,help,config-help,validate,version"
 
+if [ $# == 0 ]; then
+	echo "Missing a command"
+	exit
+fi
+
 # if CLI jar exists, check $1 against completions available in the CLI
 if [[ -f "${codegen}" && -n "$(java ${JAVA_OPTS} -jar "${codegen}" completion | grep "^$1\$" )" ]]; then
     command=$1


### PR DESCRIPTION
PR to go with issue https://github.com/OpenAPITools/openapi-generator/issues/6206 to stop `unbound variable` errors when running docker-entrypoint.sh without an argument.

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [ ] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [ ] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
