### PR TITLE
[jaxrs-cxf][jaxrs-spec] Add missing @NotNull annotation for required body parameters when using BeanValidation, fixes #4280

### DIFF
--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf/bodyParams.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf/bodyParams.mustache
@@ -1,1 +1,1 @@
-{{#isBodyParam}}{{#useBeanValidation}}@Valid {{#required}}@NotNull {{/required}}{{/useBeanValidation}}{{{dataType}}} {{paramName}}{{/isBodyParam}}
+{{#isBodyParam}}{{#useBeanValidation}}@Valid {{#required}}{{^isNullable}}@NotNull {{/isNullable}}{{/required}}{{/useBeanValidation}}{{{dataType}}} {{paramName}}{{/isBodyParam}}

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf/bodyParams.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf/bodyParams.mustache
@@ -1,1 +1,1 @@
-{{#isBodyParam}}{{#useBeanValidation}}@Valid {{/useBeanValidation}}{{{dataType}}} {{paramName}}{{/isBodyParam}}
+{{#isBodyParam}}{{#useBeanValidation}}@Valid {{#required}}@NotNull {{/required}}{{/useBeanValidation}}{{{dataType}}} {{paramName}}{{/isBodyParam}}

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/bodyParams.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/bodyParams.mustache
@@ -1,1 +1,1 @@
-{{#isBodyParam}}{{#useBeanValidation}}@Valid {{#required}}@NotNull {{/required}}{{/useBeanValidation}}{{{dataType}}} {{paramName}}{{/isBodyParam}}
+{{#isBodyParam}}{{#useBeanValidation}}@Valid {{#required}}{{^isNullable}}@NotNull {{/isNullable}}{{/required}}{{/useBeanValidation}}{{{dataType}}} {{paramName}}{{/isBodyParam}}

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/bodyParams.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/bodyParams.mustache
@@ -1,1 +1,1 @@
-{{#isBodyParam}}{{#useBeanValidation}}@Valid {{/useBeanValidation}}{{{dataType}}} {{paramName}}{{/isBodyParam}}
+{{#isBodyParam}}{{#useBeanValidation}}@Valid {{#required}}@NotNull {{/required}}{{/useBeanValidation}}{{{dataType}}} {{paramName}}{{/isBodyParam}}

--- a/samples/server/petstore/jaxrs-cxf-annotated-base-path/src/gen/java/org/openapitools/api/PetApi.java
+++ b/samples/server/petstore/jaxrs-cxf-annotated-base-path/src/gen/java/org/openapitools/api/PetApi.java
@@ -41,7 +41,7 @@ public interface PetApi  {
     @ApiOperation(value = "Add a new pet to the store", tags={ "pet" })
     @ApiResponses(value = { 
         @ApiResponse(code = 405, message = "Invalid input") })
-    public void addPet(@Valid Pet body);
+    public void addPet(@Valid @NotNull Pet body);
 
     /**
      * Deletes a pet
@@ -112,7 +112,7 @@ public interface PetApi  {
         @ApiResponse(code = 400, message = "Invalid ID supplied"),
         @ApiResponse(code = 404, message = "Pet not found"),
         @ApiResponse(code = 405, message = "Validation exception") })
-    public void updatePet(@Valid Pet body);
+    public void updatePet(@Valid @NotNull Pet body);
 
     /**
      * Updates a pet in the store with form data

--- a/samples/server/petstore/jaxrs-cxf-annotated-base-path/src/gen/java/org/openapitools/api/StoreApi.java
+++ b/samples/server/petstore/jaxrs-cxf-annotated-base-path/src/gen/java/org/openapitools/api/StoreApi.java
@@ -85,6 +85,6 @@ public interface StoreApi  {
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = Order.class),
         @ApiResponse(code = 400, message = "Invalid Order") })
-    public Order placeOrder(@Valid Order body);
+    public Order placeOrder(@Valid @NotNull Order body);
 }
 

--- a/samples/server/petstore/jaxrs-cxf-annotated-base-path/src/gen/java/org/openapitools/api/UserApi.java
+++ b/samples/server/petstore/jaxrs-cxf-annotated-base-path/src/gen/java/org/openapitools/api/UserApi.java
@@ -41,7 +41,7 @@ public interface UserApi  {
     @ApiOperation(value = "Create user", tags={ "user" })
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation") })
-    public void createUser(@Valid User body);
+    public void createUser(@Valid @NotNull User body);
 
     /**
      * Creates list of users with given input array
@@ -52,7 +52,7 @@ public interface UserApi  {
     @ApiOperation(value = "Creates list of users with given input array", tags={ "user" })
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation") })
-    public void createUsersWithArrayInput(@Valid List<User> body);
+    public void createUsersWithArrayInput(@Valid @NotNull List<User> body);
 
     /**
      * Creates list of users with given input array
@@ -63,7 +63,7 @@ public interface UserApi  {
     @ApiOperation(value = "Creates list of users with given input array", tags={ "user" })
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation") })
-    public void createUsersWithListInput(@Valid List<User> body);
+    public void createUsersWithListInput(@Valid @NotNull List<User> body);
 
     /**
      * Delete user
@@ -129,6 +129,6 @@ public interface UserApi  {
     @ApiResponses(value = { 
         @ApiResponse(code = 400, message = "Invalid user supplied"),
         @ApiResponse(code = 404, message = "User not found") })
-    public void updateUser(@PathParam("username") String username, @Valid User body);
+    public void updateUser(@PathParam("username") String username, @Valid @NotNull User body);
 }
 

--- a/samples/server/petstore/jaxrs-cxf-non-spring-app/src/gen/java/org/openapitools/api/PetApi.java
+++ b/samples/server/petstore/jaxrs-cxf-non-spring-app/src/gen/java/org/openapitools/api/PetApi.java
@@ -41,7 +41,7 @@ public interface PetApi  {
     @ApiOperation(value = "Add a new pet to the store", tags={ "pet" })
     @ApiResponses(value = { 
         @ApiResponse(code = 405, message = "Invalid input") })
-    public void addPet(@Valid Pet body);
+    public void addPet(@Valid @NotNull Pet body);
 
     /**
      * Deletes a pet
@@ -112,7 +112,7 @@ public interface PetApi  {
         @ApiResponse(code = 400, message = "Invalid ID supplied"),
         @ApiResponse(code = 404, message = "Pet not found"),
         @ApiResponse(code = 405, message = "Validation exception") })
-    public void updatePet(@Valid Pet body);
+    public void updatePet(@Valid @NotNull Pet body);
 
     /**
      * Updates a pet in the store with form data

--- a/samples/server/petstore/jaxrs-cxf-non-spring-app/src/gen/java/org/openapitools/api/StoreApi.java
+++ b/samples/server/petstore/jaxrs-cxf-non-spring-app/src/gen/java/org/openapitools/api/StoreApi.java
@@ -85,6 +85,6 @@ public interface StoreApi  {
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = Order.class),
         @ApiResponse(code = 400, message = "Invalid Order") })
-    public Order placeOrder(@Valid Order body);
+    public Order placeOrder(@Valid @NotNull Order body);
 }
 

--- a/samples/server/petstore/jaxrs-cxf-non-spring-app/src/gen/java/org/openapitools/api/UserApi.java
+++ b/samples/server/petstore/jaxrs-cxf-non-spring-app/src/gen/java/org/openapitools/api/UserApi.java
@@ -41,7 +41,7 @@ public interface UserApi  {
     @ApiOperation(value = "Create user", tags={ "user" })
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation") })
-    public void createUser(@Valid User body);
+    public void createUser(@Valid @NotNull User body);
 
     /**
      * Creates list of users with given input array
@@ -52,7 +52,7 @@ public interface UserApi  {
     @ApiOperation(value = "Creates list of users with given input array", tags={ "user" })
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation") })
-    public void createUsersWithArrayInput(@Valid List<User> body);
+    public void createUsersWithArrayInput(@Valid @NotNull List<User> body);
 
     /**
      * Creates list of users with given input array
@@ -63,7 +63,7 @@ public interface UserApi  {
     @ApiOperation(value = "Creates list of users with given input array", tags={ "user" })
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation") })
-    public void createUsersWithListInput(@Valid List<User> body);
+    public void createUsersWithListInput(@Valid @NotNull List<User> body);
 
     /**
      * Delete user
@@ -129,6 +129,6 @@ public interface UserApi  {
     @ApiResponses(value = { 
         @ApiResponse(code = 400, message = "Invalid user supplied"),
         @ApiResponse(code = 404, message = "User not found") })
-    public void updateUser(@PathParam("username") String username, @Valid User body);
+    public void updateUser(@PathParam("username") String username, @Valid @NotNull User body);
 }
 

--- a/samples/server/petstore/jaxrs-cxf/src/gen/java/org/openapitools/api/AnotherFakeApi.java
+++ b/samples/server/petstore/jaxrs-cxf/src/gen/java/org/openapitools/api/AnotherFakeApi.java
@@ -42,6 +42,6 @@ public interface AnotherFakeApi  {
     @ApiOperation(value = "To test special tags", tags={ "$another-fake?" })
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = Client.class) })
-    public Client call123testSpecialTags(@Valid Client body);
+    public Client call123testSpecialTags(@Valid @NotNull Client body);
 }
 

--- a/samples/server/petstore/jaxrs-cxf/src/gen/java/org/openapitools/api/FakeApi.java
+++ b/samples/server/petstore/jaxrs-cxf/src/gen/java/org/openapitools/api/FakeApi.java
@@ -50,7 +50,7 @@ public interface FakeApi  {
     @ApiOperation(value = "creates an XmlItem", tags={ "fake" })
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation") })
-    public void createXmlItem(@Valid XmlItem xmlItem);
+    public void createXmlItem(@Valid @NotNull XmlItem xmlItem);
 
     @POST
     @Path("/outer/boolean")
@@ -90,7 +90,7 @@ public interface FakeApi  {
     @ApiOperation(value = "", tags={ "fake" })
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "Success") })
-    public void testBodyWithFileSchema(@Valid FileSchemaTestClass body);
+    public void testBodyWithFileSchema(@Valid @NotNull FileSchemaTestClass body);
 
     @PUT
     @Path("/body-with-query-params")
@@ -98,7 +98,7 @@ public interface FakeApi  {
     @ApiOperation(value = "", tags={ "fake" })
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "Success") })
-    public void testBodyWithQueryParams(@QueryParam("query") @NotNull  String query, @Valid User body);
+    public void testBodyWithQueryParams(@QueryParam("query") @NotNull  String query, @Valid @NotNull User body);
 
     /**
      * To test \&quot;client\&quot; model
@@ -113,7 +113,7 @@ public interface FakeApi  {
     @ApiOperation(value = "To test \"client\" model", tags={ "fake" })
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = Client.class) })
-    public Client testClientModel(@Valid Client body);
+    public Client testClientModel(@Valid @NotNull Client body);
 
     /**
      * Fake endpoint for testing various parameters  假端點  偽のエンドポイント  가짜 엔드 포인트
@@ -168,7 +168,7 @@ public interface FakeApi  {
     @ApiOperation(value = "test inline additionalProperties", tags={ "fake" })
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation") })
-    public void testInlineAdditionalProperties(@Valid Map<String, String> param);
+    public void testInlineAdditionalProperties(@Valid @NotNull Map<String, String> param);
 
     /**
      * test json serialization of form data

--- a/samples/server/petstore/jaxrs-cxf/src/gen/java/org/openapitools/api/FakeClassnameTags123Api.java
+++ b/samples/server/petstore/jaxrs-cxf/src/gen/java/org/openapitools/api/FakeClassnameTags123Api.java
@@ -42,6 +42,6 @@ public interface FakeClassnameTags123Api  {
     @ApiOperation(value = "To test class name in snake case", tags={ "fake_classname_tags 123#$%^" })
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = Client.class) })
-    public Client testClassname(@Valid Client body);
+    public Client testClassname(@Valid @NotNull Client body);
 }
 

--- a/samples/server/petstore/jaxrs-cxf/src/gen/java/org/openapitools/api/PetApi.java
+++ b/samples/server/petstore/jaxrs-cxf/src/gen/java/org/openapitools/api/PetApi.java
@@ -43,7 +43,7 @@ public interface PetApi  {
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation"),
         @ApiResponse(code = 405, message = "Invalid input") })
-    public void addPet(@Valid Pet body);
+    public void addPet(@Valid @NotNull Pet body);
 
     /**
      * Deletes a pet
@@ -116,7 +116,7 @@ public interface PetApi  {
         @ApiResponse(code = 400, message = "Invalid ID supplied"),
         @ApiResponse(code = 404, message = "Pet not found"),
         @ApiResponse(code = 405, message = "Validation exception") })
-    public void updatePet(@Valid Pet body);
+    public void updatePet(@Valid @NotNull Pet body);
 
     /**
      * Updates a pet in the store with form data

--- a/samples/server/petstore/jaxrs-cxf/src/gen/java/org/openapitools/api/StoreApi.java
+++ b/samples/server/petstore/jaxrs-cxf/src/gen/java/org/openapitools/api/StoreApi.java
@@ -85,6 +85,6 @@ public interface StoreApi  {
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = Order.class),
         @ApiResponse(code = 400, message = "Invalid Order") })
-    public Order placeOrder(@Valid Order body);
+    public Order placeOrder(@Valid @NotNull Order body);
 }
 

--- a/samples/server/petstore/jaxrs-cxf/src/gen/java/org/openapitools/api/UserApi.java
+++ b/samples/server/petstore/jaxrs-cxf/src/gen/java/org/openapitools/api/UserApi.java
@@ -41,7 +41,7 @@ public interface UserApi  {
     @ApiOperation(value = "Create user", tags={ "user" })
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation") })
-    public void createUser(@Valid User body);
+    public void createUser(@Valid @NotNull User body);
 
     /**
      * Creates list of users with given input array
@@ -52,7 +52,7 @@ public interface UserApi  {
     @ApiOperation(value = "Creates list of users with given input array", tags={ "user" })
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation") })
-    public void createUsersWithArrayInput(@Valid List<User> body);
+    public void createUsersWithArrayInput(@Valid @NotNull List<User> body);
 
     /**
      * Creates list of users with given input array
@@ -63,7 +63,7 @@ public interface UserApi  {
     @ApiOperation(value = "Creates list of users with given input array", tags={ "user" })
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation") })
-    public void createUsersWithListInput(@Valid List<User> body);
+    public void createUsersWithListInput(@Valid @NotNull List<User> body);
 
     /**
      * Delete user
@@ -129,6 +129,6 @@ public interface UserApi  {
     @ApiResponses(value = { 
         @ApiResponse(code = 400, message = "Invalid user supplied"),
         @ApiResponse(code = 404, message = "User not found") })
-    public void updateUser(@PathParam("username") String username, @Valid User body);
+    public void updateUser(@PathParam("username") String username, @Valid @NotNull User body);
 }
 

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/api/AnotherFakeApi.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/api/AnotherFakeApi.java
@@ -23,5 +23,5 @@ import javax.validation.Valid;
     @ApiOperation(value = "To test special tags", notes = "To test special tags and operation ID starting with number", tags={ "$another-fake?" })
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = Client.class) })
-    Client call123testSpecialTags(@Valid Client body);
+    Client call123testSpecialTags(@Valid @NotNull Client body);
 }

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/api/FakeApi.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/api/FakeApi.java
@@ -33,7 +33,7 @@ import javax.validation.Valid;
     @ApiOperation(value = "creates an XmlItem", notes = "this route creates an XmlItem", tags={ "fake" })
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = Void.class) })
-    void createXmlItem(@Valid XmlItem xmlItem);
+    void createXmlItem(@Valid @NotNull XmlItem xmlItem);
 
     @POST
     @Path("/outer/boolean")
@@ -73,7 +73,7 @@ import javax.validation.Valid;
     @ApiOperation(value = "", notes = "For this test, the body for this request much reference a schema named `File`.", tags={ "fake" })
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "Success", response = Void.class) })
-    void testBodyWithFileSchema(@Valid FileSchemaTestClass body);
+    void testBodyWithFileSchema(@Valid @NotNull FileSchemaTestClass body);
 
     @PUT
     @Path("/body-with-query-params")
@@ -81,7 +81,7 @@ import javax.validation.Valid;
     @ApiOperation(value = "", notes = "", tags={ "fake" })
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "Success", response = Void.class) })
-    void testBodyWithQueryParams(@QueryParam("query") @NotNull    String query,@Valid User body);
+    void testBodyWithQueryParams(@QueryParam("query") @NotNull    String query,@Valid @NotNull User body);
 
     @PATCH
     @Consumes({ "application/json" })
@@ -89,7 +89,7 @@ import javax.validation.Valid;
     @ApiOperation(value = "To test \"client\" model", notes = "To test \"client\" model", tags={ "fake" })
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = Client.class) })
-    Client testClientModel(@Valid Client body);
+    Client testClientModel(@Valid @NotNull Client body);
 
     @POST
     @Consumes({ "application/x-www-form-urlencoded" })
@@ -122,7 +122,7 @@ import javax.validation.Valid;
     @ApiOperation(value = "test inline additionalProperties", notes = "", tags={ "fake" })
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = Void.class) })
-    void testInlineAdditionalProperties(@Valid Map<String, String> param);
+    void testInlineAdditionalProperties(@Valid @NotNull Map<String, String> param);
 
     @GET
     @Path("/jsonFormData")

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/api/FakeClassnameTestApi.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/api/FakeClassnameTestApi.java
@@ -26,5 +26,5 @@ import javax.validation.Valid;
          }, tags={ "fake_classname_tags 123#$%^" })
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = Client.class) })
-    Client testClassname(@Valid Client body);
+    Client testClassname(@Valid @NotNull Client body);
 }

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/api/PetApi.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/api/PetApi.java
@@ -30,7 +30,7 @@ import javax.validation.Valid;
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = Void.class),
         @ApiResponse(code = 405, message = "Invalid input", response = Void.class) })
-    void addPet(@Valid Pet body);
+    void addPet(@Valid @NotNull Pet body);
 
     @DELETE
     @Path("/{petId}")
@@ -95,7 +95,7 @@ import javax.validation.Valid;
         @ApiResponse(code = 400, message = "Invalid ID supplied", response = Void.class),
         @ApiResponse(code = 404, message = "Pet not found", response = Void.class),
         @ApiResponse(code = 405, message = "Validation exception", response = Void.class) })
-    void updatePet(@Valid Pet body);
+    void updatePet(@Valid @NotNull Pet body);
 
     @POST
     @Path("/{petId}")

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/api/StoreApi.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/api/StoreApi.java
@@ -54,5 +54,5 @@ import javax.validation.Valid;
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = Order.class),
         @ApiResponse(code = 400, message = "Invalid Order", response = Void.class) })
-    Order placeOrder(@Valid Order body);
+    Order placeOrder(@Valid @NotNull Order body);
 }

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/api/UserApi.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/api/UserApi.java
@@ -22,21 +22,21 @@ import javax.validation.Valid;
     @ApiOperation(value = "Create user", notes = "This can only be done by the logged in user.", tags={ "user" })
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = Void.class) })
-    void createUser(@Valid User body);
+    void createUser(@Valid @NotNull User body);
 
     @POST
     @Path("/createWithArray")
     @ApiOperation(value = "Creates list of users with given input array", notes = "", tags={ "user" })
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = Void.class) })
-    void createUsersWithArrayInput(@Valid List<User> body);
+    void createUsersWithArrayInput(@Valid @NotNull List<User> body);
 
     @POST
     @Path("/createWithList")
     @ApiOperation(value = "Creates list of users with given input array", notes = "", tags={ "user" })
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = Void.class) })
-    void createUsersWithListInput(@Valid List<User> body);
+    void createUsersWithListInput(@Valid @NotNull List<User> body);
 
     @DELETE
     @Path("/{username}")
@@ -78,5 +78,5 @@ import javax.validation.Valid;
     @ApiResponses(value = { 
         @ApiResponse(code = 400, message = "Invalid user supplied", response = Void.class),
         @ApiResponse(code = 404, message = "User not found", response = Void.class) })
-    void updateUser(@PathParam("username") @ApiParam("name that need to be deleted") String username,@Valid User body);
+    void updateUser(@PathParam("username") @ApiParam("name that need to be deleted") String username,@Valid @NotNull User body);
 }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/api/AnotherFakeApi.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/api/AnotherFakeApi.java
@@ -24,7 +24,7 @@ import javax.validation.Valid;
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = Client.class)
     })
-    public Response call123testSpecialTags(@Valid Client body) {
+    public Response call123testSpecialTags(@Valid @NotNull Client body) {
         return Response.ok().entity("magic!").build();
     }
 }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/api/FakeApi.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/api/FakeApi.java
@@ -34,7 +34,7 @@ import javax.validation.Valid;
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = Void.class)
     })
-    public Response createXmlItem(@Valid XmlItem xmlItem) {
+    public Response createXmlItem(@Valid @NotNull XmlItem xmlItem) {
         return Response.ok().entity("magic!").build();
     }
 
@@ -89,7 +89,7 @@ import javax.validation.Valid;
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "Success", response = Void.class)
     })
-    public Response testBodyWithFileSchema(@Valid FileSchemaTestClass body) {
+    public Response testBodyWithFileSchema(@Valid @NotNull FileSchemaTestClass body) {
         return Response.ok().entity("magic!").build();
     }
 
@@ -100,7 +100,7 @@ import javax.validation.Valid;
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "Success", response = Void.class)
     })
-    public Response testBodyWithQueryParams(@QueryParam("query") @NotNull    String query,@Valid User body) {
+    public Response testBodyWithQueryParams(@QueryParam("query") @NotNull    String query,@Valid @NotNull User body) {
         return Response.ok().entity("magic!").build();
     }
 
@@ -111,7 +111,7 @@ import javax.validation.Valid;
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = Client.class)
     })
-    public Response testClientModel(@Valid Client body) {
+    public Response testClientModel(@Valid @NotNull Client body) {
         return Response.ok().entity("magic!").build();
     }
 
@@ -156,7 +156,7 @@ import javax.validation.Valid;
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = Void.class)
     })
-    public Response testInlineAdditionalProperties(@Valid Map<String, String> param) {
+    public Response testInlineAdditionalProperties(@Valid @NotNull Map<String, String> param) {
         return Response.ok().entity("magic!").build();
     }
 

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/api/FakeClassnameTestApi.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/api/FakeClassnameTestApi.java
@@ -27,7 +27,7 @@ import javax.validation.Valid;
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = Client.class)
     })
-    public Response testClassname(@Valid Client body) {
+    public Response testClassname(@Valid @NotNull Client body) {
         return Response.ok().entity("magic!").build();
     }
 }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/api/PetApi.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/api/PetApi.java
@@ -31,7 +31,7 @@ import javax.validation.Valid;
         @ApiResponse(code = 200, message = "successful operation", response = Void.class),
         @ApiResponse(code = 405, message = "Invalid input", response = Void.class)
     })
-    public Response addPet(@Valid Pet body) {
+    public Response addPet(@Valid @NotNull Pet body) {
         return Response.ok().entity("magic!").build();
     }
 
@@ -111,7 +111,7 @@ import javax.validation.Valid;
         @ApiResponse(code = 404, message = "Pet not found", response = Void.class),
         @ApiResponse(code = 405, message = "Validation exception", response = Void.class)
     })
-    public Response updatePet(@Valid Pet body) {
+    public Response updatePet(@Valid @NotNull Pet body) {
         return Response.ok().entity("magic!").build();
     }
 

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/api/StoreApi.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/api/StoreApi.java
@@ -64,7 +64,7 @@ import javax.validation.Valid;
         @ApiResponse(code = 200, message = "successful operation", response = Order.class),
         @ApiResponse(code = 400, message = "Invalid Order", response = Void.class)
     })
-    public Response placeOrder(@Valid Order body) {
+    public Response placeOrder(@Valid @NotNull Order body) {
         return Response.ok().entity("magic!").build();
     }
 }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/api/UserApi.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/api/UserApi.java
@@ -23,7 +23,7 @@ import javax.validation.Valid;
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = Void.class)
     })
-    public Response createUser(@Valid User body) {
+    public Response createUser(@Valid @NotNull User body) {
         return Response.ok().entity("magic!").build();
     }
 
@@ -33,7 +33,7 @@ import javax.validation.Valid;
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = Void.class)
     })
-    public Response createUsersWithArrayInput(@Valid List<User> body) {
+    public Response createUsersWithArrayInput(@Valid @NotNull List<User> body) {
         return Response.ok().entity("magic!").build();
     }
 
@@ -43,7 +43,7 @@ import javax.validation.Valid;
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = Void.class)
     })
-    public Response createUsersWithListInput(@Valid List<User> body) {
+    public Response createUsersWithListInput(@Valid @NotNull List<User> body) {
         return Response.ok().entity("magic!").build();
     }
 
@@ -100,7 +100,7 @@ import javax.validation.Valid;
         @ApiResponse(code = 400, message = "Invalid user supplied", response = Void.class),
         @ApiResponse(code = 404, message = "User not found", response = Void.class)
     })
-    public Response updateUser(@PathParam("username") @ApiParam("name that need to be deleted") String username,@Valid User body) {
+    public Response updateUser(@PathParam("username") @ApiParam("name that need to be deleted") String username,@Valid @NotNull User body) {
         return Response.ok().entity("magic!").build();
     }
 }


### PR DESCRIPTION
This PR adds missing @NotNull annotations for required body parameters when using BeanValidation and fixes #4280.

I fixed all jaxrs generators which use identical bodyParams.mustache files (my company is affected by this bug in the jaxrs-spec generator):
- jaxrs-cxf
- jaxrs-cxf-extended
- jaxrs-spec

Please review by Java technical committee: 
@bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04) @lwlee2608 (2019/10) @bkabrda (2020/01)

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
