### PR TITLE
[PowerShell] Add discriminator support to anyOf 

### DIFF
--- a/modules/openapi-generator/src/main/resources/powershell/model_anyof.mustache
+++ b/modules/openapi-generator/src/main/resources/powershell/model_anyof.mustache
@@ -38,6 +38,35 @@ function ConvertFrom-{{{apiNamePrefix}}}JsonTo{{{classname}}} {
         }
 
         {{/isNullable}}
+        {{#discriminator}}
+        {{#mappedModels}}
+        {{#-first}}
+        $JsonData = ConvertFrom-Json -InputObject $Json
+        {{/-first}}
+        # check if the discriminator value is '{{{mappingName}}}'
+        if ($JsonData.PSobject.Properties["{{{propertyBaseName}}}"].value == "{{{mappingName}}}") {
+            # try to match {{{modelName}}} defined in the anyOf schemas
+            try {
+                $matchInstance = ConvertFrom-{{{apiNamePrefix}}}JsonTo{{{modelName}}} $Json
+
+                foreach($property in $matchInstance.PsObject.Properties) {
+                    if ($null -ne $property.Value) {
+                        $matchType = "{{{modelName}}}"
+                        return [PSCustomObject]@{
+                            "ActualType" = ${matchType}
+                            "ActualInstance" = ${matchInstance}
+                            "anyOfSchemas" = @({{#anyOf}}"{{{.}}}"{{^-last}}, {{/-last}}{{/anyOf}})
+                        }
+                    }
+                }
+            } catch {
+                # fail to match the schema defined in anyOf with the discriminator lookup, proceed to the next one
+                Write-Debug "Failed to match '{{{modelName}}}' defined in anyOf ({{{apiNamePrefix}}}{{{classname}}}) using the discriminator lookup ({{{mappingName}}}). Proceeding with the typical anyOf type matching."
+            }
+        }
+    
+        {{/mappedModels}}
+        {{/discriminator}}
         {{#anyOf}}
         if ($match -ne 0) { # no match yet
             # try to match {{{.}}} defined in the anyOf schemas


### PR DESCRIPTION
Add discriminator support to anyOf to speed up the lookup process with the mapping

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
