### PR TITLE
[dart-dio][dart-jaguar][client] Update type key from `oauth` to `oauth2`

### DIFF
--- a/modules/openapi-generator/src/main/resources/dart-dio/auth/oauth.mustache
+++ b/modules/openapi-generator/src/main/resources/dart-dio/auth/oauth.mustache
@@ -7,7 +7,7 @@ class OAuthInterceptor extends AuthInterceptor {
 
     @override
     Future onRequest(RequestOptions options) {
-        final authInfo = getAuthInfo(options, "oauth");
+        final authInfo = getAuthInfo(options, "oauth2");
         for (var info in authInfo) {
             final token = tokens[info["name"]];
             if(token != null) {

--- a/modules/openapi-generator/src/main/resources/dart-jaguar/auth/oauth.mustache
+++ b/modules/openapi-generator/src/main/resources/dart-jaguar/auth/oauth.mustache
@@ -7,7 +7,7 @@ class OAuthInterceptor extends AuthInterceptor {
 
     @override
     FutureOr<void> before(RouteBase route) {
-        final authInfo = getAuthInfo(route, "oauth");
+        final authInfo = getAuthInfo(route, "oauth2");
         for (var info in authInfo) {
             final token = tokens[info["name"]];
             if(token != null) {

--- a/samples/client/petstore/dart-dio/lib/auth/oauth.dart
+++ b/samples/client/petstore/dart-dio/lib/auth/oauth.dart
@@ -7,7 +7,7 @@ class OAuthInterceptor extends AuthInterceptor {
 
     @override
     Future onRequest(RequestOptions options) {
-        final authInfo = getAuthInfo(options, "oauth");
+        final authInfo = getAuthInfo(options, "oauth2");
         for (var info in authInfo) {
             final token = tokens[info["name"]];
             if(token != null) {

--- a/samples/client/petstore/dart-jaguar/flutter_petstore/openapi/lib/auth/oauth.dart
+++ b/samples/client/petstore/dart-jaguar/flutter_petstore/openapi/lib/auth/oauth.dart
@@ -7,7 +7,7 @@ class OAuthInterceptor extends AuthInterceptor {
 
     @override
     FutureOr<void> before(RouteBase route) {
-        final authInfo = getAuthInfo(route, "oauth");
+        final authInfo = getAuthInfo(route, "oauth2");
         for (var info in authInfo) {
             final token = tokens[info["name"]];
             if(token != null) {

--- a/samples/client/petstore/dart-jaguar/openapi/lib/auth/oauth.dart
+++ b/samples/client/petstore/dart-jaguar/openapi/lib/auth/oauth.dart
@@ -7,7 +7,7 @@ class OAuthInterceptor extends AuthInterceptor {
 
     @override
     FutureOr<void> before(RouteBase route) {
-        final authInfo = getAuthInfo(route, "oauth");
+        final authInfo = getAuthInfo(route, "oauth2");
         for (var info in authInfo) {
             final token = tokens[info["name"]];
             if(token != null) {


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

The interceptor for dart-dio was checking for a auth method type key of `oauth` but `oauth2` is the actual key being passed through in `authMethods`. A similar issue existed in dart-jaguar (which is what the dio code seemed to be based on). This fix is for both clients.

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@ircecho (2017/07) @swipesight (2018/09) @jaumard (2018/09) @nickmeinhold (2019/09) @athornz (2019/12) @amondnet (2019/12)