### PR TITLE
[java][jersey2] Add support for (expires) and (created) fields in HTTP signature

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/auth/HttpSignatureAuth.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/auth/HttpSignatureAuth.mustache
@@ -49,6 +49,9 @@ public class HttpSignatureAuth implements Authentication {
   // The digest algorithm which is used to calculate a cryptographic digest of the HTTP request body.
   private String digestAlgorithm;
 
+  // The maximum validity duration of the HTTP signature. 
+  private Long maxSignatureValidity;
+
   /**
    * Construct a new HTTP signature auth configuration object.
    *
@@ -57,19 +60,23 @@ public class HttpSignatureAuth implements Authentication {
    * @param algorithm The cryptographic algorithm.
    * @param digestAlgorithm The digest algorithm.
    * @param headers The list of HTTP headers that should be included in the HTTP signature.
+   * @param maxSignatureValidity The maximum validity duration of the HTTP signature.
+   *                             Used to set the '(expires)' field in the HTTP signature.
    */
   public HttpSignatureAuth(String keyId,
                            SigningAlgorithm signingAlgorithm,
                            Algorithm algorithm,
                            String digestAlgorithm,
                            AlgorithmParameterSpec parameterSpec,
-                           List<String> headers) {
+                           List<String> headers,
+                           Long maxSignatureValidity) {
     this.keyId = keyId;
     this.signingAlgorithm = signingAlgorithm;
     this.algorithm = algorithm;
     this.parameterSpec = parameterSpec;
     this.digestAlgorithm = digestAlgorithm;
     this.headers = headers;
+    this.maxSignatureValidity = maxSignatureValidity;
   }
 
   /**
@@ -180,6 +187,14 @@ public class HttpSignatureAuth implements Authentication {
   }
 
   /**
+   * Returns the maximum validity duration of the HTTP signature.
+   * @return The maximum validity duration of the HTTP signature.
+   */
+  public Long getMaxSignatureValidity() {
+    return maxSignatureValidity;
+  }
+
+  /**
    * Returns the signer instance used to sign HTTP messages.
    *
    * @return the signer instance.
@@ -209,7 +224,7 @@ public class HttpSignatureAuth implements Authentication {
     if (key == null) {
       throw new ApiException("Private key (java.security.Key) cannot be null");
     }
-    signer = new Signer(key, new Signature(keyId, signingAlgorithm, algorithm, parameterSpec, null, headers));
+    signer = new Signer(key, new Signature(keyId, signingAlgorithm, algorithm, parameterSpec, null, headers, maxSignatureValidity));
   }
 
   @Override

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/pom.mustache
@@ -407,7 +407,7 @@
         <javax-annotation-version>1.3.2</javax-annotation-version>
         <junit-version>4.13</junit-version>
         {{#hasHttpSignatureMethods}}
-        <http-signature-version>1.4</http-signature-version>
+        <http-signature-version>1.5</http-signature-version>
         {{/hasHttpSignatureMethods}}
         {{#hasOAuthMethods}}
         <scribejava-apis-version>6.9.0</scribejava-apis-version>

--- a/samples/openapi3/client/petstore/java/jersey2-java8/pom.xml
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/pom.xml
@@ -308,7 +308,7 @@
         <jackson-databind-nullable-version>0.2.1</jackson-databind-nullable-version>
         <javax-annotation-version>1.3.2</javax-annotation-version>
         <junit-version>4.13</junit-version>
-        <http-signature-version>1.4</http-signature-version>
+        <http-signature-version>1.5</http-signature-version>
         <scribejava-apis-version>6.9.0</scribejava-apis-version>
     </properties>
 </project>

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/auth/HttpSignatureAuth.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/auth/HttpSignatureAuth.java
@@ -60,6 +60,9 @@ public class HttpSignatureAuth implements Authentication {
   // The digest algorithm which is used to calculate a cryptographic digest of the HTTP request body.
   private String digestAlgorithm;
 
+  // The maximum validity duration of the HTTP signature. 
+  private Long maxSignatureValidity;
+
   /**
    * Construct a new HTTP signature auth configuration object.
    *
@@ -68,19 +71,23 @@ public class HttpSignatureAuth implements Authentication {
    * @param algorithm The cryptographic algorithm.
    * @param digestAlgorithm The digest algorithm.
    * @param headers The list of HTTP headers that should be included in the HTTP signature.
+   * @param maxSignatureValidity The maximum validity duration of the HTTP signature.
+   *                             Used to set the '(expires)' field in the HTTP signature.
    */
   public HttpSignatureAuth(String keyId,
                            SigningAlgorithm signingAlgorithm,
                            Algorithm algorithm,
                            String digestAlgorithm,
                            AlgorithmParameterSpec parameterSpec,
-                           List<String> headers) {
+                           List<String> headers,
+                           Long maxSignatureValidity) {
     this.keyId = keyId;
     this.signingAlgorithm = signingAlgorithm;
     this.algorithm = algorithm;
     this.parameterSpec = parameterSpec;
     this.digestAlgorithm = digestAlgorithm;
     this.headers = headers;
+    this.maxSignatureValidity = maxSignatureValidity;
   }
 
   /**
@@ -191,6 +198,14 @@ public class HttpSignatureAuth implements Authentication {
   }
 
   /**
+   * Returns the maximum validity duration of the HTTP signature.
+   * @return The maximum validity duration of the HTTP signature.
+   */
+  public Long getMaxSignatureValidity() {
+    return maxSignatureValidity;
+  }
+
+  /**
    * Returns the signer instance used to sign HTTP messages.
    *
    * @return the signer instance.
@@ -220,7 +235,7 @@ public class HttpSignatureAuth implements Authentication {
     if (key == null) {
       throw new ApiException("Private key (java.security.Key) cannot be null");
     }
-    signer = new Signer(key, new Signature(keyId, signingAlgorithm, algorithm, parameterSpec, null, headers));
+    signer = new Signer(key, new Signature(keyId, signingAlgorithm, algorithm, parameterSpec, null, headers, maxSignatureValidity));
   }
 
   @Override


### PR DESCRIPTION
This pull request has a dependency on https://github.com/tomitribe/http-signatures-java/pull/39. The dependent PR needs to be merged before this one, and the pom.mustache template will need to be updated when the tomitribe PR has been merged.

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/config/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
