### PR TITLE
[Python] enum serialization

### DIFF
--- a/modules/openapi-generator/src/main/resources/python/python-experimental/model_utils.mustache
+++ b/modules/openapi-generator/src/main/resources/python/python-experimental/model_utils.mustache
@@ -951,7 +951,7 @@ def is_type_nullable(input_type):
     if issubclass(input_type, OpenApiModel) and input_type._nullable:
         return True
     if issubclass(input_type, ModelComposed):
-        # If oneOf/anyOf, check if the 'null' type is one of the allowed types.          
+        # If oneOf/anyOf, check if the 'null' type is one of the allowed types.
         for t in input_type._composed_schemas.get('oneOf', ()):
             if is_type_nullable(t): return True
         for t in input_type._composed_schemas.get('anyOf', ()):
@@ -975,7 +975,7 @@ def is_valid_type(input_class_simple, valid_classes):
             input_class_simple is none_type):
         for valid_class in valid_classes:
             if input_class_simple is none_type and is_type_nullable(valid_class):
-                # Schema is oneOf/anyOf and the 'null' type is one of the allowed types.            
+                # Schema is oneOf/anyOf and the 'null' type is one of the allowed types.
                 return True
             if not (issubclass(valid_class, OpenApiModel) and valid_class.discriminator):
                 continue
@@ -1138,6 +1138,8 @@ def model_to_dict(model_instance, serialize=True):
                     if hasattr(item[1], '_data_store') else item,
                     value.items()
                 ))
+            elif isinstance(value, ModelSimple):
+                result[attr] = value.value
             elif hasattr(value, '_data_store'):
                 result[attr] = model_to_dict(value, serialize=serialize)
             else:

--- a/samples/client/petstore/python-experimental/petstore_api/model_utils.py
+++ b/samples/client/petstore/python-experimental/petstore_api/model_utils.py
@@ -1218,7 +1218,7 @@ def is_type_nullable(input_type):
     if issubclass(input_type, OpenApiModel) and input_type._nullable:
         return True
     if issubclass(input_type, ModelComposed):
-        # If oneOf/anyOf, check if the 'null' type is one of the allowed types.          
+        # If oneOf/anyOf, check if the 'null' type is one of the allowed types.
         for t in input_type._composed_schemas.get('oneOf', ()):
             if is_type_nullable(t): return True
         for t in input_type._composed_schemas.get('anyOf', ()):
@@ -1242,7 +1242,7 @@ def is_valid_type(input_class_simple, valid_classes):
             input_class_simple is none_type):
         for valid_class in valid_classes:
             if input_class_simple is none_type and is_type_nullable(valid_class):
-                # Schema is oneOf/anyOf and the 'null' type is one of the allowed types.            
+                # Schema is oneOf/anyOf and the 'null' type is one of the allowed types.
                 return True
             if not (issubclass(valid_class, OpenApiModel) and valid_class.discriminator):
                 continue
@@ -1405,6 +1405,8 @@ def model_to_dict(model_instance, serialize=True):
                     if hasattr(item[1], '_data_store') else item,
                     value.items()
                 ))
+            elif isinstance(value, ModelSimple):
+                result[attr] = value.value
             elif hasattr(value, '_data_store'):
                 result[attr] = model_to_dict(value, serialize=serialize)
             else:

--- a/samples/client/petstore/python-experimental/tests/test_serialization.py
+++ b/samples/client/petstore/python-experimental/tests/test_serialization.py
@@ -1,0 +1,81 @@
+# coding: utf-8
+
+# flake8: noqa
+
+"""
+Run the tests.
+$ pip install nose (optional)
+$ cd OpenAPIPetstore-python
+$ nosetests -v
+"""
+from collections import namedtuple
+import json
+import os
+import time
+import unittest
+import datetime
+
+import six
+
+import petstore_api
+
+from petstore_api.exceptions import (
+    ApiTypeError,
+    ApiKeyError,
+    ApiValueError,
+)
+from petstore_api.model import (
+    enum_test,
+    pet,
+    animal,
+    dog,
+    parent_pet,
+    child_lizard,
+    category,
+    outer_enum,
+    outer_number,
+    string_boolean_map,
+)
+from petstore_api.model_utils import (
+    file_type,
+    int,
+    model_to_dict,
+    str,
+)
+
+from petstore_api.rest import RESTResponse
+
+MockResponse = namedtuple('MockResponse', 'data')
+
+class SerializationTests(unittest.TestCase):
+
+    def setUp(self):
+        self.api_client = petstore_api.ApiClient()
+        self.serialize = self.api_client.sanitize_for_serialization
+
+    def test_enum_test(self):
+        """ serialize dict(str, Enum_Test) """
+        value = (
+            outer_enum.OuterEnum.allowed_values[('value',)]["PLACED"])
+        outer_enum_val = outer_enum.OuterEnum(value)
+
+        source = enum_test.EnumTest(
+            enum_string="UPPER",
+            enum_string_required="lower",
+            enum_integer=1,
+            enum_number=1.1,
+            outer_enum=outer_enum_val
+        )
+
+        result = {
+            'enum_test': {
+                "enum_string": "UPPER",
+                "enum_string_required": "lower",
+                "enum_integer": 1,
+                "enum_number": 1.1,
+                "outerEnum": "placed"
+            }
+        }
+        serialized = self.serialize({"enum_test": source})
+
+        self.assertEqual(result, serialized)

--- a/samples/openapi3/client/extensions/x-auth-id-alias/python-experimental/x_auth_id_alias/model_utils.py
+++ b/samples/openapi3/client/extensions/x-auth-id-alias/python-experimental/x_auth_id_alias/model_utils.py
@@ -1218,7 +1218,7 @@ def is_type_nullable(input_type):
     if issubclass(input_type, OpenApiModel) and input_type._nullable:
         return True
     if issubclass(input_type, ModelComposed):
-        # If oneOf/anyOf, check if the 'null' type is one of the allowed types.          
+        # If oneOf/anyOf, check if the 'null' type is one of the allowed types.
         for t in input_type._composed_schemas.get('oneOf', ()):
             if is_type_nullable(t): return True
         for t in input_type._composed_schemas.get('anyOf', ()):
@@ -1242,7 +1242,7 @@ def is_valid_type(input_class_simple, valid_classes):
             input_class_simple is none_type):
         for valid_class in valid_classes:
             if input_class_simple is none_type and is_type_nullable(valid_class):
-                # Schema is oneOf/anyOf and the 'null' type is one of the allowed types.            
+                # Schema is oneOf/anyOf and the 'null' type is one of the allowed types.
                 return True
             if not (issubclass(valid_class, OpenApiModel) and valid_class.discriminator):
                 continue
@@ -1405,6 +1405,8 @@ def model_to_dict(model_instance, serialize=True):
                     if hasattr(item[1], '_data_store') else item,
                     value.items()
                 ))
+            elif isinstance(value, ModelSimple):
+                result[attr] = value.value
             elif hasattr(value, '_data_store'):
                 result[attr] = model_to_dict(value, serialize=serialize)
             else:

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/model_utils.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/model_utils.py
@@ -1218,7 +1218,7 @@ def is_type_nullable(input_type):
     if issubclass(input_type, OpenApiModel) and input_type._nullable:
         return True
     if issubclass(input_type, ModelComposed):
-        # If oneOf/anyOf, check if the 'null' type is one of the allowed types.          
+        # If oneOf/anyOf, check if the 'null' type is one of the allowed types.
         for t in input_type._composed_schemas.get('oneOf', ()):
             if is_type_nullable(t): return True
         for t in input_type._composed_schemas.get('anyOf', ()):
@@ -1242,7 +1242,7 @@ def is_valid_type(input_class_simple, valid_classes):
             input_class_simple is none_type):
         for valid_class in valid_classes:
             if input_class_simple is none_type and is_type_nullable(valid_class):
-                # Schema is oneOf/anyOf and the 'null' type is one of the allowed types.            
+                # Schema is oneOf/anyOf and the 'null' type is one of the allowed types.
                 return True
             if not (issubclass(valid_class, OpenApiModel) and valid_class.discriminator):
                 continue
@@ -1405,6 +1405,8 @@ def model_to_dict(model_instance, serialize=True):
                     if hasattr(item[1], '_data_store') else item,
                     value.items()
                 ))
+            elif isinstance(value, ModelSimple):
+                result[attr] = value.value
             elif hasattr(value, '_data_store'):
                 result[attr] = model_to_dict(value, serialize=serialize)
             else:


### PR DESCRIPTION
Serialization for nested enums is adding extra `value` key.

`{"foo": EnumValue("bar")}` is serialized as `{"foo": {"value": "bar"}}` instead of `{"foo": "bar"}`.

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/config/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.


---
@taxpon (2017/07) @frol (2017/07) @mbohlool (2017/07) @cbornet (2017/09) @kenjones-cisco (2017/11) @tomplus (2018/10) @Jyhess (2019/01) @arun-nalla (2019/11) @spacether (2019/11)