### PR TITLE
[csharp] Rename v5.0 to netstandard1.3

### DIFF
--- a/bin/csharp-petstore-all.sh
+++ b/bin/csharp-petstore-all.sh
@@ -6,7 +6,7 @@
 # C# Petstore API client with PropertyChanged
 ./bin/csharp-property-changed-petstore.sh
 
-# C# Petstore API client (v5.0 for .net standarnd 1.3+)
+# C# Petstore API client (.net standarnd 1.3+)
 ./bin/csharp-petstore-net-standard.sh
 
 # C# Petstore API client (.NET 4.0)

--- a/bin/csharp-petstore-net-standard.json
+++ b/bin/csharp-petstore-net-standard.json
@@ -1,3 +1,3 @@
 {
-    "targetFramework": "v5.0"
+    "targetFramework": "netstandard1.3"
 }

--- a/bin/windows/csharp-petstore-all.bat
+++ b/bin/windows/csharp-petstore-all.bat
@@ -4,7 +4,7 @@ call .\bin\windows\csharp-petstore.bat
 REM C# Petstore API client with PropertyChanged
 call .\bin\windows\csharp-property-changed-petstore.bat
 
-REM C# Petstore API client (v5.0 for .net standarnd 1.3+)
+REM C# Petstore API client (.net standarnd 1.3+)
 call .\bin\windows\csharp-petstore-netstandard.bat
 
 call .\bin\windows\csharp-dotnet2-petstore.bat

--- a/bin/windows/csharp-petstore-netcore-project.bat
+++ b/bin/windows/csharp-petstore-netcore-project.bat
@@ -5,6 +5,6 @@ If Not Exist %executable% (
 )
 
 REM set JAVA_OPTS=%JAVA_OPTS% -Xmx1024M
-set ags=generate -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -g csharp -o samples\client\petstore\csharp\OpenApiClientNetCoreProject --additional-properties targetFramework=v5.0,packageGuid={67035b31-f8e5-41a4-9673-954035084f7d},netCoreProjectFile=true
+set ags=generate -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -g csharp -o samples\client\petstore\csharp\OpenApiClientNetCoreProject --additional-properties targetFramework=netstandard1.3,packageGuid={67035b31-f8e5-41a4-9673-954035084f7d},netCoreProjectFile=true
 
 java %JAVA_OPTS% -jar %executable% %ags%

--- a/bin/windows/csharp-petstore-netstandard.bat
+++ b/bin/windows/csharp-petstore-netstandard.bat
@@ -5,6 +5,6 @@ If Not Exist %executable% (
 )
 
 REM set JAVA_OPTS=%JAVA_OPTS% -Xmx1024M
-set ags=generate -i modules\openapi-generator\src\test\resources\2_0\petstore-with-fake-endpoints-models-for-testing.yaml -g csharp -o samples\client\petstore\csharp\OpenApiClientNetStandard --additional-properties targetFramework=v5.0,packageGuid={3AB1F259-1769-484B-9411-84505FCCBD55}
+set ags=generate -i modules\openapi-generator\src\test\resources\2_0\petstore-with-fake-endpoints-models-for-testing.yaml -g csharp -o samples\client\petstore\csharp\OpenApiClientNetStandard --additional-properties targetFramework=netstandard1.3,packageGuid={3AB1F259-1769-484B-9411-84505FCCBD55}
 
 java %JAVA_OPTS% -jar %executable% %ags%

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CSharpClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CSharpClientCodegen.java
@@ -47,10 +47,7 @@ public class CSharpClientCodegen extends AbstractCSharpCodegen {
     private static final String NET45 = "v4.5";
     private static final String NET40 = "v4.0";
     private static final String NET35 = "v3.5";
-    // TODO: v5.0 is PCL, not netstandard version 1.3, and not a specific .NET Framework. This needs to be updated,
-    // especially because it will conflict with .NET Framework 5.0 when released, and PCL 5 refers to Framework 4.0.
-    // We should support either NETSTANDARD, PCL, or Both… but the concepts shouldn't be mixed.
-    private static final String NETSTANDARD = "v5.0";
+    private static final String NETSTANDARD = "netstandard1.3";
     private static final String UWP = "uwp";
 
     // Defines the sdk option for targeted frameworks, which differs from targetFramework and targetFrameworkNuget
@@ -312,14 +309,12 @@ public class CSharpClientCodegen extends AbstractCSharpCodegen {
             setSupportsAsync(Boolean.FALSE);
         } else if (NETSTANDARD.equals(this.targetFramework)) {
             LOGGER.warn(".NET Standard 1.3 support has been DEPRECATED in this generator. Please use `csharp-netcore` generator instead.");
-            // TODO: NETSTANDARD here is misrepresenting a PCL v5.0 which supports .NET Framework 4.6+, .NET Core 1.0, and Windows Universal 10.0
             additionalProperties.put(MCS_NET_VERSION_KEY, "4.6-api");
             if (additionalProperties.containsKey("supportsUWP")) {
                 LOGGER.warn(".NET " + NETSTANDARD + " generator does not support UWP.");
                 additionalProperties.remove("supportsUWP");
             }
 
-            // TODO: NETSTANDARD=v5.0 and targetFrameworkNuget=netstandard1.3. These need to sync.
             setTargetFrameworkNuget("netstandard1.3");
             setSupportsAsync(Boolean.TRUE);
             setSupportsUWP(Boolean.FALSE);


### PR DESCRIPTION
The `netstandard1.3` was originally presented to users as `v5.0`. This was deprecated throughout 4.x, and is now renamed as a hard breaking change. The original implementation was from pre-fork in swagger-codegen. I never understood why `v5.0` was chosen because it's not even a [documented mapping](https://github.com/dotnet/standard/blob/master/docs/versions.md#mapping-pcl-profiles-to-net-standard).

Up for discussion: I'd be happy to fully delete this option and uwp from the csharp generator instead.

Whatever route we take, this v5.0 needs to be removed before the actual .NET 5.0 exits preview.

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
