### PR TITLE
[python-client] Enable per-request auth settings

### DIFF
--- a/modules/openapi-generator/src/main/resources/python/api.mustache
+++ b/modules/openapi-generator/src/main/resources/python/api.mustache
@@ -103,6 +103,9 @@ class {{classname}}(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -137,7 +140,8 @@ class {{classname}}(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -266,6 +270,7 @@ class {{classname}}(object):
             {{#servers.0}}
             _host=local_var_host,
             {{/servers.0}}
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 {{/operation}}
 {{/operations}}

--- a/modules/openapi-generator/src/main/resources/python/api.mustache
+++ b/modules/openapi-generator/src/main/resources/python/api.mustache
@@ -103,9 +103,10 @@ class {{classname}}(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -141,7 +142,7 @@ class {{classname}}(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -271,6 +272,6 @@ class {{classname}}(object):
             _host=local_var_host,
             {{/servers.0}}
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 {{/operation}}
 {{/operations}}

--- a/modules/openapi-generator/src/main/resources/python/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/python/api_client.mustache
@@ -133,7 +133,7 @@ class ApiClient(object):
             files=None, response_type=None, auth_settings=None,
             _return_http_data_only=None, collection_formats=None,
             _preload_content=True, _request_timeout=None, _host=None,
-            _access_token=None):
+            _request_auth=None):
 
         config = self.configuration
 
@@ -176,7 +176,7 @@ class ApiClient(object):
         # auth setting
         self.update_params_for_auth(
             header_params, query_params, auth_settings,
-            access_token=_access_token)
+            request_auth=_request_auth)
 
         # body
         if body:
@@ -351,7 +351,7 @@ class ApiClient(object):
                  response_type=None, auth_settings=None, async_req=None,
                  _return_http_data_only=None, collection_formats=None,
                  _preload_content=True, _request_timeout=None, _host=None,
-                 _access_token=None):
+                 _request_auth=None):
         """Makes the HTTP request (synchronous) and returns deserialized data.
 
         To make an async_req request, set the async_req parameter.
@@ -381,9 +381,10 @@ class ApiClient(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_token: dict, optional
         :return:
             If async_req parameter is True,
             the request will be called asynchronously.
@@ -398,7 +399,7 @@ class ApiClient(object):
                                    response_type, auth_settings,
                                    _return_http_data_only, collection_formats,
                                    _preload_content, _request_timeout, _host,
-                                   _access_token)
+                                   _request_auth)
 
         return self.pool.apply_async(self.__call_api, (resource_path,
                                                        method, path_params,
@@ -411,7 +412,7 @@ class ApiClient(object):
                                                        collection_formats,
                                                        _preload_content,
                                                        _request_timeout,
-                                                       _host, _access_token))
+                                                       _host, _request_auth))
 
     def request(self, method, url, query_params=None, headers=None,
                 post_params=None, body=None, _preload_content=True,
@@ -559,31 +560,27 @@ class ApiClient(object):
             return content_types[0]
 
     def update_params_for_auth(self, headers, querys, auth_settings,
-                               access_token=None):
+                               request_auth=None):
         """Updates header and query params based on authentication setting.
 
         :param headers: Header parameters dict to be updated.
         :param querys: Query parameters tuple list to be updated.
         :param auth_settings: Authentication setting identifiers list.
-        :param access_token: if set, the provided access token will be used
-                             instead of the token in the configuration.
+        :param request_auth: if set, the provided settings will
+                             override the token in the configuration.
         """
         if not auth_settings:
             return
 
         for auth in auth_settings:
-            auth_setting = self.configuration.auth_settings().get(auth)
+            auth_setting = request_auth or self.configuration.auth_settings().get(auth)
             if auth_setting:
-                value = auth_setting['value']
-                if access_token is not None:
-                    value = access_token
-
                 if auth_setting['in'] == 'cookie':
-                    headers['Cookie'] = value
+                    headers['Cookie'] = auth_setting['value']
                 elif auth_setting['in'] == 'header':
-                    headers[auth_setting['key']] = value
+                    headers[auth_setting['key']] = auth_setting['value']
                 elif auth_setting['in'] == 'query':
-                    querys.append((auth_setting['key'], value))
+                    querys.append((auth_setting['key'], auth_setting['value']))
                 else:
                     raise ApiValueError(
                         'Authentication token must be in `query` or `header`'

--- a/modules/openapi-generator/src/main/resources/python/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/python/api_client.mustache
@@ -132,7 +132,8 @@ class ApiClient(object):
             query_params=None, header_params=None, body=None, post_params=None,
             files=None, response_type=None, auth_settings=None,
             _return_http_data_only=None, collection_formats=None,
-            _preload_content=True, _request_timeout=None, _host=None):
+            _preload_content=True, _request_timeout=None, _host=None,
+            _access_token=None):
 
         config = self.configuration
 
@@ -173,7 +174,9 @@ class ApiClient(object):
             post_params.extend(self.files_parameters(files))
 
         # auth setting
-        self.update_params_for_auth(header_params, query_params, auth_settings)
+        self.update_params_for_auth(
+            header_params, query_params, auth_settings,
+            access_token=_access_token)
 
         # body
         if body:
@@ -347,7 +350,8 @@ class ApiClient(object):
                  body=None, post_params=None, files=None,
                  response_type=None, auth_settings=None, async_req=None,
                  _return_http_data_only=None, collection_formats=None,
-                 _preload_content=True, _request_timeout=None, _host=None):
+                 _preload_content=True, _request_timeout=None, _host=None,
+                 _access_token=None):
         """Makes the HTTP request (synchronous) and returns deserialized data.
 
         To make an async_req request, set the async_req parameter.
@@ -377,6 +381,9 @@ class ApiClient(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return:
             If async_req parameter is True,
             the request will be called asynchronously.
@@ -390,7 +397,8 @@ class ApiClient(object):
                                    body, post_params, files,
                                    response_type, auth_settings,
                                    _return_http_data_only, collection_formats,
-                                   _preload_content, _request_timeout, _host)
+                                   _preload_content, _request_timeout, _host,
+                                   _access_token)
 
         return self.pool.apply_async(self.__call_api, (resource_path,
                                                        method, path_params,
@@ -403,7 +411,7 @@ class ApiClient(object):
                                                        collection_formats,
                                                        _preload_content,
                                                        _request_timeout,
-                                                       _host))
+                                                       _host, _access_token))
 
     def request(self, method, url, query_params=None, headers=None,
                 post_params=None, body=None, _preload_content=True,
@@ -550,12 +558,15 @@ class ApiClient(object):
         else:
             return content_types[0]
 
-    def update_params_for_auth(self, headers, querys, auth_settings):
+    def update_params_for_auth(self, headers, querys, auth_settings,
+                               access_token=None):
         """Updates header and query params based on authentication setting.
 
         :param headers: Header parameters dict to be updated.
         :param querys: Query parameters tuple list to be updated.
         :param auth_settings: Authentication setting identifiers list.
+        :param access_token: if set, the provided access token will be used
+                             instead of the token in the configuration.
         """
         if not auth_settings:
             return
@@ -563,12 +574,16 @@ class ApiClient(object):
         for auth in auth_settings:
             auth_setting = self.configuration.auth_settings().get(auth)
             if auth_setting:
+                value = auth_setting['value']
+                if access_token is not None:
+                    value = access_token
+
                 if auth_setting['in'] == 'cookie':
-                    headers['Cookie'] = auth_setting['value']
+                    headers['Cookie'] = value
                 elif auth_setting['in'] == 'header':
-                    headers[auth_setting['key']] = auth_setting['value']
+                    headers[auth_setting['key']] = value
                 elif auth_setting['in'] == 'query':
-                    querys.append((auth_setting['key'], auth_setting['value']))
+                    querys.append((auth_setting['key'], value))
                 else:
                     raise ApiValueError(
                         'Authentication token must be in `query` or `header`'

--- a/modules/openapi-generator/src/main/resources/python/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/python/api_client.mustache
@@ -572,19 +572,32 @@ class ApiClient(object):
         if not auth_settings:
             return
 
+        if request_auth:
+            self._apply_auth_params(headers, querys, request_auth)
+            return
+
         for auth in auth_settings:
-            auth_setting = request_auth or self.configuration.auth_settings().get(auth)
+            auth_setting = self.configuration.auth_settings().get(auth)
             if auth_setting:
-                if auth_setting['in'] == 'cookie':
-                    headers['Cookie'] = auth_setting['value']
-                elif auth_setting['in'] == 'header':
-                    headers[auth_setting['key']] = auth_setting['value']
-                elif auth_setting['in'] == 'query':
-                    querys.append((auth_setting['key'], auth_setting['value']))
-                else:
-                    raise ApiValueError(
-                        'Authentication token must be in `query` or `header`'
-                    )
+                self._apply_auth_params(headers, querys, auth_setting)
+
+    def _apply_auth_params(self, headers, querys, auth_setting):
+        """Updates the request parameters based on a single auth_setting
+
+        :param headers: Header parameters dict to be updated.
+        :param querys: Query parameters tuple list to be updated.
+        :param auth_setting: auth settings for the endpoint
+        """
+        if auth_setting['in'] == 'cookie':
+            headers['Cookie'] = auth_setting['value']
+        elif auth_setting['in'] == 'header':
+            headers[auth_setting['key']] = auth_setting['value']
+        elif auth_setting['in'] == 'query':
+            querys.append((auth_setting['key'], auth_setting['value']))
+        else:
+            raise ApiValueError(
+                'Authentication token must be in `query` or `header`'
+            )
 
     def __deserialize_file(self, response):
         """Deserializes body to file

--- a/samples/client/petstore/python-asyncio/petstore_api/api/another_fake_api.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/api/another_fake_api.py
@@ -91,6 +91,9 @@ class AnotherFakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -107,7 +110,8 @@ class AnotherFakeApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -163,4 +167,5 @@ class AnotherFakeApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))

--- a/samples/client/petstore/python-asyncio/petstore_api/api/another_fake_api.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/api/another_fake_api.py
@@ -91,9 +91,10 @@ class AnotherFakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -111,7 +112,7 @@ class AnotherFakeApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -168,4 +169,4 @@ class AnotherFakeApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))

--- a/samples/client/petstore/python-asyncio/petstore_api/api/fake_api.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/api/fake_api.py
@@ -91,6 +91,9 @@ class FakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -107,7 +110,8 @@ class FakeApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -159,7 +163,8 @@ class FakeApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def fake_outer_boolean_serialize(self, **kwargs):  # noqa: E501
         """fake_outer_boolean_serialize  # noqa: E501
@@ -216,6 +221,9 @@ class FakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -232,7 +240,8 @@ class FakeApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -280,7 +289,8 @@ class FakeApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def fake_outer_composite_serialize(self, **kwargs):  # noqa: E501
         """fake_outer_composite_serialize  # noqa: E501
@@ -337,6 +347,9 @@ class FakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -353,7 +366,8 @@ class FakeApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -401,7 +415,8 @@ class FakeApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def fake_outer_number_serialize(self, **kwargs):  # noqa: E501
         """fake_outer_number_serialize  # noqa: E501
@@ -458,6 +473,9 @@ class FakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -474,7 +492,8 @@ class FakeApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -522,7 +541,8 @@ class FakeApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def fake_outer_string_serialize(self, **kwargs):  # noqa: E501
         """fake_outer_string_serialize  # noqa: E501
@@ -579,6 +599,9 @@ class FakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -595,7 +618,8 @@ class FakeApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -643,7 +667,8 @@ class FakeApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def test_body_with_file_schema(self, body, **kwargs):  # noqa: E501
         """test_body_with_file_schema  # noqa: E501
@@ -700,6 +725,9 @@ class FakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -716,7 +744,8 @@ class FakeApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -768,7 +797,8 @@ class FakeApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def test_body_with_query_params(self, query, body, **kwargs):  # noqa: E501
         """test_body_with_query_params  # noqa: E501
@@ -827,6 +857,9 @@ class FakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -844,7 +877,8 @@ class FakeApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -902,7 +936,8 @@ class FakeApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def test_client_model(self, body, **kwargs):  # noqa: E501
         """To test \"client\" model  # noqa: E501
@@ -959,6 +994,9 @@ class FakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -975,7 +1013,8 @@ class FakeApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -1031,7 +1070,8 @@ class FakeApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def test_endpoint_parameters(self, number, double, pattern_without_delimiter, byte, **kwargs):  # noqa: E501
         """Fake endpoint for testing various parameters  假端點  偽のエンドポイント  가짜 엔드 포인트  # noqa: E501
@@ -1140,6 +1180,9 @@ class FakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -1169,7 +1212,8 @@ class FakeApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -1287,7 +1331,8 @@ class FakeApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def test_enum_parameters(self, **kwargs):  # noqa: E501
         """To test enum parameters  # noqa: E501
@@ -1372,6 +1417,9 @@ class FakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -1395,7 +1443,8 @@ class FakeApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -1460,7 +1509,8 @@ class FakeApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def test_group_parameters(self, required_string_group, required_boolean_group, required_int64_group, **kwargs):  # noqa: E501
         """Fake endpoint to test group parameters (optional)  # noqa: E501
@@ -1537,6 +1587,9 @@ class FakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -1558,7 +1611,8 @@ class FakeApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -1624,7 +1678,8 @@ class FakeApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def test_inline_additional_properties(self, param, **kwargs):  # noqa: E501
         """test inline additionalProperties  # noqa: E501
@@ -1679,6 +1734,9 @@ class FakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -1695,7 +1753,8 @@ class FakeApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -1747,7 +1806,8 @@ class FakeApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def test_json_form_data(self, param, param2, **kwargs):  # noqa: E501
         """test json serialization of form data  # noqa: E501
@@ -1806,6 +1866,9 @@ class FakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -1823,7 +1886,8 @@ class FakeApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -1881,7 +1945,8 @@ class FakeApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def test_query_parameter_collection_format(self, pipe, ioutil, http, url, context, **kwargs):  # noqa: E501
         """test_query_parameter_collection_format  # noqa: E501
@@ -1954,6 +2019,9 @@ class FakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -1974,7 +2042,8 @@ class FakeApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -2051,4 +2120,5 @@ class FakeApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))

--- a/samples/client/petstore/python-asyncio/petstore_api/api/fake_api.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/api/fake_api.py
@@ -91,9 +91,10 @@ class FakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -111,7 +112,7 @@ class FakeApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -164,7 +165,7 @@ class FakeApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def fake_outer_boolean_serialize(self, **kwargs):  # noqa: E501
         """fake_outer_boolean_serialize  # noqa: E501
@@ -221,9 +222,10 @@ class FakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -241,7 +243,7 @@ class FakeApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -290,7 +292,7 @@ class FakeApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def fake_outer_composite_serialize(self, **kwargs):  # noqa: E501
         """fake_outer_composite_serialize  # noqa: E501
@@ -347,9 +349,10 @@ class FakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -367,7 +370,7 @@ class FakeApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -416,7 +419,7 @@ class FakeApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def fake_outer_number_serialize(self, **kwargs):  # noqa: E501
         """fake_outer_number_serialize  # noqa: E501
@@ -473,9 +476,10 @@ class FakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -493,7 +497,7 @@ class FakeApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -542,7 +546,7 @@ class FakeApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def fake_outer_string_serialize(self, **kwargs):  # noqa: E501
         """fake_outer_string_serialize  # noqa: E501
@@ -599,9 +603,10 @@ class FakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -619,7 +624,7 @@ class FakeApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -668,7 +673,7 @@ class FakeApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def test_body_with_file_schema(self, body, **kwargs):  # noqa: E501
         """test_body_with_file_schema  # noqa: E501
@@ -725,9 +730,10 @@ class FakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -745,7 +751,7 @@ class FakeApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -798,7 +804,7 @@ class FakeApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def test_body_with_query_params(self, query, body, **kwargs):  # noqa: E501
         """test_body_with_query_params  # noqa: E501
@@ -857,9 +863,10 @@ class FakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -878,7 +885,7 @@ class FakeApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -937,7 +944,7 @@ class FakeApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def test_client_model(self, body, **kwargs):  # noqa: E501
         """To test \"client\" model  # noqa: E501
@@ -994,9 +1001,10 @@ class FakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -1014,7 +1022,7 @@ class FakeApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -1071,7 +1079,7 @@ class FakeApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def test_endpoint_parameters(self, number, double, pattern_without_delimiter, byte, **kwargs):  # noqa: E501
         """Fake endpoint for testing various parameters  假端點  偽のエンドポイント  가짜 엔드 포인트  # noqa: E501
@@ -1180,9 +1188,10 @@ class FakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -1213,7 +1222,7 @@ class FakeApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -1332,7 +1341,7 @@ class FakeApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def test_enum_parameters(self, **kwargs):  # noqa: E501
         """To test enum parameters  # noqa: E501
@@ -1417,9 +1426,10 @@ class FakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -1444,7 +1454,7 @@ class FakeApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -1510,7 +1520,7 @@ class FakeApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def test_group_parameters(self, required_string_group, required_boolean_group, required_int64_group, **kwargs):  # noqa: E501
         """Fake endpoint to test group parameters (optional)  # noqa: E501
@@ -1587,9 +1597,10 @@ class FakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -1612,7 +1623,7 @@ class FakeApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -1679,7 +1690,7 @@ class FakeApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def test_inline_additional_properties(self, param, **kwargs):  # noqa: E501
         """test inline additionalProperties  # noqa: E501
@@ -1734,9 +1745,10 @@ class FakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -1754,7 +1766,7 @@ class FakeApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -1807,7 +1819,7 @@ class FakeApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def test_json_form_data(self, param, param2, **kwargs):  # noqa: E501
         """test json serialization of form data  # noqa: E501
@@ -1866,9 +1878,10 @@ class FakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -1887,7 +1900,7 @@ class FakeApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -1946,7 +1959,7 @@ class FakeApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def test_query_parameter_collection_format(self, pipe, ioutil, http, url, context, **kwargs):  # noqa: E501
         """test_query_parameter_collection_format  # noqa: E501
@@ -2019,9 +2032,10 @@ class FakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -2043,7 +2057,7 @@ class FakeApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -2121,4 +2135,4 @@ class FakeApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))

--- a/samples/client/petstore/python-asyncio/petstore_api/api/fake_classname_tags_123_api.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/api/fake_classname_tags_123_api.py
@@ -91,9 +91,10 @@ class FakeClassnameTags123Api(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -111,7 +112,7 @@ class FakeClassnameTags123Api(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -168,4 +169,4 @@ class FakeClassnameTags123Api(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))

--- a/samples/client/petstore/python-asyncio/petstore_api/api/fake_classname_tags_123_api.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/api/fake_classname_tags_123_api.py
@@ -91,6 +91,9 @@ class FakeClassnameTags123Api(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -107,7 +110,8 @@ class FakeClassnameTags123Api(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -163,4 +167,5 @@ class FakeClassnameTags123Api(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))

--- a/samples/client/petstore/python-asyncio/petstore_api/api/pet_api.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/api/pet_api.py
@@ -89,9 +89,10 @@ class PetApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -109,7 +110,7 @@ class PetApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -162,7 +163,7 @@ class PetApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def delete_pet(self, pet_id, **kwargs):  # noqa: E501
         """Deletes a pet  # noqa: E501
@@ -221,9 +222,10 @@ class PetApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -242,7 +244,7 @@ class PetApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -293,7 +295,7 @@ class PetApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def find_pets_by_status(self, status, **kwargs):  # noqa: E501
         """Finds Pets by status  # noqa: E501
@@ -350,9 +352,10 @@ class PetApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -370,7 +373,7 @@ class PetApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -424,7 +427,7 @@ class PetApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def find_pets_by_tags(self, tags, **kwargs):  # noqa: E501
         """Finds Pets by tags  # noqa: E501
@@ -481,9 +484,10 @@ class PetApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -501,7 +505,7 @@ class PetApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -555,7 +559,7 @@ class PetApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def get_pet_by_id(self, pet_id, **kwargs):  # noqa: E501
         """Find pet by ID  # noqa: E501
@@ -612,9 +616,10 @@ class PetApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -632,7 +637,7 @@ class PetApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -685,7 +690,7 @@ class PetApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def update_pet(self, body, **kwargs):  # noqa: E501
         """Update an existing pet  # noqa: E501
@@ -740,9 +745,10 @@ class PetApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -760,7 +766,7 @@ class PetApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -813,7 +819,7 @@ class PetApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def update_pet_with_form(self, pet_id, **kwargs):  # noqa: E501
         """Updates a pet in the store with form data  # noqa: E501
@@ -876,9 +882,10 @@ class PetApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -898,7 +905,7 @@ class PetApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -955,7 +962,7 @@ class PetApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def upload_file(self, pet_id, **kwargs):  # noqa: E501
         """uploads an image  # noqa: E501
@@ -1018,9 +1025,10 @@ class PetApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -1040,7 +1048,7 @@ class PetApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -1101,7 +1109,7 @@ class PetApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def upload_file_with_required_file(self, pet_id, required_file, **kwargs):  # noqa: E501
         """uploads an image (required)  # noqa: E501
@@ -1164,9 +1172,10 @@ class PetApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -1186,7 +1195,7 @@ class PetApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -1251,4 +1260,4 @@ class PetApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))

--- a/samples/client/petstore/python-asyncio/petstore_api/api/pet_api.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/api/pet_api.py
@@ -89,6 +89,9 @@ class PetApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -105,7 +108,8 @@ class PetApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -157,7 +161,8 @@ class PetApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def delete_pet(self, pet_id, **kwargs):  # noqa: E501
         """Deletes a pet  # noqa: E501
@@ -216,6 +221,9 @@ class PetApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -233,7 +241,8 @@ class PetApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -283,7 +292,8 @@ class PetApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def find_pets_by_status(self, status, **kwargs):  # noqa: E501
         """Finds Pets by status  # noqa: E501
@@ -340,6 +350,9 @@ class PetApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -356,7 +369,8 @@ class PetApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -409,7 +423,8 @@ class PetApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def find_pets_by_tags(self, tags, **kwargs):  # noqa: E501
         """Finds Pets by tags  # noqa: E501
@@ -466,6 +481,9 @@ class PetApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -482,7 +500,8 @@ class PetApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -535,7 +554,8 @@ class PetApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def get_pet_by_id(self, pet_id, **kwargs):  # noqa: E501
         """Find pet by ID  # noqa: E501
@@ -592,6 +612,9 @@ class PetApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -608,7 +631,8 @@ class PetApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -660,7 +684,8 @@ class PetApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def update_pet(self, body, **kwargs):  # noqa: E501
         """Update an existing pet  # noqa: E501
@@ -715,6 +740,9 @@ class PetApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -731,7 +759,8 @@ class PetApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -783,7 +812,8 @@ class PetApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def update_pet_with_form(self, pet_id, **kwargs):  # noqa: E501
         """Updates a pet in the store with form data  # noqa: E501
@@ -846,6 +876,9 @@ class PetApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -864,7 +897,8 @@ class PetApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -920,7 +954,8 @@ class PetApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def upload_file(self, pet_id, **kwargs):  # noqa: E501
         """uploads an image  # noqa: E501
@@ -983,6 +1018,9 @@ class PetApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -1001,7 +1039,8 @@ class PetApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -1061,7 +1100,8 @@ class PetApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def upload_file_with_required_file(self, pet_id, required_file, **kwargs):  # noqa: E501
         """uploads an image (required)  # noqa: E501
@@ -1124,6 +1164,9 @@ class PetApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -1142,7 +1185,8 @@ class PetApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -1206,4 +1250,5 @@ class PetApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))

--- a/samples/client/petstore/python-asyncio/petstore_api/api/store_api.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/api/store_api.py
@@ -91,9 +91,10 @@ class StoreApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -111,7 +112,7 @@ class StoreApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -160,7 +161,7 @@ class StoreApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def get_inventory(self, **kwargs):  # noqa: E501
         """Returns pet inventories by status  # noqa: E501
@@ -213,9 +214,10 @@ class StoreApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -232,7 +234,7 @@ class StoreApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -279,7 +281,7 @@ class StoreApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def get_order_by_id(self, order_id, **kwargs):  # noqa: E501
         """Find purchase order by ID  # noqa: E501
@@ -336,9 +338,10 @@ class StoreApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -356,7 +359,7 @@ class StoreApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -413,7 +416,7 @@ class StoreApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def place_order(self, body, **kwargs):  # noqa: E501
         """Place an order for a pet  # noqa: E501
@@ -468,9 +471,10 @@ class StoreApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -488,7 +492,7 @@ class StoreApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -541,4 +545,4 @@ class StoreApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))

--- a/samples/client/petstore/python-asyncio/petstore_api/api/store_api.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/api/store_api.py
@@ -91,6 +91,9 @@ class StoreApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -107,7 +110,8 @@ class StoreApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -155,7 +159,8 @@ class StoreApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def get_inventory(self, **kwargs):  # noqa: E501
         """Returns pet inventories by status  # noqa: E501
@@ -208,6 +213,9 @@ class StoreApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -223,7 +231,8 @@ class StoreApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -269,7 +278,8 @@ class StoreApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def get_order_by_id(self, order_id, **kwargs):  # noqa: E501
         """Find purchase order by ID  # noqa: E501
@@ -326,6 +336,9 @@ class StoreApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -342,7 +355,8 @@ class StoreApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -398,7 +412,8 @@ class StoreApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def place_order(self, body, **kwargs):  # noqa: E501
         """Place an order for a pet  # noqa: E501
@@ -453,6 +468,9 @@ class StoreApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -469,7 +487,8 @@ class StoreApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -521,4 +540,5 @@ class StoreApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))

--- a/samples/client/petstore/python-asyncio/petstore_api/api/user_api.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/api/user_api.py
@@ -91,6 +91,9 @@ class UserApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -107,7 +110,8 @@ class UserApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -155,7 +159,8 @@ class UserApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def create_users_with_array_input(self, body, **kwargs):  # noqa: E501
         """Creates list of users with given input array  # noqa: E501
@@ -210,6 +215,9 @@ class UserApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -226,7 +234,8 @@ class UserApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -274,7 +283,8 @@ class UserApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def create_users_with_list_input(self, body, **kwargs):  # noqa: E501
         """Creates list of users with given input array  # noqa: E501
@@ -329,6 +339,9 @@ class UserApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -345,7 +358,8 @@ class UserApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -393,7 +407,8 @@ class UserApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def delete_user(self, username, **kwargs):  # noqa: E501
         """Delete user  # noqa: E501
@@ -450,6 +465,9 @@ class UserApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -466,7 +484,8 @@ class UserApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -514,7 +533,8 @@ class UserApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def get_user_by_name(self, username, **kwargs):  # noqa: E501
         """Get user by user name  # noqa: E501
@@ -569,6 +589,9 @@ class UserApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -585,7 +608,8 @@ class UserApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -637,7 +661,8 @@ class UserApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def login_user(self, username, password, **kwargs):  # noqa: E501
         """Logs user into the system  # noqa: E501
@@ -696,6 +721,9 @@ class UserApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -713,7 +741,8 @@ class UserApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -771,7 +800,8 @@ class UserApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def logout_user(self, **kwargs):  # noqa: E501
         """Logs out current logged in user session  # noqa: E501
@@ -822,6 +852,9 @@ class UserApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -837,7 +870,8 @@ class UserApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -879,7 +913,8 @@ class UserApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def update_user(self, username, body, **kwargs):  # noqa: E501
         """Updated user  # noqa: E501
@@ -940,6 +975,9 @@ class UserApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -957,7 +995,8 @@ class UserApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -1011,4 +1050,5 @@ class UserApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))

--- a/samples/client/petstore/python-asyncio/petstore_api/api/user_api.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/api/user_api.py
@@ -91,9 +91,10 @@ class UserApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -111,7 +112,7 @@ class UserApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -160,7 +161,7 @@ class UserApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def create_users_with_array_input(self, body, **kwargs):  # noqa: E501
         """Creates list of users with given input array  # noqa: E501
@@ -215,9 +216,10 @@ class UserApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -235,7 +237,7 @@ class UserApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -284,7 +286,7 @@ class UserApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def create_users_with_list_input(self, body, **kwargs):  # noqa: E501
         """Creates list of users with given input array  # noqa: E501
@@ -339,9 +341,10 @@ class UserApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -359,7 +362,7 @@ class UserApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -408,7 +411,7 @@ class UserApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def delete_user(self, username, **kwargs):  # noqa: E501
         """Delete user  # noqa: E501
@@ -465,9 +468,10 @@ class UserApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -485,7 +489,7 @@ class UserApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -534,7 +538,7 @@ class UserApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def get_user_by_name(self, username, **kwargs):  # noqa: E501
         """Get user by user name  # noqa: E501
@@ -589,9 +593,10 @@ class UserApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -609,7 +614,7 @@ class UserApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -662,7 +667,7 @@ class UserApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def login_user(self, username, password, **kwargs):  # noqa: E501
         """Logs user into the system  # noqa: E501
@@ -721,9 +726,10 @@ class UserApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -742,7 +748,7 @@ class UserApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -801,7 +807,7 @@ class UserApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def logout_user(self, **kwargs):  # noqa: E501
         """Logs out current logged in user session  # noqa: E501
@@ -852,9 +858,10 @@ class UserApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -871,7 +878,7 @@ class UserApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -914,7 +921,7 @@ class UserApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def update_user(self, username, body, **kwargs):  # noqa: E501
         """Updated user  # noqa: E501
@@ -975,9 +982,10 @@ class UserApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -996,7 +1004,7 @@ class UserApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -1051,4 +1059,4 @@ class UserApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))

--- a/samples/client/petstore/python-asyncio/petstore_api/api_client.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/api_client.py
@@ -123,7 +123,8 @@ class ApiClient(object):
             query_params=None, header_params=None, body=None, post_params=None,
             files=None, response_type=None, auth_settings=None,
             _return_http_data_only=None, collection_formats=None,
-            _preload_content=True, _request_timeout=None, _host=None):
+            _preload_content=True, _request_timeout=None, _host=None,
+            _access_token=None):
 
         config = self.configuration
 
@@ -164,7 +165,9 @@ class ApiClient(object):
             post_params.extend(self.files_parameters(files))
 
         # auth setting
-        self.update_params_for_auth(header_params, query_params, auth_settings)
+        self.update_params_for_auth(
+            header_params, query_params, auth_settings,
+            access_token=_access_token)
 
         # body
         if body:
@@ -324,7 +327,8 @@ class ApiClient(object):
                  body=None, post_params=None, files=None,
                  response_type=None, auth_settings=None, async_req=None,
                  _return_http_data_only=None, collection_formats=None,
-                 _preload_content=True, _request_timeout=None, _host=None):
+                 _preload_content=True, _request_timeout=None, _host=None,
+                 _access_token=None):
         """Makes the HTTP request (synchronous) and returns deserialized data.
 
         To make an async_req request, set the async_req parameter.
@@ -354,6 +358,9 @@ class ApiClient(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return:
             If async_req parameter is True,
             the request will be called asynchronously.
@@ -367,7 +374,8 @@ class ApiClient(object):
                                    body, post_params, files,
                                    response_type, auth_settings,
                                    _return_http_data_only, collection_formats,
-                                   _preload_content, _request_timeout, _host)
+                                   _preload_content, _request_timeout, _host,
+                                   _access_token)
 
         return self.pool.apply_async(self.__call_api, (resource_path,
                                                        method, path_params,
@@ -380,7 +388,7 @@ class ApiClient(object):
                                                        collection_formats,
                                                        _preload_content,
                                                        _request_timeout,
-                                                       _host))
+                                                       _host, _access_token))
 
     def request(self, method, url, query_params=None, headers=None,
                 post_params=None, body=None, _preload_content=True,
@@ -527,12 +535,15 @@ class ApiClient(object):
         else:
             return content_types[0]
 
-    def update_params_for_auth(self, headers, querys, auth_settings):
+    def update_params_for_auth(self, headers, querys, auth_settings,
+                               access_token=None):
         """Updates header and query params based on authentication setting.
 
         :param headers: Header parameters dict to be updated.
         :param querys: Query parameters tuple list to be updated.
         :param auth_settings: Authentication setting identifiers list.
+        :param access_token: if set, the provided access token will be used
+                             instead of the token in the configuration.
         """
         if not auth_settings:
             return
@@ -540,12 +551,16 @@ class ApiClient(object):
         for auth in auth_settings:
             auth_setting = self.configuration.auth_settings().get(auth)
             if auth_setting:
+                value = auth_setting['value']
+                if access_token is not None:
+                    value = access_token
+
                 if auth_setting['in'] == 'cookie':
-                    headers['Cookie'] = auth_setting['value']
+                    headers['Cookie'] = value
                 elif auth_setting['in'] == 'header':
-                    headers[auth_setting['key']] = auth_setting['value']
+                    headers[auth_setting['key']] = value
                 elif auth_setting['in'] == 'query':
-                    querys.append((auth_setting['key'], auth_setting['value']))
+                    querys.append((auth_setting['key'], value))
                 else:
                     raise ApiValueError(
                         'Authentication token must be in `query` or `header`'

--- a/samples/client/petstore/python-asyncio/petstore_api/api_client.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/api_client.py
@@ -124,7 +124,7 @@ class ApiClient(object):
             files=None, response_type=None, auth_settings=None,
             _return_http_data_only=None, collection_formats=None,
             _preload_content=True, _request_timeout=None, _host=None,
-            _access_token=None):
+            _request_auth=None):
 
         config = self.configuration
 
@@ -167,7 +167,7 @@ class ApiClient(object):
         # auth setting
         self.update_params_for_auth(
             header_params, query_params, auth_settings,
-            access_token=_access_token)
+            request_auth=_request_auth)
 
         # body
         if body:
@@ -328,7 +328,7 @@ class ApiClient(object):
                  response_type=None, auth_settings=None, async_req=None,
                  _return_http_data_only=None, collection_formats=None,
                  _preload_content=True, _request_timeout=None, _host=None,
-                 _access_token=None):
+                 _request_auth=None):
         """Makes the HTTP request (synchronous) and returns deserialized data.
 
         To make an async_req request, set the async_req parameter.
@@ -358,9 +358,10 @@ class ApiClient(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_token: dict, optional
         :return:
             If async_req parameter is True,
             the request will be called asynchronously.
@@ -375,7 +376,7 @@ class ApiClient(object):
                                    response_type, auth_settings,
                                    _return_http_data_only, collection_formats,
                                    _preload_content, _request_timeout, _host,
-                                   _access_token)
+                                   _request_auth)
 
         return self.pool.apply_async(self.__call_api, (resource_path,
                                                        method, path_params,
@@ -388,7 +389,7 @@ class ApiClient(object):
                                                        collection_formats,
                                                        _preload_content,
                                                        _request_timeout,
-                                                       _host, _access_token))
+                                                       _host, _request_auth))
 
     def request(self, method, url, query_params=None, headers=None,
                 post_params=None, body=None, _preload_content=True,
@@ -536,31 +537,27 @@ class ApiClient(object):
             return content_types[0]
 
     def update_params_for_auth(self, headers, querys, auth_settings,
-                               access_token=None):
+                               request_auth=None):
         """Updates header and query params based on authentication setting.
 
         :param headers: Header parameters dict to be updated.
         :param querys: Query parameters tuple list to be updated.
         :param auth_settings: Authentication setting identifiers list.
-        :param access_token: if set, the provided access token will be used
-                             instead of the token in the configuration.
+        :param request_auth: if set, the provided settings will
+                             override the token in the configuration.
         """
         if not auth_settings:
             return
 
         for auth in auth_settings:
-            auth_setting = self.configuration.auth_settings().get(auth)
+            auth_setting = request_auth or self.configuration.auth_settings().get(auth)
             if auth_setting:
-                value = auth_setting['value']
-                if access_token is not None:
-                    value = access_token
-
                 if auth_setting['in'] == 'cookie':
-                    headers['Cookie'] = value
+                    headers['Cookie'] = auth_setting['value']
                 elif auth_setting['in'] == 'header':
-                    headers[auth_setting['key']] = value
+                    headers[auth_setting['key']] = auth_setting['value']
                 elif auth_setting['in'] == 'query':
-                    querys.append((auth_setting['key'], value))
+                    querys.append((auth_setting['key'], auth_setting['value']))
                 else:
                     raise ApiValueError(
                         'Authentication token must be in `query` or `header`'

--- a/samples/client/petstore/python-asyncio/petstore_api/api_client.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/api_client.py
@@ -549,19 +549,32 @@ class ApiClient(object):
         if not auth_settings:
             return
 
+        if request_auth:
+            self._apply_auth_params(headers, querys, request_auth)
+            return
+
         for auth in auth_settings:
-            auth_setting = request_auth or self.configuration.auth_settings().get(auth)
+            auth_setting = self.configuration.auth_settings().get(auth)
             if auth_setting:
-                if auth_setting['in'] == 'cookie':
-                    headers['Cookie'] = auth_setting['value']
-                elif auth_setting['in'] == 'header':
-                    headers[auth_setting['key']] = auth_setting['value']
-                elif auth_setting['in'] == 'query':
-                    querys.append((auth_setting['key'], auth_setting['value']))
-                else:
-                    raise ApiValueError(
-                        'Authentication token must be in `query` or `header`'
-                    )
+                self._apply_auth_params(headers, querys, auth_setting)
+
+    def _apply_auth_params(self, headers, querys, auth_setting):
+        """Updates the request parameters based on a single auth_setting
+
+        :param headers: Header parameters dict to be updated.
+        :param querys: Query parameters tuple list to be updated.
+        :param auth_setting: auth settings for the endpoint
+        """
+        if auth_setting['in'] == 'cookie':
+            headers['Cookie'] = auth_setting['value']
+        elif auth_setting['in'] == 'header':
+            headers[auth_setting['key']] = auth_setting['value']
+        elif auth_setting['in'] == 'query':
+            querys.append((auth_setting['key'], auth_setting['value']))
+        else:
+            raise ApiValueError(
+                'Authentication token must be in `query` or `header`'
+            )
 
     def __deserialize_file(self, response):
         """Deserializes body to file

--- a/samples/client/petstore/python-tornado/petstore_api/api/another_fake_api.py
+++ b/samples/client/petstore/python-tornado/petstore_api/api/another_fake_api.py
@@ -91,6 +91,9 @@ class AnotherFakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -107,7 +110,8 @@ class AnotherFakeApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -163,4 +167,5 @@ class AnotherFakeApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))

--- a/samples/client/petstore/python-tornado/petstore_api/api/another_fake_api.py
+++ b/samples/client/petstore/python-tornado/petstore_api/api/another_fake_api.py
@@ -91,9 +91,10 @@ class AnotherFakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -111,7 +112,7 @@ class AnotherFakeApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -168,4 +169,4 @@ class AnotherFakeApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))

--- a/samples/client/petstore/python-tornado/petstore_api/api/fake_api.py
+++ b/samples/client/petstore/python-tornado/petstore_api/api/fake_api.py
@@ -91,6 +91,9 @@ class FakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -107,7 +110,8 @@ class FakeApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -159,7 +163,8 @@ class FakeApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def fake_outer_boolean_serialize(self, **kwargs):  # noqa: E501
         """fake_outer_boolean_serialize  # noqa: E501
@@ -216,6 +221,9 @@ class FakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -232,7 +240,8 @@ class FakeApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -280,7 +289,8 @@ class FakeApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def fake_outer_composite_serialize(self, **kwargs):  # noqa: E501
         """fake_outer_composite_serialize  # noqa: E501
@@ -337,6 +347,9 @@ class FakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -353,7 +366,8 @@ class FakeApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -401,7 +415,8 @@ class FakeApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def fake_outer_number_serialize(self, **kwargs):  # noqa: E501
         """fake_outer_number_serialize  # noqa: E501
@@ -458,6 +473,9 @@ class FakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -474,7 +492,8 @@ class FakeApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -522,7 +541,8 @@ class FakeApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def fake_outer_string_serialize(self, **kwargs):  # noqa: E501
         """fake_outer_string_serialize  # noqa: E501
@@ -579,6 +599,9 @@ class FakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -595,7 +618,8 @@ class FakeApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -643,7 +667,8 @@ class FakeApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def test_body_with_file_schema(self, body, **kwargs):  # noqa: E501
         """test_body_with_file_schema  # noqa: E501
@@ -700,6 +725,9 @@ class FakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -716,7 +744,8 @@ class FakeApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -768,7 +797,8 @@ class FakeApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def test_body_with_query_params(self, query, body, **kwargs):  # noqa: E501
         """test_body_with_query_params  # noqa: E501
@@ -827,6 +857,9 @@ class FakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -844,7 +877,8 @@ class FakeApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -902,7 +936,8 @@ class FakeApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def test_client_model(self, body, **kwargs):  # noqa: E501
         """To test \"client\" model  # noqa: E501
@@ -959,6 +994,9 @@ class FakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -975,7 +1013,8 @@ class FakeApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -1031,7 +1070,8 @@ class FakeApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def test_endpoint_parameters(self, number, double, pattern_without_delimiter, byte, **kwargs):  # noqa: E501
         """Fake endpoint for testing various parameters  假端點  偽のエンドポイント  가짜 엔드 포인트  # noqa: E501
@@ -1140,6 +1180,9 @@ class FakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -1169,7 +1212,8 @@ class FakeApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -1287,7 +1331,8 @@ class FakeApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def test_enum_parameters(self, **kwargs):  # noqa: E501
         """To test enum parameters  # noqa: E501
@@ -1372,6 +1417,9 @@ class FakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -1395,7 +1443,8 @@ class FakeApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -1460,7 +1509,8 @@ class FakeApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def test_group_parameters(self, required_string_group, required_boolean_group, required_int64_group, **kwargs):  # noqa: E501
         """Fake endpoint to test group parameters (optional)  # noqa: E501
@@ -1537,6 +1587,9 @@ class FakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -1558,7 +1611,8 @@ class FakeApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -1624,7 +1678,8 @@ class FakeApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def test_inline_additional_properties(self, param, **kwargs):  # noqa: E501
         """test inline additionalProperties  # noqa: E501
@@ -1679,6 +1734,9 @@ class FakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -1695,7 +1753,8 @@ class FakeApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -1747,7 +1806,8 @@ class FakeApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def test_json_form_data(self, param, param2, **kwargs):  # noqa: E501
         """test json serialization of form data  # noqa: E501
@@ -1806,6 +1866,9 @@ class FakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -1823,7 +1886,8 @@ class FakeApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -1881,7 +1945,8 @@ class FakeApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def test_query_parameter_collection_format(self, pipe, ioutil, http, url, context, **kwargs):  # noqa: E501
         """test_query_parameter_collection_format  # noqa: E501
@@ -1954,6 +2019,9 @@ class FakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -1974,7 +2042,8 @@ class FakeApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -2051,4 +2120,5 @@ class FakeApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))

--- a/samples/client/petstore/python-tornado/petstore_api/api/fake_api.py
+++ b/samples/client/petstore/python-tornado/petstore_api/api/fake_api.py
@@ -91,9 +91,10 @@ class FakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -111,7 +112,7 @@ class FakeApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -164,7 +165,7 @@ class FakeApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def fake_outer_boolean_serialize(self, **kwargs):  # noqa: E501
         """fake_outer_boolean_serialize  # noqa: E501
@@ -221,9 +222,10 @@ class FakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -241,7 +243,7 @@ class FakeApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -290,7 +292,7 @@ class FakeApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def fake_outer_composite_serialize(self, **kwargs):  # noqa: E501
         """fake_outer_composite_serialize  # noqa: E501
@@ -347,9 +349,10 @@ class FakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -367,7 +370,7 @@ class FakeApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -416,7 +419,7 @@ class FakeApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def fake_outer_number_serialize(self, **kwargs):  # noqa: E501
         """fake_outer_number_serialize  # noqa: E501
@@ -473,9 +476,10 @@ class FakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -493,7 +497,7 @@ class FakeApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -542,7 +546,7 @@ class FakeApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def fake_outer_string_serialize(self, **kwargs):  # noqa: E501
         """fake_outer_string_serialize  # noqa: E501
@@ -599,9 +603,10 @@ class FakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -619,7 +624,7 @@ class FakeApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -668,7 +673,7 @@ class FakeApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def test_body_with_file_schema(self, body, **kwargs):  # noqa: E501
         """test_body_with_file_schema  # noqa: E501
@@ -725,9 +730,10 @@ class FakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -745,7 +751,7 @@ class FakeApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -798,7 +804,7 @@ class FakeApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def test_body_with_query_params(self, query, body, **kwargs):  # noqa: E501
         """test_body_with_query_params  # noqa: E501
@@ -857,9 +863,10 @@ class FakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -878,7 +885,7 @@ class FakeApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -937,7 +944,7 @@ class FakeApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def test_client_model(self, body, **kwargs):  # noqa: E501
         """To test \"client\" model  # noqa: E501
@@ -994,9 +1001,10 @@ class FakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -1014,7 +1022,7 @@ class FakeApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -1071,7 +1079,7 @@ class FakeApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def test_endpoint_parameters(self, number, double, pattern_without_delimiter, byte, **kwargs):  # noqa: E501
         """Fake endpoint for testing various parameters  假端點  偽のエンドポイント  가짜 엔드 포인트  # noqa: E501
@@ -1180,9 +1188,10 @@ class FakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -1213,7 +1222,7 @@ class FakeApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -1332,7 +1341,7 @@ class FakeApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def test_enum_parameters(self, **kwargs):  # noqa: E501
         """To test enum parameters  # noqa: E501
@@ -1417,9 +1426,10 @@ class FakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -1444,7 +1454,7 @@ class FakeApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -1510,7 +1520,7 @@ class FakeApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def test_group_parameters(self, required_string_group, required_boolean_group, required_int64_group, **kwargs):  # noqa: E501
         """Fake endpoint to test group parameters (optional)  # noqa: E501
@@ -1587,9 +1597,10 @@ class FakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -1612,7 +1623,7 @@ class FakeApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -1679,7 +1690,7 @@ class FakeApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def test_inline_additional_properties(self, param, **kwargs):  # noqa: E501
         """test inline additionalProperties  # noqa: E501
@@ -1734,9 +1745,10 @@ class FakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -1754,7 +1766,7 @@ class FakeApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -1807,7 +1819,7 @@ class FakeApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def test_json_form_data(self, param, param2, **kwargs):  # noqa: E501
         """test json serialization of form data  # noqa: E501
@@ -1866,9 +1878,10 @@ class FakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -1887,7 +1900,7 @@ class FakeApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -1946,7 +1959,7 @@ class FakeApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def test_query_parameter_collection_format(self, pipe, ioutil, http, url, context, **kwargs):  # noqa: E501
         """test_query_parameter_collection_format  # noqa: E501
@@ -2019,9 +2032,10 @@ class FakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -2043,7 +2057,7 @@ class FakeApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -2121,4 +2135,4 @@ class FakeApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))

--- a/samples/client/petstore/python-tornado/petstore_api/api/fake_classname_tags_123_api.py
+++ b/samples/client/petstore/python-tornado/petstore_api/api/fake_classname_tags_123_api.py
@@ -91,9 +91,10 @@ class FakeClassnameTags123Api(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -111,7 +112,7 @@ class FakeClassnameTags123Api(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -168,4 +169,4 @@ class FakeClassnameTags123Api(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))

--- a/samples/client/petstore/python-tornado/petstore_api/api/fake_classname_tags_123_api.py
+++ b/samples/client/petstore/python-tornado/petstore_api/api/fake_classname_tags_123_api.py
@@ -91,6 +91,9 @@ class FakeClassnameTags123Api(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -107,7 +110,8 @@ class FakeClassnameTags123Api(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -163,4 +167,5 @@ class FakeClassnameTags123Api(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))

--- a/samples/client/petstore/python-tornado/petstore_api/api/pet_api.py
+++ b/samples/client/petstore/python-tornado/petstore_api/api/pet_api.py
@@ -89,9 +89,10 @@ class PetApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -109,7 +110,7 @@ class PetApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -162,7 +163,7 @@ class PetApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def delete_pet(self, pet_id, **kwargs):  # noqa: E501
         """Deletes a pet  # noqa: E501
@@ -221,9 +222,10 @@ class PetApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -242,7 +244,7 @@ class PetApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -293,7 +295,7 @@ class PetApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def find_pets_by_status(self, status, **kwargs):  # noqa: E501
         """Finds Pets by status  # noqa: E501
@@ -350,9 +352,10 @@ class PetApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -370,7 +373,7 @@ class PetApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -424,7 +427,7 @@ class PetApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def find_pets_by_tags(self, tags, **kwargs):  # noqa: E501
         """Finds Pets by tags  # noqa: E501
@@ -481,9 +484,10 @@ class PetApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -501,7 +505,7 @@ class PetApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -555,7 +559,7 @@ class PetApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def get_pet_by_id(self, pet_id, **kwargs):  # noqa: E501
         """Find pet by ID  # noqa: E501
@@ -612,9 +616,10 @@ class PetApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -632,7 +637,7 @@ class PetApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -685,7 +690,7 @@ class PetApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def update_pet(self, body, **kwargs):  # noqa: E501
         """Update an existing pet  # noqa: E501
@@ -740,9 +745,10 @@ class PetApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -760,7 +766,7 @@ class PetApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -813,7 +819,7 @@ class PetApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def update_pet_with_form(self, pet_id, **kwargs):  # noqa: E501
         """Updates a pet in the store with form data  # noqa: E501
@@ -876,9 +882,10 @@ class PetApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -898,7 +905,7 @@ class PetApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -955,7 +962,7 @@ class PetApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def upload_file(self, pet_id, **kwargs):  # noqa: E501
         """uploads an image  # noqa: E501
@@ -1018,9 +1025,10 @@ class PetApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -1040,7 +1048,7 @@ class PetApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -1101,7 +1109,7 @@ class PetApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def upload_file_with_required_file(self, pet_id, required_file, **kwargs):  # noqa: E501
         """uploads an image (required)  # noqa: E501
@@ -1164,9 +1172,10 @@ class PetApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -1186,7 +1195,7 @@ class PetApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -1251,4 +1260,4 @@ class PetApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))

--- a/samples/client/petstore/python-tornado/petstore_api/api/pet_api.py
+++ b/samples/client/petstore/python-tornado/petstore_api/api/pet_api.py
@@ -89,6 +89,9 @@ class PetApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -105,7 +108,8 @@ class PetApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -157,7 +161,8 @@ class PetApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def delete_pet(self, pet_id, **kwargs):  # noqa: E501
         """Deletes a pet  # noqa: E501
@@ -216,6 +221,9 @@ class PetApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -233,7 +241,8 @@ class PetApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -283,7 +292,8 @@ class PetApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def find_pets_by_status(self, status, **kwargs):  # noqa: E501
         """Finds Pets by status  # noqa: E501
@@ -340,6 +350,9 @@ class PetApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -356,7 +369,8 @@ class PetApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -409,7 +423,8 @@ class PetApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def find_pets_by_tags(self, tags, **kwargs):  # noqa: E501
         """Finds Pets by tags  # noqa: E501
@@ -466,6 +481,9 @@ class PetApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -482,7 +500,8 @@ class PetApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -535,7 +554,8 @@ class PetApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def get_pet_by_id(self, pet_id, **kwargs):  # noqa: E501
         """Find pet by ID  # noqa: E501
@@ -592,6 +612,9 @@ class PetApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -608,7 +631,8 @@ class PetApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -660,7 +684,8 @@ class PetApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def update_pet(self, body, **kwargs):  # noqa: E501
         """Update an existing pet  # noqa: E501
@@ -715,6 +740,9 @@ class PetApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -731,7 +759,8 @@ class PetApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -783,7 +812,8 @@ class PetApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def update_pet_with_form(self, pet_id, **kwargs):  # noqa: E501
         """Updates a pet in the store with form data  # noqa: E501
@@ -846,6 +876,9 @@ class PetApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -864,7 +897,8 @@ class PetApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -920,7 +954,8 @@ class PetApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def upload_file(self, pet_id, **kwargs):  # noqa: E501
         """uploads an image  # noqa: E501
@@ -983,6 +1018,9 @@ class PetApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -1001,7 +1039,8 @@ class PetApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -1061,7 +1100,8 @@ class PetApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def upload_file_with_required_file(self, pet_id, required_file, **kwargs):  # noqa: E501
         """uploads an image (required)  # noqa: E501
@@ -1124,6 +1164,9 @@ class PetApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -1142,7 +1185,8 @@ class PetApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -1206,4 +1250,5 @@ class PetApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))

--- a/samples/client/petstore/python-tornado/petstore_api/api/store_api.py
+++ b/samples/client/petstore/python-tornado/petstore_api/api/store_api.py
@@ -91,9 +91,10 @@ class StoreApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -111,7 +112,7 @@ class StoreApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -160,7 +161,7 @@ class StoreApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def get_inventory(self, **kwargs):  # noqa: E501
         """Returns pet inventories by status  # noqa: E501
@@ -213,9 +214,10 @@ class StoreApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -232,7 +234,7 @@ class StoreApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -279,7 +281,7 @@ class StoreApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def get_order_by_id(self, order_id, **kwargs):  # noqa: E501
         """Find purchase order by ID  # noqa: E501
@@ -336,9 +338,10 @@ class StoreApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -356,7 +359,7 @@ class StoreApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -413,7 +416,7 @@ class StoreApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def place_order(self, body, **kwargs):  # noqa: E501
         """Place an order for a pet  # noqa: E501
@@ -468,9 +471,10 @@ class StoreApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -488,7 +492,7 @@ class StoreApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -541,4 +545,4 @@ class StoreApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))

--- a/samples/client/petstore/python-tornado/petstore_api/api/store_api.py
+++ b/samples/client/petstore/python-tornado/petstore_api/api/store_api.py
@@ -91,6 +91,9 @@ class StoreApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -107,7 +110,8 @@ class StoreApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -155,7 +159,8 @@ class StoreApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def get_inventory(self, **kwargs):  # noqa: E501
         """Returns pet inventories by status  # noqa: E501
@@ -208,6 +213,9 @@ class StoreApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -223,7 +231,8 @@ class StoreApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -269,7 +278,8 @@ class StoreApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def get_order_by_id(self, order_id, **kwargs):  # noqa: E501
         """Find purchase order by ID  # noqa: E501
@@ -326,6 +336,9 @@ class StoreApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -342,7 +355,8 @@ class StoreApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -398,7 +412,8 @@ class StoreApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def place_order(self, body, **kwargs):  # noqa: E501
         """Place an order for a pet  # noqa: E501
@@ -453,6 +468,9 @@ class StoreApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -469,7 +487,8 @@ class StoreApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -521,4 +540,5 @@ class StoreApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))

--- a/samples/client/petstore/python-tornado/petstore_api/api/user_api.py
+++ b/samples/client/petstore/python-tornado/petstore_api/api/user_api.py
@@ -91,6 +91,9 @@ class UserApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -107,7 +110,8 @@ class UserApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -155,7 +159,8 @@ class UserApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def create_users_with_array_input(self, body, **kwargs):  # noqa: E501
         """Creates list of users with given input array  # noqa: E501
@@ -210,6 +215,9 @@ class UserApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -226,7 +234,8 @@ class UserApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -274,7 +283,8 @@ class UserApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def create_users_with_list_input(self, body, **kwargs):  # noqa: E501
         """Creates list of users with given input array  # noqa: E501
@@ -329,6 +339,9 @@ class UserApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -345,7 +358,8 @@ class UserApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -393,7 +407,8 @@ class UserApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def delete_user(self, username, **kwargs):  # noqa: E501
         """Delete user  # noqa: E501
@@ -450,6 +465,9 @@ class UserApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -466,7 +484,8 @@ class UserApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -514,7 +533,8 @@ class UserApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def get_user_by_name(self, username, **kwargs):  # noqa: E501
         """Get user by user name  # noqa: E501
@@ -569,6 +589,9 @@ class UserApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -585,7 +608,8 @@ class UserApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -637,7 +661,8 @@ class UserApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def login_user(self, username, password, **kwargs):  # noqa: E501
         """Logs user into the system  # noqa: E501
@@ -696,6 +721,9 @@ class UserApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -713,7 +741,8 @@ class UserApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -771,7 +800,8 @@ class UserApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def logout_user(self, **kwargs):  # noqa: E501
         """Logs out current logged in user session  # noqa: E501
@@ -822,6 +852,9 @@ class UserApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -837,7 +870,8 @@ class UserApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -879,7 +913,8 @@ class UserApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def update_user(self, username, body, **kwargs):  # noqa: E501
         """Updated user  # noqa: E501
@@ -940,6 +975,9 @@ class UserApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -957,7 +995,8 @@ class UserApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -1011,4 +1050,5 @@ class UserApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))

--- a/samples/client/petstore/python-tornado/petstore_api/api/user_api.py
+++ b/samples/client/petstore/python-tornado/petstore_api/api/user_api.py
@@ -91,9 +91,10 @@ class UserApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -111,7 +112,7 @@ class UserApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -160,7 +161,7 @@ class UserApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def create_users_with_array_input(self, body, **kwargs):  # noqa: E501
         """Creates list of users with given input array  # noqa: E501
@@ -215,9 +216,10 @@ class UserApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -235,7 +237,7 @@ class UserApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -284,7 +286,7 @@ class UserApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def create_users_with_list_input(self, body, **kwargs):  # noqa: E501
         """Creates list of users with given input array  # noqa: E501
@@ -339,9 +341,10 @@ class UserApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -359,7 +362,7 @@ class UserApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -408,7 +411,7 @@ class UserApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def delete_user(self, username, **kwargs):  # noqa: E501
         """Delete user  # noqa: E501
@@ -465,9 +468,10 @@ class UserApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -485,7 +489,7 @@ class UserApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -534,7 +538,7 @@ class UserApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def get_user_by_name(self, username, **kwargs):  # noqa: E501
         """Get user by user name  # noqa: E501
@@ -589,9 +593,10 @@ class UserApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -609,7 +614,7 @@ class UserApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -662,7 +667,7 @@ class UserApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def login_user(self, username, password, **kwargs):  # noqa: E501
         """Logs user into the system  # noqa: E501
@@ -721,9 +726,10 @@ class UserApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -742,7 +748,7 @@ class UserApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -801,7 +807,7 @@ class UserApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def logout_user(self, **kwargs):  # noqa: E501
         """Logs out current logged in user session  # noqa: E501
@@ -852,9 +858,10 @@ class UserApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -871,7 +878,7 @@ class UserApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -914,7 +921,7 @@ class UserApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def update_user(self, username, body, **kwargs):  # noqa: E501
         """Updated user  # noqa: E501
@@ -975,9 +982,10 @@ class UserApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -996,7 +1004,7 @@ class UserApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -1051,4 +1059,4 @@ class UserApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))

--- a/samples/client/petstore/python-tornado/petstore_api/api_client.py
+++ b/samples/client/petstore/python-tornado/petstore_api/api_client.py
@@ -125,7 +125,7 @@ class ApiClient(object):
             files=None, response_type=None, auth_settings=None,
             _return_http_data_only=None, collection_formats=None,
             _preload_content=True, _request_timeout=None, _host=None,
-            _access_token=None):
+            _request_auth=None):
 
         config = self.configuration
 
@@ -168,7 +168,7 @@ class ApiClient(object):
         # auth setting
         self.update_params_for_auth(
             header_params, query_params, auth_settings,
-            access_token=_access_token)
+            request_auth=_request_auth)
 
         # body
         if body:
@@ -329,7 +329,7 @@ class ApiClient(object):
                  response_type=None, auth_settings=None, async_req=None,
                  _return_http_data_only=None, collection_formats=None,
                  _preload_content=True, _request_timeout=None, _host=None,
-                 _access_token=None):
+                 _request_auth=None):
         """Makes the HTTP request (synchronous) and returns deserialized data.
 
         To make an async_req request, set the async_req parameter.
@@ -359,9 +359,10 @@ class ApiClient(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_token: dict, optional
         :return:
             If async_req parameter is True,
             the request will be called asynchronously.
@@ -376,7 +377,7 @@ class ApiClient(object):
                                    response_type, auth_settings,
                                    _return_http_data_only, collection_formats,
                                    _preload_content, _request_timeout, _host,
-                                   _access_token)
+                                   _request_auth)
 
         return self.pool.apply_async(self.__call_api, (resource_path,
                                                        method, path_params,
@@ -389,7 +390,7 @@ class ApiClient(object):
                                                        collection_formats,
                                                        _preload_content,
                                                        _request_timeout,
-                                                       _host, _access_token))
+                                                       _host, _request_auth))
 
     def request(self, method, url, query_params=None, headers=None,
                 post_params=None, body=None, _preload_content=True,
@@ -537,31 +538,27 @@ class ApiClient(object):
             return content_types[0]
 
     def update_params_for_auth(self, headers, querys, auth_settings,
-                               access_token=None):
+                               request_auth=None):
         """Updates header and query params based on authentication setting.
 
         :param headers: Header parameters dict to be updated.
         :param querys: Query parameters tuple list to be updated.
         :param auth_settings: Authentication setting identifiers list.
-        :param access_token: if set, the provided access token will be used
-                             instead of the token in the configuration.
+        :param request_auth: if set, the provided settings will
+                             override the token in the configuration.
         """
         if not auth_settings:
             return
 
         for auth in auth_settings:
-            auth_setting = self.configuration.auth_settings().get(auth)
+            auth_setting = request_auth or self.configuration.auth_settings().get(auth)
             if auth_setting:
-                value = auth_setting['value']
-                if access_token is not None:
-                    value = access_token
-
                 if auth_setting['in'] == 'cookie':
-                    headers['Cookie'] = value
+                    headers['Cookie'] = auth_setting['value']
                 elif auth_setting['in'] == 'header':
-                    headers[auth_setting['key']] = value
+                    headers[auth_setting['key']] = auth_setting['value']
                 elif auth_setting['in'] == 'query':
-                    querys.append((auth_setting['key'], value))
+                    querys.append((auth_setting['key'], auth_setting['value']))
                 else:
                     raise ApiValueError(
                         'Authentication token must be in `query` or `header`'

--- a/samples/client/petstore/python-tornado/petstore_api/api_client.py
+++ b/samples/client/petstore/python-tornado/petstore_api/api_client.py
@@ -124,7 +124,8 @@ class ApiClient(object):
             query_params=None, header_params=None, body=None, post_params=None,
             files=None, response_type=None, auth_settings=None,
             _return_http_data_only=None, collection_formats=None,
-            _preload_content=True, _request_timeout=None, _host=None):
+            _preload_content=True, _request_timeout=None, _host=None,
+            _access_token=None):
 
         config = self.configuration
 
@@ -165,7 +166,9 @@ class ApiClient(object):
             post_params.extend(self.files_parameters(files))
 
         # auth setting
-        self.update_params_for_auth(header_params, query_params, auth_settings)
+        self.update_params_for_auth(
+            header_params, query_params, auth_settings,
+            access_token=_access_token)
 
         # body
         if body:
@@ -325,7 +328,8 @@ class ApiClient(object):
                  body=None, post_params=None, files=None,
                  response_type=None, auth_settings=None, async_req=None,
                  _return_http_data_only=None, collection_formats=None,
-                 _preload_content=True, _request_timeout=None, _host=None):
+                 _preload_content=True, _request_timeout=None, _host=None,
+                 _access_token=None):
         """Makes the HTTP request (synchronous) and returns deserialized data.
 
         To make an async_req request, set the async_req parameter.
@@ -355,6 +359,9 @@ class ApiClient(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return:
             If async_req parameter is True,
             the request will be called asynchronously.
@@ -368,7 +375,8 @@ class ApiClient(object):
                                    body, post_params, files,
                                    response_type, auth_settings,
                                    _return_http_data_only, collection_formats,
-                                   _preload_content, _request_timeout, _host)
+                                   _preload_content, _request_timeout, _host,
+                                   _access_token)
 
         return self.pool.apply_async(self.__call_api, (resource_path,
                                                        method, path_params,
@@ -381,7 +389,7 @@ class ApiClient(object):
                                                        collection_formats,
                                                        _preload_content,
                                                        _request_timeout,
-                                                       _host))
+                                                       _host, _access_token))
 
     def request(self, method, url, query_params=None, headers=None,
                 post_params=None, body=None, _preload_content=True,
@@ -528,12 +536,15 @@ class ApiClient(object):
         else:
             return content_types[0]
 
-    def update_params_for_auth(self, headers, querys, auth_settings):
+    def update_params_for_auth(self, headers, querys, auth_settings,
+                               access_token=None):
         """Updates header and query params based on authentication setting.
 
         :param headers: Header parameters dict to be updated.
         :param querys: Query parameters tuple list to be updated.
         :param auth_settings: Authentication setting identifiers list.
+        :param access_token: if set, the provided access token will be used
+                             instead of the token in the configuration.
         """
         if not auth_settings:
             return
@@ -541,12 +552,16 @@ class ApiClient(object):
         for auth in auth_settings:
             auth_setting = self.configuration.auth_settings().get(auth)
             if auth_setting:
+                value = auth_setting['value']
+                if access_token is not None:
+                    value = access_token
+
                 if auth_setting['in'] == 'cookie':
-                    headers['Cookie'] = auth_setting['value']
+                    headers['Cookie'] = value
                 elif auth_setting['in'] == 'header':
-                    headers[auth_setting['key']] = auth_setting['value']
+                    headers[auth_setting['key']] = value
                 elif auth_setting['in'] == 'query':
-                    querys.append((auth_setting['key'], auth_setting['value']))
+                    querys.append((auth_setting['key'], value))
                 else:
                     raise ApiValueError(
                         'Authentication token must be in `query` or `header`'

--- a/samples/client/petstore/python-tornado/petstore_api/api_client.py
+++ b/samples/client/petstore/python-tornado/petstore_api/api_client.py
@@ -550,19 +550,32 @@ class ApiClient(object):
         if not auth_settings:
             return
 
+        if request_auth:
+            self._apply_auth_params(headers, querys, request_auth)
+            return
+
         for auth in auth_settings:
-            auth_setting = request_auth or self.configuration.auth_settings().get(auth)
+            auth_setting = self.configuration.auth_settings().get(auth)
             if auth_setting:
-                if auth_setting['in'] == 'cookie':
-                    headers['Cookie'] = auth_setting['value']
-                elif auth_setting['in'] == 'header':
-                    headers[auth_setting['key']] = auth_setting['value']
-                elif auth_setting['in'] == 'query':
-                    querys.append((auth_setting['key'], auth_setting['value']))
-                else:
-                    raise ApiValueError(
-                        'Authentication token must be in `query` or `header`'
-                    )
+                self._apply_auth_params(headers, querys, auth_setting)
+
+    def _apply_auth_params(self, headers, querys, auth_setting):
+        """Updates the request parameters based on a single auth_setting
+
+        :param headers: Header parameters dict to be updated.
+        :param querys: Query parameters tuple list to be updated.
+        :param auth_setting: auth settings for the endpoint
+        """
+        if auth_setting['in'] == 'cookie':
+            headers['Cookie'] = auth_setting['value']
+        elif auth_setting['in'] == 'header':
+            headers[auth_setting['key']] = auth_setting['value']
+        elif auth_setting['in'] == 'query':
+            querys.append((auth_setting['key'], auth_setting['value']))
+        else:
+            raise ApiValueError(
+                'Authentication token must be in `query` or `header`'
+            )
 
     def __deserialize_file(self, response):
         """Deserializes body to file

--- a/samples/client/petstore/python/petstore_api/api/another_fake_api.py
+++ b/samples/client/petstore/python/petstore_api/api/another_fake_api.py
@@ -91,6 +91,9 @@ class AnotherFakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -107,7 +110,8 @@ class AnotherFakeApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -163,4 +167,5 @@ class AnotherFakeApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))

--- a/samples/client/petstore/python/petstore_api/api/another_fake_api.py
+++ b/samples/client/petstore/python/petstore_api/api/another_fake_api.py
@@ -91,9 +91,10 @@ class AnotherFakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -111,7 +112,7 @@ class AnotherFakeApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -168,4 +169,4 @@ class AnotherFakeApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))

--- a/samples/client/petstore/python/petstore_api/api/fake_api.py
+++ b/samples/client/petstore/python/petstore_api/api/fake_api.py
@@ -91,6 +91,9 @@ class FakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -107,7 +110,8 @@ class FakeApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -159,7 +163,8 @@ class FakeApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def fake_outer_boolean_serialize(self, **kwargs):  # noqa: E501
         """fake_outer_boolean_serialize  # noqa: E501
@@ -216,6 +221,9 @@ class FakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -232,7 +240,8 @@ class FakeApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -280,7 +289,8 @@ class FakeApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def fake_outer_composite_serialize(self, **kwargs):  # noqa: E501
         """fake_outer_composite_serialize  # noqa: E501
@@ -337,6 +347,9 @@ class FakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -353,7 +366,8 @@ class FakeApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -401,7 +415,8 @@ class FakeApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def fake_outer_number_serialize(self, **kwargs):  # noqa: E501
         """fake_outer_number_serialize  # noqa: E501
@@ -458,6 +473,9 @@ class FakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -474,7 +492,8 @@ class FakeApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -522,7 +541,8 @@ class FakeApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def fake_outer_string_serialize(self, **kwargs):  # noqa: E501
         """fake_outer_string_serialize  # noqa: E501
@@ -579,6 +599,9 @@ class FakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -595,7 +618,8 @@ class FakeApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -643,7 +667,8 @@ class FakeApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def test_body_with_file_schema(self, body, **kwargs):  # noqa: E501
         """test_body_with_file_schema  # noqa: E501
@@ -700,6 +725,9 @@ class FakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -716,7 +744,8 @@ class FakeApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -768,7 +797,8 @@ class FakeApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def test_body_with_query_params(self, query, body, **kwargs):  # noqa: E501
         """test_body_with_query_params  # noqa: E501
@@ -827,6 +857,9 @@ class FakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -844,7 +877,8 @@ class FakeApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -902,7 +936,8 @@ class FakeApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def test_client_model(self, body, **kwargs):  # noqa: E501
         """To test \"client\" model  # noqa: E501
@@ -959,6 +994,9 @@ class FakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -975,7 +1013,8 @@ class FakeApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -1031,7 +1070,8 @@ class FakeApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def test_endpoint_parameters(self, number, double, pattern_without_delimiter, byte, **kwargs):  # noqa: E501
         """Fake endpoint for testing various parameters  假端點  偽のエンドポイント  가짜 엔드 포인트  # noqa: E501
@@ -1140,6 +1180,9 @@ class FakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -1169,7 +1212,8 @@ class FakeApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -1287,7 +1331,8 @@ class FakeApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def test_enum_parameters(self, **kwargs):  # noqa: E501
         """To test enum parameters  # noqa: E501
@@ -1372,6 +1417,9 @@ class FakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -1395,7 +1443,8 @@ class FakeApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -1460,7 +1509,8 @@ class FakeApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def test_group_parameters(self, required_string_group, required_boolean_group, required_int64_group, **kwargs):  # noqa: E501
         """Fake endpoint to test group parameters (optional)  # noqa: E501
@@ -1537,6 +1587,9 @@ class FakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -1558,7 +1611,8 @@ class FakeApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -1624,7 +1678,8 @@ class FakeApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def test_inline_additional_properties(self, param, **kwargs):  # noqa: E501
         """test inline additionalProperties  # noqa: E501
@@ -1679,6 +1734,9 @@ class FakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -1695,7 +1753,8 @@ class FakeApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -1747,7 +1806,8 @@ class FakeApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def test_json_form_data(self, param, param2, **kwargs):  # noqa: E501
         """test json serialization of form data  # noqa: E501
@@ -1806,6 +1866,9 @@ class FakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -1823,7 +1886,8 @@ class FakeApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -1881,7 +1945,8 @@ class FakeApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def test_query_parameter_collection_format(self, pipe, ioutil, http, url, context, **kwargs):  # noqa: E501
         """test_query_parameter_collection_format  # noqa: E501
@@ -1954,6 +2019,9 @@ class FakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -1974,7 +2042,8 @@ class FakeApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -2051,4 +2120,5 @@ class FakeApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))

--- a/samples/client/petstore/python/petstore_api/api/fake_api.py
+++ b/samples/client/petstore/python/petstore_api/api/fake_api.py
@@ -91,9 +91,10 @@ class FakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -111,7 +112,7 @@ class FakeApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -164,7 +165,7 @@ class FakeApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def fake_outer_boolean_serialize(self, **kwargs):  # noqa: E501
         """fake_outer_boolean_serialize  # noqa: E501
@@ -221,9 +222,10 @@ class FakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -241,7 +243,7 @@ class FakeApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -290,7 +292,7 @@ class FakeApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def fake_outer_composite_serialize(self, **kwargs):  # noqa: E501
         """fake_outer_composite_serialize  # noqa: E501
@@ -347,9 +349,10 @@ class FakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -367,7 +370,7 @@ class FakeApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -416,7 +419,7 @@ class FakeApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def fake_outer_number_serialize(self, **kwargs):  # noqa: E501
         """fake_outer_number_serialize  # noqa: E501
@@ -473,9 +476,10 @@ class FakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -493,7 +497,7 @@ class FakeApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -542,7 +546,7 @@ class FakeApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def fake_outer_string_serialize(self, **kwargs):  # noqa: E501
         """fake_outer_string_serialize  # noqa: E501
@@ -599,9 +603,10 @@ class FakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -619,7 +624,7 @@ class FakeApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -668,7 +673,7 @@ class FakeApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def test_body_with_file_schema(self, body, **kwargs):  # noqa: E501
         """test_body_with_file_schema  # noqa: E501
@@ -725,9 +730,10 @@ class FakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -745,7 +751,7 @@ class FakeApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -798,7 +804,7 @@ class FakeApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def test_body_with_query_params(self, query, body, **kwargs):  # noqa: E501
         """test_body_with_query_params  # noqa: E501
@@ -857,9 +863,10 @@ class FakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -878,7 +885,7 @@ class FakeApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -937,7 +944,7 @@ class FakeApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def test_client_model(self, body, **kwargs):  # noqa: E501
         """To test \"client\" model  # noqa: E501
@@ -994,9 +1001,10 @@ class FakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -1014,7 +1022,7 @@ class FakeApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -1071,7 +1079,7 @@ class FakeApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def test_endpoint_parameters(self, number, double, pattern_without_delimiter, byte, **kwargs):  # noqa: E501
         """Fake endpoint for testing various parameters  假端點  偽のエンドポイント  가짜 엔드 포인트  # noqa: E501
@@ -1180,9 +1188,10 @@ class FakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -1213,7 +1222,7 @@ class FakeApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -1332,7 +1341,7 @@ class FakeApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def test_enum_parameters(self, **kwargs):  # noqa: E501
         """To test enum parameters  # noqa: E501
@@ -1417,9 +1426,10 @@ class FakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -1444,7 +1454,7 @@ class FakeApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -1510,7 +1520,7 @@ class FakeApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def test_group_parameters(self, required_string_group, required_boolean_group, required_int64_group, **kwargs):  # noqa: E501
         """Fake endpoint to test group parameters (optional)  # noqa: E501
@@ -1587,9 +1597,10 @@ class FakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -1612,7 +1623,7 @@ class FakeApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -1679,7 +1690,7 @@ class FakeApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def test_inline_additional_properties(self, param, **kwargs):  # noqa: E501
         """test inline additionalProperties  # noqa: E501
@@ -1734,9 +1745,10 @@ class FakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -1754,7 +1766,7 @@ class FakeApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -1807,7 +1819,7 @@ class FakeApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def test_json_form_data(self, param, param2, **kwargs):  # noqa: E501
         """test json serialization of form data  # noqa: E501
@@ -1866,9 +1878,10 @@ class FakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -1887,7 +1900,7 @@ class FakeApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -1946,7 +1959,7 @@ class FakeApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def test_query_parameter_collection_format(self, pipe, ioutil, http, url, context, **kwargs):  # noqa: E501
         """test_query_parameter_collection_format  # noqa: E501
@@ -2019,9 +2032,10 @@ class FakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -2043,7 +2057,7 @@ class FakeApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -2121,4 +2135,4 @@ class FakeApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))

--- a/samples/client/petstore/python/petstore_api/api/fake_classname_tags_123_api.py
+++ b/samples/client/petstore/python/petstore_api/api/fake_classname_tags_123_api.py
@@ -91,9 +91,10 @@ class FakeClassnameTags123Api(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -111,7 +112,7 @@ class FakeClassnameTags123Api(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -168,4 +169,4 @@ class FakeClassnameTags123Api(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))

--- a/samples/client/petstore/python/petstore_api/api/fake_classname_tags_123_api.py
+++ b/samples/client/petstore/python/petstore_api/api/fake_classname_tags_123_api.py
@@ -91,6 +91,9 @@ class FakeClassnameTags123Api(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -107,7 +110,8 @@ class FakeClassnameTags123Api(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -163,4 +167,5 @@ class FakeClassnameTags123Api(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))

--- a/samples/client/petstore/python/petstore_api/api/pet_api.py
+++ b/samples/client/petstore/python/petstore_api/api/pet_api.py
@@ -89,9 +89,10 @@ class PetApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -109,7 +110,7 @@ class PetApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -162,7 +163,7 @@ class PetApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def delete_pet(self, pet_id, **kwargs):  # noqa: E501
         """Deletes a pet  # noqa: E501
@@ -221,9 +222,10 @@ class PetApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -242,7 +244,7 @@ class PetApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -293,7 +295,7 @@ class PetApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def find_pets_by_status(self, status, **kwargs):  # noqa: E501
         """Finds Pets by status  # noqa: E501
@@ -350,9 +352,10 @@ class PetApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -370,7 +373,7 @@ class PetApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -424,7 +427,7 @@ class PetApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def find_pets_by_tags(self, tags, **kwargs):  # noqa: E501
         """Finds Pets by tags  # noqa: E501
@@ -481,9 +484,10 @@ class PetApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -501,7 +505,7 @@ class PetApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -555,7 +559,7 @@ class PetApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def get_pet_by_id(self, pet_id, **kwargs):  # noqa: E501
         """Find pet by ID  # noqa: E501
@@ -612,9 +616,10 @@ class PetApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -632,7 +637,7 @@ class PetApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -685,7 +690,7 @@ class PetApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def update_pet(self, body, **kwargs):  # noqa: E501
         """Update an existing pet  # noqa: E501
@@ -740,9 +745,10 @@ class PetApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -760,7 +766,7 @@ class PetApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -813,7 +819,7 @@ class PetApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def update_pet_with_form(self, pet_id, **kwargs):  # noqa: E501
         """Updates a pet in the store with form data  # noqa: E501
@@ -876,9 +882,10 @@ class PetApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -898,7 +905,7 @@ class PetApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -955,7 +962,7 @@ class PetApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def upload_file(self, pet_id, **kwargs):  # noqa: E501
         """uploads an image  # noqa: E501
@@ -1018,9 +1025,10 @@ class PetApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -1040,7 +1048,7 @@ class PetApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -1101,7 +1109,7 @@ class PetApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def upload_file_with_required_file(self, pet_id, required_file, **kwargs):  # noqa: E501
         """uploads an image (required)  # noqa: E501
@@ -1164,9 +1172,10 @@ class PetApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -1186,7 +1195,7 @@ class PetApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -1251,4 +1260,4 @@ class PetApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))

--- a/samples/client/petstore/python/petstore_api/api/pet_api.py
+++ b/samples/client/petstore/python/petstore_api/api/pet_api.py
@@ -89,6 +89,9 @@ class PetApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -105,7 +108,8 @@ class PetApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -157,7 +161,8 @@ class PetApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def delete_pet(self, pet_id, **kwargs):  # noqa: E501
         """Deletes a pet  # noqa: E501
@@ -216,6 +221,9 @@ class PetApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -233,7 +241,8 @@ class PetApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -283,7 +292,8 @@ class PetApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def find_pets_by_status(self, status, **kwargs):  # noqa: E501
         """Finds Pets by status  # noqa: E501
@@ -340,6 +350,9 @@ class PetApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -356,7 +369,8 @@ class PetApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -409,7 +423,8 @@ class PetApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def find_pets_by_tags(self, tags, **kwargs):  # noqa: E501
         """Finds Pets by tags  # noqa: E501
@@ -466,6 +481,9 @@ class PetApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -482,7 +500,8 @@ class PetApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -535,7 +554,8 @@ class PetApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def get_pet_by_id(self, pet_id, **kwargs):  # noqa: E501
         """Find pet by ID  # noqa: E501
@@ -592,6 +612,9 @@ class PetApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -608,7 +631,8 @@ class PetApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -660,7 +684,8 @@ class PetApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def update_pet(self, body, **kwargs):  # noqa: E501
         """Update an existing pet  # noqa: E501
@@ -715,6 +740,9 @@ class PetApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -731,7 +759,8 @@ class PetApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -783,7 +812,8 @@ class PetApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def update_pet_with_form(self, pet_id, **kwargs):  # noqa: E501
         """Updates a pet in the store with form data  # noqa: E501
@@ -846,6 +876,9 @@ class PetApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -864,7 +897,8 @@ class PetApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -920,7 +954,8 @@ class PetApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def upload_file(self, pet_id, **kwargs):  # noqa: E501
         """uploads an image  # noqa: E501
@@ -983,6 +1018,9 @@ class PetApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -1001,7 +1039,8 @@ class PetApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -1061,7 +1100,8 @@ class PetApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def upload_file_with_required_file(self, pet_id, required_file, **kwargs):  # noqa: E501
         """uploads an image (required)  # noqa: E501
@@ -1124,6 +1164,9 @@ class PetApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -1142,7 +1185,8 @@ class PetApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -1206,4 +1250,5 @@ class PetApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))

--- a/samples/client/petstore/python/petstore_api/api/store_api.py
+++ b/samples/client/petstore/python/petstore_api/api/store_api.py
@@ -91,9 +91,10 @@ class StoreApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -111,7 +112,7 @@ class StoreApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -160,7 +161,7 @@ class StoreApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def get_inventory(self, **kwargs):  # noqa: E501
         """Returns pet inventories by status  # noqa: E501
@@ -213,9 +214,10 @@ class StoreApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -232,7 +234,7 @@ class StoreApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -279,7 +281,7 @@ class StoreApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def get_order_by_id(self, order_id, **kwargs):  # noqa: E501
         """Find purchase order by ID  # noqa: E501
@@ -336,9 +338,10 @@ class StoreApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -356,7 +359,7 @@ class StoreApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -413,7 +416,7 @@ class StoreApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def place_order(self, body, **kwargs):  # noqa: E501
         """Place an order for a pet  # noqa: E501
@@ -468,9 +471,10 @@ class StoreApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -488,7 +492,7 @@ class StoreApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -541,4 +545,4 @@ class StoreApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))

--- a/samples/client/petstore/python/petstore_api/api/store_api.py
+++ b/samples/client/petstore/python/petstore_api/api/store_api.py
@@ -91,6 +91,9 @@ class StoreApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -107,7 +110,8 @@ class StoreApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -155,7 +159,8 @@ class StoreApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def get_inventory(self, **kwargs):  # noqa: E501
         """Returns pet inventories by status  # noqa: E501
@@ -208,6 +213,9 @@ class StoreApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -223,7 +231,8 @@ class StoreApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -269,7 +278,8 @@ class StoreApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def get_order_by_id(self, order_id, **kwargs):  # noqa: E501
         """Find purchase order by ID  # noqa: E501
@@ -326,6 +336,9 @@ class StoreApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -342,7 +355,8 @@ class StoreApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -398,7 +412,8 @@ class StoreApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def place_order(self, body, **kwargs):  # noqa: E501
         """Place an order for a pet  # noqa: E501
@@ -453,6 +468,9 @@ class StoreApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -469,7 +487,8 @@ class StoreApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -521,4 +540,5 @@ class StoreApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))

--- a/samples/client/petstore/python/petstore_api/api/user_api.py
+++ b/samples/client/petstore/python/petstore_api/api/user_api.py
@@ -91,6 +91,9 @@ class UserApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -107,7 +110,8 @@ class UserApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -155,7 +159,8 @@ class UserApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def create_users_with_array_input(self, body, **kwargs):  # noqa: E501
         """Creates list of users with given input array  # noqa: E501
@@ -210,6 +215,9 @@ class UserApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -226,7 +234,8 @@ class UserApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -274,7 +283,8 @@ class UserApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def create_users_with_list_input(self, body, **kwargs):  # noqa: E501
         """Creates list of users with given input array  # noqa: E501
@@ -329,6 +339,9 @@ class UserApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -345,7 +358,8 @@ class UserApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -393,7 +407,8 @@ class UserApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def delete_user(self, username, **kwargs):  # noqa: E501
         """Delete user  # noqa: E501
@@ -450,6 +465,9 @@ class UserApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -466,7 +484,8 @@ class UserApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -514,7 +533,8 @@ class UserApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def get_user_by_name(self, username, **kwargs):  # noqa: E501
         """Get user by user name  # noqa: E501
@@ -569,6 +589,9 @@ class UserApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -585,7 +608,8 @@ class UserApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -637,7 +661,8 @@ class UserApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def login_user(self, username, password, **kwargs):  # noqa: E501
         """Logs user into the system  # noqa: E501
@@ -696,6 +721,9 @@ class UserApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -713,7 +741,8 @@ class UserApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -771,7 +800,8 @@ class UserApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def logout_user(self, **kwargs):  # noqa: E501
         """Logs out current logged in user session  # noqa: E501
@@ -822,6 +852,9 @@ class UserApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -837,7 +870,8 @@ class UserApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -879,7 +913,8 @@ class UserApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def update_user(self, username, body, **kwargs):  # noqa: E501
         """Updated user  # noqa: E501
@@ -940,6 +975,9 @@ class UserApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -957,7 +995,8 @@ class UserApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -1011,4 +1050,5 @@ class UserApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))

--- a/samples/client/petstore/python/petstore_api/api/user_api.py
+++ b/samples/client/petstore/python/petstore_api/api/user_api.py
@@ -91,9 +91,10 @@ class UserApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -111,7 +112,7 @@ class UserApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -160,7 +161,7 @@ class UserApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def create_users_with_array_input(self, body, **kwargs):  # noqa: E501
         """Creates list of users with given input array  # noqa: E501
@@ -215,9 +216,10 @@ class UserApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -235,7 +237,7 @@ class UserApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -284,7 +286,7 @@ class UserApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def create_users_with_list_input(self, body, **kwargs):  # noqa: E501
         """Creates list of users with given input array  # noqa: E501
@@ -339,9 +341,10 @@ class UserApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -359,7 +362,7 @@ class UserApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -408,7 +411,7 @@ class UserApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def delete_user(self, username, **kwargs):  # noqa: E501
         """Delete user  # noqa: E501
@@ -465,9 +468,10 @@ class UserApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -485,7 +489,7 @@ class UserApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -534,7 +538,7 @@ class UserApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def get_user_by_name(self, username, **kwargs):  # noqa: E501
         """Get user by user name  # noqa: E501
@@ -589,9 +593,10 @@ class UserApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -609,7 +614,7 @@ class UserApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -662,7 +667,7 @@ class UserApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def login_user(self, username, password, **kwargs):  # noqa: E501
         """Logs user into the system  # noqa: E501
@@ -721,9 +726,10 @@ class UserApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -742,7 +748,7 @@ class UserApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -801,7 +807,7 @@ class UserApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def logout_user(self, **kwargs):  # noqa: E501
         """Logs out current logged in user session  # noqa: E501
@@ -852,9 +858,10 @@ class UserApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -871,7 +878,7 @@ class UserApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -914,7 +921,7 @@ class UserApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def update_user(self, username, body, **kwargs):  # noqa: E501
         """Updated user  # noqa: E501
@@ -975,9 +982,10 @@ class UserApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -996,7 +1004,7 @@ class UserApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -1051,4 +1059,4 @@ class UserApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))

--- a/samples/client/petstore/python/petstore_api/api_client.py
+++ b/samples/client/petstore/python/petstore_api/api_client.py
@@ -548,19 +548,32 @@ class ApiClient(object):
         if not auth_settings:
             return
 
+        if request_auth:
+            self._apply_auth_params(headers, querys, request_auth)
+            return
+
         for auth in auth_settings:
-            auth_setting = request_auth or self.configuration.auth_settings().get(auth)
+            auth_setting = self.configuration.auth_settings().get(auth)
             if auth_setting:
-                if auth_setting['in'] == 'cookie':
-                    headers['Cookie'] = auth_setting['value']
-                elif auth_setting['in'] == 'header':
-                    headers[auth_setting['key']] = auth_setting['value']
-                elif auth_setting['in'] == 'query':
-                    querys.append((auth_setting['key'], auth_setting['value']))
-                else:
-                    raise ApiValueError(
-                        'Authentication token must be in `query` or `header`'
-                    )
+                self._apply_auth_params(headers, querys, auth_setting)
+
+    def _apply_auth_params(self, headers, querys, auth_setting):
+        """Updates the request parameters based on a single auth_setting
+
+        :param headers: Header parameters dict to be updated.
+        :param querys: Query parameters tuple list to be updated.
+        :param auth_setting: auth settings for the endpoint
+        """
+        if auth_setting['in'] == 'cookie':
+            headers['Cookie'] = auth_setting['value']
+        elif auth_setting['in'] == 'header':
+            headers[auth_setting['key']] = auth_setting['value']
+        elif auth_setting['in'] == 'query':
+            querys.append((auth_setting['key'], auth_setting['value']))
+        else:
+            raise ApiValueError(
+                'Authentication token must be in `query` or `header`'
+            )
 
     def __deserialize_file(self, response):
         """Deserializes body to file

--- a/samples/client/petstore/python/tests/test_pet_api.py
+++ b/samples/client/petstore/python/tests/test_pet_api.py
@@ -121,6 +121,30 @@ class PetApiTests(unittest.TestCase):
         self.pet_api.add_pet(self.pet, _request_timeout=5)
         self.pet_api.add_pet(self.pet, _request_timeout=(1, 2))
 
+    def test_auth_settings(self):
+        mock_pool = MockPoolManager(self)
+        self.api_client.rest_client.pool_manager = mock_pool
+
+        mock_pool.expect_request('POST', HOST + '/pet',
+                                 body=json.dumps(self.api_client.sanitize_for_serialization(self.pet)),
+                                 headers={'Content-Type': 'application/json',
+                                          'Authorization': 'Bearer ACCESS_TOKEN',
+                                          'User-Agent': 'OpenAPI-Generator/1.0.0/python'},
+                                 preload_content=True, timeout=None)
+        mock_pool.expect_request('POST', HOST + '/pet',
+                                 body=json.dumps(self.api_client.sanitize_for_serialization(self.pet)),
+                                 headers={'Content-Type': 'application/json',
+                                          'Authorization': 'Prefix ANOTHER_TOKEN',
+                                          'User-Agent': 'OpenAPI-Generator/1.0.0/python'},
+                                 preload_content=True, timeout=None)
+
+        self.pet_api.add_pet(self.pet, _request_auth=None)
+        self.pet_api.add_pet(self.pet, _request_auth={
+            'in': 'header',
+            'key': 'Authorization',
+            'value': 'Prefix ANOTHER_TOKEN'
+        })
+
     def test_separate_default_client_instances(self):
         pet_api = petstore_api.PetApi()
         pet_api2 = petstore_api.PetApi()

--- a/samples/openapi3/client/petstore/python/petstore_api/api/another_fake_api.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api/another_fake_api.py
@@ -91,6 +91,9 @@ class AnotherFakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -107,7 +110,8 @@ class AnotherFakeApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -163,4 +167,5 @@ class AnotherFakeApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))

--- a/samples/openapi3/client/petstore/python/petstore_api/api/another_fake_api.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api/another_fake_api.py
@@ -91,9 +91,10 @@ class AnotherFakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -111,7 +112,7 @@ class AnotherFakeApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -168,4 +169,4 @@ class AnotherFakeApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))

--- a/samples/openapi3/client/petstore/python/petstore_api/api/default_api.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api/default_api.py
@@ -85,9 +85,10 @@ class DefaultApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -104,7 +105,7 @@ class DefaultApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -151,4 +152,4 @@ class DefaultApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))

--- a/samples/openapi3/client/petstore/python/petstore_api/api/default_api.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api/default_api.py
@@ -85,6 +85,9 @@ class DefaultApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -100,7 +103,8 @@ class DefaultApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -146,4 +150,5 @@ class DefaultApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))

--- a/samples/openapi3/client/petstore/python/petstore_api/api/fake_api.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api/fake_api.py
@@ -85,6 +85,9 @@ class FakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -100,7 +103,8 @@ class FakeApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -146,7 +150,8 @@ class FakeApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def fake_http_signature_test(self, pet, **kwargs):  # noqa: E501
         """test http signature authentication  # noqa: E501
@@ -209,6 +214,9 @@ class FakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -227,7 +235,8 @@ class FakeApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -283,7 +292,8 @@ class FakeApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def fake_outer_boolean_serialize(self, **kwargs):  # noqa: E501
         """fake_outer_boolean_serialize  # noqa: E501
@@ -340,6 +350,9 @@ class FakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -356,7 +369,8 @@ class FakeApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -408,7 +422,8 @@ class FakeApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def fake_outer_composite_serialize(self, **kwargs):  # noqa: E501
         """fake_outer_composite_serialize  # noqa: E501
@@ -465,6 +480,9 @@ class FakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -481,7 +499,8 @@ class FakeApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -533,7 +552,8 @@ class FakeApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def fake_outer_number_serialize(self, **kwargs):  # noqa: E501
         """fake_outer_number_serialize  # noqa: E501
@@ -590,6 +610,9 @@ class FakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -606,7 +629,8 @@ class FakeApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -658,7 +682,8 @@ class FakeApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def fake_outer_string_serialize(self, **kwargs):  # noqa: E501
         """fake_outer_string_serialize  # noqa: E501
@@ -715,6 +740,9 @@ class FakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -731,7 +759,8 @@ class FakeApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -783,7 +812,8 @@ class FakeApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def test_body_with_file_schema(self, file_schema_test_class, **kwargs):  # noqa: E501
         """test_body_with_file_schema  # noqa: E501
@@ -840,6 +870,9 @@ class FakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -856,7 +889,8 @@ class FakeApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -908,7 +942,8 @@ class FakeApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def test_body_with_query_params(self, query, user, **kwargs):  # noqa: E501
         """test_body_with_query_params  # noqa: E501
@@ -967,6 +1002,9 @@ class FakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -984,7 +1022,8 @@ class FakeApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -1042,7 +1081,8 @@ class FakeApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def test_client_model(self, client, **kwargs):  # noqa: E501
         """To test \"client\" model  # noqa: E501
@@ -1099,6 +1139,9 @@ class FakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -1115,7 +1158,8 @@ class FakeApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -1171,7 +1215,8 @@ class FakeApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def test_endpoint_parameters(self, number, double, pattern_without_delimiter, byte, **kwargs):  # noqa: E501
         """Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트   # noqa: E501
@@ -1280,6 +1325,9 @@ class FakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -1309,7 +1357,8 @@ class FakeApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -1427,7 +1476,8 @@ class FakeApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def test_enum_parameters(self, **kwargs):  # noqa: E501
         """To test enum parameters  # noqa: E501
@@ -1512,6 +1562,9 @@ class FakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -1535,7 +1588,8 @@ class FakeApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -1600,7 +1654,8 @@ class FakeApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def test_group_parameters(self, required_string_group, required_boolean_group, required_int64_group, **kwargs):  # noqa: E501
         """Fake endpoint to test group parameters (optional)  # noqa: E501
@@ -1677,6 +1732,9 @@ class FakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -1698,7 +1756,8 @@ class FakeApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -1764,7 +1823,8 @@ class FakeApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def test_inline_additional_properties(self, request_body, **kwargs):  # noqa: E501
         """test inline additionalProperties  # noqa: E501
@@ -1819,6 +1879,9 @@ class FakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -1835,7 +1898,8 @@ class FakeApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -1887,7 +1951,8 @@ class FakeApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def test_json_form_data(self, param, param2, **kwargs):  # noqa: E501
         """test json serialization of form data  # noqa: E501
@@ -1946,6 +2011,9 @@ class FakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -1963,7 +2031,8 @@ class FakeApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -2021,7 +2090,8 @@ class FakeApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def test_query_parameter_collection_format(self, pipe, ioutil, http, url, context, **kwargs):  # noqa: E501
         """test_query_parameter_collection_format  # noqa: E501
@@ -2094,6 +2164,9 @@ class FakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -2114,7 +2187,8 @@ class FakeApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -2191,4 +2265,5 @@ class FakeApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))

--- a/samples/openapi3/client/petstore/python/petstore_api/api/fake_api.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api/fake_api.py
@@ -85,9 +85,10 @@ class FakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -104,7 +105,7 @@ class FakeApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -151,7 +152,7 @@ class FakeApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def fake_http_signature_test(self, pet, **kwargs):  # noqa: E501
         """test http signature authentication  # noqa: E501
@@ -214,9 +215,10 @@ class FakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -236,7 +238,7 @@ class FakeApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -293,7 +295,7 @@ class FakeApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def fake_outer_boolean_serialize(self, **kwargs):  # noqa: E501
         """fake_outer_boolean_serialize  # noqa: E501
@@ -350,9 +352,10 @@ class FakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -370,7 +373,7 @@ class FakeApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -423,7 +426,7 @@ class FakeApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def fake_outer_composite_serialize(self, **kwargs):  # noqa: E501
         """fake_outer_composite_serialize  # noqa: E501
@@ -480,9 +483,10 @@ class FakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -500,7 +504,7 @@ class FakeApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -553,7 +557,7 @@ class FakeApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def fake_outer_number_serialize(self, **kwargs):  # noqa: E501
         """fake_outer_number_serialize  # noqa: E501
@@ -610,9 +614,10 @@ class FakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -630,7 +635,7 @@ class FakeApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -683,7 +688,7 @@ class FakeApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def fake_outer_string_serialize(self, **kwargs):  # noqa: E501
         """fake_outer_string_serialize  # noqa: E501
@@ -740,9 +745,10 @@ class FakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -760,7 +766,7 @@ class FakeApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -813,7 +819,7 @@ class FakeApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def test_body_with_file_schema(self, file_schema_test_class, **kwargs):  # noqa: E501
         """test_body_with_file_schema  # noqa: E501
@@ -870,9 +876,10 @@ class FakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -890,7 +897,7 @@ class FakeApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -943,7 +950,7 @@ class FakeApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def test_body_with_query_params(self, query, user, **kwargs):  # noqa: E501
         """test_body_with_query_params  # noqa: E501
@@ -1002,9 +1009,10 @@ class FakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -1023,7 +1031,7 @@ class FakeApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -1082,7 +1090,7 @@ class FakeApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def test_client_model(self, client, **kwargs):  # noqa: E501
         """To test \"client\" model  # noqa: E501
@@ -1139,9 +1147,10 @@ class FakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -1159,7 +1168,7 @@ class FakeApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -1216,7 +1225,7 @@ class FakeApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def test_endpoint_parameters(self, number, double, pattern_without_delimiter, byte, **kwargs):  # noqa: E501
         """Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트   # noqa: E501
@@ -1325,9 +1334,10 @@ class FakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -1358,7 +1368,7 @@ class FakeApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -1477,7 +1487,7 @@ class FakeApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def test_enum_parameters(self, **kwargs):  # noqa: E501
         """To test enum parameters  # noqa: E501
@@ -1562,9 +1572,10 @@ class FakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -1589,7 +1600,7 @@ class FakeApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -1655,7 +1666,7 @@ class FakeApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def test_group_parameters(self, required_string_group, required_boolean_group, required_int64_group, **kwargs):  # noqa: E501
         """Fake endpoint to test group parameters (optional)  # noqa: E501
@@ -1732,9 +1743,10 @@ class FakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -1757,7 +1769,7 @@ class FakeApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -1824,7 +1836,7 @@ class FakeApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def test_inline_additional_properties(self, request_body, **kwargs):  # noqa: E501
         """test inline additionalProperties  # noqa: E501
@@ -1879,9 +1891,10 @@ class FakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -1899,7 +1912,7 @@ class FakeApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -1952,7 +1965,7 @@ class FakeApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def test_json_form_data(self, param, param2, **kwargs):  # noqa: E501
         """test json serialization of form data  # noqa: E501
@@ -2011,9 +2024,10 @@ class FakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -2032,7 +2046,7 @@ class FakeApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -2091,7 +2105,7 @@ class FakeApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def test_query_parameter_collection_format(self, pipe, ioutil, http, url, context, **kwargs):  # noqa: E501
         """test_query_parameter_collection_format  # noqa: E501
@@ -2164,9 +2178,10 @@ class FakeApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -2188,7 +2203,7 @@ class FakeApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -2266,4 +2281,4 @@ class FakeApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))

--- a/samples/openapi3/client/petstore/python/petstore_api/api/fake_classname_tags_123_api.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api/fake_classname_tags_123_api.py
@@ -91,9 +91,10 @@ class FakeClassnameTags123Api(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -111,7 +112,7 @@ class FakeClassnameTags123Api(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -168,4 +169,4 @@ class FakeClassnameTags123Api(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))

--- a/samples/openapi3/client/petstore/python/petstore_api/api/fake_classname_tags_123_api.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api/fake_classname_tags_123_api.py
@@ -91,6 +91,9 @@ class FakeClassnameTags123Api(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -107,7 +110,8 @@ class FakeClassnameTags123Api(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -163,4 +167,5 @@ class FakeClassnameTags123Api(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))

--- a/samples/openapi3/client/petstore/python/petstore_api/api/pet_api.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api/pet_api.py
@@ -89,6 +89,9 @@ class PetApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -118,7 +121,8 @@ class PetApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -171,7 +175,8 @@ class PetApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             _host=local_var_host,
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def delete_pet(self, pet_id, **kwargs):  # noqa: E501
         """Deletes a pet  # noqa: E501
@@ -230,6 +235,9 @@ class PetApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -247,7 +255,8 @@ class PetApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -297,7 +306,8 @@ class PetApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def find_pets_by_status(self, status, **kwargs):  # noqa: E501
         """Finds Pets by status  # noqa: E501
@@ -354,6 +364,9 @@ class PetApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -370,7 +383,8 @@ class PetApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -423,7 +437,8 @@ class PetApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def find_pets_by_tags(self, tags, **kwargs):  # noqa: E501
         """Finds Pets by tags  # noqa: E501
@@ -480,6 +495,9 @@ class PetApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -496,7 +514,8 @@ class PetApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -549,7 +568,8 @@ class PetApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def get_pet_by_id(self, pet_id, **kwargs):  # noqa: E501
         """Find pet by ID  # noqa: E501
@@ -606,6 +626,9 @@ class PetApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -622,7 +645,8 @@ class PetApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -674,7 +698,8 @@ class PetApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def update_pet(self, pet, **kwargs):  # noqa: E501
         """Update an existing pet  # noqa: E501
@@ -729,6 +754,9 @@ class PetApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -758,7 +786,8 @@ class PetApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -811,7 +840,8 @@ class PetApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             _host=local_var_host,
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def update_pet_with_form(self, pet_id, **kwargs):  # noqa: E501
         """Updates a pet in the store with form data  # noqa: E501
@@ -874,6 +904,9 @@ class PetApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -892,7 +925,8 @@ class PetApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -948,7 +982,8 @@ class PetApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def upload_file(self, pet_id, **kwargs):  # noqa: E501
         """uploads an image  # noqa: E501
@@ -1011,6 +1046,9 @@ class PetApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -1029,7 +1067,8 @@ class PetApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -1089,7 +1128,8 @@ class PetApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def upload_file_with_required_file(self, pet_id, required_file, **kwargs):  # noqa: E501
         """uploads an image (required)  # noqa: E501
@@ -1152,6 +1192,9 @@ class PetApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -1170,7 +1213,8 @@ class PetApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -1234,4 +1278,5 @@ class PetApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))

--- a/samples/openapi3/client/petstore/python/petstore_api/api/pet_api.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api/pet_api.py
@@ -89,9 +89,10 @@ class PetApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -122,7 +123,7 @@ class PetApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -176,7 +177,7 @@ class PetApi(object):
             _request_timeout=local_var_params.get('_request_timeout'),
             _host=local_var_host,
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def delete_pet(self, pet_id, **kwargs):  # noqa: E501
         """Deletes a pet  # noqa: E501
@@ -235,9 +236,10 @@ class PetApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -256,7 +258,7 @@ class PetApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -307,7 +309,7 @@ class PetApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def find_pets_by_status(self, status, **kwargs):  # noqa: E501
         """Finds Pets by status  # noqa: E501
@@ -364,9 +366,10 @@ class PetApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -384,7 +387,7 @@ class PetApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -438,7 +441,7 @@ class PetApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def find_pets_by_tags(self, tags, **kwargs):  # noqa: E501
         """Finds Pets by tags  # noqa: E501
@@ -495,9 +498,10 @@ class PetApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -515,7 +519,7 @@ class PetApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -569,7 +573,7 @@ class PetApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def get_pet_by_id(self, pet_id, **kwargs):  # noqa: E501
         """Find pet by ID  # noqa: E501
@@ -626,9 +630,10 @@ class PetApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -646,7 +651,7 @@ class PetApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -699,7 +704,7 @@ class PetApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def update_pet(self, pet, **kwargs):  # noqa: E501
         """Update an existing pet  # noqa: E501
@@ -754,9 +759,10 @@ class PetApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -787,7 +793,7 @@ class PetApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -841,7 +847,7 @@ class PetApi(object):
             _request_timeout=local_var_params.get('_request_timeout'),
             _host=local_var_host,
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def update_pet_with_form(self, pet_id, **kwargs):  # noqa: E501
         """Updates a pet in the store with form data  # noqa: E501
@@ -904,9 +910,10 @@ class PetApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -926,7 +933,7 @@ class PetApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -983,7 +990,7 @@ class PetApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def upload_file(self, pet_id, **kwargs):  # noqa: E501
         """uploads an image  # noqa: E501
@@ -1046,9 +1053,10 @@ class PetApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -1068,7 +1076,7 @@ class PetApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -1129,7 +1137,7 @@ class PetApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def upload_file_with_required_file(self, pet_id, required_file, **kwargs):  # noqa: E501
         """uploads an image (required)  # noqa: E501
@@ -1192,9 +1200,10 @@ class PetApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -1214,7 +1223,7 @@ class PetApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -1279,4 +1288,4 @@ class PetApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))

--- a/samples/openapi3/client/petstore/python/petstore_api/api/store_api.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api/store_api.py
@@ -91,9 +91,10 @@ class StoreApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -111,7 +112,7 @@ class StoreApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -160,7 +161,7 @@ class StoreApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def get_inventory(self, **kwargs):  # noqa: E501
         """Returns pet inventories by status  # noqa: E501
@@ -213,9 +214,10 @@ class StoreApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -232,7 +234,7 @@ class StoreApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -279,7 +281,7 @@ class StoreApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def get_order_by_id(self, order_id, **kwargs):  # noqa: E501
         """Find purchase order by ID  # noqa: E501
@@ -336,9 +338,10 @@ class StoreApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -356,7 +359,7 @@ class StoreApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -413,7 +416,7 @@ class StoreApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def place_order(self, order, **kwargs):  # noqa: E501
         """Place an order for a pet  # noqa: E501
@@ -468,9 +471,10 @@ class StoreApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -488,7 +492,7 @@ class StoreApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -545,4 +549,4 @@ class StoreApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))

--- a/samples/openapi3/client/petstore/python/petstore_api/api/store_api.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api/store_api.py
@@ -91,6 +91,9 @@ class StoreApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -107,7 +110,8 @@ class StoreApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -155,7 +159,8 @@ class StoreApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def get_inventory(self, **kwargs):  # noqa: E501
         """Returns pet inventories by status  # noqa: E501
@@ -208,6 +213,9 @@ class StoreApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -223,7 +231,8 @@ class StoreApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -269,7 +278,8 @@ class StoreApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def get_order_by_id(self, order_id, **kwargs):  # noqa: E501
         """Find purchase order by ID  # noqa: E501
@@ -326,6 +336,9 @@ class StoreApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -342,7 +355,8 @@ class StoreApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -398,7 +412,8 @@ class StoreApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def place_order(self, order, **kwargs):  # noqa: E501
         """Place an order for a pet  # noqa: E501
@@ -453,6 +468,9 @@ class StoreApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -469,7 +487,8 @@ class StoreApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -525,4 +544,5 @@ class StoreApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))

--- a/samples/openapi3/client/petstore/python/petstore_api/api/user_api.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api/user_api.py
@@ -91,6 +91,9 @@ class UserApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -107,7 +110,8 @@ class UserApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -159,7 +163,8 @@ class UserApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def create_users_with_array_input(self, user, **kwargs):  # noqa: E501
         """Creates list of users with given input array  # noqa: E501
@@ -214,6 +219,9 @@ class UserApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -230,7 +238,8 @@ class UserApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -282,7 +291,8 @@ class UserApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def create_users_with_list_input(self, user, **kwargs):  # noqa: E501
         """Creates list of users with given input array  # noqa: E501
@@ -337,6 +347,9 @@ class UserApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -353,7 +366,8 @@ class UserApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -405,7 +419,8 @@ class UserApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def delete_user(self, username, **kwargs):  # noqa: E501
         """Delete user  # noqa: E501
@@ -462,6 +477,9 @@ class UserApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -478,7 +496,8 @@ class UserApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -526,7 +545,8 @@ class UserApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def get_user_by_name(self, username, **kwargs):  # noqa: E501
         """Get user by user name  # noqa: E501
@@ -581,6 +601,9 @@ class UserApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -597,7 +620,8 @@ class UserApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -649,7 +673,8 @@ class UserApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def login_user(self, username, password, **kwargs):  # noqa: E501
         """Logs user into the system  # noqa: E501
@@ -708,6 +733,9 @@ class UserApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -725,7 +753,8 @@ class UserApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -783,7 +812,8 @@ class UserApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def logout_user(self, **kwargs):  # noqa: E501
         """Logs out current logged in user session  # noqa: E501
@@ -834,6 +864,9 @@ class UserApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -849,7 +882,8 @@ class UserApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -891,7 +925,8 @@ class UserApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))
 
     def update_user(self, username, user, **kwargs):  # noqa: E501
         """Updated user  # noqa: E501
@@ -952,6 +987,9 @@ class UserApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param _access_token: set to override the default access token defined
+                              in the ApiClient's configuration for a single request.
+        :type _access_token: str, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -969,7 +1007,8 @@ class UserApi(object):
                 'async_req',
                 '_return_http_data_only',
                 '_preload_content',
-                '_request_timeout'
+                '_request_timeout',
+                '_access_token'
             ]
         )
 
@@ -1027,4 +1066,5 @@ class UserApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
-            collection_formats=collection_formats)
+            collection_formats=collection_formats,
+            _access_token=local_var_params.get('_access_token'))

--- a/samples/openapi3/client/petstore/python/petstore_api/api/user_api.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api/user_api.py
@@ -91,9 +91,10 @@ class UserApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -111,7 +112,7 @@ class UserApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -164,7 +165,7 @@ class UserApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def create_users_with_array_input(self, user, **kwargs):  # noqa: E501
         """Creates list of users with given input array  # noqa: E501
@@ -219,9 +220,10 @@ class UserApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -239,7 +241,7 @@ class UserApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -292,7 +294,7 @@ class UserApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def create_users_with_list_input(self, user, **kwargs):  # noqa: E501
         """Creates list of users with given input array  # noqa: E501
@@ -347,9 +349,10 @@ class UserApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -367,7 +370,7 @@ class UserApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -420,7 +423,7 @@ class UserApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def delete_user(self, username, **kwargs):  # noqa: E501
         """Delete user  # noqa: E501
@@ -477,9 +480,10 @@ class UserApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -497,7 +501,7 @@ class UserApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -546,7 +550,7 @@ class UserApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def get_user_by_name(self, username, **kwargs):  # noqa: E501
         """Get user by user name  # noqa: E501
@@ -601,9 +605,10 @@ class UserApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -621,7 +626,7 @@ class UserApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -674,7 +679,7 @@ class UserApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def login_user(self, username, password, **kwargs):  # noqa: E501
         """Logs user into the system  # noqa: E501
@@ -733,9 +738,10 @@ class UserApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -754,7 +760,7 @@ class UserApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -813,7 +819,7 @@ class UserApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def logout_user(self, **kwargs):  # noqa: E501
         """Logs out current logged in user session  # noqa: E501
@@ -864,9 +870,10 @@ class UserApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -883,7 +890,7 @@ class UserApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -926,7 +933,7 @@ class UserApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))
 
     def update_user(self, username, user, **kwargs):  # noqa: E501
         """Updated user  # noqa: E501
@@ -987,9 +994,10 @@ class UserApi(object):
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
-        :param _access_token: set to override the default access token defined
-                              in the ApiClient's configuration for a single request.
-        :type _access_token: str, optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -1008,7 +1016,7 @@ class UserApi(object):
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
-                '_access_token'
+                '_request_auth'
             ]
         )
 
@@ -1067,4 +1075,4 @@ class UserApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats,
-            _access_token=local_var_params.get('_access_token'))
+            _request_auth=local_var_params.get('_request_auth'))

--- a/samples/openapi3/client/petstore/python/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api_client.py
@@ -548,19 +548,32 @@ class ApiClient(object):
         if not auth_settings:
             return
 
+        if request_auth:
+            self._apply_auth_params(headers, querys, request_auth)
+            return
+
         for auth in auth_settings:
-            auth_setting = request_auth or self.configuration.auth_settings().get(auth)
+            auth_setting = self.configuration.auth_settings().get(auth)
             if auth_setting:
-                if auth_setting['in'] == 'cookie':
-                    headers['Cookie'] = auth_setting['value']
-                elif auth_setting['in'] == 'header':
-                    headers[auth_setting['key']] = auth_setting['value']
-                elif auth_setting['in'] == 'query':
-                    querys.append((auth_setting['key'], auth_setting['value']))
-                else:
-                    raise ApiValueError(
-                        'Authentication token must be in `query` or `header`'
-                    )
+                self._apply_auth_params(headers, querys, auth_setting)
+
+    def _apply_auth_params(self, headers, querys, auth_setting):
+        """Updates the request parameters based on a single auth_setting
+
+        :param headers: Header parameters dict to be updated.
+        :param querys: Query parameters tuple list to be updated.
+        :param auth_setting: auth settings for the endpoint
+        """
+        if auth_setting['in'] == 'cookie':
+            headers['Cookie'] = auth_setting['value']
+        elif auth_setting['in'] == 'header':
+            headers[auth_setting['key']] = auth_setting['value']
+        elif auth_setting['in'] == 'query':
+            querys.append((auth_setting['key'], auth_setting['value']))
+        else:
+            raise ApiValueError(
+                'Authentication token must be in `query` or `header`'
+            )
 
     def __deserialize_file(self, response):
         """Deserializes body to file


### PR DESCRIPTION
Fixes #6565 

The changes are backward compatible with existing wiring since we're only adding optional keyword arguments.

Please forgive me if I've missed something in the contributing guidelines.

@taxpon @frol @mbohlool @cbornet @kenjones-cisco @tomplus @Jyhess @arun-nalla @spacether
<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
