### PR TITLE
[Core, Rust Server] Support optional headers

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -4518,6 +4518,11 @@ public class DefaultCodegen implements CodegenConfig {
                 CodegenProperty cp = fromProperty(headerEntry.getKey(), schema);
                 cp.setDescription(escapeText(description));
                 cp.setUnescapedDescription(description);
+                if (header.getRequired() != null) {
+                    cp.setRequired(header.getRequired());
+                } else {
+                    cp.setRequired(false);
+                }
                 properties.add(cp);
             }
         }

--- a/modules/openapi-generator/src/main/resources/rust-server/client-operation.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/client-operation.mustache
@@ -373,18 +373,29 @@
             {{{code}}} => {
 {{#headers}}
                 let response_{{{name}}} = match response.headers().get(HeaderName::from_static("{{{nameInLowerCase}}}")) {
-                    Some(response_{{{name}}}) => response_{{{name}}}.clone(),
-                    None => {
-                        return Err(ApiError(String::from("Required response header {{{baseName}}} for response {{{code}}} was not found.")));
-                    }
+                    Some(response_{{{name}}}) => {
+                        let response_{{{name}}} = response_{{{name}}}.clone();
+                        let response_{{{name}}} = match TryInto::<header::IntoHeaderValue<{{{dataType}}}>>::try_into(response_{{{name}}}) {
+                            Ok(value) => value,
+                            Err(e) => {
+                                return Err(ApiError(format!("Invalid response header {{baseName}} for response {{code}} - {}", e)));
+                            },
+                        };
+                        let response_{{{name}}} = response_{{{name}}}.0;
+  {{#required}}
+                        response_{{{name}}}
+  {{/required}}
+  {{^required}}
+                        Some(response_{{{name}}})
+  {{/required}}
+                        },
+  {{#required}}
+                    None => return Err(ApiError(String::from("Required response header {{{baseName}}} for response {{{code}}} was not found."))),
+  {{/required}}
+  {{^required}}
+                    None => None,
+  {{/required}}
                 };
-                let response_{{{name}}} = match TryInto::<header::IntoHeaderValue<{{{dataType}}}>>::try_into(response_{{{name}}}) {
-                    Ok(value) => value,
-                    Err(e) => {
-                        return Err(ApiError(format!("Invalid response header {{baseName}} for response {{code}} - {}", e)));
-                    },
-                };
-                let response_{{{name}}} = response_{{{name}}}.0;
 
 {{/headers}}
                 let body = response.into_body();

--- a/modules/openapi-generator/src/main/resources/rust-server/response.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/response.mustache
@@ -38,7 +38,17 @@ pub enum {{{operationId}}}Response {
       {{/hasHeaders}}
     {{/dataType}}
     {{#headers}}
-        {{{name}}}: {{{datatype}}}{{^-last}},{{/-last}}
+        {{{name}}}:
+      {{^required}}
+        Option<
+      {{/required}}
+        {{{datatype}}}
+      {{^required}}
+        >
+      {{/required}}
+        {{^-last}}
+        ,
+        {{/-last}}
       {{#-last}}
     }
       {{/-last}}

--- a/modules/openapi-generator/src/main/resources/rust-server/server-operation.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/server-operation.mustache
@@ -496,6 +496,9 @@
 {{/dataType}}
                                                 => {
 {{#headers}}
+  {{^required}}
+                                                    if let Some({{{name}}}) = {{{name}}} {
+  {{/required}}
                                                     let {{{name}}} = match header::IntoHeaderValue({{{name}}}).try_into() {
                                                         Ok(val) => val,
                                                         Err(e) => {
@@ -506,14 +509,15 @@
                                                         }
                                                     };
 
-{{/headers}}
-                                                    *response.status_mut() = StatusCode::from_u16({{{code}}}).expect("Unable to turn {{{code}}} into a StatusCode");
-{{#headers}}
                                                     response.headers_mut().insert(
                                                         HeaderName::from_static("{{{nameInLowerCase}}}"),
                                                         {{name}}
                                                     );
+  {{^required}}
+                                                    }
+  {{/required}}
 {{/headers}}
+                                                    *response.status_mut() = StatusCode::from_u16({{{code}}}).expect("Unable to turn {{{code}}} into a StatusCode");
 {{#produces}}
 {{#-first}}
 {{#dataType}}

--- a/modules/openapi-generator/src/test/resources/3_0/rust-server/openapi-v3.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/rust-server/openapi-v3.yaml
@@ -227,6 +227,7 @@ paths:
             Success-Info:
               schema:
                 type: String
+              required: true
             Bool-Header:
               schema:
                 type: bool

--- a/samples/server/petstore/rust-server/output/multipart-v3/.openapi-generator/FILES
+++ b/samples/server/petstore/rust-server/output/multipart-v3/.openapi-generator/FILES
@@ -1,5 +1,6 @@
 .cargo/config
 .gitignore
+.openapi-generator-ignore
 Cargo.toml
 README.md
 api/openapi.yaml

--- a/samples/server/petstore/rust-server/output/no-example-v3/.openapi-generator/FILES
+++ b/samples/server/petstore/rust-server/output/no-example-v3/.openapi-generator/FILES
@@ -1,5 +1,6 @@
 .cargo/config
 .gitignore
+.openapi-generator-ignore
 Cargo.toml
 README.md
 api/openapi.yaml

--- a/samples/server/petstore/rust-server/output/openapi-v3/.openapi-generator/FILES
+++ b/samples/server/petstore/rust-server/output/openapi-v3/.openapi-generator/FILES
@@ -1,5 +1,6 @@
 .cargo/config
 .gitignore
+.openapi-generator-ignore
 Cargo.toml
 README.md
 api/openapi.yaml

--- a/samples/server/petstore/rust-server/output/openapi-v3/api/openapi.yaml
+++ b/samples/server/petstore/rust-server/output/openapi-v3/api/openapi.yaml
@@ -211,6 +211,7 @@ paths:
           headers:
             Success-Info:
               explode: false
+              required: true
               schema:
                 type: String
               style: simple

--- a/samples/server/petstore/rust-server/output/openapi-v3/src/client/mod.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/src/client/mod.rs
@@ -1425,46 +1425,49 @@ impl<C, S> Api<C> for Client<S> where
         match response.status().as_u16() {
             200 => {
                 let response_success_info = match response.headers().get(HeaderName::from_static("success-info")) {
-                    Some(response_success_info) => response_success_info.clone(),
-                    None => {
-                        return Err(ApiError(String::from("Required response header Success-Info for response 200 was not found.")));
-                    }
+                    Some(response_success_info) => {
+                        let response_success_info = response_success_info.clone();
+                        let response_success_info = match TryInto::<header::IntoHeaderValue<String>>::try_into(response_success_info) {
+                            Ok(value) => value,
+                            Err(e) => {
+                                return Err(ApiError(format!("Invalid response header Success-Info for response 200 - {}", e)));
+                            },
+                        };
+                        let response_success_info = response_success_info.0;
+                        response_success_info
+                        },
+                    None => return Err(ApiError(String::from("Required response header Success-Info for response 200 was not found."))),
                 };
-                let response_success_info = match TryInto::<header::IntoHeaderValue<String>>::try_into(response_success_info) {
-                    Ok(value) => value,
-                    Err(e) => {
-                        return Err(ApiError(format!("Invalid response header Success-Info for response 200 - {}", e)));
-                    },
-                };
-                let response_success_info = response_success_info.0;
 
                 let response_bool_header = match response.headers().get(HeaderName::from_static("bool-header")) {
-                    Some(response_bool_header) => response_bool_header.clone(),
-                    None => {
-                        return Err(ApiError(String::from("Required response header Bool-Header for response 200 was not found.")));
-                    }
+                    Some(response_bool_header) => {
+                        let response_bool_header = response_bool_header.clone();
+                        let response_bool_header = match TryInto::<header::IntoHeaderValue<bool>>::try_into(response_bool_header) {
+                            Ok(value) => value,
+                            Err(e) => {
+                                return Err(ApiError(format!("Invalid response header Bool-Header for response 200 - {}", e)));
+                            },
+                        };
+                        let response_bool_header = response_bool_header.0;
+                        Some(response_bool_header)
+                        },
+                    None => None,
                 };
-                let response_bool_header = match TryInto::<header::IntoHeaderValue<bool>>::try_into(response_bool_header) {
-                    Ok(value) => value,
-                    Err(e) => {
-                        return Err(ApiError(format!("Invalid response header Bool-Header for response 200 - {}", e)));
-                    },
-                };
-                let response_bool_header = response_bool_header.0;
 
                 let response_object_header = match response.headers().get(HeaderName::from_static("object-header")) {
-                    Some(response_object_header) => response_object_header.clone(),
-                    None => {
-                        return Err(ApiError(String::from("Required response header Object-Header for response 200 was not found.")));
-                    }
+                    Some(response_object_header) => {
+                        let response_object_header = response_object_header.clone();
+                        let response_object_header = match TryInto::<header::IntoHeaderValue<models::ObjectHeader>>::try_into(response_object_header) {
+                            Ok(value) => value,
+                            Err(e) => {
+                                return Err(ApiError(format!("Invalid response header Object-Header for response 200 - {}", e)));
+                            },
+                        };
+                        let response_object_header = response_object_header.0;
+                        Some(response_object_header)
+                        },
+                    None => None,
                 };
-                let response_object_header = match TryInto::<header::IntoHeaderValue<models::ObjectHeader>>::try_into(response_object_header) {
-                    Ok(value) => value,
-                    Err(e) => {
-                        return Err(ApiError(format!("Invalid response header Object-Header for response 200 - {}", e)));
-                    },
-                };
-                let response_object_header = response_object_header.0;
 
                 let body = response.into_body();
                 let body = body
@@ -1484,32 +1487,34 @@ impl<C, S> Api<C> for Client<S> where
             }
             412 => {
                 let response_further_info = match response.headers().get(HeaderName::from_static("further-info")) {
-                    Some(response_further_info) => response_further_info.clone(),
-                    None => {
-                        return Err(ApiError(String::from("Required response header Further-Info for response 412 was not found.")));
-                    }
+                    Some(response_further_info) => {
+                        let response_further_info = response_further_info.clone();
+                        let response_further_info = match TryInto::<header::IntoHeaderValue<String>>::try_into(response_further_info) {
+                            Ok(value) => value,
+                            Err(e) => {
+                                return Err(ApiError(format!("Invalid response header Further-Info for response 412 - {}", e)));
+                            },
+                        };
+                        let response_further_info = response_further_info.0;
+                        Some(response_further_info)
+                        },
+                    None => None,
                 };
-                let response_further_info = match TryInto::<header::IntoHeaderValue<String>>::try_into(response_further_info) {
-                    Ok(value) => value,
-                    Err(e) => {
-                        return Err(ApiError(format!("Invalid response header Further-Info for response 412 - {}", e)));
-                    },
-                };
-                let response_further_info = response_further_info.0;
 
                 let response_failure_info = match response.headers().get(HeaderName::from_static("failure-info")) {
-                    Some(response_failure_info) => response_failure_info.clone(),
-                    None => {
-                        return Err(ApiError(String::from("Required response header Failure-Info for response 412 was not found.")));
-                    }
+                    Some(response_failure_info) => {
+                        let response_failure_info = response_failure_info.clone();
+                        let response_failure_info = match TryInto::<header::IntoHeaderValue<String>>::try_into(response_failure_info) {
+                            Ok(value) => value,
+                            Err(e) => {
+                                return Err(ApiError(format!("Invalid response header Failure-Info for response 412 - {}", e)));
+                            },
+                        };
+                        let response_failure_info = response_failure_info.0;
+                        Some(response_failure_info)
+                        },
+                    None => None,
                 };
-                let response_failure_info = match TryInto::<header::IntoHeaderValue<String>>::try_into(response_failure_info) {
-                    Ok(value) => value,
-                    Err(e) => {
-                        return Err(ApiError(format!("Invalid response header Failure-Info for response 412 - {}", e)));
-                    },
-                };
-                let response_failure_info = response_failure_info.0;
 
                 let body = response.into_body();
                 Ok(

--- a/samples/server/petstore/rust-server/output/openapi-v3/src/lib.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/src/lib.rs
@@ -118,16 +118,32 @@ pub enum ResponsesWithHeadersGetResponse {
     Success
     {
         body: String,
-        success_info: String,
-        bool_header: bool,
-        object_header: models::ObjectHeader
+        success_info:
+        String
+        ,
+        bool_header:
+        Option<
+        bool
+        >
+        ,
+        object_header:
+        Option<
+        models::ObjectHeader
+        >
     }
     ,
     /// Precondition Failed
     PreconditionFailed
     {
-        further_info: String,
-        failure_info: String
+        further_info:
+        Option<
+        String
+        >
+        ,
+        failure_info:
+        Option<
+        String
+        >
     }
 }
 

--- a/samples/server/petstore/rust-server/output/openapi-v3/src/server/mod.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/src/server/mod.rs
@@ -877,6 +877,11 @@ impl<T, C> hyper::service::Service<(Request<Body>, C)> for Service<T, C> where
                                                         }
                                                     };
 
+                                                    response.headers_mut().insert(
+                                                        HeaderName::from_static("success-info"),
+                                                        success_info
+                                                    );
+                                                    if let Some(bool_header) = bool_header {
                                                     let bool_header = match header::IntoHeaderValue(bool_header).try_into() {
                                                         Ok(val) => val,
                                                         Err(e) => {
@@ -887,6 +892,12 @@ impl<T, C> hyper::service::Service<(Request<Body>, C)> for Service<T, C> where
                                                         }
                                                     };
 
+                                                    response.headers_mut().insert(
+                                                        HeaderName::from_static("bool-header"),
+                                                        bool_header
+                                                    );
+                                                    }
+                                                    if let Some(object_header) = object_header {
                                                     let object_header = match header::IntoHeaderValue(object_header).try_into() {
                                                         Ok(val) => val,
                                                         Err(e) => {
@@ -897,19 +908,12 @@ impl<T, C> hyper::service::Service<(Request<Body>, C)> for Service<T, C> where
                                                         }
                                                     };
 
-                                                    *response.status_mut() = StatusCode::from_u16(200).expect("Unable to turn 200 into a StatusCode");
-                                                    response.headers_mut().insert(
-                                                        HeaderName::from_static("success-info"),
-                                                        success_info
-                                                    );
-                                                    response.headers_mut().insert(
-                                                        HeaderName::from_static("bool-header"),
-                                                        bool_header
-                                                    );
                                                     response.headers_mut().insert(
                                                         HeaderName::from_static("object-header"),
                                                         object_header
                                                     );
+                                                    }
+                                                    *response.status_mut() = StatusCode::from_u16(200).expect("Unable to turn 200 into a StatusCode");
                                                     response.headers_mut().insert(
                                                         CONTENT_TYPE,
                                                         HeaderValue::from_str("application/json")
@@ -923,6 +927,7 @@ impl<T, C> hyper::service::Service<(Request<Body>, C)> for Service<T, C> where
                                                         failure_info
                                                     }
                                                 => {
+                                                    if let Some(further_info) = further_info {
                                                     let further_info = match header::IntoHeaderValue(further_info).try_into() {
                                                         Ok(val) => val,
                                                         Err(e) => {
@@ -933,6 +938,12 @@ impl<T, C> hyper::service::Service<(Request<Body>, C)> for Service<T, C> where
                                                         }
                                                     };
 
+                                                    response.headers_mut().insert(
+                                                        HeaderName::from_static("further-info"),
+                                                        further_info
+                                                    );
+                                                    }
+                                                    if let Some(failure_info) = failure_info {
                                                     let failure_info = match header::IntoHeaderValue(failure_info).try_into() {
                                                         Ok(val) => val,
                                                         Err(e) => {
@@ -943,15 +954,12 @@ impl<T, C> hyper::service::Service<(Request<Body>, C)> for Service<T, C> where
                                                         }
                                                     };
 
-                                                    *response.status_mut() = StatusCode::from_u16(412).expect("Unable to turn 412 into a StatusCode");
-                                                    response.headers_mut().insert(
-                                                        HeaderName::from_static("further-info"),
-                                                        further_info
-                                                    );
                                                     response.headers_mut().insert(
                                                         HeaderName::from_static("failure-info"),
                                                         failure_info
                                                     );
+                                                    }
+                                                    *response.status_mut() = StatusCode::from_u16(412).expect("Unable to turn 412 into a StatusCode");
                                                 },
                                             },
                                             Err(_) => {

--- a/samples/server/petstore/rust-server/output/ops-v3/.openapi-generator/FILES
+++ b/samples/server/petstore/rust-server/output/ops-v3/.openapi-generator/FILES
@@ -1,5 +1,6 @@
 .cargo/config
 .gitignore
+.openapi-generator-ignore
 Cargo.toml
 README.md
 api/openapi.yaml

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/.openapi-generator/FILES
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/.openapi-generator/FILES
@@ -1,5 +1,6 @@
 .cargo/config
 .gitignore
+.openapi-generator-ignore
 Cargo.toml
 README.md
 api/openapi.yaml

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/src/lib.rs
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/src/lib.rs
@@ -281,8 +281,15 @@ pub enum LoginUserResponse {
     SuccessfulOperation
     {
         body: String,
-        x_rate_limit: i32,
-        x_expires_after: chrono::DateTime::<chrono::Utc>
+        x_rate_limit:
+        Option<
+        i32
+        >
+        ,
+        x_expires_after:
+        Option<
+        chrono::DateTime::<chrono::Utc>
+        >
     }
     ,
     /// Invalid username/password supplied

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/src/server/mod.rs
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/src/server/mod.rs
@@ -2734,6 +2734,7 @@ impl<T, C> hyper::service::Service<(Request<Body>, C)> for Service<T, C> where
                                                         x_expires_after
                                                     }
                                                 => {
+                                                    if let Some(x_rate_limit) = x_rate_limit {
                                                     let x_rate_limit = match header::IntoHeaderValue(x_rate_limit).try_into() {
                                                         Ok(val) => val,
                                                         Err(e) => {
@@ -2744,6 +2745,12 @@ impl<T, C> hyper::service::Service<(Request<Body>, C)> for Service<T, C> where
                                                         }
                                                     };
 
+                                                    response.headers_mut().insert(
+                                                        HeaderName::from_static("x-rate-limit"),
+                                                        x_rate_limit
+                                                    );
+                                                    }
+                                                    if let Some(x_expires_after) = x_expires_after {
                                                     let x_expires_after = match header::IntoHeaderValue(x_expires_after).try_into() {
                                                         Ok(val) => val,
                                                         Err(e) => {
@@ -2754,15 +2761,12 @@ impl<T, C> hyper::service::Service<(Request<Body>, C)> for Service<T, C> where
                                                         }
                                                     };
 
-                                                    *response.status_mut() = StatusCode::from_u16(200).expect("Unable to turn 200 into a StatusCode");
-                                                    response.headers_mut().insert(
-                                                        HeaderName::from_static("x-rate-limit"),
-                                                        x_rate_limit
-                                                    );
                                                     response.headers_mut().insert(
                                                         HeaderName::from_static("x-expires-after"),
                                                         x_expires_after
                                                     );
+                                                    }
+                                                    *response.status_mut() = StatusCode::from_u16(200).expect("Unable to turn 200 into a StatusCode");
                                                     response.headers_mut().insert(
                                                         CONTENT_TYPE,
                                                         HeaderValue::from_str("application/xml")

--- a/samples/server/petstore/rust-server/output/rust-server-test/.openapi-generator/FILES
+++ b/samples/server/petstore/rust-server/output/rust-server-test/.openapi-generator/FILES
@@ -1,5 +1,6 @@
 .cargo/config
 .gitignore
+.openapi-generator-ignore
 Cargo.toml
 README.md
 api/openapi.yaml


### PR DESCRIPTION
Rust Server currently treats all headers declared in the OpenAPI file as mandatory, when actually they default to optional.

Furthermore, the core code doesn't pass through whether a header is mandatory or optional.

This makes a small change to the DefaultCodgen to pass this data through, defaulting correctly.

The Rust change is then fairly straightforward - we enhance Rust Server, using `Option` to represent non-required headers.

This is breaking, because we'll treat headers which were treated as required before as optional, and we'll provide them as an Option instead.

## Rust Server Technical Committee

- @frol
- @farcaller
- @bjgill
- @paladinzh

### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [X] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [X] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.