### PR TITLE
[PHP] ObjectSerializer fix for array of objects

### DIFF
--- a/modules/openapi-generator/src/main/resources/php/ObjectSerializer.mustache
+++ b/modules/openapi-generator/src/main/resources/php/ObjectSerializer.mustache
@@ -250,6 +250,14 @@ class ObjectSerializer
     {
         if (null === $data) {
             return null;
+        } elseif (strcasecmp(substr($class, -2), '[]') === 0) {
+            $data = is_string($data) ? json_decode($data) : $data;
+            $subClass = substr($class, 0, -2);
+            $values = [];
+            foreach ($data as $key => $value) {
+                $values[] = self::deserialize($value, $subClass, null);
+            }
+            return $values;
         } elseif (substr($class, 0, 4) === 'map[') { // for associative array e.g. map[string,int]
             $data = is_string($data) ? json_decode($data) : $data;
             settype($data, 'array');
@@ -263,14 +271,6 @@ class ObjectSerializer
                 }
             }
             return $deserialized;
-        } elseif (strcasecmp(substr($class, -2), '[]') === 0) {
-            $data = is_string($data) ? json_decode($data) : $data;
-            $subClass = substr($class, 0, -2);
-            $values = [];
-            foreach ($data as $key => $value) {
-                $values[] = self::deserialize($value, $subClass, null);
-            }
-            return $values;
         } elseif ($class === 'object') {
             settype($data, 'array');
             return $data;

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/ObjectSerializer.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/ObjectSerializer.php
@@ -260,6 +260,14 @@ class ObjectSerializer
     {
         if (null === $data) {
             return null;
+        } elseif (strcasecmp(substr($class, -2), '[]') === 0) {
+            $data = is_string($data) ? json_decode($data) : $data;
+            $subClass = substr($class, 0, -2);
+            $values = [];
+            foreach ($data as $key => $value) {
+                $values[] = self::deserialize($value, $subClass, null);
+            }
+            return $values;
         } elseif (substr($class, 0, 4) === 'map[') { // for associative array e.g. map[string,int]
             $data = is_string($data) ? json_decode($data) : $data;
             settype($data, 'array');
@@ -273,14 +281,6 @@ class ObjectSerializer
                 }
             }
             return $deserialized;
-        } elseif (strcasecmp(substr($class, -2), '[]') === 0) {
-            $data = is_string($data) ? json_decode($data) : $data;
-            $subClass = substr($class, 0, -2);
-            $values = [];
-            foreach ($data as $key => $value) {
-                $values[] = self::deserialize($value, $subClass, null);
-            }
-            return $values;
         } elseif ($class === 'object') {
             settype($data, 'array');
             return $data;


### PR DESCRIPTION
Array of objects translate to **map[string,object][]** and they fail to deserialize. This is because the deserialization does not parse the mapping string correctly. A quick fix is moving array deserialization before object deserialization.


```
    ObjectExample:
      type: object
      properties:
        data:
          type: array
          items:
            type: object
            additionalProperties: true
```


@jebentier @dkarlovi @mandrean @jfastnacht @ackintosh @ybelenko @renepardon 