### PR TITLE
[go-experimental] Add convenience wrapper function for oneOf members

### DIFF
--- a/modules/openapi-generator/src/main/resources/go-experimental/model_oneof.mustache
+++ b/modules/openapi-generator/src/main/resources/go-experimental/model_oneof.mustache
@@ -5,6 +5,14 @@ type {{classname}} struct {
 	{{/oneOf}}
 }
 
+{{#oneOf}}
+// {{{.}}}As{{classname}} is a convenience function that returns {{{.}}} wrapped in {{classname}}
+func {{{.}}}As{{classname}}(v *{{{.}}}) {{classname}} {
+    return {{classname}}{ {{{.}}}: v}
+}
+
+{{/oneOf}}
+
 // Unmarshl JSON data into one of the pointers in the struct
 func (dst *{{classname}}) UnmarshalJSON(data []byte) error {
 	var err error

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_fruit.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_fruit.go
@@ -20,6 +20,17 @@ type Fruit struct {
 	Banana *Banana
 }
 
+// AppleAsFruit is a convenience function that returns Apple wrapped in Fruit
+func AppleAsFruit(v *Apple) Fruit {
+    return Fruit{ Apple: v}
+}
+
+// BananaAsFruit is a convenience function that returns Banana wrapped in Fruit
+func BananaAsFruit(v *Banana) Fruit {
+    return Fruit{ Banana: v}
+}
+
+
 // Unmarshl JSON data into one of the pointers in the struct
 func (dst *Fruit) UnmarshalJSON(data []byte) error {
 	var err error

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_fruit_req.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_fruit_req.go
@@ -20,6 +20,17 @@ type FruitReq struct {
 	BananaReq *BananaReq
 }
 
+// AppleReqAsFruitReq is a convenience function that returns AppleReq wrapped in FruitReq
+func AppleReqAsFruitReq(v *AppleReq) FruitReq {
+    return FruitReq{ AppleReq: v}
+}
+
+// BananaReqAsFruitReq is a convenience function that returns BananaReq wrapped in FruitReq
+func BananaReqAsFruitReq(v *BananaReq) FruitReq {
+    return FruitReq{ BananaReq: v}
+}
+
+
 // Unmarshl JSON data into one of the pointers in the struct
 func (dst *FruitReq) UnmarshalJSON(data []byte) error {
 	var err error

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_mammal.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_mammal.go
@@ -20,6 +20,17 @@ type Mammal struct {
 	Zebra *Zebra
 }
 
+// WhaleAsMammal is a convenience function that returns Whale wrapped in Mammal
+func WhaleAsMammal(v *Whale) Mammal {
+    return Mammal{ Whale: v}
+}
+
+// ZebraAsMammal is a convenience function that returns Zebra wrapped in Mammal
+func ZebraAsMammal(v *Zebra) Mammal {
+    return Mammal{ Zebra: v}
+}
+
+
 // Unmarshl JSON data into one of the pointers in the struct
 func (dst *Mammal) UnmarshalJSON(data []byte) error {
 	var err error


### PR DESCRIPTION
This PR adds a convenience wrapper function to make it easier to work with oneOf members.

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@antihax (2017/11) @bvwells (2017/12) @grokify (2018/07) @kemokemo (2018/09) @bkabrda (2019/07)