### PR TITLE
[Typescript-node] Use strict equality (===) instead of (==) to better match rest of code

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-node/models.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-node/models.mustache
@@ -53,7 +53,7 @@ let typeMap: {[index: string]: any} = {
 
 export class ObjectSerializer {
     public static findCorrectType(data: any, expectedType: string) {
-        if (data == undefined) {
+        if (data === undefined) {
             return expectedType;
         } else if (primitives.indexOf(expectedType.toLowerCase()) !== -1) {
             return expectedType;
@@ -70,7 +70,7 @@ export class ObjectSerializer {
 
             // Check the discriminator
             let discriminatorProperty = typeMap[expectedType].discriminator;
-            if (discriminatorProperty == null) {
+            if (discriminatorProperty === null) {
                 return expectedType; // the type does not have a discriminator. use it.
             } else {
                 if (data[discriminatorProperty]) {
@@ -88,7 +88,7 @@ export class ObjectSerializer {
     }
 
     public static serialize(data: any, type: string) {
-        if (data == undefined) {
+        if (data === undefined) {
             return data;
         } else if (primitives.indexOf(type.toLowerCase()) !== -1) {
             return data;
@@ -128,7 +128,7 @@ export class ObjectSerializer {
     public static deserialize(data: any, type: string) {
         // polymorphism may change the actual type.
         type = ObjectSerializer.findCorrectType(data, type);
-        if (data == undefined) {
+        if (data === undefined) {
             return data;
         } else if (primitives.indexOf(type.toLowerCase()) !== -1) {
             return data;
@@ -200,11 +200,11 @@ export class ApiKeyAuth implements Authentication {
     }
 
     applyToRequest(requestOptions: localVarRequest.Options): void {
-        if (this.location == "query") {
+        if (this.location === "query") {
             (<any>requestOptions.qs)[this.paramName] = this.apiKey;
-        } else if (this.location == "header" && requestOptions && requestOptions.headers) {
+        } else if (this.location === "header" && requestOptions && requestOptions.headers) {
             requestOptions.headers[this.paramName] = this.apiKey;
-        } else if (this.location == 'cookie' && requestOptions && requestOptions.headers) {
+        } else if (this.location === 'cookie' && requestOptions && requestOptions.headers) {
             if (requestOptions.headers['Cookie']) {
                 requestOptions.headers['Cookie'] += '; ' + this.paramName + '=' + encodeURIComponent(this.apiKey);
             }

--- a/samples/client/petstore/typescript-node/npm/model/models.ts
+++ b/samples/client/petstore/typescript-node/npm/model/models.ts
@@ -42,7 +42,7 @@ let typeMap: {[index: string]: any} = {
 
 export class ObjectSerializer {
     public static findCorrectType(data: any, expectedType: string) {
-        if (data == undefined) {
+        if (data === undefined) {
             return expectedType;
         } else if (primitives.indexOf(expectedType.toLowerCase()) !== -1) {
             return expectedType;
@@ -59,7 +59,7 @@ export class ObjectSerializer {
 
             // Check the discriminator
             let discriminatorProperty = typeMap[expectedType].discriminator;
-            if (discriminatorProperty == null) {
+            if (discriminatorProperty === null) {
                 return expectedType; // the type does not have a discriminator. use it.
             } else {
                 if (data[discriminatorProperty]) {
@@ -77,7 +77,7 @@ export class ObjectSerializer {
     }
 
     public static serialize(data: any, type: string) {
-        if (data == undefined) {
+        if (data === undefined) {
             return data;
         } else if (primitives.indexOf(type.toLowerCase()) !== -1) {
             return data;
@@ -117,7 +117,7 @@ export class ObjectSerializer {
     public static deserialize(data: any, type: string) {
         // polymorphism may change the actual type.
         type = ObjectSerializer.findCorrectType(data, type);
-        if (data == undefined) {
+        if (data === undefined) {
             return data;
         } else if (primitives.indexOf(type.toLowerCase()) !== -1) {
             return data;
@@ -189,11 +189,11 @@ export class ApiKeyAuth implements Authentication {
     }
 
     applyToRequest(requestOptions: localVarRequest.Options): void {
-        if (this.location == "query") {
+        if (this.location === "query") {
             (<any>requestOptions.qs)[this.paramName] = this.apiKey;
-        } else if (this.location == "header" && requestOptions && requestOptions.headers) {
+        } else if (this.location === "header" && requestOptions && requestOptions.headers) {
             requestOptions.headers[this.paramName] = this.apiKey;
-        } else if (this.location == 'cookie' && requestOptions && requestOptions.headers) {
+        } else if (this.location === 'cookie' && requestOptions && requestOptions.headers) {
             if (requestOptions.headers['Cookie']) {
                 requestOptions.headers['Cookie'] += '; ' + this.paramName + '=' + encodeURIComponent(this.apiKey);
             }


### PR DESCRIPTION
In few minor cases on the `models.ts` file generated for the typescript-node client, strict equality was not used. This leads to tripping our linting requirements.

This is a minor change to use strict equality (`===` ) across the generated codebase (it is already using strict equality on the majority of the generated code).

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
  - @TiFu (2017/07) @taxpon (2017/07) @sebastianhaas (2017/07) @kenisteward (2017/07) @Vrolijkx (2017/09) @macjohnny (2018/01) @topce (2018/10) @akehir (2019/07) @petejohansonxo (2019/11) @amakhrov (2020/02)