### PR TITLE
[Objective-C] Fix thread-safety in template

### DIFF
--- a/modules/openapi-generator/src/main/resources/objc/Object-body.mustache
+++ b/modules/openapi-generator/src/main/resources/objc/Object-body.mustache
@@ -8,13 +8,15 @@
  */
 - (instancetype)initWithDictionary:(NSDictionary *)dict error:(NSError **)err {
     static NSMutableSet *classNames;
+    static NSObject *lock;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
         classNames = [NSMutableSet new];
+        lock = [NSObject new];
     });
     
     BOOL initSync;
-    @synchronized([self class])
+    @synchronized(lock)
     {
         NSString *className = NSStringFromClass([self class]);
         initSync = ![classNames containsObject:className];

--- a/samples/client/petstore/objc/core-data/SwaggerClient/Core/SWGObject.m
+++ b/samples/client/petstore/objc/core-data/SwaggerClient/Core/SWGObject.m
@@ -8,13 +8,15 @@
  */
 - (instancetype)initWithDictionary:(NSDictionary *)dict error:(NSError **)err {
     static NSMutableSet *classNames;
+    static NSObject *lock;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
         classNames = [NSMutableSet new];
+        lock = [NSObject new];
     });
     
     BOOL initSync;
-    @synchronized([self class])
+    @synchronized(lock)
     {
         NSString *className = NSStringFromClass([self class]);
         initSync = ![classNames containsObject:className];

--- a/samples/client/petstore/objc/default/SwaggerClient/Core/SWGObject.m
+++ b/samples/client/petstore/objc/default/SwaggerClient/Core/SWGObject.m
@@ -8,13 +8,15 @@
  */
 - (instancetype)initWithDictionary:(NSDictionary *)dict error:(NSError **)err {
     static NSMutableSet *classNames;
+    static NSObject *lock;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
         classNames = [NSMutableSet new];
+        lock = [NSObject new];
     });
     
     BOOL initSync;
-    @synchronized([self class])
+    @synchronized(lock)
     {
         NSString *className = NSStringFromClass([self class]);
         initSync = ![classNames containsObject:className];


### PR DESCRIPTION
- A static set needs a static lock or we get multiple locks if the class is inherited
- If this fix is not included and SWGObject is accessed from a second thread then we get EXC_BAD_ACCESS error (crash)

Example crash: 
```
Crashed: asyncRealm
0  libobjc.A.dylib                0x180f82088 objc_msgSend + 8
1  CoreFoundation                 0x1811e400c -[__NSSetM containsObject:] + 180
2  MyApp                          0x10094fc28 -[SWGObject initWithDictionary:error:] + 20 (SWGObject.m:20)
3  MyApp                          0x100e019e4 -[JSONModel __importDictionary:withKeyMapper:validation:error:] + 4310850020
4  MyApp                          0x100e00a28 -[JSONModel initWithDictionary:error:] + 4310845992
5  MyApp                          0x10094fcac -[SWGObject initWithDictionary:error:] + 29 (SWGObject.m:29)
6  MyApp                          0x100e019e4 -[JSONModel __importDictionary:withKeyMapper:validation:error:] + 4310850020
7  MyApp                          0x100e00a28 -[JSONModel initWithDictionary:error:] + 4310845992
8  MyApp                          0x10094fcac -[SWGObject initWithDictionary:error:] + 29 (SWGObject.m:29)
9  MyApp                          0x100e00700 -[JSONModel initWithData:error:] + 4310845184
10 MyApp                          0x100e0088c -[JSONModel initWithString:usingEncoding:error:] + 4310845580
11 MyApp                          0x100e007c4 -[JSONModel initWithString:error:] + 4310845380
12 MyApp                          0x100aa3138 specialized static PostPersistence.deleteOldPosts(realm:) + 4307317048 (PostPersistence.swift:4307317048)
13 MyApp                          0x100aa2238 closure #1 in static PostPersistence.persistPostsAsync(_:) + 23 (PostPersistence.swift:23)
14 MyApp                          0x1009e9840 thunk for @escaping @callee_guaranteed () -> () + 4306556992 (<compiler-generated>:4306556992)
15 libdispatch.dylib              0x180f2a610 _dispatch_call_block_and_release + 24
16 libdispatch.dylib              0x180f2b184 _dispatch_client_callout + 16
17 libdispatch.dylib              0x180f08710 _dispatch_lane_serial_drain$VARIANT$armv81 + 564
18 libdispatch.dylib              0x180f09128 _dispatch_lane_invoke$VARIANT$armv81 + 400
19 libdispatch.dylib              0x180f1243c _dispatch_workloop_worker_thread + 576
20 libsystem_pthread.dylib        0x180f7af88 _pthread_wqthread + 276
21 libsystem_pthread.dylib        0x180f7dad4 start_wqthread + 8
```

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/config/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [ ] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
