### PR TITLE
[Go][Experimental] add oneOf discrimistrator lookup

### DIFF
--- a/docs/generators/go-experimental.md
+++ b/docs/generators/go-experimental.md
@@ -12,6 +12,7 @@ sidebar_label: go-experimental
 |packageVersion|Go package version.| |1.0.0|
 |prependFormOrBodyParameters|Add form or body parameters to the beginning of the parameter list.| |false|
 |structPrefix|whether to prefix struct with the class name. e.g. DeletePetOpts =&gt; PetApiDeletePetOpts| |false|
+|useOneOfDiscriminatorLookup|Use the discriminator's mapping in oneOf to speed up the model lookup. IMPORTANT: Validation (e.g. one and onlye one match in oneOf's schemas) will be skipped.| |false|
 |withAWSV4Signature|whether to include AWS v4 signature support| |false|
 |withGoCodegenComment|whether to include Go codegen comment to disable Go Lint and collapse by default in GitHub PRs and diffs| |false|
 |withXml|whether to include support for application/xml content type and include XML annotations in the model (works with libraries that provide support for JSON and XML)| |false|

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/GoClientExperimentalCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/GoClientExperimentalCodegen.java
@@ -35,6 +35,7 @@ public class GoClientExperimentalCodegen extends GoClientCodegen {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(GoClientExperimentalCodegen.class);
     protected String goImportAlias = "openapiclient";
+    protected boolean useOneOfDiscriminatorLookup = false; // use oneOf discriminator's mapping for model lookup
 
     public GoClientExperimentalCodegen() {
         super();
@@ -44,6 +45,8 @@ public class GoClientExperimentalCodegen extends GoClientCodegen {
         usesOptionals = false;
 
         generatorMetadata = GeneratorMetadata.newBuilder(generatorMetadata).stability(Stability.EXPERIMENTAL).build();
+
+        cliOptions.add(new CliOption(CodegenConstants.USE_ONEOF_DISCRIMINATOR_LOOKUP, CodegenConstants.USE_ONEOF_DISCRIMINATOR_LOOKUP_DESC).defaultValue("false"));
     }
 
     /**
@@ -93,6 +96,20 @@ public class GoClientExperimentalCodegen extends GoClientCodegen {
             additionalProperties.put("goImportAlias", goImportAlias);
         }
 
+        if (additionalProperties.containsKey(CodegenConstants.USE_ONEOF_DISCRIMINATOR_LOOKUP)) {
+            setUseOneOfDiscriminatorLookup(convertPropertyToBooleanAndWriteBack(CodegenConstants.USE_ONEOF_DISCRIMINATOR_LOOKUP));
+        } else {
+            additionalProperties.put(CodegenConstants.USE_ONEOF_DISCRIMINATOR_LOOKUP, useOneOfDiscriminatorLookup);
+        }
+
+    }
+
+    public void setUseOneOfDiscriminatorLookup(boolean useOneOfDiscriminatorLookup) {
+        this.useOneOfDiscriminatorLookup = useOneOfDiscriminatorLookup;
+    }
+
+    public boolean getUseOneOfDiscriminatorLookup() {
+        return this.useOneOfDiscriminatorLookup;
     }
 
     public void setGoImportAlias(String goImportAlias) {

--- a/modules/openapi-generator/src/main/resources/go-experimental/model_oneof.mustache
+++ b/modules/openapi-generator/src/main/resources/go-experimental/model_oneof.mustache
@@ -24,6 +24,37 @@ func (dst *{{classname}}) UnmarshalJSON(data []byte) error {
 	}
 
 	{{/isNullable}}
+    {{#useOneOfDiscriminatorLookup}}
+    {{#discriminator}}
+    {{#mappedModels}}
+    {{#-first}}
+    // use discriminator value to speed up the lookup
+    var jsonDict map[string]interface{}
+    err := json.Unmarshal(data, &jsonDict)
+    if err != nil {
+        return fmt.Errorf("Failed to unmarshal JSON into map for the discrimintor lookup.")
+    }
+
+    {{/-first}}
+    // check if the discriminator value is '{{{mappingName}}}'
+    if jsonDict["{{{propertyBaseName}}}"] == "{{{mappingName}}}" {
+        // try to unmarshal JSON data into {{{modelName}}}
+        err = json.Unmarshal(data, &dst.{{{modelName}}});
+        if err == nil {
+            json{{{modelName}}}, _ := json.Marshal(dst.{{{modelName}}})
+            if string(json{{{modelName}}}) == "{}" { // empty struct
+                dst.{{{modelName}}} = nil
+            } else {
+                return nil // data stored in dst.{{{modelName}}}, return on the first match
+            }
+        } else {
+            dst.{{{modelName}}} = nil
+        }
+    }
+
+    {{/mappedModels}}
+    {{/discriminator}}
+    {{/useOneOfDiscriminatorLookup}}
 	{{#oneOf}}
 	// try to unmarshal data into {{{.}}}
 	err = json.Unmarshal(data, &dst.{{{.}}});

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_fruit.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_fruit.go
@@ -137,3 +137,4 @@ func (v *NullableFruit) UnmarshalJSON(src []byte) error {
 	return json.Unmarshal(src, &v.value)
 }
 
+

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_fruit_req.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_fruit_req.go
@@ -137,3 +137,4 @@ func (v *NullableFruitReq) UnmarshalJSON(src []byte) error {
 	return json.Unmarshal(src, &v.value)
 }
 
+

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_mammal.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_mammal.go
@@ -137,3 +137,4 @@ func (v *NullableMammal) UnmarshalJSON(src []byte) error {
 	return json.Unmarshal(src, &v.value)
 }
 
+


### PR DESCRIPTION
Add oneOf discriminator lookup with the option "useOneOfDiscriminatorLookup"

cc @antihax (2017/11) @bvwells (2017/12) @grokify (2018/07) @kemokemo (2018/09) @bkabrda (2019/07)

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
