### PR TITLE
Mark Silex server generator as deprecated

### DIFF
--- a/bin/ci/php-silex-petstore-server.json
+++ b/bin/ci/php-silex-petstore-server.json
@@ -1,5 +1,5 @@
 {
-  "generatorName": "php-silex",
+  "generatorName": "php-silex-deprecated",
   "inputSpec": "modules/openapi-generator/src/test/resources/2_0/petstore.yaml",
   "outputDir": "samples/server/petstore/php-silex/OpenAPIServer",
   "templateDir": "modules/openapi-generator/src/main/resources/php-silex"

--- a/bin/openapi3/php-silex-petstore-server.sh
+++ b/bin/openapi3/php-silex-petstore-server.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="generate -t modules/openapi-generator/src/main/resources/php-silex -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -g php-silex -o samples/server/petstore/php-silex/OpenAPIServer $@"
+ags="generate -t modules/openapi-generator/src/main/resources/php-silex -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -g php-silex-deprecated -o samples/server/petstore/php-silex/OpenAPIServer $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/php-silex-petstore-server.sh
+++ b/bin/php-silex-petstore-server.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="generate -t modules/openapi-generator/src/main/resources/php-silex -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g php-silex -o samples/server/petstore/php-silex/OpenAPIServer $@"
+ags="generate -t modules/openapi-generator/src/main/resources/php-silex -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g php-silex-deprecated -o samples/server/petstore/php-silex/OpenAPIServer $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/windows/php-silex-petstore-server.bat
+++ b/bin/windows/php-silex-petstore-server.bat
@@ -5,6 +5,6 @@ If Not Exist %executable% (
 )
 
 REM set JAVA_OPTS=%JAVA_OPTS% -Xmx1024M
-set ags=generate -i modules\openapi-generator\src\test\resources\2_0\petstore.yaml -g php-silex -o samples\server\petstore\php-silex\OpenAPIServer
+set ags=generate -i modules\openapi-generator\src\test\resources\2_0\petstore.yaml -g php-silex-deprecated -o samples\server\petstore\php-silex\OpenAPIServer
 
 java %JAVA_OPTS% -jar %executable% %ags%

--- a/docs/generators.md
+++ b/docs/generators.md
@@ -108,7 +108,7 @@ The following generators are available:
 * [nodejs-server-deprecated (deprecated)](generators/nodejs-server-deprecated.md)  
 * [php-laravel](generators/php-laravel.md)  
 * [php-lumen](generators/php-lumen.md)  
-* [php-silex](generators/php-silex.md)  
+* [php-silex-deprecated (deprecated)](generators/php-silex-deprecated.md)  
 * [php-slim-deprecated (deprecated)](generators/php-slim-deprecated.md)  
 * [php-slim4](generators/php-slim4.md)  
 * [php-symfony](generators/php-symfony.md)  

--- a/docs/generators/php-silex-deprecated.md
+++ b/docs/generators/php-silex-deprecated.md
@@ -1,6 +1,6 @@
 ---
-title: Config Options for php-silex
-sidebar_label: php-silex
+title: Config Options for php-silex-deprecated
+sidebar_label: php-silex-deprecated
 ---
 
 | Option | Description | Values | Default |

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PhpSilexServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PhpSilexServerCodegen.java
@@ -23,6 +23,8 @@ import org.apache.commons.lang3.StringUtils;
 import org.openapitools.codegen.*;
 import org.openapitools.codegen.meta.features.*;
 import org.openapitools.codegen.utils.ModelUtils;
+import org.openapitools.codegen.meta.GeneratorMetadata;
+import org.openapitools.codegen.meta.Stability;
 
 import java.io.File;
 import java.util.*;
@@ -38,6 +40,10 @@ public class PhpSilexServerCodegen extends DefaultCodegen implements CodegenConf
 
     public PhpSilexServerCodegen() {
         super();
+
+        generatorMetadata = GeneratorMetadata.newBuilder(generatorMetadata)
+                .stability(Stability.DEPRECATED)
+                .build();
 
         modifyFeatureSet(features -> features
                 .includeDocumentationFeatures(DocumentationFeature.Readme)
@@ -136,15 +142,13 @@ public class PhpSilexServerCodegen extends DefaultCodegen implements CodegenConf
     }
 
     @Override
-    public String getName()
-
-    {
-        return "php-silex";
+    public String getName() {
+        return "php-silex-deprecated";
     }
 
     @Override
     public String getHelp() {
-        return "Generates a PHP Silex server library.";
+        return "Generates a PHP Silex server library. IMPORTANT NOTE: this generator is no longer actively maintained.";
     }
 
     @Override


### PR DESCRIPTION
[Silex](https://packagist.org/packages/silex/silex) package has been abandoned:
> This package is **abandoned** and no longer maintained. The author suggests using the [symfony/flex](https://packagist.org/packages/symfony/flex) package instead.

> **WARNING**: Silex is in maintenance mode only. Ends of life is set to June 2018. Read more on [Symfony's blog](https://symfony.com/blog/the-end-of-silex).

Closes #6203 

cc @jebentier @dkarlovi @mandrean @jfastnacht @ackintosh @renepardon

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
