### PR TITLE
[go-experimental] Fix error message when unmarshaling wrong enum value

### DIFF
--- a/modules/openapi-generator/src/main/resources/go-experimental/model_enum.mustache
+++ b/modules/openapi-generator/src/main/resources/go-experimental/model_enum.mustache
@@ -26,7 +26,7 @@ func (v *{{{classname}}}) UnmarshalJSON(src []byte) error {
 		}
 	}
 
-	return fmt.Errorf("%+v is not a valid {{classname}}", *v)
+	return fmt.Errorf("%+v is not a valid {{classname}}", value)
 }
 
 // Ptr returns reference to {{{name}}} value

--- a/samples/client/petstore/go-experimental/go-petstore/model_enum_class.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_enum_class.go
@@ -38,7 +38,7 @@ func (v *EnumClass) UnmarshalJSON(src []byte) error {
 		}
 	}
 
-	return fmt.Errorf("%+v is not a valid EnumClass", *v)
+	return fmt.Errorf("%+v is not a valid EnumClass", value)
 }
 
 // Ptr returns reference to EnumClass value

--- a/samples/client/petstore/go-experimental/go-petstore/model_outer_enum.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_outer_enum.go
@@ -38,7 +38,7 @@ func (v *OuterEnum) UnmarshalJSON(src []byte) error {
 		}
 	}
 
-	return fmt.Errorf("%+v is not a valid OuterEnum", *v)
+	return fmt.Errorf("%+v is not a valid OuterEnum", value)
 }
 
 // Ptr returns reference to OuterEnum value

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_enum_class.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_enum_class.go
@@ -38,7 +38,7 @@ func (v *EnumClass) UnmarshalJSON(src []byte) error {
 		}
 	}
 
-	return fmt.Errorf("%+v is not a valid EnumClass", *v)
+	return fmt.Errorf("%+v is not a valid EnumClass", value)
 }
 
 // Ptr returns reference to EnumClass value

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_outer_enum.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_outer_enum.go
@@ -38,7 +38,7 @@ func (v *OuterEnum) UnmarshalJSON(src []byte) error {
 		}
 	}
 
-	return fmt.Errorf("%+v is not a valid OuterEnum", *v)
+	return fmt.Errorf("%+v is not a valid OuterEnum", value)
 }
 
 // Ptr returns reference to OuterEnum value

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_outer_enum_default_value.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_outer_enum_default_value.go
@@ -38,7 +38,7 @@ func (v *OuterEnumDefaultValue) UnmarshalJSON(src []byte) error {
 		}
 	}
 
-	return fmt.Errorf("%+v is not a valid OuterEnumDefaultValue", *v)
+	return fmt.Errorf("%+v is not a valid OuterEnumDefaultValue", value)
 }
 
 // Ptr returns reference to OuterEnumDefaultValue value

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_outer_enum_integer.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_outer_enum_integer.go
@@ -38,7 +38,7 @@ func (v *OuterEnumInteger) UnmarshalJSON(src []byte) error {
 		}
 	}
 
-	return fmt.Errorf("%+v is not a valid OuterEnumInteger", *v)
+	return fmt.Errorf("%+v is not a valid OuterEnumInteger", value)
 }
 
 // Ptr returns reference to OuterEnumInteger value

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_outer_enum_integer_default_value.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_outer_enum_integer_default_value.go
@@ -38,7 +38,7 @@ func (v *OuterEnumIntegerDefaultValue) UnmarshalJSON(src []byte) error {
 		}
 	}
 
-	return fmt.Errorf("%+v is not a valid OuterEnumIntegerDefaultValue", *v)
+	return fmt.Errorf("%+v is not a valid OuterEnumIntegerDefaultValue", value)
 }
 
 // Ptr returns reference to OuterEnumIntegerDefaultValue value


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

The error message uses the unmarshaled struct, but it is empty since the unmarshal failed. This fixes it to have a proper error message.

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/config/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
