### PR TITLE
[php-slim4] Throw specialized HttpNotImplementedException

### DIFF
--- a/modules/openapi-generator/src/main/resources/php-slim4-server/SlimRouter.mustache
+++ b/modules/openapi-generator/src/main/resources/php-slim4-server/SlimRouter.mustache
@@ -35,6 +35,7 @@ namespace {{invokerPackage}};
 
 use Slim\Factory\AppFactory;
 use Slim\Interfaces\RouteInterface;
+use Slim\Exception\HttpNotImplementedException;
 use Psr\Container\ContainerInterface;
 use InvalidArgumentException;
 use Dyorg\TokenAuthentication;
@@ -143,7 +144,8 @@ class SlimRouter
      *
      * @param ContainerInterface|array $settings Either a ContainerInterface or an associative array of app settings
      *
-     * @throws Exception When implementation class doesn't exists
+     * @throws HttpNotImplementedException When implementation class doesn't exists
+     * @throws Exception when not supported authorization schema type provided
      */
     public function __construct($settings = [])
     {
@@ -160,15 +162,15 @@ class SlimRouter
         $authPackage = '{{authPackage}}';
         $basicAuthenticator = function (ServerRequestInterface &$request, TokenSearch $tokenSearch) use ($authPackage) {
             $message = "How about extending {{abstractNamePrefix}}Authenticator{{abstractNameSuffix}} class by {$authPackage}\BasicAuthenticator?";
-            throw new Exception($message);
+            throw new HttpNotImplementedException($request, $message);
         };
         $apiKeyAuthenticator = function (ServerRequestInterface &$request, TokenSearch $tokenSearch) use ($authPackage) {
             $message = "How about extending {{abstractNamePrefix}}Authenticator{{abstractNameSuffix}} class by {$authPackage}\ApiKeyAuthenticator?";
-            throw new Exception($message);
+            throw new HttpNotImplementedException($request, $message);
         };
         $oAuthAuthenticator = function (ServerRequestInterface &$request, TokenSearch $tokenSearch) use ($authPackage) {
             $message = "How about extending {{abstractNamePrefix}}Authenticator{{abstractNameSuffix}} class by {$authPackage}\OAuthAuthenticator?";
-            throw new Exception($message);
+            throw new HttpNotImplementedException($request, $message);
         };
         {{/hasAuthMethods}}
 
@@ -183,9 +185,7 @@ class SlimRouter
         foreach ($this->operations as $operation) {
             $callback = function ($request, $response, $arguments) use ($operation) {
                 $message = "How about extending {$operation['classname']} by {$operation['apiPackage']}\\{$operation['userClassname']} class implementing {$operation['operationId']} as a {$operation['httpMethod']} method?";
-                throw new Exception($message);
-                $response->getBody()->write($message);
-                return $response->withStatus(501);
+                throw new HttpNotImplementedException($request, $message);
             };
             $middlewares = [new JsonBodyParserMiddleware()];
 

--- a/modules/openapi-generator/src/main/resources/php-slim4-server/api.mustache
+++ b/modules/openapi-generator/src/main/resources/php-slim4-server/api.mustache
@@ -37,7 +37,7 @@ namespace {{apiPackage}};
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\ResponseInterface;
-use Exception;
+use Slim\Exception\HttpNotImplementedException;
 
 /**
  * {{classname}} Class Doc Comment
@@ -84,7 +84,7 @@ abstract class {{classname}}
      * @param array|null             $args     Path arguments
      *
      * @return ResponseInterface
-     * @throws Exception to force implementation class to override this method
+     * @throws HttpNotImplementedException to force implementation class to override this method
      */
     public function {{operationId}}(ServerRequestInterface $request, ResponseInterface $response, array $args)
     {
@@ -125,10 +125,7 @@ abstract class {{classname}}
         $body = $request->getParsedBody();
         {{/hasBodyParam}}
         $message = "How about implementing {{nickname}} as a {{httpMethod}} method in {{apiPackage}}\{{userClassname}} class?";
-        throw new Exception($message);
-
-        $response->getBody()->write($message);
-        return $response->withStatus(501);
+        throw new HttpNotImplementedException($request, $message);
     }
     {{/operation}}
     {{/operations}}

--- a/samples/server/petstore/php-slim4/lib/Api/AbstractAnotherFakeApi.php
+++ b/samples/server/petstore/php-slim4/lib/Api/AbstractAnotherFakeApi.php
@@ -28,7 +28,7 @@ namespace OpenAPIServer\Api;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\ResponseInterface;
-use Exception;
+use Slim\Exception\HttpNotImplementedException;
 
 /**
  * AbstractAnotherFakeApi Class Doc Comment
@@ -67,15 +67,12 @@ abstract class AbstractAnotherFakeApi
      * @param array|null             $args     Path arguments
      *
      * @return ResponseInterface
-     * @throws Exception to force implementation class to override this method
+     * @throws HttpNotImplementedException to force implementation class to override this method
      */
     public function call123TestSpecialTags(ServerRequestInterface $request, ResponseInterface $response, array $args)
     {
         $body = $request->getParsedBody();
         $message = "How about implementing call123TestSpecialTags as a PATCH method in OpenAPIServer\Api\AnotherFakeApi class?";
-        throw new Exception($message);
-
-        $response->getBody()->write($message);
-        return $response->withStatus(501);
+        throw new HttpNotImplementedException($request, $message);
     }
 }

--- a/samples/server/petstore/php-slim4/lib/Api/AbstractFakeApi.php
+++ b/samples/server/petstore/php-slim4/lib/Api/AbstractFakeApi.php
@@ -28,7 +28,7 @@ namespace OpenAPIServer\Api;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\ResponseInterface;
-use Exception;
+use Slim\Exception\HttpNotImplementedException;
 
 /**
  * AbstractFakeApi Class Doc Comment
@@ -66,16 +66,13 @@ abstract class AbstractFakeApi
      * @param array|null             $args     Path arguments
      *
      * @return ResponseInterface
-     * @throws Exception to force implementation class to override this method
+     * @throws HttpNotImplementedException to force implementation class to override this method
      */
     public function createXmlItem(ServerRequestInterface $request, ResponseInterface $response, array $args)
     {
         $body = $request->getParsedBody();
         $message = "How about implementing createXmlItem as a POST method in OpenAPIServer\Api\FakeApi class?";
-        throw new Exception($message);
-
-        $response->getBody()->write($message);
-        return $response->withStatus(501);
+        throw new HttpNotImplementedException($request, $message);
     }
 
     /**
@@ -88,16 +85,13 @@ abstract class AbstractFakeApi
      * @param array|null             $args     Path arguments
      *
      * @return ResponseInterface
-     * @throws Exception to force implementation class to override this method
+     * @throws HttpNotImplementedException to force implementation class to override this method
      */
     public function fakeOuterBooleanSerialize(ServerRequestInterface $request, ResponseInterface $response, array $args)
     {
         $body = $request->getParsedBody();
         $message = "How about implementing fakeOuterBooleanSerialize as a POST method in OpenAPIServer\Api\FakeApi class?";
-        throw new Exception($message);
-
-        $response->getBody()->write($message);
-        return $response->withStatus(501);
+        throw new HttpNotImplementedException($request, $message);
     }
 
     /**
@@ -110,16 +104,13 @@ abstract class AbstractFakeApi
      * @param array|null             $args     Path arguments
      *
      * @return ResponseInterface
-     * @throws Exception to force implementation class to override this method
+     * @throws HttpNotImplementedException to force implementation class to override this method
      */
     public function fakeOuterCompositeSerialize(ServerRequestInterface $request, ResponseInterface $response, array $args)
     {
         $body = $request->getParsedBody();
         $message = "How about implementing fakeOuterCompositeSerialize as a POST method in OpenAPIServer\Api\FakeApi class?";
-        throw new Exception($message);
-
-        $response->getBody()->write($message);
-        return $response->withStatus(501);
+        throw new HttpNotImplementedException($request, $message);
     }
 
     /**
@@ -132,16 +123,13 @@ abstract class AbstractFakeApi
      * @param array|null             $args     Path arguments
      *
      * @return ResponseInterface
-     * @throws Exception to force implementation class to override this method
+     * @throws HttpNotImplementedException to force implementation class to override this method
      */
     public function fakeOuterNumberSerialize(ServerRequestInterface $request, ResponseInterface $response, array $args)
     {
         $body = $request->getParsedBody();
         $message = "How about implementing fakeOuterNumberSerialize as a POST method in OpenAPIServer\Api\FakeApi class?";
-        throw new Exception($message);
-
-        $response->getBody()->write($message);
-        return $response->withStatus(501);
+        throw new HttpNotImplementedException($request, $message);
     }
 
     /**
@@ -154,16 +142,13 @@ abstract class AbstractFakeApi
      * @param array|null             $args     Path arguments
      *
      * @return ResponseInterface
-     * @throws Exception to force implementation class to override this method
+     * @throws HttpNotImplementedException to force implementation class to override this method
      */
     public function fakeOuterStringSerialize(ServerRequestInterface $request, ResponseInterface $response, array $args)
     {
         $body = $request->getParsedBody();
         $message = "How about implementing fakeOuterStringSerialize as a POST method in OpenAPIServer\Api\FakeApi class?";
-        throw new Exception($message);
-
-        $response->getBody()->write($message);
-        return $response->withStatus(501);
+        throw new HttpNotImplementedException($request, $message);
     }
 
     /**
@@ -175,16 +160,13 @@ abstract class AbstractFakeApi
      * @param array|null             $args     Path arguments
      *
      * @return ResponseInterface
-     * @throws Exception to force implementation class to override this method
+     * @throws HttpNotImplementedException to force implementation class to override this method
      */
     public function testBodyWithFileSchema(ServerRequestInterface $request, ResponseInterface $response, array $args)
     {
         $body = $request->getParsedBody();
         $message = "How about implementing testBodyWithFileSchema as a PUT method in OpenAPIServer\Api\FakeApi class?";
-        throw new Exception($message);
-
-        $response->getBody()->write($message);
-        return $response->withStatus(501);
+        throw new HttpNotImplementedException($request, $message);
     }
 
     /**
@@ -195,7 +177,7 @@ abstract class AbstractFakeApi
      * @param array|null             $args     Path arguments
      *
      * @return ResponseInterface
-     * @throws Exception to force implementation class to override this method
+     * @throws HttpNotImplementedException to force implementation class to override this method
      */
     public function testBodyWithQueryParams(ServerRequestInterface $request, ResponseInterface $response, array $args)
     {
@@ -203,10 +185,7 @@ abstract class AbstractFakeApi
         $query = (key_exists('query', $queryParams)) ? $queryParams['query'] : null;
         $body = $request->getParsedBody();
         $message = "How about implementing testBodyWithQueryParams as a PUT method in OpenAPIServer\Api\FakeApi class?";
-        throw new Exception($message);
-
-        $response->getBody()->write($message);
-        return $response->withStatus(501);
+        throw new HttpNotImplementedException($request, $message);
     }
 
     /**
@@ -220,16 +199,13 @@ abstract class AbstractFakeApi
      * @param array|null             $args     Path arguments
      *
      * @return ResponseInterface
-     * @throws Exception to force implementation class to override this method
+     * @throws HttpNotImplementedException to force implementation class to override this method
      */
     public function testClientModel(ServerRequestInterface $request, ResponseInterface $response, array $args)
     {
         $body = $request->getParsedBody();
         $message = "How about implementing testClientModel as a PATCH method in OpenAPIServer\Api\FakeApi class?";
-        throw new Exception($message);
-
-        $response->getBody()->write($message);
-        return $response->withStatus(501);
+        throw new HttpNotImplementedException($request, $message);
     }
 
     /**
@@ -242,7 +218,7 @@ abstract class AbstractFakeApi
      * @param array|null             $args     Path arguments
      *
      * @return ResponseInterface
-     * @throws Exception to force implementation class to override this method
+     * @throws HttpNotImplementedException to force implementation class to override this method
      */
     public function testEndpointParameters(ServerRequestInterface $request, ResponseInterface $response, array $args)
     {
@@ -262,10 +238,7 @@ abstract class AbstractFakeApi
         $password = (isset($body['password'])) ? $body['password'] : null;
         $callback = (isset($body['callback'])) ? $body['callback'] : null;
         $message = "How about implementing testEndpointParameters as a POST method in OpenAPIServer\Api\FakeApi class?";
-        throw new Exception($message);
-
-        $response->getBody()->write($message);
-        return $response->withStatus(501);
+        throw new HttpNotImplementedException($request, $message);
     }
 
     /**
@@ -278,7 +251,7 @@ abstract class AbstractFakeApi
      * @param array|null             $args     Path arguments
      *
      * @return ResponseInterface
-     * @throws Exception to force implementation class to override this method
+     * @throws HttpNotImplementedException to force implementation class to override this method
      */
     public function testEnumParameters(ServerRequestInterface $request, ResponseInterface $response, array $args)
     {
@@ -294,10 +267,7 @@ abstract class AbstractFakeApi
         $enumFormStringArray = (isset($body['enum_form_string_array'])) ? $body['enum_form_string_array'] : null;
         $enumFormString = (isset($body['enum_form_string'])) ? $body['enum_form_string'] : null;
         $message = "How about implementing testEnumParameters as a GET method in OpenAPIServer\Api\FakeApi class?";
-        throw new Exception($message);
-
-        $response->getBody()->write($message);
-        return $response->withStatus(501);
+        throw new HttpNotImplementedException($request, $message);
     }
 
     /**
@@ -310,7 +280,7 @@ abstract class AbstractFakeApi
      * @param array|null             $args     Path arguments
      *
      * @return ResponseInterface
-     * @throws Exception to force implementation class to override this method
+     * @throws HttpNotImplementedException to force implementation class to override this method
      */
     public function testGroupParameters(ServerRequestInterface $request, ResponseInterface $response, array $args)
     {
@@ -323,10 +293,7 @@ abstract class AbstractFakeApi
         $stringGroup = (key_exists('string_group', $queryParams)) ? $queryParams['string_group'] : null;
         $int64Group = (key_exists('int64_group', $queryParams)) ? $queryParams['int64_group'] : null;
         $message = "How about implementing testGroupParameters as a DELETE method in OpenAPIServer\Api\FakeApi class?";
-        throw new Exception($message);
-
-        $response->getBody()->write($message);
-        return $response->withStatus(501);
+        throw new HttpNotImplementedException($request, $message);
     }
 
     /**
@@ -338,16 +305,13 @@ abstract class AbstractFakeApi
      * @param array|null             $args     Path arguments
      *
      * @return ResponseInterface
-     * @throws Exception to force implementation class to override this method
+     * @throws HttpNotImplementedException to force implementation class to override this method
      */
     public function testInlineAdditionalProperties(ServerRequestInterface $request, ResponseInterface $response, array $args)
     {
         $body = $request->getParsedBody();
         $message = "How about implementing testInlineAdditionalProperties as a POST method in OpenAPIServer\Api\FakeApi class?";
-        throw new Exception($message);
-
-        $response->getBody()->write($message);
-        return $response->withStatus(501);
+        throw new HttpNotImplementedException($request, $message);
     }
 
     /**
@@ -359,7 +323,7 @@ abstract class AbstractFakeApi
      * @param array|null             $args     Path arguments
      *
      * @return ResponseInterface
-     * @throws Exception to force implementation class to override this method
+     * @throws HttpNotImplementedException to force implementation class to override this method
      */
     public function testJsonFormData(ServerRequestInterface $request, ResponseInterface $response, array $args)
     {
@@ -367,10 +331,7 @@ abstract class AbstractFakeApi
         $param = (isset($body['param'])) ? $body['param'] : null;
         $param2 = (isset($body['param2'])) ? $body['param2'] : null;
         $message = "How about implementing testJsonFormData as a GET method in OpenAPIServer\Api\FakeApi class?";
-        throw new Exception($message);
-
-        $response->getBody()->write($message);
-        return $response->withStatus(501);
+        throw new HttpNotImplementedException($request, $message);
     }
 
     /**
@@ -382,7 +343,7 @@ abstract class AbstractFakeApi
      * @param array|null             $args     Path arguments
      *
      * @return ResponseInterface
-     * @throws Exception to force implementation class to override this method
+     * @throws HttpNotImplementedException to force implementation class to override this method
      */
     public function testQueryParameterCollectionFormat(ServerRequestInterface $request, ResponseInterface $response, array $args)
     {
@@ -393,9 +354,6 @@ abstract class AbstractFakeApi
         $url = (key_exists('url', $queryParams)) ? $queryParams['url'] : null;
         $context = (key_exists('context', $queryParams)) ? $queryParams['context'] : null;
         $message = "How about implementing testQueryParameterCollectionFormat as a PUT method in OpenAPIServer\Api\FakeApi class?";
-        throw new Exception($message);
-
-        $response->getBody()->write($message);
-        return $response->withStatus(501);
+        throw new HttpNotImplementedException($request, $message);
     }
 }

--- a/samples/server/petstore/php-slim4/lib/Api/AbstractFakeClassnameTags123Api.php
+++ b/samples/server/petstore/php-slim4/lib/Api/AbstractFakeClassnameTags123Api.php
@@ -28,7 +28,7 @@ namespace OpenAPIServer\Api;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\ResponseInterface;
-use Exception;
+use Slim\Exception\HttpNotImplementedException;
 
 /**
  * AbstractFakeClassnameTags123Api Class Doc Comment
@@ -67,15 +67,12 @@ abstract class AbstractFakeClassnameTags123Api
      * @param array|null             $args     Path arguments
      *
      * @return ResponseInterface
-     * @throws Exception to force implementation class to override this method
+     * @throws HttpNotImplementedException to force implementation class to override this method
      */
     public function testClassname(ServerRequestInterface $request, ResponseInterface $response, array $args)
     {
         $body = $request->getParsedBody();
         $message = "How about implementing testClassname as a PATCH method in OpenAPIServer\Api\FakeClassnameTags123Api class?";
-        throw new Exception($message);
-
-        $response->getBody()->write($message);
-        return $response->withStatus(501);
+        throw new HttpNotImplementedException($request, $message);
     }
 }

--- a/samples/server/petstore/php-slim4/lib/Api/AbstractPetApi.php
+++ b/samples/server/petstore/php-slim4/lib/Api/AbstractPetApi.php
@@ -28,7 +28,7 @@ namespace OpenAPIServer\Api;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\ResponseInterface;
-use Exception;
+use Slim\Exception\HttpNotImplementedException;
 
 /**
  * AbstractPetApi Class Doc Comment
@@ -65,16 +65,13 @@ abstract class AbstractPetApi
      * @param array|null             $args     Path arguments
      *
      * @return ResponseInterface
-     * @throws Exception to force implementation class to override this method
+     * @throws HttpNotImplementedException to force implementation class to override this method
      */
     public function addPet(ServerRequestInterface $request, ResponseInterface $response, array $args)
     {
         $body = $request->getParsedBody();
         $message = "How about implementing addPet as a POST method in OpenAPIServer\Api\PetApi class?";
-        throw new Exception($message);
-
-        $response->getBody()->write($message);
-        return $response->withStatus(501);
+        throw new HttpNotImplementedException($request, $message);
     }
 
     /**
@@ -86,7 +83,7 @@ abstract class AbstractPetApi
      * @param array|null             $args     Path arguments
      *
      * @return ResponseInterface
-     * @throws Exception to force implementation class to override this method
+     * @throws HttpNotImplementedException to force implementation class to override this method
      */
     public function deletePet(ServerRequestInterface $request, ResponseInterface $response, array $args)
     {
@@ -94,10 +91,7 @@ abstract class AbstractPetApi
         $apiKey = $request->hasHeader('api_key') ? $headers['api_key'] : null;
         $petId = $args['petId'];
         $message = "How about implementing deletePet as a DELETE method in OpenAPIServer\Api\PetApi class?";
-        throw new Exception($message);
-
-        $response->getBody()->write($message);
-        return $response->withStatus(501);
+        throw new HttpNotImplementedException($request, $message);
     }
 
     /**
@@ -111,17 +105,14 @@ abstract class AbstractPetApi
      * @param array|null             $args     Path arguments
      *
      * @return ResponseInterface
-     * @throws Exception to force implementation class to override this method
+     * @throws HttpNotImplementedException to force implementation class to override this method
      */
     public function findPetsByStatus(ServerRequestInterface $request, ResponseInterface $response, array $args)
     {
         $queryParams = $request->getQueryParams();
         $status = (key_exists('status', $queryParams)) ? $queryParams['status'] : null;
         $message = "How about implementing findPetsByStatus as a GET method in OpenAPIServer\Api\PetApi class?";
-        throw new Exception($message);
-
-        $response->getBody()->write($message);
-        return $response->withStatus(501);
+        throw new HttpNotImplementedException($request, $message);
     }
 
     /**
@@ -135,17 +126,14 @@ abstract class AbstractPetApi
      * @param array|null             $args     Path arguments
      *
      * @return ResponseInterface
-     * @throws Exception to force implementation class to override this method
+     * @throws HttpNotImplementedException to force implementation class to override this method
      */
     public function findPetsByTags(ServerRequestInterface $request, ResponseInterface $response, array $args)
     {
         $queryParams = $request->getQueryParams();
         $tags = (key_exists('tags', $queryParams)) ? $queryParams['tags'] : null;
         $message = "How about implementing findPetsByTags as a GET method in OpenAPIServer\Api\PetApi class?";
-        throw new Exception($message);
-
-        $response->getBody()->write($message);
-        return $response->withStatus(501);
+        throw new HttpNotImplementedException($request, $message);
     }
 
     /**
@@ -159,16 +147,13 @@ abstract class AbstractPetApi
      * @param array|null             $args     Path arguments
      *
      * @return ResponseInterface
-     * @throws Exception to force implementation class to override this method
+     * @throws HttpNotImplementedException to force implementation class to override this method
      */
     public function getPetById(ServerRequestInterface $request, ResponseInterface $response, array $args)
     {
         $petId = $args['petId'];
         $message = "How about implementing getPetById as a GET method in OpenAPIServer\Api\PetApi class?";
-        throw new Exception($message);
-
-        $response->getBody()->write($message);
-        return $response->withStatus(501);
+        throw new HttpNotImplementedException($request, $message);
     }
 
     /**
@@ -180,16 +165,13 @@ abstract class AbstractPetApi
      * @param array|null             $args     Path arguments
      *
      * @return ResponseInterface
-     * @throws Exception to force implementation class to override this method
+     * @throws HttpNotImplementedException to force implementation class to override this method
      */
     public function updatePet(ServerRequestInterface $request, ResponseInterface $response, array $args)
     {
         $body = $request->getParsedBody();
         $message = "How about implementing updatePet as a PUT method in OpenAPIServer\Api\PetApi class?";
-        throw new Exception($message);
-
-        $response->getBody()->write($message);
-        return $response->withStatus(501);
+        throw new HttpNotImplementedException($request, $message);
     }
 
     /**
@@ -201,7 +183,7 @@ abstract class AbstractPetApi
      * @param array|null             $args     Path arguments
      *
      * @return ResponseInterface
-     * @throws Exception to force implementation class to override this method
+     * @throws HttpNotImplementedException to force implementation class to override this method
      */
     public function updatePetWithForm(ServerRequestInterface $request, ResponseInterface $response, array $args)
     {
@@ -210,10 +192,7 @@ abstract class AbstractPetApi
         $name = (isset($body['name'])) ? $body['name'] : null;
         $status = (isset($body['status'])) ? $body['status'] : null;
         $message = "How about implementing updatePetWithForm as a POST method in OpenAPIServer\Api\PetApi class?";
-        throw new Exception($message);
-
-        $response->getBody()->write($message);
-        return $response->withStatus(501);
+        throw new HttpNotImplementedException($request, $message);
     }
 
     /**
@@ -226,7 +205,7 @@ abstract class AbstractPetApi
      * @param array|null             $args     Path arguments
      *
      * @return ResponseInterface
-     * @throws Exception to force implementation class to override this method
+     * @throws HttpNotImplementedException to force implementation class to override this method
      */
     public function uploadFile(ServerRequestInterface $request, ResponseInterface $response, array $args)
     {
@@ -235,10 +214,7 @@ abstract class AbstractPetApi
         $additionalMetadata = (isset($body['additionalMetadata'])) ? $body['additionalMetadata'] : null;
         $file = (key_exists('file', $request->getUploadedFiles())) ? $request->getUploadedFiles()['file'] : null;
         $message = "How about implementing uploadFile as a POST method in OpenAPIServer\Api\PetApi class?";
-        throw new Exception($message);
-
-        $response->getBody()->write($message);
-        return $response->withStatus(501);
+        throw new HttpNotImplementedException($request, $message);
     }
 
     /**
@@ -251,7 +227,7 @@ abstract class AbstractPetApi
      * @param array|null             $args     Path arguments
      *
      * @return ResponseInterface
-     * @throws Exception to force implementation class to override this method
+     * @throws HttpNotImplementedException to force implementation class to override this method
      */
     public function uploadFileWithRequiredFile(ServerRequestInterface $request, ResponseInterface $response, array $args)
     {
@@ -260,9 +236,6 @@ abstract class AbstractPetApi
         $additionalMetadata = (isset($body['additionalMetadata'])) ? $body['additionalMetadata'] : null;
         $requiredFile = (key_exists('requiredFile', $request->getUploadedFiles())) ? $request->getUploadedFiles()['requiredFile'] : null;
         $message = "How about implementing uploadFileWithRequiredFile as a POST method in OpenAPIServer\Api\PetApi class?";
-        throw new Exception($message);
-
-        $response->getBody()->write($message);
-        return $response->withStatus(501);
+        throw new HttpNotImplementedException($request, $message);
     }
 }

--- a/samples/server/petstore/php-slim4/lib/Api/AbstractStoreApi.php
+++ b/samples/server/petstore/php-slim4/lib/Api/AbstractStoreApi.php
@@ -28,7 +28,7 @@ namespace OpenAPIServer\Api;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\ResponseInterface;
-use Exception;
+use Slim\Exception\HttpNotImplementedException;
 
 /**
  * AbstractStoreApi Class Doc Comment
@@ -66,16 +66,13 @@ abstract class AbstractStoreApi
      * @param array|null             $args     Path arguments
      *
      * @return ResponseInterface
-     * @throws Exception to force implementation class to override this method
+     * @throws HttpNotImplementedException to force implementation class to override this method
      */
     public function deleteOrder(ServerRequestInterface $request, ResponseInterface $response, array $args)
     {
         $orderId = $args['order_id'];
         $message = "How about implementing deleteOrder as a DELETE method in OpenAPIServer\Api\StoreApi class?";
-        throw new Exception($message);
-
-        $response->getBody()->write($message);
-        return $response->withStatus(501);
+        throw new HttpNotImplementedException($request, $message);
     }
 
     /**
@@ -89,15 +86,12 @@ abstract class AbstractStoreApi
      * @param array|null             $args     Path arguments
      *
      * @return ResponseInterface
-     * @throws Exception to force implementation class to override this method
+     * @throws HttpNotImplementedException to force implementation class to override this method
      */
     public function getInventory(ServerRequestInterface $request, ResponseInterface $response, array $args)
     {
         $message = "How about implementing getInventory as a GET method in OpenAPIServer\Api\StoreApi class?";
-        throw new Exception($message);
-
-        $response->getBody()->write($message);
-        return $response->withStatus(501);
+        throw new HttpNotImplementedException($request, $message);
     }
 
     /**
@@ -111,16 +105,13 @@ abstract class AbstractStoreApi
      * @param array|null             $args     Path arguments
      *
      * @return ResponseInterface
-     * @throws Exception to force implementation class to override this method
+     * @throws HttpNotImplementedException to force implementation class to override this method
      */
     public function getOrderById(ServerRequestInterface $request, ResponseInterface $response, array $args)
     {
         $orderId = $args['order_id'];
         $message = "How about implementing getOrderById as a GET method in OpenAPIServer\Api\StoreApi class?";
-        throw new Exception($message);
-
-        $response->getBody()->write($message);
-        return $response->withStatus(501);
+        throw new HttpNotImplementedException($request, $message);
     }
 
     /**
@@ -133,15 +124,12 @@ abstract class AbstractStoreApi
      * @param array|null             $args     Path arguments
      *
      * @return ResponseInterface
-     * @throws Exception to force implementation class to override this method
+     * @throws HttpNotImplementedException to force implementation class to override this method
      */
     public function placeOrder(ServerRequestInterface $request, ResponseInterface $response, array $args)
     {
         $body = $request->getParsedBody();
         $message = "How about implementing placeOrder as a POST method in OpenAPIServer\Api\StoreApi class?";
-        throw new Exception($message);
-
-        $response->getBody()->write($message);
-        return $response->withStatus(501);
+        throw new HttpNotImplementedException($request, $message);
     }
 }

--- a/samples/server/petstore/php-slim4/lib/Api/AbstractUserApi.php
+++ b/samples/server/petstore/php-slim4/lib/Api/AbstractUserApi.php
@@ -28,7 +28,7 @@ namespace OpenAPIServer\Api;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\ResponseInterface;
-use Exception;
+use Slim\Exception\HttpNotImplementedException;
 
 /**
  * AbstractUserApi Class Doc Comment
@@ -66,16 +66,13 @@ abstract class AbstractUserApi
      * @param array|null             $args     Path arguments
      *
      * @return ResponseInterface
-     * @throws Exception to force implementation class to override this method
+     * @throws HttpNotImplementedException to force implementation class to override this method
      */
     public function createUser(ServerRequestInterface $request, ResponseInterface $response, array $args)
     {
         $body = $request->getParsedBody();
         $message = "How about implementing createUser as a POST method in OpenAPIServer\Api\UserApi class?";
-        throw new Exception($message);
-
-        $response->getBody()->write($message);
-        return $response->withStatus(501);
+        throw new HttpNotImplementedException($request, $message);
     }
 
     /**
@@ -87,16 +84,13 @@ abstract class AbstractUserApi
      * @param array|null             $args     Path arguments
      *
      * @return ResponseInterface
-     * @throws Exception to force implementation class to override this method
+     * @throws HttpNotImplementedException to force implementation class to override this method
      */
     public function createUsersWithArrayInput(ServerRequestInterface $request, ResponseInterface $response, array $args)
     {
         $body = $request->getParsedBody();
         $message = "How about implementing createUsersWithArrayInput as a POST method in OpenAPIServer\Api\UserApi class?";
-        throw new Exception($message);
-
-        $response->getBody()->write($message);
-        return $response->withStatus(501);
+        throw new HttpNotImplementedException($request, $message);
     }
 
     /**
@@ -108,16 +102,13 @@ abstract class AbstractUserApi
      * @param array|null             $args     Path arguments
      *
      * @return ResponseInterface
-     * @throws Exception to force implementation class to override this method
+     * @throws HttpNotImplementedException to force implementation class to override this method
      */
     public function createUsersWithListInput(ServerRequestInterface $request, ResponseInterface $response, array $args)
     {
         $body = $request->getParsedBody();
         $message = "How about implementing createUsersWithListInput as a POST method in OpenAPIServer\Api\UserApi class?";
-        throw new Exception($message);
-
-        $response->getBody()->write($message);
-        return $response->withStatus(501);
+        throw new HttpNotImplementedException($request, $message);
     }
 
     /**
@@ -130,16 +121,13 @@ abstract class AbstractUserApi
      * @param array|null             $args     Path arguments
      *
      * @return ResponseInterface
-     * @throws Exception to force implementation class to override this method
+     * @throws HttpNotImplementedException to force implementation class to override this method
      */
     public function deleteUser(ServerRequestInterface $request, ResponseInterface $response, array $args)
     {
         $username = $args['username'];
         $message = "How about implementing deleteUser as a DELETE method in OpenAPIServer\Api\UserApi class?";
-        throw new Exception($message);
-
-        $response->getBody()->write($message);
-        return $response->withStatus(501);
+        throw new HttpNotImplementedException($request, $message);
     }
 
     /**
@@ -152,16 +140,13 @@ abstract class AbstractUserApi
      * @param array|null             $args     Path arguments
      *
      * @return ResponseInterface
-     * @throws Exception to force implementation class to override this method
+     * @throws HttpNotImplementedException to force implementation class to override this method
      */
     public function getUserByName(ServerRequestInterface $request, ResponseInterface $response, array $args)
     {
         $username = $args['username'];
         $message = "How about implementing getUserByName as a GET method in OpenAPIServer\Api\UserApi class?";
-        throw new Exception($message);
-
-        $response->getBody()->write($message);
-        return $response->withStatus(501);
+        throw new HttpNotImplementedException($request, $message);
     }
 
     /**
@@ -174,7 +159,7 @@ abstract class AbstractUserApi
      * @param array|null             $args     Path arguments
      *
      * @return ResponseInterface
-     * @throws Exception to force implementation class to override this method
+     * @throws HttpNotImplementedException to force implementation class to override this method
      */
     public function loginUser(ServerRequestInterface $request, ResponseInterface $response, array $args)
     {
@@ -182,10 +167,7 @@ abstract class AbstractUserApi
         $username = (key_exists('username', $queryParams)) ? $queryParams['username'] : null;
         $password = (key_exists('password', $queryParams)) ? $queryParams['password'] : null;
         $message = "How about implementing loginUser as a GET method in OpenAPIServer\Api\UserApi class?";
-        throw new Exception($message);
-
-        $response->getBody()->write($message);
-        return $response->withStatus(501);
+        throw new HttpNotImplementedException($request, $message);
     }
 
     /**
@@ -197,15 +179,12 @@ abstract class AbstractUserApi
      * @param array|null             $args     Path arguments
      *
      * @return ResponseInterface
-     * @throws Exception to force implementation class to override this method
+     * @throws HttpNotImplementedException to force implementation class to override this method
      */
     public function logoutUser(ServerRequestInterface $request, ResponseInterface $response, array $args)
     {
         $message = "How about implementing logoutUser as a GET method in OpenAPIServer\Api\UserApi class?";
-        throw new Exception($message);
-
-        $response->getBody()->write($message);
-        return $response->withStatus(501);
+        throw new HttpNotImplementedException($request, $message);
     }
 
     /**
@@ -218,16 +197,13 @@ abstract class AbstractUserApi
      * @param array|null             $args     Path arguments
      *
      * @return ResponseInterface
-     * @throws Exception to force implementation class to override this method
+     * @throws HttpNotImplementedException to force implementation class to override this method
      */
     public function updateUser(ServerRequestInterface $request, ResponseInterface $response, array $args)
     {
         $username = $args['username'];
         $body = $request->getParsedBody();
         $message = "How about implementing updateUser as a PUT method in OpenAPIServer\Api\UserApi class?";
-        throw new Exception($message);
-
-        $response->getBody()->write($message);
-        return $response->withStatus(501);
+        throw new HttpNotImplementedException($request, $message);
     }
 }

--- a/samples/server/petstore/php-slim4/lib/SlimRouter.php
+++ b/samples/server/petstore/php-slim4/lib/SlimRouter.php
@@ -27,6 +27,7 @@ namespace OpenAPIServer;
 
 use Slim\Factory\AppFactory;
 use Slim\Interfaces\RouteInterface;
+use Slim\Exception\HttpNotImplementedException;
 use Psr\Container\ContainerInterface;
 use InvalidArgumentException;
 use Dyorg\TokenAuthentication;
@@ -1307,7 +1308,8 @@ class SlimRouter
      *
      * @param ContainerInterface|array $settings Either a ContainerInterface or an associative array of app settings
      *
-     * @throws Exception When implementation class doesn't exists
+     * @throws HttpNotImplementedException When implementation class doesn't exists
+     * @throws Exception when not supported authorization schema type provided
      */
     public function __construct($settings = [])
     {
@@ -1323,15 +1325,15 @@ class SlimRouter
         $authPackage = 'OpenAPIServer\Auth';
         $basicAuthenticator = function (ServerRequestInterface &$request, TokenSearch $tokenSearch) use ($authPackage) {
             $message = "How about extending AbstractAuthenticator class by {$authPackage}\BasicAuthenticator?";
-            throw new Exception($message);
+            throw new HttpNotImplementedException($request, $message);
         };
         $apiKeyAuthenticator = function (ServerRequestInterface &$request, TokenSearch $tokenSearch) use ($authPackage) {
             $message = "How about extending AbstractAuthenticator class by {$authPackage}\ApiKeyAuthenticator?";
-            throw new Exception($message);
+            throw new HttpNotImplementedException($request, $message);
         };
         $oAuthAuthenticator = function (ServerRequestInterface &$request, TokenSearch $tokenSearch) use ($authPackage) {
             $message = "How about extending AbstractAuthenticator class by {$authPackage}\OAuthAuthenticator?";
-            throw new Exception($message);
+            throw new HttpNotImplementedException($request, $message);
         };
 
         $userOptions = $this->getSetting($settings, 'tokenAuthenticationOptions', null);
@@ -1345,9 +1347,7 @@ class SlimRouter
         foreach ($this->operations as $operation) {
             $callback = function ($request, $response, $arguments) use ($operation) {
                 $message = "How about extending {$operation['classname']} by {$operation['apiPackage']}\\{$operation['userClassname']} class implementing {$operation['operationId']} as a {$operation['httpMethod']} method?";
-                throw new Exception($message);
-                $response->getBody()->write($message);
-                return $response->withStatus(501);
+                throw new HttpNotImplementedException($request, $message);
             };
             $middlewares = [new JsonBodyParserMiddleware()];
 


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
It's a bad practice to use general PHP `Exception` because it makes difficult to catch specific cases. Slim framework contains [Slim\Exception\HttpNotImplementedException](https://github.com/slimphp/Slim/blob/4.x/Slim/Exception/HttpNotImplementedException.php) class which looks better than unknown `Exception`.

Result of API call with header `Accept: application/json` and `displayErrorDetails: false` option:
`HTTP/1.1 501 Not Implemented`
```json
{
  "message": "501 Not Implemented"
}
```
and with `displayErrorDetails: true` option:
`HTTP/1.1 501 Not Implemented`
```json
{
  "message": "501 Not Implemented",
  "exception": [
    {
      "type": "Slim\\Exception\\HttpNotImplementedException",
      "code": 501,
      "message": "How about extending AbstractUserApi by OpenAPIServer\\Api\\UserApi class implementing createUser as a POST method?",
      "file": "/Users/ybelenko/Sites/openapi-generator/samples/server/petstore/php-slim4/lib/SlimRouter.php",
      "line": 1349
    }
  ]
}
```
If user isn't satisfied with mentioned responses he can:
* Change API controller template or
* Use custom [Error Handling Middleware - Slim](http://www.slimframework.com/docs/v4/middleware/error-handling.html#adding-custom-error-handlers) to catch `HttpNotImplementedException` and overwrite the result.
<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

cc @jebentier @dkarlovi @mandrean @jfastnacht @ackintosh @renepardon