### PR TITLE
[ci][cli] Allow invoking generate-samples.sh with single file + args

### DIFF
--- a/bin/generate-samples.sh
+++ b/bin/generate-samples.sh
@@ -6,21 +6,61 @@ declare cwd="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 declare root="$(cd "$cwd" && cd ../ && pwd)"
 declare executable="${root}/modules/openapi-generator-cli/target/openapi-generator-cli.jar"
 
-echo "# START SCRIPT: $0"
-echo "This script generates all configs under bin/configs by default."
-echo "You may generate a targeted script or set of scripts using glob patterns."
-echo "For example: $0 bin/configs/java-*"
-echo ""
-echo "Please press CTRL+C to stop or the script will continue in 5 seconds."
-
-sleep 5
 if [ ! -f "$executable" ]; then
   (cd "${root}" && mvn -B --no-snapshot-updates clean package -DskipTests=true -Dmaven.javadoc.skip=true -Djacoco.skip=true)
 fi
 
-export JAVA_OPTS="${JAVA_OPTS} -server -Duser.timezone=UTC"
+export JAVA_OPTS="${JAVA_OPTS} -ea -server -Duser.timezone=UTC"
 
-configs=${@:-"${root}"/bin/configs/*.yaml}
+files=()
+args=()
+end_option=false
+while [[ $# -gt 0 ]]; do
+  key="$1"
+  if [ "--" == "$key" ]; then
+    end_option=true
+  else
+    if [[ "$end_option" = true ]]; then
+      args+=("$1")
+    else
+      files+=("$1")
+    fi
+  fi
+  shift
+done
 
-# shellcheck disable=SC2086
-java $JAVA_OPTS -jar "$executable" batch --includes-base-dir "${root}" --fail-fast  -- $configs
+header="# START SCRIPT: $0
+This script generates all configs under bin/configs by default.
+You may generate a targeted script or set of scripts using glob patterns.
+
+For example:
+    $0 bin/configs/java-*
+
+You may generate a single config with additional options if you use -- to
+separate the single config file from the generator arguments.
+
+For example:
+    $0 bin/configs/java-vertx.yaml -- --global-property debugModels=true
+
+"
+
+echo "$header"
+
+if [[ ${#files[@]} -eq 1 && "${files[0]}" != *'*'* ]]; then
+    # shellcheck disable=SC2086
+    # shellcheck disable=SC2068
+    java ${JAVA_OPTS} -jar "$executable" generate -c ${files[0]} ${args[@]}
+else
+    echo "Please press CTRL+C to stop or the script will continue in 5 seconds."
+
+    sleep 5
+
+    if [ ${#files[@]} -eq 0 ]; then
+      files=("${root}"/bin/configs/*.yaml)
+    fi
+
+    # shellcheck disable=SC2086
+    # shellcheck disable=SC2068
+    java ${JAVA_OPTS} -jar "$executable" batch --includes-base-dir "${root}" --fail-fast  -- ${files[@]}
+fi
+

--- a/bin/utils/ensure-up-to-date
+++ b/bin/utils/ensure-up-to-date
@@ -8,11 +8,8 @@ declare root="$(cd "$cwd" && cd ../../ && pwd)"
 declare executable="${root}/modules/openapi-generator-cli/target/openapi-generator-cli.jar"
 
 echo "# START SCRIPT: $0"
-
 echo "IMPORTANT: this script should be run by the CI (e.g. Shippable) to ensure that the 'samples/' folder is up to date."
-echo "Please press CTRL+C to stop or the script will continue in 5 seconds."
-
-sleep 5
+echo ""
 
 "${root}/bin/generate-samples.sh"
 

--- a/modules/openapi-generator-cli/src/main/java/org/openapitools/codegen/cmd/Generate.java
+++ b/modules/openapi-generator-cli/src/main/java/org/openapitools/codegen/cmd/Generate.java
@@ -29,6 +29,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Stream;
 
+import org.apache.commons.lang3.StringUtils;
 import org.openapitools.codegen.*;
 import org.openapitools.codegen.config.CodegenConfigurator;
 import org.slf4j.Logger;
@@ -52,8 +53,8 @@ public class Generate extends OpenApiGeneratorCommand {
             description = "where to write the generated files (current dir by default)")
     private String output = "";
 
-    @Option(name = {"-i", "--input-spec"}, title = "spec file", required = true,
-            description = "location of the OpenAPI spec, as URL or file (required)")
+    @Option(name = {"-i", "--input-spec"}, title = "spec file",
+            description = "location of the OpenAPI spec, as URL or file (required if not loaded via config using -c)")
     private String spec;
 
     @Option(name = {"-t", "--template-dir"}, title = "template directory",
@@ -264,6 +265,10 @@ public class Generate extends OpenApiGeneratorCommand {
             if (configFile != null && configFile.length() > 0) {
                 // attempt to load from configFile
                 configurator = CodegenConfigurator.fromFile(configFile);
+            } else if (StringUtils.isEmpty(spec)) {
+                // if user doesn't pass configFile and does not pass spec, we can fail immediately because one of these two is required to run.
+                System.err.println("[error] Required option '-i' is missing");
+                System.exit(1);
             }
 
             // if a config file wasn't specified, or we were unable to read it
@@ -295,11 +300,9 @@ public class Generate extends OpenApiGeneratorCommand {
             configurator.setInputSpec(spec);
         }
 
+        // Generator name should not be validated here, as it's validated in toClientOptInput
         if (isNotEmpty(generatorName)) {
             configurator.setGeneratorName(generatorName);
-        } else {
-            System.err.println("[error] A generator name (--generator-name / -g) is required.");
-            System.exit(1);
         }
 
         if (isNotEmpty(output)) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/config/CodegenConfigurator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/config/CodegenConfigurator.java
@@ -466,7 +466,7 @@ public class CodegenConfigurator {
 
     @SuppressWarnings("WeakerAccess")
     public Context<?> toContext() {
-        Validate.notEmpty(generatorName, "language/generatorName must be specified");
+        Validate.notEmpty(generatorName, "generator name must be specified");
         Validate.notEmpty(inputSpec, "input spec must be specified");
 
         if (isEmpty(templatingEngineName)) {


### PR DESCRIPTION
Based on some feedback in #6509, this PR allows users to run `./bin/generate-samples.sh` with a single config and additional arguments similar to how individual bash scripts previously worked.

See also #6608 which updates docs for Windows users to execute through GitBash or equivalent.

Examples are embedded in the script as a header/preamble so users will always be presented these options without the need to `--help`.

For example:

```
# START SCRIPT: ./bin/utils/ensure-up-to-date
IMPORTANT: this script should be run by the CI (e.g. Shippable) to ensure that the 'samples/' folder is up to date.

# START SCRIPT: /Users/jim/projects/openapi-generator/bin/generate-samples.sh
This script generates all configs under bin/configs by default.
You may generate a targeted script or set of scripts using glob patterns.

For example:
    /Users/jim/projects/openapi-generator/bin/generate-samples.sh bin/configs/java-*

You may generate a single config with additional options if you use -- to
separate the single config file from the generator arguments.

For example:
    /Users/jim/projects/openapi-generator/bin/generate-samples.sh bin/configs/java-vertx.yaml -- --global-property debugModels=true


Please press CTRL+C to stop or the script will continue in 5 seconds.
```

This should have little or no impact on users following our docs, which describe running the generate command from the jar directly.

cc @OpenAPITools/generator-core-team 

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/config/java*`.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
