### PR TITLE
Fix docs typos

### DIFF
--- a/docs/faq-contributing.md
+++ b/docs/faq-contributing.md
@@ -45,9 +45,9 @@ Please refer to http://rypress.com/tutorials/git/rebasing, or follow the steps b
 
 (To setup `upstream` pointing to the official repo, please run `git remote add upstream  https://github.com/openapitools/openapi-generator.git`)
 
-## How can I update commits that are not linked to my Github account?
+## How can I update commits that are not linked to my GitHub account?
 
-Please refer to https://stackoverflow.com/questions/3042437/how-to-change-the-commit-author-for-one-specific-commit or you can simply add the email address in the commit as your secondary email address in your Github account.
+Please refer to https://stackoverflow.com/questions/3042437/how-to-change-the-commit-author-for-one-specific-commit or you can simply add the email address in the commit as your secondary email address in your GitHub account.
 
 ## Any useful git tips to share?
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -8,11 +8,11 @@ Installing OpenAPI Generator's CLI tool allows users to generate all available g
 
 Some of the following are cross-platform options and some are not, these are called out where possible.
 
-## NPM
+## npm
 
 > **Platform(s)**: Linux, macOS, Windows
 
-The [NPM package wrapper](https://github.com/openapitools/openapi-generator-cli) is cross-platform wrapper around the .jar artifact. It works by providing a CLI wrapper atop the JAR's command line options. This gives a simple interface layer which normalizes usage of the command line across operating systems, removing some differences in how options or switches are passed to the tool (depending on OS).
+The [npm package wrapper](https://github.com/openapitools/openapi-generator-cli) is cross-platform wrapper around the .jar artifact. It works by providing a CLI wrapper atop the JAR's command line options. This gives a simple interface layer which normalizes usage of the command line across operating systems, removing some differences in how options or switches are passed to the tool (depending on OS).
 **Install** the latest version of the tool globally, exposing the CLI on the command line:
 
 ```bash

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -2,7 +2,7 @@
 id: integrations
 title: Workflow Integrations
 ---
-## Workflow Integration (Maven, Github, CI/CD)
+## Workflow Integration (Maven, GitHub, CI/CD)
 
 ### Gradle Integration
 
@@ -39,7 +39,7 @@ To push the auto-generated SDK to GitHub, we provide `git_push.sh` to streamline
  -i modules/openapi-generator/src/test/resources/2_0/petstore.json -g perl \
  --git-user-id "wing328" \
  --git-repo-id "petstore-perl" \
- --release-note "Github integration demo" \
+ --release-note "GitHub integration demo" \
  -o /var/tmp/perl/petstore
 ```
  3) Push the SDK to GitHub

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -127,11 +127,11 @@ const callouts = [
     {
         id: 'try',
         imageUrl: 'img/tools/npm.svg',
-        title: <>Try via NPM</>,
+        title: <>Try via npm</>,
         content: (
             <>
                 <p>
-                    The <a href="https://github.com/openapitools/openapi-generator-cli" className="href">NPM package
+                    The <a href="https://github.com/openapitools/openapi-generator-cli" className="href">npm package
                     wrapper</a> is cross-platform wrapper around the .jar artifact.
                 </p>
                 <p>


### PR DESCRIPTION
Just a couple of minor spelling/capitalization fixes in the docs:

- `Github` -> `GitHub`
- `NPM` -> `npm`