### PR TITLE
[Go] whitelist AdditionalProperties in the field name

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractGoCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractGoCodegen.java
@@ -29,7 +29,6 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.util.*;
 
-import static org.openapitools.codegen.utils.OnceLogger.once;
 import static org.openapitools.codegen.utils.StringUtils.camelize;
 import static org.openapitools.codegen.utils.StringUtils.underscore;
 
@@ -94,7 +93,7 @@ public abstract class AbstractGoCodegen extends DefaultCodegen implements Codege
                         "byte",
                         "map[string]interface{}",
                         "interface{}"
-                        )
+                )
         );
 
         instantiationTypes.clear();
@@ -325,7 +324,7 @@ public abstract class AbstractGoCodegen extends DefaultCodegen implements Codege
 
     /**
      * Return the golang implementation type for the specified property.
-     * 
+     *
      * @param p the OAS property.
      * @return the golang implementation type.
      */
@@ -383,7 +382,7 @@ public abstract class AbstractGoCodegen extends DefaultCodegen implements Codege
 
     /**
      * Return the OpenAPI type for the property.
-     * 
+     *
      * @param p the OAS property.
      * @return the OpenAPI type.
      */
@@ -409,20 +408,19 @@ public abstract class AbstractGoCodegen extends DefaultCodegen implements Codege
 
     /**
      * Determines the golang instantiation type of the specified schema.
-     *
+     * <p>
      * This function is called when the input schema is a map, and specifically
      * when the 'additionalProperties' attribute is present in the OAS specification.
      * Codegen invokes this function to resolve the "parent" association to
      * 'additionalProperties'.
-     *
+     * <p>
      * Note the 'parent' attribute in the codegen model is used in the following scenarios:
      * - Indicate a polymorphic association with some other type (e.g. class inheritance).
      * - If the specification has a discriminator, cogegen create a “parent” based on the discriminator.
      * - Use of the 'additionalProperties' attribute in the OAS specification.
-     *   This is the specific scenario when codegen invokes this function.
+     * This is the specific scenario when codegen invokes this function.
      *
      * @param property the input schema
-     *
      * @return the golang instantiation type of the specified property.
      */
     @Override

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractGoCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractGoCodegen.java
@@ -210,6 +210,11 @@ public abstract class AbstractGoCodegen extends DefaultCodegen implements Codege
         if (name.matches("^\\d.*"))
             name = "Var" + name;
 
+        if ("AdditionalProperties".equals(name)) {
+            // AdditionalProperties is a reserved field (additionalProperties: true), use AdditionalPropertiesField instead
+            return "AdditionalPropertiesField";
+        }
+
         return name;
     }
 


### PR DESCRIPTION
Whitelist AdditionalProperties in the field name with `AdditionalPropertiesField` instead as it can be used when `additionalProperties` is set to true

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

cc @antihax (2017/11) @bvwells (2017/12) @grokify (2018/07) @kemokemo (2018/09) @bkabrda (2019/07)


