### PR TITLE
[go-experimental] Ensure enum deserialization checks enum values

### DIFF
--- a/modules/openapi-generator/src/main/resources/go-experimental/model_enum.mustache
+++ b/modules/openapi-generator/src/main/resources/go-experimental/model_enum.mustache
@@ -1,3 +1,7 @@
+import (
+    "fmt"
+)
+
 // {{{classname}}} {{#description}}{{{.}}}{{/description}}{{^description}}the model '{{{classname}}}'{{/description}}
 type {{{classname}}} {{^format}}{{dataType}}{{/format}}{{#format}}{{{format}}}{{/format}}
 
@@ -11,6 +15,23 @@ const (
 	{{/enumVars}}
 	{{/allowableValues}}
 )
+
+func (v *{{{classname}}}) UnmarshalJSON(src []byte) error {
+    var value {{^format}}{{dataType}}{{/format}}{{#format}}{{{format}}}{{/format}}
+    err := json.Unmarshal(src, &value)
+    if err != nil {
+        return err
+    }
+    enumTypeValue := {{{classname}}}(value)
+    for _, existing := range []{{classname}}{ {{#allowableValues}}{{#enumVars}}{{{value}}}, {{/enumVars}} {{/allowableValues}} } {
+        if existing == enumTypeValue {
+            *v = enumTypeValue
+            return nil
+        }
+    }
+
+    return fmt.Errorf("%+v is not a valid {{classname}}", *v)
+}
 
 // Ptr returns reference to {{{name}}} value
 func (v {{{classname}}}) Ptr() *{{{classname}}} {

--- a/samples/client/petstore/go-experimental/go-petstore/model_enum_class.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_enum_class.go
@@ -13,6 +13,10 @@ import (
 	"encoding/json"
 )
 
+import (
+    "fmt"
+)
+
 // EnumClass the model 'EnumClass'
 type EnumClass string
 
@@ -22,6 +26,23 @@ const (
 	EFG EnumClass = "-efg"
 	XYZ EnumClass = "(xyz)"
 )
+
+func (v *EnumClass) UnmarshalJSON(src []byte) error {
+    var value string
+    err := json.Unmarshal(src, &value)
+    if err != nil {
+        return err
+    }
+    enumTypeValue := EnumClass(value)
+    for _, existing := range []EnumClass{ "_abc", "-efg", "(xyz)",   } {
+        if existing == enumTypeValue {
+            *v = enumTypeValue
+            return nil
+        }
+    }
+
+    return fmt.Errorf("%+v is not a valid EnumClass", *v)
+}
 
 // Ptr returns reference to EnumClass value
 func (v EnumClass) Ptr() *EnumClass {

--- a/samples/client/petstore/go-experimental/go-petstore/model_outer_enum.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_outer_enum.go
@@ -13,6 +13,10 @@ import (
 	"encoding/json"
 )
 
+import (
+    "fmt"
+)
+
 // OuterEnum the model 'OuterEnum'
 type OuterEnum string
 
@@ -22,6 +26,23 @@ const (
 	APPROVED OuterEnum = "approved"
 	DELIVERED OuterEnum = "delivered"
 )
+
+func (v *OuterEnum) UnmarshalJSON(src []byte) error {
+    var value string
+    err := json.Unmarshal(src, &value)
+    if err != nil {
+        return err
+    }
+    enumTypeValue := OuterEnum(value)
+    for _, existing := range []OuterEnum{ "placed", "approved", "delivered",   } {
+        if existing == enumTypeValue {
+            *v = enumTypeValue
+            return nil
+        }
+    }
+
+    return fmt.Errorf("%+v is not a valid OuterEnum", *v)
+}
 
 // Ptr returns reference to OuterEnum value
 func (v OuterEnum) Ptr() *OuterEnum {

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_enum_class.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_enum_class.go
@@ -13,6 +13,10 @@ import (
 	"encoding/json"
 )
 
+import (
+    "fmt"
+)
+
 // EnumClass the model 'EnumClass'
 type EnumClass string
 
@@ -22,6 +26,23 @@ const (
 	ENUMCLASS_EFG EnumClass = "-efg"
 	ENUMCLASS_XYZ EnumClass = "(xyz)"
 )
+
+func (v *EnumClass) UnmarshalJSON(src []byte) error {
+    var value string
+    err := json.Unmarshal(src, &value)
+    if err != nil {
+        return err
+    }
+    enumTypeValue := EnumClass(value)
+    for _, existing := range []EnumClass{ "_abc", "-efg", "(xyz)",   } {
+        if existing == enumTypeValue {
+            *v = enumTypeValue
+            return nil
+        }
+    }
+
+    return fmt.Errorf("%+v is not a valid EnumClass", *v)
+}
 
 // Ptr returns reference to EnumClass value
 func (v EnumClass) Ptr() *EnumClass {

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_outer_enum.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_outer_enum.go
@@ -13,6 +13,10 @@ import (
 	"encoding/json"
 )
 
+import (
+    "fmt"
+)
+
 // OuterEnum the model 'OuterEnum'
 type OuterEnum string
 
@@ -22,6 +26,23 @@ const (
 	OUTERENUM_APPROVED OuterEnum = "approved"
 	OUTERENUM_DELIVERED OuterEnum = "delivered"
 )
+
+func (v *OuterEnum) UnmarshalJSON(src []byte) error {
+    var value string
+    err := json.Unmarshal(src, &value)
+    if err != nil {
+        return err
+    }
+    enumTypeValue := OuterEnum(value)
+    for _, existing := range []OuterEnum{ "placed", "approved", "delivered",   } {
+        if existing == enumTypeValue {
+            *v = enumTypeValue
+            return nil
+        }
+    }
+
+    return fmt.Errorf("%+v is not a valid OuterEnum", *v)
+}
 
 // Ptr returns reference to OuterEnum value
 func (v OuterEnum) Ptr() *OuterEnum {

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_outer_enum_default_value.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_outer_enum_default_value.go
@@ -13,6 +13,10 @@ import (
 	"encoding/json"
 )
 
+import (
+    "fmt"
+)
+
 // OuterEnumDefaultValue the model 'OuterEnumDefaultValue'
 type OuterEnumDefaultValue string
 
@@ -22,6 +26,23 @@ const (
 	OUTERENUMDEFAULTVALUE_APPROVED OuterEnumDefaultValue = "approved"
 	OUTERENUMDEFAULTVALUE_DELIVERED OuterEnumDefaultValue = "delivered"
 )
+
+func (v *OuterEnumDefaultValue) UnmarshalJSON(src []byte) error {
+    var value string
+    err := json.Unmarshal(src, &value)
+    if err != nil {
+        return err
+    }
+    enumTypeValue := OuterEnumDefaultValue(value)
+    for _, existing := range []OuterEnumDefaultValue{ "placed", "approved", "delivered",   } {
+        if existing == enumTypeValue {
+            *v = enumTypeValue
+            return nil
+        }
+    }
+
+    return fmt.Errorf("%+v is not a valid OuterEnumDefaultValue", *v)
+}
 
 // Ptr returns reference to OuterEnumDefaultValue value
 func (v OuterEnumDefaultValue) Ptr() *OuterEnumDefaultValue {

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_outer_enum_integer.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_outer_enum_integer.go
@@ -13,6 +13,10 @@ import (
 	"encoding/json"
 )
 
+import (
+    "fmt"
+)
+
 // OuterEnumInteger the model 'OuterEnumInteger'
 type OuterEnumInteger int32
 
@@ -22,6 +26,23 @@ const (
 	OUTERENUMINTEGER__1 OuterEnumInteger = 1
 	OUTERENUMINTEGER__2 OuterEnumInteger = 2
 )
+
+func (v *OuterEnumInteger) UnmarshalJSON(src []byte) error {
+    var value int32
+    err := json.Unmarshal(src, &value)
+    if err != nil {
+        return err
+    }
+    enumTypeValue := OuterEnumInteger(value)
+    for _, existing := range []OuterEnumInteger{ 0, 1, 2,   } {
+        if existing == enumTypeValue {
+            *v = enumTypeValue
+            return nil
+        }
+    }
+
+    return fmt.Errorf("%+v is not a valid OuterEnumInteger", *v)
+}
 
 // Ptr returns reference to OuterEnumInteger value
 func (v OuterEnumInteger) Ptr() *OuterEnumInteger {

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_outer_enum_integer_default_value.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_outer_enum_integer_default_value.go
@@ -13,6 +13,10 @@ import (
 	"encoding/json"
 )
 
+import (
+    "fmt"
+)
+
 // OuterEnumIntegerDefaultValue the model 'OuterEnumIntegerDefaultValue'
 type OuterEnumIntegerDefaultValue int32
 
@@ -22,6 +26,23 @@ const (
 	OUTERENUMINTEGERDEFAULTVALUE__1 OuterEnumIntegerDefaultValue = 1
 	OUTERENUMINTEGERDEFAULTVALUE__2 OuterEnumIntegerDefaultValue = 2
 )
+
+func (v *OuterEnumIntegerDefaultValue) UnmarshalJSON(src []byte) error {
+    var value int32
+    err := json.Unmarshal(src, &value)
+    if err != nil {
+        return err
+    }
+    enumTypeValue := OuterEnumIntegerDefaultValue(value)
+    for _, existing := range []OuterEnumIntegerDefaultValue{ 0, 1, 2,   } {
+        if existing == enumTypeValue {
+            *v = enumTypeValue
+            return nil
+        }
+    }
+
+    return fmt.Errorf("%+v is not a valid OuterEnumIntegerDefaultValue", *v)
+}
 
 // Ptr returns reference to OuterEnumIntegerDefaultValue value
 func (v OuterEnumIntegerDefaultValue) Ptr() *OuterEnumIntegerDefaultValue {


### PR DESCRIPTION
This new unmarshalling method for enums ensures that unmarshalling fails if the value is not in the enumeration choices. As the enum type is just a type alias in go, technically any value of the base type can actually be assigned to it - this patch prevents that at least on unmarshalling.

This allows to properly deserialize `oneOf` members that have a common field that has specific distinct choices for each of the members. For example:

* `A` and `B` are members of `oneOf` and both have a `foo`
* For `A`, `foo` is an enum with allowed choices `a`, `A`
* For `B`, `foo` is an enum with allowed choices `b`, `B`
* The rest of the fields is potentially the same.

Having this new unmarshalling method ensures that entity with `foo: b` can't get deserialized as `A`, but only as `B`, hence the `oneOf` deserialization works properly.

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@antihax (2017/11) @bvwells (2017/12) @grokify (2018/07) @kemokemo (2018/09) @bkabrda (2019/07)