### PR TITLE
[PS] Fix hardcoded match type

### DIFF
--- a/modules/openapi-generator/src/main/resources/powershell/model_anyof.mustache
+++ b/modules/openapi-generator/src/main/resources/powershell/model_anyof.mustache
@@ -46,7 +46,7 @@ function ConvertFrom-{{{apiNamePrefix}}}JsonTo{{{classname}}} {
 
                 foreach($property in $matchInstance.PsObject.Properties) {
                     if ($null -ne $property.Value) {
-                        $matchType = "Dog"
+                        $matchType = "{{{.}}}"
                         $match++
                         break
                     }

--- a/modules/openapi-generator/src/main/resources/powershell/model_oneof.mustache
+++ b/modules/openapi-generator/src/main/resources/powershell/model_oneof.mustache
@@ -45,7 +45,7 @@ function ConvertFrom-{{{apiNamePrefix}}}JsonTo{{{classname}}} {
 
             foreach($property in $matchInstance.PsObject.Properties) {
                 if ($null -ne $property.Value) {
-                    $matchType = "Dog"
+                    $matchType = "{{{.}}}"
                     $match++
                     break
                 }


### PR DESCRIPTION
- Fix hardcoded match type in oneOf, anyOf

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
