### PR TITLE
[java][jersey2] Fix processing of additional, undeclared properties

### DIFF
--- a/bin/configs/java-jersey2-8.yaml
+++ b/bin/configs/java-jersey2-8.yaml
@@ -8,3 +8,4 @@ additionalProperties:
   serverPort: "8082"
   dateLibrary: java8
   useOneOfDiscriminatorLookup: true
+  disallowAdditionalPropertiesIfNotPresent: false

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/anyof_model.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/anyof_model.mustache
@@ -84,28 +84,6 @@ public class {{classname}} extends AbstractOpenApiSchema{{#vendorExtensions.x-im
             throw new IOException(String.format("Failed deserialization for {{classname}}: no match found"));
         }
 
-        {{#additionalPropertiesType}}
-        /**
-         * Method called to deal with a property that did not map to a known Bean property.
-         * Method can deal with the problem as it sees fit (ignore, throw exception); but if it does return,
-         * it has to skip the matching Json content parser has.
-         *
-         * @param p - Parser that points to value of the unknown property
-         * @param ctxt - Context for deserialization; allows access to the parser, error reporting functionality
-         * @param instanceOrClass - Instance that is being populated by this deserializer, or if not known, Class that would be instantiated. If null, will assume type is what getValueClass() returns.
-         * @param propName - Name of the property that cannot be mapped
-         */
-        @Override
-        protected void handleUnknownProperty(JsonParser p,
-                                     DeserializationContext ctxt,
-                                     Object instanceOrClass,
-                                     String propName) throws IOException {
-            System.out.println("Deserializing unknown property " + propName);
-            {{{.}}} deserialized = p.readValueAs({{{.}}}.class);
-            additionalProperties.put(propName, deserialized);
-        }
-        {{/additionalPropertiesType}}
-
         /**
          * Handle deserialization of the 'null' value.
          */
@@ -128,14 +106,17 @@ public class {{classname}} extends AbstractOpenApiSchema{{#vendorExtensions.x-im
     }
 {{> libraries/jersey2/additional_properties }}
     {{#additionalPropertiesType}}
+    /**
+     * Return true if this {{name}} object is equal to o.
+     */
     @Override
     public boolean equals(Object o) {
-        return super.equals(o) && Objects.equals(this.additionalProperties, o.additionalProperties)
+        return super.equals(o) && Objects.equals(this.additionalProperties, (({{classname}})o).additionalProperties);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(instance, isNullable, schemaType, additionalProperties);
+        return Objects.hash(getActualInstance(), isNullable(), getSchemaType(), additionalProperties);
     }
     {{/additionalPropertiesType}}
     {{#anyOf}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/oneof_model.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/oneof_model.mustache
@@ -97,28 +97,6 @@ public class {{classname}} extends AbstractOpenApiSchema{{#vendorExtensions.x-im
             throw new IOException(String.format("Failed deserialization for {{classname}}: %d classes match result, expected 1", match));
         }
 
-        {{#additionalPropertiesType}}
-        /**
-         * Method called to deal with a property that did not map to a known Bean property.
-         * Method can deal with the problem as it sees fit (ignore, throw exception); but if it does return,
-         * it has to skip the matching Json content parser has.
-         *
-         * @param p - Parser that points to value of the unknown property
-         * @param ctxt - Context for deserialization; allows access to the parser, error reporting functionality
-         * @param instanceOrClass - Instance that is being populated by this deserializer, or if not known, Class that would be instantiated. If null, will assume type is what getValueClass() returns.
-         * @param propName - Name of the property that cannot be mapped
-         */
-        @Override
-        protected void handleUnknownProperty(JsonParser p,
-                                     DeserializationContext ctxt,
-                                     Object instanceOrClass,
-                                     String propName) throws IOException {
-            System.out.println("Deserializing unknown property " + propName);
-            {{{.}}} deserialized = p.readValueAs({{{.}}}.class);
-            additionalProperties.put(propName, deserialized);
-        }
-        {{/additionalPropertiesType}}
-
         /**
          * Handle deserialization of the 'null' value.
          */
@@ -141,14 +119,17 @@ public class {{classname}} extends AbstractOpenApiSchema{{#vendorExtensions.x-im
     }
 {{> libraries/jersey2/additional_properties }}
     {{#additionalPropertiesType}}
+    /**
+     * Return true if this {{name}} object is equal to o.
+     */
     @Override
     public boolean equals(Object o) {
-        return super.equals(o) && Objects.equals(this.additionalProperties, o.additionalProperties)
+        return super.equals(o) && Objects.equals(this.additionalProperties, (({{classname}})o).additionalProperties);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(instance, isNullable, schemaType, additionalProperties);
+        return Objects.hash(getActualInstance(), isNullable(), getSchemaType(), additionalProperties);
     }
     {{/additionalPropertiesType}}
     {{#oneOf}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/pojo.mustache
@@ -232,6 +232,9 @@ public class {{classname}} {{#parent}}extends {{{parent}}} {{/parent}}{{#vendorE
   {{/vars}}
 {{>libraries/jersey2/additional_properties}}
 {{^supportJava6}}
+  /**
+   * Return true if this {{name}} object is equal to o.
+   */
   @Override
   public boolean equals(java.lang.Object o) {
   {{#useReflectionEqualsHashCode}}

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -104,6 +104,9 @@ public class AdditionalPropertiesAnyType {
     return this.additionalProperties.get(key);
   }
 
+  /**
+   * Return true if this AdditionalPropertiesAnyType object is equal to o.
+   */
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -105,6 +105,9 @@ public class AdditionalPropertiesArray {
     return this.additionalProperties.get(key);
   }
 
+  /**
+   * Return true if this AdditionalPropertiesArray object is equal to o.
+   */
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -104,6 +104,9 @@ public class AdditionalPropertiesBoolean {
     return this.additionalProperties.get(key);
   }
 
+  /**
+   * Return true if this AdditionalPropertiesBoolean object is equal to o.
+   */
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -411,6 +411,9 @@ public class AdditionalPropertiesClass {
   }
 
 
+  /**
+   * Return true if this AdditionalPropertiesClass object is equal to o.
+   */
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -104,6 +104,9 @@ public class AdditionalPropertiesInteger {
     return this.additionalProperties.get(key);
   }
 
+  /**
+   * Return true if this AdditionalPropertiesInteger object is equal to o.
+   */
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -105,6 +105,9 @@ public class AdditionalPropertiesNumber {
     return this.additionalProperties.get(key);
   }
 
+  /**
+   * Return true if this AdditionalPropertiesNumber object is equal to o.
+   */
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -105,6 +105,9 @@ public class AdditionalPropertiesObject {
     return this.additionalProperties.get(key);
   }
 
+  /**
+   * Return true if this AdditionalPropertiesObject object is equal to o.
+   */
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -104,6 +104,9 @@ public class AdditionalPropertiesString {
     return this.additionalProperties.get(key);
   }
 
+  /**
+   * Return true if this AdditionalPropertiesString object is equal to o.
+   */
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Animal.java
@@ -102,6 +102,9 @@ public class Animal {
   }
 
 
+  /**
+   * Return true if this Animal object is equal to o.
+   */
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -74,6 +74,9 @@ public class ArrayOfArrayOfNumberOnly {
   }
 
 
+  /**
+   * Return true if this ArrayOfArrayOfNumberOnly object is equal to o.
+   */
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -74,6 +74,9 @@ public class ArrayOfNumberOnly {
   }
 
 
+  /**
+   * Return true if this ArrayOfNumberOnly object is equal to o.
+   */
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -146,6 +146,9 @@ public class ArrayTest {
   }
 
 
+  /**
+   * Return true if this ArrayTest object is equal to o.
+   */
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/BigCat.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/BigCat.java
@@ -110,6 +110,9 @@ public class BigCat extends Cat {
   }
 
 
+  /**
+   * Return true if this BigCat object is equal to o.
+   */
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/BigCatAllOf.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/BigCatAllOf.java
@@ -102,6 +102,9 @@ public class BigCatAllOf {
   }
 
 
+  /**
+   * Return true if this BigCat_allOf object is equal to o.
+   */
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -203,6 +203,9 @@ public class Capitalization {
   }
 
 
+  /**
+   * Return true if this Capitalization object is equal to o.
+   */
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Cat.java
@@ -73,6 +73,9 @@ public class Cat extends Animal {
   }
 
 
+  /**
+   * Return true if this Cat object is equal to o.
+   */
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -63,6 +63,9 @@ public class CatAllOf {
   }
 
 
+  /**
+   * Return true if this Cat_allOf object is equal to o.
+   */
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Category.java
@@ -90,6 +90,9 @@ public class Category {
   }
 
 
+  /**
+   * Return true if this Category object is equal to o.
+   */
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -64,6 +64,9 @@ public class ClassModel {
   }
 
 
+  /**
+   * Return true if this ClassModel object is equal to o.
+   */
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Client.java
@@ -63,6 +63,9 @@ public class Client {
   }
 
 
+  /**
+   * Return true if this Client object is equal to o.
+   */
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Dog.java
@@ -71,6 +71,9 @@ public class Dog extends Animal {
   }
 
 
+  /**
+   * Return true if this Dog object is equal to o.
+   */
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -63,6 +63,9 @@ public class DogAllOf {
   }
 
 
+  /**
+   * Return true if this Dog_allOf object is equal to o.
+   */
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -171,6 +171,9 @@ public class EnumArrays {
   }
 
 
+  /**
+   * Return true if this EnumArrays object is equal to o.
+   */
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -319,6 +319,9 @@ public class EnumTest {
   }
 
 
+  /**
+   * Return true if this Enum_Test object is equal to o.
+   */
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -101,6 +101,9 @@ public class FileSchemaTestClass {
   }
 
 
+  /**
+   * Return true if this FileSchemaTestClass object is equal to o.
+   */
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -438,6 +438,9 @@ public class FormatTest {
   }
 
 
+  /**
+   * Return true if this format_test object is equal to o.
+   */
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
@@ -75,6 +75,9 @@ public class HasOnlyReadOnly {
 
 
 
+  /**
+   * Return true if this hasOnlyReadOnly object is equal to o.
+   */
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/MapTest.java
@@ -217,6 +217,9 @@ public class MapTest {
   }
 
 
+  /**
+   * Return true if this MapTest object is equal to o.
+   */
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -133,6 +133,9 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   }
 
 
+  /**
+   * Return true if this MixedPropertiesAndAdditionalPropertiesClass object is equal to o.
+   */
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -92,6 +92,9 @@ public class Model200Response {
   }
 
 
+  /**
+   * Return true if this 200_response object is equal to o.
+   */
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -119,6 +119,9 @@ public class ModelApiResponse {
   }
 
 
+  /**
+   * Return true if this ApiResponse object is equal to o.
+   */
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -64,6 +64,9 @@ public class ModelReturn {
   }
 
 
+  /**
+   * Return true if this Return object is equal to o.
+   */
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Name.java
@@ -131,6 +131,9 @@ public class Name {
 
 
 
+  /**
+   * Return true if this Name object is equal to o.
+   */
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -64,6 +64,9 @@ public class NumberOnly {
   }
 
 
+  /**
+   * Return true if this NumberOnly object is equal to o.
+   */
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Order.java
@@ -241,6 +241,9 @@ public class Order {
   }
 
 
+  /**
+   * Return true if this Order object is equal to o.
+   */
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -120,6 +120,9 @@ public class OuterComposite {
   }
 
 
+  /**
+   * Return true if this OuterComposite object is equal to o.
+   */
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Pet.java
@@ -257,6 +257,9 @@ public class Pet {
   }
 
 
+  /**
+   * Return true if this Pet object is equal to o.
+   */
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -83,6 +83,9 @@ public class ReadOnlyFirst {
   }
 
 
+  /**
+   * Return true if this ReadOnlyFirst object is equal to o.
+   */
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -63,6 +63,9 @@ public class SpecialModelName {
   }
 
 
+  /**
+   * Return true if this $special[model.name] object is equal to o.
+   */
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Tag.java
@@ -91,6 +91,9 @@ public class Tag {
   }
 
 
+  /**
+   * Return true if this Tag object is equal to o.
+   */
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -178,6 +178,9 @@ public class TypeHolderDefault {
   }
 
 
+  /**
+   * Return true if this TypeHolderDefault object is equal to o.
+   */
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -205,6 +205,9 @@ public class TypeHolderExample {
   }
 
 
+  /**
+   * Return true if this TypeHolderExample object is equal to o.
+   */
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/User.java
@@ -259,6 +259,9 @@ public class User {
   }
 
 
+  /**
+   * Return true if this User object is equal to o.
+   */
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -922,6 +922,9 @@ public class XmlItem {
   }
 
 
+  /**
+   * Return true if this XmlItem object is equal to o.
+   */
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -307,6 +307,9 @@ public class AdditionalPropertiesClass {
   }
 
 
+  /**
+   * Return true if this AdditionalPropertiesClass object is equal to o.
+   */
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Animal.java
@@ -100,6 +100,9 @@ public class Animal {
   }
 
 
+  /**
+   * Return true if this Animal object is equal to o.
+   */
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Apple.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Apple.java
@@ -91,6 +91,9 @@ public class Apple {
   }
 
 
+  /**
+   * Return true if this apple object is equal to o.
+   */
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AppleReq.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AppleReq.java
@@ -90,6 +90,9 @@ public class AppleReq {
   }
 
 
+  /**
+   * Return true if this appleReq object is equal to o.
+   */
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -74,6 +74,9 @@ public class ArrayOfArrayOfNumberOnly {
   }
 
 
+  /**
+   * Return true if this ArrayOfArrayOfNumberOnly object is equal to o.
+   */
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -74,6 +74,9 @@ public class ArrayOfNumberOnly {
   }
 
 
+  /**
+   * Return true if this ArrayOfNumberOnly object is equal to o.
+   */
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -146,6 +146,9 @@ public class ArrayTest {
   }
 
 
+  /**
+   * Return true if this ArrayTest object is equal to o.
+   */
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Banana.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Banana.java
@@ -64,6 +64,9 @@ public class Banana {
   }
 
 
+  /**
+   * Return true if this banana object is equal to o.
+   */
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/BananaReq.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/BananaReq.java
@@ -91,6 +91,9 @@ public class BananaReq {
   }
 
 
+  /**
+   * Return true if this bananaReq object is equal to o.
+   */
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/BasquePig.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/BasquePig.java
@@ -62,6 +62,9 @@ public class BasquePig {
   }
 
 
+  /**
+   * Return true if this BasquePig object is equal to o.
+   */
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -203,6 +203,9 @@ public class Capitalization {
   }
 
 
+  /**
+   * Return true if this Capitalization object is equal to o.
+   */
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Cat.java
@@ -13,6 +13,10 @@
 
 package org.openapitools.client.model;
 
+import java.util.Map;
+import java.util.HashMap;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
 import java.util.Objects;
 import java.util.Arrays;
 import java.util.Map;
@@ -70,7 +74,47 @@ public class Cat extends Animal {
     this.declawed = declawed;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
 
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  @JsonAnySetter
+  public Cat putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  @JsonAnyGetter
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
+
+  /**
+   * Return true if this Cat object is equal to o.
+   */
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {
@@ -80,13 +124,14 @@ public class Cat extends Animal {
       return false;
     }
     Cat cat = (Cat) o;
-    return Objects.equals(this.declawed, cat.declawed) &&
+    return Objects.equals(this.declawed, cat.declawed)&&
+        Objects.equals(this.additionalProperties, cat.additionalProperties) &&
         super.equals(o);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(declawed, super.hashCode());
+    return Objects.hash(declawed, super.hashCode(), additionalProperties);
   }
 
 
@@ -96,6 +141,7 @@ public class Cat extends Animal {
     sb.append("class Cat {\n");
     sb.append("    ").append(toIndentedString(super.toString())).append("\n");
     sb.append("    declawed: ").append(toIndentedString(declawed)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -63,6 +63,9 @@ public class CatAllOf {
   }
 
 
+  /**
+   * Return true if this Cat_allOf object is equal to o.
+   */
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Category.java
@@ -90,6 +90,9 @@ public class Category {
   }
 
 
+  /**
+   * Return true if this Category object is equal to o.
+   */
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ChildCat.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ChildCat.java
@@ -13,6 +13,10 @@
 
 package org.openapitools.client.model;
 
+import java.util.Map;
+import java.util.HashMap;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
 import java.util.Objects;
 import java.util.Arrays;
 import java.util.Map;
@@ -70,7 +74,47 @@ public class ChildCat extends ParentPet {
     this.name = name;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
 
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  @JsonAnySetter
+  public ChildCat putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  @JsonAnyGetter
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
+
+  /**
+   * Return true if this ChildCat object is equal to o.
+   */
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {
@@ -80,13 +124,14 @@ public class ChildCat extends ParentPet {
       return false;
     }
     ChildCat childCat = (ChildCat) o;
-    return Objects.equals(this.name, childCat.name) &&
+    return Objects.equals(this.name, childCat.name)&&
+        Objects.equals(this.additionalProperties, childCat.additionalProperties) &&
         super.equals(o);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, super.hashCode());
+    return Objects.hash(name, super.hashCode(), additionalProperties);
   }
 
 
@@ -96,6 +141,7 @@ public class ChildCat extends ParentPet {
     sb.append("class ChildCat {\n");
     sb.append("    ").append(toIndentedString(super.toString())).append("\n");
     sb.append("    name: ").append(toIndentedString(name)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ChildCatAllOf.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ChildCatAllOf.java
@@ -63,6 +63,9 @@ public class ChildCatAllOf {
   }
 
 
+  /**
+   * Return true if this ChildCat_allOf object is equal to o.
+   */
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -64,6 +64,9 @@ public class ClassModel {
   }
 
 
+  /**
+   * Return true if this ClassModel object is equal to o.
+   */
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Client.java
@@ -63,6 +63,9 @@ public class Client {
   }
 
 
+  /**
+   * Return true if this Client object is equal to o.
+   */
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ComplexQuadrilateral.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ComplexQuadrilateral.java
@@ -13,6 +13,10 @@
 
 package org.openapitools.client.model;
 
+import java.util.Map;
+import java.util.HashMap;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
 import java.util.Objects;
 import java.util.Arrays;
 import java.util.Map;
@@ -90,7 +94,47 @@ public class ComplexQuadrilateral {
     this.quadrilateralType = quadrilateralType;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
 
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  @JsonAnySetter
+  public ComplexQuadrilateral putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  @JsonAnyGetter
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
+
+  /**
+   * Return true if this ComplexQuadrilateral object is equal to o.
+   */
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {
@@ -101,12 +145,13 @@ public class ComplexQuadrilateral {
     }
     ComplexQuadrilateral complexQuadrilateral = (ComplexQuadrilateral) o;
     return Objects.equals(this.shapeType, complexQuadrilateral.shapeType) &&
-        Objects.equals(this.quadrilateralType, complexQuadrilateral.quadrilateralType);
+        Objects.equals(this.quadrilateralType, complexQuadrilateral.quadrilateralType)&&
+        Objects.equals(this.additionalProperties, complexQuadrilateral.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(shapeType, quadrilateralType);
+    return Objects.hash(shapeType, quadrilateralType, additionalProperties);
   }
 
 
@@ -116,6 +161,7 @@ public class ComplexQuadrilateral {
     sb.append("class ComplexQuadrilateral {\n");
     sb.append("    shapeType: ").append(toIndentedString(shapeType)).append("\n");
     sb.append("    quadrilateralType: ").append(toIndentedString(quadrilateralType)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/DanishPig.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/DanishPig.java
@@ -62,6 +62,9 @@ public class DanishPig {
   }
 
 
+  /**
+   * Return true if this DanishPig object is equal to o.
+   */
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Dog.java
@@ -13,6 +13,10 @@
 
 package org.openapitools.client.model;
 
+import java.util.Map;
+import java.util.HashMap;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
 import java.util.Objects;
 import java.util.Arrays;
 import java.util.Map;
@@ -70,7 +74,47 @@ public class Dog extends Animal {
     this.breed = breed;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
 
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  @JsonAnySetter
+  public Dog putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  @JsonAnyGetter
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
+
+  /**
+   * Return true if this Dog object is equal to o.
+   */
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {
@@ -80,13 +124,14 @@ public class Dog extends Animal {
       return false;
     }
     Dog dog = (Dog) o;
-    return Objects.equals(this.breed, dog.breed) &&
+    return Objects.equals(this.breed, dog.breed)&&
+        Objects.equals(this.additionalProperties, dog.additionalProperties) &&
         super.equals(o);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(breed, super.hashCode());
+    return Objects.hash(breed, super.hashCode(), additionalProperties);
   }
 
 
@@ -96,6 +141,7 @@ public class Dog extends Animal {
     sb.append("class Dog {\n");
     sb.append("    ").append(toIndentedString(super.toString())).append("\n");
     sb.append("    breed: ").append(toIndentedString(breed)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -63,6 +63,9 @@ public class DogAllOf {
   }
 
 
+  /**
+   * Return true if this Dog_allOf object is equal to o.
+   */
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Drawing.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Drawing.java
@@ -215,6 +215,9 @@ public class Drawing {
     return this.additionalProperties.get(key);
   }
 
+  /**
+   * Return true if this Drawing object is equal to o.
+   */
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -171,6 +171,9 @@ public class EnumArrays {
   }
 
 
+  /**
+   * Return true if this EnumArrays object is equal to o.
+   */
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -419,6 +419,9 @@ public class EnumTest {
   }
 
 
+  /**
+   * Return true if this Enum_Test object is equal to o.
+   */
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/EquilateralTriangle.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/EquilateralTriangle.java
@@ -13,6 +13,10 @@
 
 package org.openapitools.client.model;
 
+import java.util.Map;
+import java.util.HashMap;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
 import java.util.Objects;
 import java.util.Arrays;
 import java.util.Map;
@@ -90,7 +94,47 @@ public class EquilateralTriangle {
     this.triangleType = triangleType;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
 
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  @JsonAnySetter
+  public EquilateralTriangle putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  @JsonAnyGetter
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
+
+  /**
+   * Return true if this EquilateralTriangle object is equal to o.
+   */
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {
@@ -101,12 +145,13 @@ public class EquilateralTriangle {
     }
     EquilateralTriangle equilateralTriangle = (EquilateralTriangle) o;
     return Objects.equals(this.shapeType, equilateralTriangle.shapeType) &&
-        Objects.equals(this.triangleType, equilateralTriangle.triangleType);
+        Objects.equals(this.triangleType, equilateralTriangle.triangleType)&&
+        Objects.equals(this.additionalProperties, equilateralTriangle.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(shapeType, triangleType);
+    return Objects.hash(shapeType, triangleType, additionalProperties);
   }
 
 
@@ -116,6 +161,7 @@ public class EquilateralTriangle {
     sb.append("class EquilateralTriangle {\n");
     sb.append("    shapeType: ").append(toIndentedString(shapeType)).append("\n");
     sb.append("    triangleType: ").append(toIndentedString(triangleType)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -101,6 +101,9 @@ public class FileSchemaTestClass {
   }
 
 
+  /**
+   * Return true if this FileSchemaTestClass object is equal to o.
+   */
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Foo.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Foo.java
@@ -63,6 +63,9 @@ public class Foo {
   }
 
 
+  /**
+   * Return true if this Foo object is equal to o.
+   */
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -466,6 +466,9 @@ public class FormatTest {
   }
 
 
+  /**
+   * Return true if this format_test object is equal to o.
+   */
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Fruit.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Fruit.java
@@ -123,7 +123,6 @@ public class Fruit extends AbstractOpenApiSchema {
             throw new IOException(String.format("Failed deserialization for Fruit: %d classes match result, expected 1", match));
         }
 
-
         /**
          * Handle deserialization of the 'null' value.
          */

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/FruitReq.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/FruitReq.java
@@ -123,7 +123,6 @@ public class FruitReq extends AbstractOpenApiSchema {
             throw new IOException(String.format("Failed deserialization for FruitReq: %d classes match result, expected 1", match));
         }
 
-
         /**
          * Handle deserialization of the 'null' value.
          */

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/GmFruit.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/GmFruit.java
@@ -113,7 +113,6 @@ public class GmFruit extends AbstractOpenApiSchema {
             throw new IOException(String.format("Failed deserialization for GmFruit: no match found"));
         }
 
-
         /**
          * Handle deserialization of the 'null' value.
          */

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/GrandparentAnimal.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/GrandparentAnimal.java
@@ -72,6 +72,9 @@ public class GrandparentAnimal {
   }
 
 
+  /**
+   * Return true if this GrandparentAnimal object is equal to o.
+   */
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
@@ -75,6 +75,9 @@ public class HasOnlyReadOnly {
 
 
 
+  /**
+   * Return true if this hasOnlyReadOnly object is equal to o.
+   */
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/HealthCheckResult.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/HealthCheckResult.java
@@ -77,6 +77,9 @@ public class HealthCheckResult {
   }
 
 
+  /**
+   * Return true if this HealthCheckResult object is equal to o.
+   */
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/InlineObject.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/InlineObject.java
@@ -91,6 +91,9 @@ public class InlineObject {
   }
 
 
+  /**
+   * Return true if this inline_object object is equal to o.
+   */
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/InlineObject1.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/InlineObject1.java
@@ -92,6 +92,9 @@ public class InlineObject1 {
   }
 
 
+  /**
+   * Return true if this inline_object_1 object is equal to o.
+   */
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/InlineObject2.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/InlineObject2.java
@@ -173,6 +173,9 @@ public class InlineObject2 {
   }
 
 
+  /**
+   * Return true if this inline_object_2 object is equal to o.
+   */
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/InlineObject3.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/InlineObject3.java
@@ -436,6 +436,9 @@ public class InlineObject3 {
   }
 
 
+  /**
+   * Return true if this inline_object_3 object is equal to o.
+   */
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/InlineObject4.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/InlineObject4.java
@@ -89,6 +89,9 @@ public class InlineObject4 {
   }
 
 
+  /**
+   * Return true if this inline_object_4 object is equal to o.
+   */
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/InlineObject5.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/InlineObject5.java
@@ -91,6 +91,9 @@ public class InlineObject5 {
   }
 
 
+  /**
+   * Return true if this inline_object_5 object is equal to o.
+   */
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/InlineResponseDefault.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/InlineResponseDefault.java
@@ -64,6 +64,9 @@ public class InlineResponseDefault {
   }
 
 
+  /**
+   * Return true if this inline_response_default object is equal to o.
+   */
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/IsoscelesTriangle.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/IsoscelesTriangle.java
@@ -91,6 +91,9 @@ public class IsoscelesTriangle {
   }
 
 
+  /**
+   * Return true if this IsoscelesTriangle object is equal to o.
+   */
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Mammal.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Mammal.java
@@ -13,6 +13,10 @@
 
 package org.openapitools.client.model;
 
+import java.util.Map;
+import java.util.HashMap;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
 import java.util.Objects;
 import java.util.Arrays;
 import java.util.Map;
@@ -158,6 +162,25 @@ public class Mammal extends AbstractOpenApiSchema {
             throw new IOException(String.format("Failed deserialization for Mammal: %d classes match result, expected 1", match));
         }
 
+        /**
+         * Method called to deal with a property that did not map to a known Bean property.
+         * Method can deal with the problem as it sees fit (ignore, throw exception); but if it does return,
+         * it has to skip the matching Json content parser has.
+         *
+         * @param p - Parser that points to value of the unknown property
+         * @param ctxt - Context for deserialization; allows access to the parser, error reporting functionality
+         * @param instanceOrClass - Instance that is being populated by this deserializer, or if not known, Class that would be instantiated. If null, will assume type is what getValueClass() returns.
+         * @param propName - Name of the property that cannot be mapped
+         */
+        @Override
+        protected void handleUnknownProperty(JsonParser p,
+                                     DeserializationContext ctxt,
+                                     Object instanceOrClass,
+                                     String propName) throws IOException {
+            System.out.println("Deserializing unknown property " + propName);
+            Object deserialized = p.readValueAs(Object.class);
+            //additionalProperties.put(propName, deserialized);
+        }
 
         /**
          * Handle deserialization of the 'null' value.
@@ -174,7 +197,56 @@ public class Mammal extends AbstractOpenApiSchema {
     public Mammal() {
         super("oneOf", Boolean.FALSE);
     }
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
 
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  @JsonAnySetter
+  public Mammal putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  @JsonAnyGetter
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
+
+    /**
+     * Return true if this mammal object is equal to o.
+     */
+    @Override
+    public boolean equals(Object o) {
+        return super.equals(o) && Objects.equals(this.additionalProperties, ((Mammal)o).additionalProperties);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getActualInstance(), isNullable(), getSchemaType(), additionalProperties);
+    }
     public Mammal(Pig o) {
         super("oneOf", Boolean.FALSE);
         setActualInstance(o);

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Mammal.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Mammal.java
@@ -163,26 +163,6 @@ public class Mammal extends AbstractOpenApiSchema {
         }
 
         /**
-         * Method called to deal with a property that did not map to a known Bean property.
-         * Method can deal with the problem as it sees fit (ignore, throw exception); but if it does return,
-         * it has to skip the matching Json content parser has.
-         *
-         * @param p - Parser that points to value of the unknown property
-         * @param ctxt - Context for deserialization; allows access to the parser, error reporting functionality
-         * @param instanceOrClass - Instance that is being populated by this deserializer, or if not known, Class that would be instantiated. If null, will assume type is what getValueClass() returns.
-         * @param propName - Name of the property that cannot be mapped
-         */
-        @Override
-        protected void handleUnknownProperty(JsonParser p,
-                                     DeserializationContext ctxt,
-                                     Object instanceOrClass,
-                                     String propName) throws IOException {
-            System.out.println("Deserializing unknown property " + propName);
-            Object deserialized = p.readValueAs(Object.class);
-            //additionalProperties.put(propName, deserialized);
-        }
-
-        /**
          * Handle deserialization of the 'null' value.
          */
         @Override

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/MapTest.java
@@ -217,6 +217,9 @@ public class MapTest {
   }
 
 
+  /**
+   * Return true if this MapTest object is equal to o.
+   */
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -133,6 +133,9 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   }
 
 
+  /**
+   * Return true if this MixedPropertiesAndAdditionalPropertiesClass object is equal to o.
+   */
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -92,6 +92,9 @@ public class Model200Response {
   }
 
 
+  /**
+   * Return true if this 200_response object is equal to o.
+   */
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -119,6 +119,9 @@ public class ModelApiResponse {
   }
 
 
+  /**
+   * Return true if this ApiResponse object is equal to o.
+   */
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -64,6 +64,9 @@ public class ModelReturn {
   }
 
 
+  /**
+   * Return true if this Return object is equal to o.
+   */
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Name.java
@@ -131,6 +131,9 @@ public class Name {
 
 
 
+  /**
+   * Return true if this Name object is equal to o.
+   */
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/NullableClass.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/NullableClass.java
@@ -586,6 +586,9 @@ public class NullableClass {
     return this.additionalProperties.get(key);
   }
 
+  /**
+   * Return true if this NullableClass object is equal to o.
+   */
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/NullableShape.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/NullableShape.java
@@ -145,26 +145,6 @@ public class NullableShape extends AbstractOpenApiSchema {
         }
 
         /**
-         * Method called to deal with a property that did not map to a known Bean property.
-         * Method can deal with the problem as it sees fit (ignore, throw exception); but if it does return,
-         * it has to skip the matching Json content parser has.
-         *
-         * @param p - Parser that points to value of the unknown property
-         * @param ctxt - Context for deserialization; allows access to the parser, error reporting functionality
-         * @param instanceOrClass - Instance that is being populated by this deserializer, or if not known, Class that would be instantiated. If null, will assume type is what getValueClass() returns.
-         * @param propName - Name of the property that cannot be mapped
-         */
-        @Override
-        protected void handleUnknownProperty(JsonParser p,
-                                     DeserializationContext ctxt,
-                                     Object instanceOrClass,
-                                     String propName) throws IOException {
-            System.out.println("Deserializing unknown property " + propName);
-            Object deserialized = p.readValueAs(Object.class);
-            //additionalProperties.put(propName, deserialized);
-        }
-
-        /**
          * Handle deserialization of the 'null' value.
          */
         @Override

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/NullableShape.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/NullableShape.java
@@ -13,6 +13,10 @@
 
 package org.openapitools.client.model;
 
+import java.util.Map;
+import java.util.HashMap;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
 import java.util.Objects;
 import java.util.Arrays;
 import java.util.Map;
@@ -140,6 +144,25 @@ public class NullableShape extends AbstractOpenApiSchema {
             throw new IOException(String.format("Failed deserialization for NullableShape: %d classes match result, expected 1", match));
         }
 
+        /**
+         * Method called to deal with a property that did not map to a known Bean property.
+         * Method can deal with the problem as it sees fit (ignore, throw exception); but if it does return,
+         * it has to skip the matching Json content parser has.
+         *
+         * @param p - Parser that points to value of the unknown property
+         * @param ctxt - Context for deserialization; allows access to the parser, error reporting functionality
+         * @param instanceOrClass - Instance that is being populated by this deserializer, or if not known, Class that would be instantiated. If null, will assume type is what getValueClass() returns.
+         * @param propName - Name of the property that cannot be mapped
+         */
+        @Override
+        protected void handleUnknownProperty(JsonParser p,
+                                     DeserializationContext ctxt,
+                                     Object instanceOrClass,
+                                     String propName) throws IOException {
+            System.out.println("Deserializing unknown property " + propName);
+            Object deserialized = p.readValueAs(Object.class);
+            //additionalProperties.put(propName, deserialized);
+        }
 
         /**
          * Handle deserialization of the 'null' value.
@@ -156,7 +179,56 @@ public class NullableShape extends AbstractOpenApiSchema {
     public NullableShape() {
         super("oneOf", Boolean.TRUE);
     }
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
 
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  @JsonAnySetter
+  public NullableShape putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  @JsonAnyGetter
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
+
+    /**
+     * Return true if this NullableShape object is equal to o.
+     */
+    @Override
+    public boolean equals(Object o) {
+        return super.equals(o) && Objects.equals(this.additionalProperties, ((NullableShape)o).additionalProperties);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getActualInstance(), isNullable(), getSchemaType(), additionalProperties);
+    }
     public NullableShape(Quadrilateral o) {
         super("oneOf", Boolean.TRUE);
         setActualInstance(o);

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -64,6 +64,9 @@ public class NumberOnly {
   }
 
 
+  /**
+   * Return true if this NumberOnly object is equal to o.
+   */
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Order.java
@@ -241,6 +241,9 @@ public class Order {
   }
 
 
+  /**
+   * Return true if this Order object is equal to o.
+   */
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -120,6 +120,9 @@ public class OuterComposite {
   }
 
 
+  /**
+   * Return true if this OuterComposite object is equal to o.
+   */
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ParentPet.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ParentPet.java
@@ -13,6 +13,10 @@
 
 package org.openapitools.client.model;
 
+import java.util.Map;
+import java.util.HashMap;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
 import java.util.Objects;
 import java.util.Arrays;
 import java.util.Map;
@@ -43,7 +47,47 @@ import org.openapitools.client.JSON;
 })
 
 public class ParentPet extends GrandparentAnimal {
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
 
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  @JsonAnySetter
+  public ParentPet putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  @JsonAnyGetter
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
+
+  /**
+   * Return true if this ParentPet object is equal to o.
+   */
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {
@@ -57,7 +101,7 @@ public class ParentPet extends GrandparentAnimal {
 
   @Override
   public int hashCode() {
-    return Objects.hash(super.hashCode());
+    return Objects.hash(super.hashCode(), additionalProperties);
   }
 
 
@@ -66,6 +110,7 @@ public class ParentPet extends GrandparentAnimal {
     StringBuilder sb = new StringBuilder();
     sb.append("class ParentPet {\n");
     sb.append("    ").append(toIndentedString(super.toString())).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Pet.java
@@ -255,6 +255,9 @@ public class Pet {
   }
 
 
+  /**
+   * Return true if this Pet object is equal to o.
+   */
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Pig.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Pig.java
@@ -145,26 +145,6 @@ public class Pig extends AbstractOpenApiSchema {
         }
 
         /**
-         * Method called to deal with a property that did not map to a known Bean property.
-         * Method can deal with the problem as it sees fit (ignore, throw exception); but if it does return,
-         * it has to skip the matching Json content parser has.
-         *
-         * @param p - Parser that points to value of the unknown property
-         * @param ctxt - Context for deserialization; allows access to the parser, error reporting functionality
-         * @param instanceOrClass - Instance that is being populated by this deserializer, or if not known, Class that would be instantiated. If null, will assume type is what getValueClass() returns.
-         * @param propName - Name of the property that cannot be mapped
-         */
-        @Override
-        protected void handleUnknownProperty(JsonParser p,
-                                     DeserializationContext ctxt,
-                                     Object instanceOrClass,
-                                     String propName) throws IOException {
-            System.out.println("Deserializing unknown property " + propName);
-            Object deserialized = p.readValueAs(Object.class);
-            //additionalProperties.put(propName, deserialized);
-        }
-
-        /**
          * Handle deserialization of the 'null' value.
          */
         @Override

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Pig.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Pig.java
@@ -13,6 +13,10 @@
 
 package org.openapitools.client.model;
 
+import java.util.Map;
+import java.util.HashMap;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
 import java.util.Objects;
 import java.util.Arrays;
 import java.util.Map;
@@ -140,6 +144,25 @@ public class Pig extends AbstractOpenApiSchema {
             throw new IOException(String.format("Failed deserialization for Pig: %d classes match result, expected 1", match));
         }
 
+        /**
+         * Method called to deal with a property that did not map to a known Bean property.
+         * Method can deal with the problem as it sees fit (ignore, throw exception); but if it does return,
+         * it has to skip the matching Json content parser has.
+         *
+         * @param p - Parser that points to value of the unknown property
+         * @param ctxt - Context for deserialization; allows access to the parser, error reporting functionality
+         * @param instanceOrClass - Instance that is being populated by this deserializer, or if not known, Class that would be instantiated. If null, will assume type is what getValueClass() returns.
+         * @param propName - Name of the property that cannot be mapped
+         */
+        @Override
+        protected void handleUnknownProperty(JsonParser p,
+                                     DeserializationContext ctxt,
+                                     Object instanceOrClass,
+                                     String propName) throws IOException {
+            System.out.println("Deserializing unknown property " + propName);
+            Object deserialized = p.readValueAs(Object.class);
+            //additionalProperties.put(propName, deserialized);
+        }
 
         /**
          * Handle deserialization of the 'null' value.
@@ -156,7 +179,56 @@ public class Pig extends AbstractOpenApiSchema {
     public Pig() {
         super("oneOf", Boolean.FALSE);
     }
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
 
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  @JsonAnySetter
+  public Pig putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  @JsonAnyGetter
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
+
+    /**
+     * Return true if this Pig object is equal to o.
+     */
+    @Override
+    public boolean equals(Object o) {
+        return super.equals(o) && Objects.equals(this.additionalProperties, ((Pig)o).additionalProperties);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getActualInstance(), isNullable(), getSchemaType(), additionalProperties);
+    }
     public Pig(BasquePig o) {
         super("oneOf", Boolean.FALSE);
         setActualInstance(o);

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Quadrilateral.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Quadrilateral.java
@@ -13,6 +13,10 @@
 
 package org.openapitools.client.model;
 
+import java.util.Map;
+import java.util.HashMap;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
 import java.util.Objects;
 import java.util.Arrays;
 import java.util.Map;
@@ -140,6 +144,25 @@ public class Quadrilateral extends AbstractOpenApiSchema {
             throw new IOException(String.format("Failed deserialization for Quadrilateral: %d classes match result, expected 1", match));
         }
 
+        /**
+         * Method called to deal with a property that did not map to a known Bean property.
+         * Method can deal with the problem as it sees fit (ignore, throw exception); but if it does return,
+         * it has to skip the matching Json content parser has.
+         *
+         * @param p - Parser that points to value of the unknown property
+         * @param ctxt - Context for deserialization; allows access to the parser, error reporting functionality
+         * @param instanceOrClass - Instance that is being populated by this deserializer, or if not known, Class that would be instantiated. If null, will assume type is what getValueClass() returns.
+         * @param propName - Name of the property that cannot be mapped
+         */
+        @Override
+        protected void handleUnknownProperty(JsonParser p,
+                                     DeserializationContext ctxt,
+                                     Object instanceOrClass,
+                                     String propName) throws IOException {
+            System.out.println("Deserializing unknown property " + propName);
+            Object deserialized = p.readValueAs(Object.class);
+            //additionalProperties.put(propName, deserialized);
+        }
 
         /**
          * Handle deserialization of the 'null' value.
@@ -156,7 +179,56 @@ public class Quadrilateral extends AbstractOpenApiSchema {
     public Quadrilateral() {
         super("oneOf", Boolean.FALSE);
     }
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
 
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  @JsonAnySetter
+  public Quadrilateral putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  @JsonAnyGetter
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
+
+    /**
+     * Return true if this Quadrilateral object is equal to o.
+     */
+    @Override
+    public boolean equals(Object o) {
+        return super.equals(o) && Objects.equals(this.additionalProperties, ((Quadrilateral)o).additionalProperties);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getActualInstance(), isNullable(), getSchemaType(), additionalProperties);
+    }
     public Quadrilateral(ComplexQuadrilateral o) {
         super("oneOf", Boolean.FALSE);
         setActualInstance(o);

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Quadrilateral.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Quadrilateral.java
@@ -145,26 +145,6 @@ public class Quadrilateral extends AbstractOpenApiSchema {
         }
 
         /**
-         * Method called to deal with a property that did not map to a known Bean property.
-         * Method can deal with the problem as it sees fit (ignore, throw exception); but if it does return,
-         * it has to skip the matching Json content parser has.
-         *
-         * @param p - Parser that points to value of the unknown property
-         * @param ctxt - Context for deserialization; allows access to the parser, error reporting functionality
-         * @param instanceOrClass - Instance that is being populated by this deserializer, or if not known, Class that would be instantiated. If null, will assume type is what getValueClass() returns.
-         * @param propName - Name of the property that cannot be mapped
-         */
-        @Override
-        protected void handleUnknownProperty(JsonParser p,
-                                     DeserializationContext ctxt,
-                                     Object instanceOrClass,
-                                     String propName) throws IOException {
-            System.out.println("Deserializing unknown property " + propName);
-            Object deserialized = p.readValueAs(Object.class);
-            //additionalProperties.put(propName, deserialized);
-        }
-
-        /**
          * Handle deserialization of the 'null' value.
          */
         @Override

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/QuadrilateralInterface.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/QuadrilateralInterface.java
@@ -62,6 +62,9 @@ public class QuadrilateralInterface {
   }
 
 
+  /**
+   * Return true if this QuadrilateralInterface object is equal to o.
+   */
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -83,6 +83,9 @@ public class ReadOnlyFirst {
   }
 
 
+  /**
+   * Return true if this ReadOnlyFirst object is equal to o.
+   */
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ScaleneTriangle.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ScaleneTriangle.java
@@ -13,6 +13,10 @@
 
 package org.openapitools.client.model;
 
+import java.util.Map;
+import java.util.HashMap;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
 import java.util.Objects;
 import java.util.Arrays;
 import java.util.Map;
@@ -90,7 +94,47 @@ public class ScaleneTriangle {
     this.triangleType = triangleType;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
 
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  @JsonAnySetter
+  public ScaleneTriangle putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  @JsonAnyGetter
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
+
+  /**
+   * Return true if this ScaleneTriangle object is equal to o.
+   */
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {
@@ -101,12 +145,13 @@ public class ScaleneTriangle {
     }
     ScaleneTriangle scaleneTriangle = (ScaleneTriangle) o;
     return Objects.equals(this.shapeType, scaleneTriangle.shapeType) &&
-        Objects.equals(this.triangleType, scaleneTriangle.triangleType);
+        Objects.equals(this.triangleType, scaleneTriangle.triangleType)&&
+        Objects.equals(this.additionalProperties, scaleneTriangle.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(shapeType, triangleType);
+    return Objects.hash(shapeType, triangleType, additionalProperties);
   }
 
 
@@ -116,6 +161,7 @@ public class ScaleneTriangle {
     sb.append("class ScaleneTriangle {\n");
     sb.append("    shapeType: ").append(toIndentedString(shapeType)).append("\n");
     sb.append("    triangleType: ").append(toIndentedString(triangleType)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Shape.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Shape.java
@@ -13,6 +13,10 @@
 
 package org.openapitools.client.model;
 
+import java.util.Map;
+import java.util.HashMap;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
 import java.util.Objects;
 import java.util.Arrays;
 import java.util.Map;
@@ -140,6 +144,25 @@ public class Shape extends AbstractOpenApiSchema {
             throw new IOException(String.format("Failed deserialization for Shape: %d classes match result, expected 1", match));
         }
 
+        /**
+         * Method called to deal with a property that did not map to a known Bean property.
+         * Method can deal with the problem as it sees fit (ignore, throw exception); but if it does return,
+         * it has to skip the matching Json content parser has.
+         *
+         * @param p - Parser that points to value of the unknown property
+         * @param ctxt - Context for deserialization; allows access to the parser, error reporting functionality
+         * @param instanceOrClass - Instance that is being populated by this deserializer, or if not known, Class that would be instantiated. If null, will assume type is what getValueClass() returns.
+         * @param propName - Name of the property that cannot be mapped
+         */
+        @Override
+        protected void handleUnknownProperty(JsonParser p,
+                                     DeserializationContext ctxt,
+                                     Object instanceOrClass,
+                                     String propName) throws IOException {
+            System.out.println("Deserializing unknown property " + propName);
+            Object deserialized = p.readValueAs(Object.class);
+            //additionalProperties.put(propName, deserialized);
+        }
 
         /**
          * Handle deserialization of the 'null' value.
@@ -156,7 +179,56 @@ public class Shape extends AbstractOpenApiSchema {
     public Shape() {
         super("oneOf", Boolean.FALSE);
     }
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
 
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  @JsonAnySetter
+  public Shape putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  @JsonAnyGetter
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
+
+    /**
+     * Return true if this Shape object is equal to o.
+     */
+    @Override
+    public boolean equals(Object o) {
+        return super.equals(o) && Objects.equals(this.additionalProperties, ((Shape)o).additionalProperties);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getActualInstance(), isNullable(), getSchemaType(), additionalProperties);
+    }
     public Shape(Quadrilateral o) {
         super("oneOf", Boolean.FALSE);
         setActualInstance(o);

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Shape.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Shape.java
@@ -145,26 +145,6 @@ public class Shape extends AbstractOpenApiSchema {
         }
 
         /**
-         * Method called to deal with a property that did not map to a known Bean property.
-         * Method can deal with the problem as it sees fit (ignore, throw exception); but if it does return,
-         * it has to skip the matching Json content parser has.
-         *
-         * @param p - Parser that points to value of the unknown property
-         * @param ctxt - Context for deserialization; allows access to the parser, error reporting functionality
-         * @param instanceOrClass - Instance that is being populated by this deserializer, or if not known, Class that would be instantiated. If null, will assume type is what getValueClass() returns.
-         * @param propName - Name of the property that cannot be mapped
-         */
-        @Override
-        protected void handleUnknownProperty(JsonParser p,
-                                     DeserializationContext ctxt,
-                                     Object instanceOrClass,
-                                     String propName) throws IOException {
-            System.out.println("Deserializing unknown property " + propName);
-            Object deserialized = p.readValueAs(Object.class);
-            //additionalProperties.put(propName, deserialized);
-        }
-
-        /**
          * Handle deserialization of the 'null' value.
          */
         @Override

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ShapeInterface.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ShapeInterface.java
@@ -62,6 +62,9 @@ public class ShapeInterface {
   }
 
 
+  /**
+   * Return true if this ShapeInterface object is equal to o.
+   */
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ShapeOrNull.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ShapeOrNull.java
@@ -13,6 +13,10 @@
 
 package org.openapitools.client.model;
 
+import java.util.Map;
+import java.util.HashMap;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
 import java.util.Objects;
 import java.util.Arrays;
 import java.util.Map;
@@ -140,6 +144,25 @@ public class ShapeOrNull extends AbstractOpenApiSchema {
             throw new IOException(String.format("Failed deserialization for ShapeOrNull: %d classes match result, expected 1", match));
         }
 
+        /**
+         * Method called to deal with a property that did not map to a known Bean property.
+         * Method can deal with the problem as it sees fit (ignore, throw exception); but if it does return,
+         * it has to skip the matching Json content parser has.
+         *
+         * @param p - Parser that points to value of the unknown property
+         * @param ctxt - Context for deserialization; allows access to the parser, error reporting functionality
+         * @param instanceOrClass - Instance that is being populated by this deserializer, or if not known, Class that would be instantiated. If null, will assume type is what getValueClass() returns.
+         * @param propName - Name of the property that cannot be mapped
+         */
+        @Override
+        protected void handleUnknownProperty(JsonParser p,
+                                     DeserializationContext ctxt,
+                                     Object instanceOrClass,
+                                     String propName) throws IOException {
+            System.out.println("Deserializing unknown property " + propName);
+            Object deserialized = p.readValueAs(Object.class);
+            //additionalProperties.put(propName, deserialized);
+        }
 
         /**
          * Handle deserialization of the 'null' value.
@@ -156,7 +179,56 @@ public class ShapeOrNull extends AbstractOpenApiSchema {
     public ShapeOrNull() {
         super("oneOf", Boolean.TRUE);
     }
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
 
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  @JsonAnySetter
+  public ShapeOrNull putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  @JsonAnyGetter
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
+
+    /**
+     * Return true if this ShapeOrNull object is equal to o.
+     */
+    @Override
+    public boolean equals(Object o) {
+        return super.equals(o) && Objects.equals(this.additionalProperties, ((ShapeOrNull)o).additionalProperties);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getActualInstance(), isNullable(), getSchemaType(), additionalProperties);
+    }
     public ShapeOrNull(Quadrilateral o) {
         super("oneOf", Boolean.TRUE);
         setActualInstance(o);

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ShapeOrNull.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ShapeOrNull.java
@@ -145,26 +145,6 @@ public class ShapeOrNull extends AbstractOpenApiSchema {
         }
 
         /**
-         * Method called to deal with a property that did not map to a known Bean property.
-         * Method can deal with the problem as it sees fit (ignore, throw exception); but if it does return,
-         * it has to skip the matching Json content parser has.
-         *
-         * @param p - Parser that points to value of the unknown property
-         * @param ctxt - Context for deserialization; allows access to the parser, error reporting functionality
-         * @param instanceOrClass - Instance that is being populated by this deserializer, or if not known, Class that would be instantiated. If null, will assume type is what getValueClass() returns.
-         * @param propName - Name of the property that cannot be mapped
-         */
-        @Override
-        protected void handleUnknownProperty(JsonParser p,
-                                     DeserializationContext ctxt,
-                                     Object instanceOrClass,
-                                     String propName) throws IOException {
-            System.out.println("Deserializing unknown property " + propName);
-            Object deserialized = p.readValueAs(Object.class);
-            //additionalProperties.put(propName, deserialized);
-        }
-
-        /**
          * Handle deserialization of the 'null' value.
          */
         @Override

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/SimpleQuadrilateral.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/SimpleQuadrilateral.java
@@ -13,6 +13,10 @@
 
 package org.openapitools.client.model;
 
+import java.util.Map;
+import java.util.HashMap;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
 import java.util.Objects;
 import java.util.Arrays;
 import java.util.Map;
@@ -90,7 +94,47 @@ public class SimpleQuadrilateral {
     this.quadrilateralType = quadrilateralType;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
 
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  @JsonAnySetter
+  public SimpleQuadrilateral putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  @JsonAnyGetter
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
+
+  /**
+   * Return true if this SimpleQuadrilateral object is equal to o.
+   */
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {
@@ -101,12 +145,13 @@ public class SimpleQuadrilateral {
     }
     SimpleQuadrilateral simpleQuadrilateral = (SimpleQuadrilateral) o;
     return Objects.equals(this.shapeType, simpleQuadrilateral.shapeType) &&
-        Objects.equals(this.quadrilateralType, simpleQuadrilateral.quadrilateralType);
+        Objects.equals(this.quadrilateralType, simpleQuadrilateral.quadrilateralType)&&
+        Objects.equals(this.additionalProperties, simpleQuadrilateral.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(shapeType, quadrilateralType);
+    return Objects.hash(shapeType, quadrilateralType, additionalProperties);
   }
 
 
@@ -116,6 +161,7 @@ public class SimpleQuadrilateral {
     sb.append("class SimpleQuadrilateral {\n");
     sb.append("    shapeType: ").append(toIndentedString(shapeType)).append("\n");
     sb.append("    quadrilateralType: ").append(toIndentedString(quadrilateralType)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -63,6 +63,9 @@ public class SpecialModelName {
   }
 
 
+  /**
+   * Return true if this _special_model.name_ object is equal to o.
+   */
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Tag.java
@@ -91,6 +91,9 @@ public class Tag {
   }
 
 
+  /**
+   * Return true if this Tag object is equal to o.
+   */
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Triangle.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Triangle.java
@@ -163,26 +163,6 @@ public class Triangle extends AbstractOpenApiSchema {
         }
 
         /**
-         * Method called to deal with a property that did not map to a known Bean property.
-         * Method can deal with the problem as it sees fit (ignore, throw exception); but if it does return,
-         * it has to skip the matching Json content parser has.
-         *
-         * @param p - Parser that points to value of the unknown property
-         * @param ctxt - Context for deserialization; allows access to the parser, error reporting functionality
-         * @param instanceOrClass - Instance that is being populated by this deserializer, or if not known, Class that would be instantiated. If null, will assume type is what getValueClass() returns.
-         * @param propName - Name of the property that cannot be mapped
-         */
-        @Override
-        protected void handleUnknownProperty(JsonParser p,
-                                     DeserializationContext ctxt,
-                                     Object instanceOrClass,
-                                     String propName) throws IOException {
-            System.out.println("Deserializing unknown property " + propName);
-            Object deserialized = p.readValueAs(Object.class);
-            //additionalProperties.put(propName, deserialized);
-        }
-
-        /**
          * Handle deserialization of the 'null' value.
          */
         @Override

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Triangle.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Triangle.java
@@ -13,6 +13,10 @@
 
 package org.openapitools.client.model;
 
+import java.util.Map;
+import java.util.HashMap;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
 import java.util.Objects;
 import java.util.Arrays;
 import java.util.Map;
@@ -158,6 +162,25 @@ public class Triangle extends AbstractOpenApiSchema {
             throw new IOException(String.format("Failed deserialization for Triangle: %d classes match result, expected 1", match));
         }
 
+        /**
+         * Method called to deal with a property that did not map to a known Bean property.
+         * Method can deal with the problem as it sees fit (ignore, throw exception); but if it does return,
+         * it has to skip the matching Json content parser has.
+         *
+         * @param p - Parser that points to value of the unknown property
+         * @param ctxt - Context for deserialization; allows access to the parser, error reporting functionality
+         * @param instanceOrClass - Instance that is being populated by this deserializer, or if not known, Class that would be instantiated. If null, will assume type is what getValueClass() returns.
+         * @param propName - Name of the property that cannot be mapped
+         */
+        @Override
+        protected void handleUnknownProperty(JsonParser p,
+                                     DeserializationContext ctxt,
+                                     Object instanceOrClass,
+                                     String propName) throws IOException {
+            System.out.println("Deserializing unknown property " + propName);
+            Object deserialized = p.readValueAs(Object.class);
+            //additionalProperties.put(propName, deserialized);
+        }
 
         /**
          * Handle deserialization of the 'null' value.
@@ -174,7 +197,56 @@ public class Triangle extends AbstractOpenApiSchema {
     public Triangle() {
         super("oneOf", Boolean.FALSE);
     }
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
 
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  @JsonAnySetter
+  public Triangle putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  @JsonAnyGetter
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
+
+    /**
+     * Return true if this Triangle object is equal to o.
+     */
+    @Override
+    public boolean equals(Object o) {
+        return super.equals(o) && Objects.equals(this.additionalProperties, ((Triangle)o).additionalProperties);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getActualInstance(), isNullable(), getSchemaType(), additionalProperties);
+    }
     public Triangle(EquilateralTriangle o) {
         super("oneOf", Boolean.FALSE);
         setActualInstance(o);

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/TriangleInterface.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/TriangleInterface.java
@@ -62,6 +62,9 @@ public class TriangleInterface {
   }
 
 
+  /**
+   * Return true if this TriangleInterface object is equal to o.
+   */
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/User.java
@@ -404,6 +404,9 @@ public class User {
   }
 
 
+  /**
+   * Return true if this User object is equal to o.
+   */
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Whale.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Whale.java
@@ -118,6 +118,9 @@ public class Whale {
   }
 
 
+  /**
+   * Return true if this whale object is equal to o.
+   */
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Zebra.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Zebra.java
@@ -168,6 +168,9 @@ public class Zebra {
     return this.additionalProperties.get(key);
   }
 
+  /**
+   * Return true if this zebra object is equal to o.
+   */
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/test/java/org/openapitools/client/JSONComposedSchemaTest.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/test/java/org/openapitools/client/JSONComposedSchemaTest.java
@@ -308,13 +308,16 @@ public class JSONComposedSchemaTest {
             assertEquals("white", d.getColor());
         }
         {
-            String str = "{ \"pet_type\": \"ChildCat\", \"name\": \"fluffy\" }";
+            String str = "{ \"pet_type\": \"ChildCat\", \"name\": \"fluffy\", " +
+                " \"more_stuff\": \"the_value\"" +  // additional, undeclared property.
+                " }";
             GrandparentAnimal o = json.getContext(null).readValue(str, GrandparentAnimal.class);            
             assertNotNull(o);
             assertTrue(o instanceof ParentPet);
             assertTrue(o instanceof ChildCat);
             ChildCat c = (ChildCat)o;
             assertEquals("fluffy", c.getName());
+            assertNotNull(c.getAdditionalProperties());
         }
         {
             String str = "{ \"pet_type\": \"ChildCat\", \"name\": \"fluffy\" }";

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/test/java/org/openapitools/client/JSONComposedSchemaTest.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/test/java/org/openapitools/client/JSONComposedSchemaTest.java
@@ -113,12 +113,47 @@ public class JSONComposedSchemaTest {
             AbstractOpenApiSchema o = json.getContext(null).readValue(str, Mammal.class);
             assertNotNull(o);
             assertTrue(o.getActualInstance() instanceof Zebra);
+            Zebra z = (Zebra)o.getActualInstance();
+            assertNotNull(z.getAdditionalProperties());
+            assertEquals(2, z.getAdditionalProperties().size());
+            assertTrue(z.getAdditionalProperties().containsKey("hasBaleen"));
+        }
+        {
+            // Same test as above, but this time deserializing directly into the Zebra class.
+            String str = "{ \"className\": \"zebra\", \"hasBaleen\": true, \"hasTeeth\": false }";
+            Zebra o = json.getContext(null).readValue(str, Zebra.class);
+            assertNotNull(o);
+            assertNotNull(o.getAdditionalProperties());
+            assertEquals(2, o.getAdditionalProperties().size());
+        }
+        {
+            // Same test as above, but with properties that belong neither to zebra nor whale
+            String str = "{ \"className\": \"zebra\", \"some_other_property\": \"abc\" }";
+            AbstractOpenApiSchema o = json.getContext(null).readValue(str, Mammal.class);
+            assertNotNull(o);
+            assertTrue(o.getActualInstance() instanceof Zebra);
+            Zebra z = (Zebra)o.getActualInstance();
+            assertNotNull(z.getAdditionalProperties());
+            assertEquals(1, z.getAdditionalProperties().size());
+        }
+        {
+            // Same test as above, but with properties that belong neither to zebra nor whale
+            // Deserialize directly into Zebra.
+            String str = "{ \"className\": \"zebra\", \"some_other_property\": \"abc\" }";
+            Zebra o = json.getContext(null).readValue(str, Zebra.class);
+            assertNotNull(o);
+            assertNotNull(o.getAdditionalProperties());
+            assertEquals(1, o.getAdditionalProperties().size());
+            assertTrue(o.getAdditionalProperties().containsKey("some_other_property"));
+            assertTrue(o.getAdditionalProperties().containsValue("abc"));
         }
         {
             String str = "{ \"className\": \"zebra\" }";
             AbstractOpenApiSchema o = json.getContext(null).readValue(str, Mammal.class);
             assertNotNull(o);
             assertTrue(o.getActualInstance() instanceof Zebra);
+            Zebra z = (Zebra)o.getActualInstance();
+            assertNull(z.getAdditionalProperties());
         }
         {
             /* comment out while unboxing nested oneOf/anyOf is still in discussion

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/test/java/org/openapitools/client/JSONComposedSchemaTest.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/test/java/org/openapitools/client/JSONComposedSchemaTest.java
@@ -2,6 +2,8 @@ package org.openapitools.client;
 
 import org.openapitools.client.model.*;
 import java.lang.Exception;
+import java.util.List;
+import java.util.Map;
 import com.fasterxml.jackson.databind.JsonMappingException;
 
 import org.junit.*;
@@ -309,7 +311,10 @@ public class JSONComposedSchemaTest {
         }
         {
             String str = "{ \"pet_type\": \"ChildCat\", \"name\": \"fluffy\", " +
-                " \"more_stuff\": \"the_value\"" +  // additional, undeclared property.
+                " \"stuff1\": \"the_value\", " +      // additional, undeclared property of type string.
+                " \"stuff2\": { \"p1\": 123 }, " +    // additional, undeclared property of type object.
+                " \"stuff3\": null," +                // additional, undeclared property with null value.
+                " \"stuff4\": [ 12, \"abc\" ]" +      // additional, undeclared property of type array.
                 " }";
             GrandparentAnimal o = json.getContext(null).readValue(str, GrandparentAnimal.class);            
             assertNotNull(o);
@@ -318,6 +323,17 @@ public class JSONComposedSchemaTest {
             ChildCat c = (ChildCat)o;
             assertEquals("fluffy", c.getName());
             assertNotNull(c.getAdditionalProperties());
+            assertEquals(4, c.getAdditionalProperties().size());
+            assertTrue(c.getAdditionalProperties().containsKey("stuff1"));
+            assertTrue(c.getAdditionalProperties().containsKey("stuff2"));
+            assertTrue(c.getAdditionalProperties().containsKey("stuff3"));
+            assertTrue(c.getAdditionalProperties().containsKey("stuff4"));
+            assertEquals("the_value", c.getAdditionalProperties().get("stuff1"));
+            assertNotNull(c.getAdditionalProperties().get("stuff2"));
+            assertTrue(c.getAdditionalProperties().get("stuff2") instanceof Map);
+            assertNull(c.getAdditionalProperties().get("stuff3"));
+            assertNotNull(c.getAdditionalProperties().get("stuff4"));
+            assertTrue(c.getAdditionalProperties().get("stuff4") instanceof List);
         }
         {
             String str = "{ \"pet_type\": \"ChildCat\", \"name\": \"fluffy\" }";


### PR DESCRIPTION
This is a fix for #6646.

1. Add more unit tests (in JSONComposedSchemaTest.java) to exercise various use cases for `additionalProperties`, such as:
   1. within composed schema
   1. non composed schemas
   1. additionalProperties with boolean value
   1. additionalProperties with schema
1. Fix processing of `additionalProperties`

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/config/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
