### PR TITLE
Remove Silex link from doc

### DIFF
--- a/docs/generators/README.md
+++ b/docs/generators/README.md
@@ -96,7 +96,6 @@ The following generators are available:
 * [nodejs-express-server (beta)](nodejs-express-server.md)  
 * [php-laravel](php-laravel.md)  
 * [php-lumen](php-lumen.md)  
-* [php-silex](php-silex.md)  
 * [php-slim4](php-slim4.md)  
 * [php-symfony](php-symfony.md)  
 * [php-ze-ph](php-ze-ph.md)  


### PR DESCRIPTION
Tiny change. There are no deprecated generators in that doc. I've deleted Silex too.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [ ] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
