### PR TITLE
[go-experimental] Ensure that all oneOf/anyOf models have their Nullable<Model> defined

### DIFF
--- a/modules/openapi-generator/src/main/resources/go-experimental/model_anyof.mustache
+++ b/modules/openapi-generator/src/main/resources/go-experimental/model_anyof.mustache
@@ -43,3 +43,5 @@ func (src *{{classname}}) MarshalJSON() ([]byte, error) {
 {{/anyOf}}
 	return nil, nil // no data in anyOf schemas
 }
+
+{{>nullable_model}}

--- a/modules/openapi-generator/src/main/resources/go-experimental/model_oneof.mustache
+++ b/modules/openapi-generator/src/main/resources/go-experimental/model_oneof.mustache
@@ -75,3 +75,5 @@ func (obj *{{classname}}) GetActualInstance() (interface{}) {
 	// all schemas are nil
 	return nil
 }
+
+{{>nullable_model}}

--- a/modules/openapi-generator/src/main/resources/go-experimental/model_simple.mustache
+++ b/modules/openapi-generator/src/main/resources/go-experimental/model_simple.mustache
@@ -249,38 +249,4 @@ func (o {{classname}}) MarshalJSON() ([]byte, error) {
 	return json.Marshal(toSerialize)
 }
 
-type Nullable{{{classname}}} struct {
-	value *{{{classname}}}
-	isSet bool
-}
-
-func (v Nullable{{classname}}) Get() *{{classname}} {
-	return v.value
-}
-
-func (v *Nullable{{classname}}) Set(val *{{classname}}) {
-	v.value = val
-	v.isSet = true
-}
-
-func (v Nullable{{classname}}) IsSet() bool {
-	return v.isSet
-}
-
-func (v *Nullable{{classname}}) Unset() {
-	v.value = nil
-	v.isSet = false
-}
-
-func NewNullable{{classname}}(val *{{classname}}) *Nullable{{classname}} {
-	return &Nullable{{classname}}{value: val, isSet: true}
-}
-
-func (v Nullable{{{classname}}}) MarshalJSON() ([]byte, error) {
-	return json.Marshal(v.value)
-}
-
-func (v *Nullable{{{classname}}}) UnmarshalJSON(src []byte) error {
-	v.isSet = true
-	return json.Unmarshal(src, &v.value)
-}
+{{>nullable_model}}

--- a/modules/openapi-generator/src/main/resources/go-experimental/nullable_model.mustache
+++ b/modules/openapi-generator/src/main/resources/go-experimental/nullable_model.mustache
@@ -1,0 +1,35 @@
+type Nullable{{{classname}}} struct {
+	value *{{{classname}}}
+	isSet bool
+}
+
+func (v Nullable{{classname}}) Get() *{{classname}} {
+	return v.value
+}
+
+func (v *Nullable{{classname}}) Set(val *{{classname}}) {
+	v.value = val
+	v.isSet = true
+}
+
+func (v Nullable{{classname}}) IsSet() bool {
+	return v.isSet
+}
+
+func (v *Nullable{{classname}}) Unset() {
+	v.value = nil
+	v.isSet = false
+}
+
+func NewNullable{{classname}}(val *{{classname}}) *Nullable{{classname}} {
+	return &Nullable{{classname}}{value: val, isSet: true}
+}
+
+func (v Nullable{{{classname}}}) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.value)
+}
+
+func (v *Nullable{{{classname}}}) UnmarshalJSON(src []byte) error {
+	v.isSet = true
+	return json.Unmarshal(src, &v.value)
+}

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_fruit.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_fruit.go
@@ -101,3 +101,39 @@ func (obj *Fruit) GetActualInstance() (interface{}) {
 	return nil
 }
 
+type NullableFruit struct {
+	value *Fruit
+	isSet bool
+}
+
+func (v NullableFruit) Get() *Fruit {
+	return v.value
+}
+
+func (v *NullableFruit) Set(val *Fruit) {
+	v.value = val
+	v.isSet = true
+}
+
+func (v NullableFruit) IsSet() bool {
+	return v.isSet
+}
+
+func (v *NullableFruit) Unset() {
+	v.value = nil
+	v.isSet = false
+}
+
+func NewNullableFruit(val *Fruit) *NullableFruit {
+	return &NullableFruit{value: val, isSet: true}
+}
+
+func (v NullableFruit) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.value)
+}
+
+func (v *NullableFruit) UnmarshalJSON(src []byte) error {
+	v.isSet = true
+	return json.Unmarshal(src, &v.value)
+}
+

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_fruit_req.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_fruit_req.go
@@ -101,3 +101,39 @@ func (obj *FruitReq) GetActualInstance() (interface{}) {
 	return nil
 }
 
+type NullableFruitReq struct {
+	value *FruitReq
+	isSet bool
+}
+
+func (v NullableFruitReq) Get() *FruitReq {
+	return v.value
+}
+
+func (v *NullableFruitReq) Set(val *FruitReq) {
+	v.value = val
+	v.isSet = true
+}
+
+func (v NullableFruitReq) IsSet() bool {
+	return v.isSet
+}
+
+func (v *NullableFruitReq) Unset() {
+	v.value = nil
+	v.isSet = false
+}
+
+func NewNullableFruitReq(val *FruitReq) *NullableFruitReq {
+	return &NullableFruitReq{value: val, isSet: true}
+}
+
+func (v NullableFruitReq) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.value)
+}
+
+func (v *NullableFruitReq) UnmarshalJSON(src []byte) error {
+	v.isSet = true
+	return json.Unmarshal(src, &v.value)
+}
+

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_gm_fruit.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_gm_fruit.go
@@ -65,3 +65,39 @@ func (src *GmFruit) MarshalJSON() ([]byte, error) {
 	return nil, nil // no data in anyOf schemas
 }
 
+type NullableGmFruit struct {
+	value *GmFruit
+	isSet bool
+}
+
+func (v NullableGmFruit) Get() *GmFruit {
+	return v.value
+}
+
+func (v *NullableGmFruit) Set(val *GmFruit) {
+	v.value = val
+	v.isSet = true
+}
+
+func (v NullableGmFruit) IsSet() bool {
+	return v.isSet
+}
+
+func (v *NullableGmFruit) Unset() {
+	v.value = nil
+	v.isSet = false
+}
+
+func NewNullableGmFruit(val *GmFruit) *NullableGmFruit {
+	return &NullableGmFruit{value: val, isSet: true}
+}
+
+func (v NullableGmFruit) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.value)
+}
+
+func (v *NullableGmFruit) UnmarshalJSON(src []byte) error {
+	v.isSet = true
+	return json.Unmarshal(src, &v.value)
+}
+

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_mammal.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_mammal.go
@@ -101,3 +101,39 @@ func (obj *Mammal) GetActualInstance() (interface{}) {
 	return nil
 }
 
+type NullableMammal struct {
+	value *Mammal
+	isSet bool
+}
+
+func (v NullableMammal) Get() *Mammal {
+	return v.value
+}
+
+func (v *NullableMammal) Set(val *Mammal) {
+	v.value = val
+	v.isSet = true
+}
+
+func (v NullableMammal) IsSet() bool {
+	return v.isSet
+}
+
+func (v *NullableMammal) Unset() {
+	v.value = nil
+	v.isSet = false
+}
+
+func NewNullableMammal(val *Mammal) *NullableMammal {
+	return &NullableMammal{value: val, isSet: true}
+}
+
+func (v NullableMammal) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.value)
+}
+
+func (v *NullableMammal) UnmarshalJSON(src []byte) error {
+	v.isSet = true
+	return json.Unmarshal(src, &v.value)
+}
+


### PR DESCRIPTION
This change ensures that `oneOf` and `anyOf` have their respective `Nullable<Model>` structures defined. These are necessary when the model is used as nullable.

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@antihax (2017/11) @bvwells (2017/12) @grokify (2018/07) @kemokemo (2018/09) @bkabrda (2019/07)