### PR TITLE
[dart-dio] Serializes request bodies using a specific serializer so a…

### DIFF
--- a/modules/openapi-generator/src/main/resources/dart-dio/api.mustache
+++ b/modules/openapi-generator/src/main/resources/dart-dio/api.mustache
@@ -76,13 +76,19 @@ class {{classname}} {
         {{/hasFormParams}}
         {{#bodyParam}}
 
-            {{#isArray}}
+        {{#isArray}}
         const type = FullType(BuiltList, [FullType({{baseType}})]);
         final serializedBody = _serializers.serialize({{paramName}}, specifiedType: type);
-            {{/isArray}}
-            {{^isArray}}
-        final serializedBody = _serializers.serialize({{paramName}});
-            {{/isArray}}
+        {{/isArray}}
+        {{^isArray}}
+        {{#isPrimitiveType}}
+        var serializedBody = {{paramName}};
+        {{/isPrimitiveType}}
+        {{^isPrimitiveType}}
+        final bodySerializer = _serializers.serializerForType({{baseType}});
+        final serializedBody = _serializers.serializeWith(bodySerializer, {{paramName}});
+        {{/isPrimitiveType}}
+        {{/isArray}}
         final json{{paramName}} = json.encode(serializedBody);
         bodyData = json{{paramName}};
         {{/bodyParam}}

--- a/samples/client/petstore/dart-dio/petstore_client_lib/lib/api/pet_api.dart
+++ b/samples/client/petstore/dart-dio/petstore_client_lib/lib/api/pet_api.dart
@@ -43,9 +43,17 @@ class PetApi {
             'application/xml',
         ];
 
+<<<<<<< HEAD
         final serializedBody = _serializers.serialize(body);
         final jsonbody = json.encode(serializedBody);
         bodyData = jsonbody;
+=======
+
+            var bodySerializer = _serializers.serializerForType(Pet);
+            var serializedBody = _serializers.serializeWith(bodySerializer, body);
+            var jsonbody = json.encode(serializedBody);
+            bodyData = jsonbody;
+>>>>>>> Updates samples
 
         return _dio.request(
             _path,
@@ -351,7 +359,17 @@ class PetApi {
         final jsonbody = json.encode(serializedBody);
         bodyData = jsonbody;
 
+<<<<<<< HEAD
         return _dio.request(
+=======
+
+            var bodySerializer = _serializers.serializerForType(Pet);
+            var serializedBody = _serializers.serializeWith(bodySerializer, body);
+            var jsonbody = json.encode(serializedBody);
+            bodyData = jsonbody;
+
+            return _dio.request(
+>>>>>>> Updates samples
             _path,
             queryParameters: queryParams,
             data: bodyData,

--- a/samples/client/petstore/dart-dio/petstore_client_lib/lib/api/pet_api.dart
+++ b/samples/client/petstore/dart-dio/petstore_client_lib/lib/api/pet_api.dart
@@ -43,17 +43,10 @@ class PetApi {
             'application/xml',
         ];
 
-<<<<<<< HEAD
-        final serializedBody = _serializers.serialize(body);
+        final bodySerializer = _serializers.serializerForType(Pet);
+        final serializedBody = _serializers.serializeWith(bodySerializer, body);
         final jsonbody = json.encode(serializedBody);
         bodyData = jsonbody;
-=======
-
-            var bodySerializer = _serializers.serializerForType(Pet);
-            var serializedBody = _serializers.serializeWith(bodySerializer, body);
-            var jsonbody = json.encode(serializedBody);
-            bodyData = jsonbody;
->>>>>>> Updates samples
 
         return _dio.request(
             _path,
@@ -355,21 +348,12 @@ class PetApi {
             'application/xml',
         ];
 
-        final serializedBody = _serializers.serialize(body);
+        final bodySerializer = _serializers.serializerForType(Pet);
+        final serializedBody = _serializers.serializeWith(bodySerializer, body);
         final jsonbody = json.encode(serializedBody);
         bodyData = jsonbody;
 
-<<<<<<< HEAD
         return _dio.request(
-=======
-
-            var bodySerializer = _serializers.serializerForType(Pet);
-            var serializedBody = _serializers.serializeWith(bodySerializer, body);
-            var jsonbody = json.encode(serializedBody);
-            bodyData = jsonbody;
-
-            return _dio.request(
->>>>>>> Updates samples
             _path,
             queryParameters: queryParams,
             data: bodyData,

--- a/samples/client/petstore/dart-dio/petstore_client_lib/lib/api/store_api.dart
+++ b/samples/client/petstore/dart-dio/petstore_client_lib/lib/api/store_api.dart
@@ -205,17 +205,10 @@ class StoreApi {
 
         final List<String> contentTypes = [];
 
-<<<<<<< HEAD
-        final serializedBody = _serializers.serialize(body);
+        final bodySerializer = _serializers.serializerForType(Order);
+        final serializedBody = _serializers.serializeWith(bodySerializer, body);
         final jsonbody = json.encode(serializedBody);
         bodyData = jsonbody;
-=======
-
-            var bodySerializer = _serializers.serializerForType(Order);
-            var serializedBody = _serializers.serializeWith(bodySerializer, body);
-            var jsonbody = json.encode(serializedBody);
-            bodyData = jsonbody;
->>>>>>> Updates samples
 
         return _dio.request(
             _path,

--- a/samples/client/petstore/dart-dio/petstore_client_lib/lib/api/store_api.dart
+++ b/samples/client/petstore/dart-dio/petstore_client_lib/lib/api/store_api.dart
@@ -205,9 +205,17 @@ class StoreApi {
 
         final List<String> contentTypes = [];
 
+<<<<<<< HEAD
         final serializedBody = _serializers.serialize(body);
         final jsonbody = json.encode(serializedBody);
         bodyData = jsonbody;
+=======
+
+            var bodySerializer = _serializers.serializerForType(Order);
+            var serializedBody = _serializers.serializeWith(bodySerializer, body);
+            var jsonbody = json.encode(serializedBody);
+            bodyData = jsonbody;
+>>>>>>> Updates samples
 
         return _dio.request(
             _path,

--- a/samples/client/petstore/dart-dio/petstore_client_lib/lib/api/user_api.dart
+++ b/samples/client/petstore/dart-dio/petstore_client_lib/lib/api/user_api.dart
@@ -37,9 +37,17 @@ class UserApi {
 
         final List<String> contentTypes = [];
 
+<<<<<<< HEAD
         final serializedBody = _serializers.serialize(body);
         final jsonbody = json.encode(serializedBody);
         bodyData = jsonbody;
+=======
+
+            var bodySerializer = _serializers.serializerForType(User);
+            var serializedBody = _serializers.serializeWith(bodySerializer, body);
+            var jsonbody = json.encode(serializedBody);
+            bodyData = jsonbody;
+>>>>>>> Updates samples
 
         return _dio.request(
             _path,
@@ -394,9 +402,17 @@ class UserApi {
 
         final List<String> contentTypes = [];
 
+<<<<<<< HEAD
         final serializedBody = _serializers.serialize(body);
         final jsonbody = json.encode(serializedBody);
         bodyData = jsonbody;
+=======
+
+            var bodySerializer = _serializers.serializerForType(User);
+            var serializedBody = _serializers.serializeWith(bodySerializer, body);
+            var jsonbody = json.encode(serializedBody);
+            bodyData = jsonbody;
+>>>>>>> Updates samples
 
         return _dio.request(
             _path,

--- a/samples/client/petstore/dart-dio/petstore_client_lib/lib/api/user_api.dart
+++ b/samples/client/petstore/dart-dio/petstore_client_lib/lib/api/user_api.dart
@@ -37,17 +37,10 @@ class UserApi {
 
         final List<String> contentTypes = [];
 
-<<<<<<< HEAD
-        final serializedBody = _serializers.serialize(body);
+        final bodySerializer = _serializers.serializerForType(User);
+        final serializedBody = _serializers.serializeWith(bodySerializer, body);
         final jsonbody = json.encode(serializedBody);
         bodyData = jsonbody;
-=======
-
-            var bodySerializer = _serializers.serializerForType(User);
-            var serializedBody = _serializers.serializeWith(bodySerializer, body);
-            var jsonbody = json.encode(serializedBody);
-            bodyData = jsonbody;
->>>>>>> Updates samples
 
         return _dio.request(
             _path,
@@ -402,17 +395,10 @@ class UserApi {
 
         final List<String> contentTypes = [];
 
-<<<<<<< HEAD
-        final serializedBody = _serializers.serialize(body);
+        final bodySerializer = _serializers.serializerForType(User);
+        final serializedBody = _serializers.serializeWith(bodySerializer, body);
         final jsonbody = json.encode(serializedBody);
         bodyData = jsonbody;
-=======
-
-            var bodySerializer = _serializers.serializerForType(User);
-            var serializedBody = _serializers.serializeWith(bodySerializer, body);
-            var jsonbody = json.encode(serializedBody);
-            bodyData = jsonbody;
->>>>>>> Updates samples
 
         return _dio.request(
             _path,

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/lib/api/pet_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/lib/api/pet_api.dart
@@ -43,17 +43,10 @@ class PetApi {
             'application/xml',
         ];
 
-<<<<<<< HEAD
-        final serializedBody = _serializers.serialize(pet);
+        final bodySerializer = _serializers.serializerForType(Pet);
+        final serializedBody = _serializers.serializeWith(bodySerializer, pet);
         final jsonpet = json.encode(serializedBody);
         bodyData = jsonpet;
-=======
-
-            var bodySerializer = _serializers.serializerForType(Pet);
-            var serializedBody = _serializers.serializeWith(bodySerializer, pet);
-            var jsonpet = json.encode(serializedBody);
-            bodyData = jsonpet;
->>>>>>> Updates samples
 
         return _dio.request(
             _path,
@@ -368,21 +361,12 @@ class PetApi {
             'application/xml',
         ];
 
-        final serializedBody = _serializers.serialize(pet);
+        final bodySerializer = _serializers.serializerForType(Pet);
+        final serializedBody = _serializers.serializeWith(bodySerializer, pet);
         final jsonpet = json.encode(serializedBody);
         bodyData = jsonpet;
 
-<<<<<<< HEAD
         return _dio.request(
-=======
-
-            var bodySerializer = _serializers.serializerForType(Pet);
-            var serializedBody = _serializers.serializeWith(bodySerializer, pet);
-            var jsonpet = json.encode(serializedBody);
-            bodyData = jsonpet;
-
-            return _dio.request(
->>>>>>> Updates samples
             _path,
             queryParameters: queryParams,
             data: bodyData,

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/lib/api/pet_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/lib/api/pet_api.dart
@@ -43,9 +43,17 @@ class PetApi {
             'application/xml',
         ];
 
+<<<<<<< HEAD
         final serializedBody = _serializers.serialize(pet);
         final jsonpet = json.encode(serializedBody);
         bodyData = jsonpet;
+=======
+
+            var bodySerializer = _serializers.serializerForType(Pet);
+            var serializedBody = _serializers.serializeWith(bodySerializer, pet);
+            var jsonpet = json.encode(serializedBody);
+            bodyData = jsonpet;
+>>>>>>> Updates samples
 
         return _dio.request(
             _path,
@@ -364,7 +372,17 @@ class PetApi {
         final jsonpet = json.encode(serializedBody);
         bodyData = jsonpet;
 
+<<<<<<< HEAD
         return _dio.request(
+=======
+
+            var bodySerializer = _serializers.serializerForType(Pet);
+            var serializedBody = _serializers.serializeWith(bodySerializer, pet);
+            var jsonpet = json.encode(serializedBody);
+            bodyData = jsonpet;
+
+            return _dio.request(
+>>>>>>> Updates samples
             _path,
             queryParameters: queryParams,
             data: bodyData,

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/lib/api/store_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/lib/api/store_api.dart
@@ -207,17 +207,10 @@ class StoreApi {
             'application/json',
         ];
 
-<<<<<<< HEAD
-        final serializedBody = _serializers.serialize(order);
+        final bodySerializer = _serializers.serializerForType(Order);
+        final serializedBody = _serializers.serializeWith(bodySerializer, order);
         final jsonorder = json.encode(serializedBody);
         bodyData = jsonorder;
-=======
-
-            var bodySerializer = _serializers.serializerForType(Order);
-            var serializedBody = _serializers.serializeWith(bodySerializer, order);
-            var jsonorder = json.encode(serializedBody);
-            bodyData = jsonorder;
->>>>>>> Updates samples
 
         return _dio.request(
             _path,

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/lib/api/store_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/lib/api/store_api.dart
@@ -207,9 +207,17 @@ class StoreApi {
             'application/json',
         ];
 
+<<<<<<< HEAD
         final serializedBody = _serializers.serialize(order);
         final jsonorder = json.encode(serializedBody);
         bodyData = jsonorder;
+=======
+
+            var bodySerializer = _serializers.serializerForType(Order);
+            var serializedBody = _serializers.serializeWith(bodySerializer, order);
+            var jsonorder = json.encode(serializedBody);
+            bodyData = jsonorder;
+>>>>>>> Updates samples
 
         return _dio.request(
             _path,

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/lib/api/user_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/lib/api/user_api.dart
@@ -39,17 +39,10 @@ class UserApi {
             'application/json',
         ];
 
-<<<<<<< HEAD
-        final serializedBody = _serializers.serialize(user);
+        final bodySerializer = _serializers.serializerForType(User);
+        final serializedBody = _serializers.serializeWith(bodySerializer, user);
         final jsonuser = json.encode(serializedBody);
         bodyData = jsonuser;
-=======
-
-            var bodySerializer = _serializers.serializerForType(User);
-            var serializedBody = _serializers.serializeWith(bodySerializer, user);
-            var jsonuser = json.encode(serializedBody);
-            bodyData = jsonuser;
->>>>>>> Updates samples
 
         return _dio.request(
             _path,
@@ -445,17 +438,10 @@ class UserApi {
             'application/json',
         ];
 
-<<<<<<< HEAD
-        final serializedBody = _serializers.serialize(user);
+        final bodySerializer = _serializers.serializerForType(User);
+        final serializedBody = _serializers.serializeWith(bodySerializer, user);
         final jsonuser = json.encode(serializedBody);
         bodyData = jsonuser;
-=======
-
-            var bodySerializer = _serializers.serializerForType(User);
-            var serializedBody = _serializers.serializeWith(bodySerializer, user);
-            var jsonuser = json.encode(serializedBody);
-            bodyData = jsonuser;
->>>>>>> Updates samples
 
         return _dio.request(
             _path,

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/lib/api/user_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/lib/api/user_api.dart
@@ -39,9 +39,17 @@ class UserApi {
             'application/json',
         ];
 
+<<<<<<< HEAD
         final serializedBody = _serializers.serialize(user);
         final jsonuser = json.encode(serializedBody);
         bodyData = jsonuser;
+=======
+
+            var bodySerializer = _serializers.serializerForType(User);
+            var serializedBody = _serializers.serializeWith(bodySerializer, user);
+            var jsonuser = json.encode(serializedBody);
+            bodyData = jsonuser;
+>>>>>>> Updates samples
 
         return _dio.request(
             _path,
@@ -437,9 +445,17 @@ class UserApi {
             'application/json',
         ];
 
+<<<<<<< HEAD
         final serializedBody = _serializers.serialize(user);
         final jsonuser = json.encode(serializedBody);
         bodyData = jsonuser;
+=======
+
+            var bodySerializer = _serializers.serializerForType(User);
+            var serializedBody = _serializers.serializeWith(bodySerializer, user);
+            var jsonuser = json.encode(serializedBody);
+            bodyData = jsonuser;
+>>>>>>> Updates samples
 
         return _dio.request(
             _path,

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/api/another_fake_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/api/another_fake_api.dart
@@ -38,17 +38,10 @@ class AnotherFakeApi {
             'application/json',
         ];
 
-<<<<<<< HEAD
-        final serializedBody = _serializers.serialize(modelClient);
+        final bodySerializer = _serializers.serializerForType(ModelClient);
+        final serializedBody = _serializers.serializeWith(bodySerializer, modelClient);
         final jsonmodelClient = json.encode(serializedBody);
         bodyData = jsonmodelClient;
-=======
-
-            var bodySerializer = _serializers.serializerForType(Client);
-            var serializedBody = _serializers.serializeWith(bodySerializer, client);
-            var jsonclient = json.encode(serializedBody);
-            bodyData = jsonclient;
->>>>>>> Updates samples
 
         return _dio.request(
             _path,

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/api/another_fake_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/api/another_fake_api.dart
@@ -38,9 +38,17 @@ class AnotherFakeApi {
             'application/json',
         ];
 
+<<<<<<< HEAD
         final serializedBody = _serializers.serialize(modelClient);
         final jsonmodelClient = json.encode(serializedBody);
         bodyData = jsonmodelClient;
+=======
+
+            var bodySerializer = _serializers.serializerForType(Client);
+            var serializedBody = _serializers.serializeWith(bodySerializer, client);
+            var jsonclient = json.encode(serializedBody);
+            bodyData = jsonclient;
+>>>>>>> Updates samples
 
         return _dio.request(
             _path,

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/api/fake_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/api/fake_api.dart
@@ -108,21 +108,12 @@ class FakeApi {
             'application/xml',
         ];
 
-        final serializedBody = _serializers.serialize(pet);
+        final bodySerializer = _serializers.serializerForType(Pet);
+        final serializedBody = _serializers.serializeWith(bodySerializer, pet);
         final jsonpet = json.encode(serializedBody);
         bodyData = jsonpet;
 
-<<<<<<< HEAD
         return _dio.request(
-=======
-
-            var bodySerializer = _serializers.serializerForType(Pet);
-            var serializedBody = _serializers.serializeWith(bodySerializer, pet);
-            var jsonpet = json.encode(serializedBody);
-            bodyData = jsonpet;
-
-            return _dio.request(
->>>>>>> Updates samples
             _path,
             queryParameters: queryParams,
             data: bodyData,
@@ -174,21 +165,11 @@ class FakeApi {
             'application/json',
         ];
 
-        final serializedBody = _serializers.serialize(body);
+        var serializedBody = body;
         final jsonbody = json.encode(serializedBody);
         bodyData = jsonbody;
 
-<<<<<<< HEAD
         return _dio.request(
-=======
-
-            var bodySerializer = _serializers.serializerForType(bool);
-            var serializedBody = _serializers.serializeWith(bodySerializer, body);
-            var jsonbody = json.encode(serializedBody);
-            bodyData = jsonbody;
-
-            return _dio.request(
->>>>>>> Updates samples
             _path,
             queryParameters: queryParams,
             data: bodyData,
@@ -247,21 +228,12 @@ class FakeApi {
             'application/json',
         ];
 
-        final serializedBody = _serializers.serialize(outerComposite);
+        final bodySerializer = _serializers.serializerForType(OuterComposite);
+        final serializedBody = _serializers.serializeWith(bodySerializer, outerComposite);
         final jsonouterComposite = json.encode(serializedBody);
         bodyData = jsonouterComposite;
 
-<<<<<<< HEAD
         return _dio.request(
-=======
-
-            var bodySerializer = _serializers.serializerForType(OuterComposite);
-            var serializedBody = _serializers.serializeWith(bodySerializer, outerComposite);
-            var jsonouterComposite = json.encode(serializedBody);
-            bodyData = jsonouterComposite;
-
-            return _dio.request(
->>>>>>> Updates samples
             _path,
             queryParameters: queryParams,
             data: bodyData,
@@ -321,21 +293,11 @@ class FakeApi {
             'application/json',
         ];
 
-        final serializedBody = _serializers.serialize(body);
+        var serializedBody = body;
         final jsonbody = json.encode(serializedBody);
         bodyData = jsonbody;
 
-<<<<<<< HEAD
         return _dio.request(
-=======
-
-            var bodySerializer = _serializers.serializerForType(num);
-            var serializedBody = _serializers.serializeWith(bodySerializer, body);
-            var jsonbody = json.encode(serializedBody);
-            bodyData = jsonbody;
-
-            return _dio.request(
->>>>>>> Updates samples
             _path,
             queryParameters: queryParams,
             data: bodyData,
@@ -394,21 +356,11 @@ class FakeApi {
             'application/json',
         ];
 
-        final serializedBody = _serializers.serialize(body);
+        var serializedBody = body;
         final jsonbody = json.encode(serializedBody);
         bodyData = jsonbody;
 
-<<<<<<< HEAD
         return _dio.request(
-=======
-
-            var bodySerializer = _serializers.serializerForType(String);
-            var serializedBody = _serializers.serializeWith(bodySerializer, body);
-            var jsonbody = json.encode(serializedBody);
-            bodyData = jsonbody;
-
-            return _dio.request(
->>>>>>> Updates samples
             _path,
             queryParameters: queryParams,
             data: bodyData,
@@ -467,21 +419,12 @@ class FakeApi {
             'application/json',
         ];
 
-        final serializedBody = _serializers.serialize(fileSchemaTestClass);
+        final bodySerializer = _serializers.serializerForType(FileSchemaTestClass);
+        final serializedBody = _serializers.serializeWith(bodySerializer, fileSchemaTestClass);
         final jsonfileSchemaTestClass = json.encode(serializedBody);
         bodyData = jsonfileSchemaTestClass;
 
-<<<<<<< HEAD
         return _dio.request(
-=======
-
-            var bodySerializer = _serializers.serializerForType(FileSchemaTestClass);
-            var serializedBody = _serializers.serializeWith(bodySerializer, fileSchemaTestClass);
-            var jsonfileSchemaTestClass = json.encode(serializedBody);
-            bodyData = jsonfileSchemaTestClass;
-
-            return _dio.request(
->>>>>>> Updates samples
             _path,
             queryParameters: queryParams,
             data: bodyData,
@@ -530,21 +473,12 @@ class FakeApi {
             'application/json',
         ];
 
-        final serializedBody = _serializers.serialize(user);
+        final bodySerializer = _serializers.serializerForType(User);
+        final serializedBody = _serializers.serializeWith(bodySerializer, user);
         final jsonuser = json.encode(serializedBody);
         bodyData = jsonuser;
 
-<<<<<<< HEAD
         return _dio.request(
-=======
-
-            var bodySerializer = _serializers.serializerForType(User);
-            var serializedBody = _serializers.serializeWith(bodySerializer, user);
-            var jsonuser = json.encode(serializedBody);
-            bodyData = jsonuser;
-
-            return _dio.request(
->>>>>>> Updates samples
             _path,
             queryParameters: queryParams,
             data: bodyData,
@@ -591,21 +525,12 @@ class FakeApi {
             'application/json',
         ];
 
-        final serializedBody = _serializers.serialize(modelClient);
+        final bodySerializer = _serializers.serializerForType(ModelClient);
+        final serializedBody = _serializers.serializeWith(bodySerializer, modelClient);
         final jsonmodelClient = json.encode(serializedBody);
         bodyData = jsonmodelClient;
 
-<<<<<<< HEAD
         return _dio.request(
-=======
-
-            var bodySerializer = _serializers.serializerForType(Client);
-            var serializedBody = _serializers.serializeWith(bodySerializer, client);
-            var jsonclient = json.encode(serializedBody);
-            bodyData = jsonclient;
-
-            return _dio.request(
->>>>>>> Updates samples
             _path,
             queryParameters: queryParams,
             data: bodyData,
@@ -873,21 +798,12 @@ class FakeApi {
             'application/json',
         ];
 
-        final serializedBody = _serializers.serialize(requestBody);
+        final bodySerializer = _serializers.serializerForType(String);
+        final serializedBody = _serializers.serializeWith(bodySerializer, requestBody);
         final jsonrequestBody = json.encode(serializedBody);
         bodyData = jsonrequestBody;
 
-<<<<<<< HEAD
         return _dio.request(
-=======
-
-            var bodySerializer = _serializers.serializerForType(String);
-            var serializedBody = _serializers.serializeWith(bodySerializer, requestBody);
-            var jsonrequestBody = json.encode(serializedBody);
-            bodyData = jsonrequestBody;
-
-            return _dio.request(
->>>>>>> Updates samples
             _path,
             queryParameters: queryParams,
             data: bodyData,

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/api/fake_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/api/fake_api.dart
@@ -112,7 +112,17 @@ class FakeApi {
         final jsonpet = json.encode(serializedBody);
         bodyData = jsonpet;
 
+<<<<<<< HEAD
         return _dio.request(
+=======
+
+            var bodySerializer = _serializers.serializerForType(Pet);
+            var serializedBody = _serializers.serializeWith(bodySerializer, pet);
+            var jsonpet = json.encode(serializedBody);
+            bodyData = jsonpet;
+
+            return _dio.request(
+>>>>>>> Updates samples
             _path,
             queryParameters: queryParams,
             data: bodyData,
@@ -168,7 +178,17 @@ class FakeApi {
         final jsonbody = json.encode(serializedBody);
         bodyData = jsonbody;
 
+<<<<<<< HEAD
         return _dio.request(
+=======
+
+            var bodySerializer = _serializers.serializerForType(bool);
+            var serializedBody = _serializers.serializeWith(bodySerializer, body);
+            var jsonbody = json.encode(serializedBody);
+            bodyData = jsonbody;
+
+            return _dio.request(
+>>>>>>> Updates samples
             _path,
             queryParameters: queryParams,
             data: bodyData,
@@ -231,7 +251,17 @@ class FakeApi {
         final jsonouterComposite = json.encode(serializedBody);
         bodyData = jsonouterComposite;
 
+<<<<<<< HEAD
         return _dio.request(
+=======
+
+            var bodySerializer = _serializers.serializerForType(OuterComposite);
+            var serializedBody = _serializers.serializeWith(bodySerializer, outerComposite);
+            var jsonouterComposite = json.encode(serializedBody);
+            bodyData = jsonouterComposite;
+
+            return _dio.request(
+>>>>>>> Updates samples
             _path,
             queryParameters: queryParams,
             data: bodyData,
@@ -295,7 +325,17 @@ class FakeApi {
         final jsonbody = json.encode(serializedBody);
         bodyData = jsonbody;
 
+<<<<<<< HEAD
         return _dio.request(
+=======
+
+            var bodySerializer = _serializers.serializerForType(num);
+            var serializedBody = _serializers.serializeWith(bodySerializer, body);
+            var jsonbody = json.encode(serializedBody);
+            bodyData = jsonbody;
+
+            return _dio.request(
+>>>>>>> Updates samples
             _path,
             queryParameters: queryParams,
             data: bodyData,
@@ -358,7 +398,17 @@ class FakeApi {
         final jsonbody = json.encode(serializedBody);
         bodyData = jsonbody;
 
+<<<<<<< HEAD
         return _dio.request(
+=======
+
+            var bodySerializer = _serializers.serializerForType(String);
+            var serializedBody = _serializers.serializeWith(bodySerializer, body);
+            var jsonbody = json.encode(serializedBody);
+            bodyData = jsonbody;
+
+            return _dio.request(
+>>>>>>> Updates samples
             _path,
             queryParameters: queryParams,
             data: bodyData,
@@ -421,7 +471,17 @@ class FakeApi {
         final jsonfileSchemaTestClass = json.encode(serializedBody);
         bodyData = jsonfileSchemaTestClass;
 
+<<<<<<< HEAD
         return _dio.request(
+=======
+
+            var bodySerializer = _serializers.serializerForType(FileSchemaTestClass);
+            var serializedBody = _serializers.serializeWith(bodySerializer, fileSchemaTestClass);
+            var jsonfileSchemaTestClass = json.encode(serializedBody);
+            bodyData = jsonfileSchemaTestClass;
+
+            return _dio.request(
+>>>>>>> Updates samples
             _path,
             queryParameters: queryParams,
             data: bodyData,
@@ -474,7 +534,17 @@ class FakeApi {
         final jsonuser = json.encode(serializedBody);
         bodyData = jsonuser;
 
+<<<<<<< HEAD
         return _dio.request(
+=======
+
+            var bodySerializer = _serializers.serializerForType(User);
+            var serializedBody = _serializers.serializeWith(bodySerializer, user);
+            var jsonuser = json.encode(serializedBody);
+            bodyData = jsonuser;
+
+            return _dio.request(
+>>>>>>> Updates samples
             _path,
             queryParameters: queryParams,
             data: bodyData,
@@ -525,7 +595,17 @@ class FakeApi {
         final jsonmodelClient = json.encode(serializedBody);
         bodyData = jsonmodelClient;
 
+<<<<<<< HEAD
         return _dio.request(
+=======
+
+            var bodySerializer = _serializers.serializerForType(Client);
+            var serializedBody = _serializers.serializeWith(bodySerializer, client);
+            var jsonclient = json.encode(serializedBody);
+            bodyData = jsonclient;
+
+            return _dio.request(
+>>>>>>> Updates samples
             _path,
             queryParameters: queryParams,
             data: bodyData,
@@ -797,7 +877,17 @@ class FakeApi {
         final jsonrequestBody = json.encode(serializedBody);
         bodyData = jsonrequestBody;
 
+<<<<<<< HEAD
         return _dio.request(
+=======
+
+            var bodySerializer = _serializers.serializerForType(String);
+            var serializedBody = _serializers.serializeWith(bodySerializer, requestBody);
+            var jsonrequestBody = json.encode(serializedBody);
+            bodyData = jsonrequestBody;
+
+            return _dio.request(
+>>>>>>> Updates samples
             _path,
             queryParameters: queryParams,
             data: bodyData,

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/api/fake_classname_tags123_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/api/fake_classname_tags123_api.dart
@@ -38,17 +38,10 @@ class FakeClassnameTags123Api {
             'application/json',
         ];
 
-<<<<<<< HEAD
-        final serializedBody = _serializers.serialize(modelClient);
+        final bodySerializer = _serializers.serializerForType(ModelClient);
+        final serializedBody = _serializers.serializeWith(bodySerializer, modelClient);
         final jsonmodelClient = json.encode(serializedBody);
         bodyData = jsonmodelClient;
-=======
-
-            var bodySerializer = _serializers.serializerForType(Client);
-            var serializedBody = _serializers.serializeWith(bodySerializer, client);
-            var jsonclient = json.encode(serializedBody);
-            bodyData = jsonclient;
->>>>>>> Updates samples
 
         return _dio.request(
             _path,

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/api/fake_classname_tags123_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/api/fake_classname_tags123_api.dart
@@ -38,9 +38,17 @@ class FakeClassnameTags123Api {
             'application/json',
         ];
 
+<<<<<<< HEAD
         final serializedBody = _serializers.serialize(modelClient);
         final jsonmodelClient = json.encode(serializedBody);
         bodyData = jsonmodelClient;
+=======
+
+            var bodySerializer = _serializers.serializerForType(Client);
+            var serializedBody = _serializers.serializeWith(bodySerializer, client);
+            var jsonclient = json.encode(serializedBody);
+            bodyData = jsonclient;
+>>>>>>> Updates samples
 
         return _dio.request(
             _path,

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/api/pet_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/api/pet_api.dart
@@ -43,21 +43,12 @@ class PetApi {
             'application/xml',
         ];
 
-        final serializedBody = _serializers.serialize(pet);
+        final bodySerializer = _serializers.serializerForType(Pet);
+        final serializedBody = _serializers.serializeWith(bodySerializer, pet);
         final jsonpet = json.encode(serializedBody);
         bodyData = jsonpet;
 
-<<<<<<< HEAD
         return _dio.request(
-=======
-
-            var bodySerializer = _serializers.serializerForType(Pet);
-            var serializedBody = _serializers.serializeWith(bodySerializer, pet);
-            var jsonpet = json.encode(serializedBody);
-            bodyData = jsonpet;
-
-            return _dio.request(
->>>>>>> Updates samples
             _path,
             queryParameters: queryParams,
             data: bodyData,
@@ -357,21 +348,12 @@ class PetApi {
             'application/xml',
         ];
 
-        final serializedBody = _serializers.serialize(pet);
+        final bodySerializer = _serializers.serializerForType(Pet);
+        final serializedBody = _serializers.serializeWith(bodySerializer, pet);
         final jsonpet = json.encode(serializedBody);
         bodyData = jsonpet;
 
-<<<<<<< HEAD
         return _dio.request(
-=======
-
-            var bodySerializer = _serializers.serializerForType(Pet);
-            var serializedBody = _serializers.serializeWith(bodySerializer, pet);
-            var jsonpet = json.encode(serializedBody);
-            bodyData = jsonpet;
-
-            return _dio.request(
->>>>>>> Updates samples
             _path,
             queryParameters: queryParams,
             data: bodyData,

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/api/pet_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/api/pet_api.dart
@@ -47,7 +47,17 @@ class PetApi {
         final jsonpet = json.encode(serializedBody);
         bodyData = jsonpet;
 
+<<<<<<< HEAD
         return _dio.request(
+=======
+
+            var bodySerializer = _serializers.serializerForType(Pet);
+            var serializedBody = _serializers.serializeWith(bodySerializer, pet);
+            var jsonpet = json.encode(serializedBody);
+            bodyData = jsonpet;
+
+            return _dio.request(
+>>>>>>> Updates samples
             _path,
             queryParameters: queryParams,
             data: bodyData,
@@ -351,7 +361,17 @@ class PetApi {
         final jsonpet = json.encode(serializedBody);
         bodyData = jsonpet;
 
+<<<<<<< HEAD
         return _dio.request(
+=======
+
+            var bodySerializer = _serializers.serializerForType(Pet);
+            var serializedBody = _serializers.serializeWith(bodySerializer, pet);
+            var jsonpet = json.encode(serializedBody);
+            bodyData = jsonpet;
+
+            return _dio.request(
+>>>>>>> Updates samples
             _path,
             queryParameters: queryParams,
             data: bodyData,

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/api/store_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/api/store_api.dart
@@ -207,17 +207,10 @@ class StoreApi {
             'application/json',
         ];
 
-<<<<<<< HEAD
-        final serializedBody = _serializers.serialize(order);
+        final bodySerializer = _serializers.serializerForType(Order);
+        final serializedBody = _serializers.serializeWith(bodySerializer, order);
         final jsonorder = json.encode(serializedBody);
         bodyData = jsonorder;
-=======
-
-            var bodySerializer = _serializers.serializerForType(Order);
-            var serializedBody = _serializers.serializeWith(bodySerializer, order);
-            var jsonorder = json.encode(serializedBody);
-            bodyData = jsonorder;
->>>>>>> Updates samples
 
         return _dio.request(
             _path,

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/api/store_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/api/store_api.dart
@@ -207,9 +207,17 @@ class StoreApi {
             'application/json',
         ];
 
+<<<<<<< HEAD
         final serializedBody = _serializers.serialize(order);
         final jsonorder = json.encode(serializedBody);
         bodyData = jsonorder;
+=======
+
+            var bodySerializer = _serializers.serializerForType(Order);
+            var serializedBody = _serializers.serializeWith(bodySerializer, order);
+            var jsonorder = json.encode(serializedBody);
+            bodyData = jsonorder;
+>>>>>>> Updates samples
 
         return _dio.request(
             _path,

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/api/user_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/api/user_api.dart
@@ -39,9 +39,17 @@ class UserApi {
             'application/json',
         ];
 
+<<<<<<< HEAD
         final serializedBody = _serializers.serialize(user);
         final jsonuser = json.encode(serializedBody);
         bodyData = jsonuser;
+=======
+
+            var bodySerializer = _serializers.serializerForType(User);
+            var serializedBody = _serializers.serializeWith(bodySerializer, user);
+            var jsonuser = json.encode(serializedBody);
+            bodyData = jsonuser;
+>>>>>>> Updates samples
 
         return _dio.request(
             _path,
@@ -402,9 +410,17 @@ class UserApi {
             'application/json',
         ];
 
+<<<<<<< HEAD
         final serializedBody = _serializers.serialize(user);
         final jsonuser = json.encode(serializedBody);
         bodyData = jsonuser;
+=======
+
+            var bodySerializer = _serializers.serializerForType(User);
+            var serializedBody = _serializers.serializeWith(bodySerializer, user);
+            var jsonuser = json.encode(serializedBody);
+            bodyData = jsonuser;
+>>>>>>> Updates samples
 
         return _dio.request(
             _path,

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/api/user_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/api/user_api.dart
@@ -39,17 +39,10 @@ class UserApi {
             'application/json',
         ];
 
-<<<<<<< HEAD
-        final serializedBody = _serializers.serialize(user);
+        final bodySerializer = _serializers.serializerForType(User);
+        final serializedBody = _serializers.serializeWith(bodySerializer, user);
         final jsonuser = json.encode(serializedBody);
         bodyData = jsonuser;
-=======
-
-            var bodySerializer = _serializers.serializerForType(User);
-            var serializedBody = _serializers.serializeWith(bodySerializer, user);
-            var jsonuser = json.encode(serializedBody);
-            bodyData = jsonuser;
->>>>>>> Updates samples
 
         return _dio.request(
             _path,
@@ -410,17 +403,10 @@ class UserApi {
             'application/json',
         ];
 
-<<<<<<< HEAD
-        final serializedBody = _serializers.serialize(user);
+        final bodySerializer = _serializers.serializerForType(User);
+        final serializedBody = _serializers.serializeWith(bodySerializer, user);
         final jsonuser = json.encode(serializedBody);
         bodyData = jsonuser;
-=======
-
-            var bodySerializer = _serializers.serializerForType(User);
-            var serializedBody = _serializers.serializeWith(bodySerializer, user);
-            var jsonuser = json.encode(serializedBody);
-            bodyData = jsonuser;
->>>>>>> Updates samples
 
         return _dio.request(
             _path,


### PR DESCRIPTION
Serializes request bodies using a specific serializer so a discriminator is not added

When using the generic `serialize` method, built value will add a descriminator to the serialized json. For APIs with strict parsing, this causes parsing errors.

By finding the specific serializer for the type built value omits the descriminator.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

CC: @ircecho @swipesight @jaumard @amondnet