### PR TITLE
[PS] automatically derive discriminator mapping for oneOf/anyOf 

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PowerShellClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PowerShellClientCodegen.java
@@ -926,6 +926,27 @@ public class PowerShellClientCodegen extends DefaultCodegen implements CodegenCo
             if ("null<String, SystemCollectionsHashtable>".equals(model.parent)) {
                 model.vendorExtensions.put("x-additional-properties", true);
             }
+
+            // automatically create discriminator mapping for oneOf/anyOf if not present
+            if (((model.oneOf != null && !model.oneOf.isEmpty()) || (model.anyOf != null && !model.anyOf.isEmpty())) &&
+                    model.discriminator != null && model.discriminator.getMapping() == null) {
+                // create mappedModels
+                Set<String> schemas = new HashSet<>();
+                if (model.oneOf != null && !model.oneOf.isEmpty()) {
+                    schemas = model.oneOf;
+                } else if (model.anyOf != null && !model.anyOf.isEmpty()) {
+                    schemas = model.anyOf;
+                }
+
+                HashSet<CodegenDiscriminator.MappedModel> mappedModels = new HashSet<>();
+
+                for (String s: schemas) {
+                    mappedModels.add(new CodegenDiscriminator.MappedModel(s, s));
+                }
+
+                model.discriminator.setMappedModels(mappedModels);
+
+            }
         }
 
         return objs;

--- a/modules/openapi-generator/src/main/resources/powershell/model_anyof.mustache
+++ b/modules/openapi-generator/src/main/resources/powershell/model_anyof.mustache
@@ -44,7 +44,7 @@ function ConvertFrom-{{{apiNamePrefix}}}JsonTo{{{classname}}} {
         $JsonData = ConvertFrom-Json -InputObject $Json
         {{/-first}}
         # check if the discriminator value is '{{{mappingName}}}'
-        if ($JsonData.PSobject.Properties["{{{propertyBaseName}}}"].value == "{{{mappingName}}}") {
+        if ($JsonData.PSobject.Properties["{{{propertyBaseName}}}"].value -eq "{{{mappingName}}}") {
             # try to match {{{modelName}}} defined in the anyOf schemas
             try {
                 $matchInstance = ConvertFrom-{{{apiNamePrefix}}}JsonTo{{{modelName}}} $Json

--- a/modules/openapi-generator/src/main/resources/powershell/model_oneof.mustache
+++ b/modules/openapi-generator/src/main/resources/powershell/model_oneof.mustache
@@ -45,7 +45,7 @@ function ConvertFrom-{{{apiNamePrefix}}}JsonTo{{{classname}}} {
         $JsonData = ConvertFrom-Json -InputObject $Json
         {{/-first}}
         # check if the discriminator value is '{{{mappingName}}}'
-        if ($JsonData.PSobject.Properties["{{{propertyBaseName}}}"].value == "{{{mappingName}}}") {
+        if ($JsonData.PSobject.Properties["{{{propertyBaseName}}}"].value -eq "{{{mappingName}}}") {
             # try to match {{{modelName}}} defined in the oneOf schemas
             try {
                 $matchInstance = ConvertFrom-{{{apiNamePrefix}}}JsonTo{{{modelName}}} $Json

--- a/samples/client/petstore/powershell/.openapi-generator/FILES
+++ b/samples/client/petstore/powershell/.openapi-generator/FILES
@@ -31,14 +31,3 @@ src/PSPetstore/Private/PSApiClient.ps1
 src/PSPetstore/Private/PSHttpSignatureAuth.ps1
 src/PSPetstore/Private/PSRSAEncryptionProvider.cs
 src/PSPetstore/en-US/about_PSPetstore.help.txt
-tests/Api/PSPetApi.Tests.ps1
-tests/Api/PSStoreApi.Tests.ps1
-tests/Api/PSUserApi.Tests.ps1
-tests/Model/ApiResponse.Tests.ps1
-tests/Model/Category.Tests.ps1
-tests/Model/InlineObject.Tests.ps1
-tests/Model/InlineObject1.Tests.ps1
-tests/Model/Order.Tests.ps1
-tests/Model/Pet.Tests.ps1
-tests/Model/Tag.Tests.ps1
-tests/Model/User.Tests.ps1


### PR DESCRIPTION
- automatically derive discriminator mapping for oneOf/anyOf if the discriminator mapping is not defined in the spec

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
