### PR TITLE
Remove the json dependency

### DIFF
--- a/modules/openapi-generator/src/main/resources/ruby-client/gemspec.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/gemspec.mustache
@@ -30,7 +30,6 @@ Gem::Specification.new do |s|
   {{^isFaraday}}
   s.add_runtime_dependency 'typhoeus', '~> 1.0', '>= 1.0.1'
   {{/isFaraday}}
-  s.add_runtime_dependency 'json', '~> 2.1', '>= 2.1.0'
 
   s.add_development_dependency 'rspec', '~> 3.6', '>= 3.6.0'
 

--- a/samples/client/petstore/ruby-faraday/petstore.gemspec
+++ b/samples/client/petstore/ruby-faraday/petstore.gemspec
@@ -28,7 +28,6 @@ Gem::Specification.new do |s|
   s.required_ruby_version = ">= 1.9"
 
   s.add_runtime_dependency 'faraday', '>= 0.14.0'
-  s.add_runtime_dependency 'json', '~> 2.1', '>= 2.1.0'
 
   s.add_development_dependency 'rspec', '~> 3.6', '>= 3.6.0'
 

--- a/samples/client/petstore/ruby/petstore.gemspec
+++ b/samples/client/petstore/ruby/petstore.gemspec
@@ -28,7 +28,6 @@ Gem::Specification.new do |s|
   s.required_ruby_version = ">= 1.9"
 
   s.add_runtime_dependency 'typhoeus', '~> 1.0', '>= 1.0.1'
-  s.add_runtime_dependency 'json', '~> 2.1', '>= 2.1.0'
 
   s.add_development_dependency 'rspec', '~> 3.6', '>= 3.6.0'
 


### PR DESCRIPTION
JSON has been included in ruby since 1.9:
```ruby
$ irb -f
irb(main):001:0> RUBY_VERSION
# => "1.9.3"
irb(main):002:0> require "json"
# => true
irb(main):003:0> JSON
# => JSON
```

Forcing everyone to use a recent version like 2.1+ is a good thing but sometimes it may be detrimental: some older apps may still be stuck on 1.x for some reason and currently they wouldn't be able to use generated clients because of the 2.1+ requirement.
Unless there's a specific reason to use 2.1+ in the clients, listing (or not) json as a dependency should be up to the user of the generated clients.

For example, rails dropped the explicit dependency a long time ago ([PR](https://github.com/rails/rails/pull/23453)).

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@cliffano @zlx @autopp @wing328 