### PR TITLE
[ci] Execute maven and verify with no-snapshot-updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -135,13 +135,13 @@ script:
   - /bin/bash ./bin/utils/detect_tab_in_java_class.sh
   # run integration tests defined in maven pom.xml
   # WARN: Travis will timeout after 10 minutes of no stdout/stderr activity, which is problematic with mvn --quiet.
-  - mvn --quiet --batch-mode --show-version clean install -Dorg.slf4j.simpleLogger.defaultLogLevel=error
-  - mvn --quiet --batch-mode --show-version verify -Psamples -Dorg.slf4j.simpleLogger.defaultLogLevel=error
+  - mvn --no-snapshot-updates --quiet --batch-mode --show-version clean install -Dorg.slf4j.simpleLogger.defaultLogLevel=error
+  - mvn --no-snapshot-updates --quiet --batch-mode --show-version verify -Psamples -Dorg.slf4j.simpleLogger.defaultLogLevel=error
   # test maven plugin
-  - mvn --quiet clean compile -f modules/openapi-generator-maven-plugin/examples/java-client.xml -Dorg.slf4j.simpleLogger.defaultLogLevel=error
-  - mvn --quiet clean compile -f modules/openapi-generator-maven-plugin/examples/multi-module/pom.xml -Dorg.slf4j.simpleLogger.defaultLogLevel=error
-  - mvn --quiet clean compile -f modules/openapi-generator-maven-plugin/examples/kotlin.xml -Dorg.slf4j.simpleLogger.defaultLogLevel=error
-  - mvn --quiet clean compile -f modules/openapi-generator-maven-plugin/examples/spring.xml -Dorg.slf4j.simpleLogger.defaultLogLevel=error
+  - mvn --no-snapshot-updates --quiet clean compile -f modules/openapi-generator-maven-plugin/examples/java-client.xml -Dorg.slf4j.simpleLogger.defaultLogLevel=error
+  - mvn --no-snapshot-updates --quiet clean compile -f modules/openapi-generator-maven-plugin/examples/multi-module/pom.xml -Dorg.slf4j.simpleLogger.defaultLogLevel=error
+  - mvn --no-snapshot-updates --quiet clean compile -f modules/openapi-generator-maven-plugin/examples/kotlin.xml -Dorg.slf4j.simpleLogger.defaultLogLevel=error
+  - mvn --no-snapshot-updates --quiet clean compile -f modules/openapi-generator-maven-plugin/examples/spring.xml -Dorg.slf4j.simpleLogger.defaultLogLevel=error
   # test gradle plugin
   - (cd modules/openapi-generator-gradle-plugin/samples/local-spec && ./gradlew buildGoSdk)
   - (cd modules/openapi-generator-gradle-plugin/samples/local-spec && ./gradlew openApiGenerate)

--- a/CI/.travis.yml.bash
+++ b/CI/.travis.yml.bash
@@ -34,4 +34,4 @@ script:
   - set -e
   # run integration tests defined in maven pom.xml
   - cp pom.xml.bash pom.xml
-  - mvn --batch-mode verify -Psamples
+  - mvn --no-snapshot-updates --batch-mode verify -Psamples

--- a/CI/.travis.yml.ios
+++ b/CI/.travis.yml.ios
@@ -34,4 +34,4 @@ before_install:
 
 script:
   # run integration tests defined in maven pom.xml
-  - mvn -q --batch-mode verify -Psamples.ios -Dmaven.javadoc.skip=true
+  - mvn --no-snapshot-updates -q --batch-mode verify -Psamples.ios -Dmaven.javadoc.skip=true

--- a/CI/bitrise.yml
+++ b/CI/bitrise.yml
@@ -28,7 +28,7 @@ workflows:
 
             set -e
 
-            mvn package -Dorg.slf4j.simpleLogger.defaultLogLevel=error
+            mvn --no-snapshot-updates package -Dorg.slf4j.simpleLogger.defaultLogLevel=error
         title: Build openapi-generator
     - script@1.1.5:
         title: Update Swift samples

--- a/CI/circle_parallel.sh
+++ b/CI/circle_parallel.sh
@@ -24,8 +24,8 @@ if [ "$NODE_INDEX" = "1" ]; then
   export PATH="/usr/local/go1.14/go/bin:$PATH"
   go version
 
-  mvn --quiet verify -Psamples.circleci -Dorg.slf4j.simpleLogger.defaultLogLevel=error
-  mvn --quiet javadoc:javadoc -Psamples.circleci -Dorg.slf4j.simpleLogger.defaultLogLevel=error
+  mvn --no-snapshot-updates --quiet verify -Psamples.circleci -Dorg.slf4j.simpleLogger.defaultLogLevel=error
+  mvn --no-snapshot-updates --quiet javadoc:javadoc -Psamples.circleci -Dorg.slf4j.simpleLogger.defaultLogLevel=error
 
 elif [ "$NODE_INDEX" = "2" ]; then
   # run ensure-up-to-date sample script on SNAPSHOT version only
@@ -58,7 +58,7 @@ elif [ "$NODE_INDEX" = "2" ]; then
   sudo apt-get -y install libcurl4-gnutls-dev
 
   # run integration tests
-  mvn --quiet verify -Psamples.misc -Dorg.slf4j.simpleLogger.defaultLogLevel=error
+  mvn --no-snapshot-updates --quiet verify -Psamples.misc -Dorg.slf4j.simpleLogger.defaultLogLevel=error
 else
   echo "Running node $NODE_INDEX to test 'samples.circleci.jdk7' defined in pom.xml ..."
   sudo update-java-alternatives -s java-1.7.0-openjdk-amd64
@@ -73,7 +73,7 @@ else
   sudo apt-get install dart
   export PATH="$PATH:/usr/lib/dart/bin"
 
-  mvn --quiet verify -Psamples.circleci.jdk7 -Dorg.slf4j.simpleLogger.defaultLogLevel=error
+  mvn --no-snapshot-updates --quiet verify -Psamples.circleci.jdk7 -Dorg.slf4j.simpleLogger.defaultLogLevel=error
 fi
 
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -48,7 +48,7 @@ build_script:
   - nuget restore samples\client\petstore\csharp\OpenAPIClientNetStandard\Org.OpenAPITools.sln
   - msbuild samples\client\petstore\csharp\OpenAPIClientNetStandard\Org.OpenAPITools.sln /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
   # install openapi-generator locally
-  - mvn clean install --quiet -Dorg.slf4j.simpleLogger.defaultLogLevel=error
+  - mvn --no-snapshot-updates --quiet clean install -Dorg.slf4j.simpleLogger.defaultLogLevel=error
   # run the locally installed openapi-generator-gradle-plugin
   - gradle -b modules\openapi-generator-gradle-plugin\samples\local-spec\build.gradle buildGoSdk --info
 test_script:

--- a/bin/utils/ensure-up-to-date
+++ b/bin/utils/ensure-up-to-date
@@ -103,7 +103,7 @@ declare -a always_iterate=(
 export JAVA_OPTS="${JAVA_OPTS} -Djava.awt.headless=true -Dorg.slf4j.simpleLogger.defaultLogLevel=warn"
 if [ "true" = "$batch_mode" ]; then
   if [ ! -f "$executable" ]; then
-    (cd "${root}" && mvn -B clean package -DskipTests=true -Dmaven.javadoc.skip=true)
+    (cd "${root}" && mvn -B --no-snapshot-updates clean package -DskipTests=true -Dmaven.javadoc.skip=true)
   fi
 
   # shellcheck disable=SC2086

--- a/circle.yml
+++ b/circle.yml
@@ -66,7 +66,7 @@ jobs:
     - run: sleep 30
     - run: cat /etc/hosts
     # Test
-    - run: mvn --quiet clean install -Dorg.slf4j.simpleLogger.defaultLogLevel=error
+    - run: mvn --no-snapshot-updates --quiet clean install -Dorg.slf4j.simpleLogger.defaultLogLevel=error
     - run: ./CI/circle_parallel.sh 
     # Save dependency cache
     - save_cache:

--- a/pom.xml
+++ b/pom.xml
@@ -227,6 +227,7 @@
                     <argLine>@{argLine} -XX:+StartAttachListener</argLine>
                     <systemPropertyVariables>
                         <org.openapitools.codegen.utils.oncelogger.expiry>1000</org.openapitools.codegen.utils.oncelogger.expiry>
+                        <org.openapitools.codegen.utils.oncelogger.cachesize>5000</org.openapitools.codegen.utils.oncelogger.cachesize>
                     </systemPropertyVariables>
                 </configuration>
                 <dependencies>

--- a/shippable.yml
+++ b/shippable.yml
@@ -15,7 +15,7 @@ build:
     - rm /etc/apt/sources.list.d/jonathonf-ubuntu-backports-xenial.list 
     # 
     - java -version
-    - mvn --quiet clean install -Dmaven.javadoc.skip=true
+    - mvn --no-snapshot-updates --quiet clean install -Dmaven.javadoc.skip=true
     # ensure all modifications created by 'mature' generators are in the git repo
     # below move to CircleCI ./bin/utils/ensure-up-to-date
     # prepare environment for tests
@@ -42,7 +42,7 @@ build:
     - elixir --version
     - mix --version
     # test samples defined in pom.xml
-    - mvn --quiet verify -P samples.shippable -Dmaven.javadoc.skip=true
+    - mvn --no-snapshot-updates --quiet verify -P samples.shippable -Dmaven.javadoc.skip=true
     # below moved to CircleCI
     ## generate all petstore samples (client, servers, doc)
     #- ./bin/run-all-petstore


### PR DESCRIPTION
Explicitly set Maven's `--no-snapshot-updates` option in CI. Although certain providers may configure snapshot updates, it's unclear across our providers what would occur if we run `mvn install` in one command, followed by `mvn verify` in another during which time a SNAPSHOT release was published on master. Declaring this option provides some certainty across all providers where we follow this approach.  Because we also run with `--quiet`, we reduce our visibility into whether CI is downloading the SNAPSHOT or using the locally cached version.

Gradle doesn't require such an option because it caches snapshot dependencies for 24 hours by default and requires either manual updates or reconfiguration to change that behavior (see https://docs.gradle.org/current/userguide/dynamic_versions.html).

cc @OpenAPITools/generator-core-team 

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
