### PR TITLE
Map "AnyType" in rust server generator

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustServerCodegen.java
@@ -211,6 +211,7 @@ public class RustServerCodegen extends DefaultCodegen implements CodegenConfig {
         typeMapping.put("array", "Vec");
         typeMapping.put("map", "std::collections::HashMap");
         typeMapping.put("object", "serde_json::Value");
+        typeMapping.put("AnyType", "serde_json::Value");
 
         importMapping = new HashMap<String, String>();
 

--- a/pom.xml
+++ b/pom.xml
@@ -1237,7 +1237,7 @@
                 <module>samples/server/petstore/python-flask-python2</module>
                 <module>samples/server/petstore/php-slim</module>
                 <module>samples/server/petstore/php-slim4</module>
-                <!--<module>samples/server/petstore/rust-server</module>-->
+                <module>samples/server/petstore/rust-server</module>
                 <!-- clients -->
                 <module>samples/client/petstore/bash</module>
                 <module>samples/client/petstore/c</module>

--- a/samples/server/petstore/rust-server/output/openapi-v3/docs/ObjectUntypedProps.md
+++ b/samples/server/petstore/rust-server/output/openapi-v3/docs/ObjectUntypedProps.md
@@ -3,10 +3,10 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**required_untyped** | [***AnyType**](.md) |  | 
-**required_untyped_nullable** | [***AnyType**](.md) |  | 
-**not_required_untyped** | [***AnyType**](.md) |  | [optional] [default to None]
-**not_required_untyped_nullable** | [***AnyType**](.md) |  | [optional] [default to None]
+**required_untyped** | [***serde_json::Value**](.md) |  | 
+**required_untyped_nullable** | [***serde_json::Value**](.md) |  | 
+**not_required_untyped** | [***serde_json::Value**](.md) |  | [optional] [default to None]
+**not_required_untyped_nullable** | [***serde_json::Value**](.md) |  | [optional] [default to None]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/server/petstore/rust-server/output/openapi-v3/src/models.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/src/models.rs
@@ -1443,23 +1443,23 @@ impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderVal
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct ObjectUntypedProps {
     #[serde(rename = "required_untyped")]
-    pub required_untyped: AnyType,
+    pub required_untyped: serde_json::Value,
 
     #[serde(rename = "required_untyped_nullable")]
-    pub required_untyped_nullable: swagger::Nullable<AnyType>,
+    pub required_untyped_nullable: swagger::Nullable<serde_json::Value>,
 
     #[serde(rename = "not_required_untyped")]
     #[serde(skip_serializing_if="Option::is_none")]
-    pub not_required_untyped: Option<AnyType>,
+    pub not_required_untyped: Option<serde_json::Value>,
 
     #[serde(rename = "not_required_untyped_nullable")]
     #[serde(skip_serializing_if="Option::is_none")]
-    pub not_required_untyped_nullable: Option<AnyType>,
+    pub not_required_untyped_nullable: Option<serde_json::Value>,
 
 }
 
 impl ObjectUntypedProps {
-    pub fn new(required_untyped: AnyType, required_untyped_nullable: swagger::Nullable<AnyType>, ) -> ObjectUntypedProps {
+    pub fn new(required_untyped: serde_json::Value, required_untyped_nullable: swagger::Nullable<serde_json::Value>, ) -> ObjectUntypedProps {
         ObjectUntypedProps {
             required_untyped: required_untyped,
             required_untyped_nullable: required_untyped_nullable,
@@ -1497,10 +1497,10 @@ impl std::str::FromStr for ObjectUntypedProps {
         #[derive(Default)]
         // An intermediate representation of the struct to use for parsing.
         struct IntermediateRep {
-            pub required_untyped: Vec<AnyType>,
-            pub required_untyped_nullable: Vec<AnyType>,
-            pub not_required_untyped: Vec<AnyType>,
-            pub not_required_untyped_nullable: Vec<AnyType>,
+            pub required_untyped: Vec<serde_json::Value>,
+            pub required_untyped_nullable: Vec<serde_json::Value>,
+            pub not_required_untyped: Vec<serde_json::Value>,
+            pub not_required_untyped_nullable: Vec<serde_json::Value>,
         }
 
         let mut intermediate_rep = IntermediateRep::default();
@@ -1517,10 +1517,10 @@ impl std::str::FromStr for ObjectUntypedProps {
 
             if let Some(key) = key_result {
                 match key {
-                    "required_untyped" => intermediate_rep.required_untyped.push(AnyType::from_str(val).map_err(|x| format!("{}", x))?),
+                    "required_untyped" => intermediate_rep.required_untyped.push(serde_json::Value::from_str(val).map_err(|x| format!("{}", x))?),
                     "required_untyped_nullable" => return std::result::Result::Err("Parsing a nullable type in this style is not supported in ObjectUntypedProps".to_string()),
-                    "not_required_untyped" => intermediate_rep.not_required_untyped.push(AnyType::from_str(val).map_err(|x| format!("{}", x))?),
-                    "not_required_untyped_nullable" => intermediate_rep.not_required_untyped_nullable.push(AnyType::from_str(val).map_err(|x| format!("{}", x))?),
+                    "not_required_untyped" => intermediate_rep.not_required_untyped.push(serde_json::Value::from_str(val).map_err(|x| format!("{}", x))?),
+                    "not_required_untyped_nullable" => intermediate_rep.not_required_untyped_nullable.push(serde_json::Value::from_str(val).map_err(|x| format!("{}", x))?),
                     _ => return std::result::Result::Err("Unexpected key while parsing ObjectUntypedProps".to_string())
                 }
             }


### PR DESCRIPTION
- Map "AnyType" in rust server generator

cc @richardwhiuk 

<!-- Please check the completed items below -->
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [ ] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [ ] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
