### PR TITLE
[Rust Server] Pass context to client middleware

### DIFF
--- a/modules/openapi-generator/src/main/resources/rust-server/client-imports.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/client-imports.mustache
@@ -9,13 +9,14 @@ use std::io::{ErrorKind, Read};
 use std::error::Error;
 use std::future::Future;
 use std::fmt;
+use std::marker::PhantomData;
 use std::path::Path;
 use std::sync::{Arc, Mutex};
 use std::str;
 use std::str::FromStr;
 use std::string::ToString;
 use std::task::{Context, Poll};
-use swagger::{ApiError, AuthData, BodyExt, Connector, Has, XSpanIdString};
+use swagger::{ApiError, AuthData, BodyExt, Connector, DropContextService, Has, XSpanIdString};
 use url::form_urlencoded;
 
 {{#apiUsesMultipartFormData}}

--- a/modules/openapi-generator/src/main/resources/rust-server/client-mod.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/client-mod.mustache
@@ -27,49 +27,57 @@ fn into_base_path(input: impl TryInto<Uri, Error=hyper::http::uri::InvalidUri>, 
 }
 
 /// A client that implements the API by making HTTP calls out to a server.
-pub struct Client<S> where
+pub struct Client<S, C> where
     S: Service<
-           Request<Body>,
+           (Request<Body>, C),
            Response=Response<Body>> + Clone + Sync + Send + 'static,
     S::Future: Send + 'static,
     S::Error: Into<crate::ServiceError> + fmt::Display,
+    C: Clone + Send + Sync + 'static
 {
     /// Inner service
     client_service: S,
 
     /// Base path of the API
     base_path: String,
+
+    /// Marker
+    marker: PhantomData<fn(C)>,
 }
 
-impl<S> fmt::Debug for Client<S> where
+impl<S, C> fmt::Debug for Client<S, C> where
     S: Service<
-           Request<Body>,
+           (Request<Body>, C),
            Response=Response<Body>> + Clone + Sync + Send + 'static,
     S::Future: Send + 'static,
     S::Error: Into<crate::ServiceError> + fmt::Display,
+    C: Clone + Send + Sync + 'static
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "Client {{ base_path: {} }}", self.base_path)
     }
 }
 
-impl<S> Clone for Client<S> where
+impl<S, C> Clone for Client<S, C> where
     S: Service<
-           Request<Body>,
+           (Request<Body>, C),
            Response=Response<Body>> + Clone + Sync + Send + 'static,
     S::Future: Send + 'static,
     S::Error: Into<crate::ServiceError> + fmt::Display,
+    C: Clone + Send + Sync + 'static
 {
     fn clone(&self) -> Self {
         Self {
             client_service: self.client_service.clone(),
             base_path: self.base_path.clone(),
+            marker: PhantomData,
         }
     }
 }
 
-impl<C> Client<hyper::client::Client<C, Body>> where
-      C: hyper::client::connect::Connect + Clone + Send + Sync + 'static
+impl<Connector, C> Client<DropContextService<hyper::client::Client<Connector, Body>, C>, C> where
+    Connector: hyper::client::connect::Connect + Clone + Send + Sync + 'static,
+    C: Clone + Send + Sync + 'static,
 {
     /// Create a client with a custom implementation of hyper::client::Connect.
     ///
@@ -88,14 +96,16 @@ impl<C> Client<hyper::client::Client<C, Body>> where
     pub fn try_new_with_connector(
         base_path: &str,
         protocol: Option<&'static str>,
-        connector: C,
+        connector: Connector,
     ) -> Result<Self, ClientInitError>
     {
         let client_service = hyper::client::Client::builder().build(connector);
+        let client_service = DropContextService::new(client_service);
 
         Ok(Self {
             client_service,
             base_path: into_base_path(base_path, protocol)?,
+            marker: PhantomData,
         })
     }
 }
@@ -126,7 +136,9 @@ impl Service<Request<Body>> for HyperClient {
     }
 }
 
-impl Client<HyperClient> {
+impl<C> Client<DropContextService<HyperClient, C>, C> where
+    C: Clone + Send + Sync + 'static,
+{
     /// Create an HTTP client.
     ///
     /// # Arguments
@@ -156,14 +168,18 @@ impl Client<HyperClient> {
             }
         };
 
+        let client_service = DropContextService::new(client_service);
+
         Ok(Self {
             client_service,
             base_path: into_base_path(base_path, None)?,
+            marker: PhantomData,
         })
     }
 }
 
-impl Client<hyper::client::Client<hyper::client::HttpConnector, Body>>
+impl<C> Client<DropContextService<hyper::client::Client<hyper::client::HttpConnector, Body>, C>, C> where
+    C: Clone + Send + Sync + 'static
 {
     /// Create an HTTP client.
     ///
@@ -184,7 +200,8 @@ type HttpsConnector = hyper_tls::HttpsConnector<hyper::client::HttpConnector>;
 #[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "ios")))]
 type HttpsConnector = hyper_openssl::HttpsConnector<hyper::client::HttpConnector>;
 
-impl Client<hyper::client::Client<HttpsConnector, Body>>
+impl<C> Client<DropContextService<hyper::client::Client<HttpsConnector, Body>, C>, C> where
+    C: Clone + Send + Sync + 'static
 {
     /// Create a client with a TLS connection to the server
     ///
@@ -249,12 +266,13 @@ impl Client<hyper::client::Client<HttpsConnector, Body>>
     }
 }
 
-impl<S> Client<S> where
+impl<S, C> Client<S, C> where
     S: Service<
-           Request<Body>,
+           (Request<Body>, C),
            Response=Response<Body>> + Clone + Sync + Send + 'static,
     S::Future: Send + 'static,
     S::Error: Into<crate::ServiceError> + fmt::Display,
+    C: Clone + Send + Sync + 'static
 {
     /// Constructor for creating a `Client` by passing in a pre-made `hyper::service::Service` /
     /// `tower::Service`
@@ -268,6 +286,7 @@ impl<S> Client<S> where
         Ok(Self {
             client_service,
             base_path: into_base_path(base_path, None)?,
+            marker: PhantomData,
         })
     }
 }
@@ -313,13 +332,13 @@ impl Error for ClientInitError {
 }
 
 #[async_trait]
-impl<C, S> Api<C> for Client<S> where
-    C: Has<XSpanIdString> {{#hasAuthMethods}}+ Has<Option<AuthData>>{{/hasAuthMethods}} + Clone + Send + Sync + 'static,
+impl<S, C> Api<C> for Client<S, C> where
     S: Service<
-       Request<Body>,
+       (Request<Body>, C),
        Response=Response<Body>> + Clone + Sync + Send + 'static,
     S::Future: Send + 'static,
     S::Error: Into<crate::ServiceError> + fmt::Display,
+    C: Has<XSpanIdString> {{#hasAuthMethods}}+ Has<Option<AuthData>>{{/hasAuthMethods}} + Clone + Send + Sync + 'static,
 {
     fn poll_ready(&self, cx: &mut Context) -> Poll<Result<(), crate::ServiceError>> {
         match self.client_service.clone().poll_ready(cx) {

--- a/modules/openapi-generator/src/main/resources/rust-server/client-operation.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/client-operation.mustache
@@ -134,6 +134,7 @@
         };
 
         *request.body_mut() = Body::from(body_string);
+
         request.headers_mut().insert(CONTENT_TYPE, match HeaderValue::from_str(&multipart_header) {
             Ok(h) => h,
             Err(e) => return Err(ApiError(format!("Unable to create header: {} - {}", multipart_header, e)))
@@ -365,7 +366,7 @@
 {{/isMapContainer}}
 
 {{/headerParams}}
-        let mut response = client_service.call(request)
+        let mut response = client_service.call((request, context.clone()))
             .map_err(|e| ApiError(format!("No response received: {}", e))).await?;
 
         match response.status().as_u16() {

--- a/modules/openapi-generator/src/main/resources/rust-server/server-callbacks.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/server-callbacks.mustache
@@ -17,45 +17,53 @@ use crate::{{{operationId}}}Response;
 {{/apiInfo}}
 
 /// A client that implements the API by making HTTP calls out to a server.
-pub struct Client<S> where
+pub struct Client<S, C> where
     S: Service<
-           Request<Body>,
+           (Request<Body>, C),
            Response=Response<Body>,
            Error=hyper::Error> + Clone + Send + Sync,
     S::Future: Send + 'static,
+    C: Clone + Send + Sync + 'static
 {
     /// Inner service
     client_service: S,
+
+    /// Marker
+    marker: PhantomData<fn(C)>,
 }
 
-impl<S> fmt::Debug for Client<S> where
+impl<S, C> fmt::Debug for Client<S, C> where
     S: Service<
-           Request<Body>,
+           (Request<Body>, C),
            Response=Response<Body>,
            Error=hyper::Error> + Clone + Send + Sync,
     S::Future: Send + 'static,
+    C: Clone + Send + Sync + 'static
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "Client")
     }
 }
 
-impl<S> Clone for Client<S> where
+impl<S, C> Clone for Client<S, C> where
     S: Service<
-           Request<Body>,
+           (Request<Body>, C),
            Response=Response<Body>,
            Error=hyper::Error> + Clone + Send + Sync,
     S::Future: Send + 'static,
+    C: Clone + Send + Sync + 'static
 {
     fn clone(&self) -> Self {
         Self {
             client_service: self.client_service.clone(),
+            marker: PhantomData,
         }
     }
 }
 
-impl<C> Client<hyper::client::Client<C, Body>> where
-      C: hyper::client::connect::Connect + Clone + Send + Sync + 'static
+impl<Connector, C> Client<DropContextService<hyper::client::Client<Connector, Body>, C>, C> where
+    Connector: hyper::client::connect::Connect + Clone + Send + Sync + 'static,
+    C: Clone + Send + Sync + 'static
 {
     /// Create a client with a custom implementation of hyper::client::Connect.
     ///
@@ -69,17 +77,20 @@ impl<C> Client<hyper::client::Client<C, Body>> where
     /// # Arguments
     ///
     /// * `connector` - Implementation of `hyper::client::Connect` to use for the client
-    pub fn new_with_connector(connector: C) -> Self
+    pub fn new_with_connector(connector: Connector) -> Self
     {
         let client_service = hyper::client::Client::builder().build(connector);
+        let client_service = DropContextService::new(client_service);
 
         Self {
             client_service,
+            marker: PhantomData,
         }
     }
 }
 
-impl Client<hyper::client::Client<hyper::client::HttpConnector, Body>>
+impl<C> Client<DropContextService<hyper::client::Client<hyper::client::HttpConnector, Body>, C>, C> where
+    C: Clone + Send + Sync + 'static
 {
     /// Create an HTTP client.
     pub fn new_http() -> Self {
@@ -94,7 +105,8 @@ type HttpConnector = hyper_tls::HttpsConnector<hyper::client::HttpConnector>;
 #[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "ios")))]
 type HttpsConnector = hyper_openssl::HttpsConnector<hyper::client::HttpConnector>;
 
-impl Client<hyper::client::Client<HttpsConnector, Body>>
+impl<C> Client<DropContextService<hyper::client::Client<HttpsConnector, Body>, C>, C> where
+    C: Clone + Send + Sync + 'static
 {
     /// Create a client with a TLS connection to the server.
     #[cfg(any(target_os = "macos", target_os = "windows", target_os = "ios"))]
@@ -155,12 +167,13 @@ impl Client<hyper::client::Client<HttpsConnector, Body>>
     }
 }
 
-impl<S> Client<S> where
+impl<S, C> Client<S, C> where
     S: Service<
-           Request<Body>,
+           (Request<Body>, C),
            Response=Response<Body>,
            Error=hyper::Error> + Clone + Send + Sync,
     S::Future: Send + 'static,
+    C: Clone + Send + Sync + 'static
 {
     /// Constructor for creating a `Client` by passing in a pre-made `swagger::Service`
     ///
@@ -170,19 +183,20 @@ impl<S> Client<S> where
     ) -> Self {
         Client {
             client_service,
+            marker: PhantomData,
         }
     }
 }
 
 #[async_trait]
-impl<C, S> CallbackApi<C> for Client<S> where
-    C: Has<XSpanIdString> {{#hasAuthMethods}}+ Has<Option<AuthData>>{{/hasAuthMethods}} + Send + Sync,
+impl<S, C> CallbackApi<C> for Client<S, C> where
     S: Service<
-           Request<Body>,
+           (Request<Body>, C),
            Response=Response<Body>,
            Error=hyper::Error> + Clone + Send + Sync,
     S::Future: Send + 'static,
     S::Error: Into<crate::ServiceError> + fmt::Display,
+    C: Has<XSpanIdString> {{#hasAuthMethods}}+ Has<Option<AuthData>>{{/hasAuthMethods}} + Clone + Send + Sync,
 {
     fn poll_ready(&self, cx: &mut Context) -> Poll<Result<(), crate::ServiceError>> {
         match self.client_service.clone().poll_ready(cx) {

--- a/samples/server/petstore/rust-server/output/multipart-v3/.openapi-generator/FILES
+++ b/samples/server/petstore/rust-server/output/multipart-v3/.openapi-generator/FILES
@@ -1,5 +1,6 @@
 .cargo/config
 .gitignore
+.openapi-generator-ignore
 Cargo.toml
 README.md
 api/openapi.yaml

--- a/samples/server/petstore/rust-server/output/multipart-v3/src/client/mod.rs
+++ b/samples/server/petstore/rust-server/output/multipart-v3/src/client/mod.rs
@@ -9,13 +9,14 @@ use std::io::{ErrorKind, Read};
 use std::error::Error;
 use std::future::Future;
 use std::fmt;
+use std::marker::PhantomData;
 use std::path::Path;
 use std::sync::{Arc, Mutex};
 use std::str;
 use std::str::FromStr;
 use std::string::ToString;
 use std::task::{Context, Poll};
-use swagger::{ApiError, AuthData, BodyExt, Connector, Has, XSpanIdString};
+use swagger::{ApiError, AuthData, BodyExt, Connector, DropContextService, Has, XSpanIdString};
 use url::form_urlencoded;
 
 use mime::Mime;
@@ -65,49 +66,57 @@ fn into_base_path(input: impl TryInto<Uri, Error=hyper::http::uri::InvalidUri>, 
 }
 
 /// A client that implements the API by making HTTP calls out to a server.
-pub struct Client<S> where
+pub struct Client<S, C> where
     S: Service<
-           Request<Body>,
+           (Request<Body>, C),
            Response=Response<Body>> + Clone + Sync + Send + 'static,
     S::Future: Send + 'static,
     S::Error: Into<crate::ServiceError> + fmt::Display,
+    C: Clone + Send + Sync + 'static
 {
     /// Inner service
     client_service: S,
 
     /// Base path of the API
     base_path: String,
+
+    /// Marker
+    marker: PhantomData<fn(C)>,
 }
 
-impl<S> fmt::Debug for Client<S> where
+impl<S, C> fmt::Debug for Client<S, C> where
     S: Service<
-           Request<Body>,
+           (Request<Body>, C),
            Response=Response<Body>> + Clone + Sync + Send + 'static,
     S::Future: Send + 'static,
     S::Error: Into<crate::ServiceError> + fmt::Display,
+    C: Clone + Send + Sync + 'static
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "Client {{ base_path: {} }}", self.base_path)
     }
 }
 
-impl<S> Clone for Client<S> where
+impl<S, C> Clone for Client<S, C> where
     S: Service<
-           Request<Body>,
+           (Request<Body>, C),
            Response=Response<Body>> + Clone + Sync + Send + 'static,
     S::Future: Send + 'static,
     S::Error: Into<crate::ServiceError> + fmt::Display,
+    C: Clone + Send + Sync + 'static
 {
     fn clone(&self) -> Self {
         Self {
             client_service: self.client_service.clone(),
             base_path: self.base_path.clone(),
+            marker: PhantomData,
         }
     }
 }
 
-impl<C> Client<hyper::client::Client<C, Body>> where
-      C: hyper::client::connect::Connect + Clone + Send + Sync + 'static
+impl<Connector, C> Client<DropContextService<hyper::client::Client<Connector, Body>, C>, C> where
+    Connector: hyper::client::connect::Connect + Clone + Send + Sync + 'static,
+    C: Clone + Send + Sync + 'static,
 {
     /// Create a client with a custom implementation of hyper::client::Connect.
     ///
@@ -126,14 +135,16 @@ impl<C> Client<hyper::client::Client<C, Body>> where
     pub fn try_new_with_connector(
         base_path: &str,
         protocol: Option<&'static str>,
-        connector: C,
+        connector: Connector,
     ) -> Result<Self, ClientInitError>
     {
         let client_service = hyper::client::Client::builder().build(connector);
+        let client_service = DropContextService::new(client_service);
 
         Ok(Self {
             client_service,
             base_path: into_base_path(base_path, protocol)?,
+            marker: PhantomData,
         })
     }
 }
@@ -164,7 +175,9 @@ impl Service<Request<Body>> for HyperClient {
     }
 }
 
-impl Client<HyperClient> {
+impl<C> Client<DropContextService<HyperClient, C>, C> where
+    C: Clone + Send + Sync + 'static,
+{
     /// Create an HTTP client.
     ///
     /// # Arguments
@@ -194,14 +207,18 @@ impl Client<HyperClient> {
             }
         };
 
+        let client_service = DropContextService::new(client_service);
+
         Ok(Self {
             client_service,
             base_path: into_base_path(base_path, None)?,
+            marker: PhantomData,
         })
     }
 }
 
-impl Client<hyper::client::Client<hyper::client::HttpConnector, Body>>
+impl<C> Client<DropContextService<hyper::client::Client<hyper::client::HttpConnector, Body>, C>, C> where
+    C: Clone + Send + Sync + 'static
 {
     /// Create an HTTP client.
     ///
@@ -222,7 +239,8 @@ type HttpsConnector = hyper_tls::HttpsConnector<hyper::client::HttpConnector>;
 #[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "ios")))]
 type HttpsConnector = hyper_openssl::HttpsConnector<hyper::client::HttpConnector>;
 
-impl Client<hyper::client::Client<HttpsConnector, Body>>
+impl<C> Client<DropContextService<hyper::client::Client<HttpsConnector, Body>, C>, C> where
+    C: Clone + Send + Sync + 'static
 {
     /// Create a client with a TLS connection to the server
     ///
@@ -287,12 +305,13 @@ impl Client<hyper::client::Client<HttpsConnector, Body>>
     }
 }
 
-impl<S> Client<S> where
+impl<S, C> Client<S, C> where
     S: Service<
-           Request<Body>,
+           (Request<Body>, C),
            Response=Response<Body>> + Clone + Sync + Send + 'static,
     S::Future: Send + 'static,
     S::Error: Into<crate::ServiceError> + fmt::Display,
+    C: Clone + Send + Sync + 'static
 {
     /// Constructor for creating a `Client` by passing in a pre-made `hyper::service::Service` /
     /// `tower::Service`
@@ -306,6 +325,7 @@ impl<S> Client<S> where
         Ok(Self {
             client_service,
             base_path: into_base_path(base_path, None)?,
+            marker: PhantomData,
         })
     }
 }
@@ -351,13 +371,13 @@ impl Error for ClientInitError {
 }
 
 #[async_trait]
-impl<C, S> Api<C> for Client<S> where
-    C: Has<XSpanIdString>  + Clone + Send + Sync + 'static,
+impl<S, C> Api<C> for Client<S, C> where
     S: Service<
-       Request<Body>,
+       (Request<Body>, C),
        Response=Response<Body>> + Clone + Sync + Send + 'static,
     S::Future: Send + 'static,
     S::Error: Into<crate::ServiceError> + fmt::Display,
+    C: Has<XSpanIdString>  + Clone + Send + Sync + 'static,
 {
     fn poll_ready(&self, cx: &mut Context) -> Poll<Result<(), crate::ServiceError>> {
         match self.client_service.clone().poll_ready(cx) {
@@ -480,7 +500,7 @@ impl<C, S> Api<C> for Client<S> where
             Err(e) => return Err(ApiError(format!("Unable to create X-Span ID header value: {}", e)))
         });
 
-        let mut response = client_service.call(request)
+        let mut response = client_service.call((request, context.clone()))
             .map_err(|e| ApiError(format!("No response received: {}", e))).await?;
 
         match response.status().as_u16() {
@@ -621,6 +641,7 @@ impl<C, S> Api<C> for Client<S> where
         };
 
         *request.body_mut() = Body::from(body_string);
+
         request.headers_mut().insert(CONTENT_TYPE, match HeaderValue::from_str(&multipart_header) {
             Ok(h) => h,
             Err(e) => return Err(ApiError(format!("Unable to create header: {} - {}", multipart_header, e)))
@@ -632,7 +653,7 @@ impl<C, S> Api<C> for Client<S> where
             Err(e) => return Err(ApiError(format!("Unable to create X-Span ID header value: {}", e)))
         });
 
-        let mut response = client_service.call(request)
+        let mut response = client_service.call((request, context.clone()))
             .map_err(|e| ApiError(format!("No response received: {}", e))).await?;
 
         match response.status().as_u16() {
@@ -759,7 +780,7 @@ impl<C, S> Api<C> for Client<S> where
             Err(e) => return Err(ApiError(format!("Unable to create X-Span ID header value: {}", e)))
         });
 
-        let mut response = client_service.call(request)
+        let mut response = client_service.call((request, context.clone()))
             .map_err(|e| ApiError(format!("No response received: {}", e))).await?;
 
         match response.status().as_u16() {

--- a/samples/server/petstore/rust-server/output/no-example-v3/.openapi-generator/FILES
+++ b/samples/server/petstore/rust-server/output/no-example-v3/.openapi-generator/FILES
@@ -1,5 +1,6 @@
 .cargo/config
 .gitignore
+.openapi-generator-ignore
 Cargo.toml
 README.md
 api/openapi.yaml

--- a/samples/server/petstore/rust-server/output/openapi-v3/.openapi-generator/FILES
+++ b/samples/server/petstore/rust-server/output/openapi-v3/.openapi-generator/FILES
@@ -1,5 +1,6 @@
 .cargo/config
 .gitignore
+.openapi-generator-ignore
 Cargo.toml
 README.md
 api/openapi.yaml

--- a/samples/server/petstore/rust-server/output/openapi-v3/src/client/mod.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/src/client/mod.rs
@@ -9,13 +9,14 @@ use std::io::{ErrorKind, Read};
 use std::error::Error;
 use std::future::Future;
 use std::fmt;
+use std::marker::PhantomData;
 use std::path::Path;
 use std::sync::{Arc, Mutex};
 use std::str;
 use std::str::FromStr;
 use std::string::ToString;
 use std::task::{Context, Poll};
-use swagger::{ApiError, AuthData, BodyExt, Connector, Has, XSpanIdString};
+use swagger::{ApiError, AuthData, BodyExt, Connector, DropContextService, Has, XSpanIdString};
 use url::form_urlencoded;
 
 
@@ -82,49 +83,57 @@ fn into_base_path(input: impl TryInto<Uri, Error=hyper::http::uri::InvalidUri>, 
 }
 
 /// A client that implements the API by making HTTP calls out to a server.
-pub struct Client<S> where
+pub struct Client<S, C> where
     S: Service<
-           Request<Body>,
+           (Request<Body>, C),
            Response=Response<Body>> + Clone + Sync + Send + 'static,
     S::Future: Send + 'static,
     S::Error: Into<crate::ServiceError> + fmt::Display,
+    C: Clone + Send + Sync + 'static
 {
     /// Inner service
     client_service: S,
 
     /// Base path of the API
     base_path: String,
+
+    /// Marker
+    marker: PhantomData<fn(C)>,
 }
 
-impl<S> fmt::Debug for Client<S> where
+impl<S, C> fmt::Debug for Client<S, C> where
     S: Service<
-           Request<Body>,
+           (Request<Body>, C),
            Response=Response<Body>> + Clone + Sync + Send + 'static,
     S::Future: Send + 'static,
     S::Error: Into<crate::ServiceError> + fmt::Display,
+    C: Clone + Send + Sync + 'static
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "Client {{ base_path: {} }}", self.base_path)
     }
 }
 
-impl<S> Clone for Client<S> where
+impl<S, C> Clone for Client<S, C> where
     S: Service<
-           Request<Body>,
+           (Request<Body>, C),
            Response=Response<Body>> + Clone + Sync + Send + 'static,
     S::Future: Send + 'static,
     S::Error: Into<crate::ServiceError> + fmt::Display,
+    C: Clone + Send + Sync + 'static
 {
     fn clone(&self) -> Self {
         Self {
             client_service: self.client_service.clone(),
             base_path: self.base_path.clone(),
+            marker: PhantomData,
         }
     }
 }
 
-impl<C> Client<hyper::client::Client<C, Body>> where
-      C: hyper::client::connect::Connect + Clone + Send + Sync + 'static
+impl<Connector, C> Client<DropContextService<hyper::client::Client<Connector, Body>, C>, C> where
+    Connector: hyper::client::connect::Connect + Clone + Send + Sync + 'static,
+    C: Clone + Send + Sync + 'static,
 {
     /// Create a client with a custom implementation of hyper::client::Connect.
     ///
@@ -143,14 +152,16 @@ impl<C> Client<hyper::client::Client<C, Body>> where
     pub fn try_new_with_connector(
         base_path: &str,
         protocol: Option<&'static str>,
-        connector: C,
+        connector: Connector,
     ) -> Result<Self, ClientInitError>
     {
         let client_service = hyper::client::Client::builder().build(connector);
+        let client_service = DropContextService::new(client_service);
 
         Ok(Self {
             client_service,
             base_path: into_base_path(base_path, protocol)?,
+            marker: PhantomData,
         })
     }
 }
@@ -181,7 +192,9 @@ impl Service<Request<Body>> for HyperClient {
     }
 }
 
-impl Client<HyperClient> {
+impl<C> Client<DropContextService<HyperClient, C>, C> where
+    C: Clone + Send + Sync + 'static,
+{
     /// Create an HTTP client.
     ///
     /// # Arguments
@@ -211,14 +224,18 @@ impl Client<HyperClient> {
             }
         };
 
+        let client_service = DropContextService::new(client_service);
+
         Ok(Self {
             client_service,
             base_path: into_base_path(base_path, None)?,
+            marker: PhantomData,
         })
     }
 }
 
-impl Client<hyper::client::Client<hyper::client::HttpConnector, Body>>
+impl<C> Client<DropContextService<hyper::client::Client<hyper::client::HttpConnector, Body>, C>, C> where
+    C: Clone + Send + Sync + 'static
 {
     /// Create an HTTP client.
     ///
@@ -239,7 +256,8 @@ type HttpsConnector = hyper_tls::HttpsConnector<hyper::client::HttpConnector>;
 #[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "ios")))]
 type HttpsConnector = hyper_openssl::HttpsConnector<hyper::client::HttpConnector>;
 
-impl Client<hyper::client::Client<HttpsConnector, Body>>
+impl<C> Client<DropContextService<hyper::client::Client<HttpsConnector, Body>, C>, C> where
+    C: Clone + Send + Sync + 'static
 {
     /// Create a client with a TLS connection to the server
     ///
@@ -304,12 +322,13 @@ impl Client<hyper::client::Client<HttpsConnector, Body>>
     }
 }
 
-impl<S> Client<S> where
+impl<S, C> Client<S, C> where
     S: Service<
-           Request<Body>,
+           (Request<Body>, C),
            Response=Response<Body>> + Clone + Sync + Send + 'static,
     S::Future: Send + 'static,
     S::Error: Into<crate::ServiceError> + fmt::Display,
+    C: Clone + Send + Sync + 'static
 {
     /// Constructor for creating a `Client` by passing in a pre-made `hyper::service::Service` /
     /// `tower::Service`
@@ -323,6 +342,7 @@ impl<S> Client<S> where
         Ok(Self {
             client_service,
             base_path: into_base_path(base_path, None)?,
+            marker: PhantomData,
         })
     }
 }
@@ -368,13 +388,13 @@ impl Error for ClientInitError {
 }
 
 #[async_trait]
-impl<C, S> Api<C> for Client<S> where
-    C: Has<XSpanIdString> + Has<Option<AuthData>> + Clone + Send + Sync + 'static,
+impl<S, C> Api<C> for Client<S, C> where
     S: Service<
-       Request<Body>,
+       (Request<Body>, C),
        Response=Response<Body>> + Clone + Sync + Send + 'static,
     S::Future: Send + 'static,
     S::Error: Into<crate::ServiceError> + fmt::Display,
+    C: Has<XSpanIdString> + Has<Option<AuthData>> + Clone + Send + Sync + 'static,
 {
     fn poll_ready(&self, cx: &mut Context) -> Poll<Result<(), crate::ServiceError>> {
         match self.client_service.clone().poll_ready(cx) {
@@ -425,7 +445,7 @@ impl<C, S> Api<C> for Client<S> where
             Err(e) => return Err(ApiError(format!("Unable to create X-Span ID header value: {}", e)))
         });
 
-        let mut response = client_service.call(request)
+        let mut response = client_service.call((request, context.clone()))
             .map_err(|e| ApiError(format!("No response received: {}", e))).await?;
 
         match response.status().as_u16() {
@@ -498,7 +518,7 @@ impl<C, S> Api<C> for Client<S> where
             Err(e) => return Err(ApiError(format!("Unable to create X-Span ID header value: {}", e)))
         });
 
-        let mut response = client_service.call(request)
+        let mut response = client_service.call((request, context.clone()))
             .map_err(|e| ApiError(format!("No response received: {}", e))).await?;
 
         match response.status().as_u16() {
@@ -569,7 +589,7 @@ impl<C, S> Api<C> for Client<S> where
             Err(e) => return Err(ApiError(format!("Unable to create X-Span ID header value: {}", e)))
         });
 
-        let mut response = client_service.call(request)
+        let mut response = client_service.call((request, context.clone()))
             .map_err(|e| ApiError(format!("No response received: {}", e))).await?;
 
         match response.status().as_u16() {
@@ -650,7 +670,7 @@ impl<C, S> Api<C> for Client<S> where
                 },
             });
 
-        let mut response = client_service.call(request)
+        let mut response = client_service.call((request, context.clone()))
             .map_err(|e| ApiError(format!("No response received: {}", e))).await?;
 
         match response.status().as_u16() {
@@ -719,7 +739,7 @@ impl<C, S> Api<C> for Client<S> where
             Err(e) => return Err(ApiError(format!("Unable to create X-Span ID header value: {}", e)))
         });
 
-        let mut response = client_service.call(request)
+        let mut response = client_service.call((request, context.clone()))
             .map_err(|e| ApiError(format!("No response received: {}", e))).await?;
 
         match response.status().as_u16() {
@@ -794,7 +814,7 @@ impl<C, S> Api<C> for Client<S> where
             Err(e) => return Err(ApiError(format!("Unable to create X-Span ID header value: {}", e)))
         });
 
-        let mut response = client_service.call(request)
+        let mut response = client_service.call((request, context.clone()))
             .map_err(|e| ApiError(format!("No response received: {}", e))).await?;
 
         match response.status().as_u16() {
@@ -959,7 +979,7 @@ impl<C, S> Api<C> for Client<S> where
             }
         }
 
-        let mut response = client_service.call(request)
+        let mut response = client_service.call((request, context.clone()))
             .map_err(|e| ApiError(format!("No response received: {}", e))).await?;
 
         match response.status().as_u16() {
@@ -1028,7 +1048,7 @@ impl<C, S> Api<C> for Client<S> where
             Err(e) => return Err(ApiError(format!("Unable to create X-Span ID header value: {}", e)))
         });
 
-        let mut response = client_service.call(request)
+        let mut response = client_service.call((request, context.clone()))
             .map_err(|e| ApiError(format!("No response received: {}", e))).await?;
 
         match response.status().as_u16() {
@@ -1109,7 +1129,7 @@ impl<C, S> Api<C> for Client<S> where
             Err(e) => return Err(ApiError(format!("Unable to create X-Span ID header value: {}", e)))
         });
 
-        let mut response = client_service.call(request)
+        let mut response = client_service.call((request, context.clone()))
             .map_err(|e| ApiError(format!("No response received: {}", e))).await?;
 
         match response.status().as_u16() {
@@ -1201,7 +1221,7 @@ impl<C, S> Api<C> for Client<S> where
             }
         }
 
-        let mut response = client_service.call(request)
+        let mut response = client_service.call((request, context.clone()))
             .map_err(|e| ApiError(format!("No response received: {}", e))).await?;
 
         match response.status().as_u16() {
@@ -1272,7 +1292,7 @@ impl<C, S> Api<C> for Client<S> where
             Err(e) => return Err(ApiError(format!("Unable to create X-Span ID header value: {}", e)))
         });
 
-        let mut response = client_service.call(request)
+        let mut response = client_service.call((request, context.clone()))
             .map_err(|e| ApiError(format!("No response received: {}", e))).await?;
 
         match response.status().as_u16() {
@@ -1350,7 +1370,7 @@ impl<C, S> Api<C> for Client<S> where
             Err(e) => return Err(ApiError(format!("Unable to create X-Span ID header value: {}", e)))
         });
 
-        let mut response = client_service.call(request)
+        let mut response = client_service.call((request, context.clone()))
             .map_err(|e| ApiError(format!("No response received: {}", e))).await?;
 
         match response.status().as_u16() {
@@ -1419,7 +1439,7 @@ impl<C, S> Api<C> for Client<S> where
             Err(e) => return Err(ApiError(format!("Unable to create X-Span ID header value: {}", e)))
         });
 
-        let mut response = client_service.call(request)
+        let mut response = client_service.call((request, context.clone()))
             .map_err(|e| ApiError(format!("No response received: {}", e))).await?;
 
         match response.status().as_u16() {
@@ -1579,7 +1599,7 @@ impl<C, S> Api<C> for Client<S> where
             Err(e) => return Err(ApiError(format!("Unable to create X-Span ID header value: {}", e)))
         });
 
-        let mut response = client_service.call(request)
+        let mut response = client_service.call((request, context.clone()))
             .map_err(|e| ApiError(format!("No response received: {}", e))).await?;
 
         match response.status().as_u16() {
@@ -1694,7 +1714,7 @@ impl<C, S> Api<C> for Client<S> where
             Err(e) => return Err(ApiError(format!("Unable to create X-Span ID header value: {}", e)))
         });
 
-        let mut response = client_service.call(request)
+        let mut response = client_service.call((request, context.clone()))
             .map_err(|e| ApiError(format!("No response received: {}", e))).await?;
 
         match response.status().as_u16() {
@@ -1763,7 +1783,7 @@ impl<C, S> Api<C> for Client<S> where
             Err(e) => return Err(ApiError(format!("Unable to create X-Span ID header value: {}", e)))
         });
 
-        let mut response = client_service.call(request)
+        let mut response = client_service.call((request, context.clone()))
             .map_err(|e| ApiError(format!("No response received: {}", e))).await?;
 
         match response.status().as_u16() {
@@ -1851,7 +1871,7 @@ impl<C, S> Api<C> for Client<S> where
             Err(e) => return Err(ApiError(format!("Unable to create X-Span ID header value: {}", e)))
         });
 
-        let mut response = client_service.call(request)
+        let mut response = client_service.call((request, context.clone()))
             .map_err(|e| ApiError(format!("No response received: {}", e))).await?;
 
         match response.status().as_u16() {
@@ -1939,7 +1959,7 @@ impl<C, S> Api<C> for Client<S> where
             Err(e) => return Err(ApiError(format!("Unable to create X-Span ID header value: {}", e)))
         });
 
-        let mut response = client_service.call(request)
+        let mut response = client_service.call((request, context.clone()))
             .map_err(|e| ApiError(format!("No response received: {}", e))).await?;
 
         match response.status().as_u16() {
@@ -2036,7 +2056,7 @@ impl<C, S> Api<C> for Client<S> where
             Err(e) => return Err(ApiError(format!("Unable to create X-Span ID header value: {}", e)))
         });
 
-        let mut response = client_service.call(request)
+        let mut response = client_service.call((request, context.clone()))
             .map_err(|e| ApiError(format!("No response received: {}", e))).await?;
 
         match response.status().as_u16() {
@@ -2124,7 +2144,7 @@ impl<C, S> Api<C> for Client<S> where
             Err(e) => return Err(ApiError(format!("Unable to create X-Span ID header value: {}", e)))
         });
 
-        let mut response = client_service.call(request)
+        let mut response = client_service.call((request, context.clone()))
             .map_err(|e| ApiError(format!("No response received: {}", e))).await?;
 
         match response.status().as_u16() {
@@ -2214,7 +2234,7 @@ impl<C, S> Api<C> for Client<S> where
             Err(e) => return Err(ApiError(format!("Unable to create X-Span ID header value: {}", e)))
         });
 
-        let mut response = client_service.call(request)
+        let mut response = client_service.call((request, context.clone()))
             .map_err(|e| ApiError(format!("No response received: {}", e))).await?;
 
         match response.status().as_u16() {
@@ -2299,7 +2319,7 @@ impl<C, S> Api<C> for Client<S> where
             Err(e) => return Err(ApiError(format!("Unable to create X-Span ID header value: {}", e)))
         });
 
-        let mut response = client_service.call(request)
+        let mut response = client_service.call((request, context.clone()))
             .map_err(|e| ApiError(format!("No response received: {}", e))).await?;
 
         match response.status().as_u16() {
@@ -2370,7 +2390,7 @@ impl<C, S> Api<C> for Client<S> where
             Err(e) => return Err(ApiError(format!("Unable to create X-Span ID header value: {}", e)))
         });
 
-        let mut response = client_service.call(request)
+        let mut response = client_service.call((request, context.clone()))
             .map_err(|e| ApiError(format!("No response received: {}", e))).await?;
 
         match response.status().as_u16() {

--- a/samples/server/petstore/rust-server/output/openapi-v3/src/server/callbacks.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/src/server/callbacks.rs
@@ -9,13 +9,14 @@ use std::io::{ErrorKind, Read};
 use std::error::Error;
 use std::future::Future;
 use std::fmt;
+use std::marker::PhantomData;
 use std::path::Path;
 use std::sync::{Arc, Mutex};
 use std::str;
 use std::str::FromStr;
 use std::string::ToString;
 use std::task::{Context, Poll};
-use swagger::{ApiError, AuthData, BodyExt, Connector, Has, XSpanIdString};
+use swagger::{ApiError, AuthData, BodyExt, Connector, DropContextService, Has, XSpanIdString};
 use url::form_urlencoded;
 
 
@@ -39,45 +40,53 @@ use crate::CallbackCallbackWithHeaderPostResponse;
 use crate::CallbackCallbackPostResponse;
 
 /// A client that implements the API by making HTTP calls out to a server.
-pub struct Client<S> where
+pub struct Client<S, C> where
     S: Service<
-           Request<Body>,
+           (Request<Body>, C),
            Response=Response<Body>,
            Error=hyper::Error> + Clone + Send + Sync,
     S::Future: Send + 'static,
+    C: Clone + Send + Sync + 'static
 {
     /// Inner service
     client_service: S,
+
+    /// Marker
+    marker: PhantomData<fn(C)>,
 }
 
-impl<S> fmt::Debug for Client<S> where
+impl<S, C> fmt::Debug for Client<S, C> where
     S: Service<
-           Request<Body>,
+           (Request<Body>, C),
            Response=Response<Body>,
            Error=hyper::Error> + Clone + Send + Sync,
     S::Future: Send + 'static,
+    C: Clone + Send + Sync + 'static
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "Client")
     }
 }
 
-impl<S> Clone for Client<S> where
+impl<S, C> Clone for Client<S, C> where
     S: Service<
-           Request<Body>,
+           (Request<Body>, C),
            Response=Response<Body>,
            Error=hyper::Error> + Clone + Send + Sync,
     S::Future: Send + 'static,
+    C: Clone + Send + Sync + 'static
 {
     fn clone(&self) -> Self {
         Self {
             client_service: self.client_service.clone(),
+            marker: PhantomData,
         }
     }
 }
 
-impl<C> Client<hyper::client::Client<C, Body>> where
-      C: hyper::client::connect::Connect + Clone + Send + Sync + 'static
+impl<Connector, C> Client<DropContextService<hyper::client::Client<Connector, Body>, C>, C> where
+    Connector: hyper::client::connect::Connect + Clone + Send + Sync + 'static,
+    C: Clone + Send + Sync + 'static
 {
     /// Create a client with a custom implementation of hyper::client::Connect.
     ///
@@ -91,17 +100,20 @@ impl<C> Client<hyper::client::Client<C, Body>> where
     /// # Arguments
     ///
     /// * `connector` - Implementation of `hyper::client::Connect` to use for the client
-    pub fn new_with_connector(connector: C) -> Self
+    pub fn new_with_connector(connector: Connector) -> Self
     {
         let client_service = hyper::client::Client::builder().build(connector);
+        let client_service = DropContextService::new(client_service);
 
         Self {
             client_service,
+            marker: PhantomData,
         }
     }
 }
 
-impl Client<hyper::client::Client<hyper::client::HttpConnector, Body>>
+impl<C> Client<DropContextService<hyper::client::Client<hyper::client::HttpConnector, Body>, C>, C> where
+    C: Clone + Send + Sync + 'static
 {
     /// Create an HTTP client.
     pub fn new_http() -> Self {
@@ -116,7 +128,8 @@ type HttpConnector = hyper_tls::HttpsConnector<hyper::client::HttpConnector>;
 #[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "ios")))]
 type HttpsConnector = hyper_openssl::HttpsConnector<hyper::client::HttpConnector>;
 
-impl Client<hyper::client::Client<HttpsConnector, Body>>
+impl<C> Client<DropContextService<hyper::client::Client<HttpsConnector, Body>, C>, C> where
+    C: Clone + Send + Sync + 'static
 {
     /// Create a client with a TLS connection to the server.
     #[cfg(any(target_os = "macos", target_os = "windows", target_os = "ios"))]
@@ -177,12 +190,13 @@ impl Client<hyper::client::Client<HttpsConnector, Body>>
     }
 }
 
-impl<S> Client<S> where
+impl<S, C> Client<S, C> where
     S: Service<
-           Request<Body>,
+           (Request<Body>, C),
            Response=Response<Body>,
            Error=hyper::Error> + Clone + Send + Sync,
     S::Future: Send + 'static,
+    C: Clone + Send + Sync + 'static
 {
     /// Constructor for creating a `Client` by passing in a pre-made `swagger::Service`
     ///
@@ -192,19 +206,20 @@ impl<S> Client<S> where
     ) -> Self {
         Client {
             client_service,
+            marker: PhantomData,
         }
     }
 }
 
 #[async_trait]
-impl<C, S> CallbackApi<C> for Client<S> where
-    C: Has<XSpanIdString> + Has<Option<AuthData>> + Send + Sync,
+impl<S, C> CallbackApi<C> for Client<S, C> where
     S: Service<
-           Request<Body>,
+           (Request<Body>, C),
            Response=Response<Body>,
            Error=hyper::Error> + Clone + Send + Sync,
     S::Future: Send + 'static,
     S::Error: Into<crate::ServiceError> + fmt::Display,
+    C: Has<XSpanIdString> + Has<Option<AuthData>> + Clone + Send + Sync,
 {
     fn poll_ready(&self, cx: &mut Context) -> Poll<Result<(), crate::ServiceError>> {
         match self.client_service.clone().poll_ready(cx) {
@@ -271,7 +286,7 @@ impl<C, S> CallbackApi<C> for Client<S> where
             None => {}
         }
 
-        let mut response = client_service.call(request)
+        let mut response = client_service.call((request, context.clone()))
             .map_err(|e| ApiError(format!("No response received: {}", e))).await?;
 
         match response.status().as_u16() {
@@ -341,7 +356,7 @@ impl<C, S> CallbackApi<C> for Client<S> where
             Err(e) => return Err(ApiError(format!("Unable to create X-Span ID header value: {}", e)))
         });
 
-        let mut response = client_service.call(request)
+        let mut response = client_service.call((request, context.clone()))
             .map_err(|e| ApiError(format!("No response received: {}", e))).await?;
 
         match response.status().as_u16() {

--- a/samples/server/petstore/rust-server/output/ops-v3/.openapi-generator/FILES
+++ b/samples/server/petstore/rust-server/output/ops-v3/.openapi-generator/FILES
@@ -1,5 +1,6 @@
 .cargo/config
 .gitignore
+.openapi-generator-ignore
 Cargo.toml
 README.md
 api/openapi.yaml

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/.openapi-generator/FILES
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/.openapi-generator/FILES
@@ -1,5 +1,6 @@
 .cargo/config
 .gitignore
+.openapi-generator-ignore
 Cargo.toml
 README.md
 api/openapi.yaml

--- a/samples/server/petstore/rust-server/output/rust-server-test/.openapi-generator/FILES
+++ b/samples/server/petstore/rust-server/output/rust-server-test/.openapi-generator/FILES
@@ -1,5 +1,6 @@
 .cargo/config
 .gitignore
+.openapi-generator-ignore
 Cargo.toml
 README.md
 api/openapi.yaml

--- a/samples/server/petstore/rust-server/output/rust-server-test/src/client/mod.rs
+++ b/samples/server/petstore/rust-server/output/rust-server-test/src/client/mod.rs
@@ -9,13 +9,14 @@ use std::io::{ErrorKind, Read};
 use std::error::Error;
 use std::future::Future;
 use std::fmt;
+use std::marker::PhantomData;
 use std::path::Path;
 use std::sync::{Arc, Mutex};
 use std::str;
 use std::str::FromStr;
 use std::string::ToString;
 use std::task::{Context, Poll};
-use swagger::{ApiError, AuthData, BodyExt, Connector, Has, XSpanIdString};
+use swagger::{ApiError, AuthData, BodyExt, Connector, DropContextService, Has, XSpanIdString};
 use url::form_urlencoded;
 
 
@@ -66,49 +67,57 @@ fn into_base_path(input: impl TryInto<Uri, Error=hyper::http::uri::InvalidUri>, 
 }
 
 /// A client that implements the API by making HTTP calls out to a server.
-pub struct Client<S> where
+pub struct Client<S, C> where
     S: Service<
-           Request<Body>,
+           (Request<Body>, C),
            Response=Response<Body>> + Clone + Sync + Send + 'static,
     S::Future: Send + 'static,
     S::Error: Into<crate::ServiceError> + fmt::Display,
+    C: Clone + Send + Sync + 'static
 {
     /// Inner service
     client_service: S,
 
     /// Base path of the API
     base_path: String,
+
+    /// Marker
+    marker: PhantomData<fn(C)>,
 }
 
-impl<S> fmt::Debug for Client<S> where
+impl<S, C> fmt::Debug for Client<S, C> where
     S: Service<
-           Request<Body>,
+           (Request<Body>, C),
            Response=Response<Body>> + Clone + Sync + Send + 'static,
     S::Future: Send + 'static,
     S::Error: Into<crate::ServiceError> + fmt::Display,
+    C: Clone + Send + Sync + 'static
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "Client {{ base_path: {} }}", self.base_path)
     }
 }
 
-impl<S> Clone for Client<S> where
+impl<S, C> Clone for Client<S, C> where
     S: Service<
-           Request<Body>,
+           (Request<Body>, C),
            Response=Response<Body>> + Clone + Sync + Send + 'static,
     S::Future: Send + 'static,
     S::Error: Into<crate::ServiceError> + fmt::Display,
+    C: Clone + Send + Sync + 'static
 {
     fn clone(&self) -> Self {
         Self {
             client_service: self.client_service.clone(),
             base_path: self.base_path.clone(),
+            marker: PhantomData,
         }
     }
 }
 
-impl<C> Client<hyper::client::Client<C, Body>> where
-      C: hyper::client::connect::Connect + Clone + Send + Sync + 'static
+impl<Connector, C> Client<DropContextService<hyper::client::Client<Connector, Body>, C>, C> where
+    Connector: hyper::client::connect::Connect + Clone + Send + Sync + 'static,
+    C: Clone + Send + Sync + 'static,
 {
     /// Create a client with a custom implementation of hyper::client::Connect.
     ///
@@ -127,14 +136,16 @@ impl<C> Client<hyper::client::Client<C, Body>> where
     pub fn try_new_with_connector(
         base_path: &str,
         protocol: Option<&'static str>,
-        connector: C,
+        connector: Connector,
     ) -> Result<Self, ClientInitError>
     {
         let client_service = hyper::client::Client::builder().build(connector);
+        let client_service = DropContextService::new(client_service);
 
         Ok(Self {
             client_service,
             base_path: into_base_path(base_path, protocol)?,
+            marker: PhantomData,
         })
     }
 }
@@ -165,7 +176,9 @@ impl Service<Request<Body>> for HyperClient {
     }
 }
 
-impl Client<HyperClient> {
+impl<C> Client<DropContextService<HyperClient, C>, C> where
+    C: Clone + Send + Sync + 'static,
+{
     /// Create an HTTP client.
     ///
     /// # Arguments
@@ -195,14 +208,18 @@ impl Client<HyperClient> {
             }
         };
 
+        let client_service = DropContextService::new(client_service);
+
         Ok(Self {
             client_service,
             base_path: into_base_path(base_path, None)?,
+            marker: PhantomData,
         })
     }
 }
 
-impl Client<hyper::client::Client<hyper::client::HttpConnector, Body>>
+impl<C> Client<DropContextService<hyper::client::Client<hyper::client::HttpConnector, Body>, C>, C> where
+    C: Clone + Send + Sync + 'static
 {
     /// Create an HTTP client.
     ///
@@ -223,7 +240,8 @@ type HttpsConnector = hyper_tls::HttpsConnector<hyper::client::HttpConnector>;
 #[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "ios")))]
 type HttpsConnector = hyper_openssl::HttpsConnector<hyper::client::HttpConnector>;
 
-impl Client<hyper::client::Client<HttpsConnector, Body>>
+impl<C> Client<DropContextService<hyper::client::Client<HttpsConnector, Body>, C>, C> where
+    C: Clone + Send + Sync + 'static
 {
     /// Create a client with a TLS connection to the server
     ///
@@ -288,12 +306,13 @@ impl Client<hyper::client::Client<HttpsConnector, Body>>
     }
 }
 
-impl<S> Client<S> where
+impl<S, C> Client<S, C> where
     S: Service<
-           Request<Body>,
+           (Request<Body>, C),
            Response=Response<Body>> + Clone + Sync + Send + 'static,
     S::Future: Send + 'static,
     S::Error: Into<crate::ServiceError> + fmt::Display,
+    C: Clone + Send + Sync + 'static
 {
     /// Constructor for creating a `Client` by passing in a pre-made `hyper::service::Service` /
     /// `tower::Service`
@@ -307,6 +326,7 @@ impl<S> Client<S> where
         Ok(Self {
             client_service,
             base_path: into_base_path(base_path, None)?,
+            marker: PhantomData,
         })
     }
 }
@@ -352,13 +372,13 @@ impl Error for ClientInitError {
 }
 
 #[async_trait]
-impl<C, S> Api<C> for Client<S> where
-    C: Has<XSpanIdString>  + Clone + Send + Sync + 'static,
+impl<S, C> Api<C> for Client<S, C> where
     S: Service<
-       Request<Body>,
+       (Request<Body>, C),
        Response=Response<Body>> + Clone + Sync + Send + 'static,
     S::Future: Send + 'static,
     S::Error: Into<crate::ServiceError> + fmt::Display,
+    C: Has<XSpanIdString>  + Clone + Send + Sync + 'static,
 {
     fn poll_ready(&self, cx: &mut Context) -> Poll<Result<(), crate::ServiceError>> {
         match self.client_service.clone().poll_ready(cx) {
@@ -407,7 +427,7 @@ impl<C, S> Api<C> for Client<S> where
             Err(e) => return Err(ApiError(format!("Unable to create X-Span ID header value: {}", e)))
         });
 
-        let mut response = client_service.call(request)
+        let mut response = client_service.call((request, context.clone()))
             .map_err(|e| ApiError(format!("No response received: {}", e))).await?;
 
         match response.status().as_u16() {
@@ -482,7 +502,7 @@ impl<C, S> Api<C> for Client<S> where
             Err(e) => return Err(ApiError(format!("Unable to create X-Span ID header value: {}", e)))
         });
 
-        let mut response = client_service.call(request)
+        let mut response = client_service.call((request, context.clone()))
             .map_err(|e| ApiError(format!("No response received: {}", e))).await?;
 
         match response.status().as_u16() {
@@ -560,7 +580,7 @@ impl<C, S> Api<C> for Client<S> where
             Err(e) => return Err(ApiError(format!("Unable to create X-Span ID header value: {}", e)))
         });
 
-        let mut response = client_service.call(request)
+        let mut response = client_service.call((request, context.clone()))
             .map_err(|e| ApiError(format!("No response received: {}", e))).await?;
 
         match response.status().as_u16() {
@@ -629,7 +649,7 @@ impl<C, S> Api<C> for Client<S> where
             Err(e) => return Err(ApiError(format!("Unable to create X-Span ID header value: {}", e)))
         });
 
-        let mut response = client_service.call(request)
+        let mut response = client_service.call((request, context.clone()))
             .map_err(|e| ApiError(format!("No response received: {}", e))).await?;
 
         match response.status().as_u16() {
@@ -704,7 +724,7 @@ impl<C, S> Api<C> for Client<S> where
             Err(e) => return Err(ApiError(format!("Unable to create X-Span ID header value: {}", e)))
         });
 
-        let mut response = client_service.call(request)
+        let mut response = client_service.call((request, context.clone()))
             .map_err(|e| ApiError(format!("No response received: {}", e))).await?;
 
         match response.status().as_u16() {
@@ -788,7 +808,7 @@ impl<C, S> Api<C> for Client<S> where
             Err(e) => return Err(ApiError(format!("Unable to create X-Span ID header value: {}", e)))
         });
 
-        let mut response = client_service.call(request)
+        let mut response = client_service.call((request, context.clone()))
             .map_err(|e| ApiError(format!("No response received: {}", e))).await?;
 
         match response.status().as_u16() {
@@ -872,7 +892,7 @@ impl<C, S> Api<C> for Client<S> where
             Err(e) => return Err(ApiError(format!("Unable to create X-Span ID header value: {}", e)))
         });
 
-        let mut response = client_service.call(request)
+        let mut response = client_service.call((request, context.clone()))
             .map_err(|e| ApiError(format!("No response received: {}", e))).await?;
 
         match response.status().as_u16() {
@@ -941,7 +961,7 @@ impl<C, S> Api<C> for Client<S> where
             Err(e) => return Err(ApiError(format!("Unable to create X-Span ID header value: {}", e)))
         });
 
-        let mut response = client_service.call(request)
+        let mut response = client_service.call((request, context.clone()))
             .map_err(|e| ApiError(format!("No response received: {}", e))).await?;
 
         match response.status().as_u16() {
@@ -1027,7 +1047,7 @@ impl<C, S> Api<C> for Client<S> where
             Err(e) => return Err(ApiError(format!("Unable to create X-Span ID header value: {}", e)))
         });
 
-        let mut response = client_service.call(request)
+        let mut response = client_service.call((request, context.clone()))
             .map_err(|e| ApiError(format!("No response received: {}", e))).await?;
 
         match response.status().as_u16() {


### PR DESCRIPTION
When creating a client with middleware, pass the context.

This allows users to pass contextual data about the requests through to the
client middleware.

Note, this is breaking, because:

a) middleware now needs to pass in a `DropContextService` wrapper when calling `Client::try_new_with_client_service()` if it's not expecting to use the context.

b) the type of a client has changed (as the Service is now wrapped in a `DropContextService`).

## Rust Server Technical Committee

- @frol
- @farcaller
- @bjgill
- @paladinzh

### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [X] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [X] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.