### PR TITLE
[Python] Add attribute_map to simple model

### DIFF
--- a/modules/openapi-generator/src/main/resources/python/python-experimental/model_templates/model_simple.mustache
+++ b/modules/openapi-generator/src/main/resources/python/python-experimental/model_templates/model_simple.mustache
@@ -11,6 +11,8 @@ class {{unescapedDescription}}(ModelSimple):
 
 {{> python-experimental/model_templates/classvars }}
 
+    attribute_map = {}
+
     _composed_schemas = None
 
 {{> python-experimental/model_templates/method_init_normal}}

--- a/samples/client/petstore/python-experimental/petstore_api/model/animal_farm.py
+++ b/samples/client/petstore/python-experimental/petstore_api/model/animal_farm.py
@@ -88,6 +88,8 @@ class AnimalFarm(ModelSimple):
     def discriminator():
         return None
 
+    attribute_map = {}
+
     _composed_schemas = None
 
     required_properties = set([

--- a/samples/client/petstore/python-experimental/petstore_api/model/enum_class.py
+++ b/samples/client/petstore/python-experimental/petstore_api/model/enum_class.py
@@ -88,6 +88,8 @@ class EnumClass(ModelSimple):
     def discriminator():
         return None
 
+    attribute_map = {}
+
     _composed_schemas = None
 
     required_properties = set([

--- a/samples/client/petstore/python-experimental/petstore_api/model/outer_enum.py
+++ b/samples/client/petstore/python-experimental/petstore_api/model/outer_enum.py
@@ -88,6 +88,8 @@ class OuterEnum(ModelSimple):
     def discriminator():
         return None
 
+    attribute_map = {}
+
     _composed_schemas = None
 
     required_properties = set([

--- a/samples/client/petstore/python-experimental/petstore_api/model/outer_number.py
+++ b/samples/client/petstore/python-experimental/petstore_api/model/outer_number.py
@@ -87,6 +87,8 @@ class OuterNumber(ModelSimple):
     def discriminator():
         return None
 
+    attribute_map = {}
+
     _composed_schemas = None
 
     required_properties = set([

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/model/animal_farm.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/model/animal_farm.py
@@ -88,6 +88,8 @@ class AnimalFarm(ModelSimple):
     def discriminator():
         return None
 
+    attribute_map = {}
+
     _composed_schemas = None
 
     required_properties = set([

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/model/array_of_enums.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/model/array_of_enums.py
@@ -88,6 +88,8 @@ class ArrayOfEnums(ModelSimple):
     def discriminator():
         return None
 
+    attribute_map = {}
+
     _composed_schemas = None
 
     required_properties = set([

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/model/enum_class.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/model/enum_class.py
@@ -88,6 +88,8 @@ class EnumClass(ModelSimple):
     def discriminator():
         return None
 
+    attribute_map = {}
+
     _composed_schemas = None
 
     required_properties = set([

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/model/outer_enum.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/model/outer_enum.py
@@ -89,6 +89,8 @@ class OuterEnum(ModelSimple):
     def discriminator():
         return None
 
+    attribute_map = {}
+
     _composed_schemas = None
 
     required_properties = set([

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/model/outer_enum_default_value.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/model/outer_enum_default_value.py
@@ -88,6 +88,8 @@ class OuterEnumDefaultValue(ModelSimple):
     def discriminator():
         return None
 
+    attribute_map = {}
+
     _composed_schemas = None
 
     required_properties = set([

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/model/outer_enum_integer.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/model/outer_enum_integer.py
@@ -88,6 +88,8 @@ class OuterEnumInteger(ModelSimple):
     def discriminator():
         return None
 
+    attribute_map = {}
+
     _composed_schemas = None
 
     required_properties = set([

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/model/outer_enum_integer_default_value.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/model/outer_enum_integer_default_value.py
@@ -88,6 +88,8 @@ class OuterEnumIntegerDefaultValue(ModelSimple):
     def discriminator():
         return None
 
+    attribute_map = {}
+
     _composed_schemas = None
 
     required_properties = set([


### PR DESCRIPTION
The `__init__` method expects the `attribute_map` to be present.

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/config/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@taxpon (2017/07) @frol (2017/07) @mbohlool (2017/07) @cbornet (2017/09) @kenjones-cisco (2017/11) @tomplus (2018/10) @Jyhess (2019/01) @arun-nalla (2019/11) @spacether (2019/11)