### PR TITLE
[ASP.NET] The templateDir for aspnet is not set correctly

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AspNetCoreServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AspNetCoreServerCodegen.java
@@ -62,7 +62,6 @@ public class AspNetCoreServerCodegen extends AbstractCSharpCodegen {
     private String packageGuid = "{" + randomUUID().toString().toUpperCase(Locale.ROOT) + "}";
     private String userSecretsGuid = randomUUID().toString();
 
-    @SuppressWarnings("hiding")
     protected Logger LOGGER = LoggerFactory.getLogger(AspNetCoreServerCodegen.class);
 
     private boolean useSwashbuckle = true;
@@ -328,7 +327,7 @@ public class AspNetCoreServerCodegen extends AbstractCSharpCodegen {
             newtonsoftVersion = (String) additionalProperties.get(NEWTONSOFT_VERSION);
         }
 
-        // CHeck for the modifiers etc.
+        // Check for the modifiers etc.
         // The order of the checks is important.
         setBuildTarget();
         setClassModifier();
@@ -337,7 +336,7 @@ public class AspNetCoreServerCodegen extends AbstractCSharpCodegen {
         setUseSwashbuckle();
         setOperationIsAsync();
 
-        // CHeck for class modifier if not present set the default value.
+        // Check for class modifier if not present set the default value.
         additionalProperties.put(PROJECT_SDK, projectSdk);
 
         additionalProperties.put("dockerTag", packageName.toLowerCase(Locale.ROOT));
@@ -447,6 +446,7 @@ public class AspNetCoreServerCodegen extends AbstractCSharpCodegen {
         return escapeText(pattern);
     }
 
+    @SuppressWarnings("rawtypes")
     @Override
     public String getNullableType(Schema p, String type) {
         if (languageSpecificPrimitives.contains(type)) {
@@ -544,7 +544,9 @@ public class AspNetCoreServerCodegen extends AbstractCSharpCodegen {
             compatibilityVersion = "Version_" + aspnetCoreVersion.getOptValue().replace(".", "_");
         }
         LOGGER.info("ASP.NET core version: " + aspnetCoreVersion.getOptValue());
-        embeddedTemplateDir = "aspnetcore/" + determineTemplateVersion(aspnetCoreVersion.getOptValue());
+        if(!additionalProperties.containsKey(CodegenConstants.TEMPLATE_DIR)){
+            templateDir = embeddedTemplateDir = "aspnetcore" + File.separator + determineTemplateVersion(aspnetCoreVersion.getOptValue());
+        }
         additionalProperties.put(COMPATIBILITY_VERSION, compatibilityVersion);
     }
 

--- a/modules/openapi-generator/src/main/resources/aspnetcore/3.0/Filters/BasePathFilter.mustache
+++ b/modules/openapi-generator/src/main/resources/aspnetcore/3.0/Filters/BasePathFilter.mustache
@@ -28,7 +28,7 @@ namespace {{packageName}}.Filters
         /// <summary>
         /// Apply the filter
         /// </summary>
-        /// <param name="swaggerDoc">SwaggerDocument</param>
+        /// <param name="swaggerDoc">OpenApiDocument</param>
         /// <param name="context">FilterContext</param>
         public void Apply(OpenApiDocument swaggerDoc, DocumentFilterContext context)
         {

--- a/modules/openapi-generator/src/main/resources/aspnetcore/3.0/Startup.mustache
+++ b/modules/openapi-generator/src/main/resources/aspnetcore/3.0/Startup.mustache
@@ -31,7 +31,7 @@ namespace {{packageName}}
         /// <summary>
         /// Constructor
         /// </summary>
-        /// <param name="env"></param>
+        /// <param name="configuration"></param>
         public Startup(IConfiguration configuration)
         {
             Configuration = configuration;
@@ -102,7 +102,6 @@ namespace {{packageName}}
                         Version = "{{#version}}{{{version}}}{{/version}}{{^version}}v1{{/version}}",
                     });
                     c.CustomSchemaIds(type => type.FriendlyId(true));
-                    c.DescribeAllEnumsAsStrings();
                     c.IncludeXmlComments($"{AppContext.BaseDirectory}{Path.DirectorySeparatorChar}{Assembly.GetEntryAssembly().GetName().Name}.xml");
                     {{#basePathWithoutHost}}
                     // Sets the basePath property in the Swagger document generated

--- a/samples/server/petstore/aspnetcore-3.0/src/Org.OpenAPITools/Filters/BasePathFilter.cs
+++ b/samples/server/petstore/aspnetcore-3.0/src/Org.OpenAPITools/Filters/BasePathFilter.cs
@@ -28,7 +28,7 @@ namespace Org.OpenAPITools.Filters
         /// <summary>
         /// Apply the filter
         /// </summary>
-        /// <param name="swaggerDoc">SwaggerDocument</param>
+        /// <param name="swaggerDoc">OpenApiDocument</param>
         /// <param name="context">FilterContext</param>
         public void Apply(OpenApiDocument swaggerDoc, DocumentFilterContext context)
         {

--- a/samples/server/petstore/aspnetcore-3.0/src/Org.OpenAPITools/Org.OpenAPITools.csproj
+++ b/samples/server/petstore/aspnetcore-3.0/src/Org.OpenAPITools/Org.OpenAPITools.csproj
@@ -7,7 +7,7 @@
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <AssemblyName>Org.OpenAPITools</AssemblyName>
     <PackageId>Org.OpenAPITools</PackageId>
-    <UserSecretsId>610f1c80-586d-488e-ae5d-e10fedfa8e85</UserSecretsId>
+    <UserSecretsId>5437bedb-0880-4b79-b60e-a06e28fd9ff2</UserSecretsId>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <DockerfileContext>..\..</DockerfileContext>
   </PropertyGroup>

--- a/samples/server/petstore/aspnetcore-3.0/src/Org.OpenAPITools/Startup.cs
+++ b/samples/server/petstore/aspnetcore-3.0/src/Org.OpenAPITools/Startup.cs
@@ -34,7 +34,7 @@ namespace Org.OpenAPITools
         /// <summary>
         /// Constructor
         /// </summary>
-        /// <param name="env"></param>
+        /// <param name="configuration"></param>
         public Startup(IConfiguration configuration)
         {
             Configuration = configuration;
@@ -96,7 +96,6 @@ namespace Org.OpenAPITools
                         Version = "1.0.0",
                     });
                     c.CustomSchemaIds(type => type.FriendlyId(true));
-                    c.DescribeAllEnumsAsStrings();
                     c.IncludeXmlComments($"{AppContext.BaseDirectory}{Path.DirectorySeparatorChar}{Assembly.GetEntryAssembly().GetName().Name}.xml");
                     // Sets the basePath property in the Swagger document generated
                     c.DocumentFilter<BasePathFilter>("/v2");

--- a/samples/server/petstore/aspnetcore-3.1/src/Org.OpenAPITools/Filters/BasePathFilter.cs
+++ b/samples/server/petstore/aspnetcore-3.1/src/Org.OpenAPITools/Filters/BasePathFilter.cs
@@ -28,7 +28,7 @@ namespace Org.OpenAPITools.Filters
         /// <summary>
         /// Apply the filter
         /// </summary>
-        /// <param name="swaggerDoc">SwaggerDocument</param>
+        /// <param name="swaggerDoc">OpenApiDocument</param>
         /// <param name="context">FilterContext</param>
         public void Apply(OpenApiDocument swaggerDoc, DocumentFilterContext context)
         {

--- a/samples/server/petstore/aspnetcore-3.1/src/Org.OpenAPITools/Org.OpenAPITools.csproj
+++ b/samples/server/petstore/aspnetcore-3.1/src/Org.OpenAPITools/Org.OpenAPITools.csproj
@@ -7,7 +7,7 @@
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <AssemblyName>Org.OpenAPITools</AssemblyName>
     <PackageId>Org.OpenAPITools</PackageId>
-    <UserSecretsId>5e9a7265-7338-4119-b897-49feb129a70a</UserSecretsId>
+    <UserSecretsId>341adb46-9edd-4976-b953-4419c5134443</UserSecretsId>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <DockerfileContext>..\..</DockerfileContext>
   </PropertyGroup>

--- a/samples/server/petstore/aspnetcore-3.1/src/Org.OpenAPITools/Startup.cs
+++ b/samples/server/petstore/aspnetcore-3.1/src/Org.OpenAPITools/Startup.cs
@@ -34,7 +34,7 @@ namespace Org.OpenAPITools
         /// <summary>
         /// Constructor
         /// </summary>
-        /// <param name="env"></param>
+        /// <param name="configuration"></param>
         public Startup(IConfiguration configuration)
         {
             Configuration = configuration;
@@ -96,7 +96,6 @@ namespace Org.OpenAPITools
                         Version = "1.0.0",
                     });
                     c.CustomSchemaIds(type => type.FriendlyId(true));
-                    c.DescribeAllEnumsAsStrings();
                     c.IncludeXmlComments($"{AppContext.BaseDirectory}{Path.DirectorySeparatorChar}{Assembly.GetEntryAssembly().GetName().Name}.xml");
                     // Sets the basePath property in the Swagger document generated
                     c.DocumentFilter<BasePathFilter>("/v2");


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

Fixes #6466

Fix Issue
Template Directory for .NET 3.1/3.0 is not updated and therefore wrong mustache files were used.
Removed obseleted call from Swashbuckle

@mandrean @jimschubert @frankyjuang @shibayan @wing328 

<!-- Please check the completed items below -->
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [X] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/config/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [X] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
