### PR TITLE
[PHP] Better handling of invalid data (array)

### DIFF
--- a/modules/openapi-generator/src/main/resources/php/ObjectSerializer.mustache
+++ b/modules/openapi-generator/src/main/resources/php/ObjectSerializer.mustache
@@ -252,6 +252,11 @@ class ObjectSerializer
             return null;
         } elseif (strcasecmp(substr($class, -2), '[]') === 0) {
             $data = is_string($data) ? json_decode($data) : $data;
+            
+            if (!is_array($data)) {
+                throw new \InvalidArgumentException("Invalid array '$class'");
+            }
+            
             $subClass = substr($class, 0, -2);
             $values = [];
             foreach ($data as $key => $value) {

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/ObjectSerializer.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/ObjectSerializer.php
@@ -262,6 +262,11 @@ class ObjectSerializer
             return null;
         } elseif (strcasecmp(substr($class, -2), '[]') === 0) {
             $data = is_string($data) ? json_decode($data) : $data;
+            
+            if (!is_array($data)) {
+                throw new \InvalidArgumentException("Invalid array '$class'");
+            }
+            
             $subClass = substr($class, 0, -2);
             $values = [];
             foreach ($data as $key => $value) {


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

If the $data is an invalid Json (for example, add an extra comma after the last property) or if data is not an array, php gives error:

Invalid argument supplied for foreach() at line 257 (Now line is 262)

This is my fist git pull request so please pardon me if I did something wrong.

Best Regards