### PR TITLE
[Go][Experimental] Reset to nil with multiple matches in oneOf

### DIFF
--- a/modules/openapi-generator/src/main/resources/go-experimental/model_enum.mustache
+++ b/modules/openapi-generator/src/main/resources/go-experimental/model_enum.mustache
@@ -1,5 +1,5 @@
 import (
-    "fmt"
+	"fmt"
 )
 
 // {{{classname}}} {{#description}}{{{.}}}{{/description}}{{^description}}the model '{{{classname}}}'{{/description}}
@@ -17,20 +17,20 @@ const (
 )
 
 func (v *{{{classname}}}) UnmarshalJSON(src []byte) error {
-    var value {{^format}}{{dataType}}{{/format}}{{#format}}{{{format}}}{{/format}}
-    err := json.Unmarshal(src, &value)
-    if err != nil {
-        return err
-    }
-    enumTypeValue := {{{classname}}}(value)
-    for _, existing := range []{{classname}}{ {{#allowableValues}}{{#enumVars}}{{{value}}}, {{/enumVars}} {{/allowableValues}} } {
-        if existing == enumTypeValue {
-            *v = enumTypeValue
-            return nil
-        }
-    }
+	var value {{^format}}{{dataType}}{{/format}}{{#format}}{{{format}}}{{/format}}
+	err := json.Unmarshal(src, &value)
+	if err != nil {
+		return err
+	}
+	enumTypeValue := {{{classname}}}(value)
+	for _, existing := range []{{classname}}{ {{#allowableValues}}{{#enumVars}}{{{value}}}, {{/enumVars}} {{/allowableValues}} } {
+		if existing == enumTypeValue {
+			*v = enumTypeValue
+			return nil
+		}
+	}
 
-    return fmt.Errorf("%+v is not a valid {{classname}}", *v)
+	return fmt.Errorf("%+v is not a valid {{classname}}", *v)
 }
 
 // Ptr returns reference to {{{name}}} value

--- a/modules/openapi-generator/src/main/resources/go-experimental/model_oneof.mustache
+++ b/modules/openapi-generator/src/main/resources/go-experimental/model_oneof.mustache
@@ -8,7 +8,7 @@ type {{classname}} struct {
 {{#oneOf}}
 // {{{.}}}As{{classname}} is a convenience function that returns {{{.}}} wrapped in {{classname}}
 func {{{.}}}As{{classname}}(v *{{{.}}}) {{classname}} {
-    return {{classname}}{ {{{.}}}: v}
+	return {{classname}}{ {{{.}}}: v}
 }
 
 {{/oneOf}}
@@ -40,6 +40,11 @@ func (dst *{{classname}}) UnmarshalJSON(data []byte) error {
 
 	{{/oneOf}}
 	if match > 1 { // more than 1 match
+		// reset to nil
+		{{#oneOf}}
+		dst.{{{.}}} = nil
+		{{/oneOf}}
+
 		return fmt.Errorf("Data matches more than one schema in oneOf({{classname}})")
 	} else if match == 1 {
 		return nil // exactly one match

--- a/samples/client/petstore/go-experimental/go-petstore/model_enum_class.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_enum_class.go
@@ -14,7 +14,7 @@ import (
 )
 
 import (
-    "fmt"
+	"fmt"
 )
 
 // EnumClass the model 'EnumClass'
@@ -28,20 +28,20 @@ const (
 )
 
 func (v *EnumClass) UnmarshalJSON(src []byte) error {
-    var value string
-    err := json.Unmarshal(src, &value)
-    if err != nil {
-        return err
-    }
-    enumTypeValue := EnumClass(value)
-    for _, existing := range []EnumClass{ "_abc", "-efg", "(xyz)",   } {
-        if existing == enumTypeValue {
-            *v = enumTypeValue
-            return nil
-        }
-    }
+	var value string
+	err := json.Unmarshal(src, &value)
+	if err != nil {
+		return err
+	}
+	enumTypeValue := EnumClass(value)
+	for _, existing := range []EnumClass{ "_abc", "-efg", "(xyz)",   } {
+		if existing == enumTypeValue {
+			*v = enumTypeValue
+			return nil
+		}
+	}
 
-    return fmt.Errorf("%+v is not a valid EnumClass", *v)
+	return fmt.Errorf("%+v is not a valid EnumClass", *v)
 }
 
 // Ptr returns reference to EnumClass value

--- a/samples/client/petstore/go-experimental/go-petstore/model_outer_enum.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_outer_enum.go
@@ -14,7 +14,7 @@ import (
 )
 
 import (
-    "fmt"
+	"fmt"
 )
 
 // OuterEnum the model 'OuterEnum'
@@ -28,20 +28,20 @@ const (
 )
 
 func (v *OuterEnum) UnmarshalJSON(src []byte) error {
-    var value string
-    err := json.Unmarshal(src, &value)
-    if err != nil {
-        return err
-    }
-    enumTypeValue := OuterEnum(value)
-    for _, existing := range []OuterEnum{ "placed", "approved", "delivered",   } {
-        if existing == enumTypeValue {
-            *v = enumTypeValue
-            return nil
-        }
-    }
+	var value string
+	err := json.Unmarshal(src, &value)
+	if err != nil {
+		return err
+	}
+	enumTypeValue := OuterEnum(value)
+	for _, existing := range []OuterEnum{ "placed", "approved", "delivered",   } {
+		if existing == enumTypeValue {
+			*v = enumTypeValue
+			return nil
+		}
+	}
 
-    return fmt.Errorf("%+v is not a valid OuterEnum", *v)
+	return fmt.Errorf("%+v is not a valid OuterEnum", *v)
 }
 
 // Ptr returns reference to OuterEnum value

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_enum_class.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_enum_class.go
@@ -14,7 +14,7 @@ import (
 )
 
 import (
-    "fmt"
+	"fmt"
 )
 
 // EnumClass the model 'EnumClass'
@@ -28,20 +28,20 @@ const (
 )
 
 func (v *EnumClass) UnmarshalJSON(src []byte) error {
-    var value string
-    err := json.Unmarshal(src, &value)
-    if err != nil {
-        return err
-    }
-    enumTypeValue := EnumClass(value)
-    for _, existing := range []EnumClass{ "_abc", "-efg", "(xyz)",   } {
-        if existing == enumTypeValue {
-            *v = enumTypeValue
-            return nil
-        }
-    }
+	var value string
+	err := json.Unmarshal(src, &value)
+	if err != nil {
+		return err
+	}
+	enumTypeValue := EnumClass(value)
+	for _, existing := range []EnumClass{ "_abc", "-efg", "(xyz)",   } {
+		if existing == enumTypeValue {
+			*v = enumTypeValue
+			return nil
+		}
+	}
 
-    return fmt.Errorf("%+v is not a valid EnumClass", *v)
+	return fmt.Errorf("%+v is not a valid EnumClass", *v)
 }
 
 // Ptr returns reference to EnumClass value

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_fruit.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_fruit.go
@@ -22,12 +22,12 @@ type Fruit struct {
 
 // AppleAsFruit is a convenience function that returns Apple wrapped in Fruit
 func AppleAsFruit(v *Apple) Fruit {
-    return Fruit{ Apple: v}
+	return Fruit{ Apple: v}
 }
 
 // BananaAsFruit is a convenience function that returns Banana wrapped in Fruit
 func BananaAsFruit(v *Banana) Fruit {
-    return Fruit{ Banana: v}
+	return Fruit{ Banana: v}
 }
 
 
@@ -62,6 +62,10 @@ func (dst *Fruit) UnmarshalJSON(data []byte) error {
 	}
 
 	if match > 1 { // more than 1 match
+		// reset to nil
+		dst.Apple = nil
+		dst.Banana = nil
+
 		return fmt.Errorf("Data matches more than one schema in oneOf(Fruit)")
 	} else if match == 1 {
 		return nil // exactly one match

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_fruit_req.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_fruit_req.go
@@ -22,12 +22,12 @@ type FruitReq struct {
 
 // AppleReqAsFruitReq is a convenience function that returns AppleReq wrapped in FruitReq
 func AppleReqAsFruitReq(v *AppleReq) FruitReq {
-    return FruitReq{ AppleReq: v}
+	return FruitReq{ AppleReq: v}
 }
 
 // BananaReqAsFruitReq is a convenience function that returns BananaReq wrapped in FruitReq
 func BananaReqAsFruitReq(v *BananaReq) FruitReq {
-    return FruitReq{ BananaReq: v}
+	return FruitReq{ BananaReq: v}
 }
 
 
@@ -62,6 +62,10 @@ func (dst *FruitReq) UnmarshalJSON(data []byte) error {
 	}
 
 	if match > 1 { // more than 1 match
+		// reset to nil
+		dst.AppleReq = nil
+		dst.BananaReq = nil
+
 		return fmt.Errorf("Data matches more than one schema in oneOf(FruitReq)")
 	} else if match == 1 {
 		return nil // exactly one match

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_mammal.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_mammal.go
@@ -22,12 +22,12 @@ type Mammal struct {
 
 // WhaleAsMammal is a convenience function that returns Whale wrapped in Mammal
 func WhaleAsMammal(v *Whale) Mammal {
-    return Mammal{ Whale: v}
+	return Mammal{ Whale: v}
 }
 
 // ZebraAsMammal is a convenience function that returns Zebra wrapped in Mammal
 func ZebraAsMammal(v *Zebra) Mammal {
-    return Mammal{ Zebra: v}
+	return Mammal{ Zebra: v}
 }
 
 
@@ -62,6 +62,10 @@ func (dst *Mammal) UnmarshalJSON(data []byte) error {
 	}
 
 	if match > 1 { // more than 1 match
+		// reset to nil
+		dst.Whale = nil
+		dst.Zebra = nil
+
 		return fmt.Errorf("Data matches more than one schema in oneOf(Mammal)")
 	} else if match == 1 {
 		return nil // exactly one match

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_outer_enum.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_outer_enum.go
@@ -14,7 +14,7 @@ import (
 )
 
 import (
-    "fmt"
+	"fmt"
 )
 
 // OuterEnum the model 'OuterEnum'
@@ -28,20 +28,20 @@ const (
 )
 
 func (v *OuterEnum) UnmarshalJSON(src []byte) error {
-    var value string
-    err := json.Unmarshal(src, &value)
-    if err != nil {
-        return err
-    }
-    enumTypeValue := OuterEnum(value)
-    for _, existing := range []OuterEnum{ "placed", "approved", "delivered",   } {
-        if existing == enumTypeValue {
-            *v = enumTypeValue
-            return nil
-        }
-    }
+	var value string
+	err := json.Unmarshal(src, &value)
+	if err != nil {
+		return err
+	}
+	enumTypeValue := OuterEnum(value)
+	for _, existing := range []OuterEnum{ "placed", "approved", "delivered",   } {
+		if existing == enumTypeValue {
+			*v = enumTypeValue
+			return nil
+		}
+	}
 
-    return fmt.Errorf("%+v is not a valid OuterEnum", *v)
+	return fmt.Errorf("%+v is not a valid OuterEnum", *v)
 }
 
 // Ptr returns reference to OuterEnum value

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_outer_enum_default_value.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_outer_enum_default_value.go
@@ -14,7 +14,7 @@ import (
 )
 
 import (
-    "fmt"
+	"fmt"
 )
 
 // OuterEnumDefaultValue the model 'OuterEnumDefaultValue'
@@ -28,20 +28,20 @@ const (
 )
 
 func (v *OuterEnumDefaultValue) UnmarshalJSON(src []byte) error {
-    var value string
-    err := json.Unmarshal(src, &value)
-    if err != nil {
-        return err
-    }
-    enumTypeValue := OuterEnumDefaultValue(value)
-    for _, existing := range []OuterEnumDefaultValue{ "placed", "approved", "delivered",   } {
-        if existing == enumTypeValue {
-            *v = enumTypeValue
-            return nil
-        }
-    }
+	var value string
+	err := json.Unmarshal(src, &value)
+	if err != nil {
+		return err
+	}
+	enumTypeValue := OuterEnumDefaultValue(value)
+	for _, existing := range []OuterEnumDefaultValue{ "placed", "approved", "delivered",   } {
+		if existing == enumTypeValue {
+			*v = enumTypeValue
+			return nil
+		}
+	}
 
-    return fmt.Errorf("%+v is not a valid OuterEnumDefaultValue", *v)
+	return fmt.Errorf("%+v is not a valid OuterEnumDefaultValue", *v)
 }
 
 // Ptr returns reference to OuterEnumDefaultValue value

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_outer_enum_integer.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_outer_enum_integer.go
@@ -14,7 +14,7 @@ import (
 )
 
 import (
-    "fmt"
+	"fmt"
 )
 
 // OuterEnumInteger the model 'OuterEnumInteger'
@@ -28,20 +28,20 @@ const (
 )
 
 func (v *OuterEnumInteger) UnmarshalJSON(src []byte) error {
-    var value int32
-    err := json.Unmarshal(src, &value)
-    if err != nil {
-        return err
-    }
-    enumTypeValue := OuterEnumInteger(value)
-    for _, existing := range []OuterEnumInteger{ 0, 1, 2,   } {
-        if existing == enumTypeValue {
-            *v = enumTypeValue
-            return nil
-        }
-    }
+	var value int32
+	err := json.Unmarshal(src, &value)
+	if err != nil {
+		return err
+	}
+	enumTypeValue := OuterEnumInteger(value)
+	for _, existing := range []OuterEnumInteger{ 0, 1, 2,   } {
+		if existing == enumTypeValue {
+			*v = enumTypeValue
+			return nil
+		}
+	}
 
-    return fmt.Errorf("%+v is not a valid OuterEnumInteger", *v)
+	return fmt.Errorf("%+v is not a valid OuterEnumInteger", *v)
 }
 
 // Ptr returns reference to OuterEnumInteger value

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_outer_enum_integer_default_value.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_outer_enum_integer_default_value.go
@@ -14,7 +14,7 @@ import (
 )
 
 import (
-    "fmt"
+	"fmt"
 )
 
 // OuterEnumIntegerDefaultValue the model 'OuterEnumIntegerDefaultValue'
@@ -28,20 +28,20 @@ const (
 )
 
 func (v *OuterEnumIntegerDefaultValue) UnmarshalJSON(src []byte) error {
-    var value int32
-    err := json.Unmarshal(src, &value)
-    if err != nil {
-        return err
-    }
-    enumTypeValue := OuterEnumIntegerDefaultValue(value)
-    for _, existing := range []OuterEnumIntegerDefaultValue{ 0, 1, 2,   } {
-        if existing == enumTypeValue {
-            *v = enumTypeValue
-            return nil
-        }
-    }
+	var value int32
+	err := json.Unmarshal(src, &value)
+	if err != nil {
+		return err
+	}
+	enumTypeValue := OuterEnumIntegerDefaultValue(value)
+	for _, existing := range []OuterEnumIntegerDefaultValue{ 0, 1, 2,   } {
+		if existing == enumTypeValue {
+			*v = enumTypeValue
+			return nil
+		}
+	}
 
-    return fmt.Errorf("%+v is not a valid OuterEnumIntegerDefaultValue", *v)
+	return fmt.Errorf("%+v is not a valid OuterEnumIntegerDefaultValue", *v)
 }
 
 // Ptr returns reference to OuterEnumIntegerDefaultValue value


### PR DESCRIPTION
- Reset to nil with multiple matches in oneOf
- replace 4-spaces with tabs

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

cc @antihax (2017/11) @bvwells (2017/12) @grokify (2018/07) @kemokemo (2018/09) @bkabrda (2019/07)


