### PR TITLE
Undo PR #6451

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonClientCodegen.java
@@ -683,12 +683,8 @@ public class PythonClientCodegen extends DefaultCodegen implements CodegenConfig
             if (p.getDefault() != null) {
                 if (Pattern.compile("\r\n|\r|\n").matcher((String) p.getDefault()).find())
                     return "'''" + p.getDefault() + "'''";
-                else if (p.getEnum() == null)
-                    // wrap using double quotes to avoid the need to escape any embedded single quotes
-                    return "\"" + p.getDefault() + "\"";
                 else
-                    // convert to enum var name later in postProcessModels
-                    return (String) p.getDefault();
+                    return "'" + ((String) p.getDefault()).replaceAll("'", "\'") + "'";
             }
         } else if (ModelUtils.isArraySchema(p)) {
             if (p.getDefault() != null) {
@@ -732,8 +728,7 @@ public class PythonClientCodegen extends DefaultCodegen implements CodegenConfig
 
         if (StringUtils.isNotBlank(example) && !"null".equals(example)) {
             if (ModelUtils.isStringSchema(schema)) {
-                // wrap using double quotes to avoid the need to escape any embedded single quotes
-                example = "\"" + example + "\"";
+                example = "'" + example + "'";
             }
             return example;
         }
@@ -907,45 +902,43 @@ public class PythonClientCodegen extends DefaultCodegen implements CodegenConfig
             type = p.dataType;
         }
 
-        if (type != null) {
-          if ("String".equalsIgnoreCase(type) || "str".equalsIgnoreCase(type)) {
+        if ("String".equalsIgnoreCase(type) || "str".equalsIgnoreCase(type)) {
             if (example == null) {
-              example = p.paramName + "_example";
+                example = p.paramName + "_example";
             }
             example = "'" + escapeText(example) + "'";
-          } else if ("Integer".equals(type) || "int".equals(type)) {
+        } else if ("Integer".equals(type) || "int".equals(type)) {
             if (example == null) {
-              example = "56";
+                example = "56";
             }
-          } else if ("Float".equalsIgnoreCase(type) || "Double".equalsIgnoreCase(type)) {
+        } else if ("Float".equalsIgnoreCase(type) || "Double".equalsIgnoreCase(type)) {
             if (example == null) {
-              example = "3.4";
+                example = "3.4";
             }
-          } else if ("BOOLEAN".equalsIgnoreCase(type) || "bool".equalsIgnoreCase(type)) {
+        } else if ("BOOLEAN".equalsIgnoreCase(type) || "bool".equalsIgnoreCase(type)) {
             if (example == null) {
-              example = "True";
+                example = "True";
             }
-          } else if ("file".equalsIgnoreCase(type)) {
+        } else if ("file".equalsIgnoreCase(type)) {
             if (example == null) {
-              example = "/path/to/file";
-            }
-            example = "'" + escapeText(example) + "'";
-          } else if ("Date".equalsIgnoreCase(type)) {
-            if (example == null) {
-              example = "2013-10-20";
+                example = "/path/to/file";
             }
             example = "'" + escapeText(example) + "'";
-          } else if ("DateTime".equalsIgnoreCase(type)) {
+        } else if ("Date".equalsIgnoreCase(type)) {
             if (example == null) {
-              example = "2013-10-20T19:20:30+01:00";
+                example = "2013-10-20";
             }
             example = "'" + escapeText(example) + "'";
-          } else if (!languageSpecificPrimitives.contains(type)) {
+        } else if ("DateTime".equalsIgnoreCase(type)) {
+            if (example == null) {
+                example = "2013-10-20T19:20:30+01:00";
+            }
+            example = "'" + escapeText(example) + "'";
+        } else if (!languageSpecificPrimitives.contains(type)) {
             // type is a model class, e.g. User
             example = this.packageName + "." + type + "()";
-          } else {
+        } else {
             LOGGER.warn("Type " + type + " not handled properly in setParameterExampleValue");
-          }
         }
 
         if (example == null) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonClientCodegen.java
@@ -711,7 +711,7 @@ public class PythonClientCodegen extends DefaultCodegen implements CodegenConfig
 
     private String toExampleValueRecursive(Schema schema, List<String> included_schemas, int indentation) {
         String indentation_string = "";
-        for (int i = 0; i < indentation; i++) indentation_string += "    ";
+        for (int i=0 ; i< indentation ; i++) indentation_string += "    ";
         String example = super.toExampleValue(schema);
 
         if (ModelUtils.isNullType(schema) && null != example) {
@@ -720,11 +720,9 @@ public class PythonClientCodegen extends DefaultCodegen implements CodegenConfig
             return "None";
         }
         // correct "true"s into "True"s, since super.toExampleValue uses "toString()" on Java booleans
-        if (ModelUtils.isBooleanSchema(schema) && null != example) {
-            if ("false".equalsIgnoreCase(example))
-                example = "False";
-            else
-                example = "True";
+        if (ModelUtils.isBooleanSchema(schema) && null!=example) {
+            if ("false".equalsIgnoreCase(example)) example = "False";
+            else example = "True";
         }
 
         // correct "&#39;"s into "'"s after toString()
@@ -741,7 +739,7 @@ public class PythonClientCodegen extends DefaultCodegen implements CodegenConfig
         }
 
         if (schema.getEnum() != null && !schema.getEnum().isEmpty()) {
-            // Enum case:
+        // Enum case:
             example = schema.getEnum().get(0).toString();
             if (ModelUtils.isStringSchema(schema)) {
                 example = "'" + escapeText(example) + "'";
@@ -751,7 +749,7 @@ public class PythonClientCodegen extends DefaultCodegen implements CodegenConfig
 
             return example;
         } else if (null != schema.get$ref()) {
-            // $ref case:
+        // $ref case:
             Map<String, Schema> allDefinitions = ModelUtils.getSchemas(this.openAPI);
             String ref = ModelUtils.getSimpleRef(schema.get$ref());
             if (allDefinitions != null) {
@@ -785,22 +783,13 @@ public class PythonClientCodegen extends DefaultCodegen implements CodegenConfig
             example = "YQ==";
         } else if (ModelUtils.isStringSchema(schema)) {
             // a BigDecimal:
-            if ("Number".equalsIgnoreCase(schema.getFormat())) {
-                return "1";
-            }
-            if (StringUtils.isNotBlank(schema.getPattern()))
-                return "'a'"; // I cheat here, since it would be too complicated to generate a string from a regexp
-
+            if ("Number".equalsIgnoreCase(schema.getFormat())) {return "1";}
+            if (StringUtils.isNotBlank(schema.getPattern())) return "'a'"; // I cheat here, since it would be too complicated to generate a string from a regexp
             int len = 0;
-
-            if (null != schema.getMinLength())
-                len = schema.getMinLength().intValue();
-
-            if (len < 1)
-                len = 1;
-
+            if (null != schema.getMinLength()) len = schema.getMinLength().intValue();
+            if (len < 1) len = 1;
             example = "";
-            for (int i = 0; i < len; i++) example += i;
+            for (int i=0;i<len;i++) example += i;
         } else if (ModelUtils.isIntegerSchema(schema)) {
             if (schema.getMinimum() != null)
                 example = schema.getMinimum().toString();
@@ -818,7 +807,7 @@ public class PythonClientCodegen extends DefaultCodegen implements CodegenConfig
                 included_schemas.add(schema.getTitle());
             }
             ArraySchema arrayschema = (ArraySchema) schema;
-            example = "[\n" + indentation_string + toExampleValueRecursive(arrayschema.getItems(), included_schemas, indentation + 1) + "\n" + indentation_string + "]";
+            example = "[\n" + indentation_string + toExampleValueRecursive(arrayschema.getItems(), included_schemas, indentation+1) + "\n" + indentation_string + "]";
         } else if (ModelUtils.isMapSchema(schema)) {
             if (StringUtils.isNotBlank(schema.getTitle()) && !"null".equals(schema.getTitle())) {
                 included_schemas.add(schema.getTitle());
@@ -833,7 +822,7 @@ public class PythonClientCodegen extends DefaultCodegen implements CodegenConfig
                         the_key = "'" + escapeText(the_key) + "'";
                     }
                 }
-                example = "{\n" + indentation_string + the_key + " : " + toExampleValueRecursive(additional, included_schemas, indentation + 1) + "\n" + indentation_string + "}";
+                example = "{\n" + indentation_string + the_key + " : " + toExampleValueRecursive(additional, included_schemas, indentation+1) + "\n" + indentation_string + "}";
             } else {
                 example = "{ }";
             }
@@ -845,11 +834,11 @@ public class PythonClientCodegen extends DefaultCodegen implements CodegenConfig
 
             // I remove any property that is a discriminator, since it is not well supported by the python generator
             String toExclude = null;
-            if (schema.getDiscriminator() != null) {
+            if (schema.getDiscriminator()!=null) {
                 toExclude = schema.getDiscriminator().getPropertyName();
             }
 
-            example = packageName + ".models." + underscore(schema.getTitle()) + "." + schema.getTitle() + "(";
+            example = packageName + ".models." + underscore(schema.getTitle())+"."+schema.getTitle()+"(";
 
             // if required only:
             // List<String> reqs = schema.getRequired();
@@ -863,8 +852,7 @@ public class PythonClientCodegen extends DefaultCodegen implements CodegenConfig
 
                 Map<String, Schema> properties = schema.getProperties();
                 Set<String> propkeys = null;
-                if (properties != null)
-                    propkeys = properties.keySet();
+                if (properties != null) propkeys = properties.keySet();
                 if (toExclude != null && reqs.contains(toExclude)) {
                     reqs.remove(toExclude);
                 }
@@ -891,7 +879,7 @@ public class PythonClientCodegen extends DefaultCodegen implements CodegenConfig
                     }
                 }
             }
-            example += ")";
+            example +=")";
         } else {
             LOGGER.warn("Type " + schema.getType() + " not handled properly in toExampleValue");
         }
@@ -920,44 +908,44 @@ public class PythonClientCodegen extends DefaultCodegen implements CodegenConfig
         }
 
         if (type != null) {
-            if ("String".equalsIgnoreCase(type) || "str".equalsIgnoreCase(type)) {
-                if (example == null) {
-                    example = p.paramName + "_example";
-                }
-                example = "'" + escapeText(example) + "'";
-            } else if ("Integer".equals(type) || "int".equals(type)) {
-                if (example == null) {
-                    example = "56";
-                }
-            } else if ("Float".equalsIgnoreCase(type) || "Double".equalsIgnoreCase(type)) {
-                if (example == null) {
-                    example = "3.4";
-                }
-            } else if ("BOOLEAN".equalsIgnoreCase(type) || "bool".equalsIgnoreCase(type)) {
-                if (example == null) {
-                    example = "True";
-                }
-            } else if ("file".equalsIgnoreCase(type)) {
-                if (example == null) {
-                    example = "/path/to/file";
-                }
-                example = "'" + escapeText(example) + "'";
-            } else if ("Date".equalsIgnoreCase(type)) {
-                if (example == null) {
-                    example = "2013-10-20";
-                }
-                example = "'" + escapeText(example) + "'";
-            } else if ("DateTime".equalsIgnoreCase(type)) {
-                if (example == null) {
-                    example = "2013-10-20T19:20:30+01:00";
-                }
-                example = "'" + escapeText(example) + "'";
-            } else if (!languageSpecificPrimitives.contains(type)) {
-                // type is a model class, e.g. User
-                example = this.packageName + "." + type + "()";
-            } else {
-                LOGGER.warn("Type " + type + " not handled properly in setParameterExampleValue");
+          if ("String".equalsIgnoreCase(type) || "str".equalsIgnoreCase(type)) {
+            if (example == null) {
+              example = p.paramName + "_example";
             }
+            example = "'" + escapeText(example) + "'";
+          } else if ("Integer".equals(type) || "int".equals(type)) {
+            if (example == null) {
+              example = "56";
+            }
+          } else if ("Float".equalsIgnoreCase(type) || "Double".equalsIgnoreCase(type)) {
+            if (example == null) {
+              example = "3.4";
+            }
+          } else if ("BOOLEAN".equalsIgnoreCase(type) || "bool".equalsIgnoreCase(type)) {
+            if (example == null) {
+              example = "True";
+            }
+          } else if ("file".equalsIgnoreCase(type)) {
+            if (example == null) {
+              example = "/path/to/file";
+            }
+            example = "'" + escapeText(example) + "'";
+          } else if ("Date".equalsIgnoreCase(type)) {
+            if (example == null) {
+              example = "2013-10-20";
+            }
+            example = "'" + escapeText(example) + "'";
+          } else if ("DateTime".equalsIgnoreCase(type)) {
+            if (example == null) {
+              example = "2013-10-20T19:20:30+01:00";
+            }
+            example = "'" + escapeText(example) + "'";
+          } else if (!languageSpecificPrimitives.contains(type)) {
+            // type is a model class, e.g. User
+            example = this.packageName + "." + type + "()";
+          } else {
+            LOGGER.warn("Type " + type + " not handled properly in setParameterExampleValue");
+          }
         }
 
         if (example == null) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonClientExperimentalCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonClientExperimentalCodegen.java
@@ -17,24 +17,30 @@
 package org.openapitools.codegen.languages;
 
 import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.examples.Example;
 import io.swagger.v3.oas.models.media.*;
+import io.swagger.v3.oas.models.media.ArraySchema;
+import io.swagger.v3.oas.models.media.MediaType;
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.parameters.Parameter;
 import io.swagger.v3.oas.models.parameters.RequestBody;
 import io.swagger.v3.oas.models.responses.ApiResponse;
 import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.openapitools.codegen.*;
 import org.openapitools.codegen.examples.ExampleGenerator;
-import org.openapitools.codegen.meta.GeneratorMetadata;
-import org.openapitools.codegen.meta.Stability;
 import org.openapitools.codegen.meta.features.*;
 import org.openapitools.codegen.utils.ModelUtils;
 import org.openapitools.codegen.utils.ProcessUtils;
+import org.openapitools.codegen.meta.GeneratorMetadata;
+import org.openapitools.codegen.meta.Stability;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.File;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
+import java.io.File;
 import java.util.*;
 import java.util.regex.Pattern;
 
@@ -77,7 +83,7 @@ public class PythonClientExperimentalCodegen extends PythonClientCodegen {
                 .excludeParameterFeatures(
                         ParameterFeature.Cookie
                 )
-        );
+         );
 
         // this may set datatype right for additional properties
         instantiationTypes.put("map", "dict");
@@ -139,7 +145,7 @@ public class PythonClientExperimentalCodegen extends PythonClientCodegen {
 
         // Generate the 'signing.py' module, but only if the 'HTTP signature' security scheme is specified in the OAS.
         Map<String, SecurityScheme> securitySchemeMap = openAPI != null ?
-                (openAPI.getComponents() != null ? openAPI.getComponents().getSecuritySchemes() : null) : null;
+           (openAPI.getComponents() != null ? openAPI.getComponents().getSecuritySchemes() : null) : null;
         List<CodegenSecurity> authMethods = fromSecurity(securitySchemeMap);
         if (ProcessUtils.hasHttpSignatureMethods(authMethods)) {
             supportingFiles.add(new SupportingFile("python-experimental/signing.mustache", packagePath(), "signing.py"));
@@ -166,12 +172,12 @@ public class PythonClientExperimentalCodegen extends PythonClientCodegen {
         supportingFiles.add(new SupportingFile(readmeTemplate, "", readmePath));
 
         if (!generateSourceCodeOnly) {
-            supportingFiles.remove(new SupportingFile("setup.mustache", "", "setup.py"));
-            supportingFiles.add(new SupportingFile("python-experimental/setup.mustache", "", "setup.py"));
-            supportingFiles.remove(new SupportingFile("requirements.mustache", "", "requirements.txt"));
-            supportingFiles.add(new SupportingFile("python-experimental/requirements.mustache", "", "requirements.txt"));
-            supportingFiles.remove(new SupportingFile("test-requirements.mustache", "", "test-requirements.txt"));
-            supportingFiles.add(new SupportingFile("python-experimental/test-requirements.mustache", "", "test-requirements.txt"));
+          supportingFiles.remove(new SupportingFile("setup.mustache", "", "setup.py"));
+          supportingFiles.add(new SupportingFile("python-experimental/setup.mustache", "", "setup.py"));
+          supportingFiles.remove(new SupportingFile("requirements.mustache", "", "requirements.txt"));
+          supportingFiles.add(new SupportingFile("python-experimental/requirements.mustache", "", "requirements.txt"));
+          supportingFiles.remove(new SupportingFile("test-requirements.mustache", "", "test-requirements.txt"));
+          supportingFiles.add(new SupportingFile("python-experimental/test-requirements.mustache", "", "test-requirements.txt"));
         }
 
         // default this to true so the python ModelSimple models will be generated
@@ -299,7 +305,7 @@ public class PythonClientExperimentalCodegen extends PythonClientCodegen {
         // name looks like cat.Cat
         String moduleName = name.split("\\.")[0];
         // https://exceptionshub.com/circular-or-cyclic-imports-in-python.html
-        return "from " + modelPackage() + " import " + moduleName;
+        return "from " + modelPackage() + " import "+ moduleName;
     }
 
     private String robustImport(String name) {
@@ -307,8 +313,8 @@ public class PythonClientExperimentalCodegen extends PythonClientCodegen {
         String moduleName = name.split("\\.")[0];
         // https://exceptionshub.com/circular-or-cyclic-imports-in-python.html
         String modelImport = "try:\n    from " + modelPackage() +
-                " import " + moduleName + "\nexcept ImportError:\n    " +
-                moduleName + " = sys.modules[\n        '" + modelPackage() + "." + moduleName + "']";
+          " import " + moduleName+ "\nexcept ImportError:\n    " +
+          moduleName + " = sys.modules[\n        '" + modelPackage() + "." + moduleName + "']";
         return modelImport;
     }
 
@@ -340,9 +346,9 @@ public class PythonClientExperimentalCodegen extends PythonClientCodegen {
     @Override
     @SuppressWarnings("static-method")
     public Map<String, Object> postProcessOperationsWithModels(Map<String, Object> objs, List<Object> allModels) {
-        HashMap<String, Object> val = (HashMap<String, Object>) objs.get("operations");
+        HashMap<String, Object> val = (HashMap<String, Object>)objs.get("operations");
         ArrayList<CodegenOperation> operations = (ArrayList<CodegenOperation>) val.get("operation");
-        ArrayList<HashMap<String, String>> imports = (ArrayList<HashMap<String, String>>) objs.get("imports");
+        ArrayList<HashMap<String, String>> imports = (ArrayList<HashMap<String, String>>)objs.get("imports");
         imports.clear();
         for (CodegenOperation operation : operations) {
             fixOperationImports(operation.imports);
@@ -371,7 +377,7 @@ public class PythonClientExperimentalCodegen extends PythonClientCodegen {
 
     /**
      * Override with special post-processing for all models.
-     */
+     */ 
     @SuppressWarnings({"static-method", "unchecked"})
     public Map<String, Object> postProcessAllModels(Map<String, Object> objs) {
         // loop through all models and delete ones where type!=object and the model has no validations and enums
@@ -714,7 +720,7 @@ public class PythonClientExperimentalCodegen extends PythonClientCodegen {
     public void postProcessParameter(CodegenParameter p) {
         postProcessPattern(p.pattern, p.vendorExtensions);
         // set baseType to null so the api docs will not point to a model for languageSpecificPrimitives
-        if (p.baseType != null && languageSpecificPrimitives.contains(p.baseType)) {
+        if (p.baseType != null && languageSpecificPrimitives.contains(p.baseType)){
             p.baseType = null;
         } else if (p.isListContainer && p.mostInnerItems.complexType != null && !languageSpecificPrimitives.contains(p.mostInnerItems.complexType)) {
             // fix ListContainers
@@ -722,7 +728,7 @@ public class PythonClientExperimentalCodegen extends PythonClientCodegen {
         }
     }
 
-    private void addNullDefaultToOneOfAnyOfReqProps(Schema schema, CodegenModel result) {
+    private void addNullDefaultToOneOfAnyOfReqProps(Schema schema, CodegenModel result){
         // for composed schema models, if the required properties are only from oneOf or anyOf models
         // give them a nulltype.Null so the user can omit including them in python
         ComposedSchema cs = (ComposedSchema) schema;
@@ -744,7 +750,7 @@ public class PythonClientExperimentalCodegen extends PythonClientCodegen {
         if (anyOf != null) {
             oneOfanyOfSchemas.addAll(anyOf);
         }
-        for (Schema sc : oneOfanyOfSchemas) {
+        for (Schema sc: oneOfanyOfSchemas) {
             Schema refSchema = ModelUtils.getReferencedSchema(this.openAPI, sc);
             addProperties(otherProperties, otherRequired, refSchema);
         }
@@ -762,7 +768,7 @@ public class PythonClientExperimentalCodegen extends PythonClientCodegen {
 
         List<CodegenProperty> reqVars = result.getRequiredVars();
         if (reqVars != null) {
-            for (CodegenProperty cp : reqVars) {
+            for (CodegenProperty cp: reqVars) {
                 String propName = cp.baseName;
                 if (otherRequiredSet.contains(propName) && !selfRequiredSet.contains(propName)) {
                     // if var is in otherRequiredSet and is not in selfRequiredSet and is in result.requiredVars
@@ -899,20 +905,20 @@ public class PythonClientExperimentalCodegen extends PythonClientCodegen {
      * Primitive types in the OAS specification are implemented in Python using the corresponding
      * Python primitive types.
      * Composed types (e.g. allAll, oneOf, anyOf) are represented in Python using list of types.
-     * <p>
+     * 
      * The caller should set the prefix and suffix arguments to empty string, except when
      * getTypeString invokes itself recursively. A non-empty prefix/suffix may be specified
      * to wrap the return value in a python dict, list or tuple.
-     * <p>
+     *
      * Examples:
      * - "bool, date, float"  The data must be a bool, date or float.
      * - "[bool, date]"       The data must be an array, and the array items must be a bool or date.
-     *
-     * @param p                    The OAS schema.
-     * @param prefix               prepended to the returned value.
-     * @param suffix               appended to the returned value.
+     * 
+     * @param p The OAS schema.
+     * @param prefix prepended to the returned value.
+     * @param suffix appended to the returned value.
      * @param referencedModelNames a list of models that are being referenced while generating the types,
-     *                             may be used to generate imports.
+     *          may be used to generate imports.
      * @return a comma-separated string representation of the Python types
      */
     private String getTypeString(Schema p, String prefix, String suffix, List<String> referencedModelNames) {
@@ -962,7 +968,7 @@ public class PythonClientExperimentalCodegen extends PythonClientCodegen {
             } else {
                 return prefix + getTypeString(inner, "[", "]", referencedModelNames) + fullSuffix;
             }
-        }
+        } 
         if (ModelUtils.isFileSchema(p)) {
             return prefix + "file_type" + fullSuffix;
         }
@@ -1052,7 +1058,7 @@ public class PythonClientExperimentalCodegen extends PythonClientCodegen {
             if (example == null) {
                 example = "/path/to/file";
             }
-            example = "open('" + example + "', 'rb')";
+            example = "open('"+example+"', 'rb')";
         } else if ("Date".equalsIgnoreCase(type)) {
             if (example == null) {
                 example = "2013-10-20";
@@ -1123,7 +1129,7 @@ public class PythonClientExperimentalCodegen extends PythonClientCodegen {
     @Override
     public String toModelName(String name) {
         // we have a custom version of this function so we can support circular references in python 2 and 3
-        return toModelFilename(name) + "." + simpleModelName(name);
+        return toModelFilename(name)+"."+simpleModelName(name);
     }
 
     @Override

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/python/PythonClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/python/PythonClientCodegenTest.java
@@ -19,17 +19,11 @@ package org.openapitools.codegen.python;
 
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.Operation;
-import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.media.StringSchema;
-import java.util.HashSet;
 import org.openapitools.codegen.CodegenConstants;
-import org.openapitools.codegen.CodegenModelFactory;
-import org.openapitools.codegen.CodegenModelType;
 import org.openapitools.codegen.CodegenOperation;
-import org.openapitools.codegen.CodegenParameter;
 import org.openapitools.codegen.TestUtils;
 import org.openapitools.codegen.languages.PythonClientCodegen;
-import org.openapitools.codegen.utils.ModelUtils;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -99,99 +93,12 @@ public class PythonClientCodegenTest {
         Assert.assertEquals(op.allParams.get(5).pattern, "/^pattern\\d{3}$/i");
     }
 
-    @Test(description = "test default value with single quotes")
-    public void testSingleQuotesDefaultValue() {
+    @Test(description = "test single quotes escape")
+    public void testSingleQuotes() {
         final PythonClientCodegen codegen = new PythonClientCodegen();
         StringSchema schema = new StringSchema();
         schema.setDefault("Text containing 'single' quote");
         String defaultValue = codegen.toDefaultValue(schema);
-        Assert.assertEquals(defaultValue, "\"Text containing 'single' quote\"");
-    }
-
-    @Test(description = "test example value with single quotes")
-    public void testSingleQuotesExampleValue() {
-        final PythonClientCodegen codegen = new PythonClientCodegen();
-        StringSchema schema = new StringSchema();
-        schema.setExample("Text containing 'single' quote");
-        String exampleValue = codegen.toExampleValue(schema);
-        Assert.assertEquals(exampleValue, "\"Text containing 'single' quote\"");
-    }
-
-    @Test
-    public void testFormParameterHasDefaultValue() {
-        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml");
-        final PythonClientCodegen codegen = new PythonClientCodegen();
-        codegen.setOpenAPI(openAPI);
-
-        Schema requestBodySchema = ModelUtils.getSchemaFromRequestBody(openAPI.getPaths().get("/fake").getGet().getRequestBody());
-        CodegenParameter codegenParameter = codegen.fromFormProperty("enum_form_string", (Schema) requestBodySchema.getProperties().get("enum_form_string"), new HashSet<String>());
-
-        Assert.assertEquals(codegenParameter.defaultValue, "-efg");
-    }
-
-    @Test
-    public void testExample1() {
-        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/examples.yaml");
-        final PythonClientCodegen codegen = new PythonClientCodegen();
-
-        Operation operation = openAPI.getPaths().get("/example1/singular").getGet();
-        CodegenParameter codegenParameter = CodegenModelFactory.newInstance(CodegenModelType.PARAMETER);
-        codegen.setParameterExampleValue(codegenParameter, operation.getParameters().get(0));
-
-        Assert.assertEquals(codegenParameter.example, "example1 value");
-
-        Operation operation2 = openAPI.getPaths().get("/example1/plural").getGet();
-        CodegenParameter codegenParameter2 = CodegenModelFactory.newInstance(CodegenModelType.PARAMETER);
-        codegen.setParameterExampleValue(codegenParameter2, operation2.getParameters().get(0));
-
-        Assert.assertEquals(codegenParameter2.example, "An example1 value");
-    }
-
-    @Test
-    public void testExample2() {
-        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/examples.yaml");
-        final PythonClientCodegen codegen = new PythonClientCodegen();
-
-        Operation operation = openAPI.getPaths().get("/example2/singular").getGet();
-        CodegenParameter codegenParameter = CodegenModelFactory.newInstance(CodegenModelType.PARAMETER);
-        codegen.setParameterExampleValue(codegenParameter, operation.getParameters().get(0));
-
-        Assert.assertEquals(codegenParameter.example, "example2 value");
-    }
-
-    @Test
-    public void testExample3() {
-        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/examples.yaml");
-        final PythonClientCodegen codegen = new PythonClientCodegen();
-
-        Operation operation = openAPI.getPaths().get("/example3/singular").getGet();
-        CodegenParameter codegenParameter = CodegenModelFactory.newInstance(CodegenModelType.PARAMETER);
-        codegen.setParameterExampleValue(codegenParameter, operation.getParameters().get(0));
-
-        Assert.assertEquals(codegenParameter.example, "example3: parameter value");
-
-        Operation operation2 = openAPI.getPaths().get("/example3/plural").getGet();
-        CodegenParameter codegenParameter2 = CodegenModelFactory.newInstance(CodegenModelType.PARAMETER);
-        codegen.setParameterExampleValue(codegenParameter2, operation2.getParameters().get(0));
-
-        Assert.assertEquals(codegenParameter2.example, "example3: parameter value");
-    }
-
-    @Test
-    public void testExample4() {
-        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/examples.yaml");
-        final PythonClientCodegen codegen = new PythonClientCodegen();
-
-        Operation operation = openAPI.getPaths().get("/example4/singular").getPost();
-        CodegenParameter codegenParameter = CodegenModelFactory.newInstance(CodegenModelType.PARAMETER);
-        codegen.setParameterExampleValue(codegenParameter, operation.getRequestBody());
-
-        Assert.assertEquals(codegenParameter.example, "example4 value");
-
-        Operation operation2 = openAPI.getPaths().get("/example4/plural").getPost();
-        CodegenParameter codegenParameter2 = CodegenModelFactory.newInstance(CodegenModelType.PARAMETER);
-        codegen.setParameterExampleValue(codegenParameter2, operation2.getRequestBody());
-
-        Assert.assertEquals(codegenParameter2.example, "An example4 value");
+        Assert.assertEquals("'Text containing \'single\' quote'", defaultValue);
     }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/python/PythonClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/python/PythonClientCodegenTest.java
@@ -21,7 +21,13 @@ import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.media.StringSchema;
-import org.openapitools.codegen.*;
+import java.util.HashSet;
+import org.openapitools.codegen.CodegenConstants;
+import org.openapitools.codegen.CodegenModelFactory;
+import org.openapitools.codegen.CodegenModelType;
+import org.openapitools.codegen.CodegenOperation;
+import org.openapitools.codegen.CodegenParameter;
+import org.openapitools.codegen.TestUtils;
 import org.openapitools.codegen.languages.PythonClientCodegen;
 import org.openapitools.codegen.utils.ModelUtils;
 import org.testng.Assert;
@@ -29,7 +35,6 @@ import org.testng.annotations.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashSet;
 
 public class PythonClientCodegenTest {
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/python/PythonClientExperimentalTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/python/PythonClientExperimentalTest.java
@@ -31,7 +31,7 @@ public class PythonClientExperimentalTest {
 
     @Test(description = "convert a python model with dots")
     public void modelTest() {
-        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/2_0/v1beta3.json");
+        final OpenAPI openAPI= TestUtils.parseFlattenSpec("src/test/resources/2_0/v1beta3.json");
         final DefaultCodegen codegen = new PythonClientExperimentalCodegen();
         codegen.setOpenAPI(openAPI);
 


### PR DESCRIPTION
Undo PR #6451 (and https://github.com/OpenAPITools/openapi-generator/pull/6510, which is a follow-up PR to #6451) due to CI failure (outdated samples and changes to enum example values): https://app.circleci.com/pipelines/github/OpenAPITools/openapi-generator/3043/workflows/2c13f8cb-583f-401a-b865-e5184d035f35/jobs/16404

cc @taxpon (2017/07) @frol (2017/07) @mbohlool (2017/07) @cbornet (2017/09) @kenjones-cisco (2017/11) @tomplus (2018/10) @Jyhess (2019/01) @arun-nalla (2019/11) @spacether (2019/11)

<!-- Please check the completed items below -->
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [ ] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [ ] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
