### PR TITLE
Fix build.gradle in some Java clients

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/build.gradle.mustache
@@ -134,6 +134,10 @@ ext {
     {{#threetenbp}}
     threetenbp_version = "2.9.10"
     {{/threetenbp}}
+    {{#hasOAuthMethods}}
+    scribejava_apis_version = "6.9.0"
+    {{/hasOAuthMethods}}
+    tomitribe_http_signatures_version = "1.3"
 }
 
 dependencies {
@@ -152,6 +156,10 @@ dependencies {
     {{#java8}}
     compile "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jackson_version"
     {{/java8}}
+    {{#hasOAuthMethods}}
+    compile "com.github.scribejava:scribejava-apis:$scribejava_apis_version"
+    {{/hasOAuthMethods}}
+    compile "org.tomitribe:tomitribe-http-signatures:$tomitribe_http_signatures_version"
     {{#supportJava6}}
     compile "commons-io:commons-io:$commons_io_version"
     compile "org.apache.commons:commons-lang3:$commons_lang3_version"

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/build.sbt.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/build.sbt.mustache
@@ -25,6 +25,10 @@ lazy val root = (project in file(".")).
       {{#threetenbp}}
       "com.github.joschi.jackson" % "jackson-datatype-threetenbp" % "2.9.10" % "compile",
       {{/threetenbp}}
+      {{#hasOAuthMethods}}
+      "com.github.scribejava" % "scribejava-apis" % "6.9.0" % "compile",
+      {{/hasOAuthMethods}}
+      "org.tomitribe" % "tomitribe-http-signatures" % "1.3" % "compile",
       {{^java8}}
       "com.brsanthu" % "migbase64" % "2.2",
       {{/java8}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/pom.mustache
@@ -347,7 +347,7 @@
         <dependency>
             <groupId>com.github.scribejava</groupId>
             <artifactId>scribejava-apis</artifactId>
-            <version>6.9.0</version>
+            <version>${scribejava-apis-version}</version>
         </dependency>
         {{/hasOAuthMethods}}
         {{#useBeanValidation}}
@@ -386,5 +386,8 @@
         {{/threetenbp}}
         <junit-version>4.13</junit-version>
         <http-signature-version>1.3</http-signature-version>
+        {{#hasOAuthMethods}}
+        <scribejava-apis-version>6.9.0</scribejava-apis-version>
+        {{/hasOAuthMethods}}
     </properties>
 </project>

--- a/modules/openapi-generator/src/main/resources/Java/libraries/vertx/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/vertx/build.gradle.mustache
@@ -32,6 +32,7 @@ ext {
     jackson_databind_version = "2.10.4"
     vertx_version = "3.4.2"
     junit_version = "4.13"
+    jackson_databind_nullable_version = "0.2.1"
 }
 
 dependencies {
@@ -51,6 +52,7 @@ dependencies {
     {{#threetenbp}}
     compile "com.github.joschi.jackson:jackson-datatype-threetenbp:$jackson_version"
     {{/threetenbp}}
+    compile "org.openapitools:jackson-databind-nullable:$jackson_databind_nullable_version"
     testCompile "junit:junit:$junit_version"
     testCompile "io.vertx:vertx-unit:$vertx_version"
 }

--- a/samples/client/petstore/java/jersey2-java7/build.gradle
+++ b/samples/client/petstore/java/jersey2-java7/build.gradle
@@ -101,6 +101,8 @@ ext {
     jersey_version = "2.27"
     junit_version = "4.13"
     threetenbp_version = "2.9.10"
+    scribejava_apis_version = "6.9.0"
+    tomitribe_http_signatures_version = "1.3"
 }
 
 dependencies {
@@ -113,6 +115,8 @@ dependencies {
     compile "com.fasterxml.jackson.core:jackson-annotations:$jackson_version"
     compile "com.fasterxml.jackson.core:jackson-databind:$jackson_databind_version"
     compile "org.openapitools:jackson-databind-nullable:$jackson_databind_nullable_version"
+    compile "com.github.scribejava:scribejava-apis:$scribejava_apis_version"
+    compile "org.tomitribe:tomitribe-http-signatures:$tomitribe_http_signatures_version"
     compile "com.github.joschi.jackson:jackson-datatype-threetenbp:$threetenbp_version"
     compile "com.brsanthu:migbase64:2.2"
     testCompile "junit:junit:$junit_version"

--- a/samples/client/petstore/java/jersey2-java7/build.sbt
+++ b/samples/client/petstore/java/jersey2-java7/build.sbt
@@ -17,6 +17,8 @@ lazy val root = (project in file(".")).
       "com.fasterxml.jackson.core" % "jackson-annotations" % "2.10.4" % "compile",
       "com.fasterxml.jackson.core" % "jackson-databind" % "2.10.4" % "compile",
       "com.github.joschi.jackson" % "jackson-datatype-threetenbp" % "2.9.10" % "compile",
+      "com.github.scribejava" % "scribejava-apis" % "6.9.0" % "compile",
+      "org.tomitribe" % "tomitribe-http-signatures" % "1.3" % "compile",
       "com.brsanthu" % "migbase64" % "2.2",
       "junit" % "junit" % "4.13" % "test",
       "com.novocode" % "junit-interface" % "0.10" % "test"

--- a/samples/client/petstore/java/jersey2-java7/pom.xml
+++ b/samples/client/petstore/java/jersey2-java7/pom.xml
@@ -287,7 +287,7 @@
         <dependency>
             <groupId>com.github.scribejava</groupId>
             <artifactId>scribejava-apis</artifactId>
-            <version>6.9.0</version>
+            <version>${scribejava-apis-version}</version>
         </dependency>
         <!-- test dependencies -->
         <dependency>
@@ -307,5 +307,6 @@
         <threetenbp-version>2.9.10</threetenbp-version>
         <junit-version>4.13</junit-version>
         <http-signature-version>1.3</http-signature-version>
+        <scribejava-apis-version>6.9.0</scribejava-apis-version>
     </properties>
 </project>

--- a/samples/client/petstore/java/jersey2-java8/build.gradle
+++ b/samples/client/petstore/java/jersey2-java8/build.gradle
@@ -100,6 +100,8 @@ ext {
     jackson_databind_nullable_version = "0.2.1"
     jersey_version = "2.27"
     junit_version = "4.13"
+    scribejava_apis_version = "6.9.0"
+    tomitribe_http_signatures_version = "1.3"
 }
 
 dependencies {
@@ -113,6 +115,8 @@ dependencies {
     compile "com.fasterxml.jackson.core:jackson-databind:$jackson_databind_version"
     compile "org.openapitools:jackson-databind-nullable:$jackson_databind_nullable_version"
     compile "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jackson_version"
+    compile "com.github.scribejava:scribejava-apis:$scribejava_apis_version"
+    compile "org.tomitribe:tomitribe-http-signatures:$tomitribe_http_signatures_version"
     testCompile "junit:junit:$junit_version"
 }
 

--- a/samples/client/petstore/java/jersey2-java8/build.sbt
+++ b/samples/client/petstore/java/jersey2-java8/build.sbt
@@ -17,6 +17,8 @@ lazy val root = (project in file(".")).
       "com.fasterxml.jackson.core" % "jackson-annotations" % "2.10.4" % "compile",
       "com.fasterxml.jackson.core" % "jackson-databind" % "2.10.4" % "compile",
       "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % "2.9.10" % "compile",
+      "com.github.scribejava" % "scribejava-apis" % "6.9.0" % "compile",
+      "org.tomitribe" % "tomitribe-http-signatures" % "1.3" % "compile",
       "junit" % "junit" % "4.13" % "test",
       "com.novocode" % "junit-interface" % "0.10" % "test"
     )

--- a/samples/client/petstore/java/jersey2-java8/pom.xml
+++ b/samples/client/petstore/java/jersey2-java8/pom.xml
@@ -281,7 +281,7 @@
         <dependency>
             <groupId>com.github.scribejava</groupId>
             <artifactId>scribejava-apis</artifactId>
-            <version>6.9.0</version>
+            <version>${scribejava-apis-version}</version>
         </dependency>
         <!-- test dependencies -->
         <dependency>
@@ -300,5 +300,6 @@
         <jackson-databind-nullable-version>0.2.1</jackson-databind-nullable-version>
         <junit-version>4.13</junit-version>
         <http-signature-version>1.3</http-signature-version>
+        <scribejava-apis-version>6.9.0</scribejava-apis-version>
     </properties>
 </project>

--- a/samples/client/petstore/java/vertx/build.gradle
+++ b/samples/client/petstore/java/vertx/build.gradle
@@ -32,6 +32,7 @@ ext {
     jackson_databind_version = "2.10.4"
     vertx_version = "3.4.2"
     junit_version = "4.13"
+    jackson_databind_nullable_version = "0.2.1"
 }
 
 dependencies {
@@ -43,6 +44,7 @@ dependencies {
     compile "com.fasterxml.jackson.core:jackson-annotations:$jackson_version"
     compile "com.fasterxml.jackson.core:jackson-databind:$jackson_databind_version"
     compile "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jackson_version"
+    compile "org.openapitools:jackson-databind-nullable:$jackson_databind_nullable_version"
     testCompile "junit:junit:$junit_version"
     testCompile "io.vertx:vertx-unit:$vertx_version"
 }


### PR DESCRIPTION
Fix build.gradle in some Java clients due to missing dependencies.

Tested locally. I'll update the CI to catch these issues moving forward.

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

cc @bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04) @lwlee2608 (2019/10) @bkabrda (2020/01)



