### PR TITLE
Update ObjectSerializer.mustache

### DIFF
--- a/modules/openapi-generator/src/main/resources/php/ObjectSerializer.mustache
+++ b/modules/openapi-generator/src/main/resources/php/ObjectSerializer.mustache
@@ -255,7 +255,18 @@ class ObjectSerializer
             $subClass = substr($class, 0, -2);
             $values = [];
             foreach ($data as $key => $value) {
-                $values[] = self::deserialize($value, $subClass, null);
+                //$values[] = self::deserialize($value, $subClass, null);
+                
+                $mTemp = self::deserialize($value, $subClass, null);
+
+				if (is_object($mTemp) && $mTemp instanceof {{invokerPackage}}\Model\ModelInterface) {
+					$a_invalidProperties = $mTemp->listInvalidProperties();
+
+					if (count($a_invalidProperties) != 0) {
+						throw new \InvalidArgumentException(implode (' ', $a_invalidProperties));
+					}
+				}
+				$values[] = $mTemp;
             }
             return $values;
         } elseif (substr($class, 0, 4) === 'map[') { // for associative array e.g. map[string,int]


### PR DESCRIPTION
When we deserialize a json structure, only the first level of validation is done and accessible with "listInvalidProperties"

To validate all sub objects, everyone would need to loop again on the objects and follow all properties, check if they are objects and call listInvalidProperties on each of them.

A better approach would be to have the "listInvalidProperties" shared between parent and childs, but this would be a major structural change so this easy fix seems like a nice compromise.

