### PR TITLE
[typescript-fetch] support explode query parameters

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-fetch/apis.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/apis.mustache
@@ -107,7 +107,12 @@ export class {{classname}} extends runtime.BaseAPI {
             queryParameters['{{baseName}}'] = requestParameters.{{paramName}};
             {{/isCollectionFormatMulti}}
             {{^isCollectionFormatMulti}}
+            {{#isExplode}}
+            queryParameters['{{baseName}}'] = requestParameters.{{paramName}};
+            {{/isExplode}}
+            {{^isExplode}}
             queryParameters['{{baseName}}'] = requestParameters.{{paramName}}.join(runtime.COLLECTION_FORMATS["{{collectionFormat}}"]);
+            {{/isExplode}}
             {{/isCollectionFormatMulti}}
         }
 


### PR DESCRIPTION
Related to https://github.com/OpenAPITools/openapi-generator/issues/3781

Currently multiple query parameters that are serialized as CSV. `param: [1,2,3]` becomes `param=1,2,3`.

The OpenAPI specification https://swagger.io/docs/specification/serialization/#query says the default serialization for query parameters with multiple values is `style: form` with `explode: true`. That means that means that serialization for `param: [1,2,3]` should be `param=1&param=2&param=3`.

This PR attempts to add such support for `explode` for `typescript-fetch`.

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
