### PR TITLE
[PS] Set pester version to v4.3.1

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,7 +32,7 @@ install:
   - git clone https://github.com/wing328/swagger-samples
   - ps: Start-Process -FilePath 'C:\maven\apache-maven-3.2.5\bin\mvn' -ArgumentList 'jetty:run' -WorkingDirectory "$env:appveyor_build_folder\swagger-samples\java\java-jersey-jaxrs-ci"
   - ps: $PSVersionTable.PSVersion
-  - ps: Install-Module Pester -Force -Scope CurrentUser
+  - ps: Install-Module Pester -Force -Scope CurrentUser -RequiredVersion 4.3.1
 build_script:
   - dotnet --info
   # build C# API client (netcore)


### PR DESCRIPTION
Fixed pester version to fix the following errors due to recent release of pester 5.0:

```
Starting discovery in 12 files.
Discovery finished in 658ms.
[-] Integration Tests.Pet.CRUD tests 688ms (481ms|207ms)
 ActionPreferenceStopException: The running command stopped because the preference variable "ErrorActionPreference" or common parameter is set to Stop: Legacy Should syntax (without dashes) is not supported in Pester 5. Please refer to migration guide at: https://pester.dev/docs/migrations/v3-to-v4
 ParameterBindingException: Cannot retrieve the dynamic parameters for the cmdlet. The running command stopped because the preference variable "ErrorActionPreference" or common parameter is set to Stop: Legacy Should syntax (without dashes) is not supported in Pester 5. Please refer to migration guide at: https://pester.dev/docs/migrations/v3-to-v4
 at <ScriptBlock>, C:\projects\openapi-generator\samples\client\petstore\powershell\tests\Petstore.Tests.ps1:26
[-] Integration Tests.Pet.Find pets test 138ms (136ms|3ms)
 ActionPreferenceStopException: The running command stopped because the preference variable "ErrorActionPreference" or common parameter is set to Stop: Legacy Should syntax (without dashes) is not supported in Pester 5. Please refer to migration guide at: https://pester.dev/docs/migrations/v3-to-v4
 ParameterBindingException: Cannot retrieve the dynamic parameters for the cmdlet. The running command stopped because the preference variable "ErrorActionPreference" or common parameter is set to Stop: Legacy Should syntax (without dashes) is not supported in Pester 5. Please refer to migration guide at: https://pester.dev/docs/migrations/v3-to-v4
 at <ScriptBlock>, C:\projects\openapi-generator\samples\client\petstore\powershell\tests\Petstore.Tests.ps1:112
[-] Integration Tests.Configuration.Get-PSHostSetting tests 9ms (6ms|3ms)
 ActionPreferenceStopException: The running command stopped because the preference variable "ErrorActionPreference" or common parameter is set to Stop: Legacy Should syntax (without dashes) is not supported in Pester 5. Please refer to migration guide at: https://pester.dev/docs/migrations/v3-to-v4
 ParameterBindingException: Cannot retrieve the dynamic parameters for the cmdlet. The running command stopped because the preference variable "ErrorActionPreference" or common parameter is set to Stop: Legacy Should syntax (without dashes) is not supported in Pester 5. Please refer to migration guide at: https://pester.dev/docs/migrations/v3-to-v4
 at <ScriptBlock>, C:\projects\openapi-generator\samples\client\petstore\powershell\tests\Petstore.Tests.ps1:135
[-] Integration Tests.Configuration.Get-PSUrlFromHostSetting tests 65ms (56ms|9ms)
 ActionPreferenceStopException: The running command stopped because the preference variable "ErrorActionPreference" or common parameter is set to Stop: Legacy Should syntax (without dashes) is not supported in Pester 5. Please refer to migration guide at: https://pester.dev/docs/migrations/v3-to-v4
 ParameterBindingException: Cannot retrieve the dynamic parameters for the cmdlet. The running command stopped because the preference variable "ErrorActionPreference" or common parameter is set to Stop: Legacy Should syntax (without dashes) is not supported in Pester 5. Please refer to migration guide at: https://pester.dev/docs/migrations/v3-to-v4
 at <ScriptBlock>, C:\projects\openapi-generator\samples\client\petstore\powershell\tests\Petstore.Tests.ps1:146
[-] Integration Tests.Configuration.Default header tests 21ms (18ms|3ms)
 ActionPreferenceStopException: The running command stopped because the preference variable "ErrorActionPreference" or common parameter is set to Stop: Legacy Should syntax (without dashes) is not supported in Pester 5. Please refer to migration guide at: https://pester.dev/docs/migrations/v3-to-v4
 ParameterBindingException: Cannot retrieve the dynamic parameters for the cmdlet. The running command stopped because the preference variable "ErrorActionPreference" or common parameter is set to Stop: Legacy Should syntax (without dashes) is not supported in Pester 5. Please refer to migration guide at: https://pester.dev/docs/migrations/v3-to-v4
 at <ScriptBlock>, C:\projects\openapi-generator\samples\client\petstore\powershell\tests\Petstore.Tests.ps1:159
[-] Integration Tests.Configuration.Configuration tests 8ms (5ms|3ms)
 ActionPreferenceStopException: The running command stopped because the preference variable "ErrorActionPreference" or common parameter is set to Stop: Legacy Should syntax (without dashes) is not supported in Pester 5. Please refer to migration guide at: https://pester.dev/docs/migrations/v3-to-v4
 ParameterBindingException: Cannot retrieve the dynamic parameters for the cmdlet. The running command stopped because the preference variable "ErrorActionPreference" or common parameter is set to Stop: Legacy Should syntax (without dashes) is not supported in Pester 5. Please refer to migration guide at: https://pester.dev/docs/migrations/v3-to-v4
 at <ScriptBlock>, C:\projects\openapi-generator\samples\client\petstore\powershell\tests\Petstore.Tests.ps1:166
[-] Integration Tests.PSObject.Create Object from JSON tests 57ms (54ms|3ms)
 ActionPreferenceStopException: The running command stopped because the preference variable "ErrorActionPreference" or common parameter is set to Stop: Legacy Should syntax (without dashes) is not supported in Pester 5. Please refer to migration guide at: https://pester.dev/docs/migrations/v3-to-v4
 ParameterBindingException: Cannot retrieve the dynamic parameters for the cmdlet. The running command stopped because the preference variable "ErrorActionPreference" or common parameter is set to Stop: Legacy Should syntax (without dashes) is not supported in Pester 5. Please refer to migration guide at: https://pester.dev/docs/migrations/v3-to-v4
 at <ScriptBlock>, C:\projects\openapi-generator\samples\client\petstore\powershell\tests\Petstore.Tests.ps1:182
[+] PSPetApi.Tests.ps1 382ms (18ms|337ms)
[+] PSStoreApi.Tests.ps1 217ms (7ms|191ms)
[+] PSUserApi.Tests.ps1 311ms (16ms|276ms)
[+] ApiResponse.Tests.ps1 81ms (6ms|66ms)
[+] Category.Tests.ps1 74ms (3ms|63ms)
[+] InlineObject.Tests.ps1 157ms (29ms|101ms)
```
 
<!-- Please check the completed items below -->
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [ ] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [ ] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
