### PR TITLE
[Go][Experimental] Better logic when using useOneOfDiscriminatorLookup

### DIFF
--- a/modules/openapi-generator/src/main/resources/go-experimental/model_oneof.mustache
+++ b/modules/openapi-generator/src/main/resources/go-experimental/model_oneof.mustache
@@ -16,7 +16,6 @@ func {{{.}}}As{{classname}}(v *{{{.}}}) {{classname}} {
 // Unmarshal JSON data into one of the pointers in the struct
 func (dst *{{classname}}) UnmarshalJSON(data []byte) error {
 	var err error
-	match := 0
 	{{#isNullable}}
 	// this object is nullable so check if the payload is null or empty string
 	if string(data) == "" || string(data) == "{}" {
@@ -41,20 +40,19 @@ func (dst *{{classname}}) UnmarshalJSON(data []byte) error {
 		// try to unmarshal JSON data into {{{modelName}}}
 		err = json.Unmarshal(data, &dst.{{{modelName}}})
 		if err == nil {
-			json{{{modelName}}}, _ := json.Marshal(dst.{{{modelName}}})
-			if string(json{{{modelName}}}) == "{}" { // empty struct
-				dst.{{{modelName}}} = nil
-			} else {
-				return nil // data stored in dst.{{{modelName}}}, return on the first match
-			}
+			return nil // data stored in dst.{{{modelName}}}, return on the first match
 		} else {
 			dst.{{{modelName}}} = nil
+			return fmt.Errorf("Failed to unmarshal {{classname}} as {{{modelName}}}: %s", err.Error())
 		}
 	}
 
 	{{/mappedModels}}
 	{{/discriminator}}
+	return nil
 	{{/useOneOfDiscriminatorLookup}}
+	{{^useOneOfDiscriminatorLookup}}
+	match := 0
 	{{#oneOf}}
 	// try to unmarshal data into {{{.}}}
 	err = json.Unmarshal(data, &dst.{{{.}}})
@@ -82,6 +80,7 @@ func (dst *{{classname}}) UnmarshalJSON(data []byte) error {
 	} else { // no match
 		return fmt.Errorf("Data failed to match schemas in oneOf({{classname}})")
 	}
+	{{/useOneOfDiscriminatorLookup}}
 }
 
 // Marshal data from the first non-nil pointers in the struct to JSON


### PR DESCRIPTION
cherry-pick the enhancement from https://github.com/OpenAPITools/openapi-generator/pull/6672

credits: @bkabrda 

cc @antihax (2017/11) @bvwells (2017/12) @grokify (2018/07) @kemokemo (2018/09) @bkabrda (2019/07)




<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/config/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
