### PR TITLE
Typescipt angular fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -821,3 +821,18 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 ---
+
+### Build and push to ECR
+
+```
+cd modules/openapi-generator-cli
+REGISTRY="XXXXX"
+CURRENT_DIR="${PWD##*/}"
+IMAGE_NAME="openapi-generator-cli"
+FULL_IMAGE_NAME="${REGISTRY}/${IMAGE_NAME}:${TAG}"
+# login to docker registery
+$(aws ecr get-login --no-include-email)
+cp ../../docker-entrypoint.sh docker-entrypoint.sh
+docker build -t ${REGISTRY}/${IMAGE_NAME}:latest .
+docker push ${REGISTRY}/${IMAGE_NAME}:latest
+```

--- a/README.md
+++ b/README.md
@@ -826,13 +826,7 @@ limitations under the License.
 
 ```
 cd modules/openapi-generator-cli
-REGISTRY="XXXXX"
-CURRENT_DIR="${PWD##*/}"
-IMAGE_NAME="openapi-generator-cli"
-FULL_IMAGE_NAME="${REGISTRY}/${IMAGE_NAME}:${TAG}"
-# login to docker registery
-$(aws ecr get-login --no-include-email)
 cp ../../docker-entrypoint.sh docker-entrypoint.sh
-docker build -t ${REGISTRY}/${IMAGE_NAME}:latest .
-docker push ${REGISTRY}/${IMAGE_NAME}:latest
+docker build -t aitheon/openapi-generator-cli:latest .
+docker push aitheon/openapi-generator-cli
 ```

--- a/modules/openapi-generator-cli/docker-entrypoint.sh
+++ b/modules/openapi-generator-cli/docker-entrypoint.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# GEN_DIR allows to share the entrypoint between Dockerfile and run-in-docker.sh (backward compatible)
+GEN_DIR=${GEN_DIR:-/opt/openapi-generator}
+JAVA_OPTS=${JAVA_OPTS:-"-Xmx1024M -DloggerPath=conf/log4j.properties"}
+
+cli="${GEN_DIR}/modules/openapi-generator-cli"
+codegen="${cli}/target/openapi-generator-cli.jar"
+
+# We code in a list of commands here as source processing is potentially buggy (requires undocumented conventional use of annotations).
+# A list of known commands helps us determine if we should compile CLI. There's an edge-case where a new command not added to this
+# list won't be considered a "real" command. We can get around that a bit by checking CLI completions beforehand if it exists.
+commands="list,generate,meta,help,config-help,validate,version"
+
+# if CLI jar exists, check $1 against completions available in the CLI
+if [[ -f "${codegen}" && -n "$(java ${JAVA_OPTS} -jar "${codegen}" completion | grep "^$1\$" )" ]]; then
+    command=$1
+    shift
+    exec java ${JAVA_OPTS} -jar "${codegen}" "${command}" "$@"
+elif [[ -n "$(echo commands | tr ',' '\n' | grep "^$1\$" )" ]]; then
+    # If CLI jar does not exist, and $1 is a known CLI command, build the CLI jar and run that command.
+    if [[ ! -f "${codegen}" ]]; then
+        (cd "${GEN_DIR}" && exec mvn -am -pl "modules/openapi-generator-cli" -Duser.home=$(dirname $MAVEN_CONFIG) package)
+    fi
+    command=$1
+    shift
+    exec java ${JAVA_OPTS} -jar "${codegen}" "${command}" "$@"
+else
+    # Pass args as linux commands. This allows us to do something like: docker run -it (-e…, -v…) image ls -la
+    exec "$@"
+fi

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppPistacheServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppPistacheServerCodegen.java
@@ -38,6 +38,10 @@ public class CppPistacheServerCodegen extends AbstractCppCodegen {
     public static final String OPTIONAL_EXTERNAL_LIB_DESC = "Add the Possibility to fetch and compile external Libraries needed by this Framework.";
     public static final String HELPERS_PACKAGE_NAME = "helpersPackage";
     public static final String HELPERS_PACKAGE_NAME_DESC = "Specify the package name to be used for the helpers (e.g. org.openapitools.server.helpers).";
+    public static final String MODELS_PACKAGE_NAME = "modelPackage";
+    public static final String MODELS_PACKAGE_NAME_DESC = "Specify the package name to be used for the model (e.g. org.openapitools.server.model).";
+    public static final String API_PACKAGE_NAME = "apiPackage";
+    public static final String API_PACKAGE_NAME_DESC = "Specify the package name to be used for the api (e.g. org.openapitools.server.api).";
     protected final String PREFIX = "";
     protected String helpersPackage = "";
     @Override
@@ -78,6 +82,8 @@ public class CppPistacheServerCodegen extends AbstractCppCodegen {
         cliOptions.clear();
         addSwitch(OPTIONAL_EXTERNAL_LIB, OPTIONAL_EXTERNAL_LIB_DESC, this.isAddExternalLibs);
         addOption(HELPERS_PACKAGE_NAME, HELPERS_PACKAGE_NAME_DESC, this.helpersPackage);
+        addOption(MODELS_PACKAGE_NAME, MODELS_PACKAGE_NAME_DESC, this.modelPackage);
+        addOption(API_PACKAGE_NAME, API_PACKAGE_NAME_DESC, this.apiPackage);
 
         reservedWords = new HashSet<>();
 

--- a/modules/openapi-generator/src/main/resources/typescript-angular/modelGeneric.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-angular/modelGeneric.mustache
@@ -5,6 +5,6 @@ export class {{classname}}{{#allParents}}{{#-first}} extends {{/-first}}{{{.}}}{
      * {{{description}}}
      */
     {{/description}}
-    {{#isReadOnly}}readonly {{/isReadOnly}}{{{name}}}{{^required}}?{{/required}}: {{#isEnum}}{{{datatypeWithEnum}}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}{{#isNullable}} | null{{/isNullable}};
+    {{#isReadOnly}}readonly {{/isReadOnly}}{{{name}}}{{^required}}?{{/required}}: {{#isEnum}}{{{datatypeWithEnum}}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}{{#isNullable}} | null{{/isNullable}}{{#isReadOnly}}{{#defaultValue}} = {{{.}}}{{/defaultValue}}{{/isReadOnly}};
 {{/vars}}
 }{{>modelGenericEnums}}

--- a/modules/openapi-generator/src/main/resources/typescript-angular/modelGeneric.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-angular/modelGeneric.mustache
@@ -1,4 +1,4 @@
-export interface {{classname}}{{#allParents}}{{#-first}} extends {{/-first}}{{{.}}}{{^-last}}, {{/-last}}{{/allParents}} { {{>modelGenericAdditionalProperties}}
+export class {{classname}}{{#allParents}}{{#-first}} extends {{/-first}}{{{.}}}{{^-last}}, {{/-last}}{{/allParents}} { {{>modelGenericAdditionalProperties}}
 {{#vars}}
     {{#description}}
     /**


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
Add readonly and default fields to the typescript generator
Add namespace cli option for the api and model of cpp pistache generator
<!-- Please check the completed items below -->
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [ ] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [ ] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
