### PR TITLE
[Rust Server] Support arrays within additional properties

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustServerCodegen.java
@@ -188,7 +188,7 @@ public class RustServerCodegen extends DefaultCodegen implements CodegenConfig {
 
         instantiationTypes.clear();
         instantiationTypes.put("array", "Vec");
-        instantiationTypes.put("map", "Map");
+        instantiationTypes.put("map", "std::collections::HashMap");
 
         typeMapping.clear();
         typeMapping.put("number", "f64");
@@ -1235,7 +1235,7 @@ public class RustServerCodegen extends DefaultCodegen implements CodegenConfig {
         Schema additionalProperties = getAdditionalProperties(model);
 
         if (additionalProperties != null) {
-            mdl.additionalPropertiesType = getSchemaType(additionalProperties);
+            mdl.additionalPropertiesType = getTypeDeclaration(additionalProperties);
         }
 
         return mdl;
@@ -1537,16 +1537,10 @@ public class RustServerCodegen extends DefaultCodegen implements CodegenConfig {
                     // the user than the alternative.
                     LOGGER.warn("Ignoring additionalProperties (see https://github.com/OpenAPITools/openapi-generator/issues/318) alongside defined properties");
                     cm.dataType = null;
-                } else {
-                    String type;
-
-                    if (typeMapping.containsKey(cm.additionalPropertiesType)) {
-                        type = typeMapping.get(cm.additionalPropertiesType);
-                    } else {
-                        type = toModelName(cm.additionalPropertiesType);
-                    }
-
-                    cm.dataType = "std::collections::HashMap<String, " + type + ">";
+                }
+                else
+                {
+                    cm.dataType = "std::collections::HashMap<String, " + cm.additionalPropertiesType + ">";
                 }
             } else if (cm.dataType != null) {
                 // We need to hack about with single-parameter models to

--- a/modules/openapi-generator/src/test/resources/3_0/rust-server/openapi-v3.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/rust-server/openapi-v3.yaml
@@ -521,6 +521,13 @@ components:
       type: boolean
     OptionalObjectHeader:
       type: integer
+    AdditionalPropertiesWithList:
+      type: object
+      maxProperties: 1
+      additionalProperties:
+        type: list
+        items:
+          type: string
     NullableTest:
       type: object
       required:

--- a/samples/server/petstore/rust-server/output/multipart-v3/.openapi-generator/FILES
+++ b/samples/server/petstore/rust-server/output/multipart-v3/.openapi-generator/FILES
@@ -1,5 +1,6 @@
 .cargo/config
 .gitignore
+.openapi-generator-ignore
 Cargo.toml
 README.md
 api/openapi.yaml

--- a/samples/server/petstore/rust-server/output/no-example-v3/.openapi-generator/FILES
+++ b/samples/server/petstore/rust-server/output/no-example-v3/.openapi-generator/FILES
@@ -1,5 +1,6 @@
 .cargo/config
 .gitignore
+.openapi-generator-ignore
 Cargo.toml
 README.md
 api/openapi.yaml

--- a/samples/server/petstore/rust-server/output/openapi-v3/.openapi-generator/FILES
+++ b/samples/server/petstore/rust-server/output/openapi-v3/.openapi-generator/FILES
@@ -1,8 +1,10 @@
 .cargo/config
 .gitignore
+.openapi-generator-ignore
 Cargo.toml
 README.md
 api/openapi.yaml
+docs/AdditionalPropertiesWithList.md
 docs/AnotherXmlArray.md
 docs/AnotherXmlInner.md
 docs/AnotherXmlObject.md

--- a/samples/server/petstore/rust-server/output/openapi-v3/README.md
+++ b/samples/server/petstore/rust-server/output/openapi-v3/README.md
@@ -143,6 +143,7 @@ Method | HTTP request | Description
 
 ## Documentation For Models
 
+ - [AdditionalPropertiesWithList](docs/AdditionalPropertiesWithList.md)
  - [AnotherXmlArray](docs/AnotherXmlArray.md)
  - [AnotherXmlInner](docs/AnotherXmlInner.md)
  - [AnotherXmlObject](docs/AnotherXmlObject.md)

--- a/samples/server/petstore/rust-server/output/openapi-v3/api/openapi.yaml
+++ b/samples/server/petstore/rust-server/output/openapi-v3/api/openapi.yaml
@@ -540,6 +540,13 @@ components:
       type: boolean
     OptionalObjectHeader:
       type: integer
+    AdditionalPropertiesWithList:
+      additionalProperties:
+        items:
+          type: string
+        type: array
+      maxProperties: 1
+      type: object
     NullableTest:
       properties:
         nullable:

--- a/samples/server/petstore/rust-server/output/openapi-v3/docs/AdditionalPropertiesWithList.md
+++ b/samples/server/petstore/rust-server/output/openapi-v3/docs/AdditionalPropertiesWithList.md
@@ -1,0 +1,9 @@
+# AdditionalPropertiesWithList
+
+## Properties
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+
+

--- a/samples/server/petstore/rust-server/output/openapi-v3/src/models.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/src/models.rs
@@ -5,6 +5,66 @@ use crate::models;
 use crate::header;
 
 
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
+pub struct AdditionalPropertiesWithList(std::collections::HashMap<String, Vec<String>>);
+
+impl std::convert::From<std::collections::HashMap<String, Vec<String>>> for AdditionalPropertiesWithList {
+    fn from(x: std::collections::HashMap<String, Vec<String>>) -> Self {
+        AdditionalPropertiesWithList(x)
+    }
+}
+
+
+impl std::convert::From<AdditionalPropertiesWithList> for std::collections::HashMap<String, Vec<String>> {
+    fn from(x: AdditionalPropertiesWithList) -> Self {
+        x.0
+    }
+}
+
+impl std::ops::Deref for AdditionalPropertiesWithList {
+    type Target = std::collections::HashMap<String, Vec<String>>;
+    fn deref(&self) -> &std::collections::HashMap<String, Vec<String>> {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for AdditionalPropertiesWithList {
+    fn deref_mut(&mut self) -> &mut std::collections::HashMap<String, Vec<String>> {
+        &mut self.0
+    }
+}
+
+/// Converts the AdditionalPropertiesWithList value to the Query Parameters representation (style=form, explode=false)
+/// specified in https://swagger.io/docs/specification/serialization/
+/// Should be implemented in a serde serializer
+impl ::std::string::ToString for AdditionalPropertiesWithList {
+    fn to_string(&self) -> String {
+        // Skipping additionalProperties in query parameter serialization
+        "".to_string()
+    }
+}
+
+/// Converts Query Parameters representation (style=form, explode=false) to a AdditionalPropertiesWithList value
+/// as specified in https://swagger.io/docs/specification/serialization/
+/// Should be implemented in a serde deserializer
+impl ::std::str::FromStr for AdditionalPropertiesWithList {
+    type Err = &'static str;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        std::result::Result::Err("Parsing additionalProperties for AdditionalPropertiesWithList is not supported")
+    }
+}
+
+impl AdditionalPropertiesWithList {
+    /// Helper function to allow us to convert this model to an XML string.
+    /// Will panic if serialisation fails.
+    #[allow(dead_code)]
+    pub(crate) fn to_xml(&self) -> String {
+        serde_xml_rs::to_string(&self).expect("impossible to fail to serialize")
+    }
+}
+
 // Methods for converting between header::IntoHeaderValue<AnotherXmlArray> and hyper::header::HeaderValue
 
 #[cfg(any(feature = "client", feature = "server"))]

--- a/samples/server/petstore/rust-server/output/ops-v3/.openapi-generator/FILES
+++ b/samples/server/petstore/rust-server/output/ops-v3/.openapi-generator/FILES
@@ -1,5 +1,6 @@
 .cargo/config
 .gitignore
+.openapi-generator-ignore
 Cargo.toml
 README.md
 api/openapi.yaml

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/.openapi-generator/FILES
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/.openapi-generator/FILES
@@ -1,5 +1,6 @@
 .cargo/config
 .gitignore
+.openapi-generator-ignore
 Cargo.toml
 README.md
 api/openapi.yaml

--- a/samples/server/petstore/rust-server/output/rust-server-test/.openapi-generator/FILES
+++ b/samples/server/petstore/rust-server/output/rust-server-test/.openapi-generator/FILES
@@ -1,5 +1,6 @@
 .cargo/config
 .gitignore
+.openapi-generator-ignore
 Cargo.toml
 README.md
 api/openapi.yaml


### PR DESCRIPTION
Support models which contain an array directly within additional properties - e.g.

```
    AdditionalPropertiesWithList:
      type: object
      additionalProperties:
        type: list
        items:
          type: string
```

## Rust Server Technical Committee

- @frol
- @farcaller
- @bjgill
- @paladinzh

### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [X] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [X] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.