### PR TITLE
[go-experimental] Fix usage of discriminator for oneOf deserialization

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -2539,7 +2539,7 @@ public class DefaultCodegen implements CodegenConfig {
     private CodegenProperty discriminatorFound(String composedSchemaName, Schema sc, String discPropName, OpenAPI openAPI) {
         Schema refSchema = ModelUtils.getReferencedSchema(openAPI, sc);
         if (refSchema.getProperties() != null && refSchema.getProperties().get(discPropName) != null) {
-            Schema discSchema = (Schema) refSchema.getProperties().get(discPropName);
+            Schema discSchema = ModelUtils.getReferencedSchema(openAPI, (Schema) refSchema.getProperties().get(discPropName));
             CodegenProperty cp = new CodegenProperty();
             if (ModelUtils.isStringSchema(discSchema)) {
                 cp.isString = true;

--- a/modules/openapi-generator/src/main/resources/go-experimental/model_oneof.mustache
+++ b/modules/openapi-generator/src/main/resources/go-experimental/model_oneof.mustache
@@ -16,7 +16,6 @@ func {{{.}}}As{{classname}}(v *{{{.}}}) {{classname}} {
 // Unmarshal JSON data into one of the pointers in the struct
 func (dst *{{classname}}) UnmarshalJSON(data []byte) error {
 	var err error
-	match := 0
 	{{#isNullable}}
 	// this object is nullable so check if the payload is null or empty string
 	if string(data) == "" || string(data) == "{}" {
@@ -41,20 +40,19 @@ func (dst *{{classname}}) UnmarshalJSON(data []byte) error {
 		// try to unmarshal JSON data into {{{modelName}}}
 		err = json.Unmarshal(data, &dst.{{{modelName}}})
 		if err == nil {
-			json{{{modelName}}}, _ := json.Marshal(dst.{{{modelName}}})
-			if string(json{{{modelName}}}) == "{}" { // empty struct
-				dst.{{{modelName}}} = nil
-			} else {
-				return nil // data stored in dst.{{{modelName}}}, return on the first match
-			}
+			return nil // data stored in dst.{{{modelName}}}, return on the first match
 		} else {
 			dst.{{{modelName}}} = nil
+			return fmt.Errorf("Failed to unmarshal {{classname}} as {{{modelName}}}: %s", err.Error())
 		}
 	}
 
 	{{/mappedModels}}
 	{{/discriminator}}
+	return nil
 	{{/useOneOfDiscriminatorLookup}}
+	{{^useOneOfDiscriminatorLookup}}
+	match := 0
 	{{#oneOf}}
 	// try to unmarshal data into {{{.}}}
 	err = json.Unmarshal(data, &dst.{{{.}}})
@@ -82,6 +80,7 @@ func (dst *{{classname}}) UnmarshalJSON(data []byte) error {
 	} else { // no match
 		return fmt.Errorf("Data failed to match schemas in oneOf({{classname}})")
 	}
+	{{/useOneOfDiscriminatorLookup}}
 }
 
 // Marshal data from the first non-nil pointers in the struct to JSON


### PR DESCRIPTION
This PR partially fixes the new style usage of discriminator for better deserialization of `oneOf` composed schemas. Changes:

* Enables usage of string schemas referenced by `$ref` as type of the discriminator property (see `OneType` in example below).
* Removes some unnecessary (AFAICS) logic for unmarshalling - we don't need to check `if string(json{{{modelName}}}) == "{}"`, as we know that `json{{{modelName}}}` contains at least the discriminator property.

There's one more issue that I'm not sure to address. Consider this example:

```yaml
openapi: 3.0.0
info:
  title: test
  version: 1.0.0
paths:
  /test:
    patch:
      responses:
        '200':
          description: all good
      requestBody:
        description: request
        required: true
        content:
          application/json:
            schema:
              $ref: '#/components/schemas/Something'
components:
  schemas:
    Something:
      type: object
      oneOf:
        - $ref: '#/components/schemas/One'
        - $ref: '#/components/schemas/Two'
      discriminator:
         propertyName: foobar
         mapping:
           fooone: '#/components/schemas/One'
           footwo: '#/components/schemas/Two'

    OneType:
      type: string
      enum:
        - fooone
    One:
      type: object
      required: [foobar]
      properties:
        foobar:
          $ref: '#/components/schemas/OneType'
        one:
          type: string

    Two:
      type: object
      required: [foobar]
      properties:
        foobar:
          type: string
        two:
          type: string
```

When I run `openapi-generator generate -i min.yaml -g go-experimental -o go --additional-properties useOneOfDiscriminatorLookup=true`

I get unmarshaling code like this (even without my change for working with the referenced schema):

```go
// Unmarshal JSON data into one of the pointers in the struct
func (dst *Something) UnmarshalJSON(data []byte) error {
	var err error
	// use discriminator value to speed up the lookup
	var jsonDict map[string]interface{}
	err = json.Unmarshal(data, &jsonDict)
	if err != nil {
		return fmt.Errorf("Failed to unmarshal JSON into map for the discrimintor lookup.")
	}

	// check if the discriminator value is 'One'
	if jsonDict["foobar"] == "One" {
		// try to unmarshal JSON data into One
		err = json.Unmarshal(data, &dst.One)
		if err == nil {
			return nil // data stored in dst.One, return on the first match
		} else {
			dst.One = nil
			return fmt.Errorf("Failed to unmarshal Something as One: %s", err.Error())
		}
	}

	// check if the discriminator value is 'Two'
        // <MORE-CODE>

	// check if the discriminator value is 'fooone'
	if jsonDict["foobar"] == "fooone" {
		// try to unmarshal JSON data into One
		err = json.Unmarshal(data, &dst.One)
		if err == nil {
			return nil // data stored in dst.One, return on the first match
		} else {
			dst.One = nil
			return fmt.Errorf("Failed to unmarshal Something as One: %s", err.Error())
		}
	}

	// check if the discriminator value is 'footwo'
        // <MORE-CODE>

	return nil
}
```

As you can see, the deserialization logic is generated twice, once for `One` and once for `fooone`. The `if jsonDict["foobar"] == "One" {` line is obviously wrong. I tracked it down to being added at [this line](https://github.com/OpenAPITools/openapi-generator/blob/ff68128c15363ece22d7b6376952eb4eabc1f0bd/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java#L2862). I would like to fix that, but I honestly don't understand the whole purpose of the `getOneOfAnyOfDescendants` function which returns these results. AFAICS it's redundant and isn't necessary at all, but maybe I'm missing some context. Any help would be appreciated.

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [ ] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/config/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@antihax (2017/11) @bvwells (2017/12) @grokify (2018/07) @kemokemo (2018/09) @bkabrda (2019/07)