### PR TITLE
Move Ruby tests to Travis CI

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1193,7 +1193,6 @@
                 </property>
             </activation>
             <modules>
-                <module>samples/client/petstore/perl</module>
                 <!-- servers -->
                 <module>samples/server/petstore/python-aiohttp</module>
                 <module>samples/server/petstore/python-aiohttp-srclayout</module>
@@ -1203,6 +1202,8 @@
                 <module>samples/server/petstore/php-slim4</module>
                 <module>samples/server/petstore/rust-server</module>
                 <!-- clients -->
+                <module>samples/client/petstore/perl</module>
+                <module>samples/client/petstore/ruby</module>
                 <module>samples/client/petstore/bash</module>
                 <module>samples/client/petstore/c</module>
                 <module>samples/client/petstore/cpp-qt5</module>
@@ -1346,8 +1347,6 @@
             <modules>
                 <module>samples/server/petstore/go-api-server</module>
                 <module>samples/server/petstore/go-gin-api-server</module>
-                <!-- clients -->
-                <module>samples/client/petstore/ruby</module>
                 <!-- test java-related projects -->
                 <module>samples/client/petstore/dart2/petstore</module>
                 <module>samples/client/petstore/dart-jaguar/openapi</module>


### PR DESCRIPTION
Move Ruby tests to Travis from CircleCI to address the failure due to requirement of a newer version of Ruby 

<!-- Please check the completed items below -->
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [ ] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [ ] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
