### PR TITLE
[java][jersey2] Differentiate request with no body vs request that contains the null value

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/ApiClient.mustache
@@ -886,6 +886,7 @@ public class ApiClient {
           return formString.substring(0, formString.length() - 1);
         }
       } else {
+        // The BodyHolder obj is null if the request has an empty body.
         return obj == null ? "" : json.getMapper().writeValueAsString(obj.body);
       }
     } catch (Exception ex) {

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/ApiClient.mustache
@@ -832,7 +832,7 @@ public class ApiClient {
    * @return Entity
    * @throws ApiException API exception
    */
-  public Entity<?> serialize(Object obj, Map<String, Object> formParams, String contentType) throws ApiException {
+  public Entity<?> serialize(BodyHolder obj, Map<String, Object> formParams, String contentType) throws ApiException {
     Entity<?> entity;
     if (contentType.startsWith("multipart/form-data")) {
       MultiPart multiPart = new MultiPart();
@@ -856,7 +856,7 @@ public class ApiClient {
       entity = Entity.entity(form, MediaType.APPLICATION_FORM_URLENCODED_TYPE);
     } else {
       // We let jersey handle the serialization
-      entity = Entity.entity(obj == null ? Entity.text("") : obj, contentType);
+      entity = Entity.entity(obj == null ? Entity.text("") : obj.body, contentType);
     }
     return entity;
   }
@@ -870,7 +870,7 @@ public class ApiClient {
    * @return String
    * @throws ApiException API exception
    */
-  public String serializeToString(Object obj, Map<String, Object> formParams, String contentType) throws ApiException {
+  public String serializeToString(BodyHolder obj, Map<String, Object> formParams, String contentType) throws ApiException {
     try {
       if (contentType.startsWith("multipart/form-data")) {
         throw new ApiException("multipart/form-data not yet supported for serializeToString (http signature authentication)");
@@ -886,7 +886,7 @@ public class ApiClient {
           return formString.substring(0, formString.length() - 1);
         }
       } else {
-        return json.getMapper().writeValueAsString(obj);
+        return obj == null ? "" : json.getMapper().writeValueAsString(obj.body);
       }
     } catch (Exception ex) {
       throw new ApiException("Failed to perform serializeToString: " + ex.toString());
@@ -985,6 +985,19 @@ public class ApiClient {
   }
 
   /**
+   * A wrapper class for the request body.
+   *
+   * This is needed to differentiate between a request without body (e.g. HTTP GET)
+   * versus a request with the 'null' value in the body.
+   */
+  public static class BodyHolder {
+    private Object  body;
+    public BodyHolder(Object body) {
+      this.body = body;
+    }
+  }
+
+  /**
    * Invoke API by sending HTTP request with the given options.
    *
    * @param <T> Type
@@ -1008,7 +1021,7 @@ public class ApiClient {
       String path,
       String method,
       List<Pair> queryParams,
-      Object body,
+      BodyHolder body,
       Map<String, String> headerParams,
       Map<String, String> cookieParams,
       Map<String, Object> formParams,
@@ -1163,7 +1176,7 @@ public class ApiClient {
    * @deprecated Add qualified name of the operation as a first parameter.
    */
   @Deprecated
-  public <T> ApiResponse<T> invokeAPI(String path, String method, List<Pair> queryParams, Object body, Map<String, String> headerParams, Map<String, String> cookieParams, Map<String, Object> formParams, String accept, String contentType, String[] authNames, GenericType<T> returnType) throws ApiException {
+  public <T> ApiResponse<T> invokeAPI(String path, String method, List<Pair> queryParams, BodyHolder body, Map<String, String> headerParams, Map<String, String> cookieParams, Map<String, Object> formParams, String accept, String contentType, String[] authNames, GenericType<T> returnType) throws ApiException {
     return invokeAPI(null, path, method, queryParams, body, headerParams, cookieParams, formParams, accept, contentType, authNames, returnType);
   }
 

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/api.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/api.mustache
@@ -116,7 +116,10 @@ public class {{classname}} {
   @Deprecated
   {{/isDeprecated}}
   public{{/vendorExtensions.x-group-parameters}}{{#vendorExtensions.x-group-parameters}}private{{/vendorExtensions.x-group-parameters}} ApiResponse<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}> {{operationId}}WithHttpInfo({{#allParams}}{{{dataType}}} {{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) throws ApiException {
-    Object localVarPostBody = {{#bodyParam}}{{paramName}}{{/bodyParam}}{{^bodyParam}}null{{/bodyParam}};
+    // BodyHolder is set to null when the HTTP request body is not set (e.g. for HTTP GET requests).
+    // When the body is set (e.g HTTP POST request), the object maybe have a null value which needs
+    // to be serialized as the 'null' value.
+    ApiClient.BodyHolder localVarPostBody = {{#bodyParam}}new ApiClient.BodyHolder({{paramName}}){{/bodyParam}}{{^bodyParam}}null{{/bodyParam}};
     {{#allParams}}{{#required}}
     // verify the required parameter '{{paramName}}' is set
     if ({{paramName}} == null) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/ApiClient.java
@@ -25,13 +25,6 @@ import java.io.IOException;
 import java.io.InputStream;
 
 import java.net.URI;
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.TrustManager;
-import javax.net.ssl.X509TrustManager;
-import java.security.cert.X509Certificate;
-import java.security.KeyManagementException;
-import java.security.NoSuchAlgorithmException;
-import java.security.SecureRandom;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
 import org.glassfish.jersey.logging.LoggingFeature;
@@ -810,6 +803,7 @@ public class ApiClient {
           return formString.substring(0, formString.length() - 1);
         }
       } else {
+        // The BodyHolder obj is null if the request has an empty body.
         return obj == null ? "" : json.getMapper().writeValueAsString(obj.body);
       }
     } catch (Exception ex) {
@@ -1119,62 +1113,11 @@ public class ApiClient {
       java.util.logging.Logger.getLogger("org.glassfish.jersey.client").setLevel(java.util.logging.Level.SEVERE);
     }
     performAdditionalClientConfiguration(clientConfig);
-    ClientBuilder clientBuilder = ClientBuilder.newBuilder();
-    customizeClientBuilder(clientBuilder);
-    clientBuilder = clientBuilder.withConfig(clientConfig);
-    return clientBuilder.build();
+    return ClientBuilder.newClient(clientConfig);
   }
 
-  /**
-   * Perform additional configuration of the API client.
-   * This method can be overriden to customize the API client.
-   */
   protected void performAdditionalClientConfiguration(ClientConfig clientConfig) {
     // No-op extension point
-  }
-
-  /**
-   * Customize the client builder.
-   *
-   * This method can be overriden to customize the API client. For example, this can be used to:
-   * 1. Set the hostname verifier to be used by the client to verify the endpoint's hostname
-   *    against its identification information.
-   * 2. Set the client-side key store.
-   * 3. Set the SSL context that will be used when creating secured transport connections to
-   *    server endpoints from web targets created by the client instance that is using this SSL context.
-   * 4. Set the client-side trust store.
-   *
-   * To completely disable certificate validation (at your own risk), you can
-   * override this method and invoke disableCertificateValidation(clientBuilder).
-   */
-  protected void customizeClientBuilder(ClientBuilder clientBuilder) {
-    // No-op extension point
-  }
-
-  /**
-   * Disable X.509 certificate validation in TLS connections.
-   *
-   * Please note that trusting all certificates is extremely risky.
-   * This may be useful in a development environment with self-signed certificates.
-   */
-  protected void disableCertificateValidation(ClientBuilder clientBuilder) throws KeyManagementException, NoSuchAlgorithmException {
-    TrustManager[] trustAllCerts = new X509TrustManager[] {
-      new X509TrustManager() {
-        @Override
-        public X509Certificate[] getAcceptedIssuers() {
-          return null;
-        }
-        @Override
-        public void checkClientTrusted(X509Certificate[] certs, String authType) {
-        }
-        @Override
-        public void checkServerTrusted(X509Certificate[] certs, String authType) {
-        }
-      }
-    };
-    SSLContext sslContext = SSLContext.getInstance("TLS");
-    sslContext.init(null, trustAllCerts, new SecureRandom());
-    clientBuilder.sslContext(sslContext);
   }
 
   protected Map<String, List<String>> buildResponseHeaders(Response response) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
@@ -74,7 +74,10 @@ public class AnotherFakeApi {
      </table>
    */
   public ApiResponse<Client> call123testSpecialTagsWithHttpInfo(Client body) throws ApiException {
-    Object localVarPostBody = body;
+    // BodyHolder is set to null when the HTTP request body is not set (e.g. for HTTP GET requests).
+    // When the body is set (e.g HTTP POST request), the object maybe have a null value which needs
+    // to be serialized as the 'null' value.
+    ApiClient.BodyHolder localVarPostBody = new ApiClient.BodyHolder(body);
     
     // verify the required parameter 'body' is set
     if (body == null) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -81,7 +81,10 @@ public class FakeApi {
      </table>
    */
   public ApiResponse<Void> createXmlItemWithHttpInfo(XmlItem xmlItem) throws ApiException {
-    Object localVarPostBody = xmlItem;
+    // BodyHolder is set to null when the HTTP request body is not set (e.g. for HTTP GET requests).
+    // When the body is set (e.g HTTP POST request), the object maybe have a null value which needs
+    // to be serialized as the 'null' value.
+    ApiClient.BodyHolder localVarPostBody = new ApiClient.BodyHolder(xmlItem);
     
     // verify the required parameter 'xmlItem' is set
     if (xmlItem == null) {
@@ -146,7 +149,10 @@ public class FakeApi {
      </table>
    */
   public ApiResponse<Boolean> fakeOuterBooleanSerializeWithHttpInfo(Boolean body) throws ApiException {
-    Object localVarPostBody = body;
+    // BodyHolder is set to null when the HTTP request body is not set (e.g. for HTTP GET requests).
+    // When the body is set (e.g HTTP POST request), the object maybe have a null value which needs
+    // to be serialized as the 'null' value.
+    ApiClient.BodyHolder localVarPostBody = new ApiClient.BodyHolder(body);
     
     // create path and map variables
     String localVarPath = "/fake/outer/boolean";
@@ -208,7 +214,10 @@ public class FakeApi {
      </table>
    */
   public ApiResponse<OuterComposite> fakeOuterCompositeSerializeWithHttpInfo(OuterComposite body) throws ApiException {
-    Object localVarPostBody = body;
+    // BodyHolder is set to null when the HTTP request body is not set (e.g. for HTTP GET requests).
+    // When the body is set (e.g HTTP POST request), the object maybe have a null value which needs
+    // to be serialized as the 'null' value.
+    ApiClient.BodyHolder localVarPostBody = new ApiClient.BodyHolder(body);
     
     // create path and map variables
     String localVarPath = "/fake/outer/composite";
@@ -270,7 +279,10 @@ public class FakeApi {
      </table>
    */
   public ApiResponse<BigDecimal> fakeOuterNumberSerializeWithHttpInfo(BigDecimal body) throws ApiException {
-    Object localVarPostBody = body;
+    // BodyHolder is set to null when the HTTP request body is not set (e.g. for HTTP GET requests).
+    // When the body is set (e.g HTTP POST request), the object maybe have a null value which needs
+    // to be serialized as the 'null' value.
+    ApiClient.BodyHolder localVarPostBody = new ApiClient.BodyHolder(body);
     
     // create path and map variables
     String localVarPath = "/fake/outer/number";
@@ -332,7 +344,10 @@ public class FakeApi {
      </table>
    */
   public ApiResponse<String> fakeOuterStringSerializeWithHttpInfo(String body) throws ApiException {
-    Object localVarPostBody = body;
+    // BodyHolder is set to null when the HTTP request body is not set (e.g. for HTTP GET requests).
+    // When the body is set (e.g HTTP POST request), the object maybe have a null value which needs
+    // to be serialized as the 'null' value.
+    ApiClient.BodyHolder localVarPostBody = new ApiClient.BodyHolder(body);
     
     // create path and map variables
     String localVarPath = "/fake/outer/string";
@@ -393,7 +408,10 @@ public class FakeApi {
      </table>
    */
   public ApiResponse<Void> testBodyWithFileSchemaWithHttpInfo(FileSchemaTestClass body) throws ApiException {
-    Object localVarPostBody = body;
+    // BodyHolder is set to null when the HTTP request body is not set (e.g. for HTTP GET requests).
+    // When the body is set (e.g HTTP POST request), the object maybe have a null value which needs
+    // to be serialized as the 'null' value.
+    ApiClient.BodyHolder localVarPostBody = new ApiClient.BodyHolder(body);
     
     // verify the required parameter 'body' is set
     if (body == null) {
@@ -459,7 +477,10 @@ public class FakeApi {
      </table>
    */
   public ApiResponse<Void> testBodyWithQueryParamsWithHttpInfo(String query, User body) throws ApiException {
-    Object localVarPostBody = body;
+    // BodyHolder is set to null when the HTTP request body is not set (e.g. for HTTP GET requests).
+    // When the body is set (e.g HTTP POST request), the object maybe have a null value which needs
+    // to be serialized as the 'null' value.
+    ApiClient.BodyHolder localVarPostBody = new ApiClient.BodyHolder(body);
     
     // verify the required parameter 'query' is set
     if (query == null) {
@@ -530,7 +551,10 @@ public class FakeApi {
      </table>
    */
   public ApiResponse<Client> testClientModelWithHttpInfo(Client body) throws ApiException {
-    Object localVarPostBody = body;
+    // BodyHolder is set to null when the HTTP request body is not set (e.g. for HTTP GET requests).
+    // When the body is set (e.g HTTP POST request), the object maybe have a null value which needs
+    // to be serialized as the 'null' value.
+    ApiClient.BodyHolder localVarPostBody = new ApiClient.BodyHolder(body);
     
     // verify the required parameter 'body' is set
     if (body == null) {
@@ -624,7 +648,10 @@ public class FakeApi {
      </table>
    */
   public ApiResponse<Void> testEndpointParametersWithHttpInfo(BigDecimal number, Double _double, String patternWithoutDelimiter, byte[] _byte, Integer integer, Integer int32, Long int64, Float _float, String string, File binary, LocalDate date, OffsetDateTime dateTime, String password, String paramCallback) throws ApiException {
-    Object localVarPostBody = null;
+    // BodyHolder is set to null when the HTTP request body is not set (e.g. for HTTP GET requests).
+    // When the body is set (e.g HTTP POST request), the object maybe have a null value which needs
+    // to be serialized as the 'null' value.
+    ApiClient.BodyHolder localVarPostBody = null;
     
     // verify the required parameter 'number' is set
     if (number == null) {
@@ -747,7 +774,10 @@ if (paramCallback != null)
      </table>
    */
   public ApiResponse<Void> testEnumParametersWithHttpInfo(List<String> enumHeaderStringArray, String enumHeaderString, List<String> enumQueryStringArray, String enumQueryString, Integer enumQueryInteger, Double enumQueryDouble, List<String> enumFormStringArray, String enumFormString) throws ApiException {
-    Object localVarPostBody = null;
+    // BodyHolder is set to null when the HTTP request body is not set (e.g. for HTTP GET requests).
+    // When the body is set (e.g HTTP POST request), the object maybe have a null value which needs
+    // to be serialized as the 'null' value.
+    ApiClient.BodyHolder localVarPostBody = null;
     
     // create path and map variables
     String localVarPath = "/fake";
@@ -792,7 +822,10 @@ if (enumFormString != null)
   }
 
 private ApiResponse<Void> testGroupParametersWithHttpInfo(Integer requiredStringGroup, Boolean requiredBooleanGroup, Long requiredInt64Group, Integer stringGroup, Boolean booleanGroup, Long int64Group) throws ApiException {
-    Object localVarPostBody = null;
+    // BodyHolder is set to null when the HTTP request body is not set (e.g. for HTTP GET requests).
+    // When the body is set (e.g HTTP POST request), the object maybe have a null value which needs
+    // to be serialized as the 'null' value.
+    ApiClient.BodyHolder localVarPostBody = null;
     
     // verify the required parameter 'requiredStringGroup' is set
     if (requiredStringGroup == null) {
@@ -989,7 +1022,10 @@ if (booleanGroup != null)
      </table>
    */
   public ApiResponse<Void> testInlineAdditionalPropertiesWithHttpInfo(Map<String, String> param) throws ApiException {
-    Object localVarPostBody = param;
+    // BodyHolder is set to null when the HTTP request body is not set (e.g. for HTTP GET requests).
+    // When the body is set (e.g HTTP POST request), the object maybe have a null value which needs
+    // to be serialized as the 'null' value.
+    ApiClient.BodyHolder localVarPostBody = new ApiClient.BodyHolder(param);
     
     // verify the required parameter 'param' is set
     if (param == null) {
@@ -1055,7 +1091,10 @@ if (booleanGroup != null)
      </table>
    */
   public ApiResponse<Void> testJsonFormDataWithHttpInfo(String param, String param2) throws ApiException {
-    Object localVarPostBody = null;
+    // BodyHolder is set to null when the HTTP request body is not set (e.g. for HTTP GET requests).
+    // When the body is set (e.g HTTP POST request), the object maybe have a null value which needs
+    // to be serialized as the 'null' value.
+    ApiClient.BodyHolder localVarPostBody = null;
     
     // verify the required parameter 'param' is set
     if (param == null) {
@@ -1136,7 +1175,10 @@ if (param2 != null)
      </table>
    */
   public ApiResponse<Void> testQueryParameterCollectionFormatWithHttpInfo(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context) throws ApiException {
-    Object localVarPostBody = null;
+    // BodyHolder is set to null when the HTTP request body is not set (e.g. for HTTP GET requests).
+    // When the body is set (e.g HTTP POST request), the object maybe have a null value which needs
+    // to be serialized as the 'null' value.
+    ApiClient.BodyHolder localVarPostBody = null;
     
     // verify the required parameter 'pipe' is set
     if (pipe == null) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
@@ -74,7 +74,10 @@ public class FakeClassnameTags123Api {
      </table>
    */
   public ApiResponse<Client> testClassnameWithHttpInfo(Client body) throws ApiException {
-    Object localVarPostBody = body;
+    // BodyHolder is set to null when the HTTP request body is not set (e.g. for HTTP GET requests).
+    // When the body is set (e.g HTTP POST request), the object maybe have a null value which needs
+    // to be serialized as the 'null' value.
+    ApiClient.BodyHolder localVarPostBody = new ApiClient.BodyHolder(body);
     
     // verify the required parameter 'body' is set
     if (body == null) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/PetApi.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/PetApi.java
@@ -78,7 +78,10 @@ public class PetApi {
      </table>
    */
   public ApiResponse<Void> addPetWithHttpInfo(Pet body) throws ApiException {
-    Object localVarPostBody = body;
+    // BodyHolder is set to null when the HTTP request body is not set (e.g. for HTTP GET requests).
+    // When the body is set (e.g HTTP POST request), the object maybe have a null value which needs
+    // to be serialized as the 'null' value.
+    ApiClient.BodyHolder localVarPostBody = new ApiClient.BodyHolder(body);
     
     // verify the required parameter 'body' is set
     if (body == null) {
@@ -146,7 +149,10 @@ public class PetApi {
      </table>
    */
   public ApiResponse<Void> deletePetWithHttpInfo(Long petId, String apiKey) throws ApiException {
-    Object localVarPostBody = null;
+    // BodyHolder is set to null when the HTTP request body is not set (e.g. for HTTP GET requests).
+    // When the body is set (e.g HTTP POST request), the object maybe have a null value which needs
+    // to be serialized as the 'null' value.
+    ApiClient.BodyHolder localVarPostBody = null;
     
     // verify the required parameter 'petId' is set
     if (petId == null) {
@@ -216,7 +222,10 @@ public class PetApi {
      </table>
    */
   public ApiResponse<List<Pet>> findPetsByStatusWithHttpInfo(List<String> status) throws ApiException {
-    Object localVarPostBody = null;
+    // BodyHolder is set to null when the HTTP request body is not set (e.g. for HTTP GET requests).
+    // When the body is set (e.g HTTP POST request), the object maybe have a null value which needs
+    // to be serialized as the 'null' value.
+    ApiClient.BodyHolder localVarPostBody = null;
     
     // verify the required parameter 'status' is set
     if (status == null) {
@@ -290,7 +299,10 @@ public class PetApi {
    */
   @Deprecated
   public ApiResponse<Set<Pet>> findPetsByTagsWithHttpInfo(Set<String> tags) throws ApiException {
-    Object localVarPostBody = null;
+    // BodyHolder is set to null when the HTTP request body is not set (e.g. for HTTP GET requests).
+    // When the body is set (e.g HTTP POST request), the object maybe have a null value which needs
+    // to be serialized as the 'null' value.
+    ApiClient.BodyHolder localVarPostBody = null;
     
     // verify the required parameter 'tags' is set
     if (tags == null) {
@@ -362,7 +374,10 @@ public class PetApi {
      </table>
    */
   public ApiResponse<Pet> getPetByIdWithHttpInfo(Long petId) throws ApiException {
-    Object localVarPostBody = null;
+    // BodyHolder is set to null when the HTTP request body is not set (e.g. for HTTP GET requests).
+    // When the body is set (e.g HTTP POST request), the object maybe have a null value which needs
+    // to be serialized as the 'null' value.
+    ApiClient.BodyHolder localVarPostBody = null;
     
     // verify the required parameter 'petId' is set
     if (petId == null) {
@@ -435,7 +450,10 @@ public class PetApi {
      </table>
    */
   public ApiResponse<Void> updatePetWithHttpInfo(Pet body) throws ApiException {
-    Object localVarPostBody = body;
+    // BodyHolder is set to null when the HTTP request body is not set (e.g. for HTTP GET requests).
+    // When the body is set (e.g HTTP POST request), the object maybe have a null value which needs
+    // to be serialized as the 'null' value.
+    ApiClient.BodyHolder localVarPostBody = new ApiClient.BodyHolder(body);
     
     // verify the required parameter 'body' is set
     if (body == null) {
@@ -503,7 +521,10 @@ public class PetApi {
      </table>
    */
   public ApiResponse<Void> updatePetWithFormWithHttpInfo(Long petId, String name, String status) throws ApiException {
-    Object localVarPostBody = null;
+    // BodyHolder is set to null when the HTTP request body is not set (e.g. for HTTP GET requests).
+    // When the body is set (e.g HTTP POST request), the object maybe have a null value which needs
+    // to be serialized as the 'null' value.
+    ApiClient.BodyHolder localVarPostBody = null;
     
     // verify the required parameter 'petId' is set
     if (petId == null) {
@@ -577,7 +598,10 @@ if (status != null)
      </table>
    */
   public ApiResponse<ModelApiResponse> uploadFileWithHttpInfo(Long petId, String additionalMetadata, File file) throws ApiException {
-    Object localVarPostBody = null;
+    // BodyHolder is set to null when the HTTP request body is not set (e.g. for HTTP GET requests).
+    // When the body is set (e.g HTTP POST request), the object maybe have a null value which needs
+    // to be serialized as the 'null' value.
+    ApiClient.BodyHolder localVarPostBody = null;
     
     // verify the required parameter 'petId' is set
     if (petId == null) {
@@ -653,7 +677,10 @@ if (file != null)
      </table>
    */
   public ApiResponse<ModelApiResponse> uploadFileWithRequiredFileWithHttpInfo(Long petId, File requiredFile, String additionalMetadata) throws ApiException {
-    Object localVarPostBody = null;
+    // BodyHolder is set to null when the HTTP request body is not set (e.g. for HTTP GET requests).
+    // When the body is set (e.g HTTP POST request), the object maybe have a null value which needs
+    // to be serialized as the 'null' value.
+    ApiClient.BodyHolder localVarPostBody = null;
     
     // verify the required parameter 'petId' is set
     if (petId == null) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/StoreApi.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/StoreApi.java
@@ -75,7 +75,10 @@ public class StoreApi {
      </table>
    */
   public ApiResponse<Void> deleteOrderWithHttpInfo(String orderId) throws ApiException {
-    Object localVarPostBody = null;
+    // BodyHolder is set to null when the HTTP request body is not set (e.g. for HTTP GET requests).
+    // When the body is set (e.g HTTP POST request), the object maybe have a null value which needs
+    // to be serialized as the 'null' value.
+    ApiClient.BodyHolder localVarPostBody = null;
     
     // verify the required parameter 'orderId' is set
     if (orderId == null) {
@@ -139,7 +142,10 @@ public class StoreApi {
      </table>
    */
   public ApiResponse<Map<String, Integer>> getInventoryWithHttpInfo() throws ApiException {
-    Object localVarPostBody = null;
+    // BodyHolder is set to null when the HTTP request body is not set (e.g. for HTTP GET requests).
+    // When the body is set (e.g HTTP POST request), the object maybe have a null value which needs
+    // to be serialized as the 'null' value.
+    ApiClient.BodyHolder localVarPostBody = null;
     
     // create path and map variables
     String localVarPath = "/store/inventory";
@@ -205,7 +211,10 @@ public class StoreApi {
      </table>
    */
   public ApiResponse<Order> getOrderByIdWithHttpInfo(Long orderId) throws ApiException {
-    Object localVarPostBody = null;
+    // BodyHolder is set to null when the HTTP request body is not set (e.g. for HTTP GET requests).
+    // When the body is set (e.g HTTP POST request), the object maybe have a null value which needs
+    // to be serialized as the 'null' value.
+    ApiClient.BodyHolder localVarPostBody = null;
     
     // verify the required parameter 'orderId' is set
     if (orderId == null) {
@@ -275,7 +284,10 @@ public class StoreApi {
      </table>
    */
   public ApiResponse<Order> placeOrderWithHttpInfo(Order body) throws ApiException {
-    Object localVarPostBody = body;
+    // BodyHolder is set to null when the HTTP request body is not set (e.g. for HTTP GET requests).
+    // When the body is set (e.g HTTP POST request), the object maybe have a null value which needs
+    // to be serialized as the 'null' value.
+    ApiClient.BodyHolder localVarPostBody = new ApiClient.BodyHolder(body);
     
     // verify the required parameter 'body' is set
     if (body == null) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/UserApi.java
@@ -73,7 +73,10 @@ public class UserApi {
      </table>
    */
   public ApiResponse<Void> createUserWithHttpInfo(User body) throws ApiException {
-    Object localVarPostBody = body;
+    // BodyHolder is set to null when the HTTP request body is not set (e.g. for HTTP GET requests).
+    // When the body is set (e.g HTTP POST request), the object maybe have a null value which needs
+    // to be serialized as the 'null' value.
+    ApiClient.BodyHolder localVarPostBody = new ApiClient.BodyHolder(body);
     
     // verify the required parameter 'body' is set
     if (body == null) {
@@ -137,7 +140,10 @@ public class UserApi {
      </table>
    */
   public ApiResponse<Void> createUsersWithArrayInputWithHttpInfo(List<User> body) throws ApiException {
-    Object localVarPostBody = body;
+    // BodyHolder is set to null when the HTTP request body is not set (e.g. for HTTP GET requests).
+    // When the body is set (e.g HTTP POST request), the object maybe have a null value which needs
+    // to be serialized as the 'null' value.
+    ApiClient.BodyHolder localVarPostBody = new ApiClient.BodyHolder(body);
     
     // verify the required parameter 'body' is set
     if (body == null) {
@@ -201,7 +207,10 @@ public class UserApi {
      </table>
    */
   public ApiResponse<Void> createUsersWithListInputWithHttpInfo(List<User> body) throws ApiException {
-    Object localVarPostBody = body;
+    // BodyHolder is set to null when the HTTP request body is not set (e.g. for HTTP GET requests).
+    // When the body is set (e.g HTTP POST request), the object maybe have a null value which needs
+    // to be serialized as the 'null' value.
+    ApiClient.BodyHolder localVarPostBody = new ApiClient.BodyHolder(body);
     
     // verify the required parameter 'body' is set
     if (body == null) {
@@ -267,7 +276,10 @@ public class UserApi {
      </table>
    */
   public ApiResponse<Void> deleteUserWithHttpInfo(String username) throws ApiException {
-    Object localVarPostBody = null;
+    // BodyHolder is set to null when the HTTP request body is not set (e.g. for HTTP GET requests).
+    // When the body is set (e.g HTTP POST request), the object maybe have a null value which needs
+    // to be serialized as the 'null' value.
+    ApiClient.BodyHolder localVarPostBody = null;
     
     // verify the required parameter 'username' is set
     if (username == null) {
@@ -337,7 +349,10 @@ public class UserApi {
      </table>
    */
   public ApiResponse<User> getUserByNameWithHttpInfo(String username) throws ApiException {
-    Object localVarPostBody = null;
+    // BodyHolder is set to null when the HTTP request body is not set (e.g. for HTTP GET requests).
+    // When the body is set (e.g HTTP POST request), the object maybe have a null value which needs
+    // to be serialized as the 'null' value.
+    ApiClient.BodyHolder localVarPostBody = null;
     
     // verify the required parameter 'username' is set
     if (username == null) {
@@ -409,7 +424,10 @@ public class UserApi {
      </table>
    */
   public ApiResponse<String> loginUserWithHttpInfo(String username, String password) throws ApiException {
-    Object localVarPostBody = null;
+    // BodyHolder is set to null when the HTTP request body is not set (e.g. for HTTP GET requests).
+    // When the body is set (e.g HTTP POST request), the object maybe have a null value which needs
+    // to be serialized as the 'null' value.
+    ApiClient.BodyHolder localVarPostBody = null;
     
     // verify the required parameter 'username' is set
     if (username == null) {
@@ -480,7 +498,10 @@ public class UserApi {
      </table>
    */
   public ApiResponse<Void> logoutUserWithHttpInfo() throws ApiException {
-    Object localVarPostBody = null;
+    // BodyHolder is set to null when the HTTP request body is not set (e.g. for HTTP GET requests).
+    // When the body is set (e.g HTTP POST request), the object maybe have a null value which needs
+    // to be serialized as the 'null' value.
+    ApiClient.BodyHolder localVarPostBody = null;
     
     // create path and map variables
     String localVarPath = "/user/logout";
@@ -543,7 +564,10 @@ public class UserApi {
      </table>
    */
   public ApiResponse<Void> updateUserWithHttpInfo(String username, User body) throws ApiException {
-    Object localVarPostBody = body;
+    // BodyHolder is set to null when the HTTP request body is not set (e.g. for HTTP GET requests).
+    // When the body is set (e.g HTTP POST request), the object maybe have a null value which needs
+    // to be serialized as the 'null' value.
+    ApiClient.BodyHolder localVarPostBody = new ApiClient.BodyHolder(body);
     
     // verify the required parameter 'username' is set
     if (username == null) {

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/ApiClient.java
@@ -882,6 +882,7 @@ public class ApiClient {
           return formString.substring(0, formString.length() - 1);
         }
       } else {
+        // The BodyHolder obj is null if the request has an empty body.
         return obj == null ? "" : json.getMapper().writeValueAsString(obj.body);
       }
     } catch (Exception ex) {

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/ApiClient.java
@@ -828,7 +828,7 @@ public class ApiClient {
    * @return Entity
    * @throws ApiException API exception
    */
-  public Entity<?> serialize(Object obj, Map<String, Object> formParams, String contentType) throws ApiException {
+  public Entity<?> serialize(BodyHolder obj, Map<String, Object> formParams, String contentType) throws ApiException {
     Entity<?> entity;
     if (contentType.startsWith("multipart/form-data")) {
       MultiPart multiPart = new MultiPart();
@@ -852,7 +852,7 @@ public class ApiClient {
       entity = Entity.entity(form, MediaType.APPLICATION_FORM_URLENCODED_TYPE);
     } else {
       // We let jersey handle the serialization
-      entity = Entity.entity(obj == null ? Entity.text("") : obj, contentType);
+      entity = Entity.entity(obj == null ? Entity.text("") : obj.body, contentType);
     }
     return entity;
   }
@@ -866,7 +866,7 @@ public class ApiClient {
    * @return String
    * @throws ApiException API exception
    */
-  public String serializeToString(Object obj, Map<String, Object> formParams, String contentType) throws ApiException {
+  public String serializeToString(BodyHolder obj, Map<String, Object> formParams, String contentType) throws ApiException {
     try {
       if (contentType.startsWith("multipart/form-data")) {
         throw new ApiException("multipart/form-data not yet supported for serializeToString (http signature authentication)");
@@ -882,7 +882,7 @@ public class ApiClient {
           return formString.substring(0, formString.length() - 1);
         }
       } else {
-        return json.getMapper().writeValueAsString(obj);
+        return obj == null ? "" : json.getMapper().writeValueAsString(obj.body);
       }
     } catch (Exception ex) {
       throw new ApiException("Failed to perform serializeToString: " + ex.toString());
@@ -975,6 +975,19 @@ public class ApiClient {
   }
 
   /**
+   * A wrapper class for the request body.
+   *
+   * This is needed to differentiate between a request without body (e.g. HTTP GET)
+   * versus a request with the 'null' value in the body.
+   */
+  public static class BodyHolder {
+    private Object  body;
+    public BodyHolder(Object body) {
+      this.body = body;
+    }
+  }
+
+  /**
    * Invoke API by sending HTTP request with the given options.
    *
    * @param <T> Type
@@ -998,7 +1011,7 @@ public class ApiClient {
       String path,
       String method,
       List<Pair> queryParams,
-      Object body,
+      BodyHolder body,
       Map<String, String> headerParams,
       Map<String, String> cookieParams,
       Map<String, Object> formParams,
@@ -1151,7 +1164,7 @@ public class ApiClient {
    * @deprecated Add qualified name of the operation as a first parameter.
    */
   @Deprecated
-  public <T> ApiResponse<T> invokeAPI(String path, String method, List<Pair> queryParams, Object body, Map<String, String> headerParams, Map<String, String> cookieParams, Map<String, Object> formParams, String accept, String contentType, String[] authNames, GenericType<T> returnType) throws ApiException {
+  public <T> ApiResponse<T> invokeAPI(String path, String method, List<Pair> queryParams, BodyHolder body, Map<String, String> headerParams, Map<String, String> cookieParams, Map<String, Object> formParams, String accept, String contentType, String[] authNames, GenericType<T> returnType) throws ApiException {
     return invokeAPI(null, path, method, queryParams, body, headerParams, cookieParams, formParams, accept, contentType, authNames, returnType);
   }
 

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
@@ -74,7 +74,10 @@ public class AnotherFakeApi {
      </table>
    */
   public ApiResponse<Client> call123testSpecialTagsWithHttpInfo(Client client) throws ApiException {
-    Object localVarPostBody = client;
+    // BodyHolder is set to null when the HTTP request body is not set (e.g. for HTTP GET requests).
+    // When the body is set (e.g HTTP POST request), the object maybe have a null value which needs
+    // to be serialized as the 'null' value.
+    ApiClient.BodyHolder localVarPostBody = new ApiClient.BodyHolder(client);
     
     // verify the required parameter 'client' is set
     if (client == null) {

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/DefaultApi.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/DefaultApi.java
@@ -72,7 +72,10 @@ public class DefaultApi {
      </table>
    */
   public ApiResponse<InlineResponseDefault> fooGetWithHttpInfo() throws ApiException {
-    Object localVarPostBody = null;
+    // BodyHolder is set to null when the HTTP request body is not set (e.g. for HTTP GET requests).
+    // When the body is set (e.g HTTP POST request), the object maybe have a null value which needs
+    // to be serialized as the 'null' value.
+    ApiClient.BodyHolder localVarPostBody = null;
     
     // create path and map variables
     String localVarPath = "/foo";

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -81,7 +81,10 @@ public class FakeApi {
      </table>
    */
   public ApiResponse<HealthCheckResult> fakeHealthGetWithHttpInfo() throws ApiException {
-    Object localVarPostBody = null;
+    // BodyHolder is set to null when the HTTP request body is not set (e.g. for HTTP GET requests).
+    // When the body is set (e.g HTTP POST request), the object maybe have a null value which needs
+    // to be serialized as the 'null' value.
+    ApiClient.BodyHolder localVarPostBody = null;
     
     // create path and map variables
     String localVarPath = "/fake/health";
@@ -143,7 +146,10 @@ public class FakeApi {
      </table>
    */
   public ApiResponse<Boolean> fakeOuterBooleanSerializeWithHttpInfo(Boolean body) throws ApiException {
-    Object localVarPostBody = body;
+    // BodyHolder is set to null when the HTTP request body is not set (e.g. for HTTP GET requests).
+    // When the body is set (e.g HTTP POST request), the object maybe have a null value which needs
+    // to be serialized as the 'null' value.
+    ApiClient.BodyHolder localVarPostBody = new ApiClient.BodyHolder(body);
     
     // create path and map variables
     String localVarPath = "/fake/outer/boolean";
@@ -205,7 +211,10 @@ public class FakeApi {
      </table>
    */
   public ApiResponse<OuterComposite> fakeOuterCompositeSerializeWithHttpInfo(OuterComposite outerComposite) throws ApiException {
-    Object localVarPostBody = outerComposite;
+    // BodyHolder is set to null when the HTTP request body is not set (e.g. for HTTP GET requests).
+    // When the body is set (e.g HTTP POST request), the object maybe have a null value which needs
+    // to be serialized as the 'null' value.
+    ApiClient.BodyHolder localVarPostBody = new ApiClient.BodyHolder(outerComposite);
     
     // create path and map variables
     String localVarPath = "/fake/outer/composite";
@@ -267,7 +276,10 @@ public class FakeApi {
      </table>
    */
   public ApiResponse<BigDecimal> fakeOuterNumberSerializeWithHttpInfo(BigDecimal body) throws ApiException {
-    Object localVarPostBody = body;
+    // BodyHolder is set to null when the HTTP request body is not set (e.g. for HTTP GET requests).
+    // When the body is set (e.g HTTP POST request), the object maybe have a null value which needs
+    // to be serialized as the 'null' value.
+    ApiClient.BodyHolder localVarPostBody = new ApiClient.BodyHolder(body);
     
     // create path and map variables
     String localVarPath = "/fake/outer/number";
@@ -329,7 +341,10 @@ public class FakeApi {
      </table>
    */
   public ApiResponse<String> fakeOuterStringSerializeWithHttpInfo(String body) throws ApiException {
-    Object localVarPostBody = body;
+    // BodyHolder is set to null when the HTTP request body is not set (e.g. for HTTP GET requests).
+    // When the body is set (e.g HTTP POST request), the object maybe have a null value which needs
+    // to be serialized as the 'null' value.
+    ApiClient.BodyHolder localVarPostBody = new ApiClient.BodyHolder(body);
     
     // create path and map variables
     String localVarPath = "/fake/outer/string";
@@ -389,7 +404,10 @@ public class FakeApi {
      </table>
    */
   public ApiResponse<List<OuterEnum>> getArrayOfEnumsWithHttpInfo() throws ApiException {
-    Object localVarPostBody = null;
+    // BodyHolder is set to null when the HTTP request body is not set (e.g. for HTTP GET requests).
+    // When the body is set (e.g HTTP POST request), the object maybe have a null value which needs
+    // to be serialized as the 'null' value.
+    ApiClient.BodyHolder localVarPostBody = null;
     
     // create path and map variables
     String localVarPath = "/fake/array-of-enums";
@@ -450,7 +468,10 @@ public class FakeApi {
      </table>
    */
   public ApiResponse<Void> testBodyWithFileSchemaWithHttpInfo(FileSchemaTestClass fileSchemaTestClass) throws ApiException {
-    Object localVarPostBody = fileSchemaTestClass;
+    // BodyHolder is set to null when the HTTP request body is not set (e.g. for HTTP GET requests).
+    // When the body is set (e.g HTTP POST request), the object maybe have a null value which needs
+    // to be serialized as the 'null' value.
+    ApiClient.BodyHolder localVarPostBody = new ApiClient.BodyHolder(fileSchemaTestClass);
     
     // verify the required parameter 'fileSchemaTestClass' is set
     if (fileSchemaTestClass == null) {
@@ -516,7 +537,10 @@ public class FakeApi {
      </table>
    */
   public ApiResponse<Void> testBodyWithQueryParamsWithHttpInfo(String query, User user) throws ApiException {
-    Object localVarPostBody = user;
+    // BodyHolder is set to null when the HTTP request body is not set (e.g. for HTTP GET requests).
+    // When the body is set (e.g HTTP POST request), the object maybe have a null value which needs
+    // to be serialized as the 'null' value.
+    ApiClient.BodyHolder localVarPostBody = new ApiClient.BodyHolder(user);
     
     // verify the required parameter 'query' is set
     if (query == null) {
@@ -587,7 +611,10 @@ public class FakeApi {
      </table>
    */
   public ApiResponse<Client> testClientModelWithHttpInfo(Client client) throws ApiException {
-    Object localVarPostBody = client;
+    // BodyHolder is set to null when the HTTP request body is not set (e.g. for HTTP GET requests).
+    // When the body is set (e.g HTTP POST request), the object maybe have a null value which needs
+    // to be serialized as the 'null' value.
+    ApiClient.BodyHolder localVarPostBody = new ApiClient.BodyHolder(client);
     
     // verify the required parameter 'client' is set
     if (client == null) {
@@ -681,7 +708,10 @@ public class FakeApi {
      </table>
    */
   public ApiResponse<Void> testEndpointParametersWithHttpInfo(BigDecimal number, Double _double, String patternWithoutDelimiter, byte[] _byte, Integer integer, Integer int32, Long int64, Float _float, String string, File binary, LocalDate date, OffsetDateTime dateTime, String password, String paramCallback) throws ApiException {
-    Object localVarPostBody = null;
+    // BodyHolder is set to null when the HTTP request body is not set (e.g. for HTTP GET requests).
+    // When the body is set (e.g HTTP POST request), the object maybe have a null value which needs
+    // to be serialized as the 'null' value.
+    ApiClient.BodyHolder localVarPostBody = null;
     
     // verify the required parameter 'number' is set
     if (number == null) {
@@ -804,7 +834,10 @@ if (paramCallback != null)
      </table>
    */
   public ApiResponse<Void> testEnumParametersWithHttpInfo(List<String> enumHeaderStringArray, String enumHeaderString, List<String> enumQueryStringArray, String enumQueryString, Integer enumQueryInteger, Double enumQueryDouble, List<String> enumFormStringArray, String enumFormString) throws ApiException {
-    Object localVarPostBody = null;
+    // BodyHolder is set to null when the HTTP request body is not set (e.g. for HTTP GET requests).
+    // When the body is set (e.g HTTP POST request), the object maybe have a null value which needs
+    // to be serialized as the 'null' value.
+    ApiClient.BodyHolder localVarPostBody = null;
     
     // create path and map variables
     String localVarPath = "/fake";
@@ -849,7 +882,10 @@ if (enumFormString != null)
   }
 
 private ApiResponse<Void> testGroupParametersWithHttpInfo(Integer requiredStringGroup, Boolean requiredBooleanGroup, Long requiredInt64Group, Integer stringGroup, Boolean booleanGroup, Long int64Group) throws ApiException {
-    Object localVarPostBody = null;
+    // BodyHolder is set to null when the HTTP request body is not set (e.g. for HTTP GET requests).
+    // When the body is set (e.g HTTP POST request), the object maybe have a null value which needs
+    // to be serialized as the 'null' value.
+    ApiClient.BodyHolder localVarPostBody = null;
     
     // verify the required parameter 'requiredStringGroup' is set
     if (requiredStringGroup == null) {
@@ -1046,7 +1082,10 @@ if (booleanGroup != null)
      </table>
    */
   public ApiResponse<Void> testInlineAdditionalPropertiesWithHttpInfo(Map<String, String> requestBody) throws ApiException {
-    Object localVarPostBody = requestBody;
+    // BodyHolder is set to null when the HTTP request body is not set (e.g. for HTTP GET requests).
+    // When the body is set (e.g HTTP POST request), the object maybe have a null value which needs
+    // to be serialized as the 'null' value.
+    ApiClient.BodyHolder localVarPostBody = new ApiClient.BodyHolder(requestBody);
     
     // verify the required parameter 'requestBody' is set
     if (requestBody == null) {
@@ -1112,7 +1151,10 @@ if (booleanGroup != null)
      </table>
    */
   public ApiResponse<Void> testJsonFormDataWithHttpInfo(String param, String param2) throws ApiException {
-    Object localVarPostBody = null;
+    // BodyHolder is set to null when the HTTP request body is not set (e.g. for HTTP GET requests).
+    // When the body is set (e.g HTTP POST request), the object maybe have a null value which needs
+    // to be serialized as the 'null' value.
+    ApiClient.BodyHolder localVarPostBody = null;
     
     // verify the required parameter 'param' is set
     if (param == null) {
@@ -1193,7 +1235,10 @@ if (param2 != null)
      </table>
    */
   public ApiResponse<Void> testQueryParameterCollectionFormatWithHttpInfo(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context) throws ApiException {
-    Object localVarPostBody = null;
+    // BodyHolder is set to null when the HTTP request body is not set (e.g. for HTTP GET requests).
+    // When the body is set (e.g HTTP POST request), the object maybe have a null value which needs
+    // to be serialized as the 'null' value.
+    ApiClient.BodyHolder localVarPostBody = null;
     
     // verify the required parameter 'pipe' is set
     if (pipe == null) {

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
@@ -74,7 +74,10 @@ public class FakeClassnameTags123Api {
      </table>
    */
   public ApiResponse<Client> testClassnameWithHttpInfo(Client client) throws ApiException {
-    Object localVarPostBody = client;
+    // BodyHolder is set to null when the HTTP request body is not set (e.g. for HTTP GET requests).
+    // When the body is set (e.g HTTP POST request), the object maybe have a null value which needs
+    // to be serialized as the 'null' value.
+    ApiClient.BodyHolder localVarPostBody = new ApiClient.BodyHolder(client);
     
     // verify the required parameter 'client' is set
     if (client == null) {

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/PetApi.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/PetApi.java
@@ -75,7 +75,10 @@ public class PetApi {
      </table>
    */
   public ApiResponse<Void> addPetWithHttpInfo(Pet pet) throws ApiException {
-    Object localVarPostBody = pet;
+    // BodyHolder is set to null when the HTTP request body is not set (e.g. for HTTP GET requests).
+    // When the body is set (e.g HTTP POST request), the object maybe have a null value which needs
+    // to be serialized as the 'null' value.
+    ApiClient.BodyHolder localVarPostBody = new ApiClient.BodyHolder(pet);
     
     // verify the required parameter 'pet' is set
     if (pet == null) {
@@ -141,7 +144,10 @@ public class PetApi {
      </table>
    */
   public ApiResponse<Void> deletePetWithHttpInfo(Long petId, String apiKey) throws ApiException {
-    Object localVarPostBody = null;
+    // BodyHolder is set to null when the HTTP request body is not set (e.g. for HTTP GET requests).
+    // When the body is set (e.g HTTP POST request), the object maybe have a null value which needs
+    // to be serialized as the 'null' value.
+    ApiClient.BodyHolder localVarPostBody = null;
     
     // verify the required parameter 'petId' is set
     if (petId == null) {
@@ -211,7 +217,10 @@ public class PetApi {
      </table>
    */
   public ApiResponse<List<Pet>> findPetsByStatusWithHttpInfo(List<String> status) throws ApiException {
-    Object localVarPostBody = null;
+    // BodyHolder is set to null when the HTTP request body is not set (e.g. for HTTP GET requests).
+    // When the body is set (e.g HTTP POST request), the object maybe have a null value which needs
+    // to be serialized as the 'null' value.
+    ApiClient.BodyHolder localVarPostBody = null;
     
     // verify the required parameter 'status' is set
     if (status == null) {
@@ -285,7 +294,10 @@ public class PetApi {
    */
   @Deprecated
   public ApiResponse<List<Pet>> findPetsByTagsWithHttpInfo(List<String> tags) throws ApiException {
-    Object localVarPostBody = null;
+    // BodyHolder is set to null when the HTTP request body is not set (e.g. for HTTP GET requests).
+    // When the body is set (e.g HTTP POST request), the object maybe have a null value which needs
+    // to be serialized as the 'null' value.
+    ApiClient.BodyHolder localVarPostBody = null;
     
     // verify the required parameter 'tags' is set
     if (tags == null) {
@@ -357,7 +369,10 @@ public class PetApi {
      </table>
    */
   public ApiResponse<Pet> getPetByIdWithHttpInfo(Long petId) throws ApiException {
-    Object localVarPostBody = null;
+    // BodyHolder is set to null when the HTTP request body is not set (e.g. for HTTP GET requests).
+    // When the body is set (e.g HTTP POST request), the object maybe have a null value which needs
+    // to be serialized as the 'null' value.
+    ApiClient.BodyHolder localVarPostBody = null;
     
     // verify the required parameter 'petId' is set
     if (petId == null) {
@@ -428,7 +443,10 @@ public class PetApi {
      </table>
    */
   public ApiResponse<Void> updatePetWithHttpInfo(Pet pet) throws ApiException {
-    Object localVarPostBody = pet;
+    // BodyHolder is set to null when the HTTP request body is not set (e.g. for HTTP GET requests).
+    // When the body is set (e.g HTTP POST request), the object maybe have a null value which needs
+    // to be serialized as the 'null' value.
+    ApiClient.BodyHolder localVarPostBody = new ApiClient.BodyHolder(pet);
     
     // verify the required parameter 'pet' is set
     if (pet == null) {
@@ -496,7 +514,10 @@ public class PetApi {
      </table>
    */
   public ApiResponse<Void> updatePetWithFormWithHttpInfo(Long petId, String name, String status) throws ApiException {
-    Object localVarPostBody = null;
+    // BodyHolder is set to null when the HTTP request body is not set (e.g. for HTTP GET requests).
+    // When the body is set (e.g HTTP POST request), the object maybe have a null value which needs
+    // to be serialized as the 'null' value.
+    ApiClient.BodyHolder localVarPostBody = null;
     
     // verify the required parameter 'petId' is set
     if (petId == null) {
@@ -570,7 +591,10 @@ if (status != null)
      </table>
    */
   public ApiResponse<ModelApiResponse> uploadFileWithHttpInfo(Long petId, String additionalMetadata, File file) throws ApiException {
-    Object localVarPostBody = null;
+    // BodyHolder is set to null when the HTTP request body is not set (e.g. for HTTP GET requests).
+    // When the body is set (e.g HTTP POST request), the object maybe have a null value which needs
+    // to be serialized as the 'null' value.
+    ApiClient.BodyHolder localVarPostBody = null;
     
     // verify the required parameter 'petId' is set
     if (petId == null) {
@@ -646,7 +670,10 @@ if (file != null)
      </table>
    */
   public ApiResponse<ModelApiResponse> uploadFileWithRequiredFileWithHttpInfo(Long petId, File requiredFile, String additionalMetadata) throws ApiException {
-    Object localVarPostBody = null;
+    // BodyHolder is set to null when the HTTP request body is not set (e.g. for HTTP GET requests).
+    // When the body is set (e.g HTTP POST request), the object maybe have a null value which needs
+    // to be serialized as the 'null' value.
+    ApiClient.BodyHolder localVarPostBody = null;
     
     // verify the required parameter 'petId' is set
     if (petId == null) {

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/StoreApi.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/StoreApi.java
@@ -75,7 +75,10 @@ public class StoreApi {
      </table>
    */
   public ApiResponse<Void> deleteOrderWithHttpInfo(String orderId) throws ApiException {
-    Object localVarPostBody = null;
+    // BodyHolder is set to null when the HTTP request body is not set (e.g. for HTTP GET requests).
+    // When the body is set (e.g HTTP POST request), the object maybe have a null value which needs
+    // to be serialized as the 'null' value.
+    ApiClient.BodyHolder localVarPostBody = null;
     
     // verify the required parameter 'orderId' is set
     if (orderId == null) {
@@ -139,7 +142,10 @@ public class StoreApi {
      </table>
    */
   public ApiResponse<Map<String, Integer>> getInventoryWithHttpInfo() throws ApiException {
-    Object localVarPostBody = null;
+    // BodyHolder is set to null when the HTTP request body is not set (e.g. for HTTP GET requests).
+    // When the body is set (e.g HTTP POST request), the object maybe have a null value which needs
+    // to be serialized as the 'null' value.
+    ApiClient.BodyHolder localVarPostBody = null;
     
     // create path and map variables
     String localVarPath = "/store/inventory";
@@ -205,7 +211,10 @@ public class StoreApi {
      </table>
    */
   public ApiResponse<Order> getOrderByIdWithHttpInfo(Long orderId) throws ApiException {
-    Object localVarPostBody = null;
+    // BodyHolder is set to null when the HTTP request body is not set (e.g. for HTTP GET requests).
+    // When the body is set (e.g HTTP POST request), the object maybe have a null value which needs
+    // to be serialized as the 'null' value.
+    ApiClient.BodyHolder localVarPostBody = null;
     
     // verify the required parameter 'orderId' is set
     if (orderId == null) {
@@ -275,7 +284,10 @@ public class StoreApi {
      </table>
    */
   public ApiResponse<Order> placeOrderWithHttpInfo(Order order) throws ApiException {
-    Object localVarPostBody = order;
+    // BodyHolder is set to null when the HTTP request body is not set (e.g. for HTTP GET requests).
+    // When the body is set (e.g HTTP POST request), the object maybe have a null value which needs
+    // to be serialized as the 'null' value.
+    ApiClient.BodyHolder localVarPostBody = new ApiClient.BodyHolder(order);
     
     // verify the required parameter 'order' is set
     if (order == null) {

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/UserApi.java
@@ -73,7 +73,10 @@ public class UserApi {
      </table>
    */
   public ApiResponse<Void> createUserWithHttpInfo(User user) throws ApiException {
-    Object localVarPostBody = user;
+    // BodyHolder is set to null when the HTTP request body is not set (e.g. for HTTP GET requests).
+    // When the body is set (e.g HTTP POST request), the object maybe have a null value which needs
+    // to be serialized as the 'null' value.
+    ApiClient.BodyHolder localVarPostBody = new ApiClient.BodyHolder(user);
     
     // verify the required parameter 'user' is set
     if (user == null) {
@@ -137,7 +140,10 @@ public class UserApi {
      </table>
    */
   public ApiResponse<Void> createUsersWithArrayInputWithHttpInfo(List<User> user) throws ApiException {
-    Object localVarPostBody = user;
+    // BodyHolder is set to null when the HTTP request body is not set (e.g. for HTTP GET requests).
+    // When the body is set (e.g HTTP POST request), the object maybe have a null value which needs
+    // to be serialized as the 'null' value.
+    ApiClient.BodyHolder localVarPostBody = new ApiClient.BodyHolder(user);
     
     // verify the required parameter 'user' is set
     if (user == null) {
@@ -201,7 +207,10 @@ public class UserApi {
      </table>
    */
   public ApiResponse<Void> createUsersWithListInputWithHttpInfo(List<User> user) throws ApiException {
-    Object localVarPostBody = user;
+    // BodyHolder is set to null when the HTTP request body is not set (e.g. for HTTP GET requests).
+    // When the body is set (e.g HTTP POST request), the object maybe have a null value which needs
+    // to be serialized as the 'null' value.
+    ApiClient.BodyHolder localVarPostBody = new ApiClient.BodyHolder(user);
     
     // verify the required parameter 'user' is set
     if (user == null) {
@@ -267,7 +276,10 @@ public class UserApi {
      </table>
    */
   public ApiResponse<Void> deleteUserWithHttpInfo(String username) throws ApiException {
-    Object localVarPostBody = null;
+    // BodyHolder is set to null when the HTTP request body is not set (e.g. for HTTP GET requests).
+    // When the body is set (e.g HTTP POST request), the object maybe have a null value which needs
+    // to be serialized as the 'null' value.
+    ApiClient.BodyHolder localVarPostBody = null;
     
     // verify the required parameter 'username' is set
     if (username == null) {
@@ -337,7 +349,10 @@ public class UserApi {
      </table>
    */
   public ApiResponse<User> getUserByNameWithHttpInfo(String username) throws ApiException {
-    Object localVarPostBody = null;
+    // BodyHolder is set to null when the HTTP request body is not set (e.g. for HTTP GET requests).
+    // When the body is set (e.g HTTP POST request), the object maybe have a null value which needs
+    // to be serialized as the 'null' value.
+    ApiClient.BodyHolder localVarPostBody = null;
     
     // verify the required parameter 'username' is set
     if (username == null) {
@@ -409,7 +424,10 @@ public class UserApi {
      </table>
    */
   public ApiResponse<String> loginUserWithHttpInfo(String username, String password) throws ApiException {
-    Object localVarPostBody = null;
+    // BodyHolder is set to null when the HTTP request body is not set (e.g. for HTTP GET requests).
+    // When the body is set (e.g HTTP POST request), the object maybe have a null value which needs
+    // to be serialized as the 'null' value.
+    ApiClient.BodyHolder localVarPostBody = null;
     
     // verify the required parameter 'username' is set
     if (username == null) {
@@ -480,7 +498,10 @@ public class UserApi {
      </table>
    */
   public ApiResponse<Void> logoutUserWithHttpInfo() throws ApiException {
-    Object localVarPostBody = null;
+    // BodyHolder is set to null when the HTTP request body is not set (e.g. for HTTP GET requests).
+    // When the body is set (e.g HTTP POST request), the object maybe have a null value which needs
+    // to be serialized as the 'null' value.
+    ApiClient.BodyHolder localVarPostBody = null;
     
     // create path and map variables
     String localVarPath = "/user/logout";
@@ -543,7 +564,10 @@ public class UserApi {
      </table>
    */
   public ApiResponse<Void> updateUserWithHttpInfo(String username, User user) throws ApiException {
-    Object localVarPostBody = user;
+    // BodyHolder is set to null when the HTTP request body is not set (e.g. for HTTP GET requests).
+    // When the body is set (e.g HTTP POST request), the object maybe have a null value which needs
+    // to be serialized as the 'null' value.
+    ApiClient.BodyHolder localVarPostBody = new ApiClient.BodyHolder(user);
     
     // verify the required parameter 'username' is set
     if (username == null) {


### PR DESCRIPTION
Two scenarios need to be differentiated:
1. HTTP requests may have an empty body, e.g. HTTP GET requests.
1. HTTP requests may also have a body with the 'null' value.

We need to be able to differentiate these two cases when serializing the body. In particular, for HTTP GET request which have an empty body, the input object was set to null, and it was serialized as the 'null' value instead of the empty string.

This leads to incorrect message digest being calculated.

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/config/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
