### PR TITLE
Use supplied packageName instead of hardcoded

### DIFF
--- a/modules/openapi-generator/src/main/resources/erlang-server/auth.mustache
+++ b/modules/openapi-generator/src/main/resources/erlang-server/auth.mustache
@@ -40,7 +40,7 @@ get_api_key(header, KeyParam, Req) ->
     Headers = cowboy_req:headers(Req),
     {
         maps:get(
-            openapi_utils:to_header(KeyParam),
+            {{packageName}}_utils:to_header(KeyParam),
             Headers,
             undefined
         ),


### PR DESCRIPTION
Hardcoding open_api_utils there breaks this package if packageName option is used for generating the server code.
Use the provided {{packageName}} template variable the same as it is used in the rest of the file.
The samples do not change when using the default packageName.

CC erlang technical committe
@tsloughter @jfacorro @robertoaloi

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
