### PR TITLE
[Java][jersey2] Make (de)serialization work for oneOf models

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/AbstractOpenApiSchema.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/AbstractOpenApiSchema.mustache
@@ -3,9 +3,12 @@
 package {{invokerPackage}}.model;
 
 import {{invokerPackage}}.ApiException;
+import java.util.Objects;
 import java.lang.reflect.Type;
 import java.util.Map;
 import javax.ws.rs.core.GenericType;
+
+import com.fasterxml.jackson.annotation.JsonValue;
 
 /**
  * Abstract class for oneOf,anyOf schemas defined in OpenAPI spec
@@ -39,6 +42,7 @@ public abstract class AbstractOpenApiSchema {
      *
      * @return an instance of the actual schema/object
      */
+    @JsonValue
     public Object getActualInstance() {return instance;}
 
     /***
@@ -55,6 +59,46 @@ public abstract class AbstractOpenApiSchema {
      */
     public String getSchemaType() {
         return schemaType;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class ").append(getClass()).append(" {\n");
+        sb.append("    instance: ").append(toIndentedString(instance)).append("\n");
+        sb.append("    isNullable: ").append(toIndentedString(isNullable)).append("\n");
+        sb.append("    schemaType: ").append(toIndentedString(schemaType)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(java.lang.Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        AbstractOpenApiSchema a = (AbstractOpenApiSchema) o;
+        return Objects.equals(this.instance, a.instance) &&
+            Objects.equals(this.isNullable, a.isNullable) &&
+            Objects.equals(this.schemaType, a.schemaType);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(instance, isNullable, schemaType);
     }
 
     /***

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/oneof_model.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/oneof_model.mustache
@@ -1,11 +1,51 @@
 import javax.ws.rs.core.GenericType;
 import javax.ws.rs.core.Response;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+
 {{>additionalModelTypeAnnotations}}{{>generatedAnnotation}}{{>xmlAnnotation}}
+@JsonDeserialize(using={{classname}}.{{classname}}Deserializer.class)
 public class {{classname}} extends AbstractOpenApiSchema{{#vendorExtensions.x-implements}}, {{{.}}}{{/vendorExtensions.x-implements}} {
+    public static class {{classname}}Deserializer extends StdDeserializer<{{classname}}> {
+        public {{classname}}Deserializer() {
+            this({{classname}}.class);
+        }
+
+        public {{classname}}Deserializer(Class<?> vc) {
+            super(vc);
+        }
+
+        @Override
+        public {{classname}} deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException, JsonProcessingException {
+            JsonNode tree = jp.readValueAsTree();
+
+            int match = 0;
+            Object deserialized = null;
+            {{#oneOf}}
+            try {
+                deserialized = tree.traverse(jp.getCodec()).readValueAs({{{.}}}.class);
+                match++;
+            } catch (Exception e) {
+                // deserialization failed, continue
+            }
+            {{/oneOf}}
+            if (match == 1) {
+                {{classname}} ret = new {{classname}}();
+                ret.setActualInstance(deserialized);
+                return ret;
+            }
+            throw new IOException(String.format("Failed deserialization for {{classname}}: %d classes match result, expected 1", match));
+        }
+    }
 
     // store a list of schema names defined in oneOf
     public final static Map<String, GenericType> schemas = new HashMap<String, GenericType>();
@@ -13,6 +53,13 @@ public class {{classname}} extends AbstractOpenApiSchema{{#vendorExtensions.x-im
     public {{classname}}() {
         super("oneOf", {{#isNullable}}Boolean.TRUE{{/isNullable}}{{^isNullable}}Boolean.FALSE{{/isNullable}});
     }
+
+    {{#oneOf}}
+    public {{classname}}({{{.}}} o) {
+        super("oneOf", {{#isNullable}}Boolean.TRUE{{/isNullable}}{{^isNullable}}Boolean.FALSE{{/isNullable}});
+        setActualInstance(o);
+    }
+    {{/oneOf}}
 
     static {
         {{#oneOf}}

--- a/samples/client/petstore/java/jersey2-java7/src/main/java/org/openapitools/client/model/AbstractOpenApiSchema.java
+++ b/samples/client/petstore/java/jersey2-java7/src/main/java/org/openapitools/client/model/AbstractOpenApiSchema.java
@@ -14,9 +14,12 @@
 package org.openapitools.client.model;
 
 import org.openapitools.client.ApiException;
+import java.util.Objects;
 import java.lang.reflect.Type;
 import java.util.Map;
 import javax.ws.rs.core.GenericType;
+
+import com.fasterxml.jackson.annotation.JsonValue;
 
 /**
  * Abstract class for oneOf,anyOf schemas defined in OpenAPI spec
@@ -50,6 +53,7 @@ public abstract class AbstractOpenApiSchema {
      *
      * @return an instance of the actual schema/object
      */
+    @JsonValue
     public Object getActualInstance() {return instance;}
 
     /***
@@ -66,6 +70,46 @@ public abstract class AbstractOpenApiSchema {
      */
     public String getSchemaType() {
         return schemaType;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class ").append(getClass()).append(" {\n");
+        sb.append("    instance: ").append(toIndentedString(instance)).append("\n");
+        sb.append("    isNullable: ").append(toIndentedString(isNullable)).append("\n");
+        sb.append("    schemaType: ").append(toIndentedString(schemaType)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(java.lang.Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        AbstractOpenApiSchema a = (AbstractOpenApiSchema) o;
+        return Objects.equals(this.instance, a.instance) &&
+            Objects.equals(this.isNullable, a.isNullable) &&
+            Objects.equals(this.schemaType, a.schemaType);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(instance, isNullable, schemaType);
     }
 
     /***

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AbstractOpenApiSchema.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AbstractOpenApiSchema.java
@@ -14,9 +14,12 @@
 package org.openapitools.client.model;
 
 import org.openapitools.client.ApiException;
+import java.util.Objects;
 import java.lang.reflect.Type;
 import java.util.Map;
 import javax.ws.rs.core.GenericType;
+
+import com.fasterxml.jackson.annotation.JsonValue;
 
 /**
  * Abstract class for oneOf,anyOf schemas defined in OpenAPI spec
@@ -50,6 +53,7 @@ public abstract class AbstractOpenApiSchema {
      *
      * @return an instance of the actual schema/object
      */
+    @JsonValue
     public Object getActualInstance() {return instance;}
 
     /***
@@ -66,6 +70,46 @@ public abstract class AbstractOpenApiSchema {
      */
     public String getSchemaType() {
         return schemaType;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class ").append(getClass()).append(" {\n");
+        sb.append("    instance: ").append(toIndentedString(instance)).append("\n");
+        sb.append("    isNullable: ").append(toIndentedString(isNullable)).append("\n");
+        sb.append("    schemaType: ").append(toIndentedString(schemaType)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(java.lang.Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        AbstractOpenApiSchema a = (AbstractOpenApiSchema) o;
+        return Objects.equals(this.instance, a.instance) &&
+            Objects.equals(this.isNullable, a.isNullable) &&
+            Objects.equals(this.schemaType, a.schemaType);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(instance, isNullable, schemaType);
     }
 
     /***


### PR DESCRIPTION
This PR makes `oneOf` (de)serialization actually work properly, also adds some convenience constructors for the `oneOf` models and equals/toString/hashcode for proper comparison and debugging.

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04) @lwlee2608 (2019/10) @bkabrda (2020/01)