### PR TITLE
[Rust][Client] Multiple returns becomes optional (fixes #6650).

### DIFF
--- a/bin/configs/rust-reqwest-petstore-async.yaml
+++ b/bin/configs/rust-reqwest-petstore-async.yaml
@@ -5,6 +5,6 @@ inputSpec: modules/openapi-generator/src/test/resources/2_0/petstore.yaml
 templateDir: modules/openapi-generator/src/main/resources/rust
 additionalProperties:
   supportAsync: true
-  supportMultipleReturns: true
+  supportMultipleResponses: true
   packageName: petstore-reqwest-async
   useSingleRequestParameter: true

--- a/bin/configs/rust-reqwest-petstore-async.yaml
+++ b/bin/configs/rust-reqwest-petstore-async.yaml
@@ -5,5 +5,6 @@ inputSpec: modules/openapi-generator/src/test/resources/2_0/petstore.yaml
 templateDir: modules/openapi-generator/src/main/resources/rust
 additionalProperties:
   supportAsync: true
+  supportMultipleReturns: true
   packageName: petstore-reqwest-async
   useSingleRequestParameter: true

--- a/docs/generators/rust.md
+++ b/docs/generators/rust.md
@@ -10,6 +10,7 @@ sidebar_label: rust
 |packageName|Rust package name (convention: lowercase).| |openapi|
 |packageVersion|Rust package version.| |1.0.0|
 |supportAsync|If set, generate async function call instead. This option is for 'reqwest' library only| |true|
+|supportMultipleResponses|If set, return type wraps an enum of all possible 2xx schemas. This option is for 'reqwest' library only| |false|
 |useSingleRequestParameter|Setting this property to true will generate functions with a single argument containing all API endpoint parameters instead of one argument per parameter.| |false|
 
 ## IMPORT MAPPING

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustClientCodegen.java
@@ -40,12 +40,14 @@ public class RustClientCodegen extends DefaultCodegen implements CodegenConfig {
     private static final Logger LOGGER = LoggerFactory.getLogger(RustClientCodegen.class);
     private boolean useSingleRequestParameter = false;
     private boolean supportAsync = true;
+    private boolean supportMultipleReturns = false;
 
     public static final String PACKAGE_NAME = "packageName";
     public static final String PACKAGE_VERSION = "packageVersion";
     public static final String HYPER_LIBRARY = "hyper";
     public static final String REQWEST_LIBRARY = "reqwest";
     public static final String SUPPORT_ASYNC = "supportAsync";
+    public static final String SUPPORT_MULTIPLE_RETURNS = "supportMultipleReturns";
 
     protected String packageName = "openapi";
     protected String packageVersion = "1.0.0";
@@ -175,6 +177,8 @@ public class RustClientCodegen extends DefaultCodegen implements CodegenConfig {
                 .defaultValue(Boolean.FALSE.toString()));
         cliOptions.add(new CliOption(SUPPORT_ASYNC, "If set, generate async function call instead. This option is for 'reqwest' library only", SchemaTypeUtil.BOOLEAN_TYPE)
                 .defaultValue(Boolean.TRUE.toString()));
+        cliOptions.add(new CliOption(SUPPORT_MULTIPLE_RETURNS, "If set, return type is an enum of all possible 2xx schemas. This option is for 'reqwest' library only", SchemaTypeUtil.BOOLEAN_TYPE)
+            .defaultValue(Boolean.FALSE.toString()));
 
         supportedLibraries.put(HYPER_LIBRARY, "HTTP client: Hyper.");
         supportedLibraries.put(REQWEST_LIBRARY, "HTTP client: Reqwest.");
@@ -260,6 +264,11 @@ public class RustClientCodegen extends DefaultCodegen implements CodegenConfig {
         }
         writePropertyBack(SUPPORT_ASYNC, getSupportAsync());
 
+        if (additionalProperties.containsKey(SUPPORT_MULTIPLE_RETURNS)) {
+            this.setSupportMultipleReturns(convertPropertyToBoolean(SUPPORT_MULTIPLE_RETURNS));
+        }
+        writePropertyBack(SUPPORT_MULTIPLE_RETURNS, getSupportMultipleReturns());
+
         additionalProperties.put(CodegenConstants.PACKAGE_NAME, packageName);
         additionalProperties.put(CodegenConstants.PACKAGE_VERSION, packageVersion);
 
@@ -303,6 +312,14 @@ public class RustClientCodegen extends DefaultCodegen implements CodegenConfig {
 
     private void setSupportAsync(boolean supportAsync) {
         this.supportAsync = supportAsync;
+    }
+
+    public boolean getSupportMultipleReturns() {
+        return supportMultipleReturns;
+    }
+
+    public void setSupportMultipleReturns(boolean supportMultipleReturns) {
+        this.supportMultipleReturns = supportMultipleReturns;
     }
 
     private boolean getUseSingleRequestParameter() {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustClientCodegen.java
@@ -40,14 +40,14 @@ public class RustClientCodegen extends DefaultCodegen implements CodegenConfig {
     private static final Logger LOGGER = LoggerFactory.getLogger(RustClientCodegen.class);
     private boolean useSingleRequestParameter = false;
     private boolean supportAsync = true;
-    private boolean supportMultipleReturns = false;
+    private boolean supportMultipleResponses = false;
 
     public static final String PACKAGE_NAME = "packageName";
     public static final String PACKAGE_VERSION = "packageVersion";
     public static final String HYPER_LIBRARY = "hyper";
     public static final String REQWEST_LIBRARY = "reqwest";
     public static final String SUPPORT_ASYNC = "supportAsync";
-    public static final String SUPPORT_MULTIPLE_RETURNS = "supportMultipleReturns";
+    public static final String SUPPORT_MULTIPLE_RESPONSES = "supportMultipleResponses";
 
     protected String packageName = "openapi";
     protected String packageVersion = "1.0.0";
@@ -177,7 +177,7 @@ public class RustClientCodegen extends DefaultCodegen implements CodegenConfig {
                 .defaultValue(Boolean.FALSE.toString()));
         cliOptions.add(new CliOption(SUPPORT_ASYNC, "If set, generate async function call instead. This option is for 'reqwest' library only", SchemaTypeUtil.BOOLEAN_TYPE)
                 .defaultValue(Boolean.TRUE.toString()));
-        cliOptions.add(new CliOption(SUPPORT_MULTIPLE_RETURNS, "If set, return type is an enum of all possible 2xx schemas. This option is for 'reqwest' library only", SchemaTypeUtil.BOOLEAN_TYPE)
+        cliOptions.add(new CliOption(SUPPORT_MULTIPLE_RESPONSES, "If set, return type wraps an enum of all possible 2xx schemas. This option is for 'reqwest' library only", SchemaTypeUtil.BOOLEAN_TYPE)
             .defaultValue(Boolean.FALSE.toString()));
 
         supportedLibraries.put(HYPER_LIBRARY, "HTTP client: Hyper.");
@@ -264,10 +264,10 @@ public class RustClientCodegen extends DefaultCodegen implements CodegenConfig {
         }
         writePropertyBack(SUPPORT_ASYNC, getSupportAsync());
 
-        if (additionalProperties.containsKey(SUPPORT_MULTIPLE_RETURNS)) {
-            this.setSupportMultipleReturns(convertPropertyToBoolean(SUPPORT_MULTIPLE_RETURNS));
+        if (additionalProperties.containsKey(SUPPORT_MULTIPLE_RESPONSES)) {
+            this.setSupportMultipleReturns(convertPropertyToBoolean(SUPPORT_MULTIPLE_RESPONSES));
         }
-        writePropertyBack(SUPPORT_MULTIPLE_RETURNS, getSupportMultipleReturns());
+        writePropertyBack(SUPPORT_MULTIPLE_RESPONSES, getSupportMultipleReturns());
 
         additionalProperties.put(CodegenConstants.PACKAGE_NAME, packageName);
         additionalProperties.put(CodegenConstants.PACKAGE_VERSION, packageVersion);
@@ -315,11 +315,11 @@ public class RustClientCodegen extends DefaultCodegen implements CodegenConfig {
     }
 
     public boolean getSupportMultipleReturns() {
-        return supportMultipleReturns;
+        return supportMultipleResponses;
     }
 
-    public void setSupportMultipleReturns(boolean supportMultipleReturns) {
-        this.supportMultipleReturns = supportMultipleReturns;
+    public void setSupportMultipleReturns(boolean supportMultipleResponses) {
+        this.supportMultipleResponses = supportMultipleResponses;
     }
 
     private boolean getUseSingleRequestParameter() {

--- a/modules/openapi-generator/src/main/resources/rust/reqwest/api.mustache
+++ b/modules/openapi-generator/src/main/resources/rust/reqwest/api.mustache
@@ -45,6 +45,7 @@ pub struct {{{operationIdCamelCase}}}Params {
 {{/operation}}
 {{/operations}}
 
+{{#supportMultipleReturns}}
 {{#operations}}
 {{#operation}}
 /// struct for typed successes of method `{{operationId}}`
@@ -65,6 +66,7 @@ pub enum {{{operationIdCamelCase}}}Success {
 
 {{/operation}}
 {{/operations}}
+{{/supportMultipleReturns}}
 {{#operations}}
 {{#operation}}
 /// struct for typed errors of method `{{operationId}}`
@@ -94,10 +96,10 @@ pub trait {{{classname}}} {
 {{#operations}}
 {{#operation}}
     {{#vendorExtensions.x-group-parameters}}
-    fn {{{operationId}}}(&self{{#allParams}}{{#-first}}, params: {{{operationIdCamelCase}}}Params{{/-first}}{{/allParams}}) -> Result<ResponseContent<{{{operationIdCamelCase}}}Success>, Error<{{{operationIdCamelCase}}}Error>>;
+    fn {{{operationId}}}(&self{{#allParams}}{{#-first}}, params: {{{operationIdCamelCase}}}Params{{/-first}}{{/allParams}}) -> Result<{{#supportMultipleReturns}}ResponseContent<{{{operationIdCamelCase}}}Success>{{/supportMultipleReturns}}{{^supportMultipleReturns}}{{^returnType}}(){{/returnType}}{{#returnType}}{{{returnType}}}{{/returnType}}{{/supportMultipleReturns}}, Error<{{{operationIdCamelCase}}}Error>>;
     {{/vendorExtensions.x-group-parameters}}
     {{^vendorExtensions.x-group-parameters}}
-    fn {{{operationId}}}(&self, {{#allParams}}{{{paramName}}}: {{^required}}Option<{{/required}}{{#required}}{{#isNullable}}Option<{{/isNullable}}{{/required}}{{#isString}}&str{{/isString}}{{#isUuid}}&str{{/isUuid}}{{^isString}}{{^isUuid}}{{^isPrimitiveType}}{{^isContainer}}crate::models::{{/isContainer}}{{/isPrimitiveType}}{{{dataType}}}{{/isUuid}}{{/isString}}{{^required}}>{{/required}}{{#required}}{{#isNullable}}>{{/isNullable}}{{/required}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) -> Result<ResponseContent<{{{operationIdCamelCase}}}Success>, Error<{{{operationIdCamelCase}}}Error>>;
+    fn {{{operationId}}}(&self, {{#allParams}}{{{paramName}}}: {{^required}}Option<{{/required}}{{#required}}{{#isNullable}}Option<{{/isNullable}}{{/required}}{{#isString}}&str{{/isString}}{{#isUuid}}&str{{/isUuid}}{{^isString}}{{^isUuid}}{{^isPrimitiveType}}{{^isContainer}}crate::models::{{/isContainer}}{{/isPrimitiveType}}{{{dataType}}}{{/isUuid}}{{/isString}}{{^required}}>{{/required}}{{#required}}{{#isNullable}}>{{/isNullable}}{{/required}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) -> Result<{{#supportMultipleReturns}}ResponseContent<{{{operationIdCamelCase}}}Success>{{/supportMultipleReturns}}{{^supportMultipleReturns}}{{^returnType}}(){{/returnType}}{{#returnType}}{{{returnType}}}{{/returnType}}{{/supportMultipleReturns}}, Error<{{{operationIdCamelCase}}}Error>>;
     {{/vendorExtensions.x-group-parameters}}
 {{/operation}}
 {{/operations}}
@@ -108,7 +110,7 @@ impl {{{classname}}} for {{{classname}}}Client {
 {{#operations}}
 {{#operation}}
     {{#vendorExtensions.x-group-parameters}}
-    {{#supportAsync}}pub async {{/supportAsync}}fn {{{operationId}}}({{^supportAsync}}&self{{/supportAsync}}{{#supportAsync}}configuration: &configuration::Configuration{{/supportAsync}}{{#allParams}}{{#-first}}, params: {{{operationIdCamelCase}}}Params{{/-first}}{{/allParams}}) -> Result<ResponseContent<{{{operationIdCamelCase}}}Success>, Error<{{{operationIdCamelCase}}}Error>> {
+    {{#supportAsync}}pub async {{/supportAsync}}fn {{{operationId}}}({{^supportAsync}}&self{{/supportAsync}}{{#supportAsync}}configuration: &configuration::Configuration{{/supportAsync}}{{#allParams}}{{#-first}}, params: {{{operationIdCamelCase}}}Params{{/-first}}{{/allParams}}) -> Result<{{#supportMultipleReturns}}ResponseContent<{{{operationIdCamelCase}}}Success>{{/supportMultipleReturns}}{{^supportMultipleReturns}}{{^returnType}}(){{/returnType}}{{#returnType}}{{{returnType}}}{{/returnType}}{{/supportMultipleReturns}}, Error<{{{operationIdCamelCase}}}Error>> {
         // unbox the parameters
         {{#allParams}}
         let {{paramName}} = params.{{paramName}};
@@ -116,7 +118,7 @@ impl {{{classname}}} for {{{classname}}}Client {
 
     {{/vendorExtensions.x-group-parameters}}
     {{^vendorExtensions.x-group-parameters}}
-    {{#supportAsync}}pub async {{/supportAsync}}fn {{{operationId}}}({{^supportAsync}}&self{{/supportAsync}}{{#supportAsync}}configuration: &configuration::Configuration{{/supportAsync}}, {{#allParams}}{{{paramName}}}: {{^required}}Option<{{/required}}{{#required}}{{#isNullable}}Option<{{/isNullable}}{{/required}}{{#isString}}&str{{/isString}}{{#isUuid}}&str{{/isUuid}}{{^isString}}{{^isUuid}}{{^isPrimitiveType}}{{^isContainer}}crate::models::{{/isContainer}}{{/isPrimitiveType}}{{{dataType}}}{{/isUuid}}{{/isString}}{{^required}}>{{/required}}{{#required}}{{#isNullable}}>{{/isNullable}}{{/required}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) -> Result<ResponseContent<{{{operationIdCamelCase}}}Success>, Error<{{{operationIdCamelCase}}}Error>> {
+    {{#supportAsync}}pub async {{/supportAsync}}fn {{{operationId}}}({{^supportAsync}}&self{{/supportAsync}}{{#supportAsync}}configuration: &configuration::Configuration{{/supportAsync}}, {{#allParams}}{{{paramName}}}: {{^required}}Option<{{/required}}{{#required}}{{#isNullable}}Option<{{/isNullable}}{{/required}}{{#isString}}&str{{/isString}}{{#isUuid}}&str{{/isUuid}}{{^isString}}{{^isUuid}}{{^isPrimitiveType}}{{^isContainer}}crate::models::{{/isContainer}}{{/isPrimitiveType}}{{{dataType}}}{{/isUuid}}{{/isString}}{{^required}}>{{/required}}{{#required}}{{#isNullable}}>{{/isNullable}}{{/required}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) -> Result<{{#supportMultipleReturns}}ResponseContent<{{{operationIdCamelCase}}}Success>{{/supportMultipleReturns}}{{^supportMultipleReturns}}{{^returnType}}(){{/returnType}}{{#returnType}}{{{returnType}}}{{/returnType}}{{/supportMultipleReturns}}, Error<{{{operationIdCamelCase}}}Error>> {
     {{/vendorExtensions.x-group-parameters}}
         {{^supportAsync}}
         let configuration: &configuration::Configuration = self.configuration.borrow();
@@ -314,9 +316,19 @@ impl {{{classname}}} for {{{classname}}}Client {
         let content = resp.text(){{#supportAsync}}.await{{/supportAsync}}?;
 
         if status.is_success() {
+            {{^supportMultipleReturns}}
+            {{^returnType}}
+            Ok(())
+            {{/returnType}}
+            {{#returnType}}
+            serde_json::from_str(&content).map_err(Error::from)
+            {{/returnType}}
+            {{/supportMultipleReturns}}
+            {{#supportMultipleReturns}}
             let entity: Option<{{{operationIdCamelCase}}}Success> = serde_json::from_str(&content).ok();
             let result = ResponseContent { status, content, entity };
             Ok(result)
+            {{/supportMultipleReturns}}
         } else {
             let entity: Option<{{{operationIdCamelCase}}}Error> = serde_json::from_str(&content).ok();
             let error = ResponseContent { status, content, entity };

--- a/modules/openapi-generator/src/main/resources/rust/reqwest/api.mustache
+++ b/modules/openapi-generator/src/main/resources/rust/reqwest/api.mustache
@@ -45,7 +45,7 @@ pub struct {{{operationIdCamelCase}}}Params {
 {{/operation}}
 {{/operations}}
 
-{{#supportMultipleReturns}}
+{{#supportMultipleResponses}}
 {{#operations}}
 {{#operation}}
 /// struct for typed successes of method `{{operationId}}`
@@ -66,7 +66,7 @@ pub enum {{{operationIdCamelCase}}}Success {
 
 {{/operation}}
 {{/operations}}
-{{/supportMultipleReturns}}
+{{/supportMultipleResponses}}
 {{#operations}}
 {{#operation}}
 /// struct for typed errors of method `{{operationId}}`
@@ -96,10 +96,10 @@ pub trait {{{classname}}} {
 {{#operations}}
 {{#operation}}
     {{#vendorExtensions.x-group-parameters}}
-    fn {{{operationId}}}(&self{{#allParams}}{{#-first}}, params: {{{operationIdCamelCase}}}Params{{/-first}}{{/allParams}}) -> Result<{{#supportMultipleReturns}}ResponseContent<{{{operationIdCamelCase}}}Success>{{/supportMultipleReturns}}{{^supportMultipleReturns}}{{^returnType}}(){{/returnType}}{{#returnType}}{{{returnType}}}{{/returnType}}{{/supportMultipleReturns}}, Error<{{{operationIdCamelCase}}}Error>>;
+    fn {{{operationId}}}(&self{{#allParams}}{{#-first}}, params: {{{operationIdCamelCase}}}Params{{/-first}}{{/allParams}}) -> Result<{{#supportMultipleResponses}}ResponseContent<{{{operationIdCamelCase}}}Success>{{/supportMultipleResponses}}{{^supportMultipleResponses}}{{^returnType}}(){{/returnType}}{{#returnType}}{{{returnType}}}{{/returnType}}{{/supportMultipleResponses}}, Error<{{{operationIdCamelCase}}}Error>>;
     {{/vendorExtensions.x-group-parameters}}
     {{^vendorExtensions.x-group-parameters}}
-    fn {{{operationId}}}(&self, {{#allParams}}{{{paramName}}}: {{^required}}Option<{{/required}}{{#required}}{{#isNullable}}Option<{{/isNullable}}{{/required}}{{#isString}}&str{{/isString}}{{#isUuid}}&str{{/isUuid}}{{^isString}}{{^isUuid}}{{^isPrimitiveType}}{{^isContainer}}crate::models::{{/isContainer}}{{/isPrimitiveType}}{{{dataType}}}{{/isUuid}}{{/isString}}{{^required}}>{{/required}}{{#required}}{{#isNullable}}>{{/isNullable}}{{/required}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) -> Result<{{#supportMultipleReturns}}ResponseContent<{{{operationIdCamelCase}}}Success>{{/supportMultipleReturns}}{{^supportMultipleReturns}}{{^returnType}}(){{/returnType}}{{#returnType}}{{{returnType}}}{{/returnType}}{{/supportMultipleReturns}}, Error<{{{operationIdCamelCase}}}Error>>;
+    fn {{{operationId}}}(&self, {{#allParams}}{{{paramName}}}: {{^required}}Option<{{/required}}{{#required}}{{#isNullable}}Option<{{/isNullable}}{{/required}}{{#isString}}&str{{/isString}}{{#isUuid}}&str{{/isUuid}}{{^isString}}{{^isUuid}}{{^isPrimitiveType}}{{^isContainer}}crate::models::{{/isContainer}}{{/isPrimitiveType}}{{{dataType}}}{{/isUuid}}{{/isString}}{{^required}}>{{/required}}{{#required}}{{#isNullable}}>{{/isNullable}}{{/required}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) -> Result<{{#supportMultipleResponses}}ResponseContent<{{{operationIdCamelCase}}}Success>{{/supportMultipleResponses}}{{^supportMultipleResponses}}{{^returnType}}(){{/returnType}}{{#returnType}}{{{returnType}}}{{/returnType}}{{/supportMultipleResponses}}, Error<{{{operationIdCamelCase}}}Error>>;
     {{/vendorExtensions.x-group-parameters}}
 {{/operation}}
 {{/operations}}
@@ -110,7 +110,7 @@ impl {{{classname}}} for {{{classname}}}Client {
 {{#operations}}
 {{#operation}}
     {{#vendorExtensions.x-group-parameters}}
-    {{#supportAsync}}pub async {{/supportAsync}}fn {{{operationId}}}({{^supportAsync}}&self{{/supportAsync}}{{#supportAsync}}configuration: &configuration::Configuration{{/supportAsync}}{{#allParams}}{{#-first}}, params: {{{operationIdCamelCase}}}Params{{/-first}}{{/allParams}}) -> Result<{{#supportMultipleReturns}}ResponseContent<{{{operationIdCamelCase}}}Success>{{/supportMultipleReturns}}{{^supportMultipleReturns}}{{^returnType}}(){{/returnType}}{{#returnType}}{{{returnType}}}{{/returnType}}{{/supportMultipleReturns}}, Error<{{{operationIdCamelCase}}}Error>> {
+    {{#supportAsync}}pub async {{/supportAsync}}fn {{{operationId}}}({{^supportAsync}}&self{{/supportAsync}}{{#supportAsync}}configuration: &configuration::Configuration{{/supportAsync}}{{#allParams}}{{#-first}}, params: {{{operationIdCamelCase}}}Params{{/-first}}{{/allParams}}) -> Result<{{#supportMultipleResponses}}ResponseContent<{{{operationIdCamelCase}}}Success>{{/supportMultipleResponses}}{{^supportMultipleResponses}}{{^returnType}}(){{/returnType}}{{#returnType}}{{{returnType}}}{{/returnType}}{{/supportMultipleResponses}}, Error<{{{operationIdCamelCase}}}Error>> {
         // unbox the parameters
         {{#allParams}}
         let {{paramName}} = params.{{paramName}};
@@ -118,7 +118,7 @@ impl {{{classname}}} for {{{classname}}}Client {
 
     {{/vendorExtensions.x-group-parameters}}
     {{^vendorExtensions.x-group-parameters}}
-    {{#supportAsync}}pub async {{/supportAsync}}fn {{{operationId}}}({{^supportAsync}}&self{{/supportAsync}}{{#supportAsync}}configuration: &configuration::Configuration{{/supportAsync}}, {{#allParams}}{{{paramName}}}: {{^required}}Option<{{/required}}{{#required}}{{#isNullable}}Option<{{/isNullable}}{{/required}}{{#isString}}&str{{/isString}}{{#isUuid}}&str{{/isUuid}}{{^isString}}{{^isUuid}}{{^isPrimitiveType}}{{^isContainer}}crate::models::{{/isContainer}}{{/isPrimitiveType}}{{{dataType}}}{{/isUuid}}{{/isString}}{{^required}}>{{/required}}{{#required}}{{#isNullable}}>{{/isNullable}}{{/required}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) -> Result<{{#supportMultipleReturns}}ResponseContent<{{{operationIdCamelCase}}}Success>{{/supportMultipleReturns}}{{^supportMultipleReturns}}{{^returnType}}(){{/returnType}}{{#returnType}}{{{returnType}}}{{/returnType}}{{/supportMultipleReturns}}, Error<{{{operationIdCamelCase}}}Error>> {
+    {{#supportAsync}}pub async {{/supportAsync}}fn {{{operationId}}}({{^supportAsync}}&self{{/supportAsync}}{{#supportAsync}}configuration: &configuration::Configuration{{/supportAsync}}, {{#allParams}}{{{paramName}}}: {{^required}}Option<{{/required}}{{#required}}{{#isNullable}}Option<{{/isNullable}}{{/required}}{{#isString}}&str{{/isString}}{{#isUuid}}&str{{/isUuid}}{{^isString}}{{^isUuid}}{{^isPrimitiveType}}{{^isContainer}}crate::models::{{/isContainer}}{{/isPrimitiveType}}{{{dataType}}}{{/isUuid}}{{/isString}}{{^required}}>{{/required}}{{#required}}{{#isNullable}}>{{/isNullable}}{{/required}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) -> Result<{{#supportMultipleResponses}}ResponseContent<{{{operationIdCamelCase}}}Success>{{/supportMultipleResponses}}{{^supportMultipleResponses}}{{^returnType}}(){{/returnType}}{{#returnType}}{{{returnType}}}{{/returnType}}{{/supportMultipleResponses}}, Error<{{{operationIdCamelCase}}}Error>> {
     {{/vendorExtensions.x-group-parameters}}
         {{^supportAsync}}
         let configuration: &configuration::Configuration = self.configuration.borrow();
@@ -316,19 +316,19 @@ impl {{{classname}}} for {{{classname}}}Client {
         let content = resp.text(){{#supportAsync}}.await{{/supportAsync}}?;
 
         if status.is_success() {
-            {{^supportMultipleReturns}}
+            {{^supportMultipleResponses}}
             {{^returnType}}
             Ok(())
             {{/returnType}}
             {{#returnType}}
             serde_json::from_str(&content).map_err(Error::from)
             {{/returnType}}
-            {{/supportMultipleReturns}}
-            {{#supportMultipleReturns}}
+            {{/supportMultipleResponses}}
+            {{#supportMultipleResponses}}
             let entity: Option<{{{operationIdCamelCase}}}Success> = serde_json::from_str(&content).ok();
             let result = ResponseContent { status, content, entity };
             Ok(result)
-            {{/supportMultipleReturns}}
+            {{/supportMultipleResponses}}
         } else {
             let entity: Option<{{{operationIdCamelCase}}}Error> = serde_json::from_str(&content).ok();
             let error = ResponseContent { status, content, entity };

--- a/modules/openapi-generator/src/main/resources/rust/reqwest/api.mustache
+++ b/modules/openapi-generator/src/main/resources/rust/reqwest/api.mustache
@@ -60,7 +60,6 @@ pub enum {{{operationIdCamelCase}}}Success {
     Status{{code}}({{#isEnum}}{{{enumName}}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}),
     {{/is3xx}}
     {{/responses}}
-    UnknownList(Vec<serde_json::Value>),
     UnknownValue(serde_json::Value),
 }
 
@@ -84,7 +83,6 @@ pub enum {{{operationIdCamelCase}}}Error {
     DefaultResponse({{#isEnum}}{{{enumName}}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}),
     {{/isDefault}}
     {{/responses}}
-    UnknownList(Vec<serde_json::Value>),
     UnknownValue(serde_json::Value),
 }
 

--- a/samples/client/petstore/rust/reqwest/fileResponseTest/src/apis/default_api.rs
+++ b/samples/client/petstore/rust/reqwest/fileResponseTest/src/apis/default_api.rs
@@ -31,31 +31,21 @@ impl DefaultApiClient {
 }
 
 
-/// struct for typed successes of method `fileresponsetest`
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(untagged)]
-pub enum FileresponsetestSuccess {
-    Status200(std::path::PathBuf),
-    UnknownList(Vec<serde_json::Value>),
-    UnknownValue(serde_json::Value),
-}
-
 /// struct for typed errors of method `fileresponsetest`
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum FileresponsetestError {
-    DefaultResponse(std::path::PathBuf),
     UnknownList(Vec<serde_json::Value>),
     UnknownValue(serde_json::Value),
 }
 
 
 pub trait DefaultApi {
-    fn fileresponsetest(&self, ) -> Result<ResponseContent<FileresponsetestSuccess>, Error<FileresponsetestError>>;
+    fn fileresponsetest(&self, ) -> Result<std::path::PathBuf, Error<FileresponsetestError>>;
 }
 
 impl DefaultApi for DefaultApiClient {
-    fn fileresponsetest(&self, ) -> Result<ResponseContent<FileresponsetestSuccess>, Error<FileresponsetestError>> {
+    fn fileresponsetest(&self, ) -> Result<std::path::PathBuf, Error<FileresponsetestError>> {
         let configuration: &configuration::Configuration = self.configuration.borrow();
         let client = &configuration.client;
 
@@ -73,9 +63,7 @@ impl DefaultApi for DefaultApiClient {
         let content = resp.text()?;
 
         if status.is_success() {
-            let entity: Option<FileresponsetestSuccess> = serde_json::from_str(&content).ok();
-            let result = ResponseContent { status, content, entity };
-            Ok(result)
+            serde_json::from_str(&content).map_err(Error::from)
         } else {
             let entity: Option<FileresponsetestError> = serde_json::from_str(&content).ok();
             let error = ResponseContent { status, content, entity };

--- a/samples/client/petstore/rust/reqwest/fileResponseTest/src/apis/default_api.rs
+++ b/samples/client/petstore/rust/reqwest/fileResponseTest/src/apis/default_api.rs
@@ -35,7 +35,6 @@ impl DefaultApiClient {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum FileresponsetestError {
-    UnknownList(Vec<serde_json::Value>),
     UnknownValue(serde_json::Value),
 }
 

--- a/samples/client/petstore/rust/reqwest/petstore-async/src/apis/pet_api.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-async/src/apis/pet_api.rs
@@ -88,7 +88,6 @@ pub struct UploadFileParams {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum AddPetSuccess {
-    UnknownList(Vec<serde_json::Value>),
     UnknownValue(serde_json::Value),
 }
 
@@ -96,7 +95,6 @@ pub enum AddPetSuccess {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum DeletePetSuccess {
-    UnknownList(Vec<serde_json::Value>),
     UnknownValue(serde_json::Value),
 }
 
@@ -105,7 +103,6 @@ pub enum DeletePetSuccess {
 #[serde(untagged)]
 pub enum FindPetsByStatusSuccess {
     Status200(Vec<crate::models::Pet>),
-    UnknownList(Vec<serde_json::Value>),
     UnknownValue(serde_json::Value),
 }
 
@@ -114,7 +111,6 @@ pub enum FindPetsByStatusSuccess {
 #[serde(untagged)]
 pub enum FindPetsByTagsSuccess {
     Status200(Vec<crate::models::Pet>),
-    UnknownList(Vec<serde_json::Value>),
     UnknownValue(serde_json::Value),
 }
 
@@ -123,7 +119,6 @@ pub enum FindPetsByTagsSuccess {
 #[serde(untagged)]
 pub enum GetPetByIdSuccess {
     Status200(crate::models::Pet),
-    UnknownList(Vec<serde_json::Value>),
     UnknownValue(serde_json::Value),
 }
 
@@ -131,7 +126,6 @@ pub enum GetPetByIdSuccess {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum UpdatePetSuccess {
-    UnknownList(Vec<serde_json::Value>),
     UnknownValue(serde_json::Value),
 }
 
@@ -139,7 +133,6 @@ pub enum UpdatePetSuccess {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum UpdatePetWithFormSuccess {
-    UnknownList(Vec<serde_json::Value>),
     UnknownValue(serde_json::Value),
 }
 
@@ -148,7 +141,6 @@ pub enum UpdatePetWithFormSuccess {
 #[serde(untagged)]
 pub enum UploadFileSuccess {
     Status200(crate::models::ApiResponse),
-    UnknownList(Vec<serde_json::Value>),
     UnknownValue(serde_json::Value),
 }
 
@@ -157,7 +149,6 @@ pub enum UploadFileSuccess {
 #[serde(untagged)]
 pub enum AddPetError {
     Status405(),
-    UnknownList(Vec<serde_json::Value>),
     UnknownValue(serde_json::Value),
 }
 
@@ -166,7 +157,6 @@ pub enum AddPetError {
 #[serde(untagged)]
 pub enum DeletePetError {
     Status400(),
-    UnknownList(Vec<serde_json::Value>),
     UnknownValue(serde_json::Value),
 }
 
@@ -175,7 +165,6 @@ pub enum DeletePetError {
 #[serde(untagged)]
 pub enum FindPetsByStatusError {
     Status400(),
-    UnknownList(Vec<serde_json::Value>),
     UnknownValue(serde_json::Value),
 }
 
@@ -184,7 +173,6 @@ pub enum FindPetsByStatusError {
 #[serde(untagged)]
 pub enum FindPetsByTagsError {
     Status400(),
-    UnknownList(Vec<serde_json::Value>),
     UnknownValue(serde_json::Value),
 }
 
@@ -194,7 +182,6 @@ pub enum FindPetsByTagsError {
 pub enum GetPetByIdError {
     Status400(),
     Status404(),
-    UnknownList(Vec<serde_json::Value>),
     UnknownValue(serde_json::Value),
 }
 
@@ -205,7 +192,6 @@ pub enum UpdatePetError {
     Status400(),
     Status404(),
     Status405(),
-    UnknownList(Vec<serde_json::Value>),
     UnknownValue(serde_json::Value),
 }
 
@@ -214,7 +200,6 @@ pub enum UpdatePetError {
 #[serde(untagged)]
 pub enum UpdatePetWithFormError {
     Status405(),
-    UnknownList(Vec<serde_json::Value>),
     UnknownValue(serde_json::Value),
 }
 
@@ -222,7 +207,6 @@ pub enum UpdatePetWithFormError {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum UploadFileError {
-    UnknownList(Vec<serde_json::Value>),
     UnknownValue(serde_json::Value),
 }
 

--- a/samples/client/petstore/rust/reqwest/petstore-async/src/apis/store_api.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-async/src/apis/store_api.rs
@@ -44,7 +44,6 @@ pub struct PlaceOrderParams {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum DeleteOrderSuccess {
-    UnknownList(Vec<serde_json::Value>),
     UnknownValue(serde_json::Value),
 }
 
@@ -53,7 +52,6 @@ pub enum DeleteOrderSuccess {
 #[serde(untagged)]
 pub enum GetInventorySuccess {
     Status200(::std::collections::HashMap<String, i32>),
-    UnknownList(Vec<serde_json::Value>),
     UnknownValue(serde_json::Value),
 }
 
@@ -62,7 +60,6 @@ pub enum GetInventorySuccess {
 #[serde(untagged)]
 pub enum GetOrderByIdSuccess {
     Status200(crate::models::Order),
-    UnknownList(Vec<serde_json::Value>),
     UnknownValue(serde_json::Value),
 }
 
@@ -71,7 +68,6 @@ pub enum GetOrderByIdSuccess {
 #[serde(untagged)]
 pub enum PlaceOrderSuccess {
     Status200(crate::models::Order),
-    UnknownList(Vec<serde_json::Value>),
     UnknownValue(serde_json::Value),
 }
 
@@ -81,7 +77,6 @@ pub enum PlaceOrderSuccess {
 pub enum DeleteOrderError {
     Status400(),
     Status404(),
-    UnknownList(Vec<serde_json::Value>),
     UnknownValue(serde_json::Value),
 }
 
@@ -89,7 +84,6 @@ pub enum DeleteOrderError {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum GetInventoryError {
-    UnknownList(Vec<serde_json::Value>),
     UnknownValue(serde_json::Value),
 }
 
@@ -99,7 +93,6 @@ pub enum GetInventoryError {
 pub enum GetOrderByIdError {
     Status400(),
     Status404(),
-    UnknownList(Vec<serde_json::Value>),
     UnknownValue(serde_json::Value),
 }
 
@@ -108,7 +101,6 @@ pub enum GetOrderByIdError {
 #[serde(untagged)]
 pub enum PlaceOrderError {
     Status400(),
-    UnknownList(Vec<serde_json::Value>),
     UnknownValue(serde_json::Value),
 }
 

--- a/samples/client/petstore/rust/reqwest/petstore-async/src/apis/user_api.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-async/src/apis/user_api.rs
@@ -76,7 +76,6 @@ pub struct UpdateUserParams {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum CreateUserSuccess {
-    UnknownList(Vec<serde_json::Value>),
     UnknownValue(serde_json::Value),
 }
 
@@ -84,7 +83,6 @@ pub enum CreateUserSuccess {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum CreateUsersWithArrayInputSuccess {
-    UnknownList(Vec<serde_json::Value>),
     UnknownValue(serde_json::Value),
 }
 
@@ -92,7 +90,6 @@ pub enum CreateUsersWithArrayInputSuccess {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum CreateUsersWithListInputSuccess {
-    UnknownList(Vec<serde_json::Value>),
     UnknownValue(serde_json::Value),
 }
 
@@ -100,7 +97,6 @@ pub enum CreateUsersWithListInputSuccess {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum DeleteUserSuccess {
-    UnknownList(Vec<serde_json::Value>),
     UnknownValue(serde_json::Value),
 }
 
@@ -109,7 +105,6 @@ pub enum DeleteUserSuccess {
 #[serde(untagged)]
 pub enum GetUserByNameSuccess {
     Status200(crate::models::User),
-    UnknownList(Vec<serde_json::Value>),
     UnknownValue(serde_json::Value),
 }
 
@@ -118,7 +113,6 @@ pub enum GetUserByNameSuccess {
 #[serde(untagged)]
 pub enum LoginUserSuccess {
     Status200(String),
-    UnknownList(Vec<serde_json::Value>),
     UnknownValue(serde_json::Value),
 }
 
@@ -126,7 +120,6 @@ pub enum LoginUserSuccess {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum LogoutUserSuccess {
-    UnknownList(Vec<serde_json::Value>),
     UnknownValue(serde_json::Value),
 }
 
@@ -134,7 +127,6 @@ pub enum LogoutUserSuccess {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum UpdateUserSuccess {
-    UnknownList(Vec<serde_json::Value>),
     UnknownValue(serde_json::Value),
 }
 
@@ -143,7 +135,6 @@ pub enum UpdateUserSuccess {
 #[serde(untagged)]
 pub enum CreateUserError {
     DefaultResponse(),
-    UnknownList(Vec<serde_json::Value>),
     UnknownValue(serde_json::Value),
 }
 
@@ -152,7 +143,6 @@ pub enum CreateUserError {
 #[serde(untagged)]
 pub enum CreateUsersWithArrayInputError {
     DefaultResponse(),
-    UnknownList(Vec<serde_json::Value>),
     UnknownValue(serde_json::Value),
 }
 
@@ -161,7 +151,6 @@ pub enum CreateUsersWithArrayInputError {
 #[serde(untagged)]
 pub enum CreateUsersWithListInputError {
     DefaultResponse(),
-    UnknownList(Vec<serde_json::Value>),
     UnknownValue(serde_json::Value),
 }
 
@@ -171,7 +160,6 @@ pub enum CreateUsersWithListInputError {
 pub enum DeleteUserError {
     Status400(),
     Status404(),
-    UnknownList(Vec<serde_json::Value>),
     UnknownValue(serde_json::Value),
 }
 
@@ -181,7 +169,6 @@ pub enum DeleteUserError {
 pub enum GetUserByNameError {
     Status400(),
     Status404(),
-    UnknownList(Vec<serde_json::Value>),
     UnknownValue(serde_json::Value),
 }
 
@@ -190,7 +177,6 @@ pub enum GetUserByNameError {
 #[serde(untagged)]
 pub enum LoginUserError {
     Status400(),
-    UnknownList(Vec<serde_json::Value>),
     UnknownValue(serde_json::Value),
 }
 
@@ -199,7 +185,6 @@ pub enum LoginUserError {
 #[serde(untagged)]
 pub enum LogoutUserError {
     DefaultResponse(),
-    UnknownList(Vec<serde_json::Value>),
     UnknownValue(serde_json::Value),
 }
 
@@ -209,7 +194,6 @@ pub enum LogoutUserError {
 pub enum UpdateUserError {
     Status400(),
     Status404(),
-    UnknownList(Vec<serde_json::Value>),
     UnknownValue(serde_json::Value),
 }
 

--- a/samples/client/petstore/rust/reqwest/petstore-async/tests/pet_tests.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-async/tests/pet_tests.rs
@@ -16,11 +16,19 @@ fn test_pet() {
     let mut new_pet = Pet::new("Rust Pet".to_string(), photo_urls);
     new_pet.id = Option::Some(8787);
 
+    let new_pet_params = petstore_reqwest_async::apis::pet_api::AddPetParams {
+        body: new_pet,
+    };
+
     // add pet
-    let _add_result = petstore_reqwest_async::apis::pet_api::add_pet(&config, new_pet);
+    let _add_result = petstore_reqwest_async::apis::pet_api::add_pet(&config, new_pet_params);
+
+    let get_pet_params = petstore_reqwest_async::apis::pet_api::GetPetByIdParams {
+        pet_id: 8787,
+    };
 
     // get pet
-    let pet_result = petstore_reqwest_async::apis::pet_api::get_pet_by_id(&config, 8787);
+    let pet_result = petstore_reqwest_async::apis::pet_api::get_pet_by_id(&config, get_pet_params);
 
     // TODO Testing async functions requires some additionnal testing crates.
 }

--- a/samples/client/petstore/rust/reqwest/petstore/src/apis/pet_api.rs
+++ b/samples/client/petstore/rust/reqwest/petstore/src/apis/pet_api.rs
@@ -36,7 +36,6 @@ impl PetApiClient {
 #[serde(untagged)]
 pub enum AddPetError {
     Status405(),
-    UnknownList(Vec<serde_json::Value>),
     UnknownValue(serde_json::Value),
 }
 
@@ -45,7 +44,6 @@ pub enum AddPetError {
 #[serde(untagged)]
 pub enum DeletePetError {
     Status400(),
-    UnknownList(Vec<serde_json::Value>),
     UnknownValue(serde_json::Value),
 }
 
@@ -54,7 +52,6 @@ pub enum DeletePetError {
 #[serde(untagged)]
 pub enum FindPetsByStatusError {
     Status400(),
-    UnknownList(Vec<serde_json::Value>),
     UnknownValue(serde_json::Value),
 }
 
@@ -63,7 +60,6 @@ pub enum FindPetsByStatusError {
 #[serde(untagged)]
 pub enum FindPetsByTagsError {
     Status400(),
-    UnknownList(Vec<serde_json::Value>),
     UnknownValue(serde_json::Value),
 }
 
@@ -73,7 +69,6 @@ pub enum FindPetsByTagsError {
 pub enum GetPetByIdError {
     Status400(),
     Status404(),
-    UnknownList(Vec<serde_json::Value>),
     UnknownValue(serde_json::Value),
 }
 
@@ -84,7 +79,6 @@ pub enum UpdatePetError {
     Status400(),
     Status404(),
     Status405(),
-    UnknownList(Vec<serde_json::Value>),
     UnknownValue(serde_json::Value),
 }
 
@@ -93,7 +87,6 @@ pub enum UpdatePetError {
 #[serde(untagged)]
 pub enum UpdatePetWithFormError {
     Status405(),
-    UnknownList(Vec<serde_json::Value>),
     UnknownValue(serde_json::Value),
 }
 
@@ -101,7 +94,6 @@ pub enum UpdatePetWithFormError {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum UploadFileError {
-    UnknownList(Vec<serde_json::Value>),
     UnknownValue(serde_json::Value),
 }
 

--- a/samples/client/petstore/rust/reqwest/petstore/src/apis/pet_api.rs
+++ b/samples/client/petstore/rust/reqwest/petstore/src/apis/pet_api.rs
@@ -31,74 +31,6 @@ impl PetApiClient {
 }
 
 
-/// struct for typed successes of method `add_pet`
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(untagged)]
-pub enum AddPetSuccess {
-    UnknownList(Vec<serde_json::Value>),
-    UnknownValue(serde_json::Value),
-}
-
-/// struct for typed successes of method `delete_pet`
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(untagged)]
-pub enum DeletePetSuccess {
-    UnknownList(Vec<serde_json::Value>),
-    UnknownValue(serde_json::Value),
-}
-
-/// struct for typed successes of method `find_pets_by_status`
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(untagged)]
-pub enum FindPetsByStatusSuccess {
-    Status200(Vec<crate::models::Pet>),
-    UnknownList(Vec<serde_json::Value>),
-    UnknownValue(serde_json::Value),
-}
-
-/// struct for typed successes of method `find_pets_by_tags`
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(untagged)]
-pub enum FindPetsByTagsSuccess {
-    Status200(Vec<crate::models::Pet>),
-    UnknownList(Vec<serde_json::Value>),
-    UnknownValue(serde_json::Value),
-}
-
-/// struct for typed successes of method `get_pet_by_id`
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(untagged)]
-pub enum GetPetByIdSuccess {
-    Status200(crate::models::Pet),
-    UnknownList(Vec<serde_json::Value>),
-    UnknownValue(serde_json::Value),
-}
-
-/// struct for typed successes of method `update_pet`
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(untagged)]
-pub enum UpdatePetSuccess {
-    UnknownList(Vec<serde_json::Value>),
-    UnknownValue(serde_json::Value),
-}
-
-/// struct for typed successes of method `update_pet_with_form`
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(untagged)]
-pub enum UpdatePetWithFormSuccess {
-    UnknownList(Vec<serde_json::Value>),
-    UnknownValue(serde_json::Value),
-}
-
-/// struct for typed successes of method `upload_file`
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(untagged)]
-pub enum UploadFileSuccess {
-    Status200(crate::models::ApiResponse),
-    UnknownList(Vec<serde_json::Value>),
-    UnknownValue(serde_json::Value),
-}
-
 /// struct for typed errors of method `add_pet`
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
@@ -175,18 +107,18 @@ pub enum UploadFileError {
 
 
 pub trait PetApi {
-    fn add_pet(&self, body: crate::models::Pet) -> Result<ResponseContent<AddPetSuccess>, Error<AddPetError>>;
-    fn delete_pet(&self, pet_id: i64, api_key: Option<&str>) -> Result<ResponseContent<DeletePetSuccess>, Error<DeletePetError>>;
-    fn find_pets_by_status(&self, status: Vec<String>) -> Result<ResponseContent<FindPetsByStatusSuccess>, Error<FindPetsByStatusError>>;
-    fn find_pets_by_tags(&self, tags: Vec<String>) -> Result<ResponseContent<FindPetsByTagsSuccess>, Error<FindPetsByTagsError>>;
-    fn get_pet_by_id(&self, pet_id: i64) -> Result<ResponseContent<GetPetByIdSuccess>, Error<GetPetByIdError>>;
-    fn update_pet(&self, body: crate::models::Pet) -> Result<ResponseContent<UpdatePetSuccess>, Error<UpdatePetError>>;
-    fn update_pet_with_form(&self, pet_id: i64, name: Option<&str>, status: Option<&str>) -> Result<ResponseContent<UpdatePetWithFormSuccess>, Error<UpdatePetWithFormError>>;
-    fn upload_file(&self, pet_id: i64, additional_metadata: Option<&str>, file: Option<std::path::PathBuf>) -> Result<ResponseContent<UploadFileSuccess>, Error<UploadFileError>>;
+    fn add_pet(&self, body: crate::models::Pet) -> Result<(), Error<AddPetError>>;
+    fn delete_pet(&self, pet_id: i64, api_key: Option<&str>) -> Result<(), Error<DeletePetError>>;
+    fn find_pets_by_status(&self, status: Vec<String>) -> Result<Vec<crate::models::Pet>, Error<FindPetsByStatusError>>;
+    fn find_pets_by_tags(&self, tags: Vec<String>) -> Result<Vec<crate::models::Pet>, Error<FindPetsByTagsError>>;
+    fn get_pet_by_id(&self, pet_id: i64) -> Result<crate::models::Pet, Error<GetPetByIdError>>;
+    fn update_pet(&self, body: crate::models::Pet) -> Result<(), Error<UpdatePetError>>;
+    fn update_pet_with_form(&self, pet_id: i64, name: Option<&str>, status: Option<&str>) -> Result<(), Error<UpdatePetWithFormError>>;
+    fn upload_file(&self, pet_id: i64, additional_metadata: Option<&str>, file: Option<std::path::PathBuf>) -> Result<crate::models::ApiResponse, Error<UploadFileError>>;
 }
 
 impl PetApi for PetApiClient {
-    fn add_pet(&self, body: crate::models::Pet) -> Result<ResponseContent<AddPetSuccess>, Error<AddPetError>> {
+    fn add_pet(&self, body: crate::models::Pet) -> Result<(), Error<AddPetError>> {
         let configuration: &configuration::Configuration = self.configuration.borrow();
         let client = &configuration.client;
 
@@ -208,9 +140,7 @@ impl PetApi for PetApiClient {
         let content = resp.text()?;
 
         if status.is_success() {
-            let entity: Option<AddPetSuccess> = serde_json::from_str(&content).ok();
-            let result = ResponseContent { status, content, entity };
-            Ok(result)
+            Ok(())
         } else {
             let entity: Option<AddPetError> = serde_json::from_str(&content).ok();
             let error = ResponseContent { status, content, entity };
@@ -218,7 +148,7 @@ impl PetApi for PetApiClient {
         }
     }
 
-    fn delete_pet(&self, pet_id: i64, api_key: Option<&str>) -> Result<ResponseContent<DeletePetSuccess>, Error<DeletePetError>> {
+    fn delete_pet(&self, pet_id: i64, api_key: Option<&str>) -> Result<(), Error<DeletePetError>> {
         let configuration: &configuration::Configuration = self.configuration.borrow();
         let client = &configuration.client;
 
@@ -242,9 +172,7 @@ impl PetApi for PetApiClient {
         let content = resp.text()?;
 
         if status.is_success() {
-            let entity: Option<DeletePetSuccess> = serde_json::from_str(&content).ok();
-            let result = ResponseContent { status, content, entity };
-            Ok(result)
+            Ok(())
         } else {
             let entity: Option<DeletePetError> = serde_json::from_str(&content).ok();
             let error = ResponseContent { status, content, entity };
@@ -252,7 +180,7 @@ impl PetApi for PetApiClient {
         }
     }
 
-    fn find_pets_by_status(&self, status: Vec<String>) -> Result<ResponseContent<FindPetsByStatusSuccess>, Error<FindPetsByStatusError>> {
+    fn find_pets_by_status(&self, status: Vec<String>) -> Result<Vec<crate::models::Pet>, Error<FindPetsByStatusError>> {
         let configuration: &configuration::Configuration = self.configuration.borrow();
         let client = &configuration.client;
 
@@ -274,9 +202,7 @@ impl PetApi for PetApiClient {
         let content = resp.text()?;
 
         if status.is_success() {
-            let entity: Option<FindPetsByStatusSuccess> = serde_json::from_str(&content).ok();
-            let result = ResponseContent { status, content, entity };
-            Ok(result)
+            serde_json::from_str(&content).map_err(Error::from)
         } else {
             let entity: Option<FindPetsByStatusError> = serde_json::from_str(&content).ok();
             let error = ResponseContent { status, content, entity };
@@ -284,7 +210,7 @@ impl PetApi for PetApiClient {
         }
     }
 
-    fn find_pets_by_tags(&self, tags: Vec<String>) -> Result<ResponseContent<FindPetsByTagsSuccess>, Error<FindPetsByTagsError>> {
+    fn find_pets_by_tags(&self, tags: Vec<String>) -> Result<Vec<crate::models::Pet>, Error<FindPetsByTagsError>> {
         let configuration: &configuration::Configuration = self.configuration.borrow();
         let client = &configuration.client;
 
@@ -306,9 +232,7 @@ impl PetApi for PetApiClient {
         let content = resp.text()?;
 
         if status.is_success() {
-            let entity: Option<FindPetsByTagsSuccess> = serde_json::from_str(&content).ok();
-            let result = ResponseContent { status, content, entity };
-            Ok(result)
+            serde_json::from_str(&content).map_err(Error::from)
         } else {
             let entity: Option<FindPetsByTagsError> = serde_json::from_str(&content).ok();
             let error = ResponseContent { status, content, entity };
@@ -316,7 +240,7 @@ impl PetApi for PetApiClient {
         }
     }
 
-    fn get_pet_by_id(&self, pet_id: i64) -> Result<ResponseContent<GetPetByIdSuccess>, Error<GetPetByIdError>> {
+    fn get_pet_by_id(&self, pet_id: i64) -> Result<crate::models::Pet, Error<GetPetByIdError>> {
         let configuration: &configuration::Configuration = self.configuration.borrow();
         let client = &configuration.client;
 
@@ -342,9 +266,7 @@ impl PetApi for PetApiClient {
         let content = resp.text()?;
 
         if status.is_success() {
-            let entity: Option<GetPetByIdSuccess> = serde_json::from_str(&content).ok();
-            let result = ResponseContent { status, content, entity };
-            Ok(result)
+            serde_json::from_str(&content).map_err(Error::from)
         } else {
             let entity: Option<GetPetByIdError> = serde_json::from_str(&content).ok();
             let error = ResponseContent { status, content, entity };
@@ -352,7 +274,7 @@ impl PetApi for PetApiClient {
         }
     }
 
-    fn update_pet(&self, body: crate::models::Pet) -> Result<ResponseContent<UpdatePetSuccess>, Error<UpdatePetError>> {
+    fn update_pet(&self, body: crate::models::Pet) -> Result<(), Error<UpdatePetError>> {
         let configuration: &configuration::Configuration = self.configuration.borrow();
         let client = &configuration.client;
 
@@ -374,9 +296,7 @@ impl PetApi for PetApiClient {
         let content = resp.text()?;
 
         if status.is_success() {
-            let entity: Option<UpdatePetSuccess> = serde_json::from_str(&content).ok();
-            let result = ResponseContent { status, content, entity };
-            Ok(result)
+            Ok(())
         } else {
             let entity: Option<UpdatePetError> = serde_json::from_str(&content).ok();
             let error = ResponseContent { status, content, entity };
@@ -384,7 +304,7 @@ impl PetApi for PetApiClient {
         }
     }
 
-    fn update_pet_with_form(&self, pet_id: i64, name: Option<&str>, status: Option<&str>) -> Result<ResponseContent<UpdatePetWithFormSuccess>, Error<UpdatePetWithFormError>> {
+    fn update_pet_with_form(&self, pet_id: i64, name: Option<&str>, status: Option<&str>) -> Result<(), Error<UpdatePetWithFormError>> {
         let configuration: &configuration::Configuration = self.configuration.borrow();
         let client = &configuration.client;
 
@@ -413,9 +333,7 @@ impl PetApi for PetApiClient {
         let content = resp.text()?;
 
         if status.is_success() {
-            let entity: Option<UpdatePetWithFormSuccess> = serde_json::from_str(&content).ok();
-            let result = ResponseContent { status, content, entity };
-            Ok(result)
+            Ok(())
         } else {
             let entity: Option<UpdatePetWithFormError> = serde_json::from_str(&content).ok();
             let error = ResponseContent { status, content, entity };
@@ -423,7 +341,7 @@ impl PetApi for PetApiClient {
         }
     }
 
-    fn upload_file(&self, pet_id: i64, additional_metadata: Option<&str>, file: Option<std::path::PathBuf>) -> Result<ResponseContent<UploadFileSuccess>, Error<UploadFileError>> {
+    fn upload_file(&self, pet_id: i64, additional_metadata: Option<&str>, file: Option<std::path::PathBuf>) -> Result<crate::models::ApiResponse, Error<UploadFileError>> {
         let configuration: &configuration::Configuration = self.configuration.borrow();
         let client = &configuration.client;
 
@@ -452,9 +370,7 @@ impl PetApi for PetApiClient {
         let content = resp.text()?;
 
         if status.is_success() {
-            let entity: Option<UploadFileSuccess> = serde_json::from_str(&content).ok();
-            let result = ResponseContent { status, content, entity };
-            Ok(result)
+            serde_json::from_str(&content).map_err(Error::from)
         } else {
             let entity: Option<UploadFileError> = serde_json::from_str(&content).ok();
             let error = ResponseContent { status, content, entity };

--- a/samples/client/petstore/rust/reqwest/petstore/src/apis/store_api.rs
+++ b/samples/client/petstore/rust/reqwest/petstore/src/apis/store_api.rs
@@ -31,41 +31,6 @@ impl StoreApiClient {
 }
 
 
-/// struct for typed successes of method `delete_order`
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(untagged)]
-pub enum DeleteOrderSuccess {
-    UnknownList(Vec<serde_json::Value>),
-    UnknownValue(serde_json::Value),
-}
-
-/// struct for typed successes of method `get_inventory`
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(untagged)]
-pub enum GetInventorySuccess {
-    Status200(::std::collections::HashMap<String, i32>),
-    UnknownList(Vec<serde_json::Value>),
-    UnknownValue(serde_json::Value),
-}
-
-/// struct for typed successes of method `get_order_by_id`
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(untagged)]
-pub enum GetOrderByIdSuccess {
-    Status200(crate::models::Order),
-    UnknownList(Vec<serde_json::Value>),
-    UnknownValue(serde_json::Value),
-}
-
-/// struct for typed successes of method `place_order`
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(untagged)]
-pub enum PlaceOrderSuccess {
-    Status200(crate::models::Order),
-    UnknownList(Vec<serde_json::Value>),
-    UnknownValue(serde_json::Value),
-}
-
 /// struct for typed errors of method `delete_order`
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
@@ -105,14 +70,14 @@ pub enum PlaceOrderError {
 
 
 pub trait StoreApi {
-    fn delete_order(&self, order_id: &str) -> Result<ResponseContent<DeleteOrderSuccess>, Error<DeleteOrderError>>;
-    fn get_inventory(&self, ) -> Result<ResponseContent<GetInventorySuccess>, Error<GetInventoryError>>;
-    fn get_order_by_id(&self, order_id: i64) -> Result<ResponseContent<GetOrderByIdSuccess>, Error<GetOrderByIdError>>;
-    fn place_order(&self, body: crate::models::Order) -> Result<ResponseContent<PlaceOrderSuccess>, Error<PlaceOrderError>>;
+    fn delete_order(&self, order_id: &str) -> Result<(), Error<DeleteOrderError>>;
+    fn get_inventory(&self, ) -> Result<::std::collections::HashMap<String, i32>, Error<GetInventoryError>>;
+    fn get_order_by_id(&self, order_id: i64) -> Result<crate::models::Order, Error<GetOrderByIdError>>;
+    fn place_order(&self, body: crate::models::Order) -> Result<crate::models::Order, Error<PlaceOrderError>>;
 }
 
 impl StoreApi for StoreApiClient {
-    fn delete_order(&self, order_id: &str) -> Result<ResponseContent<DeleteOrderSuccess>, Error<DeleteOrderError>> {
+    fn delete_order(&self, order_id: &str) -> Result<(), Error<DeleteOrderError>> {
         let configuration: &configuration::Configuration = self.configuration.borrow();
         let client = &configuration.client;
 
@@ -130,9 +95,7 @@ impl StoreApi for StoreApiClient {
         let content = resp.text()?;
 
         if status.is_success() {
-            let entity: Option<DeleteOrderSuccess> = serde_json::from_str(&content).ok();
-            let result = ResponseContent { status, content, entity };
-            Ok(result)
+            Ok(())
         } else {
             let entity: Option<DeleteOrderError> = serde_json::from_str(&content).ok();
             let error = ResponseContent { status, content, entity };
@@ -140,7 +103,7 @@ impl StoreApi for StoreApiClient {
         }
     }
 
-    fn get_inventory(&self, ) -> Result<ResponseContent<GetInventorySuccess>, Error<GetInventoryError>> {
+    fn get_inventory(&self, ) -> Result<::std::collections::HashMap<String, i32>, Error<GetInventoryError>> {
         let configuration: &configuration::Configuration = self.configuration.borrow();
         let client = &configuration.client;
 
@@ -166,9 +129,7 @@ impl StoreApi for StoreApiClient {
         let content = resp.text()?;
 
         if status.is_success() {
-            let entity: Option<GetInventorySuccess> = serde_json::from_str(&content).ok();
-            let result = ResponseContent { status, content, entity };
-            Ok(result)
+            serde_json::from_str(&content).map_err(Error::from)
         } else {
             let entity: Option<GetInventoryError> = serde_json::from_str(&content).ok();
             let error = ResponseContent { status, content, entity };
@@ -176,7 +137,7 @@ impl StoreApi for StoreApiClient {
         }
     }
 
-    fn get_order_by_id(&self, order_id: i64) -> Result<ResponseContent<GetOrderByIdSuccess>, Error<GetOrderByIdError>> {
+    fn get_order_by_id(&self, order_id: i64) -> Result<crate::models::Order, Error<GetOrderByIdError>> {
         let configuration: &configuration::Configuration = self.configuration.borrow();
         let client = &configuration.client;
 
@@ -194,9 +155,7 @@ impl StoreApi for StoreApiClient {
         let content = resp.text()?;
 
         if status.is_success() {
-            let entity: Option<GetOrderByIdSuccess> = serde_json::from_str(&content).ok();
-            let result = ResponseContent { status, content, entity };
-            Ok(result)
+            serde_json::from_str(&content).map_err(Error::from)
         } else {
             let entity: Option<GetOrderByIdError> = serde_json::from_str(&content).ok();
             let error = ResponseContent { status, content, entity };
@@ -204,7 +163,7 @@ impl StoreApi for StoreApiClient {
         }
     }
 
-    fn place_order(&self, body: crate::models::Order) -> Result<ResponseContent<PlaceOrderSuccess>, Error<PlaceOrderError>> {
+    fn place_order(&self, body: crate::models::Order) -> Result<crate::models::Order, Error<PlaceOrderError>> {
         let configuration: &configuration::Configuration = self.configuration.borrow();
         let client = &configuration.client;
 
@@ -223,9 +182,7 @@ impl StoreApi for StoreApiClient {
         let content = resp.text()?;
 
         if status.is_success() {
-            let entity: Option<PlaceOrderSuccess> = serde_json::from_str(&content).ok();
-            let result = ResponseContent { status, content, entity };
-            Ok(result)
+            serde_json::from_str(&content).map_err(Error::from)
         } else {
             let entity: Option<PlaceOrderError> = serde_json::from_str(&content).ok();
             let error = ResponseContent { status, content, entity };

--- a/samples/client/petstore/rust/reqwest/petstore/src/apis/store_api.rs
+++ b/samples/client/petstore/rust/reqwest/petstore/src/apis/store_api.rs
@@ -37,7 +37,6 @@ impl StoreApiClient {
 pub enum DeleteOrderError {
     Status400(),
     Status404(),
-    UnknownList(Vec<serde_json::Value>),
     UnknownValue(serde_json::Value),
 }
 
@@ -45,7 +44,6 @@ pub enum DeleteOrderError {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum GetInventoryError {
-    UnknownList(Vec<serde_json::Value>),
     UnknownValue(serde_json::Value),
 }
 
@@ -55,7 +53,6 @@ pub enum GetInventoryError {
 pub enum GetOrderByIdError {
     Status400(),
     Status404(),
-    UnknownList(Vec<serde_json::Value>),
     UnknownValue(serde_json::Value),
 }
 
@@ -64,7 +61,6 @@ pub enum GetOrderByIdError {
 #[serde(untagged)]
 pub enum PlaceOrderError {
     Status400(),
-    UnknownList(Vec<serde_json::Value>),
     UnknownValue(serde_json::Value),
 }
 

--- a/samples/client/petstore/rust/reqwest/petstore/src/apis/user_api.rs
+++ b/samples/client/petstore/rust/reqwest/petstore/src/apis/user_api.rs
@@ -36,7 +36,6 @@ impl UserApiClient {
 #[serde(untagged)]
 pub enum CreateUserError {
     DefaultResponse(),
-    UnknownList(Vec<serde_json::Value>),
     UnknownValue(serde_json::Value),
 }
 
@@ -45,7 +44,6 @@ pub enum CreateUserError {
 #[serde(untagged)]
 pub enum CreateUsersWithArrayInputError {
     DefaultResponse(),
-    UnknownList(Vec<serde_json::Value>),
     UnknownValue(serde_json::Value),
 }
 
@@ -54,7 +52,6 @@ pub enum CreateUsersWithArrayInputError {
 #[serde(untagged)]
 pub enum CreateUsersWithListInputError {
     DefaultResponse(),
-    UnknownList(Vec<serde_json::Value>),
     UnknownValue(serde_json::Value),
 }
 
@@ -64,7 +61,6 @@ pub enum CreateUsersWithListInputError {
 pub enum DeleteUserError {
     Status400(),
     Status404(),
-    UnknownList(Vec<serde_json::Value>),
     UnknownValue(serde_json::Value),
 }
 
@@ -74,7 +70,6 @@ pub enum DeleteUserError {
 pub enum GetUserByNameError {
     Status400(),
     Status404(),
-    UnknownList(Vec<serde_json::Value>),
     UnknownValue(serde_json::Value),
 }
 
@@ -83,7 +78,6 @@ pub enum GetUserByNameError {
 #[serde(untagged)]
 pub enum LoginUserError {
     Status400(),
-    UnknownList(Vec<serde_json::Value>),
     UnknownValue(serde_json::Value),
 }
 
@@ -92,7 +86,6 @@ pub enum LoginUserError {
 #[serde(untagged)]
 pub enum LogoutUserError {
     DefaultResponse(),
-    UnknownList(Vec<serde_json::Value>),
     UnknownValue(serde_json::Value),
 }
 
@@ -102,7 +95,6 @@ pub enum LogoutUserError {
 pub enum UpdateUserError {
     Status400(),
     Status404(),
-    UnknownList(Vec<serde_json::Value>),
     UnknownValue(serde_json::Value),
 }
 

--- a/samples/client/petstore/rust/reqwest/petstore/src/apis/user_api.rs
+++ b/samples/client/petstore/rust/reqwest/petstore/src/apis/user_api.rs
@@ -31,72 +31,6 @@ impl UserApiClient {
 }
 
 
-/// struct for typed successes of method `create_user`
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(untagged)]
-pub enum CreateUserSuccess {
-    UnknownList(Vec<serde_json::Value>),
-    UnknownValue(serde_json::Value),
-}
-
-/// struct for typed successes of method `create_users_with_array_input`
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(untagged)]
-pub enum CreateUsersWithArrayInputSuccess {
-    UnknownList(Vec<serde_json::Value>),
-    UnknownValue(serde_json::Value),
-}
-
-/// struct for typed successes of method `create_users_with_list_input`
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(untagged)]
-pub enum CreateUsersWithListInputSuccess {
-    UnknownList(Vec<serde_json::Value>),
-    UnknownValue(serde_json::Value),
-}
-
-/// struct for typed successes of method `delete_user`
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(untagged)]
-pub enum DeleteUserSuccess {
-    UnknownList(Vec<serde_json::Value>),
-    UnknownValue(serde_json::Value),
-}
-
-/// struct for typed successes of method `get_user_by_name`
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(untagged)]
-pub enum GetUserByNameSuccess {
-    Status200(crate::models::User),
-    UnknownList(Vec<serde_json::Value>),
-    UnknownValue(serde_json::Value),
-}
-
-/// struct for typed successes of method `login_user`
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(untagged)]
-pub enum LoginUserSuccess {
-    Status200(String),
-    UnknownList(Vec<serde_json::Value>),
-    UnknownValue(serde_json::Value),
-}
-
-/// struct for typed successes of method `logout_user`
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(untagged)]
-pub enum LogoutUserSuccess {
-    UnknownList(Vec<serde_json::Value>),
-    UnknownValue(serde_json::Value),
-}
-
-/// struct for typed successes of method `update_user`
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(untagged)]
-pub enum UpdateUserSuccess {
-    UnknownList(Vec<serde_json::Value>),
-    UnknownValue(serde_json::Value),
-}
-
 /// struct for typed errors of method `create_user`
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
@@ -174,18 +108,18 @@ pub enum UpdateUserError {
 
 
 pub trait UserApi {
-    fn create_user(&self, body: crate::models::User) -> Result<ResponseContent<CreateUserSuccess>, Error<CreateUserError>>;
-    fn create_users_with_array_input(&self, body: Vec<crate::models::User>) -> Result<ResponseContent<CreateUsersWithArrayInputSuccess>, Error<CreateUsersWithArrayInputError>>;
-    fn create_users_with_list_input(&self, body: Vec<crate::models::User>) -> Result<ResponseContent<CreateUsersWithListInputSuccess>, Error<CreateUsersWithListInputError>>;
-    fn delete_user(&self, username: &str) -> Result<ResponseContent<DeleteUserSuccess>, Error<DeleteUserError>>;
-    fn get_user_by_name(&self, username: &str) -> Result<ResponseContent<GetUserByNameSuccess>, Error<GetUserByNameError>>;
-    fn login_user(&self, username: &str, password: &str) -> Result<ResponseContent<LoginUserSuccess>, Error<LoginUserError>>;
-    fn logout_user(&self, ) -> Result<ResponseContent<LogoutUserSuccess>, Error<LogoutUserError>>;
-    fn update_user(&self, username: &str, body: crate::models::User) -> Result<ResponseContent<UpdateUserSuccess>, Error<UpdateUserError>>;
+    fn create_user(&self, body: crate::models::User) -> Result<(), Error<CreateUserError>>;
+    fn create_users_with_array_input(&self, body: Vec<crate::models::User>) -> Result<(), Error<CreateUsersWithArrayInputError>>;
+    fn create_users_with_list_input(&self, body: Vec<crate::models::User>) -> Result<(), Error<CreateUsersWithListInputError>>;
+    fn delete_user(&self, username: &str) -> Result<(), Error<DeleteUserError>>;
+    fn get_user_by_name(&self, username: &str) -> Result<crate::models::User, Error<GetUserByNameError>>;
+    fn login_user(&self, username: &str, password: &str) -> Result<String, Error<LoginUserError>>;
+    fn logout_user(&self, ) -> Result<(), Error<LogoutUserError>>;
+    fn update_user(&self, username: &str, body: crate::models::User) -> Result<(), Error<UpdateUserError>>;
 }
 
 impl UserApi for UserApiClient {
-    fn create_user(&self, body: crate::models::User) -> Result<ResponseContent<CreateUserSuccess>, Error<CreateUserError>> {
+    fn create_user(&self, body: crate::models::User) -> Result<(), Error<CreateUserError>> {
         let configuration: &configuration::Configuration = self.configuration.borrow();
         let client = &configuration.client;
 
@@ -204,9 +138,7 @@ impl UserApi for UserApiClient {
         let content = resp.text()?;
 
         if status.is_success() {
-            let entity: Option<CreateUserSuccess> = serde_json::from_str(&content).ok();
-            let result = ResponseContent { status, content, entity };
-            Ok(result)
+            Ok(())
         } else {
             let entity: Option<CreateUserError> = serde_json::from_str(&content).ok();
             let error = ResponseContent { status, content, entity };
@@ -214,7 +146,7 @@ impl UserApi for UserApiClient {
         }
     }
 
-    fn create_users_with_array_input(&self, body: Vec<crate::models::User>) -> Result<ResponseContent<CreateUsersWithArrayInputSuccess>, Error<CreateUsersWithArrayInputError>> {
+    fn create_users_with_array_input(&self, body: Vec<crate::models::User>) -> Result<(), Error<CreateUsersWithArrayInputError>> {
         let configuration: &configuration::Configuration = self.configuration.borrow();
         let client = &configuration.client;
 
@@ -233,9 +165,7 @@ impl UserApi for UserApiClient {
         let content = resp.text()?;
 
         if status.is_success() {
-            let entity: Option<CreateUsersWithArrayInputSuccess> = serde_json::from_str(&content).ok();
-            let result = ResponseContent { status, content, entity };
-            Ok(result)
+            Ok(())
         } else {
             let entity: Option<CreateUsersWithArrayInputError> = serde_json::from_str(&content).ok();
             let error = ResponseContent { status, content, entity };
@@ -243,7 +173,7 @@ impl UserApi for UserApiClient {
         }
     }
 
-    fn create_users_with_list_input(&self, body: Vec<crate::models::User>) -> Result<ResponseContent<CreateUsersWithListInputSuccess>, Error<CreateUsersWithListInputError>> {
+    fn create_users_with_list_input(&self, body: Vec<crate::models::User>) -> Result<(), Error<CreateUsersWithListInputError>> {
         let configuration: &configuration::Configuration = self.configuration.borrow();
         let client = &configuration.client;
 
@@ -262,9 +192,7 @@ impl UserApi for UserApiClient {
         let content = resp.text()?;
 
         if status.is_success() {
-            let entity: Option<CreateUsersWithListInputSuccess> = serde_json::from_str(&content).ok();
-            let result = ResponseContent { status, content, entity };
-            Ok(result)
+            Ok(())
         } else {
             let entity: Option<CreateUsersWithListInputError> = serde_json::from_str(&content).ok();
             let error = ResponseContent { status, content, entity };
@@ -272,7 +200,7 @@ impl UserApi for UserApiClient {
         }
     }
 
-    fn delete_user(&self, username: &str) -> Result<ResponseContent<DeleteUserSuccess>, Error<DeleteUserError>> {
+    fn delete_user(&self, username: &str) -> Result<(), Error<DeleteUserError>> {
         let configuration: &configuration::Configuration = self.configuration.borrow();
         let client = &configuration.client;
 
@@ -290,9 +218,7 @@ impl UserApi for UserApiClient {
         let content = resp.text()?;
 
         if status.is_success() {
-            let entity: Option<DeleteUserSuccess> = serde_json::from_str(&content).ok();
-            let result = ResponseContent { status, content, entity };
-            Ok(result)
+            Ok(())
         } else {
             let entity: Option<DeleteUserError> = serde_json::from_str(&content).ok();
             let error = ResponseContent { status, content, entity };
@@ -300,7 +226,7 @@ impl UserApi for UserApiClient {
         }
     }
 
-    fn get_user_by_name(&self, username: &str) -> Result<ResponseContent<GetUserByNameSuccess>, Error<GetUserByNameError>> {
+    fn get_user_by_name(&self, username: &str) -> Result<crate::models::User, Error<GetUserByNameError>> {
         let configuration: &configuration::Configuration = self.configuration.borrow();
         let client = &configuration.client;
 
@@ -318,9 +244,7 @@ impl UserApi for UserApiClient {
         let content = resp.text()?;
 
         if status.is_success() {
-            let entity: Option<GetUserByNameSuccess> = serde_json::from_str(&content).ok();
-            let result = ResponseContent { status, content, entity };
-            Ok(result)
+            serde_json::from_str(&content).map_err(Error::from)
         } else {
             let entity: Option<GetUserByNameError> = serde_json::from_str(&content).ok();
             let error = ResponseContent { status, content, entity };
@@ -328,7 +252,7 @@ impl UserApi for UserApiClient {
         }
     }
 
-    fn login_user(&self, username: &str, password: &str) -> Result<ResponseContent<LoginUserSuccess>, Error<LoginUserError>> {
+    fn login_user(&self, username: &str, password: &str) -> Result<String, Error<LoginUserError>> {
         let configuration: &configuration::Configuration = self.configuration.borrow();
         let client = &configuration.client;
 
@@ -348,9 +272,7 @@ impl UserApi for UserApiClient {
         let content = resp.text()?;
 
         if status.is_success() {
-            let entity: Option<LoginUserSuccess> = serde_json::from_str(&content).ok();
-            let result = ResponseContent { status, content, entity };
-            Ok(result)
+            serde_json::from_str(&content).map_err(Error::from)
         } else {
             let entity: Option<LoginUserError> = serde_json::from_str(&content).ok();
             let error = ResponseContent { status, content, entity };
@@ -358,7 +280,7 @@ impl UserApi for UserApiClient {
         }
     }
 
-    fn logout_user(&self, ) -> Result<ResponseContent<LogoutUserSuccess>, Error<LogoutUserError>> {
+    fn logout_user(&self, ) -> Result<(), Error<LogoutUserError>> {
         let configuration: &configuration::Configuration = self.configuration.borrow();
         let client = &configuration.client;
 
@@ -376,9 +298,7 @@ impl UserApi for UserApiClient {
         let content = resp.text()?;
 
         if status.is_success() {
-            let entity: Option<LogoutUserSuccess> = serde_json::from_str(&content).ok();
-            let result = ResponseContent { status, content, entity };
-            Ok(result)
+            Ok(())
         } else {
             let entity: Option<LogoutUserError> = serde_json::from_str(&content).ok();
             let error = ResponseContent { status, content, entity };
@@ -386,7 +306,7 @@ impl UserApi for UserApiClient {
         }
     }
 
-    fn update_user(&self, username: &str, body: crate::models::User) -> Result<ResponseContent<UpdateUserSuccess>, Error<UpdateUserError>> {
+    fn update_user(&self, username: &str, body: crate::models::User) -> Result<(), Error<UpdateUserError>> {
         let configuration: &configuration::Configuration = self.configuration.borrow();
         let client = &configuration.client;
 
@@ -405,9 +325,7 @@ impl UserApi for UserApiClient {
         let content = resp.text()?;
 
         if status.is_success() {
-            let entity: Option<UpdateUserSuccess> = serde_json::from_str(&content).ok();
-            let result = ResponseContent { status, content, entity };
-            Ok(result)
+            Ok(())
         } else {
             let entity: Option<UpdateUserError> = serde_json::from_str(&content).ok();
             let error = ResponseContent { status, content, entity };

--- a/samples/client/petstore/rust/reqwest/petstore/tests/pet_tests.rs
+++ b/samples/client/petstore/rust/reqwest/petstore/tests/pet_tests.rs
@@ -24,6 +24,11 @@ fn test_pet() {
 
     match pet_result {
         Ok(resp) => {
+            /* Test code when multiple returns option is not set. */
+            assert_eq!(resp.id, Option::Some(8787));
+            assert_eq!(resp.name, "Rust Pet");
+            assert_eq!(resp.photo_urls, vec!["https://11".to_string(), "https://22".to_string()]);
+            /* Test code for multiple returns option.
             match resp.entity {
                 Some(petstore_reqwest::apis::pet_api::GetPetByIdSuccess::Status200(pet)) => {
                     assert_eq!(pet.id, Option::Some(8787));
@@ -34,6 +39,7 @@ fn test_pet() {
                     panic!("Response should contain a pet entity");
                 },
             };
+            */
         },
         Err(error) => {
             println!("error: {:?}", error);

--- a/samples/client/petstore/rust/reqwest/rust-test/src/apis/default_api.rs
+++ b/samples/client/petstore/rust/reqwest/rust-test/src/apis/default_api.rs
@@ -31,31 +31,21 @@ impl DefaultApiClient {
 }
 
 
-/// struct for typed successes of method `dummy_get`
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(untagged)]
-pub enum DummyGetSuccess {
-    Status200(),
-    UnknownList(Vec<serde_json::Value>),
-    UnknownValue(serde_json::Value),
-}
-
 /// struct for typed errors of method `dummy_get`
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum DummyGetError {
-    DefaultResponse(),
     UnknownList(Vec<serde_json::Value>),
     UnknownValue(serde_json::Value),
 }
 
 
 pub trait DefaultApi {
-    fn dummy_get(&self, ) -> Result<ResponseContent<DummyGetSuccess>, Error<DummyGetError>>;
+    fn dummy_get(&self, ) -> Result<(), Error<DummyGetError>>;
 }
 
 impl DefaultApi for DefaultApiClient {
-    fn dummy_get(&self, ) -> Result<ResponseContent<DummyGetSuccess>, Error<DummyGetError>> {
+    fn dummy_get(&self, ) -> Result<(), Error<DummyGetError>> {
         let configuration: &configuration::Configuration = self.configuration.borrow();
         let client = &configuration.client;
 
@@ -73,9 +63,7 @@ impl DefaultApi for DefaultApiClient {
         let content = resp.text()?;
 
         if status.is_success() {
-            let entity: Option<DummyGetSuccess> = serde_json::from_str(&content).ok();
-            let result = ResponseContent { status, content, entity };
-            Ok(result)
+            Ok(())
         } else {
             let entity: Option<DummyGetError> = serde_json::from_str(&content).ok();
             let error = ResponseContent { status, content, entity };

--- a/samples/client/petstore/rust/reqwest/rust-test/src/apis/default_api.rs
+++ b/samples/client/petstore/rust/reqwest/rust-test/src/apis/default_api.rs
@@ -35,7 +35,6 @@ impl DefaultApiClient {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum DummyGetError {
-    UnknownList(Vec<serde_json::Value>),
     UnknownValue(serde_json::Value),
 }
 


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

By default, rust client (using Reqwest) returns a simple return type. Handling multiple returns (several 2xx codes is optional).

<!-- Please check the completed items below -->
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [X] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/config/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [X] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

cc @frol (2017/07) @farcaller (2017/08) @bjgill (2017/12) @richardwhiuk (2019/07) @paladinzh (2020/05) @wing328