### PR TITLE
[C++] [Qt5] Fixed missing headers and wrong status code

### DIFF
--- a/modules/openapi-generator/src/main/resources/cpp-qt5-qhttpengine-server/apirequest.cpp.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-qhttpengine-server/apirequest.cpp.mustache
@@ -114,14 +114,15 @@ void {{classname}}Request::{{nickname}}Request({{#hasPathParams}}{{#pathParams}}
 {{/operation}}{{/operations}}
 
 {{#operations}}{{#operation}}void {{classname}}Request::{{nickname}}Response({{#returnType}}const {{{returnType}}}& res{{/returnType}}){
-    writeResponseHeaders();{{#returnType}}{{#isMapContainer}}
+    setSocketResponseHeaders();{{#returnType}}{{#isMapContainer}}
     QJsonDocument resDoc(::{{cppNamespace}}::toJsonValue(res).toObject());
     socket->writeJson(resDoc);{{/isMapContainer}}{{^isMapContainer}}{{^returnTypeIsPrimitive}}{{^vendorExtensions.x-returns-enum}}
     QJsonDocument resDoc(::{{cppNamespace}}::toJsonValue(res).to{{^isListContainer}}Object{{/isListContainer}}{{#isListContainer}}Array{{/isListContainer}}());
     socket->writeJson(resDoc);{{/vendorExtensions.x-returns-enum}}{{#vendorExtensions.x-returns-enum}}
     socket->write(::{{cppNamespace}}::toStringValue(res).toUtf8());{{/vendorExtensions.x-returns-enum}}{{/returnTypeIsPrimitive}}{{#returnTypeIsPrimitive}}
     socket->write({{#isListContainer}}QString("["+{{/isListContainer}}::{{cppNamespace}}::toStringValue(res){{#isListContainer}}+"]"){{/isListContainer}}.toUtf8());{{/returnTypeIsPrimitive}}{{/isMapContainer}}{{/returnType}}{{^returnType}}
-    socket->setStatusCode(QHttpEngine::Socket::OK);{{/returnType}}
+    socket->setStatusCode(QHttpEngine::Socket::OK);
+    socket->writeHeaders();{{/returnType}}
     if(socket->isOpen()){
         socket->close();
     }
@@ -130,7 +131,7 @@ void {{classname}}Request::{{nickname}}Request({{#hasPathParams}}{{#pathParams}}
 {{/operation}}{{/operations}}
 {{#operations}}{{#operation}}void {{classname}}Request::{{nickname}}Error({{#returnType}}const {{{returnType}}}& res, {{/returnType}}QNetworkReply::NetworkError error_type, QString& error_str){
     Q_UNUSED(error_type); // TODO: Remap error_type to QHttpEngine::Socket errors
-    writeResponseHeaders();{{#returnType}}
+    setSocketResponseHeaders();{{#returnType}}
     Q_UNUSED(error_str);  // response will be used instead of error string{{#isMapContainer}}
     QJsonDocument resDoc(::{{cppNamespace}}::toJsonValue(res).toObject());
     socket->writeJson(resDoc);{{/isMapContainer}}{{^isMapContainer}}{{^returnTypeIsPrimitive}}{{^vendorExtensions.x-returns-enum}}

--- a/modules/openapi-generator/src/main/resources/cpp-qt5-qhttpengine-server/apirequest.h.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-qhttpengine-server/apirequest.h.mustache
@@ -54,13 +54,12 @@ private:
     QHttpEngine::Socket  *socket;
     QSharedPointer<{{classname}}Handler> handler;
 
-    inline void writeResponseHeaders(){
+    inline void setSocketResponseHeaders(){
         QHttpEngine::Socket::HeaderMap resHeaders;
         for(auto itr = responseHeaders.begin(); itr != responseHeaders.end(); ++itr) {
             resHeaders.insert(itr.key().toUtf8(), itr.value().toUtf8());
         }
         socket->setHeaders(resHeaders);
-        socket->writeHeaders();
     }
 };
 

--- a/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/requests/OAIPetApiRequest.cpp
+++ b/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/requests/OAIPetApiRequest.cpp
@@ -180,23 +180,25 @@ void OAIPetApiRequest::uploadFileRequest(const QString& pet_idstr){
 
 
 void OAIPetApiRequest::addPetResponse(){
-    writeResponseHeaders();
+    setSocketResponseHeaders();
     socket->setStatusCode(QHttpEngine::Socket::OK);
+    socket->writeHeaders();
     if(socket->isOpen()){
         socket->close();
     }
 }
 
 void OAIPetApiRequest::deletePetResponse(){
-    writeResponseHeaders();
+    setSocketResponseHeaders();
     socket->setStatusCode(QHttpEngine::Socket::OK);
+    socket->writeHeaders();
     if(socket->isOpen()){
         socket->close();
     }
 }
 
 void OAIPetApiRequest::findPetsByStatusResponse(const QList<OAIPet>& res){
-    writeResponseHeaders();
+    setSocketResponseHeaders();
     QJsonDocument resDoc(::OpenAPI::toJsonValue(res).toArray());
     socket->writeJson(resDoc);
     if(socket->isOpen()){
@@ -205,7 +207,7 @@ void OAIPetApiRequest::findPetsByStatusResponse(const QList<OAIPet>& res){
 }
 
 void OAIPetApiRequest::findPetsByTagsResponse(const QList<OAIPet>& res){
-    writeResponseHeaders();
+    setSocketResponseHeaders();
     QJsonDocument resDoc(::OpenAPI::toJsonValue(res).toArray());
     socket->writeJson(resDoc);
     if(socket->isOpen()){
@@ -214,7 +216,7 @@ void OAIPetApiRequest::findPetsByTagsResponse(const QList<OAIPet>& res){
 }
 
 void OAIPetApiRequest::getPetByIdResponse(const OAIPet& res){
-    writeResponseHeaders();
+    setSocketResponseHeaders();
     QJsonDocument resDoc(::OpenAPI::toJsonValue(res).toObject());
     socket->writeJson(resDoc);
     if(socket->isOpen()){
@@ -223,23 +225,25 @@ void OAIPetApiRequest::getPetByIdResponse(const OAIPet& res){
 }
 
 void OAIPetApiRequest::updatePetResponse(){
-    writeResponseHeaders();
+    setSocketResponseHeaders();
     socket->setStatusCode(QHttpEngine::Socket::OK);
+    socket->writeHeaders();
     if(socket->isOpen()){
         socket->close();
     }
 }
 
 void OAIPetApiRequest::updatePetWithFormResponse(){
-    writeResponseHeaders();
+    setSocketResponseHeaders();
     socket->setStatusCode(QHttpEngine::Socket::OK);
+    socket->writeHeaders();
     if(socket->isOpen()){
         socket->close();
     }
 }
 
 void OAIPetApiRequest::uploadFileResponse(const OAIApiResponse& res){
-    writeResponseHeaders();
+    setSocketResponseHeaders();
     QJsonDocument resDoc(::OpenAPI::toJsonValue(res).toObject());
     socket->writeJson(resDoc);
     if(socket->isOpen()){
@@ -250,7 +254,7 @@ void OAIPetApiRequest::uploadFileResponse(const OAIApiResponse& res){
 
 void OAIPetApiRequest::addPetError(QNetworkReply::NetworkError error_type, QString& error_str){
     Q_UNUSED(error_type); // TODO: Remap error_type to QHttpEngine::Socket errors
-    writeResponseHeaders();
+    setSocketResponseHeaders();
     socket->setStatusCode(QHttpEngine::Socket::NotFound);
     socket->write(error_str.toUtf8());
     if(socket->isOpen()){
@@ -260,7 +264,7 @@ void OAIPetApiRequest::addPetError(QNetworkReply::NetworkError error_type, QStri
 
 void OAIPetApiRequest::deletePetError(QNetworkReply::NetworkError error_type, QString& error_str){
     Q_UNUSED(error_type); // TODO: Remap error_type to QHttpEngine::Socket errors
-    writeResponseHeaders();
+    setSocketResponseHeaders();
     socket->setStatusCode(QHttpEngine::Socket::NotFound);
     socket->write(error_str.toUtf8());
     if(socket->isOpen()){
@@ -270,7 +274,7 @@ void OAIPetApiRequest::deletePetError(QNetworkReply::NetworkError error_type, QS
 
 void OAIPetApiRequest::findPetsByStatusError(const QList<OAIPet>& res, QNetworkReply::NetworkError error_type, QString& error_str){
     Q_UNUSED(error_type); // TODO: Remap error_type to QHttpEngine::Socket errors
-    writeResponseHeaders();
+    setSocketResponseHeaders();
     Q_UNUSED(error_str);  // response will be used instead of error string
     QJsonDocument resDoc(::OpenAPI::toJsonValue(res).toArray());
     socket->writeJson(resDoc);
@@ -281,7 +285,7 @@ void OAIPetApiRequest::findPetsByStatusError(const QList<OAIPet>& res, QNetworkR
 
 void OAIPetApiRequest::findPetsByTagsError(const QList<OAIPet>& res, QNetworkReply::NetworkError error_type, QString& error_str){
     Q_UNUSED(error_type); // TODO: Remap error_type to QHttpEngine::Socket errors
-    writeResponseHeaders();
+    setSocketResponseHeaders();
     Q_UNUSED(error_str);  // response will be used instead of error string
     QJsonDocument resDoc(::OpenAPI::toJsonValue(res).toArray());
     socket->writeJson(resDoc);
@@ -292,7 +296,7 @@ void OAIPetApiRequest::findPetsByTagsError(const QList<OAIPet>& res, QNetworkRep
 
 void OAIPetApiRequest::getPetByIdError(const OAIPet& res, QNetworkReply::NetworkError error_type, QString& error_str){
     Q_UNUSED(error_type); // TODO: Remap error_type to QHttpEngine::Socket errors
-    writeResponseHeaders();
+    setSocketResponseHeaders();
     Q_UNUSED(error_str);  // response will be used instead of error string
     QJsonDocument resDoc(::OpenAPI::toJsonValue(res).toObject());
     socket->writeJson(resDoc);
@@ -303,7 +307,7 @@ void OAIPetApiRequest::getPetByIdError(const OAIPet& res, QNetworkReply::Network
 
 void OAIPetApiRequest::updatePetError(QNetworkReply::NetworkError error_type, QString& error_str){
     Q_UNUSED(error_type); // TODO: Remap error_type to QHttpEngine::Socket errors
-    writeResponseHeaders();
+    setSocketResponseHeaders();
     socket->setStatusCode(QHttpEngine::Socket::NotFound);
     socket->write(error_str.toUtf8());
     if(socket->isOpen()){
@@ -313,7 +317,7 @@ void OAIPetApiRequest::updatePetError(QNetworkReply::NetworkError error_type, QS
 
 void OAIPetApiRequest::updatePetWithFormError(QNetworkReply::NetworkError error_type, QString& error_str){
     Q_UNUSED(error_type); // TODO: Remap error_type to QHttpEngine::Socket errors
-    writeResponseHeaders();
+    setSocketResponseHeaders();
     socket->setStatusCode(QHttpEngine::Socket::NotFound);
     socket->write(error_str.toUtf8());
     if(socket->isOpen()){
@@ -323,7 +327,7 @@ void OAIPetApiRequest::updatePetWithFormError(QNetworkReply::NetworkError error_
 
 void OAIPetApiRequest::uploadFileError(const OAIApiResponse& res, QNetworkReply::NetworkError error_type, QString& error_str){
     Q_UNUSED(error_type); // TODO: Remap error_type to QHttpEngine::Socket errors
-    writeResponseHeaders();
+    setSocketResponseHeaders();
     Q_UNUSED(error_str);  // response will be used instead of error string
     QJsonDocument resDoc(::OpenAPI::toJsonValue(res).toObject());
     socket->writeJson(resDoc);

--- a/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/requests/OAIPetApiRequest.h
+++ b/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/requests/OAIPetApiRequest.h
@@ -92,13 +92,12 @@ private:
     QHttpEngine::Socket  *socket;
     QSharedPointer<OAIPetApiHandler> handler;
 
-    inline void writeResponseHeaders(){
+    inline void setSocketResponseHeaders(){
         QHttpEngine::Socket::HeaderMap resHeaders;
         for(auto itr = responseHeaders.begin(); itr != responseHeaders.end(); ++itr) {
             resHeaders.insert(itr.key().toUtf8(), itr.value().toUtf8());
         }
         socket->setHeaders(resHeaders);
-        socket->writeHeaders();
     }
 };
 

--- a/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/requests/OAIStoreApiRequest.cpp
+++ b/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/requests/OAIStoreApiRequest.cpp
@@ -106,15 +106,16 @@ void OAIStoreApiRequest::placeOrderRequest(){
 
 
 void OAIStoreApiRequest::deleteOrderResponse(){
-    writeResponseHeaders();
+    setSocketResponseHeaders();
     socket->setStatusCode(QHttpEngine::Socket::OK);
+    socket->writeHeaders();
     if(socket->isOpen()){
         socket->close();
     }
 }
 
 void OAIStoreApiRequest::getInventoryResponse(const QMap<QString, qint32>& res){
-    writeResponseHeaders();
+    setSocketResponseHeaders();
     QJsonDocument resDoc(::OpenAPI::toJsonValue(res).toObject());
     socket->writeJson(resDoc);
     if(socket->isOpen()){
@@ -123,7 +124,7 @@ void OAIStoreApiRequest::getInventoryResponse(const QMap<QString, qint32>& res){
 }
 
 void OAIStoreApiRequest::getOrderByIdResponse(const OAIOrder& res){
-    writeResponseHeaders();
+    setSocketResponseHeaders();
     QJsonDocument resDoc(::OpenAPI::toJsonValue(res).toObject());
     socket->writeJson(resDoc);
     if(socket->isOpen()){
@@ -132,7 +133,7 @@ void OAIStoreApiRequest::getOrderByIdResponse(const OAIOrder& res){
 }
 
 void OAIStoreApiRequest::placeOrderResponse(const OAIOrder& res){
-    writeResponseHeaders();
+    setSocketResponseHeaders();
     QJsonDocument resDoc(::OpenAPI::toJsonValue(res).toObject());
     socket->writeJson(resDoc);
     if(socket->isOpen()){
@@ -143,7 +144,7 @@ void OAIStoreApiRequest::placeOrderResponse(const OAIOrder& res){
 
 void OAIStoreApiRequest::deleteOrderError(QNetworkReply::NetworkError error_type, QString& error_str){
     Q_UNUSED(error_type); // TODO: Remap error_type to QHttpEngine::Socket errors
-    writeResponseHeaders();
+    setSocketResponseHeaders();
     socket->setStatusCode(QHttpEngine::Socket::NotFound);
     socket->write(error_str.toUtf8());
     if(socket->isOpen()){
@@ -153,7 +154,7 @@ void OAIStoreApiRequest::deleteOrderError(QNetworkReply::NetworkError error_type
 
 void OAIStoreApiRequest::getInventoryError(const QMap<QString, qint32>& res, QNetworkReply::NetworkError error_type, QString& error_str){
     Q_UNUSED(error_type); // TODO: Remap error_type to QHttpEngine::Socket errors
-    writeResponseHeaders();
+    setSocketResponseHeaders();
     Q_UNUSED(error_str);  // response will be used instead of error string
     QJsonDocument resDoc(::OpenAPI::toJsonValue(res).toObject());
     socket->writeJson(resDoc);
@@ -164,7 +165,7 @@ void OAIStoreApiRequest::getInventoryError(const QMap<QString, qint32>& res, QNe
 
 void OAIStoreApiRequest::getOrderByIdError(const OAIOrder& res, QNetworkReply::NetworkError error_type, QString& error_str){
     Q_UNUSED(error_type); // TODO: Remap error_type to QHttpEngine::Socket errors
-    writeResponseHeaders();
+    setSocketResponseHeaders();
     Q_UNUSED(error_str);  // response will be used instead of error string
     QJsonDocument resDoc(::OpenAPI::toJsonValue(res).toObject());
     socket->writeJson(resDoc);
@@ -175,7 +176,7 @@ void OAIStoreApiRequest::getOrderByIdError(const OAIOrder& res, QNetworkReply::N
 
 void OAIStoreApiRequest::placeOrderError(const OAIOrder& res, QNetworkReply::NetworkError error_type, QString& error_str){
     Q_UNUSED(error_type); // TODO: Remap error_type to QHttpEngine::Socket errors
-    writeResponseHeaders();
+    setSocketResponseHeaders();
     Q_UNUSED(error_str);  // response will be used instead of error string
     QJsonDocument resDoc(::OpenAPI::toJsonValue(res).toObject());
     socket->writeJson(resDoc);

--- a/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/requests/OAIStoreApiRequest.h
+++ b/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/requests/OAIStoreApiRequest.h
@@ -75,13 +75,12 @@ private:
     QHttpEngine::Socket  *socket;
     QSharedPointer<OAIStoreApiHandler> handler;
 
-    inline void writeResponseHeaders(){
+    inline void setSocketResponseHeaders(){
         QHttpEngine::Socket::HeaderMap resHeaders;
         for(auto itr = responseHeaders.begin(); itr != responseHeaders.end(); ++itr) {
             resHeaders.insert(itr.key().toUtf8(), itr.value().toUtf8());
         }
         socket->setHeaders(resHeaders);
-        socket->writeHeaders();
     }
 };
 

--- a/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/requests/OAIUserApiRequest.cpp
+++ b/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/requests/OAIUserApiRequest.cpp
@@ -191,39 +191,43 @@ void OAIUserApiRequest::updateUserRequest(const QString& usernamestr){
 
 
 void OAIUserApiRequest::createUserResponse(){
-    writeResponseHeaders();
+    setSocketResponseHeaders();
     socket->setStatusCode(QHttpEngine::Socket::OK);
+    socket->writeHeaders();
     if(socket->isOpen()){
         socket->close();
     }
 }
 
 void OAIUserApiRequest::createUsersWithArrayInputResponse(){
-    writeResponseHeaders();
+    setSocketResponseHeaders();
     socket->setStatusCode(QHttpEngine::Socket::OK);
+    socket->writeHeaders();
     if(socket->isOpen()){
         socket->close();
     }
 }
 
 void OAIUserApiRequest::createUsersWithListInputResponse(){
-    writeResponseHeaders();
+    setSocketResponseHeaders();
     socket->setStatusCode(QHttpEngine::Socket::OK);
+    socket->writeHeaders();
     if(socket->isOpen()){
         socket->close();
     }
 }
 
 void OAIUserApiRequest::deleteUserResponse(){
-    writeResponseHeaders();
+    setSocketResponseHeaders();
     socket->setStatusCode(QHttpEngine::Socket::OK);
+    socket->writeHeaders();
     if(socket->isOpen()){
         socket->close();
     }
 }
 
 void OAIUserApiRequest::getUserByNameResponse(const OAIUser& res){
-    writeResponseHeaders();
+    setSocketResponseHeaders();
     QJsonDocument resDoc(::OpenAPI::toJsonValue(res).toObject());
     socket->writeJson(resDoc);
     if(socket->isOpen()){
@@ -232,7 +236,7 @@ void OAIUserApiRequest::getUserByNameResponse(const OAIUser& res){
 }
 
 void OAIUserApiRequest::loginUserResponse(const QString& res){
-    writeResponseHeaders();
+    setSocketResponseHeaders();
     socket->write(::OpenAPI::toStringValue(res).toUtf8());
     if(socket->isOpen()){
         socket->close();
@@ -240,16 +244,18 @@ void OAIUserApiRequest::loginUserResponse(const QString& res){
 }
 
 void OAIUserApiRequest::logoutUserResponse(){
-    writeResponseHeaders();
+    setSocketResponseHeaders();
     socket->setStatusCode(QHttpEngine::Socket::OK);
+    socket->writeHeaders();
     if(socket->isOpen()){
         socket->close();
     }
 }
 
 void OAIUserApiRequest::updateUserResponse(){
-    writeResponseHeaders();
+    setSocketResponseHeaders();
     socket->setStatusCode(QHttpEngine::Socket::OK);
+    socket->writeHeaders();
     if(socket->isOpen()){
         socket->close();
     }
@@ -258,7 +264,7 @@ void OAIUserApiRequest::updateUserResponse(){
 
 void OAIUserApiRequest::createUserError(QNetworkReply::NetworkError error_type, QString& error_str){
     Q_UNUSED(error_type); // TODO: Remap error_type to QHttpEngine::Socket errors
-    writeResponseHeaders();
+    setSocketResponseHeaders();
     socket->setStatusCode(QHttpEngine::Socket::NotFound);
     socket->write(error_str.toUtf8());
     if(socket->isOpen()){
@@ -268,7 +274,7 @@ void OAIUserApiRequest::createUserError(QNetworkReply::NetworkError error_type, 
 
 void OAIUserApiRequest::createUsersWithArrayInputError(QNetworkReply::NetworkError error_type, QString& error_str){
     Q_UNUSED(error_type); // TODO: Remap error_type to QHttpEngine::Socket errors
-    writeResponseHeaders();
+    setSocketResponseHeaders();
     socket->setStatusCode(QHttpEngine::Socket::NotFound);
     socket->write(error_str.toUtf8());
     if(socket->isOpen()){
@@ -278,7 +284,7 @@ void OAIUserApiRequest::createUsersWithArrayInputError(QNetworkReply::NetworkErr
 
 void OAIUserApiRequest::createUsersWithListInputError(QNetworkReply::NetworkError error_type, QString& error_str){
     Q_UNUSED(error_type); // TODO: Remap error_type to QHttpEngine::Socket errors
-    writeResponseHeaders();
+    setSocketResponseHeaders();
     socket->setStatusCode(QHttpEngine::Socket::NotFound);
     socket->write(error_str.toUtf8());
     if(socket->isOpen()){
@@ -288,7 +294,7 @@ void OAIUserApiRequest::createUsersWithListInputError(QNetworkReply::NetworkErro
 
 void OAIUserApiRequest::deleteUserError(QNetworkReply::NetworkError error_type, QString& error_str){
     Q_UNUSED(error_type); // TODO: Remap error_type to QHttpEngine::Socket errors
-    writeResponseHeaders();
+    setSocketResponseHeaders();
     socket->setStatusCode(QHttpEngine::Socket::NotFound);
     socket->write(error_str.toUtf8());
     if(socket->isOpen()){
@@ -298,7 +304,7 @@ void OAIUserApiRequest::deleteUserError(QNetworkReply::NetworkError error_type, 
 
 void OAIUserApiRequest::getUserByNameError(const OAIUser& res, QNetworkReply::NetworkError error_type, QString& error_str){
     Q_UNUSED(error_type); // TODO: Remap error_type to QHttpEngine::Socket errors
-    writeResponseHeaders();
+    setSocketResponseHeaders();
     Q_UNUSED(error_str);  // response will be used instead of error string
     QJsonDocument resDoc(::OpenAPI::toJsonValue(res).toObject());
     socket->writeJson(resDoc);
@@ -309,7 +315,7 @@ void OAIUserApiRequest::getUserByNameError(const OAIUser& res, QNetworkReply::Ne
 
 void OAIUserApiRequest::loginUserError(const QString& res, QNetworkReply::NetworkError error_type, QString& error_str){
     Q_UNUSED(error_type); // TODO: Remap error_type to QHttpEngine::Socket errors
-    writeResponseHeaders();
+    setSocketResponseHeaders();
     Q_UNUSED(error_str);  // response will be used instead of error string
     socket->write(::OpenAPI::toStringValue(res).toUtf8());
     if(socket->isOpen()){
@@ -319,7 +325,7 @@ void OAIUserApiRequest::loginUserError(const QString& res, QNetworkReply::Networ
 
 void OAIUserApiRequest::logoutUserError(QNetworkReply::NetworkError error_type, QString& error_str){
     Q_UNUSED(error_type); // TODO: Remap error_type to QHttpEngine::Socket errors
-    writeResponseHeaders();
+    setSocketResponseHeaders();
     socket->setStatusCode(QHttpEngine::Socket::NotFound);
     socket->write(error_str.toUtf8());
     if(socket->isOpen()){
@@ -329,7 +335,7 @@ void OAIUserApiRequest::logoutUserError(QNetworkReply::NetworkError error_type, 
 
 void OAIUserApiRequest::updateUserError(QNetworkReply::NetworkError error_type, QString& error_str){
     Q_UNUSED(error_type); // TODO: Remap error_type to QHttpEngine::Socket errors
-    writeResponseHeaders();
+    setSocketResponseHeaders();
     socket->setStatusCode(QHttpEngine::Socket::NotFound);
     socket->write(error_str.toUtf8());
     if(socket->isOpen()){

--- a/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/requests/OAIUserApiRequest.h
+++ b/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/requests/OAIUserApiRequest.h
@@ -91,13 +91,12 @@ private:
     QHttpEngine::Socket  *socket;
     QSharedPointer<OAIUserApiHandler> handler;
 
-    inline void writeResponseHeaders(){
+    inline void setSocketResponseHeaders(){
         QHttpEngine::Socket::HeaderMap resHeaders;
         for(auto itr = responseHeaders.begin(); itr != responseHeaders.end(); ++itr) {
             resHeaders.insert(itr.key().toUtf8(), itr.value().toUtf8());
         }
         socket->setHeaders(resHeaders);
-        socket->writeHeaders();
     }
 };
 


### PR DESCRIPTION
Change helper method ```writeResponseHeaders``` implementation to just set the headers, instead of write them, and also rename the method to ```setSocketResponseHeaders```, to maintain the new semantic.
The implementation of ```QHttpEngine::Socket::write``` or ```QHttpEngine::Socket::writeJson``` implementations will call ```Socket::writeData``` that writes the Headers and Status Code before write the content if they are not already written.
If these methods are not called (e.g.: empty reply), we could set the headers just before close the socket.

Fixes #6344
cc
@ravinikam @stkrwork @etherealjoy @martindelille @muttleyxd
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [X] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [X] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
