### PR TITLE
adding handling for epoch dates in javascript ApiClient mustache file…

### DIFF
--- a/modules/openapi-generator/src/main/resources/Javascript/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Javascript/ApiClient.mustache
@@ -541,12 +541,15 @@
 {{/usePromises}}  };
 
 {{#emitJSDoc}}  /**
-   * Parses an ISO-8601 string representation of a date value.
+   * Parses an ISO-8601 string representation or epoch representation of a date value.
    * @param {String} str The date value as a string.
    * @returns {Date} The parsed date object.
    */
 {{/emitJSDoc}}  exports.parseDate = function(str) {
-    return new Date(str.replace(/T/i, ' '));
+    if (isNaN(str)) {
+      return new Date(str.replace(/T/i, ' '));
+    }
+    return new Date(+str);
   };
 
 {{#emitJSDoc}}  /**

--- a/modules/openapi-generator/src/main/resources/Javascript/es6/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Javascript/es6/ApiClient.mustache
@@ -519,12 +519,15 @@ class ApiClient {
     }
 
     {{#emitJSDoc}}/**
-    * Parses an ISO-8601 string representation of a date value.
+    * Parses an ISO-8601 string representation or epoch representation of a date value.
     * @param {String} str The date value as a string.
     * @returns {Date} The parsed date object.
     */{{/emitJSDoc}}
     static parseDate(str) {
-        return new Date(str);
+        if (isNaN(str)) {
+            return new Date(str);
+        }
+        return new Date(+str);
     }
 
     {{#emitJSDoc}}/**

--- a/samples/client/petstore/javascript-es6/src/ApiClient.js
+++ b/samples/client/petstore/javascript-es6/src/ApiClient.js
@@ -475,12 +475,15 @@ class ApiClient {
     }
 
     /**
-    * Parses an ISO-8601 string representation of a date value.
+    * Parses an ISO-8601 string representation or epoch representation of a date value.
     * @param {String} str The date value as a string.
     * @returns {Date} The parsed date object.
     */
     static parseDate(str) {
-        return new Date(str);
+        if (isNaN(str)) {
+            return new Date(str);
+        }
+        return new Date(+str);
     }
 
     /**

--- a/samples/client/petstore/javascript-promise-es6/src/ApiClient.js
+++ b/samples/client/petstore/javascript-promise-es6/src/ApiClient.js
@@ -476,12 +476,15 @@ class ApiClient {
     }
 
     /**
-    * Parses an ISO-8601 string representation of a date value.
+    * Parses an ISO-8601 string representation or epoch representation of a date value.
     * @param {String} str The date value as a string.
     * @returns {Date} The parsed date object.
     */
     static parseDate(str) {
-        return new Date(str);
+        if (isNaN(str)) {
+            return new Date(str);
+        }
+        return new Date(+str);
     }
 
     /**


### PR DESCRIPTION
… (#6497)

Added simple branching logic where a number is sent directly to the Date constructor or execute the previous logic.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

cc @CodeNinjai @frol @cliffano