### PR TITLE
Add support of useOneOfInterfaces for Spring and all JaxRS based generators

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
@@ -59,6 +59,7 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
     public static final String BOOLEAN_GETTER_PREFIX = "booleanGetterPrefix";
     public static final String ADDITIONAL_MODEL_TYPE_ANNOTATIONS = "additionalModelTypeAnnotations";
     public static final String DISCRIMINATOR_CASE_SENSITIVE = "discriminatorCaseSensitive";
+    public static final String USE_ONEOF_INTERFACES = "useOneOfInterfaces";
 
     protected String dateLibrary = "threetenbp";
     protected boolean supportAsync = false;
@@ -195,6 +196,7 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
         cliOptions.add(CliOption.newBoolean(DISCRIMINATOR_CASE_SENSITIVE, "Whether the discriminator value lookup should be case-sensitive or not. This option only works for Java API client", discriminatorCaseSensitive));
         cliOptions.add(CliOption.newBoolean(CodegenConstants.HIDE_GENERATION_TIMESTAMP, CodegenConstants.HIDE_GENERATION_TIMESTAMP_DESC, this.isHideGenerationTimestamp()));
         cliOptions.add(CliOption.newBoolean(WITH_XML, "whether to include support for application/xml content type and include XML annotations in the model (works with libraries that provide support for JSON and XML)"));
+        cliOptions.add(CliOption.newBoolean(USE_ONEOF_INTERFACES, "Generate interfaces for OneOf types", useOneOfInterfaces));
 
         CliOption dateLibrary = new CliOption(DATE_LIBRARY, "Option. Date library to use").defaultValue(this.getDateLibrary());
         Map<String, String> dateOptions = new HashMap<>();
@@ -537,6 +539,11 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
             }
         } else if (dateLibrary.equals("legacy")) {
             additionalProperties.put("legacyDates", "true");
+        }
+
+        if(additionalProperties.containsKey(USE_ONEOF_INTERFACES)) {
+            useOneOfInterfaces = Boolean.valueOf(additionalProperties.get(USE_ONEOF_INTERFACES).toString());
+            addOneOfInterfaceImports = useOneOfInterfaces;
         }
     }
 

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf-cdi/model.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf-cdi/model.mustache
@@ -13,7 +13,6 @@ import javax.validation.constraints.*;
 /**
  * {{description}}
  **/{{/description}}
-{{#isEnum}}{{>enumOuterClass}}{{/isEnum}}
-{{^isEnum}}{{>pojo}}{{/isEnum}}
+{{#isEnum}}{{>enumOuterClass}}{{/isEnum}}{{^isEnum}}{{#vendorExtensions.x-is-one-of-interface}}{{>oneof_interface}}{{/vendorExtensions.x-is-one-of-interface}}{{^vendorExtensions.x-is-one-of-interface}}{{>pojo}}{{/vendorExtensions.x-is-one-of-interface}}{{/isEnum}}
 {{/model}}
 {{/models}}

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf-cdi/oneof_interface.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf-cdi/oneof_interface.mustache
@@ -1,0 +1,6 @@
+{{>additionalModelTypeAnnotations}}{{>generatedAnnotation}}{{>typeInfoAnnotation}}
+public interface {{classname}} {{#vendorExtensions.x-implements}}{{#-first}}extends {{{.}}}{{/-first}}{{^-first}}, {{{.}}}{{/-first}}{{/vendorExtensions.x-implements}} {
+    {{#discriminator}}
+    public {{propertyType}} {{propertyGetter}}();
+    {{/discriminator}}
+}

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf-cdi/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf-cdi/pojo.mustache
@@ -4,7 +4,7 @@ import java.util.Objects;
 import javax.xml.bind.annotation.*;
 
 {{#description}}@ApiModel(description = "{{{description}}}"){{/description}}{{>additionalModelTypeAnnotations}}{{#discriminator}}{{>typeInfoAnnotation}}{{/discriminator}}
-public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}} {{#serializableModel}}implements Serializable{{/serializableModel}} {
+public class {{classname}}{{#parent}} extends {{{parent}}}{{/parent}}{{#vendorExtensions.implements}}{{#-first}} implements {{{.}}}{{/-first}}{{^-first}}, {{{.}}}{{/-first}}{{#-last}} {{/-last}}{{/vendorExtensions.implements}}{{^vendorExtensions.implements}}{{#serializableModel}} implements Serializable{{/serializableModel}}{{/vendorExtensions.implements}} {
   {{#vars}}{{#isEnum}}{{^isContainer}}
 
 {{>enumClass}}{{/isContainer}}{{#isContainer}}{{#mostInnerItems}}

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf-cdi/typeInfoAnnotation.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf-cdi/typeInfoAnnotation.mustache
@@ -1,5 +1,5 @@
 {{#jackson}}
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "{{{discriminator.propertyBaseName}}}", visible = true)
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXISTING_PROPERTY, property = "{{{discriminator.propertyBaseName}}}", visible = true)
 @JsonSubTypes({
   {{#discriminator.mappedModels}}
   @JsonSubTypes.Type(value = {{modelName}}.class, name = "{{^vendorExtensions.x-discriminator-value}}{{mappingName}}{{/vendorExtensions.x-discriminator-value}}{{#vendorExtensions.x-discriminator-value}}{{{vendorExtensions.x-discriminator-value}}}{{/vendorExtensions.x-discriminator-value}}"),

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf-ext/model.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf-ext/model.mustache
@@ -12,11 +12,6 @@ import javax.validation.Valid;
 
 {{#models}}
 {{#model}}
-{{#isEnum}}
-{{>enumOuterClass}}
-{{/isEnum}}
-{{^isEnum}}
-{{>pojo}}
-{{/isEnum}}
+{{#isEnum}}{{>enumOuterClass}}{{/isEnum}}{{^isEnum}}{{#vendorExtensions.x-is-one-of-interface}}{{>oneof_interface}}{{/vendorExtensions.x-is-one-of-interface}}{{^vendorExtensions.x-is-one-of-interface}}{{>pojo}}{{/vendorExtensions.x-is-one-of-interface}}{{/isEnum}}
 {{/model}}
 {{/models}}

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf-ext/oneof_interface.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf-ext/oneof_interface.mustache
@@ -1,0 +1,6 @@
+{{>additionalModelTypeAnnotations}}{{>generatedAnnotation}}{{>typeInfoAnnotation}}
+public interface {{classname}} {{#vendorExtensions.x-implements}}{{#-first}}extends {{{.}}}{{/-first}}{{^-first}}, {{{.}}}{{/-first}}{{/vendorExtensions.x-implements}} {
+    {{#discriminator}}
+    public {{propertyType}} {{propertyGetter}}();
+    {{/discriminator}}
+}

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf-ext/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf-ext/pojo.mustache
@@ -23,7 +23,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  */
 @ApiModel(description="{{{description}}}")
 {{/description}}{{>additionalModelTypeAnnotations}}
-public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}}{{#serializableModel}} implements Serializable{{/serializableModel}} {
+public class {{classname}}{{#parent}} extends {{{parent}}}{{/parent}}{{#vendorExtensions.implements}}{{#-first}} implements {{{.}}}{{/-first}}{{^-first}}, {{{.}}}{{/-first}}{{#-last}} {{/-last}}{{/vendorExtensions.implements}}{{^vendorExtensions.implements}}{{#serializableModel}} implements Serializable{{/serializableModel}}{{/vendorExtensions.implements}} {
   {{#vars}}{{#isEnum}}{{^isContainer}}
 {{>enumClass}}{{/isContainer}}{{#isContainer}}{{#mostInnerItems}}
 {{>enumClass}}{{/mostInnerItems}}{{/isContainer}}{{/isEnum}}

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf-ext/typeInfoAnnotation.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf-ext/typeInfoAnnotation.mustache
@@ -1,5 +1,5 @@
 {{#jackson}}
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "{{{discriminator.propertyBaseName}}}", visible = true)
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXISTING_PROPERTY, property = "{{{discriminator.propertyBaseName}}}", visible = true)
 @JsonSubTypes({
   {{#discriminator.mappedModels}}
   @JsonSubTypes.Type(value = {{modelName}}.class, name = "{{^vendorExtensions.x-discriminator-value}}{{mappingName}}{{/vendorExtensions.x-discriminator-value}}{{#vendorExtensions.x-discriminator-value}}{{{vendorExtensions.x-discriminator-value}}}{{/vendorExtensions.x-discriminator-value}}"),

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf/model.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf/model.mustache
@@ -12,11 +12,6 @@ import javax.validation.Valid;
 
 {{#models}}
 {{#model}}
-{{#isEnum}}
-{{>enumOuterClass}}
-{{/isEnum}}
-{{^isEnum}}
-{{>pojo}}
-{{/isEnum}}
+{{#isEnum}}{{>enumOuterClass}}{{/isEnum}}{{^isEnum}}{{#vendorExtensions.x-is-one-of-interface}}{{>oneof_interface}}{{/vendorExtensions.x-is-one-of-interface}}{{^vendorExtensions.x-is-one-of-interface}}{{>pojo}}{{/vendorExtensions.x-is-one-of-interface}}{{/isEnum}}
 {{/model}}
 {{/models}}

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf/oneof_interface.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf/oneof_interface.mustache
@@ -1,0 +1,6 @@
+{{>additionalModelTypeAnnotations}}{{>generatedAnnotation}}{{>typeInfoAnnotation}}
+public interface {{classname}} {{#vendorExtensions.x-implements}}{{#-first}}extends {{{.}}}{{/-first}}{{^-first}}, {{{.}}}{{/-first}}{{/vendorExtensions.x-implements}} {
+    {{#discriminator}}
+    public {{propertyType}} {{propertyGetter}}();
+    {{/discriminator}}
+}

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf/pojo.mustache
@@ -14,7 +14,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  **/
 @ApiModel(description="{{{description}}}")
 {{/description}}
-{{>additionalModelTypeAnnotations}}{{>xmlPojoAnnotation}}{{#discriminator}}{{>typeInfoAnnotation}}{{/discriminator}}public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}}{{#serializableModel}} implements Serializable{{/serializableModel}} {
+{{>additionalModelTypeAnnotations}}{{>xmlPojoAnnotation}}{{#discriminator}}{{>typeInfoAnnotation}}{{/discriminator}}public class {{classname}}{{#parent}} extends {{{parent}}}{{/parent}}{{#vendorExtensions.implements}}{{#-first}} implements {{{.}}}{{/-first}}{{^-first}}, {{{.}}}{{/-first}}{{#-last}} {{/-last}}{{/vendorExtensions.implements}}{{^vendorExtensions.implements}}{{#serializableModel}} implements Serializable{{/serializableModel}}{{/vendorExtensions.implements}} {
   {{#vars}}{{#isEnum}}{{^isContainer}}
 {{>enumClass}}{{/isContainer}}{{#isContainer}}{{#mostInnerItems}}
 {{>enumClass}}{{/mostInnerItems}}{{/isContainer}}{{/isEnum}}

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf/typeInfoAnnotation.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf/typeInfoAnnotation.mustache
@@ -1,5 +1,5 @@
 {{#jackson}}
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "{{{discriminator.propertyBaseName}}}", visible = true)
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXISTING_PROPERTY, property = "{{{discriminator.propertyBaseName}}}", visible = true)
 @JsonSubTypes({
   {{#discriminator.mappedModels}}
   @JsonSubTypes.Type(value = {{modelName}}.class, name = "{{^vendorExtensions.x-discriminator-value}}{{mappingName}}{{/vendorExtensions.x-discriminator-value}}{{#vendorExtensions.x-discriminator-value}}{{{vendorExtensions.x-discriminator-value}}}{{/vendorExtensions.x-discriminator-value}}"),

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/model.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/model.mustache
@@ -23,6 +23,6 @@ import javax.validation.Valid;
 
 {{#models}}
 {{#model}}
-{{#isEnum}}{{>modelEnum}}{{/isEnum}}{{^isEnum}}{{>pojo}}{{/isEnum}}
+{{#isEnum}}{{>modelEnum}}{{/isEnum}}{{^isEnum}}{{#vendorExtensions.x-is-one-of-interface}}{{>oneof_interface}}{{/vendorExtensions.x-is-one-of-interface}}{{^vendorExtensions.x-is-one-of-interface}}{{>pojo}}{{/vendorExtensions.x-is-one-of-interface}}{{/isEnum}}
 {{/model}}
 {{/models}}

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/oneof_interface.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/oneof_interface.mustache
@@ -1,0 +1,6 @@
+{{>additionalModelTypeAnnotations}}{{>generatedAnnotation}}{{>typeInfoAnnotation}}
+public interface {{classname}} {{#vendorExtensions.x-implements}}{{#-first}}extends {{{.}}}{{/-first}}{{^-first}}, {{{.}}}{{/-first}}{{/vendorExtensions.x-implements}} {
+    {{#discriminator}}
+    public {{propertyType}} {{propertyGetter}}();
+    {{/discriminator}}
+}

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/pojo.mustache
@@ -10,7 +10,7 @@
 })
 {{/jackson}}
 {{>additionalModelTypeAnnotations}}{{>generatedAnnotation}}{{#discriminator}}{{>typeInfoAnnotation}}{{/discriminator}}
-public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}} {{#serializableModel}}implements Serializable{{/serializableModel}} {
+public class {{classname}}{{#parent}} extends {{{parent}}}{{/parent}}{{#vendorExtensions.implements}}{{#-first}} implements {{{.}}}{{/-first}}{{^-first}}, {{{.}}}{{/-first}}{{#-last}} {{/-last}}{{/vendorExtensions.implements}}{{^vendorExtensions.implements}}{{#serializableModel}} implements Serializable{{/serializableModel}}{{/vendorExtensions.implements}} {
   {{#vars}}
     {{#isEnum}}
     {{^isContainer}}

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy/eap/model.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy/eap/model.mustache
@@ -12,11 +12,6 @@ import javax.validation.constraints.*;
 {{/useBeanValidation}}
 {{#models}}
 {{#model}}
-{{#isEnum}}
-{{>enumOuterClass}}
-{{/isEnum}}
-{{^isEnum}}
-{{>pojo}}
-{{/isEnum}}
+{{#isEnum}}{{>enumOuterClass}}{{/isEnum}}{{^isEnum}}{{#vendorExtensions.x-is-one-of-interface}}{{>oneof_interface}}{{/vendorExtensions.x-is-one-of-interface}}{{^vendorExtensions.x-is-one-of-interface}}{{>pojo}}{{/vendorExtensions.x-is-one-of-interface}}{{/isEnum}}
 {{/model}}
 {{/models}}

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy/eap/oneof_interface.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy/eap/oneof_interface.mustache
@@ -1,0 +1,6 @@
+{{>additionalModelTypeAnnotations}}{{>generatedAnnotation}}{{>typeInfoAnnotation}}
+public interface {{classname}} {{#vendorExtensions.x-implements}}{{#-first}}extends {{{.}}}{{/-first}}{{^-first}}, {{{.}}}{{/-first}}{{/vendorExtensions.x-implements}} {
+    {{#discriminator}}
+    public {{propertyType}} {{propertyGetter}}();
+    {{/discriminator}}
+}

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy/eap/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy/eap/pojo.mustache
@@ -1,7 +1,7 @@
 import io.swagger.annotations.*;
 
 {{#description}}@ApiModel(description="{{{description}}}"){{/description}}{{>additionalModelTypeAnnotations}}{{>generatedAnnotation}}{{#discriminator}}{{>typeInfoAnnotation}}{{/discriminator}}
-public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}} {{#serializableModel}}implements Serializable{{/serializableModel}} {
+public class {{classname}}{{#parent}} extends {{{parent}}}{{/parent}}{{#vendorExtensions.implements}}{{#-first}} implements {{{.}}}{{/-first}}{{^-first}}, {{{.}}}{{/-first}}{{#-last}} {{/-last}}{{/vendorExtensions.implements}}{{^vendorExtensions.implements}}{{#serializableModel}} implements Serializable{{/serializableModel}}{{/vendorExtensions.implements}} {
 {{#serializableModel}}
   private static final long serialVersionUID = 1L;
 {{/serializableModel}}

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy/eap/typeInfoAnnotation.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy/eap/typeInfoAnnotation.mustache
@@ -1,5 +1,5 @@
 {{#jackson}}
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "{{{discriminator.propertyBaseName}}}", visible = true)
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXISTING_PROPERTY, property = "{{{discriminator.propertyBaseName}}}", visible = true)
 @JsonSubTypes({
   {{#discriminator.mappedModels}}
   @JsonSubTypes.Type(value = {{modelName}}.class, name = "{{^vendorExtensions.x-discriminator-value}}{{mappingName}}{{/vendorExtensions.x-discriminator-value}}{{#vendorExtensions.x-discriminator-value}}{{{vendorExtensions.x-discriminator-value}}}{{/vendorExtensions.x-discriminator-value}}"),

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy/model.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy/model.mustache
@@ -12,11 +12,6 @@ import javax.validation.constraints.*;
 {{/useBeanValidation}}
 {{#models}}
 {{#model}}
-{{#isEnum}}
-{{>enumOuterClass}}
-{{/isEnum}}
-{{^isEnum}}
-{{>pojo}}
-{{/isEnum}}
+{{#isEnum}}{{>enumOuterClass}}{{/isEnum}}{{^isEnum}}{{#vendorExtensions.x-is-one-of-interface}}{{>oneof_interface}}{{/vendorExtensions.x-is-one-of-interface}}{{^vendorExtensions.x-is-one-of-interface}}{{>pojo}}{{/vendorExtensions.x-is-one-of-interface}}{{/isEnum}}
 {{/model}}
 {{/models}}

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy/oneof_interface.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy/oneof_interface.mustache
@@ -1,0 +1,6 @@
+{{>additionalModelTypeAnnotations}}{{>generatedAnnotation}}{{>typeInfoAnnotation}}
+public interface {{classname}} {{#vendorExtensions.x-implements}}{{#-first}}extends {{{.}}}{{/-first}}{{^-first}}, {{{.}}}{{/-first}}{{/vendorExtensions.x-implements}} {
+    {{#discriminator}}
+    public {{propertyType}} {{propertyGetter}}();
+    {{/discriminator}}
+}

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy/pojo.mustache
@@ -1,7 +1,7 @@
 import io.swagger.annotations.*;
 
 {{#description}}@ApiModel(description="{{{description}}}"){{/description}}{{>additionalModelTypeAnnotations}}{{>generatedAnnotation}}{{#discriminator}}{{>typeInfoAnnotation}}{{/discriminator}}
-public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}} {{#serializableModel}}implements Serializable{{/serializableModel}} {
+public class {{classname}}{{#parent}} extends {{{parent}}}{{/parent}}{{#vendorExtensions.implements}}{{#-first}} implements {{{.}}}{{/-first}}{{^-first}}, {{{.}}}{{/-first}}{{#-last}} {{/-last}}{{/vendorExtensions.implements}}{{^vendorExtensions.implements}}{{#serializableModel}} implements Serializable{{/serializableModel}}{{/vendorExtensions.implements}} {
 {{#serializableModel}}
   private static final long serialVersionUID = 1L;
 {{/serializableModel}}

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy/typeInfoAnnotation.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy/typeInfoAnnotation.mustache
@@ -1,5 +1,5 @@
 {{#jackson}}
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "{{{discriminator.propertyBaseName}}}", visible = true)
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXISTING_PROPERTY, property = "{{{discriminator.propertyBaseName}}}", visible = true)
 @JsonSubTypes({
   {{#discriminator.mappedModels}}
   @JsonSubTypes.Type(value = {{modelName}}.class, name = "{{^vendorExtensions.x-discriminator-value}}{{mappingName}}{{/vendorExtensions.x-discriminator-value}}{{#vendorExtensions.x-discriminator-value}}{{{vendorExtensions.x-discriminator-value}}}{{/vendorExtensions.x-discriminator-value}}"),

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/model.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/model.mustache
@@ -12,9 +12,6 @@ import javax.validation.Valid;
 
 {{#models}}
 {{#model}}
-{{#isEnum}}
-{{>enumOuterClass}}
-{{/isEnum}}
-{{^isEnum}}{{>pojo}}{{/isEnum}}
+{{#isEnum}}{{>enumOuterClass}}{{/isEnum}}{{^isEnum}}{{#vendorExtensions.x-is-one-of-interface}}{{>oneof_interface}}{{/vendorExtensions.x-is-one-of-interface}}{{^vendorExtensions.x-is-one-of-interface}}{{>pojo}}{{/vendorExtensions.x-is-one-of-interface}}{{/isEnum}}
 {{/model}}
 {{/models}}

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/oneof_interface.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/oneof_interface.mustache
@@ -1,0 +1,6 @@
+{{>additionalModelTypeAnnotations}}{{>generatedAnnotation}}{{>typeInfoAnnotation}}
+public interface {{classname}} {{#vendorExtensions.x-implements}}{{#-first}}extends {{{.}}}{{/-first}}{{^-first}}, {{{.}}}{{/-first}}{{/vendorExtensions.x-implements}} {
+    {{#discriminator}}
+    public {{propertyType}} {{propertyGetter}}();
+    {{/discriminator}}
+}

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/pojo.mustache
@@ -10,7 +10,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
  * {{description}}
  **/{{/description}}
 {{#useSwaggerAnnotations}}{{#description}}{{>additionalModelTypeAnnotations}}@ApiModel(description = "{{{description}}}"){{/description}}{{/useSwaggerAnnotations}}
-{{>generatedAnnotation}}public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}} {{#serializableModel}}implements Serializable{{/serializableModel}} {
+{{>generatedAnnotation}}public class {{classname}}{{#parent}} extends {{{parent}}}{{/parent}}{{#vendorExtensions.implements}}{{#-first}} implements {{{.}}}{{/-first}}{{^-first}}, {{{.}}}{{/-first}}{{#-last}} {{/-last}}{{/vendorExtensions.implements}}{{^vendorExtensions.implements}}{{#serializableModel}} implements Serializable{{/serializableModel}}{{/vendorExtensions.implements}} {
   {{#vars}}{{#isEnum}}{{^isContainer}}
 
 {{>enumClass}}{{/isContainer}}{{#isContainer}}{{#mostInnerItems}}

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/typeInfoAnnotation.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/typeInfoAnnotation.mustache
@@ -1,5 +1,5 @@
 {{#jackson}}
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "{{{discriminator.propertyBaseName}}}", visible = true)
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXISTING_PROPERTY, property = "{{{discriminator.propertyBaseName}}}", visible = true)
 @JsonSubTypes({
   {{#discriminator.mappedModels}}
   @JsonSubTypes.Type(value = {{modelName}}.class, name = "{{^vendorExtensions.x-discriminator-value}}{{mappingName}}{{/vendorExtensions.x-discriminator-value}}{{#vendorExtensions.x-discriminator-value}}{{{vendorExtensions.x-discriminator-value}}}{{/vendorExtensions.x-discriminator-value}}"),

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/typeInfoAnnotation.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/typeInfoAnnotation.mustache
@@ -1,5 +1,5 @@
 {{#jackson}}
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "{{{discriminator.propertyBaseName}}}", visible = true)
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXISTING_PROPERTY, property = "{{{discriminator.propertyBaseName}}}", visible = true)
 @JsonSubTypes({
   {{#discriminator.mappedModels}}
   @JsonSubTypes.Type(value = {{modelName}}.class, name = "{{^vendorExtensions.x-discriminator-value}}{{mappingName}}{{/vendorExtensions.x-discriminator-value}}{{#vendorExtensions.x-discriminator-value}}{{{vendorExtensions.x-discriminator-value}}}{{/vendorExtensions.x-discriminator-value}}"),

--- a/modules/openapi-generator/src/main/resources/JavaSpring/model.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/model.mustache
@@ -31,11 +31,6 @@ import org.springframework.hateoas.RepresentationModel;
 
 {{#models}}
 {{#model}}
-{{#isEnum}}
-{{>enumOuterClass}}
-{{/isEnum}}
-{{^isEnum}}
-{{>pojo}}
-{{/isEnum}}
+{{#isEnum}}{{>enumOuterClass}}{{/isEnum}}{{^isEnum}}{{#vendorExtensions.x-is-one-of-interface}}{{>oneof_interface}}{{/vendorExtensions.x-is-one-of-interface}}{{^vendorExtensions.x-is-one-of-interface}}{{>pojo}}{{/vendorExtensions.x-is-one-of-interface}}{{/isEnum}}
 {{/model}}
 {{/models}}

--- a/modules/openapi-generator/src/main/resources/JavaSpring/oneof_interface.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/oneof_interface.mustache
@@ -1,0 +1,6 @@
+{{>additionalModelTypeAnnotations}}{{>generatedAnnotation}}{{>typeInfoAnnotation}}{{>xmlAnnotation}}
+public interface {{classname}} {{#vendorExtensions.x-implements}}{{#-first}}extends {{{.}}}{{/-first}}{{^-first}}, {{{.}}}{{/-first}}{{/vendorExtensions.x-implements}} {
+    {{#discriminator}}
+    public {{propertyType}} {{propertyGetter}}();
+    {{/discriminator}}
+}

--- a/modules/openapi-generator/src/main/resources/JavaSpring/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/pojo.mustache
@@ -3,7 +3,7 @@
  */{{#description}}
 @ApiModel(description = "{{{description}}}"){{/description}}
 {{>generatedAnnotation}}{{#discriminator}}{{>typeInfoAnnotation}}{{/discriminator}}{{>xmlAnnotation}}{{>additionalModelTypeAnnotations}}
-public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}}{{^parent}}{{#hateoas}}extends RepresentationModel<{{classname}}> {{/hateoas}}{{/parent}} {{#serializableModel}}implements Serializable{{/serializableModel}} {
+public class {{classname}}{{#parent}} extends {{{parent}}}{{/parent}}{{^parent}}{{#hateoas}} extends RepresentationModel<{{classname}}>{{/hateoas}}{{/parent}}{{#vendorExtensions.implements}}{{#-first}} implements {{{.}}}{{/-first}}{{^-first}}, {{{.}}}{{/-first}}{{#-last}} {{/-last}}{{/vendorExtensions.implements}}{{^vendorExtensions.implements}}{{#serializableModel}} implements Serializable{{/serializableModel}}{{/vendorExtensions.implements}} {
 {{#serializableModel}}
   private static final long serialVersionUID = 1L;
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/jaxrs/JavaJaxrsBaseTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/jaxrs/JavaJaxrsBaseTest.java
@@ -42,7 +42,7 @@ public abstract class JavaJaxrsBaseTest {
         DefaultGenerator generator = new DefaultGenerator();
         generator.opts(input).generate();
 
-        String jsonTypeInfo = "@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = \"className\", visible = true)";
+        String jsonTypeInfo = "@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXISTING_PROPERTY, property = \"className\", visible = true)";
         String jsonSubType = "@JsonSubTypes({\n" +
                 "  @JsonSubTypes.Type(value = Dog.class, name = \"Dog\"),\n" +
                 "  @JsonSubTypes.Type(value = Cat.class, name = \"Cat\"),\n" +
@@ -73,7 +73,7 @@ public abstract class JavaJaxrsBaseTest {
         generator.opts(input).generate();
 
 
-        String jsonTypeInfo = "@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = \"className\", visible = true)";
+        String jsonTypeInfo = "@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXISTING_PROPERTY, property = \"className\", visible = true)";
         String jsonSubType = "@JsonSubTypes({\n" +
                 "  @JsonSubTypes.Type(value = Dog.class, name = \"Dog\"),\n" +
                 "  @JsonSubTypes.Type(value = Cat.class, name = \"Cat\"),\n" +


### PR DESCRIPTION
This is actually referenced [here](https://github.com/OpenAPITools/openapi-generator/issues/15#issuecomment-607724472) and it addresses issue #5381 nicely.

I'm willing to do the legwork to get the PR in, however I'm not actually the author, and I'd think to maintain the license agreement we'd need consent from @mmalygin

<!-- Please check the completed items below -->
### PR checklist

- [ X ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ X ] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.

*this step is unclear to me, I run a bunch of the scripts and it seems many seemingly unrelated files changed like all the FakeApi.java files changed `put("http", EncodingUtils.encodeCollection(value, "ssv"));` to `put("http", EncodingUtils.encodeCollection(value, "space"));` which seems completely outside of the scope of this bugfix*
- [ ] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [ X ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
*further guidance would be appreciated here*
- [ ] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
