### PR TITLE
Added basic bearer authentication to objc template

### DIFF
--- a/modules/openapi-generator/src/main/resources/objc/DefaultConfiguration-body.mustache
+++ b/modules/openapi-generator/src/main/resources/objc/DefaultConfiguration-body.mustache
@@ -115,6 +115,7 @@
                    },
 {{/isApiKey}}
 {{#isBasic}}
+  {{#isBasicBasic}}
                @"{{name}}":
                    @{
                        @"type": @"basic",
@@ -122,6 +123,16 @@
                        @"key": @"Authorization",
                        @"value": [self getBasicAuthToken]
                    },
+   {{/isBasicBasic}}
+   {{#isBasicBearer}}
+               @"{{name}}":
+                   @{
+                       @"type": @"bearer",
+                       @"in": @"header",
+                       @"key": @"Authorization",
+                       @"value": [self getAccessToken]
+                   },
+   {{/isBasicBearer}}
 {{/isBasic}}
 {{#isOAuth}}
                @"{{name}}":


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
Referred to the OpenAPI Spec https://swagger.io/docs/specification/authentication/bearer-authentication/ it is able to add bearer authentication to OpenAPI.
The Basic Bearer was ignored in OBJC Template. 

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/config/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [ ] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
