### PR TITLE
A single oneOf-referred schema is not a parent

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
@@ -1212,8 +1212,9 @@ public class ModelUtils {
             }
         }
 
-        // parent name only makes sense when there is a single obvious parent
-        if (refedWithoutDiscriminator.size() == 1) {
+        // parent name only makes sense when there is a single obvious parent in not 'oneOf' case
+        boolean isOneOf = composedSchema.getOneOf() != null && !composedSchema.getOneOf().isEmpty();
+        if (!isOneOf && refedWithoutDiscriminator.size() == 1) {
             if (hasAmbiguousParents) {
                 LOGGER.warn("[deprecated] inheritance without use of 'discriminator.propertyName' is deprecated " +
                                 "and will be removed in a future release. Generating model for composed schema name: {}. Title: {}",

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
@@ -813,4 +813,22 @@ public class JavaClientCodegenTest {
         Assert.assertFalse(cp9.isFreeFormObject);
         Assert.assertFalse(cp9.isAnyType);
     }
+
+    @Test
+    public void testOneOfWithASingleVariant() {
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/oneOf-single-variant.yaml");
+        JavaClientCodegen codegen = new JavaClientCodegen();
+
+        Schema test1 = openAPI.getComponents().getSchemas().get("Enum");
+        codegen.setOpenAPI(openAPI);
+        CodegenModel cm1 = codegen.fromModel("Enum", test1);
+        Assert.assertEquals(cm1.getClassname(), "ModelEnum");
+
+        // check that the discriminator property exists
+        Assert.assertEquals(cm1.vars.size(), 1);
+        final CodegenProperty property1 = cm1.vars.get(0);
+        Assert.assertEquals(property1.baseName, "type");
+        Assert.assertEquals(property1.dataType, "String");
+        Assert.assertTrue(property1.isPrimitiveType);
+    }
 }

--- a/modules/openapi-generator/src/test/resources/3_0/oneOf-single-variant.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/oneOf-single-variant.yaml
@@ -1,0 +1,34 @@
+openapi: 3.0.1
+info:
+  version: 1.0.0
+  title: Example
+  license:
+    name: MIT
+servers:
+  - url: http://api.example.xyz/v1
+paths:
+  /endpoint:
+    get:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Enum"
+components:
+  schemas:
+    Enum:
+      oneOf:
+        - $ref: '#/components/schemas/Variant'
+      discriminator:
+        propertyName: type
+        mapping:
+          unit: '#/components/schemas/Variant'
+
+    Variant:
+      properties:
+        type:
+          type: string
+      required:
+        - type


### PR DESCRIPTION
A schema referring another single schema in oneOf is not its child,
and the latter is not the parent of the former. This assumption
prevented population of `schema.vars` from the referred schema.
And this in turn yielded invalid generated model for the oneOf
schema.

Also see the example provided as a test.

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
