### PR TITLE
[typescript-fetch] fix double parsing deep object parameters

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-fetch/apis.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/apis.mustache
@@ -122,12 +122,7 @@ export class {{classname}} extends runtime.BaseAPI {
             queryParameters['{{baseName}}'] = (requestParameters.{{paramName}} as any).toISOString().substr(0,10);
             {{/isDate}}
             {{^isDate}}
-            {{#vendorExtensions.x-codegen-isDeepObject}}
-            queryParameters['{{baseName}}'] = runtime.querystring(requestParameters.{{paramName}} as unknown as runtime.HTTPQuery, '{{baseName}}');
-            {{/vendorExtensions.x-codegen-isDeepObject}}
-            {{^vendorExtensions.x-codegen-isDeepObject}}
             queryParameters['{{baseName}}'] = requestParameters.{{paramName}};
-            {{/vendorExtensions.x-codegen-isDeepObject}}
             {{/isDate}}
             {{/isDateTime}}
         }


### PR DESCRIPTION
Fixing double parsing query parameters for deep object.

Currently it generates something like this:

```
...&filter=filter%255Bstatus%255D%3Denabled%26
```

It's because there is double parsing one of it is what i removing and another one here: https://github.com/OpenAPITools/openapi-generator/blob/ca3a23bfa8d2d46612d9370db830ec6751566d99/modules/openapi-generator/src/main/resources/typescript-fetch/runtime.mustache#L209-L226 but deep object can be handled by this one: https://github.com/OpenAPITools/openapi-generator/blob/ca3a23bfa8d2d46612d9370db830ec6751566d99/modules/openapi-generator/src/main/resources/typescript-fetch/runtime.mustache#L219-L221

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/config/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@TiFu @taxpon @sebastianhaas @kenisteward @Vrolijkx @macjohnny @topce @akehir @petejohansonxo @amakhrov
