### PR TITLE
replacing caTools dependency with base64enc

### DIFF
--- a/modules/openapi-generator/src/main/resources/r/README.mustache
+++ b/modules/openapi-generator/src/main/resources/r/README.mustache
@@ -26,7 +26,7 @@ Install the dependencies
 ```R
 install.packages("jsonlite")
 install.packages("httr")
-install.packages("caTools")
+install.packages("base64enc")
 ```
 
 ### Build the package

--- a/modules/openapi-generator/src/main/resources/r/api.mustache
+++ b/modules/openapi-generator/src/main/resources/r/api.mustache
@@ -141,7 +141,7 @@
 {{/operation}}
 #' }
 #' @importFrom R6 R6Class
-#' @importFrom caTools base64encode
+#' @importFrom base64enc base64encode
 {{#useRlangExceptionHandling}}
 #' @importFrom rlang abort
 {{/useRlangExceptionHandling}}
@@ -239,7 +239,7 @@
       {{#isBasic}}
       {{#isBasicBasic}}
       # HTTP basic auth
-      headerParams['Authorization'] <- paste("Basic", caTools::base64encode(paste(self$apiClient$username, self$apiClient$password, sep=":")), sep=" ")
+      headerParams['Authorization'] <- paste("Basic", base64enc::base64encode(charToRaw(paste(self$apiClient$username, self$apiClient$password, sep=":"))))
       {{/isBasicBasic}}
       {{/isBasic}}
       {{#isApiKey}}

--- a/modules/openapi-generator/src/main/resources/r/description.mustache
+++ b/modules/openapi-generator/src/main/resources/r/description.mustache
@@ -10,5 +10,5 @@ Encoding: UTF-8
 License: {{#licenseInfo}}{{licenseInfo}}{{/licenseInfo}}{{^licenseInfo}}Unlicense{{/licenseInfo}}
 LazyData: true
 Suggests: testthat
-Imports: jsonlite, httr, R6, caTools{{#useRlangExceptionHandling}}, rlang{{/useRlangExceptionHandling}}
+Imports: jsonlite, httr, R6, base64enc{{#useRlangExceptionHandling}}, rlang{{/useRlangExceptionHandling}}
 RoxygenNote: 6.0.1.9000

--- a/samples/client/petstore/R/DESCRIPTION
+++ b/samples/client/petstore/R/DESCRIPTION
@@ -10,5 +10,5 @@ Encoding: UTF-8
 License: Apache-2.0
 LazyData: true
 Suggests: testthat
-Imports: jsonlite, httr, R6, caTools
+Imports: jsonlite, httr, R6, base64enc
 RoxygenNote: 6.0.1.9000

--- a/samples/client/petstore/R/R/pet_api.R
+++ b/samples/client/petstore/R/R/pet_api.R
@@ -317,7 +317,7 @@
 #'
 #' }
 #' @importFrom R6 R6Class
-#' @importFrom caTools base64encode
+#' @importFrom base64enc base64encode
 #' @export
 PetApi <- R6::R6Class(
   'PetApi',

--- a/samples/client/petstore/R/R/store_api.R
+++ b/samples/client/petstore/R/R/store_api.R
@@ -160,7 +160,7 @@
 #'
 #' }
 #' @importFrom R6 R6Class
-#' @importFrom caTools base64encode
+#' @importFrom base64enc base64encode
 #' @export
 StoreApi <- R6::R6Class(
   'StoreApi',

--- a/samples/client/petstore/R/R/user_api.R
+++ b/samples/client/petstore/R/R/user_api.R
@@ -277,7 +277,7 @@
 #'
 #' }
 #' @importFrom R6 R6Class
-#' @importFrom caTools base64encode
+#' @importFrom base64enc base64encode
 #' @export
 UserApi <- R6::R6Class(
   'UserApi',

--- a/samples/client/petstore/R/README.md
+++ b/samples/client/petstore/R/README.md
@@ -18,7 +18,7 @@ Install the dependencies
 ```R
 install.packages("jsonlite")
 install.packages("httr")
-install.packages("caTools")
+install.packages("base64enc")
 ```
 
 ### Build the package

--- a/samples/client/petstore/R/test_petstore.bash
+++ b/samples/client/petstore/R/test_petstore.bash
@@ -2,7 +2,7 @@
 
 set -e
 
-REPO=http://cran.revolutionanalytics.com
+REPO=https://cloud.r-project.org
 
 export R_LIBS_USER=$HOME/R
 

--- a/samples/client/petstore/R/test_petstore.bash
+++ b/samples/client/petstore/R/test_petstore.bash
@@ -14,7 +14,7 @@ Rscript -e "install.packages('jsonlite', repos='$REPO', lib='$R_LIBS_USER')"
 Rscript -e "install.packages('httr', repos='$REPO', lib='$R_LIBS_USER')"
 Rscript -e "install.packages('testthat', repos='$REPO', lib='$R_LIBS_USER')"
 Rscript -e "install.packages('R6', repos='$REPO', lib='$R_LIBS_USER')"
-Rscript -e "install.packages('caTools', repos='$REPO', lib='$R_LIBS_USER')"
+Rscript -e "install.packages('base64enc', repos='$REPO', lib='$R_LIBS_USER')"
 Rscript -e "install.packages('rlang', repos='$REPO', lib='$R_LIBS_USER')"
 
 R CMD build .


### PR DESCRIPTION
Replacing caTools with base64enc library
As the caTools has recently upgraded to new version and it is now not available for R versions less than 3.6.1, which is causing installation errors of the R generator on lower R versions.

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.


@wing328  @saigiridhar21 