### PR TITLE
Fix for incorrect examples used by Flask codegenerator. Issue #6711

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonAbstractConnexionServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonAbstractConnexionServerCodegen.java
@@ -963,7 +963,9 @@ public class PythonAbstractConnexionServerCodegen extends DefaultCodegen impleme
             }
             if (operation.requestBodyExamples != null) {
                 for (Map<String, String> example : operation.requestBodyExamples) {
-                    if (example.get("contentType") != null && example.get("contentType").equals("application/json")) {
+                    if (operation.bodyParam.example == null
+                    		&& example.get("contentType") != null 
+                    		&& example.get("contentType").equals("application/json")) {
                         operation.bodyParam.example = example.get("example");
                     }
                 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/python/PythonTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/python/PythonTest.java
@@ -17,7 +17,6 @@
 
 package org.openapitools.codegen.python;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Sets;
@@ -30,28 +29,16 @@ import io.swagger.v3.parser.util.SchemaTypeUtil;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.TreeSet;
-
 import org.openapitools.codegen.*;
 import org.openapitools.codegen.config.CodegenConfigurator;
-import org.openapitools.codegen.examples.ExampleGenerator;
-import org.openapitools.codegen.languages.AsciidocDocumentationCodegen;
-import org.openapitools.codegen.languages.BashClientCodegen;
 import org.openapitools.codegen.languages.PythonClientCodegen;
-import org.openapitools.codegen.languages.PythonFlaskConnexionServerCodegen;
-import org.openapitools.codegen.utils.ModelUtils;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -132,7 +119,7 @@ public class PythonTest {
         String line = buf.readLine();
         StringBuilder sb = new StringBuilder();
                 
-        while(line != null){
+        while(line != null){	
            sb.append(line);
            line = buf.readLine();
         }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/python/PythonTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/python/PythonTest.java
@@ -36,6 +36,7 @@ import java.io.InputStreamReader;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.List;
+
 import org.openapitools.codegen.*;
 import org.openapitools.codegen.config.CodegenConfigurator;
 import org.openapitools.codegen.languages.PythonClientCodegen;
@@ -44,34 +45,6 @@ import org.testng.annotations.Test;
 
 @SuppressWarnings("static-method")
 public class PythonTest {
-
-	@Test(description = "convert a python model with dots")
-	public void modelTest() {
-		final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/2_0/v1beta3.json");
-		final DefaultCodegen codegen = new PythonClientCodegen();
-		codegen.setOpenAPI(openAPI);
-
-		codegen.setOpenAPI(openAPI);
-		final CodegenModel simpleName = codegen.fromModel("v1beta3.Binding",
-				openAPI.getComponents().getSchemas().get("v1beta3.Binding"));
-		Assert.assertEquals(simpleName.name, "v1beta3.Binding");
-		Assert.assertEquals(simpleName.classname, "V1beta3Binding");
-		Assert.assertEquals(simpleName.classVarName, "v1beta3_binding");
-
-		codegen.setOpenAPI(openAPI);
-		final CodegenModel compoundName = codegen.fromModel("v1beta3.ComponentStatus",
-				openAPI.getComponents().getSchemas().get("v1beta3.ComponentStatus"));
-		Assert.assertEquals(compoundName.name, "v1beta3.ComponentStatus");
-		Assert.assertEquals(compoundName.classname, "V1beta3ComponentStatus");
-		Assert.assertEquals(compoundName.classVarName, "v1beta3_component_status");
-
-		final String path = "/api/v1beta3/namespaces/{namespaces}/bindings";
-		final Operation operation = openAPI.getPaths().get(path).getPost();
-		final CodegenOperation codegenOperation = codegen.fromOperation(path, "get", operation, null);
-		Assert.assertEquals(codegenOperation.returnType, "V1beta3Binding");
-		Assert.assertEquals(codegenOperation.returnBaseType, "V1beta3Binding");
-	}
-
 	@Test(description = "Request body parameters")
 	public void modelRequestBodyParametersTest() throws IOException {
         // Setup inputs and outputs
@@ -79,10 +52,10 @@ public class PythonTest {
         output.deleteOnExit();
         File template = Files.createTempDirectory("test").toFile();
         template.deleteOnExit();
-        
+
         String outDir = Paths.get(output.toURI()).toAbsolutePath().toString();
         String templateDir = Paths.get(template.toURI()).toAbsolutePath().toString();
-        
+
         // Create template which contains only bodyParam
         FileWriter templateWriter = new FileWriter(Paths.get(templateDir, "controller_test.mustache").toFile());
         templateWriter.write("{{#operations}}\n"
@@ -94,7 +67,7 @@ public class PythonTest {
         		+ "{{/operations}}"
         		);
         templateWriter.close();
-        
+
         final CodegenConfigurator configurator = new CodegenConfigurator().setGeneratorName("python-flask")
                 .setInputSpec("src/test/resources/3_0/post-request-body-array-value.yaml")
                 .setOutputDir(outDir)
@@ -103,10 +76,10 @@ public class PythonTest {
         final ClientOptInput clientOptInput = configurator.toClientOptInput();
         DefaultGenerator generator = new DefaultGenerator();
         generator.setGenerateMetadata(false);
-        
+
         // Generate file
         List<File> generatedFiles = generator.opts(clientOptInput).generate();
-        
+
         // Read generated data
         String defaultControllerPath = Paths.get("openapi_server","test","test_default_controller.py").toString();
         TestUtils.ensureContainsFile(generatedFiles, output, defaultControllerPath );
@@ -115,10 +88,10 @@ public class PythonTest {
         		Paths.get(outDir, defaultControllerPath).toString());
 
         BufferedReader buf = new BufferedReader(new InputStreamReader(is));
-                
+
         String line = buf.readLine();
         StringBuilder sb = new StringBuilder();
-                
+
         while(line != null){	
            sb.append(line);
            line = buf.readLine();
@@ -136,229 +109,269 @@ public class PythonTest {
 		Assert.assertEquals(actual, expected);
 	}
 
-	@Test(description = "convert a simple java model")
-	public void simpleModelTest() {
-		final Schema schema = new Schema().description("a sample model")
-				.addProperties("id", new IntegerSchema().format(SchemaTypeUtil.INTEGER64_FORMAT))
-				.addProperties("name", new StringSchema()).addProperties("createdAt", new DateTimeSchema())
-				.addRequiredItem("id").addRequiredItem("name");
-		final DefaultCodegen codegen = new PythonClientCodegen();
-		OpenAPI openAPI = TestUtils.createOpenAPIWithOneSchema("sample", schema);
-		codegen.setOpenAPI(openAPI);
-		final CodegenModel cm = codegen.fromModel("sample", schema);
 
-		Assert.assertEquals(cm.name, "sample");
-		Assert.assertEquals(cm.classname, "Sample");
-		Assert.assertEquals(cm.description, "a sample model");
-		Assert.assertEquals(cm.vars.size(), 3);
+    @Test(description = "convert a python model with dots")
+    public void modelTest() {
+        final OpenAPI openAPI= TestUtils.parseFlattenSpec("src/test/resources/2_0/v1beta3.json");
+        final DefaultCodegen codegen = new PythonClientCodegen();
+        codegen.setOpenAPI(openAPI);
 
-		final CodegenProperty property1 = cm.vars.get(0);
-		Assert.assertEquals(property1.baseName, "id");
-		Assert.assertEquals(property1.dataType, "int");
-		Assert.assertEquals(property1.name, "id");
-		Assert.assertNull(property1.defaultValue);
-		Assert.assertEquals(property1.baseType, "int");
-		Assert.assertTrue(property1.hasMore);
-		Assert.assertTrue(property1.required);
-		Assert.assertTrue(property1.isPrimitiveType);
+        codegen.setOpenAPI(openAPI);
+        final CodegenModel simpleName = codegen.fromModel("v1beta3.Binding", openAPI.getComponents().getSchemas().get("v1beta3.Binding"));
+        Assert.assertEquals(simpleName.name, "v1beta3.Binding");
+        Assert.assertEquals(simpleName.classname, "V1beta3Binding");
+        Assert.assertEquals(simpleName.classVarName, "v1beta3_binding");
 
-		final CodegenProperty property2 = cm.vars.get(1);
-		Assert.assertEquals(property2.baseName, "name");
-		Assert.assertEquals(property2.dataType, "str");
-		Assert.assertEquals(property2.name, "name");
-		Assert.assertNull(property2.defaultValue);
-		Assert.assertEquals(property2.baseType, "str");
-		Assert.assertTrue(property2.hasMore);
-		Assert.assertTrue(property2.required);
-		Assert.assertTrue(property2.isPrimitiveType);
+        codegen.setOpenAPI(openAPI);
+        final CodegenModel compoundName = codegen.fromModel("v1beta3.ComponentStatus", openAPI.getComponents().getSchemas().get("v1beta3.ComponentStatus"));
+        Assert.assertEquals(compoundName.name, "v1beta3.ComponentStatus");
+        Assert.assertEquals(compoundName.classname, "V1beta3ComponentStatus");
+        Assert.assertEquals(compoundName.classVarName, "v1beta3_component_status");
 
-		final CodegenProperty property3 = cm.vars.get(2);
-		Assert.assertEquals(property3.baseName, "createdAt");
-		Assert.assertEquals(property3.dataType, "datetime");
-		Assert.assertEquals(property3.name, "created_at");
-		Assert.assertNull(property3.defaultValue);
-		Assert.assertEquals(property3.baseType, "datetime");
-		Assert.assertFalse(property3.hasMore);
-		Assert.assertFalse(property3.required);
-	}
+        final String path = "/api/v1beta3/namespaces/{namespaces}/bindings";
+        final Operation operation = openAPI.getPaths().get(path).getPost();
+        final CodegenOperation codegenOperation = codegen.fromOperation(path, "get", operation, null);
+        Assert.assertEquals(codegenOperation.returnType, "V1beta3Binding");
+        Assert.assertEquals(codegenOperation.returnBaseType, "V1beta3Binding");
+    }
 
-	@Test(description = "convert a model with list property")
-	public void listPropertyTest() {
-		final Schema model = new Schema().description("a sample model")
-				.addProperties("id", new IntegerSchema().format(SchemaTypeUtil.INTEGER64_FORMAT))
-				.addProperties("urls", new ArraySchema().items(new StringSchema())).addRequiredItem("id");
-		final DefaultCodegen codegen = new PythonClientCodegen();
-		OpenAPI openAPI = TestUtils.createOpenAPIWithOneSchema("sample", model);
-		codegen.setOpenAPI(openAPI);
-		final CodegenModel cm = codegen.fromModel("sample", model);
+    @Test(description = "convert a simple java model")
+    public void simpleModelTest() {
+        final Schema schema = new Schema()
+                .description("a sample model")
+                .addProperties("id", new IntegerSchema().format(SchemaTypeUtil.INTEGER64_FORMAT))
+                .addProperties("name", new StringSchema())
+                .addProperties("createdAt", new DateTimeSchema())
+                .addRequiredItem("id")
+                .addRequiredItem("name");
+        final DefaultCodegen codegen = new PythonClientCodegen();
+        OpenAPI openAPI = TestUtils.createOpenAPIWithOneSchema("sample", schema);
+        codegen.setOpenAPI(openAPI);
+        final CodegenModel cm = codegen.fromModel("sample", schema);
 
-		Assert.assertEquals(cm.name, "sample");
-		Assert.assertEquals(cm.classname, "Sample");
-		Assert.assertEquals(cm.description, "a sample model");
-		Assert.assertEquals(cm.vars.size(), 2);
+        Assert.assertEquals(cm.name, "sample");
+        Assert.assertEquals(cm.classname, "Sample");
+        Assert.assertEquals(cm.description, "a sample model");
+        Assert.assertEquals(cm.vars.size(), 3);
 
-		final CodegenProperty property1 = cm.vars.get(0);
-		Assert.assertEquals(property1.baseName, "id");
-		Assert.assertEquals(property1.dataType, "int");
-		Assert.assertEquals(property1.name, "id");
-		Assert.assertNull(property1.defaultValue);
-		Assert.assertEquals(property1.baseType, "int");
-		Assert.assertTrue(property1.hasMore);
-		Assert.assertTrue(property1.required);
-		Assert.assertTrue(property1.isPrimitiveType);
+        final CodegenProperty property1 = cm.vars.get(0);
+        Assert.assertEquals(property1.baseName, "id");
+        Assert.assertEquals(property1.dataType, "int");
+        Assert.assertEquals(property1.name, "id");
+        Assert.assertNull(property1.defaultValue);
+        Assert.assertEquals(property1.baseType, "int");
+        Assert.assertTrue(property1.hasMore);
+        Assert.assertTrue(property1.required);
+        Assert.assertTrue(property1.isPrimitiveType);
 
-		final CodegenProperty property2 = cm.vars.get(1);
-		Assert.assertEquals(property2.baseName, "urls");
-		Assert.assertEquals(property2.dataType, "list[str]");
-		Assert.assertEquals(property2.name, "urls");
-		Assert.assertNull(property2.defaultValue);
-		Assert.assertEquals(property2.baseType, "list");
-		Assert.assertFalse(property2.hasMore);
-		Assert.assertEquals(property2.containerType, "array");
-		Assert.assertFalse(property2.required);
-		Assert.assertTrue(property2.isPrimitiveType);
-		Assert.assertTrue(property2.isContainer);
-	}
+        final CodegenProperty property2 = cm.vars.get(1);
+        Assert.assertEquals(property2.baseName, "name");
+        Assert.assertEquals(property2.dataType, "str");
+        Assert.assertEquals(property2.name, "name");
+        Assert.assertNull(property2.defaultValue);
+        Assert.assertEquals(property2.baseType, "str");
+        Assert.assertTrue(property2.hasMore);
+        Assert.assertTrue(property2.required);
+        Assert.assertTrue(property2.isPrimitiveType);
 
-	@Test(description = "convert a model with a map property")
-	public void mapPropertyTest() {
-		final Schema model = new Schema().description("a sample model")
-				.addProperties("translations", new MapSchema().additionalProperties(new StringSchema()))
-				.addRequiredItem("id");
-		final DefaultCodegen codegen = new PythonClientCodegen();
-		OpenAPI openAPI = TestUtils.createOpenAPIWithOneSchema("sample", model);
-		codegen.setOpenAPI(openAPI);
-		final CodegenModel cm = codegen.fromModel("sample", model);
+        final CodegenProperty property3 = cm.vars.get(2);
+        Assert.assertEquals(property3.baseName, "createdAt");
+        Assert.assertEquals(property3.dataType, "datetime");
+        Assert.assertEquals(property3.name, "created_at");
+        Assert.assertNull(property3.defaultValue);
+        Assert.assertEquals(property3.baseType, "datetime");
+        Assert.assertFalse(property3.hasMore);
+        Assert.assertFalse(property3.required);
+    }
 
-		Assert.assertEquals(cm.name, "sample");
-		Assert.assertEquals(cm.classname, "Sample");
-		Assert.assertEquals(cm.description, "a sample model");
-		Assert.assertEquals(cm.vars.size(), 1);
+    @Test(description = "convert a model with list property")
+    public void listPropertyTest() {
+        final Schema model = new Schema()
+                .description("a sample model")
+                .addProperties("id", new IntegerSchema().format(SchemaTypeUtil.INTEGER64_FORMAT))
+                .addProperties("urls", new ArraySchema()
+                        .items(new StringSchema()))
+                .addRequiredItem("id");
+        final DefaultCodegen codegen = new PythonClientCodegen();
+        OpenAPI openAPI = TestUtils.createOpenAPIWithOneSchema("sample", model);
+        codegen.setOpenAPI(openAPI);
+        final CodegenModel cm = codegen.fromModel("sample", model);
 
-		final CodegenProperty property1 = cm.vars.get(0);
-		Assert.assertEquals(property1.baseName, "translations");
-		Assert.assertEquals(property1.dataType, "dict(str, str)");
-		Assert.assertEquals(property1.name, "translations");
-		Assert.assertEquals(property1.baseType, "dict");
-		Assert.assertEquals(property1.containerType, "map");
-		Assert.assertFalse(property1.required);
-		Assert.assertTrue(property1.isContainer);
-		Assert.assertTrue(property1.isPrimitiveType);
-	}
+        Assert.assertEquals(cm.name, "sample");
+        Assert.assertEquals(cm.classname, "Sample");
+        Assert.assertEquals(cm.description, "a sample model");
+        Assert.assertEquals(cm.vars.size(), 2);
 
-	@Test(description = "convert a model with complex property")
-	public void complexPropertyTest() {
-		final Schema model = new Schema().description("a sample model").addProperties("children",
-				new Schema().$ref("#/definitions/Children"));
-		final DefaultCodegen codegen = new PythonClientCodegen();
-		OpenAPI openAPI = TestUtils.createOpenAPIWithOneSchema("sample", model);
-		codegen.setOpenAPI(openAPI);
-		final CodegenModel cm = codegen.fromModel("sample", model);
+        final CodegenProperty property1 = cm.vars.get(0);
+        Assert.assertEquals(property1.baseName, "id");
+        Assert.assertEquals(property1.dataType, "int");
+        Assert.assertEquals(property1.name, "id");
+        Assert.assertNull(property1.defaultValue);
+        Assert.assertEquals(property1.baseType, "int");
+        Assert.assertTrue(property1.hasMore);
+        Assert.assertTrue(property1.required);
+        Assert.assertTrue(property1.isPrimitiveType);
 
-		Assert.assertEquals(cm.name, "sample");
-		Assert.assertEquals(cm.classname, "Sample");
-		Assert.assertEquals(cm.description, "a sample model");
-		Assert.assertEquals(cm.vars.size(), 1);
+        final CodegenProperty property2 = cm.vars.get(1);
+        Assert.assertEquals(property2.baseName, "urls");
+        Assert.assertEquals(property2.dataType, "list[str]");
+        Assert.assertEquals(property2.name, "urls");
+        Assert.assertNull(property2.defaultValue);
+        Assert.assertEquals(property2.baseType, "list");
+        Assert.assertFalse(property2.hasMore);
+        Assert.assertEquals(property2.containerType, "array");
+        Assert.assertFalse(property2.required);
+        Assert.assertTrue(property2.isPrimitiveType);
+        Assert.assertTrue(property2.isContainer);
+    }
 
-		final CodegenProperty property1 = cm.vars.get(0);
-		Assert.assertEquals(property1.baseName, "children");
-		Assert.assertEquals(property1.dataType, "Children");
-		Assert.assertEquals(property1.name, "children");
-		Assert.assertEquals(property1.baseType, "Children");
-		Assert.assertFalse(property1.required);
-		Assert.assertFalse(property1.isContainer);
-	}
+    @Test(description = "convert a model with a map property")
+    public void mapPropertyTest() {
+        final Schema model = new Schema()
+                .description("a sample model")
+                .addProperties("translations", new MapSchema()
+                        .additionalProperties(new StringSchema()))
+                .addRequiredItem("id");
+        final DefaultCodegen codegen = new PythonClientCodegen();
+        OpenAPI openAPI = TestUtils.createOpenAPIWithOneSchema("sample", model);
+        codegen.setOpenAPI(openAPI);
+        final CodegenModel cm = codegen.fromModel("sample", model);
 
-	@Test(description = "convert a model with complex list property")
-	public void complexListPropertyTest() {
-		final Schema model = new Schema().description("a sample model").addProperties("children",
-				new ArraySchema().items(new Schema().$ref("#/definitions/Children")));
-		final DefaultCodegen codegen = new PythonClientCodegen();
-		OpenAPI openAPI = TestUtils.createOpenAPIWithOneSchema("sample", model);
-		codegen.setOpenAPI(openAPI);
-		final CodegenModel cm = codegen.fromModel("sample", model);
+        Assert.assertEquals(cm.name, "sample");
+        Assert.assertEquals(cm.classname, "Sample");
+        Assert.assertEquals(cm.description, "a sample model");
+        Assert.assertEquals(cm.vars.size(), 1);
 
-		Assert.assertEquals(cm.name, "sample");
-		Assert.assertEquals(cm.classname, "Sample");
-		Assert.assertEquals(cm.description, "a sample model");
-		Assert.assertEquals(cm.vars.size(), 1);
+        final CodegenProperty property1 = cm.vars.get(0);
+        Assert.assertEquals(property1.baseName, "translations");
+        Assert.assertEquals(property1.dataType, "dict(str, str)");
+        Assert.assertEquals(property1.name, "translations");
+        Assert.assertEquals(property1.baseType, "dict");
+        Assert.assertEquals(property1.containerType, "map");
+        Assert.assertFalse(property1.required);
+        Assert.assertTrue(property1.isContainer);
+        Assert.assertTrue(property1.isPrimitiveType);
+    }
 
-		final CodegenProperty property1 = cm.vars.get(0);
-		Assert.assertEquals(property1.baseName, "children");
-		Assert.assertEquals(property1.complexType, "Children");
-		Assert.assertEquals(property1.dataType, "list[Children]");
-		Assert.assertEquals(property1.name, "children");
-		Assert.assertEquals(property1.baseType, "list");
-		Assert.assertEquals(property1.containerType, "array");
-		Assert.assertFalse(property1.required);
-		Assert.assertTrue(property1.isContainer);
-	}
+    @Test(description = "convert a model with complex property")
+    public void complexPropertyTest() {
+        final Schema model = new Schema()
+                .description("a sample model")
+                .addProperties("children", new Schema().$ref("#/definitions/Children"));
+        final DefaultCodegen codegen = new PythonClientCodegen();
+        OpenAPI openAPI = TestUtils.createOpenAPIWithOneSchema("sample", model);
+        codegen.setOpenAPI(openAPI);
+        final CodegenModel cm = codegen.fromModel("sample", model);
 
-	@Test(description = "convert a model with complex map property")
-	public void complexMapPropertyTest() {
-		final Schema model = new Schema().description("a sample model").addProperties("children",
-				new MapSchema().additionalProperties(new Schema().$ref("#/definitions/Children")));
-		final DefaultCodegen codegen = new PythonClientCodegen();
-		OpenAPI openAPI = TestUtils.createOpenAPIWithOneSchema("sample", model);
-		codegen.setOpenAPI(openAPI);
-		final CodegenModel cm = codegen.fromModel("sample", model);
+        Assert.assertEquals(cm.name, "sample");
+        Assert.assertEquals(cm.classname, "Sample");
+        Assert.assertEquals(cm.description, "a sample model");
+        Assert.assertEquals(cm.vars.size(), 1);
 
-		Assert.assertEquals(cm.name, "sample");
-		Assert.assertEquals(cm.classname, "Sample");
-		Assert.assertEquals(cm.description, "a sample model");
-		Assert.assertEquals(cm.vars.size(), 1);
-		Assert.assertEquals(Sets.intersection(cm.imports, Sets.newHashSet("Children")).size(), 1);
+        final CodegenProperty property1 = cm.vars.get(0);
+        Assert.assertEquals(property1.baseName, "children");
+        Assert.assertEquals(property1.dataType, "Children");
+        Assert.assertEquals(property1.name, "children");
+        Assert.assertEquals(property1.baseType, "Children");
+        Assert.assertFalse(property1.required);
+        Assert.assertFalse(property1.isContainer);
+    }
 
-		final CodegenProperty property1 = cm.vars.get(0);
-		Assert.assertEquals(property1.baseName, "children");
-		Assert.assertEquals(property1.complexType, "Children");
-		Assert.assertEquals(property1.dataType, "dict(str, Children)");
-		Assert.assertEquals(property1.name, "children");
-		Assert.assertEquals(property1.baseType, "dict");
-		Assert.assertEquals(property1.containerType, "map");
-		Assert.assertFalse(property1.required);
-		Assert.assertTrue(property1.isContainer);
-	}
+    @Test(description = "convert a model with complex list property")
+    public void complexListPropertyTest() {
+        final Schema model = new Schema()
+                .description("a sample model")
+                .addProperties("children", new ArraySchema()
+                        .items(new Schema().$ref("#/definitions/Children")));
+        final DefaultCodegen codegen = new PythonClientCodegen();
+        OpenAPI openAPI = TestUtils.createOpenAPIWithOneSchema("sample", model);
+        codegen.setOpenAPI(openAPI);
+        final CodegenModel cm = codegen.fromModel("sample", model);
 
-	// should not start with 'null'. need help from the community to investigate
-	// further
-	@Test(description = "convert an array model")
-	public void arrayModelTest() {
-		final Schema model = new ArraySchema()
-				// .description()
-				.items(new Schema().$ref("#/definitions/Children")).description("an array model");
-		final DefaultCodegen codegen = new PythonClientCodegen();
-		OpenAPI openAPI = TestUtils.createOpenAPIWithOneSchema("sample", model);
-		codegen.setOpenAPI(openAPI);
-		final CodegenModel cm = codegen.fromModel("sample", model);
+        Assert.assertEquals(cm.name, "sample");
+        Assert.assertEquals(cm.classname, "Sample");
+        Assert.assertEquals(cm.description, "a sample model");
+        Assert.assertEquals(cm.vars.size(), 1);
 
-		Assert.assertEquals(cm.name, "sample");
-		Assert.assertEquals(cm.classname, "Sample");
-		Assert.assertEquals(cm.description, "an array model");
-		Assert.assertEquals(cm.vars.size(), 0);
-		Assert.assertEquals(cm.parent, "null<Children>");
-		Assert.assertEquals(cm.imports.size(), 1);
-		Assert.assertEquals(Sets.intersection(cm.imports, Sets.newHashSet("Children")).size(), 1);
-	}
+        final CodegenProperty property1 = cm.vars.get(0);
+        Assert.assertEquals(property1.baseName, "children");
+        Assert.assertEquals(property1.complexType, "Children");
+        Assert.assertEquals(property1.dataType, "list[Children]");
+        Assert.assertEquals(property1.name, "children");
+        Assert.assertEquals(property1.baseType, "list");
+        Assert.assertEquals(property1.containerType, "array");
+        Assert.assertFalse(property1.required);
+        Assert.assertTrue(property1.isContainer);
+    }
 
-	// should not start with 'null'. need help from the community to investigate
-	// further
-	@Test(description = "convert a map model")
-	public void mapModelTest() {
-		final Schema model = new Schema().description("a map model")
-				.additionalProperties(new Schema().$ref("#/definitions/Children"));
-		final DefaultCodegen codegen = new PythonClientCodegen();
-		OpenAPI openAPI = TestUtils.createOpenAPIWithOneSchema("sample", model);
-		codegen.setOpenAPI(openAPI);
-		final CodegenModel cm = codegen.fromModel("sample", model);
+    @Test(description = "convert a model with complex map property")
+    public void complexMapPropertyTest() {
+        final Schema model = new Schema()
+                .description("a sample model")
+                .addProperties("children", new MapSchema()
+                        .additionalProperties(new Schema().$ref("#/definitions/Children")));
+        final DefaultCodegen codegen = new PythonClientCodegen();
+        OpenAPI openAPI = TestUtils.createOpenAPIWithOneSchema("sample", model);
+        codegen.setOpenAPI(openAPI);
+        final CodegenModel cm = codegen.fromModel("sample", model);
 
-		Assert.assertEquals(cm.name, "sample");
-		Assert.assertEquals(cm.classname, "Sample");
-		Assert.assertEquals(cm.description, "a map model");
-		Assert.assertEquals(cm.vars.size(), 0);
-		Assert.assertEquals(cm.parent, "null<String, Children>");
-		Assert.assertEquals(cm.imports.size(), 1);
-		Assert.assertEquals(Sets.intersection(cm.imports, Sets.newHashSet("Children")).size(), 1);
-	}
+        Assert.assertEquals(cm.name, "sample");
+        Assert.assertEquals(cm.classname, "Sample");
+        Assert.assertEquals(cm.description, "a sample model");
+        Assert.assertEquals(cm.vars.size(), 1);
+        Assert.assertEquals(Sets.intersection(cm.imports, Sets.newHashSet("Children")).size(), 1);
+
+        final CodegenProperty property1 = cm.vars.get(0);
+        Assert.assertEquals(property1.baseName, "children");
+        Assert.assertEquals(property1.complexType, "Children");
+        Assert.assertEquals(property1.dataType, "dict(str, Children)");
+        Assert.assertEquals(property1.name, "children");
+        Assert.assertEquals(property1.baseType, "dict");
+        Assert.assertEquals(property1.containerType, "map");
+        Assert.assertFalse(property1.required);
+        Assert.assertTrue(property1.isContainer);
+    }
+
+
+    // should not start with 'null'. need help from the community to investigate further
+    @Test(description = "convert an array model")
+    public void arrayModelTest() {
+        final Schema model = new ArraySchema()
+                //.description()
+                .items(new Schema().$ref("#/definitions/Children"))
+                .description("an array model");
+        final DefaultCodegen codegen = new PythonClientCodegen();
+        OpenAPI openAPI = TestUtils.createOpenAPIWithOneSchema("sample", model);
+        codegen.setOpenAPI(openAPI);
+        final CodegenModel cm = codegen.fromModel("sample", model);
+
+        Assert.assertEquals(cm.name, "sample");
+        Assert.assertEquals(cm.classname, "Sample");
+        Assert.assertEquals(cm.description, "an array model");
+        Assert.assertEquals(cm.vars.size(), 0);
+        Assert.assertEquals(cm.parent, "null<Children>");
+        Assert.assertEquals(cm.imports.size(), 1);
+        Assert.assertEquals(Sets.intersection(cm.imports, Sets.newHashSet("Children")).size(), 1);
+    }
+
+    // should not start with 'null'. need help from the community to investigate further
+    @Test(description = "convert a map model")
+    public void mapModelTest() {
+        final Schema model = new Schema()
+                .description("a map model")
+                .additionalProperties(new Schema().$ref("#/definitions/Children"));
+        final DefaultCodegen codegen = new PythonClientCodegen();
+        OpenAPI openAPI = TestUtils.createOpenAPIWithOneSchema("sample", model);
+        codegen.setOpenAPI(openAPI);
+        final CodegenModel cm = codegen.fromModel("sample", model);
+
+        Assert.assertEquals(cm.name, "sample");
+        Assert.assertEquals(cm.classname, "Sample");
+        Assert.assertEquals(cm.description, "a map model");
+        Assert.assertEquals(cm.vars.size(), 0);
+        Assert.assertEquals(cm.parent, "null<String, Children>");
+        Assert.assertEquals(cm.imports.size(), 1);
+        Assert.assertEquals(Sets.intersection(cm.imports, Sets.newHashSet("Children")).size(), 1);
+    }
 
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/python/PythonTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/python/PythonTest.java
@@ -17,281 +17,361 @@
 
 package org.openapitools.codegen.python;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Sets;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.media.*;
+import io.swagger.v3.parser.ObjectMapperFactory;
 import io.swagger.v3.parser.util.SchemaTypeUtil;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+
 import org.openapitools.codegen.*;
+import org.openapitools.codegen.config.CodegenConfigurator;
+import org.openapitools.codegen.examples.ExampleGenerator;
+import org.openapitools.codegen.languages.AsciidocDocumentationCodegen;
+import org.openapitools.codegen.languages.BashClientCodegen;
 import org.openapitools.codegen.languages.PythonClientCodegen;
+import org.openapitools.codegen.languages.PythonFlaskConnexionServerCodegen;
+import org.openapitools.codegen.utils.ModelUtils;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
 @SuppressWarnings("static-method")
 public class PythonTest {
 
-    @Test(description = "convert a python model with dots")
-    public void modelTest() {
-        final OpenAPI openAPI= TestUtils.parseFlattenSpec("src/test/resources/2_0/v1beta3.json");
-        final DefaultCodegen codegen = new PythonClientCodegen();
-        codegen.setOpenAPI(openAPI);
+	@Test(description = "convert a python model with dots")
+	public void modelTest() {
+		final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/2_0/v1beta3.json");
+		final DefaultCodegen codegen = new PythonClientCodegen();
+		codegen.setOpenAPI(openAPI);
 
-        codegen.setOpenAPI(openAPI);
-        final CodegenModel simpleName = codegen.fromModel("v1beta3.Binding", openAPI.getComponents().getSchemas().get("v1beta3.Binding"));
-        Assert.assertEquals(simpleName.name, "v1beta3.Binding");
-        Assert.assertEquals(simpleName.classname, "V1beta3Binding");
-        Assert.assertEquals(simpleName.classVarName, "v1beta3_binding");
+		codegen.setOpenAPI(openAPI);
+		final CodegenModel simpleName = codegen.fromModel("v1beta3.Binding",
+				openAPI.getComponents().getSchemas().get("v1beta3.Binding"));
+		Assert.assertEquals(simpleName.name, "v1beta3.Binding");
+		Assert.assertEquals(simpleName.classname, "V1beta3Binding");
+		Assert.assertEquals(simpleName.classVarName, "v1beta3_binding");
 
-        codegen.setOpenAPI(openAPI);
-        final CodegenModel compoundName = codegen.fromModel("v1beta3.ComponentStatus", openAPI.getComponents().getSchemas().get("v1beta3.ComponentStatus"));
-        Assert.assertEquals(compoundName.name, "v1beta3.ComponentStatus");
-        Assert.assertEquals(compoundName.classname, "V1beta3ComponentStatus");
-        Assert.assertEquals(compoundName.classVarName, "v1beta3_component_status");
+		codegen.setOpenAPI(openAPI);
+		final CodegenModel compoundName = codegen.fromModel("v1beta3.ComponentStatus",
+				openAPI.getComponents().getSchemas().get("v1beta3.ComponentStatus"));
+		Assert.assertEquals(compoundName.name, "v1beta3.ComponentStatus");
+		Assert.assertEquals(compoundName.classname, "V1beta3ComponentStatus");
+		Assert.assertEquals(compoundName.classVarName, "v1beta3_component_status");
 
-        final String path = "/api/v1beta3/namespaces/{namespaces}/bindings";
-        final Operation operation = openAPI.getPaths().get(path).getPost();
-        final CodegenOperation codegenOperation = codegen.fromOperation(path, "get", operation, null);
-        Assert.assertEquals(codegenOperation.returnType, "V1beta3Binding");
-        Assert.assertEquals(codegenOperation.returnBaseType, "V1beta3Binding");
-    }
+		final String path = "/api/v1beta3/namespaces/{namespaces}/bindings";
+		final Operation operation = openAPI.getPaths().get(path).getPost();
+		final CodegenOperation codegenOperation = codegen.fromOperation(path, "get", operation, null);
+		Assert.assertEquals(codegenOperation.returnType, "V1beta3Binding");
+		Assert.assertEquals(codegenOperation.returnBaseType, "V1beta3Binding");
+	}
 
-    @Test(description = "convert a simple java model")
-    public void simpleModelTest() {
-        final Schema schema = new Schema()
-                .description("a sample model")
-                .addProperties("id", new IntegerSchema().format(SchemaTypeUtil.INTEGER64_FORMAT))
-                .addProperties("name", new StringSchema())
-                .addProperties("createdAt", new DateTimeSchema())
-                .addRequiredItem("id")
-                .addRequiredItem("name");
-        final DefaultCodegen codegen = new PythonClientCodegen();
-        OpenAPI openAPI = TestUtils.createOpenAPIWithOneSchema("sample", schema);
-        codegen.setOpenAPI(openAPI);
-        final CodegenModel cm = codegen.fromModel("sample", schema);
+	@Test(description = "Request body parameters")
+	public void modelRequestBodyParametersTest() throws IOException {
+        // Setup inputs and outputs
+		File output = Files.createTempDirectory("test").toFile();
+        output.deleteOnExit();
+        File template = Files.createTempDirectory("test").toFile();
+        template.deleteOnExit();
+        
+        String outDir = Paths.get(output.toURI()).toAbsolutePath().toString();
+        String templateDir = Paths.get(template.toURI()).toAbsolutePath().toString();
+        
+        // Create template which contains only bodyParam
+        FileWriter templateWriter = new FileWriter(Paths.get(templateDir, "controller_test.mustache").toFile());
+        templateWriter.write("{{#operations}}\n"
+        		+ "{{#operation}}\n"
+        		+ "{{#bodyParam}}\n" 
+        		+ "{{{example}}}\n" 
+        		+ "{{/bodyParam}}\n"
+        		+ "{{/operation}}\n"
+        		+ "{{/operations}}"
+        		);
+        templateWriter.close();
+        
+        final CodegenConfigurator configurator = new CodegenConfigurator().setGeneratorName("python-flask")
+                .setInputSpec("src/test/resources/3_0/post-request-body-array-value.yaml")
+                .setOutputDir(outDir)
+                .setTemplateDir(templateDir);
 
-        Assert.assertEquals(cm.name, "sample");
-        Assert.assertEquals(cm.classname, "Sample");
-        Assert.assertEquals(cm.description, "a sample model");
-        Assert.assertEquals(cm.vars.size(), 3);
+        final ClientOptInput clientOptInput = configurator.toClientOptInput();
+        DefaultGenerator generator = new DefaultGenerator();
+        generator.setGenerateMetadata(false);
+        
+        // Generate file
+        List<File> generatedFiles = generator.opts(clientOptInput).generate();
+        
+        // Read generated data
+        String defaultControllerPath = Paths.get("openapi_server","test","test_default_controller.py").toString();
+        TestUtils.ensureContainsFile(generatedFiles, output, defaultControllerPath );
 
-        final CodegenProperty property1 = cm.vars.get(0);
-        Assert.assertEquals(property1.baseName, "id");
-        Assert.assertEquals(property1.dataType, "int");
-        Assert.assertEquals(property1.name, "id");
-        Assert.assertNull(property1.defaultValue);
-        Assert.assertEquals(property1.baseType, "int");
-        Assert.assertTrue(property1.hasMore);
-        Assert.assertTrue(property1.required);
-        Assert.assertTrue(property1.isPrimitiveType);
+        InputStream is = new FileInputStream(
+        		Paths.get(outDir, defaultControllerPath).toString());
 
-        final CodegenProperty property2 = cm.vars.get(1);
-        Assert.assertEquals(property2.baseName, "name");
-        Assert.assertEquals(property2.dataType, "str");
-        Assert.assertEquals(property2.name, "name");
-        Assert.assertNull(property2.defaultValue);
-        Assert.assertEquals(property2.baseType, "str");
-        Assert.assertTrue(property2.hasMore);
-        Assert.assertTrue(property2.required);
-        Assert.assertTrue(property2.isPrimitiveType);
+        BufferedReader buf = new BufferedReader(new InputStreamReader(is));
+                
+        String line = buf.readLine();
+        StringBuilder sb = new StringBuilder();
+                
+        while(line != null){
+           sb.append(line);
+           line = buf.readLine();
+        }
 
-        final CodegenProperty property3 = cm.vars.get(2);
-        Assert.assertEquals(property3.baseName, "createdAt");
-        Assert.assertEquals(property3.dataType, "datetime");
-        Assert.assertEquals(property3.name, "created_at");
-        Assert.assertNull(property3.defaultValue);
-        Assert.assertEquals(property3.baseType, "datetime");
-        Assert.assertFalse(property3.hasMore);
-        Assert.assertFalse(property3.required);
-    }
+        String resultString = sb.toString();
+        buf.close();
+        is.close();
 
-    @Test(description = "convert a model with list property")
-    public void listPropertyTest() {
-        final Schema model = new Schema()
-                .description("a sample model")
-                .addProperties("id", new IntegerSchema().format(SchemaTypeUtil.INTEGER64_FORMAT))
-                .addProperties("urls", new ArraySchema()
-                        .items(new StringSchema()))
-                .addRequiredItem("id");
-        final DefaultCodegen codegen = new PythonClientCodegen();
-        OpenAPI openAPI = TestUtils.createOpenAPIWithOneSchema("sample", model);
-        codegen.setOpenAPI(openAPI);
-        final CodegenModel cm = codegen.fromModel("sample", model);
+        // Compare generated to expected
+        ObjectMapper jsonMapper = ObjectMapperFactory.createJson();
+		JsonNode expected = jsonMapper.readTree("[{\"text\":\"some text\", \"id\":19},{\"id\":63, \"text\":\"some text\"}]");
+		JsonNode actual = jsonMapper.readTree(resultString);
+		System.out.print(resultString);
+		Assert.assertEquals(actual, expected);
+	}
 
-        Assert.assertEquals(cm.name, "sample");
-        Assert.assertEquals(cm.classname, "Sample");
-        Assert.assertEquals(cm.description, "a sample model");
-        Assert.assertEquals(cm.vars.size(), 2);
+	@Test(description = "convert a simple java model")
+	public void simpleModelTest() {
+		final Schema schema = new Schema().description("a sample model")
+				.addProperties("id", new IntegerSchema().format(SchemaTypeUtil.INTEGER64_FORMAT))
+				.addProperties("name", new StringSchema()).addProperties("createdAt", new DateTimeSchema())
+				.addRequiredItem("id").addRequiredItem("name");
+		final DefaultCodegen codegen = new PythonClientCodegen();
+		OpenAPI openAPI = TestUtils.createOpenAPIWithOneSchema("sample", schema);
+		codegen.setOpenAPI(openAPI);
+		final CodegenModel cm = codegen.fromModel("sample", schema);
 
-        final CodegenProperty property1 = cm.vars.get(0);
-        Assert.assertEquals(property1.baseName, "id");
-        Assert.assertEquals(property1.dataType, "int");
-        Assert.assertEquals(property1.name, "id");
-        Assert.assertNull(property1.defaultValue);
-        Assert.assertEquals(property1.baseType, "int");
-        Assert.assertTrue(property1.hasMore);
-        Assert.assertTrue(property1.required);
-        Assert.assertTrue(property1.isPrimitiveType);
+		Assert.assertEquals(cm.name, "sample");
+		Assert.assertEquals(cm.classname, "Sample");
+		Assert.assertEquals(cm.description, "a sample model");
+		Assert.assertEquals(cm.vars.size(), 3);
 
-        final CodegenProperty property2 = cm.vars.get(1);
-        Assert.assertEquals(property2.baseName, "urls");
-        Assert.assertEquals(property2.dataType, "list[str]");
-        Assert.assertEquals(property2.name, "urls");
-        Assert.assertNull(property2.defaultValue);
-        Assert.assertEquals(property2.baseType, "list");
-        Assert.assertFalse(property2.hasMore);
-        Assert.assertEquals(property2.containerType, "array");
-        Assert.assertFalse(property2.required);
-        Assert.assertTrue(property2.isPrimitiveType);
-        Assert.assertTrue(property2.isContainer);
-    }
+		final CodegenProperty property1 = cm.vars.get(0);
+		Assert.assertEquals(property1.baseName, "id");
+		Assert.assertEquals(property1.dataType, "int");
+		Assert.assertEquals(property1.name, "id");
+		Assert.assertNull(property1.defaultValue);
+		Assert.assertEquals(property1.baseType, "int");
+		Assert.assertTrue(property1.hasMore);
+		Assert.assertTrue(property1.required);
+		Assert.assertTrue(property1.isPrimitiveType);
 
-    @Test(description = "convert a model with a map property")
-    public void mapPropertyTest() {
-        final Schema model = new Schema()
-                .description("a sample model")
-                .addProperties("translations", new MapSchema()
-                        .additionalProperties(new StringSchema()))
-                .addRequiredItem("id");
-        final DefaultCodegen codegen = new PythonClientCodegen();
-        OpenAPI openAPI = TestUtils.createOpenAPIWithOneSchema("sample", model);
-        codegen.setOpenAPI(openAPI);
-        final CodegenModel cm = codegen.fromModel("sample", model);
+		final CodegenProperty property2 = cm.vars.get(1);
+		Assert.assertEquals(property2.baseName, "name");
+		Assert.assertEquals(property2.dataType, "str");
+		Assert.assertEquals(property2.name, "name");
+		Assert.assertNull(property2.defaultValue);
+		Assert.assertEquals(property2.baseType, "str");
+		Assert.assertTrue(property2.hasMore);
+		Assert.assertTrue(property2.required);
+		Assert.assertTrue(property2.isPrimitiveType);
 
-        Assert.assertEquals(cm.name, "sample");
-        Assert.assertEquals(cm.classname, "Sample");
-        Assert.assertEquals(cm.description, "a sample model");
-        Assert.assertEquals(cm.vars.size(), 1);
+		final CodegenProperty property3 = cm.vars.get(2);
+		Assert.assertEquals(property3.baseName, "createdAt");
+		Assert.assertEquals(property3.dataType, "datetime");
+		Assert.assertEquals(property3.name, "created_at");
+		Assert.assertNull(property3.defaultValue);
+		Assert.assertEquals(property3.baseType, "datetime");
+		Assert.assertFalse(property3.hasMore);
+		Assert.assertFalse(property3.required);
+	}
 
-        final CodegenProperty property1 = cm.vars.get(0);
-        Assert.assertEquals(property1.baseName, "translations");
-        Assert.assertEquals(property1.dataType, "dict(str, str)");
-        Assert.assertEquals(property1.name, "translations");
-        Assert.assertEquals(property1.baseType, "dict");
-        Assert.assertEquals(property1.containerType, "map");
-        Assert.assertFalse(property1.required);
-        Assert.assertTrue(property1.isContainer);
-        Assert.assertTrue(property1.isPrimitiveType);
-    }
+	@Test(description = "convert a model with list property")
+	public void listPropertyTest() {
+		final Schema model = new Schema().description("a sample model")
+				.addProperties("id", new IntegerSchema().format(SchemaTypeUtil.INTEGER64_FORMAT))
+				.addProperties("urls", new ArraySchema().items(new StringSchema())).addRequiredItem("id");
+		final DefaultCodegen codegen = new PythonClientCodegen();
+		OpenAPI openAPI = TestUtils.createOpenAPIWithOneSchema("sample", model);
+		codegen.setOpenAPI(openAPI);
+		final CodegenModel cm = codegen.fromModel("sample", model);
 
-    @Test(description = "convert a model with complex property")
-    public void complexPropertyTest() {
-        final Schema model = new Schema()
-                .description("a sample model")
-                .addProperties("children", new Schema().$ref("#/definitions/Children"));
-        final DefaultCodegen codegen = new PythonClientCodegen();
-        OpenAPI openAPI = TestUtils.createOpenAPIWithOneSchema("sample", model);
-        codegen.setOpenAPI(openAPI);
-        final CodegenModel cm = codegen.fromModel("sample", model);
+		Assert.assertEquals(cm.name, "sample");
+		Assert.assertEquals(cm.classname, "Sample");
+		Assert.assertEquals(cm.description, "a sample model");
+		Assert.assertEquals(cm.vars.size(), 2);
 
-        Assert.assertEquals(cm.name, "sample");
-        Assert.assertEquals(cm.classname, "Sample");
-        Assert.assertEquals(cm.description, "a sample model");
-        Assert.assertEquals(cm.vars.size(), 1);
+		final CodegenProperty property1 = cm.vars.get(0);
+		Assert.assertEquals(property1.baseName, "id");
+		Assert.assertEquals(property1.dataType, "int");
+		Assert.assertEquals(property1.name, "id");
+		Assert.assertNull(property1.defaultValue);
+		Assert.assertEquals(property1.baseType, "int");
+		Assert.assertTrue(property1.hasMore);
+		Assert.assertTrue(property1.required);
+		Assert.assertTrue(property1.isPrimitiveType);
 
-        final CodegenProperty property1 = cm.vars.get(0);
-        Assert.assertEquals(property1.baseName, "children");
-        Assert.assertEquals(property1.dataType, "Children");
-        Assert.assertEquals(property1.name, "children");
-        Assert.assertEquals(property1.baseType, "Children");
-        Assert.assertFalse(property1.required);
-        Assert.assertFalse(property1.isContainer);
-    }
+		final CodegenProperty property2 = cm.vars.get(1);
+		Assert.assertEquals(property2.baseName, "urls");
+		Assert.assertEquals(property2.dataType, "list[str]");
+		Assert.assertEquals(property2.name, "urls");
+		Assert.assertNull(property2.defaultValue);
+		Assert.assertEquals(property2.baseType, "list");
+		Assert.assertFalse(property2.hasMore);
+		Assert.assertEquals(property2.containerType, "array");
+		Assert.assertFalse(property2.required);
+		Assert.assertTrue(property2.isPrimitiveType);
+		Assert.assertTrue(property2.isContainer);
+	}
 
-    @Test(description = "convert a model with complex list property")
-    public void complexListPropertyTest() {
-        final Schema model = new Schema()
-                .description("a sample model")
-                .addProperties("children", new ArraySchema()
-                        .items(new Schema().$ref("#/definitions/Children")));
-        final DefaultCodegen codegen = new PythonClientCodegen();
-        OpenAPI openAPI = TestUtils.createOpenAPIWithOneSchema("sample", model);
-        codegen.setOpenAPI(openAPI);
-        final CodegenModel cm = codegen.fromModel("sample", model);
+	@Test(description = "convert a model with a map property")
+	public void mapPropertyTest() {
+		final Schema model = new Schema().description("a sample model")
+				.addProperties("translations", new MapSchema().additionalProperties(new StringSchema()))
+				.addRequiredItem("id");
+		final DefaultCodegen codegen = new PythonClientCodegen();
+		OpenAPI openAPI = TestUtils.createOpenAPIWithOneSchema("sample", model);
+		codegen.setOpenAPI(openAPI);
+		final CodegenModel cm = codegen.fromModel("sample", model);
 
-        Assert.assertEquals(cm.name, "sample");
-        Assert.assertEquals(cm.classname, "Sample");
-        Assert.assertEquals(cm.description, "a sample model");
-        Assert.assertEquals(cm.vars.size(), 1);
+		Assert.assertEquals(cm.name, "sample");
+		Assert.assertEquals(cm.classname, "Sample");
+		Assert.assertEquals(cm.description, "a sample model");
+		Assert.assertEquals(cm.vars.size(), 1);
 
-        final CodegenProperty property1 = cm.vars.get(0);
-        Assert.assertEquals(property1.baseName, "children");
-        Assert.assertEquals(property1.complexType, "Children");
-        Assert.assertEquals(property1.dataType, "list[Children]");
-        Assert.assertEquals(property1.name, "children");
-        Assert.assertEquals(property1.baseType, "list");
-        Assert.assertEquals(property1.containerType, "array");
-        Assert.assertFalse(property1.required);
-        Assert.assertTrue(property1.isContainer);
-    }
+		final CodegenProperty property1 = cm.vars.get(0);
+		Assert.assertEquals(property1.baseName, "translations");
+		Assert.assertEquals(property1.dataType, "dict(str, str)");
+		Assert.assertEquals(property1.name, "translations");
+		Assert.assertEquals(property1.baseType, "dict");
+		Assert.assertEquals(property1.containerType, "map");
+		Assert.assertFalse(property1.required);
+		Assert.assertTrue(property1.isContainer);
+		Assert.assertTrue(property1.isPrimitiveType);
+	}
 
-    @Test(description = "convert a model with complex map property")
-    public void complexMapPropertyTest() {
-        final Schema model = new Schema()
-                .description("a sample model")
-                .addProperties("children", new MapSchema()
-                        .additionalProperties(new Schema().$ref("#/definitions/Children")));
-        final DefaultCodegen codegen = new PythonClientCodegen();
-        OpenAPI openAPI = TestUtils.createOpenAPIWithOneSchema("sample", model);
-        codegen.setOpenAPI(openAPI);
-        final CodegenModel cm = codegen.fromModel("sample", model);
+	@Test(description = "convert a model with complex property")
+	public void complexPropertyTest() {
+		final Schema model = new Schema().description("a sample model").addProperties("children",
+				new Schema().$ref("#/definitions/Children"));
+		final DefaultCodegen codegen = new PythonClientCodegen();
+		OpenAPI openAPI = TestUtils.createOpenAPIWithOneSchema("sample", model);
+		codegen.setOpenAPI(openAPI);
+		final CodegenModel cm = codegen.fromModel("sample", model);
 
-        Assert.assertEquals(cm.name, "sample");
-        Assert.assertEquals(cm.classname, "Sample");
-        Assert.assertEquals(cm.description, "a sample model");
-        Assert.assertEquals(cm.vars.size(), 1);
-        Assert.assertEquals(Sets.intersection(cm.imports, Sets.newHashSet("Children")).size(), 1);
+		Assert.assertEquals(cm.name, "sample");
+		Assert.assertEquals(cm.classname, "Sample");
+		Assert.assertEquals(cm.description, "a sample model");
+		Assert.assertEquals(cm.vars.size(), 1);
 
-        final CodegenProperty property1 = cm.vars.get(0);
-        Assert.assertEquals(property1.baseName, "children");
-        Assert.assertEquals(property1.complexType, "Children");
-        Assert.assertEquals(property1.dataType, "dict(str, Children)");
-        Assert.assertEquals(property1.name, "children");
-        Assert.assertEquals(property1.baseType, "dict");
-        Assert.assertEquals(property1.containerType, "map");
-        Assert.assertFalse(property1.required);
-        Assert.assertTrue(property1.isContainer);
-    }
+		final CodegenProperty property1 = cm.vars.get(0);
+		Assert.assertEquals(property1.baseName, "children");
+		Assert.assertEquals(property1.dataType, "Children");
+		Assert.assertEquals(property1.name, "children");
+		Assert.assertEquals(property1.baseType, "Children");
+		Assert.assertFalse(property1.required);
+		Assert.assertFalse(property1.isContainer);
+	}
 
+	@Test(description = "convert a model with complex list property")
+	public void complexListPropertyTest() {
+		final Schema model = new Schema().description("a sample model").addProperties("children",
+				new ArraySchema().items(new Schema().$ref("#/definitions/Children")));
+		final DefaultCodegen codegen = new PythonClientCodegen();
+		OpenAPI openAPI = TestUtils.createOpenAPIWithOneSchema("sample", model);
+		codegen.setOpenAPI(openAPI);
+		final CodegenModel cm = codegen.fromModel("sample", model);
 
-    // should not start with 'null'. need help from the community to investigate further
-    @Test(description = "convert an array model")
-    public void arrayModelTest() {
-        final Schema model = new ArraySchema()
-                //.description()
-                .items(new Schema().$ref("#/definitions/Children"))
-                .description("an array model");
-        final DefaultCodegen codegen = new PythonClientCodegen();
-        OpenAPI openAPI = TestUtils.createOpenAPIWithOneSchema("sample", model);
-        codegen.setOpenAPI(openAPI);
-        final CodegenModel cm = codegen.fromModel("sample", model);
+		Assert.assertEquals(cm.name, "sample");
+		Assert.assertEquals(cm.classname, "Sample");
+		Assert.assertEquals(cm.description, "a sample model");
+		Assert.assertEquals(cm.vars.size(), 1);
 
-        Assert.assertEquals(cm.name, "sample");
-        Assert.assertEquals(cm.classname, "Sample");
-        Assert.assertEquals(cm.description, "an array model");
-        Assert.assertEquals(cm.vars.size(), 0);
-        Assert.assertEquals(cm.parent, "null<Children>");
-        Assert.assertEquals(cm.imports.size(), 1);
-        Assert.assertEquals(Sets.intersection(cm.imports, Sets.newHashSet("Children")).size(), 1);
-    }
+		final CodegenProperty property1 = cm.vars.get(0);
+		Assert.assertEquals(property1.baseName, "children");
+		Assert.assertEquals(property1.complexType, "Children");
+		Assert.assertEquals(property1.dataType, "list[Children]");
+		Assert.assertEquals(property1.name, "children");
+		Assert.assertEquals(property1.baseType, "list");
+		Assert.assertEquals(property1.containerType, "array");
+		Assert.assertFalse(property1.required);
+		Assert.assertTrue(property1.isContainer);
+	}
 
-    // should not start with 'null'. need help from the community to investigate further
-    @Test(description = "convert a map model")
-    public void mapModelTest() {
-        final Schema model = new Schema()
-                .description("a map model")
-                .additionalProperties(new Schema().$ref("#/definitions/Children"));
-        final DefaultCodegen codegen = new PythonClientCodegen();
-        OpenAPI openAPI = TestUtils.createOpenAPIWithOneSchema("sample", model);
-        codegen.setOpenAPI(openAPI);
-        final CodegenModel cm = codegen.fromModel("sample", model);
+	@Test(description = "convert a model with complex map property")
+	public void complexMapPropertyTest() {
+		final Schema model = new Schema().description("a sample model").addProperties("children",
+				new MapSchema().additionalProperties(new Schema().$ref("#/definitions/Children")));
+		final DefaultCodegen codegen = new PythonClientCodegen();
+		OpenAPI openAPI = TestUtils.createOpenAPIWithOneSchema("sample", model);
+		codegen.setOpenAPI(openAPI);
+		final CodegenModel cm = codegen.fromModel("sample", model);
 
-        Assert.assertEquals(cm.name, "sample");
-        Assert.assertEquals(cm.classname, "Sample");
-        Assert.assertEquals(cm.description, "a map model");
-        Assert.assertEquals(cm.vars.size(), 0);
-        Assert.assertEquals(cm.parent, "null<String, Children>");
-        Assert.assertEquals(cm.imports.size(), 1);
-        Assert.assertEquals(Sets.intersection(cm.imports, Sets.newHashSet("Children")).size(), 1);
-    }
+		Assert.assertEquals(cm.name, "sample");
+		Assert.assertEquals(cm.classname, "Sample");
+		Assert.assertEquals(cm.description, "a sample model");
+		Assert.assertEquals(cm.vars.size(), 1);
+		Assert.assertEquals(Sets.intersection(cm.imports, Sets.newHashSet("Children")).size(), 1);
+
+		final CodegenProperty property1 = cm.vars.get(0);
+		Assert.assertEquals(property1.baseName, "children");
+		Assert.assertEquals(property1.complexType, "Children");
+		Assert.assertEquals(property1.dataType, "dict(str, Children)");
+		Assert.assertEquals(property1.name, "children");
+		Assert.assertEquals(property1.baseType, "dict");
+		Assert.assertEquals(property1.containerType, "map");
+		Assert.assertFalse(property1.required);
+		Assert.assertTrue(property1.isContainer);
+	}
+
+	// should not start with 'null'. need help from the community to investigate
+	// further
+	@Test(description = "convert an array model")
+	public void arrayModelTest() {
+		final Schema model = new ArraySchema()
+				// .description()
+				.items(new Schema().$ref("#/definitions/Children")).description("an array model");
+		final DefaultCodegen codegen = new PythonClientCodegen();
+		OpenAPI openAPI = TestUtils.createOpenAPIWithOneSchema("sample", model);
+		codegen.setOpenAPI(openAPI);
+		final CodegenModel cm = codegen.fromModel("sample", model);
+
+		Assert.assertEquals(cm.name, "sample");
+		Assert.assertEquals(cm.classname, "Sample");
+		Assert.assertEquals(cm.description, "an array model");
+		Assert.assertEquals(cm.vars.size(), 0);
+		Assert.assertEquals(cm.parent, "null<Children>");
+		Assert.assertEquals(cm.imports.size(), 1);
+		Assert.assertEquals(Sets.intersection(cm.imports, Sets.newHashSet("Children")).size(), 1);
+	}
+
+	// should not start with 'null'. need help from the community to investigate
+	// further
+	@Test(description = "convert a map model")
+	public void mapModelTest() {
+		final Schema model = new Schema().description("a map model")
+				.additionalProperties(new Schema().$ref("#/definitions/Children"));
+		final DefaultCodegen codegen = new PythonClientCodegen();
+		OpenAPI openAPI = TestUtils.createOpenAPIWithOneSchema("sample", model);
+		codegen.setOpenAPI(openAPI);
+		final CodegenModel cm = codegen.fromModel("sample", model);
+
+		Assert.assertEquals(cm.name, "sample");
+		Assert.assertEquals(cm.classname, "Sample");
+		Assert.assertEquals(cm.description, "a map model");
+		Assert.assertEquals(cm.vars.size(), 0);
+		Assert.assertEquals(cm.parent, "null<String, Children>");
+		Assert.assertEquals(cm.imports.size(), 1);
+		Assert.assertEquals(Sets.intersection(cm.imports, Sets.newHashSet("Children")).size(), 1);
+	}
 
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/python/PythonTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/python/PythonTest.java
@@ -47,10 +47,10 @@ import org.testng.annotations.Test;
 
 @SuppressWarnings("static-method")
 public class PythonTest {
-	@Test(description = "Request body parameters")
-	public void modelRequestBodyParametersTest() throws IOException {
+    @Test(description = "Request body parameters")
+    public void modelRequestBodyParametersTest() throws IOException {
         // Setup inputs and outputs
-		File output = Files.createTempDirectory("test").toFile();
+        File output = Files.createTempDirectory("test").toFile();
         output.deleteOnExit();
         File template = Files.createTempDirectory("test").toFile();
         template.deleteOnExit();
@@ -60,12 +60,12 @@ public class PythonTest {
 
         // Create template which contains only bodyParam
         String templateContent = "{{#operations}}\n"
-        		+ "{{#operation}}\n"
-        		+ "{{#bodyParam}}\n" 
-        		+ "{{{example}}}\n" 
-        		+ "{{/bodyParam}}\n"
-        		+ "{{/operation}}\n"
-        		+ "{{/operations}}";
+                + "{{#operation}}\n"
+                + "{{#bodyParam}}\n" 
+                + "{{{example}}}\n" 
+                + "{{/bodyParam}}\n"
+                + "{{/operation}}\n"
+                + "{{/operations}}";
         
         OutputStream templateWriter = new FileOutputStream(Paths.get(templateDir, "controller_test.mustache").toFile());
         OutputStreamWriter templateStreamWriter = new OutputStreamWriter(templateWriter, "UTF-8");
@@ -90,14 +90,14 @@ public class PythonTest {
         TestUtils.ensureContainsFile(generatedFiles, output, defaultControllerPath );
 
         InputStream is = new FileInputStream(
-        		Paths.get(outDir, defaultControllerPath).toString());
+                Paths.get(outDir, defaultControllerPath).toString());
 
         BufferedReader buf = new BufferedReader(new InputStreamReader(is, "UTF-8"));
 
         String line = buf.readLine();
         StringBuilder sb = new StringBuilder();
 
-        while(line != null){	
+        while(line != null){
            sb.append(line);
            line = buf.readLine();
         }
@@ -108,11 +108,11 @@ public class PythonTest {
 
         // Compare generated to expected
         ObjectMapper jsonMapper = ObjectMapperFactory.createJson();
-		JsonNode expected = jsonMapper.readTree("[{\"text\":\"some text\", \"id\":19},{\"id\":63, \"text\":\"some text\"}]");
-		JsonNode actual = jsonMapper.readTree(resultString);
-		System.out.print(resultString);
-		Assert.assertEquals(actual, expected);
-	}
+        JsonNode expected = jsonMapper.readTree("[{\"text\":\"some text\", \"id\":19},{\"id\":63, \"text\":\"some text\"}]");
+        JsonNode actual = jsonMapper.readTree(resultString);
+        System.out.print(resultString);
+        Assert.assertEquals(actual, expected);
+    }
 
 
     @Test(description = "convert a python model with dots")

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/python/PythonTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/python/PythonTest.java
@@ -29,10 +29,12 @@ import io.swagger.v3.parser.util.SchemaTypeUtil;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileWriter;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.List;
@@ -57,17 +59,20 @@ public class PythonTest {
         String templateDir = Paths.get(template.toURI()).toAbsolutePath().toString();
 
         // Create template which contains only bodyParam
-        FileWriter templateWriter = new FileWriter(Paths.get(templateDir, "controller_test.mustache").toFile());
-        templateWriter.write("{{#operations}}\n"
+        String templateContent = "{{#operations}}\n"
         		+ "{{#operation}}\n"
         		+ "{{#bodyParam}}\n" 
         		+ "{{{example}}}\n" 
         		+ "{{/bodyParam}}\n"
         		+ "{{/operation}}\n"
-        		+ "{{/operations}}"
-        		);
-        templateWriter.close();
-
+        		+ "{{/operations}}";
+        
+        OutputStream templateWriter = new FileOutputStream(Paths.get(templateDir, "controller_test.mustache").toFile());
+        OutputStreamWriter templateStreamWriter = new OutputStreamWriter(templateWriter, "UTF-8");
+        templateStreamWriter.write(templateContent);
+        templateStreamWriter.close();
+        
+        
         final CodegenConfigurator configurator = new CodegenConfigurator().setGeneratorName("python-flask")
                 .setInputSpec("src/test/resources/3_0/post-request-body-array-value.yaml")
                 .setOutputDir(outDir)
@@ -87,7 +92,7 @@ public class PythonTest {
         InputStream is = new FileInputStream(
         		Paths.get(outDir, defaultControllerPath).toString());
 
-        BufferedReader buf = new BufferedReader(new InputStreamReader(is));
+        BufferedReader buf = new BufferedReader(new InputStreamReader(is, "UTF-8"));
 
         String line = buf.readLine();
         StringBuilder sb = new StringBuilder();

--- a/modules/openapi-generator/src/test/resources/3_0/post-request-body-array-value.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/post-request-body-array-value.yaml
@@ -1,0 +1,53 @@
+---
+openapi: 3.0.2
+info:
+  title: OpenApiGeneratorTest
+  version: 1.0.0
+paths:
+  /example:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/ExampleComplexType'
+            examples:
+              Random request data:
+                value:
+                - id: 19
+                  text: some text
+                - id: 63
+                  text: some text
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ExampleComplexType'
+              examples:
+                Random results:
+                  value:
+                  - id: 50
+                    text: some text
+                  - id: 3
+                    text: some text
+          description: Responce description text
+components:
+  schemas:
+    ExampleComplexType:
+      title: Root Type for ExampleComplexType
+      description: ""
+      type: object
+      properties:
+        id:
+          format: int32
+          type: integer
+        text:
+          type: string
+      example:
+        id: 0
+        text: Some text


### PR DESCRIPTION
Guys, can you please review proposed changes
@taxpon  @frol  @mbohlool  @cbornet  @kenjones-cisco  @tomplus  @Jyhess  @arun-nalla  @spacether 

Fix is relatively simple: just to avoid re-setting parameter example in case if it is already set in 
modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonAbstractConnexionServerCodegen.java:966.

The rest of PR - test which reproduces issue and proof the fix 