### PR TITLE
[Typescript] Support http bearer authentication with token provider

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript/api/api.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/api/api.mustache
@@ -33,7 +33,7 @@ export class {{classname}}RequestFactory extends BaseAPIRequestFactory {
      * @param {{paramName}} {{description}}
      {{/allParams}}
      */
-    public {{nickname}}({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/allParams}}options?: Configuration): RequestContext {
+    public async {{nickname}}({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/allParams}}options?: Configuration): Promise<RequestContext> {
 		let config = options || this.configuration;
 		{{#allParams}}
 		
@@ -120,22 +120,22 @@ export class {{classname}}RequestFactory extends BaseAPIRequestFactory {
         );
         requestContext.setBody(serializedBody);
 	    {{/bodyParam}}
-		
-		{{#hasAuthMethods}}    
-		let authMethod = null;
-		{{/hasAuthMethods}}
-    	// Apply auth methods
-    	{{#authMethods}}
-    	authMethod = config.authMethods["{{name}}"]
-    	if (authMethod) {
-    		authMethod.applySecurityAuthentication(requestContext);
-    	}
-    	{{/authMethods}}
-    	
-    	return requestContext;
+
+        {{#hasAuthMethods}}
+        let authMethod = null;
+        {{/hasAuthMethods}}
+        // Apply auth methods
+        {{#authMethods}}
+        authMethod = config.authMethods["{{name}}"]
+        if (authMethod) {
+            await authMethod.applySecurityAuthentication(requestContext);
+        }
+        {{/authMethods}}
+
+        return requestContext;
     }
-			
-	{{/operation}}
+
+    {{/operation}}
 }
 {{/operations}}
 

--- a/modules/openapi-generator/src/main/resources/typescript/auth/auth.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/auth/auth.mustache
@@ -26,7 +26,7 @@ export abstract class SecurityAuthentication {
 	 * 
 	 * @params context the request context which should use this authentication scheme
 	 */
-	public abstract applySecurityAuthentication(context: RequestContext): void;
+   public abstract applySecurityAuthentication(context: RequestContext): void | Promise<void>;
 
 }
 
@@ -100,7 +100,7 @@ export class HttpBasicAuthentication extends SecurityAuthentication {
 }
 
 export interface TokenProvider {
-  getToken(): string;
+  getToken(): Promise<string> | string;
 }
 
 /**
@@ -119,8 +119,8 @@ export class HttpBearerAuthentication extends SecurityAuthentication {
         super(authName);
     }
 
-    public applySecurityAuthentication(context: RequestContext) {
-        context.setHeaderParam("Authorization", "Bearer " + this.tokenProvider.getToken());
+    public async applySecurityAuthentication(context: RequestContext) {
+        context.setHeaderParam("Authorization", "Bearer " + await this.tokenProvider.getToken());
     }
 }
 

--- a/modules/openapi-generator/src/main/resources/typescript/auth/auth.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/auth/auth.mustache
@@ -99,6 +99,31 @@ export class HttpBasicAuthentication extends SecurityAuthentication {
 	}
 }
 
+export interface TokenProvider {
+  getToken(): string;
+}
+
+/**
+ * Applies http bearer authentication to a request.
+ *
+ */
+export class HttpBearerAuthentication extends SecurityAuthentication {
+    /**
+     * Configures the http authentication with the required details.
+     *
+     *
+     * @param authName name of the authentication scheme as defined in openapi specification
+     * @param tokenProvider service that can provide the up-to-date token when needed
+     */
+    public constructor(authName: string, private tokenProvider: TokenProvider) {
+        super(authName);
+    }
+
+    public applySecurityAuthentication(context: RequestContext) {
+        context.setHeaderParam("Authentication", "Bearer " + this.tokenProvider.getToken());
+    }
+}
+
 // TODO: How to handle oauth2 authentication!
 export class OAuth2Authentication extends SecurityAuthentication {
 	public constructor(authName: string) {
@@ -112,36 +137,39 @@ export class OAuth2Authentication extends SecurityAuthentication {
 
 export type AuthMethods = {
 	{{#authMethods}}
-		"{{name}}"?: {{#isApiKey}}APIKeyAuthentication{{/isApiKey}}{{#isHttp}}HttpBasicAuthentication{{/isHttp}}{{#isOAuth}}OAuth2Authentication{{/isOAuth}},
+		"{{name}}"?: {{#isApiKey}}APIKeyAuthentication{{/isApiKey}}{{#isBasicBasic}}HttpBasicAuthentication{{/isBasicBasic}}{{#isBasicBearer}}HttpBearerAuthentication{{/isBasicBearer}}{{#isOAuth}}OAuth2Authentication{{/isOAuth}},
 	{{/authMethods}}
 }
 
 export type ApiKeyConfiguration = string;
 export type HttpBasicConfiguration = { "username": string, "password": string };
+export type HttpBearerConfiguration = { tokenProvider: TokenProvider };
 export type OAuth2Configuration = string;
 
-export type AuthMethodsConfiguration = { {{#authMethods}}"{{name}}"?:{{#isApiKey}}ApiKeyConfiguration{{/isApiKey}}{{#isHttp}}HttpBasicConfiguration{{/isHttp}}{{#isOAuth}}OAuth2Configuration{{/isOAuth}},  {{/authMethods}} }
+export type AuthMethodsConfiguration = { {{#authMethods}}"{{name}}"?:{{#isApiKey}}ApiKeyConfiguration{{/isApiKey}}{{#isBasicBasic}}HttpBasicConfiguration{{/isBasicBasic}}{{#isBasicBearer}}HttpBearerConfiguration{{/isBasicBearer}}{{#isOAuth}}OAuth2Configuration{{/isOAuth}},  {{/authMethods}} }
 
 /**
  * Creates the authentication methods from a swagger description.
  *
  */
-export function configureAuthMethods(conf: AuthMethodsConfiguration | undefined): AuthMethods {
-	let authMethods: AuthMethods = {
-	}
+export function configureAuthMethods(config: AuthMethodsConfiguration | undefined): AuthMethods {
+    let authMethods: AuthMethods = {}
 
-	if (!conf) {
-		return authMethods;
-	}		
+    if (!config) {
+        return authMethods;
+    }
 
 	{{#authMethods}}
-	if (conf["{{name}}"]) {
-		{{#isApiKey}}
-		authMethods["{{name}}"] = new APIKeyAuthentication("{{name}}",  "{{keyParamName}}", {{#isKeyInQuery}}"query"{{/isKeyInQuery}}{{#isKeyInHeader}}"header"{{/isKeyInHeader}}{{#isKeyInCookie}}"cookie"{{/isKeyInCookie}}, <string> conf["{{name}}"]);
-		{{/isApiKey}}
-		{{#isBasic}}
-		authMethods["{{name}}"] = new HttpBasicAuthentication("{{name}}", config["{{name}}"]["username"], config["{{name}}"]["password"]);
-		{{/isBasic}}
+    if (config["{{name}}"]) {
+        {{#isApiKey}}
+        authMethods["{{name}}"] = new APIKeyAuthentication("{{name}}",  "{{keyParamName}}", {{#isKeyInQuery}}"query"{{/isKeyInQuery}}{{#isKeyInHeader}}"header"{{/isKeyInHeader}}{{#isKeyInCookie}}"cookie"{{/isKeyInCookie}}, <string> config["{{name}}"]);
+        {{/isApiKey}}
+        {{#isBasicBasic}}
+        authMethods["{{name}}"] = new HttpBasicAuthentication("{{name}}", config["{{name}}"]["username"], config["{{name}}"]["password"]);
+        {{/isBasicBasic}}
+        {{#isBasicBearer}}
+        authMethods["{{name}}"] = new HttpBearerAuthentication("{{name}}", config["{{name}}"]["tokenProvider"]);
+        {{/isBasicBearer}}
 		{{#isOAuth}}
 		authMethods["{{name}}"] = new OAuth2Authentication("{{name}}");
 		{{/isOAuth}}

--- a/modules/openapi-generator/src/main/resources/typescript/auth/auth.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/auth/auth.mustache
@@ -95,7 +95,7 @@ export class HttpBasicAuthentication extends SecurityAuthentication {
 	
 	public applySecurityAuthentication(context: RequestContext) {
 		let comb = this.username + ":" + this.password;
-		context.setHeaderParam("Authentication", "Basic " + btoa(comb));
+		context.setHeaderParam("Authorization", "Basic " + btoa(comb));
 	}
 }
 
@@ -120,7 +120,7 @@ export class HttpBearerAuthentication extends SecurityAuthentication {
     }
 
     public applySecurityAuthentication(context: RequestContext) {
-        context.setHeaderParam("Authentication", "Bearer " + this.tokenProvider.getToken());
+        context.setHeaderParam("Authorization", "Bearer " + this.tokenProvider.getToken());
     }
 }
 

--- a/modules/openapi-generator/src/main/resources/typescript/http/http.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/http/http.mustache
@@ -172,7 +172,7 @@ export class SelfDecodingBody implements ResponseBody {
 
         return new Promise<string>((resolve, reject) => {
             const reader = new FileReader();
-            reader.addEventListener("load", () => resolve(reader.result));
+            reader.addEventListener("load", () => resolve(reader.result as string));
             reader.addEventListener("error", () => reject(reader.error));
             reader.readAsText(data);
         });

--- a/modules/openapi-generator/src/main/resources/typescript/http/servers.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/http/servers.mustache
@@ -6,25 +6,17 @@ import {RequestContext, HttpMethod} from './http/http';
  * url template and variable configuration based on the url.
  *
  */
-export class ServerConfiguration<T> {
-	
-    public constructor(private url: string, private variableConfiguration: T) {
+export class ServerConfiguration<T extends { [key: string]: string }> {
+    public constructor(private url: string, private variableConfiguration: T) {}
+
+    /**
+     * Sets the value of the variables of this server.
+     *
+     * @param variableConfiguration a partial variable configuration for the variables contained in the url
+     */
+    public setVariables(variableConfiguration: Partial<T>) {
+        Object.assign(this.variableConfiguration, variableConfiguration);
     }
-	
-	/**
-	 * Sets the value of the variables of this server.
-	 *
-	 * @param variableConfiguration a partial variable configuration for the variables contained in the url
-	 */
-	public setVariables(variableConfiguration: Partial<T>) {
-		for (const key in variableConfiguration) {
-			const val = variableConfiguration[key]
-			// We know that val isn't undefined here - hopefully
-			if (val !== undefined) {
-				this.variableConfiguration[key] = val as T[Extract<keyof T, string>];
-			}
-		}
-	}
 
 	public getConfiguration(): T {
 		return this.variableConfiguration
@@ -34,7 +26,7 @@ export class ServerConfiguration<T> {
 		let replacedUrl = this.url;
 		for (const key in this.variableConfiguration) {
 			var re = new RegExp("{" + key + "}","g");
-			replacedUrl = replacedUrl.replace(re, this.variableConfiguration[key].toString());
+			replacedUrl = replacedUrl.replace(re, this.variableConfiguration[key]);
 		}
 		return replacedUrl
 	}

--- a/modules/openapi-generator/src/main/resources/typescript/package.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/package.mustache
@@ -48,7 +48,7 @@
     "url-parse": "^1.4.3"
   },
   "devDependencies": {
-    "typescript": "^2.9.2"
+    "typescript": "^3.9.3"
   }{{#npmRepository}},{{/npmRepository}}
 {{#npmRepository}}
   "publishConfig":{

--- a/modules/openapi-generator/src/main/resources/typescript/types/ObservableAPI.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/types/ObservableAPI.mustache
@@ -1,7 +1,7 @@
 import { ResponseContext, RequestContext, HttpFile } from '../http/http';
 import * as models from '../models/all';
 import { Configuration} from '../configuration'
-import { Observable, of } from {{#useRxJS}}'rxjs'{{/useRxJS}}{{^useRxJS}}'../rxjsStub'{{/useRxJS}};
+import { Observable, of, from } from {{#useRxJS}}'rxjs'{{/useRxJS}}{{^useRxJS}}'../rxjsStub'{{/useRxJS}};
 import {mergeMap, map} from  {{#useRxJS}}'rxjs/operators'{{/useRxJS}}{{^useRxJS}}'../rxjsStub'{{/useRxJS}};
 
 {{#models}}
@@ -38,10 +38,10 @@ export class Observable{{classname}} {
      {{/allParams}}
      */
     public {{nickname}}({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/allParams}}options?: Configuration): Observable<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/returnType}}> {
-    	const requestContext = this.requestFactory.{{nickname}}({{#allParams}}{{paramName}}, {{/allParams}}options);
+    	const requestContextPromise = this.requestFactory.{{nickname}}({{#allParams}}{{paramName}}, {{/allParams}}options);
 
 		// build promise chain
-    	let middlewarePreObservable = of(requestContext);
+    let middlewarePreObservable = from<RequestContext>(requestContextPromise);
     	for (let middleware of this.configuration.middleware) {
     		middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
     	}

--- a/samples/openapi3/client/petstore/typescript/builds/default/apis/PetApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/default/apis/PetApi.ts
@@ -19,7 +19,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
      * Add a new pet to the store
      * @param pet Pet object that needs to be added to the store
      */
-    public addPet(pet: Pet, options?: Configuration): RequestContext {
+    public async addPet(pet: Pet, options?: Configuration): Promise<RequestContext> {
 		let config = options || this.configuration;
 		
         // verify required parameter 'pet' is not null or undefined
@@ -54,23 +54,23 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
             contentType
         );
         requestContext.setBody(serializedBody);
-		
-		let authMethod = null;
-    	// Apply auth methods
-    	authMethod = config.authMethods["petstore_auth"]
-    	if (authMethod) {
-    		authMethod.applySecurityAuthentication(requestContext);
-    	}
-    	
-    	return requestContext;
+
+        let authMethod = null;
+        // Apply auth methods
+        authMethod = config.authMethods["petstore_auth"]
+        if (authMethod) {
+            await authMethod.applySecurityAuthentication(requestContext);
+        }
+
+        return requestContext;
     }
-			
+
     /**
      * Deletes a pet
      * @param petId Pet id to delete
      * @param apiKey 
      */
-    public deletePet(petId: number, apiKey?: string, options?: Configuration): RequestContext {
+    public async deletePet(petId: number, apiKey?: string, options?: Configuration): Promise<RequestContext> {
 		let config = options || this.configuration;
 		
         // verify required parameter 'petId' is not null or undefined
@@ -97,23 +97,23 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
 
 
 		// Body Params
-		
-		let authMethod = null;
-    	// Apply auth methods
-    	authMethod = config.authMethods["petstore_auth"]
-    	if (authMethod) {
-    		authMethod.applySecurityAuthentication(requestContext);
-    	}
-    	
-    	return requestContext;
+
+        let authMethod = null;
+        // Apply auth methods
+        authMethod = config.authMethods["petstore_auth"]
+        if (authMethod) {
+            await authMethod.applySecurityAuthentication(requestContext);
+        }
+
+        return requestContext;
     }
-			
+
     /**
      * Multiple status values can be provided with comma separated strings
      * Finds Pets by status
      * @param status Status values that need to be considered for filter
      */
-    public findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, options?: Configuration): RequestContext {
+    public async findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, options?: Configuration): Promise<RequestContext> {
 		let config = options || this.configuration;
 		
         // verify required parameter 'status' is not null or undefined
@@ -140,23 +140,23 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
 
 
 		// Body Params
-		
-		let authMethod = null;
-    	// Apply auth methods
-    	authMethod = config.authMethods["petstore_auth"]
-    	if (authMethod) {
-    		authMethod.applySecurityAuthentication(requestContext);
-    	}
-    	
-    	return requestContext;
+
+        let authMethod = null;
+        // Apply auth methods
+        authMethod = config.authMethods["petstore_auth"]
+        if (authMethod) {
+            await authMethod.applySecurityAuthentication(requestContext);
+        }
+
+        return requestContext;
     }
-			
+
     /**
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * Finds Pets by tags
      * @param tags Tags to filter by
      */
-    public findPetsByTags(tags: Array<string>, options?: Configuration): RequestContext {
+    public async findPetsByTags(tags: Array<string>, options?: Configuration): Promise<RequestContext> {
 		let config = options || this.configuration;
 		
         // verify required parameter 'tags' is not null or undefined
@@ -183,23 +183,23 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
 
 
 		// Body Params
-		
-		let authMethod = null;
-    	// Apply auth methods
-    	authMethod = config.authMethods["petstore_auth"]
-    	if (authMethod) {
-    		authMethod.applySecurityAuthentication(requestContext);
-    	}
-    	
-    	return requestContext;
+
+        let authMethod = null;
+        // Apply auth methods
+        authMethod = config.authMethods["petstore_auth"]
+        if (authMethod) {
+            await authMethod.applySecurityAuthentication(requestContext);
+        }
+
+        return requestContext;
     }
-			
+
     /**
      * Returns a single pet
      * Find pet by ID
      * @param petId ID of pet to return
      */
-    public getPetById(petId: number, options?: Configuration): RequestContext {
+    public async getPetById(petId: number, options?: Configuration): Promise<RequestContext> {
 		let config = options || this.configuration;
 		
         // verify required parameter 'petId' is not null or undefined
@@ -224,22 +224,22 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
 
 
 		// Body Params
-		
-		let authMethod = null;
-    	// Apply auth methods
-    	authMethod = config.authMethods["api_key"]
-    	if (authMethod) {
-    		authMethod.applySecurityAuthentication(requestContext);
-    	}
-    	
-    	return requestContext;
+
+        let authMethod = null;
+        // Apply auth methods
+        authMethod = config.authMethods["api_key"]
+        if (authMethod) {
+            await authMethod.applySecurityAuthentication(requestContext);
+        }
+
+        return requestContext;
     }
-			
+
     /**
      * Update an existing pet
      * @param pet Pet object that needs to be added to the store
      */
-    public updatePet(pet: Pet, options?: Configuration): RequestContext {
+    public async updatePet(pet: Pet, options?: Configuration): Promise<RequestContext> {
 		let config = options || this.configuration;
 		
         // verify required parameter 'pet' is not null or undefined
@@ -274,24 +274,24 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
             contentType
         );
         requestContext.setBody(serializedBody);
-		
-		let authMethod = null;
-    	// Apply auth methods
-    	authMethod = config.authMethods["petstore_auth"]
-    	if (authMethod) {
-    		authMethod.applySecurityAuthentication(requestContext);
-    	}
-    	
-    	return requestContext;
+
+        let authMethod = null;
+        // Apply auth methods
+        authMethod = config.authMethods["petstore_auth"]
+        if (authMethod) {
+            await authMethod.applySecurityAuthentication(requestContext);
+        }
+
+        return requestContext;
     }
-			
+
     /**
      * Updates a pet in the store with form data
      * @param petId ID of pet that needs to be updated
      * @param name Updated name of the pet
      * @param status Updated status of the pet
      */
-    public updatePetWithForm(petId: number, name?: string, status?: string, options?: Configuration): RequestContext {
+    public async updatePetWithForm(petId: number, name?: string, status?: string, options?: Configuration): Promise<RequestContext> {
 		let config = options || this.configuration;
 		
         // verify required parameter 'petId' is not null or undefined
@@ -328,24 +328,24 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
 		requestContext.setBody(localVarFormParams);
 
 		// Body Params
-		
-		let authMethod = null;
-    	// Apply auth methods
-    	authMethod = config.authMethods["petstore_auth"]
-    	if (authMethod) {
-    		authMethod.applySecurityAuthentication(requestContext);
-    	}
-    	
-    	return requestContext;
+
+        let authMethod = null;
+        // Apply auth methods
+        authMethod = config.authMethods["petstore_auth"]
+        if (authMethod) {
+            await authMethod.applySecurityAuthentication(requestContext);
+        }
+
+        return requestContext;
     }
-			
+
     /**
      * uploads an image
      * @param petId ID of pet to update
      * @param additionalMetadata Additional data to pass to server
      * @param file file to upload
      */
-    public uploadFile(petId: number, additionalMetadata?: string, file?: HttpFile, options?: Configuration): RequestContext {
+    public async uploadFile(petId: number, additionalMetadata?: string, file?: HttpFile, options?: Configuration): Promise<RequestContext> {
 		let config = options || this.configuration;
 		
         // verify required parameter 'petId' is not null or undefined
@@ -382,17 +382,17 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
 		requestContext.setBody(localVarFormParams);
 
 		// Body Params
-		
-		let authMethod = null;
-    	// Apply auth methods
-    	authMethod = config.authMethods["petstore_auth"]
-    	if (authMethod) {
-    		authMethod.applySecurityAuthentication(requestContext);
-    	}
-    	
-    	return requestContext;
+
+        let authMethod = null;
+        // Apply auth methods
+        authMethod = config.authMethods["petstore_auth"]
+        if (authMethod) {
+            await authMethod.applySecurityAuthentication(requestContext);
+        }
+
+        return requestContext;
     }
-			
+
 }
 
 

--- a/samples/openapi3/client/petstore/typescript/builds/default/apis/StoreApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/default/apis/StoreApi.ts
@@ -19,7 +19,7 @@ export class StoreApiRequestFactory extends BaseAPIRequestFactory {
      * Delete purchase order by ID
      * @param orderId ID of the order that needs to be deleted
      */
-    public deleteOrder(orderId: string, options?: Configuration): RequestContext {
+    public async deleteOrder(orderId: string, options?: Configuration): Promise<RequestContext> {
 		let config = options || this.configuration;
 		
         // verify required parameter 'orderId' is not null or undefined
@@ -44,17 +44,17 @@ export class StoreApiRequestFactory extends BaseAPIRequestFactory {
 
 
 		// Body Params
-		
-    	// Apply auth methods
-    	
-    	return requestContext;
+
+        // Apply auth methods
+
+        return requestContext;
     }
-			
+
     /**
      * Returns a map of status codes to quantities
      * Returns pet inventories by status
      */
-    public getInventory(options?: Configuration): RequestContext {
+    public async getInventory(options?: Configuration): Promise<RequestContext> {
 		let config = options || this.configuration;
 		
 		// Path Params
@@ -72,23 +72,23 @@ export class StoreApiRequestFactory extends BaseAPIRequestFactory {
 
 
 		// Body Params
-		
-		let authMethod = null;
-    	// Apply auth methods
-    	authMethod = config.authMethods["api_key"]
-    	if (authMethod) {
-    		authMethod.applySecurityAuthentication(requestContext);
-    	}
-    	
-    	return requestContext;
+
+        let authMethod = null;
+        // Apply auth methods
+        authMethod = config.authMethods["api_key"]
+        if (authMethod) {
+            await authMethod.applySecurityAuthentication(requestContext);
+        }
+
+        return requestContext;
     }
-			
+
     /**
      * For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
      * Find purchase order by ID
      * @param orderId ID of pet that needs to be fetched
      */
-    public getOrderById(orderId: number, options?: Configuration): RequestContext {
+    public async getOrderById(orderId: number, options?: Configuration): Promise<RequestContext> {
 		let config = options || this.configuration;
 		
         // verify required parameter 'orderId' is not null or undefined
@@ -113,17 +113,17 @@ export class StoreApiRequestFactory extends BaseAPIRequestFactory {
 
 
 		// Body Params
-		
-    	// Apply auth methods
-    	
-    	return requestContext;
+
+        // Apply auth methods
+
+        return requestContext;
     }
-			
+
     /**
      * Place an order for a pet
      * @param order order placed for purchasing the pet
      */
-    public placeOrder(order: Order, options?: Configuration): RequestContext {
+    public async placeOrder(order: Order, options?: Configuration): Promise<RequestContext> {
 		let config = options || this.configuration;
 		
         // verify required parameter 'order' is not null or undefined
@@ -156,12 +156,12 @@ export class StoreApiRequestFactory extends BaseAPIRequestFactory {
             contentType
         );
         requestContext.setBody(serializedBody);
-		
-    	// Apply auth methods
-    	
-    	return requestContext;
+
+        // Apply auth methods
+
+        return requestContext;
     }
-			
+
 }
 
 

--- a/samples/openapi3/client/petstore/typescript/builds/default/apis/UserApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/default/apis/UserApi.ts
@@ -19,7 +19,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
      * Create user
      * @param user Created user object
      */
-    public createUser(user: User, options?: Configuration): RequestContext {
+    public async createUser(user: User, options?: Configuration): Promise<RequestContext> {
 		let config = options || this.configuration;
 		
         // verify required parameter 'user' is not null or undefined
@@ -52,22 +52,22 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
             contentType
         );
         requestContext.setBody(serializedBody);
-		
-		let authMethod = null;
-    	// Apply auth methods
-    	authMethod = config.authMethods["api_key"]
-    	if (authMethod) {
-    		authMethod.applySecurityAuthentication(requestContext);
-    	}
-    	
-    	return requestContext;
+
+        let authMethod = null;
+        // Apply auth methods
+        authMethod = config.authMethods["api_key"]
+        if (authMethod) {
+            await authMethod.applySecurityAuthentication(requestContext);
+        }
+
+        return requestContext;
     }
-			
+
     /**
      * Creates list of users with given input array
      * @param user List of user object
      */
-    public createUsersWithArrayInput(user: Array<User>, options?: Configuration): RequestContext {
+    public async createUsersWithArrayInput(user: Array<User>, options?: Configuration): Promise<RequestContext> {
 		let config = options || this.configuration;
 		
         // verify required parameter 'user' is not null or undefined
@@ -100,22 +100,22 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
             contentType
         );
         requestContext.setBody(serializedBody);
-		
-		let authMethod = null;
-    	// Apply auth methods
-    	authMethod = config.authMethods["api_key"]
-    	if (authMethod) {
-    		authMethod.applySecurityAuthentication(requestContext);
-    	}
-    	
-    	return requestContext;
+
+        let authMethod = null;
+        // Apply auth methods
+        authMethod = config.authMethods["api_key"]
+        if (authMethod) {
+            await authMethod.applySecurityAuthentication(requestContext);
+        }
+
+        return requestContext;
     }
-			
+
     /**
      * Creates list of users with given input array
      * @param user List of user object
      */
-    public createUsersWithListInput(user: Array<User>, options?: Configuration): RequestContext {
+    public async createUsersWithListInput(user: Array<User>, options?: Configuration): Promise<RequestContext> {
 		let config = options || this.configuration;
 		
         // verify required parameter 'user' is not null or undefined
@@ -148,23 +148,23 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
             contentType
         );
         requestContext.setBody(serializedBody);
-		
-		let authMethod = null;
-    	// Apply auth methods
-    	authMethod = config.authMethods["api_key"]
-    	if (authMethod) {
-    		authMethod.applySecurityAuthentication(requestContext);
-    	}
-    	
-    	return requestContext;
+
+        let authMethod = null;
+        // Apply auth methods
+        authMethod = config.authMethods["api_key"]
+        if (authMethod) {
+            await authMethod.applySecurityAuthentication(requestContext);
+        }
+
+        return requestContext;
     }
-			
+
     /**
      * This can only be done by the logged in user.
      * Delete user
      * @param username The name that needs to be deleted
      */
-    public deleteUser(username: string, options?: Configuration): RequestContext {
+    public async deleteUser(username: string, options?: Configuration): Promise<RequestContext> {
 		let config = options || this.configuration;
 		
         // verify required parameter 'username' is not null or undefined
@@ -189,22 +189,22 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
 
 
 		// Body Params
-		
-		let authMethod = null;
-    	// Apply auth methods
-    	authMethod = config.authMethods["api_key"]
-    	if (authMethod) {
-    		authMethod.applySecurityAuthentication(requestContext);
-    	}
-    	
-    	return requestContext;
+
+        let authMethod = null;
+        // Apply auth methods
+        authMethod = config.authMethods["api_key"]
+        if (authMethod) {
+            await authMethod.applySecurityAuthentication(requestContext);
+        }
+
+        return requestContext;
     }
-			
+
     /**
      * Get user by user name
      * @param username The name that needs to be fetched. Use user1 for testing.
      */
-    public getUserByName(username: string, options?: Configuration): RequestContext {
+    public async getUserByName(username: string, options?: Configuration): Promise<RequestContext> {
 		let config = options || this.configuration;
 		
         // verify required parameter 'username' is not null or undefined
@@ -229,18 +229,18 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
 
 
 		// Body Params
-		
-    	// Apply auth methods
-    	
-    	return requestContext;
+
+        // Apply auth methods
+
+        return requestContext;
     }
-			
+
     /**
      * Logs user into the system
      * @param username The user name for login
      * @param password The password for login in clear text
      */
-    public loginUser(username: string, password: string, options?: Configuration): RequestContext {
+    public async loginUser(username: string, password: string, options?: Configuration): Promise<RequestContext> {
 		let config = options || this.configuration;
 		
         // verify required parameter 'username' is not null or undefined
@@ -276,16 +276,16 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
 
 
 		// Body Params
-		
-    	// Apply auth methods
-    	
-    	return requestContext;
+
+        // Apply auth methods
+
+        return requestContext;
     }
-			
+
     /**
      * Logs out current logged in user session
      */
-    public logoutUser(options?: Configuration): RequestContext {
+    public async logoutUser(options?: Configuration): Promise<RequestContext> {
 		let config = options || this.configuration;
 		
 		// Path Params
@@ -303,24 +303,24 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
 
 
 		// Body Params
-		
-		let authMethod = null;
-    	// Apply auth methods
-    	authMethod = config.authMethods["api_key"]
-    	if (authMethod) {
-    		authMethod.applySecurityAuthentication(requestContext);
-    	}
-    	
-    	return requestContext;
+
+        let authMethod = null;
+        // Apply auth methods
+        authMethod = config.authMethods["api_key"]
+        if (authMethod) {
+            await authMethod.applySecurityAuthentication(requestContext);
+        }
+
+        return requestContext;
     }
-			
+
     /**
      * This can only be done by the logged in user.
      * Updated user
      * @param username name that need to be deleted
      * @param user Updated user object
      */
-    public updateUser(username: string, user: User, options?: Configuration): RequestContext {
+    public async updateUser(username: string, user: User, options?: Configuration): Promise<RequestContext> {
 		let config = options || this.configuration;
 		
         // verify required parameter 'username' is not null or undefined
@@ -360,17 +360,17 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
             contentType
         );
         requestContext.setBody(serializedBody);
-		
-		let authMethod = null;
-    	// Apply auth methods
-    	authMethod = config.authMethods["api_key"]
-    	if (authMethod) {
-    		authMethod.applySecurityAuthentication(requestContext);
-    	}
-    	
-    	return requestContext;
+
+        let authMethod = null;
+        // Apply auth methods
+        authMethod = config.authMethods["api_key"]
+        if (authMethod) {
+            await authMethod.applySecurityAuthentication(requestContext);
+        }
+
+        return requestContext;
     }
-			
+
 }
 
 

--- a/samples/openapi3/client/petstore/typescript/builds/default/auth/auth.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/default/auth/auth.ts
@@ -26,7 +26,7 @@ export abstract class SecurityAuthentication {
 	 * 
 	 * @params context the request context which should use this authentication scheme
 	 */
-	public abstract applySecurityAuthentication(context: RequestContext): void;
+   public abstract applySecurityAuthentication(context: RequestContext): void | Promise<void>;
 
 }
 
@@ -100,7 +100,7 @@ export class HttpBasicAuthentication extends SecurityAuthentication {
 }
 
 export interface TokenProvider {
-  getToken(): string;
+  getToken(): Promise<string> | string;
 }
 
 /**
@@ -119,8 +119,8 @@ export class HttpBearerAuthentication extends SecurityAuthentication {
         super(authName);
     }
 
-    public applySecurityAuthentication(context: RequestContext) {
-        context.setHeaderParam("Authorization", "Bearer " + this.tokenProvider.getToken());
+    public async applySecurityAuthentication(context: RequestContext) {
+        context.setHeaderParam("Authorization", "Bearer " + await this.tokenProvider.getToken());
     }
 }
 

--- a/samples/openapi3/client/petstore/typescript/builds/default/auth/auth.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/default/auth/auth.ts
@@ -99,6 +99,31 @@ export class HttpBasicAuthentication extends SecurityAuthentication {
 	}
 }
 
+export interface TokenProvider {
+  getToken(): string;
+}
+
+/**
+ * Applies http bearer authentication to a request.
+ *
+ */
+export class HttpBearerAuthentication extends SecurityAuthentication {
+    /**
+     * Configures the http authentication with the required details.
+     *
+     *
+     * @param authName name of the authentication scheme as defined in openapi specification
+     * @param tokenProvider service that can provide the up-to-date token when needed
+     */
+    public constructor(authName: string, private tokenProvider: TokenProvider) {
+        super(authName);
+    }
+
+    public applySecurityAuthentication(context: RequestContext) {
+        context.setHeaderParam("Authentication", "Bearer " + this.tokenProvider.getToken());
+    }
+}
+
 // TODO: How to handle oauth2 authentication!
 export class OAuth2Authentication extends SecurityAuthentication {
 	public constructor(authName: string) {
@@ -117,6 +142,7 @@ export type AuthMethods = {
 
 export type ApiKeyConfiguration = string;
 export type HttpBasicConfiguration = { "username": string, "password": string };
+export type HttpBearerConfiguration = { tokenProvider: TokenProvider };
 export type OAuth2Configuration = string;
 
 export type AuthMethodsConfiguration = { "api_key"?:ApiKeyConfiguration,  "petstore_auth"?:OAuth2Configuration,   }
@@ -125,19 +151,18 @@ export type AuthMethodsConfiguration = { "api_key"?:ApiKeyConfiguration,  "petst
  * Creates the authentication methods from a swagger description.
  *
  */
-export function configureAuthMethods(conf: AuthMethodsConfiguration | undefined): AuthMethods {
-	let authMethods: AuthMethods = {
+export function configureAuthMethods(config: AuthMethodsConfiguration | undefined): AuthMethods {
+    let authMethods: AuthMethods = {}
+
+    if (!config) {
+        return authMethods;
+    }
+
+    if (config["api_key"]) {
+        authMethods["api_key"] = new APIKeyAuthentication("api_key",  "api_key", "header", <string> config["api_key"]);
 	}
 
-	if (!conf) {
-		return authMethods;
-	}		
-
-	if (conf["api_key"]) {
-		authMethods["api_key"] = new APIKeyAuthentication("api_key",  "api_key", "header", <string> conf["api_key"]);
-	}
-
-	if (conf["petstore_auth"]) {
+    if (config["petstore_auth"]) {
 		authMethods["petstore_auth"] = new OAuth2Authentication("petstore_auth");
 	}
 

--- a/samples/openapi3/client/petstore/typescript/builds/default/auth/auth.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/default/auth/auth.ts
@@ -95,7 +95,7 @@ export class HttpBasicAuthentication extends SecurityAuthentication {
 	
 	public applySecurityAuthentication(context: RequestContext) {
 		let comb = this.username + ":" + this.password;
-		context.setHeaderParam("Authentication", "Basic " + btoa(comb));
+		context.setHeaderParam("Authorization", "Basic " + btoa(comb));
 	}
 }
 
@@ -120,7 +120,7 @@ export class HttpBearerAuthentication extends SecurityAuthentication {
     }
 
     public applySecurityAuthentication(context: RequestContext) {
-        context.setHeaderParam("Authentication", "Bearer " + this.tokenProvider.getToken());
+        context.setHeaderParam("Authorization", "Bearer " + this.tokenProvider.getToken());
     }
 }
 

--- a/samples/openapi3/client/petstore/typescript/builds/default/package-lock.json
+++ b/samples/openapi3/client/petstore/typescript/builds/default/package-lock.json
@@ -97,9 +97,9 @@
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
     },
     "typescript": {
-      "version": "2.9.2",
-      "resolved": false,
-      "integrity": "sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==",
+      "version": "3.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.3.tgz",
+      "integrity": "sha512-D/wqnB2xzNFIcoBG9FG8cXRDjiqSTbG2wd8DMZeQyJlP1vfTkIxH4GKveWaEBYySKIg+USu+E+EDIR47SqnaMQ==",
       "dev": true
     },
     "url-parse": {

--- a/samples/openapi3/client/petstore/typescript/builds/default/package.json
+++ b/samples/openapi3/client/petstore/typescript/builds/default/package.json
@@ -26,6 +26,6 @@
     "url-parse": "^1.4.3"
   },
   "devDependencies": {
-    "typescript": "^2.9.2"
+    "typescript": "^3.9.3"
   }
 }

--- a/samples/openapi3/client/petstore/typescript/builds/default/servers.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/default/servers.ts
@@ -6,25 +6,17 @@ import {RequestContext, HttpMethod} from './http/http';
  * url template and variable configuration based on the url.
  *
  */
-export class ServerConfiguration<T> {
-	
-    public constructor(private url: string, private variableConfiguration: T) {
+export class ServerConfiguration<T extends { [key: string]: string }> {
+    public constructor(private url: string, private variableConfiguration: T) {}
+
+    /**
+     * Sets the value of the variables of this server.
+     *
+     * @param variableConfiguration a partial variable configuration for the variables contained in the url
+     */
+    public setVariables(variableConfiguration: Partial<T>) {
+        Object.assign(this.variableConfiguration, variableConfiguration);
     }
-	
-	/**
-	 * Sets the value of the variables of this server.
-	 *
-	 * @param variableConfiguration a partial variable configuration for the variables contained in the url
-	 */
-	public setVariables(variableConfiguration: Partial<T>) {
-		for (const key in variableConfiguration) {
-			const val = variableConfiguration[key]
-			// We know that val isn't undefined here - hopefully
-			if (val !== undefined) {
-				this.variableConfiguration[key] = val as T[Extract<keyof T, string>];
-			}
-		}
-	}
 
 	public getConfiguration(): T {
 		return this.variableConfiguration
@@ -34,7 +26,7 @@ export class ServerConfiguration<T> {
 		let replacedUrl = this.url;
 		for (const key in this.variableConfiguration) {
 			var re = new RegExp("{" + key + "}","g");
-			replacedUrl = replacedUrl.replace(re, this.variableConfiguration[key].toString());
+			replacedUrl = replacedUrl.replace(re, this.variableConfiguration[key]);
 		}
 		return replacedUrl
 	}

--- a/samples/openapi3/client/petstore/typescript/builds/default/types/ObservableAPI.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/default/types/ObservableAPI.ts
@@ -1,7 +1,7 @@
 import { ResponseContext, RequestContext, HttpFile } from '../http/http';
 import * as models from '../models/all';
 import { Configuration} from '../configuration'
-import { Observable, of } from '../rxjsStub';
+import { Observable, of, from } from '../rxjsStub';
 import {mergeMap, map} from  '../rxjsStub';
 
 import { ApiResponse } from '../models/ApiResponse';
@@ -30,10 +30,10 @@ export class ObservablePetApi {
      * @param pet Pet object that needs to be added to the store
      */
     public addPet(pet: Pet, options?: Configuration): Observable<Pet> {
-    	const requestContext = this.requestFactory.addPet(pet, options);
+    	const requestContextPromise = this.requestFactory.addPet(pet, options);
 
 		// build promise chain
-    	let middlewarePreObservable = of(requestContext);
+    let middlewarePreObservable = from<RequestContext>(requestContextPromise);
     	for (let middleware of this.configuration.middleware) {
     		middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
     	}
@@ -54,10 +54,10 @@ export class ObservablePetApi {
      * @param apiKey 
      */
     public deletePet(petId: number, apiKey?: string, options?: Configuration): Observable<void> {
-    	const requestContext = this.requestFactory.deletePet(petId, apiKey, options);
+    	const requestContextPromise = this.requestFactory.deletePet(petId, apiKey, options);
 
 		// build promise chain
-    	let middlewarePreObservable = of(requestContext);
+    let middlewarePreObservable = from<RequestContext>(requestContextPromise);
     	for (let middleware of this.configuration.middleware) {
     		middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
     	}
@@ -78,10 +78,10 @@ export class ObservablePetApi {
      * @param status Status values that need to be considered for filter
      */
     public findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, options?: Configuration): Observable<Array<Pet>> {
-    	const requestContext = this.requestFactory.findPetsByStatus(status, options);
+    	const requestContextPromise = this.requestFactory.findPetsByStatus(status, options);
 
 		// build promise chain
-    	let middlewarePreObservable = of(requestContext);
+    let middlewarePreObservable = from<RequestContext>(requestContextPromise);
     	for (let middleware of this.configuration.middleware) {
     		middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
     	}
@@ -102,10 +102,10 @@ export class ObservablePetApi {
      * @param tags Tags to filter by
      */
     public findPetsByTags(tags: Array<string>, options?: Configuration): Observable<Array<Pet>> {
-    	const requestContext = this.requestFactory.findPetsByTags(tags, options);
+    	const requestContextPromise = this.requestFactory.findPetsByTags(tags, options);
 
 		// build promise chain
-    	let middlewarePreObservable = of(requestContext);
+    let middlewarePreObservable = from<RequestContext>(requestContextPromise);
     	for (let middleware of this.configuration.middleware) {
     		middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
     	}
@@ -126,10 +126,10 @@ export class ObservablePetApi {
      * @param petId ID of pet to return
      */
     public getPetById(petId: number, options?: Configuration): Observable<Pet> {
-    	const requestContext = this.requestFactory.getPetById(petId, options);
+    	const requestContextPromise = this.requestFactory.getPetById(petId, options);
 
 		// build promise chain
-    	let middlewarePreObservable = of(requestContext);
+    let middlewarePreObservable = from<RequestContext>(requestContextPromise);
     	for (let middleware of this.configuration.middleware) {
     		middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
     	}
@@ -149,10 +149,10 @@ export class ObservablePetApi {
      * @param pet Pet object that needs to be added to the store
      */
     public updatePet(pet: Pet, options?: Configuration): Observable<Pet> {
-    	const requestContext = this.requestFactory.updatePet(pet, options);
+    	const requestContextPromise = this.requestFactory.updatePet(pet, options);
 
 		// build promise chain
-    	let middlewarePreObservable = of(requestContext);
+    let middlewarePreObservable = from<RequestContext>(requestContextPromise);
     	for (let middleware of this.configuration.middleware) {
     		middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
     	}
@@ -174,10 +174,10 @@ export class ObservablePetApi {
      * @param status Updated status of the pet
      */
     public updatePetWithForm(petId: number, name?: string, status?: string, options?: Configuration): Observable<void> {
-    	const requestContext = this.requestFactory.updatePetWithForm(petId, name, status, options);
+    	const requestContextPromise = this.requestFactory.updatePetWithForm(petId, name, status, options);
 
 		// build promise chain
-    	let middlewarePreObservable = of(requestContext);
+    let middlewarePreObservable = from<RequestContext>(requestContextPromise);
     	for (let middleware of this.configuration.middleware) {
     		middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
     	}
@@ -199,10 +199,10 @@ export class ObservablePetApi {
      * @param file file to upload
      */
     public uploadFile(petId: number, additionalMetadata?: string, file?: HttpFile, options?: Configuration): Observable<ApiResponse> {
-    	const requestContext = this.requestFactory.uploadFile(petId, additionalMetadata, file, options);
+    	const requestContextPromise = this.requestFactory.uploadFile(petId, additionalMetadata, file, options);
 
 		// build promise chain
-    	let middlewarePreObservable = of(requestContext);
+    let middlewarePreObservable = from<RequestContext>(requestContextPromise);
     	for (let middleware of this.configuration.middleware) {
     		middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
     	}
@@ -241,10 +241,10 @@ export class ObservableStoreApi {
      * @param orderId ID of the order that needs to be deleted
      */
     public deleteOrder(orderId: string, options?: Configuration): Observable<void> {
-    	const requestContext = this.requestFactory.deleteOrder(orderId, options);
+    	const requestContextPromise = this.requestFactory.deleteOrder(orderId, options);
 
 		// build promise chain
-    	let middlewarePreObservable = of(requestContext);
+    let middlewarePreObservable = from<RequestContext>(requestContextPromise);
     	for (let middleware of this.configuration.middleware) {
     		middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
     	}
@@ -264,10 +264,10 @@ export class ObservableStoreApi {
      * Returns pet inventories by status
      */
     public getInventory(options?: Configuration): Observable<{ [key: string]: number; }> {
-    	const requestContext = this.requestFactory.getInventory(options);
+    	const requestContextPromise = this.requestFactory.getInventory(options);
 
 		// build promise chain
-    	let middlewarePreObservable = of(requestContext);
+    let middlewarePreObservable = from<RequestContext>(requestContextPromise);
     	for (let middleware of this.configuration.middleware) {
     		middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
     	}
@@ -288,10 +288,10 @@ export class ObservableStoreApi {
      * @param orderId ID of pet that needs to be fetched
      */
     public getOrderById(orderId: number, options?: Configuration): Observable<Order> {
-    	const requestContext = this.requestFactory.getOrderById(orderId, options);
+    	const requestContextPromise = this.requestFactory.getOrderById(orderId, options);
 
 		// build promise chain
-    	let middlewarePreObservable = of(requestContext);
+    let middlewarePreObservable = from<RequestContext>(requestContextPromise);
     	for (let middleware of this.configuration.middleware) {
     		middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
     	}
@@ -311,10 +311,10 @@ export class ObservableStoreApi {
      * @param order order placed for purchasing the pet
      */
     public placeOrder(order: Order, options?: Configuration): Observable<Order> {
-    	const requestContext = this.requestFactory.placeOrder(order, options);
+    	const requestContextPromise = this.requestFactory.placeOrder(order, options);
 
 		// build promise chain
-    	let middlewarePreObservable = of(requestContext);
+    let middlewarePreObservable = from<RequestContext>(requestContextPromise);
     	for (let middleware of this.configuration.middleware) {
     		middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
     	}
@@ -353,10 +353,10 @@ export class ObservableUserApi {
      * @param user Created user object
      */
     public createUser(user: User, options?: Configuration): Observable<void> {
-    	const requestContext = this.requestFactory.createUser(user, options);
+    	const requestContextPromise = this.requestFactory.createUser(user, options);
 
 		// build promise chain
-    	let middlewarePreObservable = of(requestContext);
+    let middlewarePreObservable = from<RequestContext>(requestContextPromise);
     	for (let middleware of this.configuration.middleware) {
     		middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
     	}
@@ -376,10 +376,10 @@ export class ObservableUserApi {
      * @param user List of user object
      */
     public createUsersWithArrayInput(user: Array<User>, options?: Configuration): Observable<void> {
-    	const requestContext = this.requestFactory.createUsersWithArrayInput(user, options);
+    	const requestContextPromise = this.requestFactory.createUsersWithArrayInput(user, options);
 
 		// build promise chain
-    	let middlewarePreObservable = of(requestContext);
+    let middlewarePreObservable = from<RequestContext>(requestContextPromise);
     	for (let middleware of this.configuration.middleware) {
     		middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
     	}
@@ -399,10 +399,10 @@ export class ObservableUserApi {
      * @param user List of user object
      */
     public createUsersWithListInput(user: Array<User>, options?: Configuration): Observable<void> {
-    	const requestContext = this.requestFactory.createUsersWithListInput(user, options);
+    	const requestContextPromise = this.requestFactory.createUsersWithListInput(user, options);
 
 		// build promise chain
-    	let middlewarePreObservable = of(requestContext);
+    let middlewarePreObservable = from<RequestContext>(requestContextPromise);
     	for (let middleware of this.configuration.middleware) {
     		middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
     	}
@@ -423,10 +423,10 @@ export class ObservableUserApi {
      * @param username The name that needs to be deleted
      */
     public deleteUser(username: string, options?: Configuration): Observable<void> {
-    	const requestContext = this.requestFactory.deleteUser(username, options);
+    	const requestContextPromise = this.requestFactory.deleteUser(username, options);
 
 		// build promise chain
-    	let middlewarePreObservable = of(requestContext);
+    let middlewarePreObservable = from<RequestContext>(requestContextPromise);
     	for (let middleware of this.configuration.middleware) {
     		middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
     	}
@@ -446,10 +446,10 @@ export class ObservableUserApi {
      * @param username The name that needs to be fetched. Use user1 for testing.
      */
     public getUserByName(username: string, options?: Configuration): Observable<User> {
-    	const requestContext = this.requestFactory.getUserByName(username, options);
+    	const requestContextPromise = this.requestFactory.getUserByName(username, options);
 
 		// build promise chain
-    	let middlewarePreObservable = of(requestContext);
+    let middlewarePreObservable = from<RequestContext>(requestContextPromise);
     	for (let middleware of this.configuration.middleware) {
     		middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
     	}
@@ -470,10 +470,10 @@ export class ObservableUserApi {
      * @param password The password for login in clear text
      */
     public loginUser(username: string, password: string, options?: Configuration): Observable<string> {
-    	const requestContext = this.requestFactory.loginUser(username, password, options);
+    	const requestContextPromise = this.requestFactory.loginUser(username, password, options);
 
 		// build promise chain
-    	let middlewarePreObservable = of(requestContext);
+    let middlewarePreObservable = from<RequestContext>(requestContextPromise);
     	for (let middleware of this.configuration.middleware) {
     		middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
     	}
@@ -492,10 +492,10 @@ export class ObservableUserApi {
      * Logs out current logged in user session
      */
     public logoutUser(options?: Configuration): Observable<void> {
-    	const requestContext = this.requestFactory.logoutUser(options);
+    	const requestContextPromise = this.requestFactory.logoutUser(options);
 
 		// build promise chain
-    	let middlewarePreObservable = of(requestContext);
+    let middlewarePreObservable = from<RequestContext>(requestContextPromise);
     	for (let middleware of this.configuration.middleware) {
     		middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
     	}
@@ -517,10 +517,10 @@ export class ObservableUserApi {
      * @param user Updated user object
      */
     public updateUser(username: string, user: User, options?: Configuration): Observable<void> {
-    	const requestContext = this.requestFactory.updateUser(username, user, options);
+    	const requestContextPromise = this.requestFactory.updateUser(username, user, options);
 
 		// build promise chain
-    	let middlewarePreObservable = of(requestContext);
+    let middlewarePreObservable = from<RequestContext>(requestContextPromise);
     	for (let middleware of this.configuration.middleware) {
     		middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
     	}

--- a/samples/openapi3/client/petstore/typescript/builds/jquery/apis/PetApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/jquery/apis/PetApi.ts
@@ -18,7 +18,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
      * Add a new pet to the store
      * @param pet Pet object that needs to be added to the store
      */
-    public addPet(pet: Pet, options?: Configuration): RequestContext {
+    public async addPet(pet: Pet, options?: Configuration): Promise<RequestContext> {
 		let config = options || this.configuration;
 		
         // verify required parameter 'pet' is not null or undefined
@@ -53,23 +53,23 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
             contentType
         );
         requestContext.setBody(serializedBody);
-		
-		let authMethod = null;
-    	// Apply auth methods
-    	authMethod = config.authMethods["petstore_auth"]
-    	if (authMethod) {
-    		authMethod.applySecurityAuthentication(requestContext);
-    	}
-    	
-    	return requestContext;
+
+        let authMethod = null;
+        // Apply auth methods
+        authMethod = config.authMethods["petstore_auth"]
+        if (authMethod) {
+            await authMethod.applySecurityAuthentication(requestContext);
+        }
+
+        return requestContext;
     }
-			
+
     /**
      * Deletes a pet
      * @param petId Pet id to delete
      * @param apiKey 
      */
-    public deletePet(petId: number, apiKey?: string, options?: Configuration): RequestContext {
+    public async deletePet(petId: number, apiKey?: string, options?: Configuration): Promise<RequestContext> {
 		let config = options || this.configuration;
 		
         // verify required parameter 'petId' is not null or undefined
@@ -96,23 +96,23 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
 
 
 		// Body Params
-		
-		let authMethod = null;
-    	// Apply auth methods
-    	authMethod = config.authMethods["petstore_auth"]
-    	if (authMethod) {
-    		authMethod.applySecurityAuthentication(requestContext);
-    	}
-    	
-    	return requestContext;
+
+        let authMethod = null;
+        // Apply auth methods
+        authMethod = config.authMethods["petstore_auth"]
+        if (authMethod) {
+            await authMethod.applySecurityAuthentication(requestContext);
+        }
+
+        return requestContext;
     }
-			
+
     /**
      * Multiple status values can be provided with comma separated strings
      * Finds Pets by status
      * @param status Status values that need to be considered for filter
      */
-    public findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, options?: Configuration): RequestContext {
+    public async findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, options?: Configuration): Promise<RequestContext> {
 		let config = options || this.configuration;
 		
         // verify required parameter 'status' is not null or undefined
@@ -139,23 +139,23 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
 
 
 		// Body Params
-		
-		let authMethod = null;
-    	// Apply auth methods
-    	authMethod = config.authMethods["petstore_auth"]
-    	if (authMethod) {
-    		authMethod.applySecurityAuthentication(requestContext);
-    	}
-    	
-    	return requestContext;
+
+        let authMethod = null;
+        // Apply auth methods
+        authMethod = config.authMethods["petstore_auth"]
+        if (authMethod) {
+            await authMethod.applySecurityAuthentication(requestContext);
+        }
+
+        return requestContext;
     }
-			
+
     /**
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * Finds Pets by tags
      * @param tags Tags to filter by
      */
-    public findPetsByTags(tags: Array<string>, options?: Configuration): RequestContext {
+    public async findPetsByTags(tags: Array<string>, options?: Configuration): Promise<RequestContext> {
 		let config = options || this.configuration;
 		
         // verify required parameter 'tags' is not null or undefined
@@ -182,23 +182,23 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
 
 
 		// Body Params
-		
-		let authMethod = null;
-    	// Apply auth methods
-    	authMethod = config.authMethods["petstore_auth"]
-    	if (authMethod) {
-    		authMethod.applySecurityAuthentication(requestContext);
-    	}
-    	
-    	return requestContext;
+
+        let authMethod = null;
+        // Apply auth methods
+        authMethod = config.authMethods["petstore_auth"]
+        if (authMethod) {
+            await authMethod.applySecurityAuthentication(requestContext);
+        }
+
+        return requestContext;
     }
-			
+
     /**
      * Returns a single pet
      * Find pet by ID
      * @param petId ID of pet to return
      */
-    public getPetById(petId: number, options?: Configuration): RequestContext {
+    public async getPetById(petId: number, options?: Configuration): Promise<RequestContext> {
 		let config = options || this.configuration;
 		
         // verify required parameter 'petId' is not null or undefined
@@ -223,22 +223,22 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
 
 
 		// Body Params
-		
-		let authMethod = null;
-    	// Apply auth methods
-    	authMethod = config.authMethods["api_key"]
-    	if (authMethod) {
-    		authMethod.applySecurityAuthentication(requestContext);
-    	}
-    	
-    	return requestContext;
+
+        let authMethod = null;
+        // Apply auth methods
+        authMethod = config.authMethods["api_key"]
+        if (authMethod) {
+            await authMethod.applySecurityAuthentication(requestContext);
+        }
+
+        return requestContext;
     }
-			
+
     /**
      * Update an existing pet
      * @param pet Pet object that needs to be added to the store
      */
-    public updatePet(pet: Pet, options?: Configuration): RequestContext {
+    public async updatePet(pet: Pet, options?: Configuration): Promise<RequestContext> {
 		let config = options || this.configuration;
 		
         // verify required parameter 'pet' is not null or undefined
@@ -273,24 +273,24 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
             contentType
         );
         requestContext.setBody(serializedBody);
-		
-		let authMethod = null;
-    	// Apply auth methods
-    	authMethod = config.authMethods["petstore_auth"]
-    	if (authMethod) {
-    		authMethod.applySecurityAuthentication(requestContext);
-    	}
-    	
-    	return requestContext;
+
+        let authMethod = null;
+        // Apply auth methods
+        authMethod = config.authMethods["petstore_auth"]
+        if (authMethod) {
+            await authMethod.applySecurityAuthentication(requestContext);
+        }
+
+        return requestContext;
     }
-			
+
     /**
      * Updates a pet in the store with form data
      * @param petId ID of pet that needs to be updated
      * @param name Updated name of the pet
      * @param status Updated status of the pet
      */
-    public updatePetWithForm(petId: number, name?: string, status?: string, options?: Configuration): RequestContext {
+    public async updatePetWithForm(petId: number, name?: string, status?: string, options?: Configuration): Promise<RequestContext> {
 		let config = options || this.configuration;
 		
         // verify required parameter 'petId' is not null or undefined
@@ -327,24 +327,24 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
 		requestContext.setBody(localVarFormParams);
 
 		// Body Params
-		
-		let authMethod = null;
-    	// Apply auth methods
-    	authMethod = config.authMethods["petstore_auth"]
-    	if (authMethod) {
-    		authMethod.applySecurityAuthentication(requestContext);
-    	}
-    	
-    	return requestContext;
+
+        let authMethod = null;
+        // Apply auth methods
+        authMethod = config.authMethods["petstore_auth"]
+        if (authMethod) {
+            await authMethod.applySecurityAuthentication(requestContext);
+        }
+
+        return requestContext;
     }
-			
+
     /**
      * uploads an image
      * @param petId ID of pet to update
      * @param additionalMetadata Additional data to pass to server
      * @param file file to upload
      */
-    public uploadFile(petId: number, additionalMetadata?: string, file?: HttpFile, options?: Configuration): RequestContext {
+    public async uploadFile(petId: number, additionalMetadata?: string, file?: HttpFile, options?: Configuration): Promise<RequestContext> {
 		let config = options || this.configuration;
 		
         // verify required parameter 'petId' is not null or undefined
@@ -381,17 +381,17 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
 		requestContext.setBody(localVarFormParams);
 
 		// Body Params
-		
-		let authMethod = null;
-    	// Apply auth methods
-    	authMethod = config.authMethods["petstore_auth"]
-    	if (authMethod) {
-    		authMethod.applySecurityAuthentication(requestContext);
-    	}
-    	
-    	return requestContext;
+
+        let authMethod = null;
+        // Apply auth methods
+        authMethod = config.authMethods["petstore_auth"]
+        if (authMethod) {
+            await authMethod.applySecurityAuthentication(requestContext);
+        }
+
+        return requestContext;
     }
-			
+
 }
 
 

--- a/samples/openapi3/client/petstore/typescript/builds/jquery/apis/StoreApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/jquery/apis/StoreApi.ts
@@ -18,7 +18,7 @@ export class StoreApiRequestFactory extends BaseAPIRequestFactory {
      * Delete purchase order by ID
      * @param orderId ID of the order that needs to be deleted
      */
-    public deleteOrder(orderId: string, options?: Configuration): RequestContext {
+    public async deleteOrder(orderId: string, options?: Configuration): Promise<RequestContext> {
 		let config = options || this.configuration;
 		
         // verify required parameter 'orderId' is not null or undefined
@@ -43,17 +43,17 @@ export class StoreApiRequestFactory extends BaseAPIRequestFactory {
 
 
 		// Body Params
-		
-    	// Apply auth methods
-    	
-    	return requestContext;
+
+        // Apply auth methods
+
+        return requestContext;
     }
-			
+
     /**
      * Returns a map of status codes to quantities
      * Returns pet inventories by status
      */
-    public getInventory(options?: Configuration): RequestContext {
+    public async getInventory(options?: Configuration): Promise<RequestContext> {
 		let config = options || this.configuration;
 		
 		// Path Params
@@ -71,23 +71,23 @@ export class StoreApiRequestFactory extends BaseAPIRequestFactory {
 
 
 		// Body Params
-		
-		let authMethod = null;
-    	// Apply auth methods
-    	authMethod = config.authMethods["api_key"]
-    	if (authMethod) {
-    		authMethod.applySecurityAuthentication(requestContext);
-    	}
-    	
-    	return requestContext;
+
+        let authMethod = null;
+        // Apply auth methods
+        authMethod = config.authMethods["api_key"]
+        if (authMethod) {
+            await authMethod.applySecurityAuthentication(requestContext);
+        }
+
+        return requestContext;
     }
-			
+
     /**
      * For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
      * Find purchase order by ID
      * @param orderId ID of pet that needs to be fetched
      */
-    public getOrderById(orderId: number, options?: Configuration): RequestContext {
+    public async getOrderById(orderId: number, options?: Configuration): Promise<RequestContext> {
 		let config = options || this.configuration;
 		
         // verify required parameter 'orderId' is not null or undefined
@@ -112,17 +112,17 @@ export class StoreApiRequestFactory extends BaseAPIRequestFactory {
 
 
 		// Body Params
-		
-    	// Apply auth methods
-    	
-    	return requestContext;
+
+        // Apply auth methods
+
+        return requestContext;
     }
-			
+
     /**
      * Place an order for a pet
      * @param order order placed for purchasing the pet
      */
-    public placeOrder(order: Order, options?: Configuration): RequestContext {
+    public async placeOrder(order: Order, options?: Configuration): Promise<RequestContext> {
 		let config = options || this.configuration;
 		
         // verify required parameter 'order' is not null or undefined
@@ -155,12 +155,12 @@ export class StoreApiRequestFactory extends BaseAPIRequestFactory {
             contentType
         );
         requestContext.setBody(serializedBody);
-		
-    	// Apply auth methods
-    	
-    	return requestContext;
+
+        // Apply auth methods
+
+        return requestContext;
     }
-			
+
 }
 
 

--- a/samples/openapi3/client/petstore/typescript/builds/jquery/apis/UserApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/jquery/apis/UserApi.ts
@@ -18,7 +18,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
      * Create user
      * @param user Created user object
      */
-    public createUser(user: User, options?: Configuration): RequestContext {
+    public async createUser(user: User, options?: Configuration): Promise<RequestContext> {
 		let config = options || this.configuration;
 		
         // verify required parameter 'user' is not null or undefined
@@ -51,22 +51,22 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
             contentType
         );
         requestContext.setBody(serializedBody);
-		
-		let authMethod = null;
-    	// Apply auth methods
-    	authMethod = config.authMethods["api_key"]
-    	if (authMethod) {
-    		authMethod.applySecurityAuthentication(requestContext);
-    	}
-    	
-    	return requestContext;
+
+        let authMethod = null;
+        // Apply auth methods
+        authMethod = config.authMethods["api_key"]
+        if (authMethod) {
+            await authMethod.applySecurityAuthentication(requestContext);
+        }
+
+        return requestContext;
     }
-			
+
     /**
      * Creates list of users with given input array
      * @param user List of user object
      */
-    public createUsersWithArrayInput(user: Array<User>, options?: Configuration): RequestContext {
+    public async createUsersWithArrayInput(user: Array<User>, options?: Configuration): Promise<RequestContext> {
 		let config = options || this.configuration;
 		
         // verify required parameter 'user' is not null or undefined
@@ -99,22 +99,22 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
             contentType
         );
         requestContext.setBody(serializedBody);
-		
-		let authMethod = null;
-    	// Apply auth methods
-    	authMethod = config.authMethods["api_key"]
-    	if (authMethod) {
-    		authMethod.applySecurityAuthentication(requestContext);
-    	}
-    	
-    	return requestContext;
+
+        let authMethod = null;
+        // Apply auth methods
+        authMethod = config.authMethods["api_key"]
+        if (authMethod) {
+            await authMethod.applySecurityAuthentication(requestContext);
+        }
+
+        return requestContext;
     }
-			
+
     /**
      * Creates list of users with given input array
      * @param user List of user object
      */
-    public createUsersWithListInput(user: Array<User>, options?: Configuration): RequestContext {
+    public async createUsersWithListInput(user: Array<User>, options?: Configuration): Promise<RequestContext> {
 		let config = options || this.configuration;
 		
         // verify required parameter 'user' is not null or undefined
@@ -147,23 +147,23 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
             contentType
         );
         requestContext.setBody(serializedBody);
-		
-		let authMethod = null;
-    	// Apply auth methods
-    	authMethod = config.authMethods["api_key"]
-    	if (authMethod) {
-    		authMethod.applySecurityAuthentication(requestContext);
-    	}
-    	
-    	return requestContext;
+
+        let authMethod = null;
+        // Apply auth methods
+        authMethod = config.authMethods["api_key"]
+        if (authMethod) {
+            await authMethod.applySecurityAuthentication(requestContext);
+        }
+
+        return requestContext;
     }
-			
+
     /**
      * This can only be done by the logged in user.
      * Delete user
      * @param username The name that needs to be deleted
      */
-    public deleteUser(username: string, options?: Configuration): RequestContext {
+    public async deleteUser(username: string, options?: Configuration): Promise<RequestContext> {
 		let config = options || this.configuration;
 		
         // verify required parameter 'username' is not null or undefined
@@ -188,22 +188,22 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
 
 
 		// Body Params
-		
-		let authMethod = null;
-    	// Apply auth methods
-    	authMethod = config.authMethods["api_key"]
-    	if (authMethod) {
-    		authMethod.applySecurityAuthentication(requestContext);
-    	}
-    	
-    	return requestContext;
+
+        let authMethod = null;
+        // Apply auth methods
+        authMethod = config.authMethods["api_key"]
+        if (authMethod) {
+            await authMethod.applySecurityAuthentication(requestContext);
+        }
+
+        return requestContext;
     }
-			
+
     /**
      * Get user by user name
      * @param username The name that needs to be fetched. Use user1 for testing.
      */
-    public getUserByName(username: string, options?: Configuration): RequestContext {
+    public async getUserByName(username: string, options?: Configuration): Promise<RequestContext> {
 		let config = options || this.configuration;
 		
         // verify required parameter 'username' is not null or undefined
@@ -228,18 +228,18 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
 
 
 		// Body Params
-		
-    	// Apply auth methods
-    	
-    	return requestContext;
+
+        // Apply auth methods
+
+        return requestContext;
     }
-			
+
     /**
      * Logs user into the system
      * @param username The user name for login
      * @param password The password for login in clear text
      */
-    public loginUser(username: string, password: string, options?: Configuration): RequestContext {
+    public async loginUser(username: string, password: string, options?: Configuration): Promise<RequestContext> {
 		let config = options || this.configuration;
 		
         // verify required parameter 'username' is not null or undefined
@@ -275,16 +275,16 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
 
 
 		// Body Params
-		
-    	// Apply auth methods
-    	
-    	return requestContext;
+
+        // Apply auth methods
+
+        return requestContext;
     }
-			
+
     /**
      * Logs out current logged in user session
      */
-    public logoutUser(options?: Configuration): RequestContext {
+    public async logoutUser(options?: Configuration): Promise<RequestContext> {
 		let config = options || this.configuration;
 		
 		// Path Params
@@ -302,24 +302,24 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
 
 
 		// Body Params
-		
-		let authMethod = null;
-    	// Apply auth methods
-    	authMethod = config.authMethods["api_key"]
-    	if (authMethod) {
-    		authMethod.applySecurityAuthentication(requestContext);
-    	}
-    	
-    	return requestContext;
+
+        let authMethod = null;
+        // Apply auth methods
+        authMethod = config.authMethods["api_key"]
+        if (authMethod) {
+            await authMethod.applySecurityAuthentication(requestContext);
+        }
+
+        return requestContext;
     }
-			
+
     /**
      * This can only be done by the logged in user.
      * Updated user
      * @param username name that need to be deleted
      * @param user Updated user object
      */
-    public updateUser(username: string, user: User, options?: Configuration): RequestContext {
+    public async updateUser(username: string, user: User, options?: Configuration): Promise<RequestContext> {
 		let config = options || this.configuration;
 		
         // verify required parameter 'username' is not null or undefined
@@ -359,17 +359,17 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
             contentType
         );
         requestContext.setBody(serializedBody);
-		
-		let authMethod = null;
-    	// Apply auth methods
-    	authMethod = config.authMethods["api_key"]
-    	if (authMethod) {
-    		authMethod.applySecurityAuthentication(requestContext);
-    	}
-    	
-    	return requestContext;
+
+        let authMethod = null;
+        // Apply auth methods
+        authMethod = config.authMethods["api_key"]
+        if (authMethod) {
+            await authMethod.applySecurityAuthentication(requestContext);
+        }
+
+        return requestContext;
     }
-			
+
 }
 
 

--- a/samples/openapi3/client/petstore/typescript/builds/jquery/auth/auth.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/jquery/auth/auth.ts
@@ -26,7 +26,7 @@ export abstract class SecurityAuthentication {
 	 * 
 	 * @params context the request context which should use this authentication scheme
 	 */
-	public abstract applySecurityAuthentication(context: RequestContext): void;
+   public abstract applySecurityAuthentication(context: RequestContext): void | Promise<void>;
 
 }
 
@@ -100,7 +100,7 @@ export class HttpBasicAuthentication extends SecurityAuthentication {
 }
 
 export interface TokenProvider {
-  getToken(): string;
+  getToken(): Promise<string> | string;
 }
 
 /**
@@ -119,8 +119,8 @@ export class HttpBearerAuthentication extends SecurityAuthentication {
         super(authName);
     }
 
-    public applySecurityAuthentication(context: RequestContext) {
-        context.setHeaderParam("Authorization", "Bearer " + this.tokenProvider.getToken());
+    public async applySecurityAuthentication(context: RequestContext) {
+        context.setHeaderParam("Authorization", "Bearer " + await this.tokenProvider.getToken());
     }
 }
 

--- a/samples/openapi3/client/petstore/typescript/builds/jquery/auth/auth.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/jquery/auth/auth.ts
@@ -99,6 +99,31 @@ export class HttpBasicAuthentication extends SecurityAuthentication {
 	}
 }
 
+export interface TokenProvider {
+  getToken(): string;
+}
+
+/**
+ * Applies http bearer authentication to a request.
+ *
+ */
+export class HttpBearerAuthentication extends SecurityAuthentication {
+    /**
+     * Configures the http authentication with the required details.
+     *
+     *
+     * @param authName name of the authentication scheme as defined in openapi specification
+     * @param tokenProvider service that can provide the up-to-date token when needed
+     */
+    public constructor(authName: string, private tokenProvider: TokenProvider) {
+        super(authName);
+    }
+
+    public applySecurityAuthentication(context: RequestContext) {
+        context.setHeaderParam("Authentication", "Bearer " + this.tokenProvider.getToken());
+    }
+}
+
 // TODO: How to handle oauth2 authentication!
 export class OAuth2Authentication extends SecurityAuthentication {
 	public constructor(authName: string) {
@@ -117,6 +142,7 @@ export type AuthMethods = {
 
 export type ApiKeyConfiguration = string;
 export type HttpBasicConfiguration = { "username": string, "password": string };
+export type HttpBearerConfiguration = { tokenProvider: TokenProvider };
 export type OAuth2Configuration = string;
 
 export type AuthMethodsConfiguration = { "api_key"?:ApiKeyConfiguration,  "petstore_auth"?:OAuth2Configuration,   }
@@ -125,19 +151,18 @@ export type AuthMethodsConfiguration = { "api_key"?:ApiKeyConfiguration,  "petst
  * Creates the authentication methods from a swagger description.
  *
  */
-export function configureAuthMethods(conf: AuthMethodsConfiguration | undefined): AuthMethods {
-	let authMethods: AuthMethods = {
+export function configureAuthMethods(config: AuthMethodsConfiguration | undefined): AuthMethods {
+    let authMethods: AuthMethods = {}
+
+    if (!config) {
+        return authMethods;
+    }
+
+    if (config["api_key"]) {
+        authMethods["api_key"] = new APIKeyAuthentication("api_key",  "api_key", "header", <string> config["api_key"]);
 	}
 
-	if (!conf) {
-		return authMethods;
-	}		
-
-	if (conf["api_key"]) {
-		authMethods["api_key"] = new APIKeyAuthentication("api_key",  "api_key", "header", <string> conf["api_key"]);
-	}
-
-	if (conf["petstore_auth"]) {
+    if (config["petstore_auth"]) {
 		authMethods["petstore_auth"] = new OAuth2Authentication("petstore_auth");
 	}
 

--- a/samples/openapi3/client/petstore/typescript/builds/jquery/auth/auth.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/jquery/auth/auth.ts
@@ -95,7 +95,7 @@ export class HttpBasicAuthentication extends SecurityAuthentication {
 	
 	public applySecurityAuthentication(context: RequestContext) {
 		let comb = this.username + ":" + this.password;
-		context.setHeaderParam("Authentication", "Basic " + btoa(comb));
+		context.setHeaderParam("Authorization", "Basic " + btoa(comb));
 	}
 }
 
@@ -120,7 +120,7 @@ export class HttpBearerAuthentication extends SecurityAuthentication {
     }
 
     public applySecurityAuthentication(context: RequestContext) {
-        context.setHeaderParam("Authentication", "Bearer " + this.tokenProvider.getToken());
+        context.setHeaderParam("Authorization", "Bearer " + this.tokenProvider.getToken());
     }
 }
 

--- a/samples/openapi3/client/petstore/typescript/builds/jquery/http/http.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/jquery/http/http.ts
@@ -144,7 +144,7 @@ export class SelfDecodingBody implements ResponseBody {
 
         return new Promise<string>((resolve, reject) => {
             const reader = new FileReader();
-            reader.addEventListener("load", () => resolve(reader.result));
+            reader.addEventListener("load", () => resolve(reader.result as string));
             reader.addEventListener("error", () => reject(reader.error));
             reader.readAsText(data);
         });

--- a/samples/openapi3/client/petstore/typescript/builds/jquery/package-lock.json
+++ b/samples/openapi3/client/petstore/typescript/builds/jquery/package-lock.json
@@ -43,9 +43,9 @@
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
     },
     "typescript": {
-      "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.9.2.tgz",
-      "integrity": "sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==",
+      "version": "3.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.3.tgz",
+      "integrity": "sha512-D/wqnB2xzNFIcoBG9FG8cXRDjiqSTbG2wd8DMZeQyJlP1vfTkIxH4GKveWaEBYySKIg+USu+E+EDIR47SqnaMQ==",
       "dev": true
     },
     "url-parse": {

--- a/samples/openapi3/client/petstore/typescript/builds/jquery/package.json
+++ b/samples/openapi3/client/petstore/typescript/builds/jquery/package.json
@@ -24,6 +24,6 @@
     "url-parse": "^1.4.3"
   },
   "devDependencies": {
-    "typescript": "^2.9.2"
+    "typescript": "^3.9.3"
   }
 }

--- a/samples/openapi3/client/petstore/typescript/builds/jquery/servers.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/jquery/servers.ts
@@ -6,25 +6,17 @@ import {RequestContext, HttpMethod} from './http/http';
  * url template and variable configuration based on the url.
  *
  */
-export class ServerConfiguration<T> {
-	
-    public constructor(private url: string, private variableConfiguration: T) {
+export class ServerConfiguration<T extends { [key: string]: string }> {
+    public constructor(private url: string, private variableConfiguration: T) {}
+
+    /**
+     * Sets the value of the variables of this server.
+     *
+     * @param variableConfiguration a partial variable configuration for the variables contained in the url
+     */
+    public setVariables(variableConfiguration: Partial<T>) {
+        Object.assign(this.variableConfiguration, variableConfiguration);
     }
-	
-	/**
-	 * Sets the value of the variables of this server.
-	 *
-	 * @param variableConfiguration a partial variable configuration for the variables contained in the url
-	 */
-	public setVariables(variableConfiguration: Partial<T>) {
-		for (const key in variableConfiguration) {
-			const val = variableConfiguration[key]
-			// We know that val isn't undefined here - hopefully
-			if (val !== undefined) {
-				this.variableConfiguration[key] = val as T[Extract<keyof T, string>];
-			}
-		}
-	}
 
 	public getConfiguration(): T {
 		return this.variableConfiguration
@@ -34,7 +26,7 @@ export class ServerConfiguration<T> {
 		let replacedUrl = this.url;
 		for (const key in this.variableConfiguration) {
 			var re = new RegExp("{" + key + "}","g");
-			replacedUrl = replacedUrl.replace(re, this.variableConfiguration[key].toString());
+			replacedUrl = replacedUrl.replace(re, this.variableConfiguration[key]);
 		}
 		return replacedUrl
 	}

--- a/samples/openapi3/client/petstore/typescript/builds/jquery/types/ObservableAPI.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/jquery/types/ObservableAPI.ts
@@ -1,7 +1,7 @@
 import { ResponseContext, RequestContext, HttpFile } from '../http/http';
 import * as models from '../models/all';
 import { Configuration} from '../configuration'
-import { Observable, of } from '../rxjsStub';
+import { Observable, of, from } from '../rxjsStub';
 import {mergeMap, map} from  '../rxjsStub';
 
 import { ApiResponse } from '../models/ApiResponse';
@@ -30,10 +30,10 @@ export class ObservablePetApi {
      * @param pet Pet object that needs to be added to the store
      */
     public addPet(pet: Pet, options?: Configuration): Observable<Pet> {
-    	const requestContext = this.requestFactory.addPet(pet, options);
+    	const requestContextPromise = this.requestFactory.addPet(pet, options);
 
 		// build promise chain
-    	let middlewarePreObservable = of(requestContext);
+    let middlewarePreObservable = from<RequestContext>(requestContextPromise);
     	for (let middleware of this.configuration.middleware) {
     		middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
     	}
@@ -54,10 +54,10 @@ export class ObservablePetApi {
      * @param apiKey 
      */
     public deletePet(petId: number, apiKey?: string, options?: Configuration): Observable<void> {
-    	const requestContext = this.requestFactory.deletePet(petId, apiKey, options);
+    	const requestContextPromise = this.requestFactory.deletePet(petId, apiKey, options);
 
 		// build promise chain
-    	let middlewarePreObservable = of(requestContext);
+    let middlewarePreObservable = from<RequestContext>(requestContextPromise);
     	for (let middleware of this.configuration.middleware) {
     		middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
     	}
@@ -78,10 +78,10 @@ export class ObservablePetApi {
      * @param status Status values that need to be considered for filter
      */
     public findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, options?: Configuration): Observable<Array<Pet>> {
-    	const requestContext = this.requestFactory.findPetsByStatus(status, options);
+    	const requestContextPromise = this.requestFactory.findPetsByStatus(status, options);
 
 		// build promise chain
-    	let middlewarePreObservable = of(requestContext);
+    let middlewarePreObservable = from<RequestContext>(requestContextPromise);
     	for (let middleware of this.configuration.middleware) {
     		middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
     	}
@@ -102,10 +102,10 @@ export class ObservablePetApi {
      * @param tags Tags to filter by
      */
     public findPetsByTags(tags: Array<string>, options?: Configuration): Observable<Array<Pet>> {
-    	const requestContext = this.requestFactory.findPetsByTags(tags, options);
+    	const requestContextPromise = this.requestFactory.findPetsByTags(tags, options);
 
 		// build promise chain
-    	let middlewarePreObservable = of(requestContext);
+    let middlewarePreObservable = from<RequestContext>(requestContextPromise);
     	for (let middleware of this.configuration.middleware) {
     		middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
     	}
@@ -126,10 +126,10 @@ export class ObservablePetApi {
      * @param petId ID of pet to return
      */
     public getPetById(petId: number, options?: Configuration): Observable<Pet> {
-    	const requestContext = this.requestFactory.getPetById(petId, options);
+    	const requestContextPromise = this.requestFactory.getPetById(petId, options);
 
 		// build promise chain
-    	let middlewarePreObservable = of(requestContext);
+    let middlewarePreObservable = from<RequestContext>(requestContextPromise);
     	for (let middleware of this.configuration.middleware) {
     		middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
     	}
@@ -149,10 +149,10 @@ export class ObservablePetApi {
      * @param pet Pet object that needs to be added to the store
      */
     public updatePet(pet: Pet, options?: Configuration): Observable<Pet> {
-    	const requestContext = this.requestFactory.updatePet(pet, options);
+    	const requestContextPromise = this.requestFactory.updatePet(pet, options);
 
 		// build promise chain
-    	let middlewarePreObservable = of(requestContext);
+    let middlewarePreObservable = from<RequestContext>(requestContextPromise);
     	for (let middleware of this.configuration.middleware) {
     		middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
     	}
@@ -174,10 +174,10 @@ export class ObservablePetApi {
      * @param status Updated status of the pet
      */
     public updatePetWithForm(petId: number, name?: string, status?: string, options?: Configuration): Observable<void> {
-    	const requestContext = this.requestFactory.updatePetWithForm(petId, name, status, options);
+    	const requestContextPromise = this.requestFactory.updatePetWithForm(petId, name, status, options);
 
 		// build promise chain
-    	let middlewarePreObservable = of(requestContext);
+    let middlewarePreObservable = from<RequestContext>(requestContextPromise);
     	for (let middleware of this.configuration.middleware) {
     		middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
     	}
@@ -199,10 +199,10 @@ export class ObservablePetApi {
      * @param file file to upload
      */
     public uploadFile(petId: number, additionalMetadata?: string, file?: HttpFile, options?: Configuration): Observable<ApiResponse> {
-    	const requestContext = this.requestFactory.uploadFile(petId, additionalMetadata, file, options);
+    	const requestContextPromise = this.requestFactory.uploadFile(petId, additionalMetadata, file, options);
 
 		// build promise chain
-    	let middlewarePreObservable = of(requestContext);
+    let middlewarePreObservable = from<RequestContext>(requestContextPromise);
     	for (let middleware of this.configuration.middleware) {
     		middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
     	}
@@ -241,10 +241,10 @@ export class ObservableStoreApi {
      * @param orderId ID of the order that needs to be deleted
      */
     public deleteOrder(orderId: string, options?: Configuration): Observable<void> {
-    	const requestContext = this.requestFactory.deleteOrder(orderId, options);
+    	const requestContextPromise = this.requestFactory.deleteOrder(orderId, options);
 
 		// build promise chain
-    	let middlewarePreObservable = of(requestContext);
+    let middlewarePreObservable = from<RequestContext>(requestContextPromise);
     	for (let middleware of this.configuration.middleware) {
     		middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
     	}
@@ -264,10 +264,10 @@ export class ObservableStoreApi {
      * Returns pet inventories by status
      */
     public getInventory(options?: Configuration): Observable<{ [key: string]: number; }> {
-    	const requestContext = this.requestFactory.getInventory(options);
+    	const requestContextPromise = this.requestFactory.getInventory(options);
 
 		// build promise chain
-    	let middlewarePreObservable = of(requestContext);
+    let middlewarePreObservable = from<RequestContext>(requestContextPromise);
     	for (let middleware of this.configuration.middleware) {
     		middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
     	}
@@ -288,10 +288,10 @@ export class ObservableStoreApi {
      * @param orderId ID of pet that needs to be fetched
      */
     public getOrderById(orderId: number, options?: Configuration): Observable<Order> {
-    	const requestContext = this.requestFactory.getOrderById(orderId, options);
+    	const requestContextPromise = this.requestFactory.getOrderById(orderId, options);
 
 		// build promise chain
-    	let middlewarePreObservable = of(requestContext);
+    let middlewarePreObservable = from<RequestContext>(requestContextPromise);
     	for (let middleware of this.configuration.middleware) {
     		middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
     	}
@@ -311,10 +311,10 @@ export class ObservableStoreApi {
      * @param order order placed for purchasing the pet
      */
     public placeOrder(order: Order, options?: Configuration): Observable<Order> {
-    	const requestContext = this.requestFactory.placeOrder(order, options);
+    	const requestContextPromise = this.requestFactory.placeOrder(order, options);
 
 		// build promise chain
-    	let middlewarePreObservable = of(requestContext);
+    let middlewarePreObservable = from<RequestContext>(requestContextPromise);
     	for (let middleware of this.configuration.middleware) {
     		middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
     	}
@@ -353,10 +353,10 @@ export class ObservableUserApi {
      * @param user Created user object
      */
     public createUser(user: User, options?: Configuration): Observable<void> {
-    	const requestContext = this.requestFactory.createUser(user, options);
+    	const requestContextPromise = this.requestFactory.createUser(user, options);
 
 		// build promise chain
-    	let middlewarePreObservable = of(requestContext);
+    let middlewarePreObservable = from<RequestContext>(requestContextPromise);
     	for (let middleware of this.configuration.middleware) {
     		middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
     	}
@@ -376,10 +376,10 @@ export class ObservableUserApi {
      * @param user List of user object
      */
     public createUsersWithArrayInput(user: Array<User>, options?: Configuration): Observable<void> {
-    	const requestContext = this.requestFactory.createUsersWithArrayInput(user, options);
+    	const requestContextPromise = this.requestFactory.createUsersWithArrayInput(user, options);
 
 		// build promise chain
-    	let middlewarePreObservable = of(requestContext);
+    let middlewarePreObservable = from<RequestContext>(requestContextPromise);
     	for (let middleware of this.configuration.middleware) {
     		middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
     	}
@@ -399,10 +399,10 @@ export class ObservableUserApi {
      * @param user List of user object
      */
     public createUsersWithListInput(user: Array<User>, options?: Configuration): Observable<void> {
-    	const requestContext = this.requestFactory.createUsersWithListInput(user, options);
+    	const requestContextPromise = this.requestFactory.createUsersWithListInput(user, options);
 
 		// build promise chain
-    	let middlewarePreObservable = of(requestContext);
+    let middlewarePreObservable = from<RequestContext>(requestContextPromise);
     	for (let middleware of this.configuration.middleware) {
     		middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
     	}
@@ -423,10 +423,10 @@ export class ObservableUserApi {
      * @param username The name that needs to be deleted
      */
     public deleteUser(username: string, options?: Configuration): Observable<void> {
-    	const requestContext = this.requestFactory.deleteUser(username, options);
+    	const requestContextPromise = this.requestFactory.deleteUser(username, options);
 
 		// build promise chain
-    	let middlewarePreObservable = of(requestContext);
+    let middlewarePreObservable = from<RequestContext>(requestContextPromise);
     	for (let middleware of this.configuration.middleware) {
     		middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
     	}
@@ -446,10 +446,10 @@ export class ObservableUserApi {
      * @param username The name that needs to be fetched. Use user1 for testing.
      */
     public getUserByName(username: string, options?: Configuration): Observable<User> {
-    	const requestContext = this.requestFactory.getUserByName(username, options);
+    	const requestContextPromise = this.requestFactory.getUserByName(username, options);
 
 		// build promise chain
-    	let middlewarePreObservable = of(requestContext);
+    let middlewarePreObservable = from<RequestContext>(requestContextPromise);
     	for (let middleware of this.configuration.middleware) {
     		middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
     	}
@@ -470,10 +470,10 @@ export class ObservableUserApi {
      * @param password The password for login in clear text
      */
     public loginUser(username: string, password: string, options?: Configuration): Observable<string> {
-    	const requestContext = this.requestFactory.loginUser(username, password, options);
+    	const requestContextPromise = this.requestFactory.loginUser(username, password, options);
 
 		// build promise chain
-    	let middlewarePreObservable = of(requestContext);
+    let middlewarePreObservable = from<RequestContext>(requestContextPromise);
     	for (let middleware of this.configuration.middleware) {
     		middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
     	}
@@ -492,10 +492,10 @@ export class ObservableUserApi {
      * Logs out current logged in user session
      */
     public logoutUser(options?: Configuration): Observable<void> {
-    	const requestContext = this.requestFactory.logoutUser(options);
+    	const requestContextPromise = this.requestFactory.logoutUser(options);
 
 		// build promise chain
-    	let middlewarePreObservable = of(requestContext);
+    let middlewarePreObservable = from<RequestContext>(requestContextPromise);
     	for (let middleware of this.configuration.middleware) {
     		middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
     	}
@@ -517,10 +517,10 @@ export class ObservableUserApi {
      * @param user Updated user object
      */
     public updateUser(username: string, user: User, options?: Configuration): Observable<void> {
-    	const requestContext = this.requestFactory.updateUser(username, user, options);
+    	const requestContextPromise = this.requestFactory.updateUser(username, user, options);
 
 		// build promise chain
-    	let middlewarePreObservable = of(requestContext);
+    let middlewarePreObservable = from<RequestContext>(requestContextPromise);
     	for (let middleware of this.configuration.middleware) {
     		middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
     	}

--- a/samples/openapi3/client/petstore/typescript/tests/default/package-lock.json
+++ b/samples/openapi3/client/petstore/typescript/tests/default/package-lock.json
@@ -1259,6 +1259,27 @@
             }
           }
         },
+        "@types/node-fetch": {
+          "version": "2.5.7",
+          "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.7.tgz",
+          "integrity": "sha512-o2WVNf5UhWRkxlf6eq+jMZDu7kjgpgJfl4xVNlvryc95O/6F2ld8ztKX+qu+Rjyet93WAWm5LjeX9H5FGkODvw==",
+          "requires": {
+            "@types/node": "*",
+            "form-data": "^3.0.0"
+          },
+          "dependencies": {
+            "form-data": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
+              "integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
+              "requires": {
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.8",
+                "mime-types": "^2.1.12"
+              }
+            }
+          }
+        },
         "asynckit": {
           "version": "0.4.0",
           "bundled": true


### PR DESCRIPTION
Previously I defined my own SecurityAuthentication class. This PR adds support for bearer token authentication directly to the typescript generator.
The configuration requires a (possibly asynchronous) token provider class. This is so that the token can be refreshed if necessary. Also the token provider can later be injected with inversifyjs.

Would it be useful, to also use credential providers in the other security types? Maybe a more generic solution could be used?
In our use case the bearer token changes frequently, but I'm not sure what the common api token or basic auth use cases need.

I also updated typescript to 3.9 which hopefully avoids some issues with the ancient version we where using before.
Some commits are cherry-picked from typescript-refactor-master-oaiv3 to make the tests work, but once #6416 is merged, I can remove them again.
Furthermore I added a fix for http basic auth.

Cf. #802
CC @TiFu

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
