### PR TITLE
[Rust Server] Bugfix #5950 (yaml self reference code compile error.)

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenModel.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenModel.java
@@ -776,8 +776,8 @@ public class CodegenModel implements IJsonSchemaValidationProperties {
                 // TODO cp shouldn't be null. Show a warning message instead
             } else {
                 // detect self import
-                if (this.classname.equalsIgnoreCase(cp.dataType) ||
-                        (cp.isContainer && cp.items != null && this.classname.equalsIgnoreCase(cp.items.dataType))) {
+                if (this.classname.equalsIgnoreCase(cp.baseType) ||
+                        (cp.isContainer && cp.items != null && this.classname.equalsIgnoreCase(cp.items.baseType))) {
                     this.imports.remove(this.classname); // remove self import
                     cp.isSelfReference = true;
                 }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -482,9 +482,17 @@ public class DefaultCodegen implements CodegenConfig {
             List<Map<String, Object>> models = (List<Map<String, Object>>) inner.get("models");
             for (Map<String, Object> mo : models) {
                 CodegenModel cm = (CodegenModel) mo.get("model");
+                for (CodegenProperty cp : cm.vars) {
+                    // detect self import
+                    if (cp.baseType.equalsIgnoreCase(getTypeDeclaration(cm.classname)) ||
+                            (cp.isContainer && cp.items != null && cp.items.dataType.equalsIgnoreCase(cm.classname))) {
+                        cm.imports.remove(cm.classname); // remove self import
+                        cp.isSelfReference = true;
+                    }
+                }
                 for (CodegenProperty cp : cm.allVars) {
                     // detect self import
-                    if (cp.dataType.equalsIgnoreCase(cm.classname) ||
+                    if (cp.baseType.equalsIgnoreCase(getTypeDeclaration(cm.classname)) ||
                             (cp.isContainer && cp.items != null && cp.items.dataType.equalsIgnoreCase(cm.classname))) {
                         cm.imports.remove(cm.classname); // remove self import
                         cp.isSelfReference = true;

--- a/modules/openapi-generator/src/main/resources/rust-server/models.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/models.mustache
@@ -268,7 +268,7 @@ pub struct {{{classname}}} {
     #[serde(default = "swagger::nullable_format::default_optional_nullable")]
 {{/isNullable}}
     #[serde(skip_serializing_if="Option::is_none")]
-    pub {{{name}}}: Option<{{#isNullable}}swagger::Nullable<{{/isNullable}}{{{dataType}}}{{#isNullable}}>{{/isNullable}}>,
+    pub {{{name}}}: {{#isSelfReference}}Box<{{/isSelfReference}}Option<{{#isNullable}}swagger::Nullable<{{/isNullable}}{{{dataType}}}{{#isNullable}}>{{/isNullable}}>{{#isSelfReference}}>{{/isSelfReference}},
 {{/required}}
 
 {{/vars}}
@@ -277,7 +277,7 @@ pub struct {{{classname}}} {
 impl {{{classname}}} {
     pub fn new({{#vars}}{{^defaultValue}}{{{name}}}: {{#isNullable}}swagger::Nullable<{{/isNullable}}{{{dataType}}}{{#isNullable}}>{{/isNullable}}, {{/defaultValue}}{{/vars}}) -> {{{classname}}} {
         {{{classname}}} {
-{{#vars}}            {{{name}}}: {{#defaultValue}}{{{defaultValue}}}{{/defaultValue}}{{^defaultValue}}{{{name}}}{{/defaultValue}},
+{{#vars}}            {{{name}}}: {{#isSelfReference}}Box::new({{/isSelfReference}}{{#defaultValue}}{{{defaultValue}}}{{/defaultValue}}{{^defaultValue}}{{{name}}}{{/defaultValue}}{{#isSelfReference}}){{/isSelfReference}},
 {{/vars}}
         }
     }
@@ -416,7 +416,7 @@ impl std::str::FromStr for {{{classname}}} {
             {{{name}}}: std::result::Result::Err("Nullable types not supported in {{{classname}}}".to_string())?,
             {{/isNullable}}
             {{^isNullable}}
-            {{{name}}}: intermediate_rep.{{{name}}}.into_iter().next(){{#required}}.ok_or("{{{baseName}}} missing in {{{classname}}}".to_string())?{{/required}},
+            {{{name}}}: {{#isSelfReference}}Box::new({{/isSelfReference}}intermediate_rep.{{{name}}}.into_iter().next(){{#required}}.ok_or("{{{baseName}}} missing in {{{classname}}}".to_string())?{{/required}}{{#isSelfReference}}){{/isSelfReference}},
             {{/isNullable}}
             {{/vars}}
         })

--- a/modules/openapi-generator/src/test/resources/3_0/rust-server/openapi-v3.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/rust-server/openapi-v3.yaml
@@ -387,6 +387,10 @@ paths:
       responses:
         '200':
           description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
 
 components:
   securitySchemes:
@@ -549,9 +553,31 @@ components:
         - BAR
     Ok:
       type: string
-    Error:
-      type: string
     Err:
       type: string
     Result:
       type: string
+    Error:
+      type: object
+      required:
+        - code
+        - retryable
+        - message
+      properties:
+        code:
+          type: integer
+        retryable:
+          type: boolean
+        message:
+          type: string
+          example: NotFound
+        innerError:
+          $ref: "#/components/schemas/Error"
+      additionalProperties: true
+      example:
+        code: -1
+        retryable: false
+        message: We failed to update the object in your request
+        innerError:
+          code: -100
+          message: You are trying to access an absent object

--- a/samples/server/petstore/rust-server/output/openapi-v3/api/openapi.yaml
+++ b/samples/server/petstore/rust-server/output/openapi-v3/api/openapi.yaml
@@ -398,6 +398,10 @@ paths:
         required: true
       responses:
         "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
           description: Success
       tags:
       - Repo
@@ -566,12 +570,34 @@ components:
       type: string
     Ok:
       type: string
-    Error:
-      type: string
     Err:
       type: string
     Result:
       type: string
+    Error:
+      additionalProperties: true
+      example:
+        code: -1
+        retryable: false
+        message: We failed to update the object in your request
+        innerError:
+          code: -100
+          message: You are trying to access an absent object
+      properties:
+        code:
+          type: integer
+        retryable:
+          type: boolean
+        message:
+          example: NotFound
+          type: string
+        innerError:
+          $ref: '#/components/schemas/Error'
+      required:
+      - code
+      - message
+      - retryable
+      type: object
     inline_response_201:
       properties:
         foo:

--- a/samples/server/petstore/rust-server/output/openapi-v3/docs/Error.md
+++ b/samples/server/petstore/rust-server/output/openapi-v3/docs/Error.md
@@ -3,6 +3,10 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
+**code** | **isize** |  | 
+**retryable** | **bool** |  | 
+**message** | **String** |  | 
+**inner_error** | [***models::Error**](Error.md) |  | [optional] [default to None]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/server/petstore/rust-server/output/openapi-v3/docs/repo_api.md
+++ b/samples/server/petstore/rust-server/output/openapi-v3/docs/repo_api.md
@@ -9,7 +9,7 @@ Method | HTTP request | Description
 
 
 # **CreateRepo**
-> CreateRepo(object_param)
+> models::Error CreateRepo(object_param)
 
 
 ### Required Parameters
@@ -20,7 +20,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
- (empty response body)
+[**models::Error**](Error.md)
 
 ### Authorization
 
@@ -29,7 +29,7 @@ No authorization required
 ### HTTP request headers
 
  - **Content-Type**: application/json
- - **Accept**: Not defined
+ - **Accept**: application/json, 
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 

--- a/samples/server/petstore/rust-server/output/openapi-v3/src/client/mod.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/src/client/mod.rs
@@ -2287,9 +2287,21 @@ impl<C, F> Api<C> for Client<F> where
                 200 => {
                     let body = response.into_body();
                     Box::new(
-                        future::ok(
+                        body
+                        .concat2()
+                        .map_err(|e| ApiError(format!("Failed to read response: {}", e)))
+                        .and_then(|body|
+                        str::from_utf8(&body)
+                                             .map_err(|e| ApiError(format!("Response was not valid UTF8: {}", e)))
+                                             .and_then(|body|
+                                                 serde_json::from_str::<models::Error>(body)
+                                                     .map_err(|e| e.into())
+                                             )
+                                 )
+                        .map(move |body| {
                             CreateRepoResponse::Success
-                        )
+                            (body)
+                        })
                     ) as Box<dyn Future<Item=_, Error=_> + Send>
                 },
                 code => {

--- a/samples/server/petstore/rust-server/output/openapi-v3/src/lib.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/src/lib.rs
@@ -214,6 +214,7 @@ pub enum XmlPutResponse {
 pub enum CreateRepoResponse {
     /// Success
     Success
+    (models::Error)
 }
 
 #[derive(Debug, PartialEq)]

--- a/samples/server/petstore/rust-server/output/openapi-v3/src/models.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/src/models.rs
@@ -553,7 +553,7 @@ pub struct Error {
 
     #[serde(rename = "innerError")]
     #[serde(skip_serializing_if="Option::is_none")]
-    pub inner_error: Option<models::Error>,
+    pub inner_error: Box<Option<models::Error>>,
 
 }
 
@@ -563,7 +563,7 @@ impl Error {
             code: code,
             retryable: retryable,
             message: message,
-            inner_error: None,
+            inner_error: Box::new(None),
         }
     }
 }
@@ -639,7 +639,7 @@ impl std::str::FromStr for Error {
             code: intermediate_rep.code.into_iter().next().ok_or("code missing in Error".to_string())?,
             retryable: intermediate_rep.retryable.into_iter().next().ok_or("retryable missing in Error".to_string())?,
             message: intermediate_rep.message.into_iter().next().ok_or("message missing in Error".to_string())?,
-            inner_error: intermediate_rep.inner_error.into_iter().next(),
+            inner_error: Box::new(intermediate_rep.inner_error.into_iter().next()),
         })
     }
 }

--- a/samples/server/petstore/rust-server/output/openapi-v3/src/server/mod.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/src/server/mod.rs
@@ -1578,8 +1578,15 @@ where
                                         match result {
                                             Ok(rsp) => match rsp {
                                                 CreateRepoResponse::Success
+                                                    (body)
                                                 => {
                                                     *response.status_mut() = StatusCode::from_u16(200).expect("Unable to turn 200 into a StatusCode");
+                                                    response.headers_mut().insert(
+                                                        CONTENT_TYPE,
+                                                        HeaderValue::from_str("application/json")
+                                                            .expect("Unable to create Content-Type header for CREATE_REPO_SUCCESS"));
+                                                    let body = serde_json::to_string(&body).expect("impossible to fail to serialize");
+                                                    *response.body_mut() = Body::from(body);
                                                 },
                                             },
                                             Err(_) => {


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
#5950 [BUG] [Rust Server] yaml self reference code compile error. 

<!-- Please check the completed items below -->
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [ ] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [ ] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

Same to https://github.com/OpenAPITools/openapi-generator/pull/5951
as branch 5.0.x rename to master.