### PR TITLE
[docker] Tag latest-release for stable latest tagging

### DIFF
--- a/.github/workflows/docker-tag-latest-release.yml
+++ b/.github/workflows/docker-tag-latest-release.yml
@@ -1,0 +1,62 @@
+name: Docker Tag latest-release
+
+# Run every couple of days
+on:
+  schedule:
+  - cron: "* */48 * * *"
+
+jobs:
+  # This pulls all containers for the last known release tag, and tags as latest-release or x-latest-release for shared repo
+  tagLatestRelease:
+    runs-on: ubuntu-latest
+
+    steps:
+
+    # Pull the code so we have git metadata
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    # This action will "unshallow" so we have all tag info
+    - name: Get latest tag
+      id: tagger
+      uses: jimschubert/query-tag-action@v1
+      with:
+        include: 'v*'
+        exclude: '*-rc*'
+        commit-ish: 'HEAD~'
+
+    - name: DockerHub Login
+      run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
+    
+    # Tags openapitools/openapi-generator-online, which is an automated build
+    - name: "Tag openapi-generator-online:x"
+      id: tag-openapi-generator-online
+      run: |
+        echo Tagging as latest-release: ${{steps.tagger.outputs.tag}}'
+        docker pull openapitools/openapi-generator-online:${{steps.tagger.outputs.tag}}
+        docker tag openapitools/openapi-generator-online:${{steps.tagger.outputs.tag}} openapitools/openapi-generator-online:latest-release
+        docker push openapitools/openapi-generator-online:latest-release
+
+    # Tags openapitools/openapi-generator's CLI image (this repo holds CLI + Online via tag prefix)
+    - name: "Tag openapi-generator:cli-x"
+      id: tag-cli
+      run: |
+        echo 'Tagging as latest-release: ${{steps.tagger.outputs.tag}}'
+        docker pull openapitools/openapi-generator:cli-${{steps.tagger.outputs.tag}}
+        docker tag openapitools/openapi-generator:cli-${{steps.tagger.outputs.tag}} openapitools/openapi-generator:cli-latest-release
+        docker push openapitools/openapi-generator:cli-latest-release
+
+    # Tags openapitools/openapi-generator's ONLINE image (this repo holds CLI + Online via tag prefix)
+    - name: "Tag openapi-generator:online-x"
+      id: tag-online
+      run: |
+        echo 'Tagging as latest-release: ${{steps.tagger.outputs.tag}}'
+        docker pull openapitools/openapi-generator:online-${{steps.tagger.outputs.tag}}
+        docker tag openapitools/openapi-generator:online-${{steps.tagger.outputs.tag}} openapitools/openapi-generator:online-latest-release
+        docker push openapitools/openapi-generator:online-latest-release
+
+    # Clean up docker credentials/configs/etc.
+    - name: Cleanup
+      if: always()
+      run: |
+        rm -f ${HOME}/.docker/config.json


### PR DESCRIPTION
Our `latest` tags track master. We don't currently have a stable tracking tag.

This github workflow runs every couple of days, gets the last known tagged release from git metadata, pulls that image from dockerhub if it exists, and creates/updates a tag which represents the latest release.

* `openapitools/openapi-generator-online:latest-release`
* `openapitools/openapi-generator:cli-latest-release`
* `openapitools/openapi-generator:online-latest-release`

Review [github workflow docs](https://help.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets#using-encrypted-secrets-in-a-workflow) for details on secrets usage.

Secrets are already setup and ready for this to be merged.

fixes #3840

cc @OpenAPITools/generator-core-team 

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
