### PR TITLE
[Java][jersey2] Allow setting serverIndex to null

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/ApiClient.mustache
@@ -251,7 +251,9 @@ public class ApiClient {
   }
 
   private void updateBasePath() {
-    setBasePath(servers.get(serverIndex).URL(serverVariables));
+    if (serverIndex != null) {
+        setBasePath(servers.get(serverIndex).URL(serverVariables));
+    }
   }
 
   {{#hasOAuthMethods}}
@@ -1030,7 +1032,7 @@ public class ApiClient {
     // Not using `.target(targetURL).path(path)` below,
     // to support (constant) query string in `path`, e.g. "/posts?draft=1"
     String targetURL;
-    if (operationServers.containsKey(operation)) {
+    if (serverIndex != null && operationServers.containsKey(operation)) {
       Integer index = operationServerIndex.containsKey(operation) ? operationServerIndex.get(operation) : serverIndex;
       Map<String, String> variables = operationServerVariables.containsKey(operation) ?
         operationServerVariables.get(operation) : serverVariables;

--- a/samples/client/petstore/java/jersey2-java7/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/jersey2-java7/src/main/java/org/openapitools/client/ApiClient.java
@@ -168,7 +168,9 @@ public class ApiClient {
   }
 
   private void updateBasePath() {
-    setBasePath(servers.get(serverIndex).URL(serverVariables));
+    if (serverIndex != null) {
+        setBasePath(servers.get(serverIndex).URL(serverVariables));
+    }
   }
 
   private void setOauthBasePath(String basePath) {
@@ -937,7 +939,7 @@ public class ApiClient {
     // Not using `.target(targetURL).path(path)` below,
     // to support (constant) query string in `path`, e.g. "/posts?draft=1"
     String targetURL;
-    if (operationServers.containsKey(operation)) {
+    if (serverIndex != null && operationServers.containsKey(operation)) {
       Integer index = operationServerIndex.containsKey(operation) ? operationServerIndex.get(operation) : serverIndex;
       Map<String, String> variables = operationServerVariables.containsKey(operation) ?
         operationServerVariables.get(operation) : serverVariables;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/ApiClient.java
@@ -168,7 +168,9 @@ public class ApiClient {
   }
 
   private void updateBasePath() {
-    setBasePath(servers.get(serverIndex).URL(serverVariables));
+    if (serverIndex != null) {
+        setBasePath(servers.get(serverIndex).URL(serverVariables));
+    }
   }
 
   private void setOauthBasePath(String basePath) {
@@ -937,7 +939,7 @@ public class ApiClient {
     // Not using `.target(targetURL).path(path)` below,
     // to support (constant) query string in `path`, e.g. "/posts?draft=1"
     String targetURL;
-    if (operationServers.containsKey(operation)) {
+    if (serverIndex != null && operationServers.containsKey(operation)) {
       Integer index = operationServerIndex.containsKey(operation) ? operationServerIndex.get(operation) : serverIndex;
       Map<String, String> variables = operationServerVariables.containsKey(operation) ?
         operationServerVariables.get(operation) : serverVariables;


### PR DESCRIPTION
Make it possible to set `serverIndex` to `null`. This is useful when one wants to use the `ApiClient` to send a custom request with URL that doesn't map to generated operation URLs. This was possible in 4.3.1, but regressed in 5.0 snapshot - this PR fixes it.

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.


@bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04) @lwlee2608 (2019/10) @bkabrda (2020/01)