### PR TITLE
Remove cookie authentication from petstore.yaml (oas3.0)

### DIFF
--- a/modules/openapi-generator/src/test/resources/3_0/petstore.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/petstore.yaml
@@ -391,7 +391,7 @@ paths:
         default:
           description: successful operation
       security:
-        - auth_cookie: []
+        - api_key: []
       requestBody:
         content:
           application/json:
@@ -410,7 +410,7 @@ paths:
         default:
           description: successful operation
       security:
-        - auth_cookie: []
+        - api_key: []
       requestBody:
         $ref: '#/components/requestBodies/UserArray'
   /user/createWithList:
@@ -424,7 +424,7 @@ paths:
         default:
           description: successful operation
       security:
-        - auth_cookie: []
+        - api_key: []
       requestBody:
         $ref: '#/components/requestBodies/UserArray'
   /user/login:
@@ -454,7 +454,7 @@ paths:
           headers:
             Set-Cookie:
               description: >-
-                Cookie authentication key for use with the `auth_cookie`
+                Cookie authentication key for use with the `api_key`
                 apiKey authentication.
               schema:
                 type: string
@@ -489,7 +489,7 @@ paths:
         default:
           description: successful operation
       security:
-        - auth_cookie: []
+        - api_key: []
   '/user/{username}':
     get:
       tags:
@@ -537,7 +537,7 @@ paths:
         '404':
           description: User not found
       security:
-        - auth_cookie: []
+        - api_key: []
       requestBody:
         content:
           application/json:
@@ -564,7 +564,7 @@ paths:
         '404':
           description: User not found
       security:
-        - auth_cookie: []
+        - api_key: []
 externalDocs:
   description: Find out more about Swagger
   url: 'http://swagger.io'
@@ -602,10 +602,6 @@ components:
       type: apiKey
       name: api_key
       in: header
-    auth_cookie:
-      type: apiKey
-      name: AUTH_KEY
-      in: cookie
   schemas:
     Order:
       title: Pet Order

--- a/samples/client/petstore/lua/petstore/api/user_api.lua
+++ b/samples/client/petstore/lua/petstore/api/user_api.lua
@@ -61,6 +61,10 @@ function user_api:create_user(user)
 
 	req:set_body(dkjson.encode(user))
 
+	-- api key in headers 'api_key'
+	if self.api_key['api_key'] then
+		req.headers:upsert("api_key", self.api_key['api_key'])
+	end
 
 	-- make the HTTP call
 	local headers, stream, errno = req:go()
@@ -98,6 +102,10 @@ function user_api:create_users_with_array_input(user)
 
 	req:set_body(dkjson.encode(user))
 
+	-- api key in headers 'api_key'
+	if self.api_key['api_key'] then
+		req.headers:upsert("api_key", self.api_key['api_key'])
+	end
 
 	-- make the HTTP call
 	local headers, stream, errno = req:go()
@@ -135,6 +143,10 @@ function user_api:create_users_with_list_input(user)
 
 	req:set_body(dkjson.encode(user))
 
+	-- api key in headers 'api_key'
+	if self.api_key['api_key'] then
+		req.headers:upsert("api_key", self.api_key['api_key'])
+	end
 
 	-- make the HTTP call
 	local headers, stream, errno = req:go()
@@ -166,6 +178,10 @@ function user_api:delete_user(username)
 
 	-- set HTTP verb
 	req.headers:upsert(":method", "DELETE")
+	-- api key in headers 'api_key'
+	if self.api_key['api_key'] then
+		req.headers:upsert("api_key", self.api_key['api_key'])
+	end
 
 	-- make the HTTP call
 	local headers, stream, errno = req:go()
@@ -289,6 +305,10 @@ function user_api:logout_user()
 
 	-- set HTTP verb
 	req.headers:upsert(":method", "GET")
+	-- api key in headers 'api_key'
+	if self.api_key['api_key'] then
+		req.headers:upsert("api_key", self.api_key['api_key'])
+	end
 
 	-- make the HTTP call
 	local headers, stream, errno = req:go()
@@ -326,6 +346,10 @@ function user_api:update_user(username, user)
 
 	req:set_body(dkjson.encode(user))
 
+	-- api key in headers 'api_key'
+	if self.api_key['api_key'] then
+		req.headers:upsert("api_key", self.api_key['api_key'])
+	end
 
 	-- make the HTTP call
 	local headers, stream, errno = req:go()

--- a/samples/openapi3/client/petstore/scala-sttp/README.md
+++ b/samples/openapi3/client/petstore/scala-sttp/README.md
@@ -108,12 +108,6 @@ Authentication schemes defined for the API:
 - **API key parameter name**: api_key
 - **Location**: HTTP header
 
-### auth_cookie
-
-- **Type**: API key
-- **API key parameter name**: AUTH_KEY
-- **Location**: 
-
 
 ## Author
 

--- a/samples/openapi3/client/petstore/scala-sttp/src/main/scala/org/openapitools/client/api/UserApi.scala
+++ b/samples/openapi3/client/petstore/scala-sttp/src/main/scala/org/openapitools/client/api/UserApi.scala
@@ -34,7 +34,7 @@ class UserApi(baseUrl: String)(implicit serializer: SttpSerializer) {
    *   code 0 :  (successful operation)
    * 
    * Available security schemes:
-   *   auth_cookie (apiKey)
+   *   api_key (apiKey)
    * 
    * @param user Created user object
    */
@@ -42,7 +42,7 @@ class UserApi(baseUrl: String)(implicit serializer: SttpSerializer) {
     basicRequest
       .method(Method.POST, uri"$baseUrl/user")
       .contentType("application/json")
-      .cookie("AUTH_KEY", apiKey.value)
+      .header("api_key", apiKey.value)
       .body(user)
       .response(asJson[Unit])
 
@@ -51,7 +51,7 @@ class UserApi(baseUrl: String)(implicit serializer: SttpSerializer) {
    *   code 0 :  (successful operation)
    * 
    * Available security schemes:
-   *   auth_cookie (apiKey)
+   *   api_key (apiKey)
    * 
    * @param user List of user object
    */
@@ -59,7 +59,7 @@ class UserApi(baseUrl: String)(implicit serializer: SttpSerializer) {
     basicRequest
       .method(Method.POST, uri"$baseUrl/user/createWithArray")
       .contentType("application/json")
-      .cookie("AUTH_KEY", apiKey.value)
+      .header("api_key", apiKey.value)
       .body(user)
       .response(asJson[Unit])
 
@@ -68,7 +68,7 @@ class UserApi(baseUrl: String)(implicit serializer: SttpSerializer) {
    *   code 0 :  (successful operation)
    * 
    * Available security schemes:
-   *   auth_cookie (apiKey)
+   *   api_key (apiKey)
    * 
    * @param user List of user object
    */
@@ -76,7 +76,7 @@ class UserApi(baseUrl: String)(implicit serializer: SttpSerializer) {
     basicRequest
       .method(Method.POST, uri"$baseUrl/user/createWithList")
       .contentType("application/json")
-      .cookie("AUTH_KEY", apiKey.value)
+      .header("api_key", apiKey.value)
       .body(user)
       .response(asJson[Unit])
 
@@ -88,7 +88,7 @@ class UserApi(baseUrl: String)(implicit serializer: SttpSerializer) {
    *   code 404 :  (User not found)
    * 
    * Available security schemes:
-   *   auth_cookie (apiKey)
+   *   api_key (apiKey)
    * 
    * @param username The name that needs to be deleted
    */
@@ -96,7 +96,7 @@ class UserApi(baseUrl: String)(implicit serializer: SttpSerializer) {
     basicRequest
       .method(Method.DELETE, uri"$baseUrl/user/${username}")
       .contentType("application/json")
-      .cookie("AUTH_KEY", apiKey.value)
+      .header("api_key", apiKey.value)
       .response(asJson[Unit])
 
   /**
@@ -117,7 +117,7 @@ class UserApi(baseUrl: String)(implicit serializer: SttpSerializer) {
    * Expected answers:
    *   code 200 : String (successful operation)
    *              Headers :
-   *                Set-Cookie - Cookie authentication key for use with the `auth_cookie` apiKey authentication.
+   *                Set-Cookie - Cookie authentication key for use with the `api_key` apiKey authentication.
    *                X-Rate-Limit - calls per hour allowed by the user
    *                X-Expires-After - date in UTC when toekn expires
    *   code 400 :  (Invalid username/password supplied)
@@ -136,13 +136,13 @@ class UserApi(baseUrl: String)(implicit serializer: SttpSerializer) {
    *   code 0 :  (successful operation)
    * 
    * Available security schemes:
-   *   auth_cookie (apiKey)
+   *   api_key (apiKey)
    */
   def logoutUser()(implicit apiKey: ApiKeyValue): ApiRequestT[Unit] =
     basicRequest
       .method(Method.GET, uri"$baseUrl/user/logout")
       .contentType("application/json")
-      .cookie("AUTH_KEY", apiKey.value)
+      .header("api_key", apiKey.value)
       .response(asJson[Unit])
 
   /**
@@ -153,7 +153,7 @@ class UserApi(baseUrl: String)(implicit serializer: SttpSerializer) {
    *   code 404 :  (User not found)
    * 
    * Available security schemes:
-   *   auth_cookie (apiKey)
+   *   api_key (apiKey)
    * 
    * @param username name that need to be deleted
    * @param user Updated user object
@@ -162,7 +162,7 @@ class UserApi(baseUrl: String)(implicit serializer: SttpSerializer) {
     basicRequest
       .method(Method.PUT, uri"$baseUrl/user/${username}")
       .contentType("application/json")
-      .cookie("AUTH_KEY", apiKey.value)
+      .header("api_key", apiKey.value)
       .body(user)
       .response(asJson[Unit])
 


### PR DESCRIPTION
Remove cookie authentication from petstore.yaml (oas3.0) as it's for testing purposes only.

<!-- Please check the completed items below -->
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [ ] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [ ] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
