### PR TITLE
[C++]Enable forward declaration for C++

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractCppCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractCppCodegen.java
@@ -375,14 +375,14 @@ abstract public class AbstractCppCodegen extends DefaultCodegen implements Codeg
         }
         for(CodegenProperty property : model.vars){
             if((property.isContainer && property.mostInnerItems.isModel) || (property.isModel)) {
-                String innerPropertyName = property.isContainer?property.mostInnerItems.baseType:property.baseType;
+                String innerPropertyType = property.isContainer? property.mostInnerItems.baseType : property.baseType;
                 for(final Entry<String, Object> mo : objs.entrySet()) {
                     CodegenModel innerModel = ModelUtils.getModelByName(mo.getKey(), objs);
-                    if(innerPropertyName.equals(innerModel.classname) && !innerPropertyName.equals(model.classname)){
+                    if(innerPropertyType.equals(innerModel.classname) && !innerPropertyType.equals(model.classname)){
                         if(innerModel.hasVars) {
                             for(CodegenProperty p : innerModel.vars) {
                                 if(((p.isModel && p.dataType.equals(model.classname)) || (p.isContainer && p.mostInnerItems.baseType.equals(model.classname)))) {
-                                    String forwardDecl = "class " + innerModel.classname + ";\n";
+                                    String forwardDecl = "class " + innerModel.classname + ";";
                                     if(!forwardDeclarations.contains(forwardDecl)) {
                                         forwardDeclarations.add(forwardDecl);
                                     }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractCppCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractCppCodegen.java
@@ -28,15 +28,18 @@ import org.openapitools.codegen.CodegenModel;
 import org.openapitools.codegen.CodegenProperty;
 import org.openapitools.codegen.DefaultCodegen;
 import org.openapitools.codegen.templating.mustache.IndentedLambda;
+import org.openapitools.codegen.utils.ModelUtils;
 import org.openapitools.codegen.utils.URLPathUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 
 abstract public class AbstractCppCodegen extends DefaultCodegen implements CodegenConfig {
     private static final Logger LOGGER = LoggerFactory.getLogger(AbstractCppCodegen.class);
@@ -237,6 +240,7 @@ abstract public class AbstractCppCodegen extends DefaultCodegen implements Codeg
         return sanitizeName(super.toParamName(name));
     }
 
+    @SuppressWarnings("rawtypes")
     @Override
     public CodegenProperty fromProperty(String name, Schema p) {
         CodegenProperty property = super.fromProperty(name, p);
@@ -352,5 +356,48 @@ abstract public class AbstractCppCodegen extends DefaultCodegen implements Codeg
             }
         }
         return postProcessModelsEnum(objs);
+    }
+
+    @Override
+    public Map<String, Object> postProcessAllModels(Map<String, Object> objs){
+        Map<String, Object> models = super.postProcessAllModels(objs);
+        for (final Entry<String, Object> model : models.entrySet()) {
+            CodegenModel mo = ModelUtils.getModelByName(model.getKey(), models);
+            addForwardDeclarations(mo, models);
+        }
+        return models;
+    }
+
+    private void addForwardDeclarations(CodegenModel model, Map<String, Object> objs) {
+        List<String> forwardDeclarations = new ArrayList<String>();
+        if(!model.hasVars) {
+            return;
+        }
+        for(CodegenProperty property : model.vars){
+            if((property.isContainer && property.mostInnerItems.isModel) || (property.isModel)) {
+                String innerPropertyName = property.isContainer?property.mostInnerItems.baseType:property.baseType;
+                for(final Entry<String, Object> mo : objs.entrySet()) {
+                    CodegenModel innerModel = ModelUtils.getModelByName(mo.getKey(), objs);
+                    if(innerPropertyName.equals(innerModel.classname) && !innerPropertyName.equals(model.classname)){
+                        if(innerModel.hasVars) {
+                            for(CodegenProperty p : innerModel.vars) {
+                                if(((p.isModel && p.dataType.equals(model.classname)) || (p.isContainer && p.mostInnerItems.baseType.equals(model.classname)))) {
+                                    String forwardDecl = "class " + innerModel.classname + ";\n";
+                                    if(!forwardDeclarations.contains(forwardDecl)) {
+                                        forwardDeclarations.add(forwardDecl);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        if(!forwardDeclarations.isEmpty())
+        {
+            model.vendorExtensions.put("x-has-forward-declarations", true);
+            model.vendorExtensions.put("x-forward-declarations", forwardDeclarations);
+        }
+        return;
     }
 }

--- a/modules/openapi-generator/src/main/resources/cpp-qt5-client/model-header.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-client/model-header.mustache
@@ -22,8 +22,8 @@
 namespace {{this}} {
 {{/cppNamespaceDeclarations}}
 {{#vendorExtensions.x-has-forward-declarations}}
-{{#vendorExtensions.x-forward-declarations}}{{.}}{{/vendorExtensions.x-forward-declarations}}
-{{/vendorExtensions.x-has-forward-declarations}}
+{{#vendorExtensions.x-forward-declarations}}{{.}}
+{{/vendorExtensions.x-forward-declarations}}{{/vendorExtensions.x-has-forward-declarations}}
 class {{classname}} : public {{prefix}}{{^isEnum}}Object{{/isEnum}}{{#isEnum}}Enum{{/isEnum}} {
 public:
     {{classname}}();

--- a/modules/openapi-generator/src/main/resources/cpp-qt5-client/model-header.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-client/model-header.mustache
@@ -21,7 +21,9 @@
 {{#cppNamespaceDeclarations}}
 namespace {{this}} {
 {{/cppNamespaceDeclarations}}
-
+{{#vendorExtensions.x-has-forward-declarations}}
+{{#vendorExtensions.x-forward-declarations}}{{.}}{{/vendorExtensions.x-forward-declarations}}
+{{/vendorExtensions.x-has-forward-declarations}}
 class {{classname}} : public {{prefix}}{{^isEnum}}Object{{/isEnum}}{{#isEnum}}Enum{{/isEnum}} {
 public:
     {{classname}}();


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
Fixes #6377
@muttleyxd @MartinDelille @stkrwork @ravinikam 
@wing328 
<!-- Please check the completed items below -->
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [X] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/config/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [X] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

**Fixes this spec below**
```yaml
openapi: 3.0.0
info:
  version: 0.0.1
  title: Test
paths:
  /endpoint:
    get:
      operationId: getOptions
      description: "-"
      parameters:
      - name: OptionA
        in: header
        schema:
          $ref: '#/components/schemas/OptionA'
      responses:
        200:
          description: Success
          content:
            application/json:
              schema:
                type: array
                items:
                  $ref: '#/components/schemas/OptionA'
components:
  schemas:
    OptionA:
      type: object
      description: 'OptionA'
      properties:
        suboptions:
          type: array
          description: 'Suboptions of OptionA'
          items:
            $ref: '#/components/schemas/OptionB'
    OptionB:
      type: object
      description: 'OptionB'
      properties:
        suboptions1:
          type: array
          description: 'Suboptions 1 of OptionB'
          items:
            $ref: '#/components/schemas/OptionA'
        suboptions2:
          type: array
          description: 'Suboptions 2 of OptionB'
          items:
            $ref: '#/components/schemas/OptionB'
```

**This spec below cannot be fixed due to C++ limitations.**

```yaml
openapi: 3.0.0
info:
  version: 0.0.1
  title: Test
paths:
  /endpoint:
    get:
      operationId: getOptions
      description: "-"
      parameters:
      - name: OptionA
        in: header
        schema:
          $ref: '#/components/schemas/OptionA'
      responses:
        200:
          description: Success
          content:
            application/json:
              schema:
                type: array
                items:
                  $ref: '#/components/schemas/OptionA'
components:
  schemas:
    OptionA:
      type: object
      description: 'OptionA'
      properties:
        suboptions:
          $ref: '#/components/schemas/OptionB'
    OptionB:
      type: object
      description: 'OptionB'
      properties:
        suboptions1:
          $ref: '#/components/schemas/OptionA'
```
**Generated code below has forward declaration and include as well.**
```C++
#ifndef OAIOptionB_H
#define OAIOptionB_H

#include <QJsonObject>

#include "OAIOptionA.h"

#include "OAIEnum.h"
#include "OAIObject.h"

namespace OpenAPI {
class OAIOptionA;

class OAIOptionB : public OAIObject {
public:
    OAIOptionB();
    OAIOptionB(QString json);
    ~OAIOptionB() override;

    QString asJson() const override;
    QJsonObject asJsonObject() const override;
    void fromJsonObject(QJsonObject json) override;
    void fromJson(QString jsonString) override;

    OAIOptionA getSuboptions1() const;
    void setSuboptions1(const OAIOptionA &suboptions1);
    bool is_suboptions1_Set() const;
    bool is_suboptions1_Valid() const;

    virtual bool isSet() const override;
    virtual bool isValid() const override;

private:
    void initializeModel();

    OAIOptionA suboptions1;
    bool m_suboptions1_isSet;
    bool m_suboptions1_isValid;
};

} // namespace OpenAPI
```
**Error for the one above**
```shell
OAIOptionB.h:53: error: field ‘suboptions1’ has incomplete type ‘OpenAPI::OAIOptionA’
   53 |     OAIOptionA suboptions1;
      |                ^~~~~~~~~~~
```