### PR TITLE
Fix #6350 by removing if statement with arbitrary condition

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/HaskellHttpClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/HaskellHttpClientCodegen.java
@@ -757,21 +757,16 @@ public class HaskellHttpClientCodegen extends DefaultCodegen implements CodegenC
                 op.vendorExtensions.put(VENDOR_EXTENSION_X_HAS_OPTIONAL_PARAMS, true);
             }
 
-            if (typeMapping.containsKey(param.dataType)
-                    || param.isMapContainer || param.isListContainer
-                    || param.isPrimitiveType || param.isFile || param.isEnum) {
+            String dataType = genEnums && param.isEnum ? param.datatypeWithEnum : param.dataType;
 
-                String dataType = genEnums && param.isEnum ? param.datatypeWithEnum : param.dataType;
+            String paramNameType = toDedupedModelName(toTypeName("Param", param.paramName), dataType, !param.isEnum);
+            param.vendorExtensions.put(X_PARAM_NAME_TYPE, paramNameType); // TODO: 5.0 Remove
+            param.vendorExtensions.put(VENDOR_EXTENSION_X_PARAM_NAME_TYPE, paramNameType);
 
-                String paramNameType = toDedupedModelName(toTypeName("Param", param.paramName), dataType, !param.isEnum);
-                param.vendorExtensions.put(X_PARAM_NAME_TYPE, paramNameType); // TODO: 5.0 Remove
-                param.vendorExtensions.put(VENDOR_EXTENSION_X_PARAM_NAME_TYPE, paramNameType);
-
-                HashMap<String, Object> props = new HashMap<>();
-                props.put(X_IS_BODY_PARAM, param.isBodyParam);
-                addToUniques(X_NEWTYPE, paramNameType, dataType, props);
-            }
-        }
+            HashMap<String, Object> props = new HashMap<>();
+            props.put(X_IS_BODY_PARAM, param.isBodyParam);
+            addToUniques(X_NEWTYPE, paramNameType, dataType, props);
+    }
 
         processPathExpr(op);
 


### PR DESCRIPTION
else branch was also missing. Not doing something in the else
branch simply resulted in empty strings put in the templates,
which resulted in broken haskell code which did not compile.

Fixes #6350
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [ ] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
