### PR TITLE
[java][jersey2] Fix URL encoding problem for HTTP signatures

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/auth/HttpSignatureAuth.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/auth/HttpSignatureAuth.mustache
@@ -234,16 +234,12 @@ public class HttpSignatureAuth implements Authentication {
         throw new ApiException("Signer cannot be null. Please call the method `setPrivateKey` to set it up correctly");
       }
 
-      // construct the path with the URL query string
-      String path = uri.getPath();
-
-      List<String> urlQueries = new ArrayList<String>();
-      for (Pair queryParam : queryParams) {
-        urlQueries.add(queryParam.getName() + "=" + URLEncoder.encode(queryParam.getValue(), "utf8").replaceAll("\\+", "%20"));
-      }
-
-      if (!urlQueries.isEmpty()) {
-        path = path + "?" + String.join("&", urlQueries);
+      // construct the path with the URL-encoded path and query.
+      // Calling getRawPath and getRawQuery ensures the path is URL-encoded as it will be serialized
+      // on the wire. The HTTP signature must use the encode URL as it is sent on the wire.
+      String path = uri.getRawPath();
+      if (uri.getRawQuery() != "") {
+        path += "?" + uri.getRawQuery();
       }
 
       headerParams.put("Authorization", signer.sign(method, path, headerParams).toString());

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/auth/HttpSignatureAuth.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/auth/HttpSignatureAuth.java
@@ -245,16 +245,12 @@ public class HttpSignatureAuth implements Authentication {
         throw new ApiException("Signer cannot be null. Please call the method `setPrivateKey` to set it up correctly");
       }
 
-      // construct the path with the URL query string
-      String path = uri.getPath();
-
-      List<String> urlQueries = new ArrayList<String>();
-      for (Pair queryParam : queryParams) {
-        urlQueries.add(queryParam.getName() + "=" + URLEncoder.encode(queryParam.getValue(), "utf8").replaceAll("\\+", "%20"));
-      }
-
-      if (!urlQueries.isEmpty()) {
-        path = path + "?" + String.join("&", urlQueries);
+      // construct the path with the URL-encoded path and query.
+      // Calling getRawPath and getRawQuery ensures the path is URL-encoded as it will be serialized
+      // on the wire. The HTTP signature must use the encode URL as it is sent on the wire.
+      String path = uri.getRawPath();
+      if (uri.getRawQuery() != "") {
+        path += "?" + uri.getRawQuery();
       }
 
       headerParams.put("Authorization", signer.sign(method, path, headerParams).toString());


### PR DESCRIPTION
Fix problem with HTTP signatures when the URL path and/or query include characters that need to be encoded. For example, `/api/v1/Request?$orderby=-CreateTime&$top=10` may be encoded to `/api/v1/Request?%24orderby=-CreateTime&%24top=10` on the wire. When the HTTP signature includes the `(request-target)` field, the path and query must be written exactly as it is on the wire.

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/config/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
