### PR TITLE
[Java][jersey2] Add null type support to oneOf/anyOf

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaClientCodegen.java
@@ -606,7 +606,6 @@ public class JavaClientCodegen extends AbstractJavaCodegen
                 HashMap<String, Object> h = (HashMap<String, Object>) o;
                 CodegenModel m = (CodegenModel) h.get("model");
                 modelMaps.put(m.classname, m);
-
             }
 
             // check if return type is oneOf/anyeOf model
@@ -809,6 +808,18 @@ public class JavaClientCodegen extends AbstractJavaCodegen
             //List<String> impl = (List<String>) cm.getVendorExtensions().get("x-implements");
             if (JERSEY2.equals(getLibrary())) {
                 cm.getVendorExtensions().put("x-implements", new ArrayList<String>());
+
+                if (cm.oneOf != null && !cm.oneOf.isEmpty() && cm.oneOf.contains("ModelNull")) {
+                    // if oneOf contains "null" type
+                    cm.isNullable = true;
+                    cm.oneOf.remove("ModelNull");
+                }
+
+                if (cm.anyOf != null && !cm.anyOf.isEmpty() && cm.anyOf.contains("ModelNull")) {
+                    // if anyOf contains "null" type
+                    cm.isNullable = true;
+                    cm.anyOf.remove("ModelNull");
+                }
             }
             if (this.parcelableModel) {
                 ((ArrayList<String>) cm.getVendorExtensions().get("x-implements")).add("Parcelable");

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/AbstractOpenApiSchema.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/AbstractOpenApiSchema.mustache
@@ -16,11 +16,15 @@ public abstract class AbstractOpenApiSchema {
     // store the actual instance of the schema/object
     private Object instance;
 
+    // is nullable
+    private Boolean isNullable;
+
     // schema type (e.g. oneOf, anyOf)
     private final String schemaType;
 
-    public AbstractOpenApiSchema(String schemaType) {
+    public AbstractOpenApiSchema(String schemaType, Boolean isNullable) {
         this.schemaType = schemaType;
+        this.isNullable = isNullable;
     }
 
     /***
@@ -51,5 +55,18 @@ public abstract class AbstractOpenApiSchema {
      */
     public String getSchemaType() {
         return schemaType;
+    }
+
+    /***
+     * Is nullalble
+     *
+     * @return true if it's nullable
+     */
+    public Boolean isNullable() {
+        if (Boolean.TRUE.equals(isNullable)) {
+            return Boolean.TRUE;
+        } else {
+            return Boolean.FALSE;
+        }
     }
 }

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/ApiClient.mustache
@@ -848,6 +848,15 @@ public class ApiClient {
     int matchCounter = 0;
     ArrayList<String> matchSchemas = new ArrayList<>();
 
+    if (schema.isNullable()) {
+      response.bufferEntity();
+      if ("{}".equals(String.valueOf(response.readEntity(String.class))) ||
+          "".equals(String.valueOf(response.readEntity(String.class)))) {
+        // schema is nullable and the response body is {} or empty string
+        return schema;
+      }
+    }
+
     for (Map.Entry<String, GenericType> entry : schema.getSchemas().entrySet()) {
       String schemaName = entry.getKey();
       GenericType schemaType = entry.getValue();

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/anyof_model.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/anyof_model.mustache
@@ -11,7 +11,7 @@ public class {{classname}} extends AbstractOpenApiSchema{{#vendorExtensions.x-im
     public final static Map<String, GenericType> schemas = new HashMap<String, GenericType>();
 
     public {{classname}}() {
-        super("anyOf");
+        super("anyOf", {{#isNullable}}Boolean.TRUE{{/isNullable}}{{^isNullable}}Boolean.FALSE{{/isNullable}});
     }
 
     static {
@@ -24,5 +24,24 @@ public class {{classname}} extends AbstractOpenApiSchema{{#vendorExtensions.x-im
     @Override
     public Map<String, GenericType> getSchemas() {
         return {{classname}}.schemas;
+    }
+
+    @Override
+    public void setActualInstance(Object instance) {
+        {{#isNulalble}}
+        if (instance == null) {
+           super.setActualInstance(instance);
+           return;
+        }
+
+        {{/isNulalble}}
+        {{#anyOf}}
+        if (instance instanceof {{{.}}}) {
+            super.setActualInstance(instance);
+            return;
+        }
+
+        {{/anyOf}}
+        throw new RuntimeException("Invalid instance type. Must be {{#oneOf}}{{{.}}}{{^-last}}, {{/-last}}{{/oneOf}}");
     }
 }

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/oneof_model.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/oneof_model.mustache
@@ -11,7 +11,7 @@ public class {{classname}} extends AbstractOpenApiSchema{{#vendorExtensions.x-im
     public final static Map<String, GenericType> schemas = new HashMap<String, GenericType>();
 
     public {{classname}}() {
-        super("oneOf");
+        super("oneOf", {{#isNullable}}Boolean.TRUE{{/isNullable}}{{^isNullable}}Boolean.FALSE{{/isNullable}});
     }
 
     static {
@@ -28,6 +28,13 @@ public class {{classname}} extends AbstractOpenApiSchema{{#vendorExtensions.x-im
 
     @Override
     public void setActualInstance(Object instance) {
+        {{#isNulalble}}
+        if (instance == null) {
+           super.setActualInstance(instance);
+           return;
+        }
+
+        {{/isNulalble}}
         {{#oneOf}}
         if (instance instanceof {{{.}}}) {
             super.setActualInstance(instance);
@@ -37,5 +44,7 @@ public class {{classname}} extends AbstractOpenApiSchema{{#vendorExtensions.x-im
         {{/oneOf}}
         throw new RuntimeException("Invalid instance type. Must be {{#oneOf}}{{{.}}}{{^-last}}, {{/-last}}{{/oneOf}}");
     }
+
+
 
 }

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/ApiClient.java
@@ -760,6 +760,15 @@ public class ApiClient {
     int matchCounter = 0;
     ArrayList<String> matchSchemas = new ArrayList<>();
 
+    if (schema.isNullable()) {
+      response.bufferEntity();
+      if ("{}".equals(String.valueOf(response.readEntity(String.class))) ||
+          "".equals(String.valueOf(response.readEntity(String.class)))) {
+        // schema is nullable and the response body is {} or empty string
+        return schema;
+      }
+    }
+
     for (Map.Entry<String, GenericType> entry : schema.getSchemas().entrySet()) {
       String schemaName = entry.getKey();
       GenericType schemaType = entry.getValue();

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/AbstractOpenApiSchema.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/AbstractOpenApiSchema.java
@@ -27,11 +27,15 @@ public abstract class AbstractOpenApiSchema {
     // store the actual instance of the schema/object
     private Object instance;
 
+    // is nullable
+    private Boolean isNullable;
+
     // schema type (e.g. oneOf, anyOf)
     private final String schemaType;
 
-    public AbstractOpenApiSchema(String schemaType) {
+    public AbstractOpenApiSchema(String schemaType, Boolean isNullable) {
         this.schemaType = schemaType;
+        this.isNullable = isNullable;
     }
 
     /***
@@ -62,5 +66,18 @@ public abstract class AbstractOpenApiSchema {
      */
     public String getSchemaType() {
         return schemaType;
+    }
+
+    /***
+     * Is nullalble
+     *
+     * @return true if it's nullable
+     */
+    public Boolean isNullable() {
+        if (Boolean.TRUE.equals(isNullable)) {
+            return Boolean.TRUE;
+        } else {
+            return Boolean.FALSE;
+        }
     }
 }

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/ApiClient.java
@@ -761,6 +761,15 @@ public class ApiClient {
     int matchCounter = 0;
     ArrayList<String> matchSchemas = new ArrayList<>();
 
+    if (schema.isNullable()) {
+      response.bufferEntity();
+      if ("{}".equals(String.valueOf(response.readEntity(String.class))) ||
+          "".equals(String.valueOf(response.readEntity(String.class)))) {
+        // schema is nullable and the response body is {} or empty string
+        return schema;
+      }
+    }
+
     for (Map.Entry<String, GenericType> entry : schema.getSchemas().entrySet()) {
       String schemaName = entry.getKey();
       GenericType schemaType = entry.getValue();

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AbstractOpenApiSchema.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AbstractOpenApiSchema.java
@@ -27,11 +27,15 @@ public abstract class AbstractOpenApiSchema {
     // store the actual instance of the schema/object
     private Object instance;
 
+    // is nullable
+    private Boolean isNullable;
+
     // schema type (e.g. oneOf, anyOf)
     private final String schemaType;
 
-    public AbstractOpenApiSchema(String schemaType) {
+    public AbstractOpenApiSchema(String schemaType, Boolean isNullable) {
         this.schemaType = schemaType;
+        this.isNullable = isNullable;
     }
 
     /***
@@ -62,5 +66,18 @@ public abstract class AbstractOpenApiSchema {
      */
     public String getSchemaType() {
         return schemaType;
+    }
+
+    /***
+     * Is nullalble
+     *
+     * @return true if it's nullable
+     */
+    public Boolean isNullable() {
+        if (Boolean.TRUE.equals(isNullable)) {
+            return Boolean.TRUE;
+        } else {
+            return Boolean.FALSE;
+        }
     }
 }

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/ApiClient.java
@@ -761,6 +761,15 @@ public class ApiClient {
     int matchCounter = 0;
     ArrayList<String> matchSchemas = new ArrayList<>();
 
+    if (schema.isNullable()) {
+      response.bufferEntity();
+      if ("{}".equals(String.valueOf(response.readEntity(String.class))) ||
+          "".equals(String.valueOf(response.readEntity(String.class)))) {
+        // schema is nullable and the response body is {} or empty string
+        return schema;
+      }
+    }
+
     for (Map.Entry<String, GenericType> entry : schema.getSchemas().entrySet()) {
       String schemaName = entry.getKey();
       GenericType schemaType = entry.getValue();

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/AbstractOpenApiSchema.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/AbstractOpenApiSchema.java
@@ -27,11 +27,15 @@ public abstract class AbstractOpenApiSchema {
     // store the actual instance of the schema/object
     private Object instance;
 
+    // is nullable
+    private Boolean isNullable;
+
     // schema type (e.g. oneOf, anyOf)
     private final String schemaType;
 
-    public AbstractOpenApiSchema(String schemaType) {
+    public AbstractOpenApiSchema(String schemaType, Boolean isNullable) {
         this.schemaType = schemaType;
+        this.isNullable = isNullable;
     }
 
     /***
@@ -62,5 +66,18 @@ public abstract class AbstractOpenApiSchema {
      */
     public String getSchemaType() {
         return schemaType;
+    }
+
+    /***
+     * Is nullalble
+     *
+     * @return true if it's nullable
+     */
+    public Boolean isNullable() {
+        if (Boolean.TRUE.equals(isNullable)) {
+            return Boolean.TRUE;
+        } else {
+            return Boolean.FALSE;
+        }
     }
 }


### PR DESCRIPTION
- Add null type support to oneOf/anyOf
- tested locally with a spec using oneOf and "type: null"

To fix https://github.com/OpenAPITools/openapi-generator/issues/6257

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

cc @bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04) @lwlee2608 (2019/10) @bkabrda (2020/01)


