### PR TITLE
[dart-dio][client] Allow passing progress callbacks through client methods.

### DIFF
--- a/modules/openapi-generator/src/main/resources/dart-dio/api.mustache
+++ b/modules/openapi-generator/src/main/resources/dart-dio/api.mustache
@@ -21,7 +21,7 @@ class {{classname}} {
         /// {{summary}}
         ///
         /// {{notes}}
-        Future<Response{{#returnType}}<{{{returnType}}}>{{/returnType}}>{{nickname}}({{#allParams}}{{#required}}{{{dataType}}} {{paramName}},{{/required}}{{/allParams}}{ {{#allParams}}{{^required}}{{{dataType}}} {{paramName}},{{/required}}{{/allParams}}CancelToken cancelToken, Map<String, String> headers,}) async {
+        Future<Response{{#returnType}}<{{{returnType}}}>{{/returnType}}>{{nickname}}({{#allParams}}{{#required}}{{{dataType}}} {{paramName}},{{/required}}{{/allParams}}{ {{#allParams}}{{^required}}{{{dataType}}} {{paramName}},{{/required}}{{/allParams}}CancelToken cancelToken, Map<String, String> headers, ProgressCallback onSendProgress, ProgressCallback onReceiveProgress,}) async {
 
         String _path = "{{{path}}}"{{#pathParams}}.replaceAll("{" r'{{baseName}}' "}", {{{paramName}}}.toString()){{/pathParams}};
 
@@ -90,6 +90,8 @@ class {{classname}} {
             contentType: contentTypes.isNotEmpty ? contentTypes[0] : "application/json",
             ),
             cancelToken: cancelToken,
+            onSendProgress: onSendProgress,
+            onReceiveProgress: onReceiveProgress,
             ){{#returnType}}.then((response) {
 
         {{#isResponseFile}}

--- a/samples/client/petstore/dart-dio/lib/api/pet_api.dart
+++ b/samples/client/petstore/dart-dio/lib/api/pet_api.dart
@@ -19,7 +19,7 @@ class PetApi {
         /// Add a new pet to the store
         ///
         /// 
-        Future<Response>addPet(Pet body,{ CancelToken cancelToken, Map<String, String> headers,}) async {
+        Future<Response>addPet(Pet body,{ CancelToken cancelToken, Map<String, String> headers, ProgressCallback onSendProgress, ProgressCallback onReceiveProgress,}) async {
 
         String _path = "/pet";
 
@@ -50,12 +50,14 @@ class PetApi {
             contentType: contentTypes.isNotEmpty ? contentTypes[0] : "application/json",
             ),
             cancelToken: cancelToken,
+            onSendProgress: onSendProgress,
+            onReceiveProgress: onReceiveProgress,
             );
             }
         /// Deletes a pet
         ///
         /// 
-        Future<Response>deletePet(int petId,{ String apiKey,CancelToken cancelToken, Map<String, String> headers,}) async {
+        Future<Response>deletePet(int petId,{ String apiKey,CancelToken cancelToken, Map<String, String> headers, ProgressCallback onSendProgress, ProgressCallback onReceiveProgress,}) async {
 
         String _path = "/pet/{petId}".replaceAll("{" r'petId' "}", petId.toString());
 
@@ -84,12 +86,14 @@ class PetApi {
             contentType: contentTypes.isNotEmpty ? contentTypes[0] : "application/json",
             ),
             cancelToken: cancelToken,
+            onSendProgress: onSendProgress,
+            onReceiveProgress: onReceiveProgress,
             );
             }
         /// Finds Pets by status
         ///
         /// Multiple status values can be provided with comma separated strings
-        Future<Response<List<Pet>>>findPetsByStatus(List<String> status,{ CancelToken cancelToken, Map<String, String> headers,}) async {
+        Future<Response<List<Pet>>>findPetsByStatus(List<String> status,{ CancelToken cancelToken, Map<String, String> headers, ProgressCallback onSendProgress, ProgressCallback onReceiveProgress,}) async {
 
         String _path = "/pet/findByStatus";
 
@@ -118,6 +122,8 @@ class PetApi {
             contentType: contentTypes.isNotEmpty ? contentTypes[0] : "application/json",
             ),
             cancelToken: cancelToken,
+            onSendProgress: onSendProgress,
+            onReceiveProgress: onReceiveProgress,
             ).then((response) {
 
                 final FullType type = const FullType(BuiltList, const [const FullType(Pet)]);
@@ -138,7 +144,7 @@ class PetApi {
         /// Finds Pets by tags
         ///
         /// Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
-        Future<Response<List<Pet>>>findPetsByTags(List<String> tags,{ CancelToken cancelToken, Map<String, String> headers,}) async {
+        Future<Response<List<Pet>>>findPetsByTags(List<String> tags,{ CancelToken cancelToken, Map<String, String> headers, ProgressCallback onSendProgress, ProgressCallback onReceiveProgress,}) async {
 
         String _path = "/pet/findByTags";
 
@@ -167,6 +173,8 @@ class PetApi {
             contentType: contentTypes.isNotEmpty ? contentTypes[0] : "application/json",
             ),
             cancelToken: cancelToken,
+            onSendProgress: onSendProgress,
+            onReceiveProgress: onReceiveProgress,
             ).then((response) {
 
                 final FullType type = const FullType(BuiltList, const [const FullType(Pet)]);
@@ -187,7 +195,7 @@ class PetApi {
         /// Find pet by ID
         ///
         /// Returns a single pet
-        Future<Response<Pet>>getPetById(int petId,{ CancelToken cancelToken, Map<String, String> headers,}) async {
+        Future<Response<Pet>>getPetById(int petId,{ CancelToken cancelToken, Map<String, String> headers, ProgressCallback onSendProgress, ProgressCallback onReceiveProgress,}) async {
 
         String _path = "/pet/{petId}".replaceAll("{" r'petId' "}", petId.toString());
 
@@ -215,6 +223,8 @@ class PetApi {
             contentType: contentTypes.isNotEmpty ? contentTypes[0] : "application/json",
             ),
             cancelToken: cancelToken,
+            onSendProgress: onSendProgress,
+            onReceiveProgress: onReceiveProgress,
             ).then((response) {
 
                 var serializer = _serializers.serializerForType(Pet);
@@ -234,7 +244,7 @@ class PetApi {
         /// Update an existing pet
         ///
         /// 
-        Future<Response>updatePet(Pet body,{ CancelToken cancelToken, Map<String, String> headers,}) async {
+        Future<Response>updatePet(Pet body,{ CancelToken cancelToken, Map<String, String> headers, ProgressCallback onSendProgress, ProgressCallback onReceiveProgress,}) async {
 
         String _path = "/pet";
 
@@ -265,12 +275,14 @@ class PetApi {
             contentType: contentTypes.isNotEmpty ? contentTypes[0] : "application/json",
             ),
             cancelToken: cancelToken,
+            onSendProgress: onSendProgress,
+            onReceiveProgress: onReceiveProgress,
             );
             }
         /// Updates a pet in the store with form data
         ///
         /// 
-        Future<Response>updatePetWithForm(int petId,{ String name,String status,CancelToken cancelToken, Map<String, String> headers,}) async {
+        Future<Response>updatePetWithForm(int petId,{ String name,String status,CancelToken cancelToken, Map<String, String> headers, ProgressCallback onSendProgress, ProgressCallback onReceiveProgress,}) async {
 
         String _path = "/pet/{petId}".replaceAll("{" r'petId' "}", petId.toString());
 
@@ -302,12 +314,14 @@ class PetApi {
             contentType: contentTypes.isNotEmpty ? contentTypes[0] : "application/json",
             ),
             cancelToken: cancelToken,
+            onSendProgress: onSendProgress,
+            onReceiveProgress: onReceiveProgress,
             );
             }
         /// uploads an image
         ///
         /// 
-        Future<Response<ApiResponse>>uploadFile(int petId,{ String additionalMetadata,Uint8List file,CancelToken cancelToken, Map<String, String> headers,}) async {
+        Future<Response<ApiResponse>>uploadFile(int petId,{ String additionalMetadata,Uint8List file,CancelToken cancelToken, Map<String, String> headers, ProgressCallback onSendProgress, ProgressCallback onReceiveProgress,}) async {
 
         String _path = "/pet/{petId}/uploadImage".replaceAll("{" r'petId' "}", petId.toString());
 
@@ -343,6 +357,8 @@ class PetApi {
             contentType: contentTypes.isNotEmpty ? contentTypes[0] : "application/json",
             ),
             cancelToken: cancelToken,
+            onSendProgress: onSendProgress,
+            onReceiveProgress: onReceiveProgress,
             ).then((response) {
 
                 var serializer = _serializers.serializerForType(ApiResponse);

--- a/samples/client/petstore/dart-dio/lib/api/store_api.dart
+++ b/samples/client/petstore/dart-dio/lib/api/store_api.dart
@@ -16,7 +16,7 @@ class StoreApi {
         /// Delete purchase order by ID
         ///
         /// For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
-        Future<Response>deleteOrder(String orderId,{ CancelToken cancelToken, Map<String, String> headers,}) async {
+        Future<Response>deleteOrder(String orderId,{ CancelToken cancelToken, Map<String, String> headers, ProgressCallback onSendProgress, ProgressCallback onReceiveProgress,}) async {
 
         String _path = "/store/order/{orderId}".replaceAll("{" r'orderId' "}", orderId.toString());
 
@@ -44,12 +44,14 @@ class StoreApi {
             contentType: contentTypes.isNotEmpty ? contentTypes[0] : "application/json",
             ),
             cancelToken: cancelToken,
+            onSendProgress: onSendProgress,
+            onReceiveProgress: onReceiveProgress,
             );
             }
         /// Returns pet inventories by status
         ///
         /// Returns a map of status codes to quantities
-        Future<Response<Map<String, int>>>getInventory({ CancelToken cancelToken, Map<String, String> headers,}) async {
+        Future<Response<Map<String, int>>>getInventory({ CancelToken cancelToken, Map<String, String> headers, ProgressCallback onSendProgress, ProgressCallback onReceiveProgress,}) async {
 
         String _path = "/store/inventory";
 
@@ -77,6 +79,8 @@ class StoreApi {
             contentType: contentTypes.isNotEmpty ? contentTypes[0] : "application/json",
             ),
             cancelToken: cancelToken,
+            onSendProgress: onSendProgress,
+            onReceiveProgress: onReceiveProgress,
             ).then((response) {
 
                 var serializer = _serializers.serializerForType(Map<String, int>);
@@ -96,7 +100,7 @@ class StoreApi {
         /// Find purchase order by ID
         ///
         /// For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generated exceptions
-        Future<Response<Order>>getOrderById(int orderId,{ CancelToken cancelToken, Map<String, String> headers,}) async {
+        Future<Response<Order>>getOrderById(int orderId,{ CancelToken cancelToken, Map<String, String> headers, ProgressCallback onSendProgress, ProgressCallback onReceiveProgress,}) async {
 
         String _path = "/store/order/{orderId}".replaceAll("{" r'orderId' "}", orderId.toString());
 
@@ -124,6 +128,8 @@ class StoreApi {
             contentType: contentTypes.isNotEmpty ? contentTypes[0] : "application/json",
             ),
             cancelToken: cancelToken,
+            onSendProgress: onSendProgress,
+            onReceiveProgress: onReceiveProgress,
             ).then((response) {
 
                 var serializer = _serializers.serializerForType(Order);
@@ -143,7 +149,7 @@ class StoreApi {
         /// Place an order for a pet
         ///
         /// 
-        Future<Response<Order>>placeOrder(Order body,{ CancelToken cancelToken, Map<String, String> headers,}) async {
+        Future<Response<Order>>placeOrder(Order body,{ CancelToken cancelToken, Map<String, String> headers, ProgressCallback onSendProgress, ProgressCallback onReceiveProgress,}) async {
 
         String _path = "/store/order";
 
@@ -174,6 +180,8 @@ class StoreApi {
             contentType: contentTypes.isNotEmpty ? contentTypes[0] : "application/json",
             ),
             cancelToken: cancelToken,
+            onSendProgress: onSendProgress,
+            onReceiveProgress: onReceiveProgress,
             ).then((response) {
 
                 var serializer = _serializers.serializerForType(Order);

--- a/samples/client/petstore/dart-dio/lib/api/user_api.dart
+++ b/samples/client/petstore/dart-dio/lib/api/user_api.dart
@@ -16,7 +16,7 @@ class UserApi {
         /// Create user
         ///
         /// This can only be done by the logged in user.
-        Future<Response>createUser(User body,{ CancelToken cancelToken, Map<String, String> headers,}) async {
+        Future<Response>createUser(User body,{ CancelToken cancelToken, Map<String, String> headers, ProgressCallback onSendProgress, ProgressCallback onReceiveProgress,}) async {
 
         String _path = "/user";
 
@@ -47,12 +47,14 @@ class UserApi {
             contentType: contentTypes.isNotEmpty ? contentTypes[0] : "application/json",
             ),
             cancelToken: cancelToken,
+            onSendProgress: onSendProgress,
+            onReceiveProgress: onReceiveProgress,
             );
             }
         /// Creates list of users with given input array
         ///
         /// 
-        Future<Response>createUsersWithArrayInput(List<User> body,{ CancelToken cancelToken, Map<String, String> headers,}) async {
+        Future<Response>createUsersWithArrayInput(List<User> body,{ CancelToken cancelToken, Map<String, String> headers, ProgressCallback onSendProgress, ProgressCallback onReceiveProgress,}) async {
 
         String _path = "/user/createWithArray";
 
@@ -84,12 +86,14 @@ class UserApi {
             contentType: contentTypes.isNotEmpty ? contentTypes[0] : "application/json",
             ),
             cancelToken: cancelToken,
+            onSendProgress: onSendProgress,
+            onReceiveProgress: onReceiveProgress,
             );
             }
         /// Creates list of users with given input array
         ///
         /// 
-        Future<Response>createUsersWithListInput(List<User> body,{ CancelToken cancelToken, Map<String, String> headers,}) async {
+        Future<Response>createUsersWithListInput(List<User> body,{ CancelToken cancelToken, Map<String, String> headers, ProgressCallback onSendProgress, ProgressCallback onReceiveProgress,}) async {
 
         String _path = "/user/createWithList";
 
@@ -121,12 +125,14 @@ class UserApi {
             contentType: contentTypes.isNotEmpty ? contentTypes[0] : "application/json",
             ),
             cancelToken: cancelToken,
+            onSendProgress: onSendProgress,
+            onReceiveProgress: onReceiveProgress,
             );
             }
         /// Delete user
         ///
         /// This can only be done by the logged in user.
-        Future<Response>deleteUser(String username,{ CancelToken cancelToken, Map<String, String> headers,}) async {
+        Future<Response>deleteUser(String username,{ CancelToken cancelToken, Map<String, String> headers, ProgressCallback onSendProgress, ProgressCallback onReceiveProgress,}) async {
 
         String _path = "/user/{username}".replaceAll("{" r'username' "}", username.toString());
 
@@ -154,12 +160,14 @@ class UserApi {
             contentType: contentTypes.isNotEmpty ? contentTypes[0] : "application/json",
             ),
             cancelToken: cancelToken,
+            onSendProgress: onSendProgress,
+            onReceiveProgress: onReceiveProgress,
             );
             }
         /// Get user by user name
         ///
         /// 
-        Future<Response<User>>getUserByName(String username,{ CancelToken cancelToken, Map<String, String> headers,}) async {
+        Future<Response<User>>getUserByName(String username,{ CancelToken cancelToken, Map<String, String> headers, ProgressCallback onSendProgress, ProgressCallback onReceiveProgress,}) async {
 
         String _path = "/user/{username}".replaceAll("{" r'username' "}", username.toString());
 
@@ -187,6 +195,8 @@ class UserApi {
             contentType: contentTypes.isNotEmpty ? contentTypes[0] : "application/json",
             ),
             cancelToken: cancelToken,
+            onSendProgress: onSendProgress,
+            onReceiveProgress: onReceiveProgress,
             ).then((response) {
 
                 var serializer = _serializers.serializerForType(User);
@@ -206,7 +216,7 @@ class UserApi {
         /// Logs user into the system
         ///
         /// 
-        Future<Response<String>>loginUser(String username,String password,{ CancelToken cancelToken, Map<String, String> headers,}) async {
+        Future<Response<String>>loginUser(String username,String password,{ CancelToken cancelToken, Map<String, String> headers, ProgressCallback onSendProgress, ProgressCallback onReceiveProgress,}) async {
 
         String _path = "/user/login";
 
@@ -236,6 +246,8 @@ class UserApi {
             contentType: contentTypes.isNotEmpty ? contentTypes[0] : "application/json",
             ),
             cancelToken: cancelToken,
+            onSendProgress: onSendProgress,
+            onReceiveProgress: onReceiveProgress,
             ).then((response) {
 
                 var serializer = _serializers.serializerForType(String);
@@ -255,7 +267,7 @@ class UserApi {
         /// Logs out current logged in user session
         ///
         /// 
-        Future<Response>logoutUser({ CancelToken cancelToken, Map<String, String> headers,}) async {
+        Future<Response>logoutUser({ CancelToken cancelToken, Map<String, String> headers, ProgressCallback onSendProgress, ProgressCallback onReceiveProgress,}) async {
 
         String _path = "/user/logout";
 
@@ -283,12 +295,14 @@ class UserApi {
             contentType: contentTypes.isNotEmpty ? contentTypes[0] : "application/json",
             ),
             cancelToken: cancelToken,
+            onSendProgress: onSendProgress,
+            onReceiveProgress: onReceiveProgress,
             );
             }
         /// Updated user
         ///
         /// This can only be done by the logged in user.
-        Future<Response>updateUser(String username,User body,{ CancelToken cancelToken, Map<String, String> headers,}) async {
+        Future<Response>updateUser(String username,User body,{ CancelToken cancelToken, Map<String, String> headers, ProgressCallback onSendProgress, ProgressCallback onReceiveProgress,}) async {
 
         String _path = "/user/{username}".replaceAll("{" r'username' "}", username.toString());
 
@@ -319,6 +333,8 @@ class UserApi {
             contentType: contentTypes.isNotEmpty ? contentTypes[0] : "application/json",
             ),
             cancelToken: cancelToken,
+            onSendProgress: onSendProgress,
+            onReceiveProgress: onReceiveProgress,
             );
             }
         }


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

Dio supports using callbacks to report send/recv progress. This PR adds the ability to pass those callbacks as parameters to api method.

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@ircecho (2017/07) @swipesight (2018/09) @jaumard (2018/09) @nickmeinhold (2019/09) @athornz (2019/12) @amondnet (2019/12)
