### PR TITLE
Add null type support to Go (experimental) oneOf/anyOf schemas

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractGoCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractGoCodegen.java
@@ -119,6 +119,7 @@ public abstract class AbstractGoCodegen extends DefaultCodegen implements Codege
         typeMapping.put("file", "*os.File");
         typeMapping.put("binary", "*os.File");
         typeMapping.put("ByteArray", "string");
+        typeMapping.put("null", "nil");
         // A 'type: object' OAS schema without any declared property is
         // (per JSON schema specification) "an unordered set of properties
         // mapping a string to an instance".
@@ -639,6 +640,19 @@ public abstract class AbstractGoCodegen extends DefaultCodegen implements Codege
                         addedOSImport = true;
                     }
                 }
+
+                if (model.oneOf != null && !model.oneOf.isEmpty() && model.oneOf.contains("nil")) {
+                    // if oneOf contains "null" type
+                    model.isNullable = true;
+                    model.oneOf.remove("nil");
+                }
+
+                if (model.anyOf != null && !model.anyOf.isEmpty() && model.anyOf.contains("nil")) {
+                    // if anyOf contains "null" type
+                    model.isNullable = true;
+                    model.oneOf.remove("nil");
+                }
+
             }
         }
         // recursively add import for mapping one type to multiple imports

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractGoCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractGoCodegen.java
@@ -641,18 +641,17 @@ public abstract class AbstractGoCodegen extends DefaultCodegen implements Codege
                     }
                 }
 
+                // if oneOf contains "null" type
                 if (model.oneOf != null && !model.oneOf.isEmpty() && model.oneOf.contains("nil")) {
-                    // if oneOf contains "null" type
                     model.isNullable = true;
                     model.oneOf.remove("nil");
                 }
 
+                // if anyOf contains "null" type
                 if (model.anyOf != null && !model.anyOf.isEmpty() && model.anyOf.contains("nil")) {
-                    // if anyOf contains "null" type
                     model.isNullable = true;
-                    model.oneOf.remove("nil");
+                    model.anyOf.remove("nil");
                 }
-
             }
         }
         // recursively add import for mapping one type to multiple imports

--- a/modules/openapi-generator/src/main/resources/go-experimental/model_anyof.mustache
+++ b/modules/openapi-generator/src/main/resources/go-experimental/model_anyof.mustache
@@ -8,14 +8,14 @@ type {{classname}} struct {
 // Unmarshal JSON data into any of the pointers in the struct
 func (dst *{{classname}}) UnmarshalJSON(data []byte) error {
 	var err error
-    {{#isNullable}}
-    // this object is nullable so check if the payload is null or empty string
-    if string(data) == "" || string(data) == "{}" {
-        return nil
-    }
+	{{#isNullable}}
+	// this object is nullable so check if the payload is null or empty string
+	if string(data) == "" || string(data) == "{}" {
+		return nil
+	}
 
-    {{/isNullable}}
-    {{#anyOf}}
+	{{/isNullable}}
+	{{#anyOf}}
 	// try to unmarshal JSON data into {{{.}}}
 	err = json.Unmarshal(data, &dst.{{{.}}});
 	if err == nil {
@@ -29,7 +29,7 @@ func (dst *{{classname}}) UnmarshalJSON(data []byte) error {
 		dst.{{{.}}} = nil
 	}
 
-    {{/anyOf}}
+	{{/anyOf}}
 	return fmt.Errorf("Data failed to match schemas in anyOf({{classname}})")
 }
 

--- a/modules/openapi-generator/src/main/resources/go-experimental/model_anyof.mustache
+++ b/modules/openapi-generator/src/main/resources/go-experimental/model_anyof.mustache
@@ -8,7 +8,14 @@ type {{classname}} struct {
 // Unmarshal JSON data into any of the pointers in the struct
 func (dst *{{classname}}) UnmarshalJSON(data []byte) error {
 	var err error
-{{#anyOf}}
+    {{#isNullable}}
+    // this object is nullable so check if the payload is null or empty string
+    if string(data) == "" || string(data) == "{}" {
+        return nil
+    }
+
+    {{/isNullable}}
+    {{#anyOf}}
 	// try to unmarshal JSON data into {{{.}}}
 	err = json.Unmarshal(data, &dst.{{{.}}});
 	if err == nil {
@@ -22,7 +29,7 @@ func (dst *{{classname}}) UnmarshalJSON(data []byte) error {
 		dst.{{{.}}} = nil
 	}
 
-{{/anyOf}}
+    {{/anyOf}}
 	return fmt.Errorf("Data failed to match schemas in anyOf({{classname}})")
 }
 

--- a/modules/openapi-generator/src/main/resources/go-experimental/model_oneof.mustache
+++ b/modules/openapi-generator/src/main/resources/go-experimental/model_oneof.mustache
@@ -9,6 +9,13 @@ type {{classname}} struct {
 func (dst *{{classname}}) UnmarshalJSON(data []byte) error {
 	var err error
 	match := 0
+	{{#isNullable}}
+	// this object is nullable so check if the payload is null or empty string
+	if string(data) == "" || string(data) == "{}" {
+		return nil
+	}
+
+	{{/isNullable}}
 	{{#oneOf}}
 	// try to unmarshal data into {{{.}}}
 	err = json.Unmarshal(data, &dst.{{{.}}});


### PR DESCRIPTION
- Add null type support to Go (experimental) oneOf/anyOf schemas
- Tested locally and no issue found so far

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

cc @antihax (2017/11) @bvwells (2017/12) @grokify (2018/07) @kemokemo (2018/09) @bkabrda (2019/07)


