### PR TITLE
Response was unable to process nested json object more than 2 level 

### DIFF
--- a/modules/openapi-generator/src/main/resources/powershell/api.mustache
+++ b/modules/openapi-generator/src/main/resources/powershell/api.mustache
@@ -172,7 +172,7 @@ function {{{vendorExtensions.x-powershell-method-name}}} {
 
         {{/isNullable}}
         {{/required}}
-        $LocalVarBodyParameter = ${{{paramName}}} | ConvertTo-Json
+        $LocalVarBodyParameter = ${{{paramName}}} | ConvertTo-Json -Depth 100
 
         {{/bodyParam}}
         {{#authMethods}}
@@ -225,12 +225,12 @@ function {{{vendorExtensions.x-powershell-method-name}}} {
 
         {{#vendorExtensions.x-ps-return-type-one-of}}
         # process oneOf response
-        $LocalVarResult["Response"] = ConvertFrom-{{apiNamePrefix}}JsonTo{{returnType}} (ConvertTo-Json $LocalVarResult["Response"])
+        $LocalVarResult["Response"] = ConvertFrom-{{apiNamePrefix}}JsonTo{{returnType}} (ConvertTo-Json $LocalVarResult["Response"] -Depth 100)
 
         {{/vendorExtensions.x-ps-return-type-one-of}}
         {{#vendorExtensions.x-ps-return-type-any-of}}
         # process anyOf response
-        $LocalVarResult["Response"] = ConvertFrom-{{apiNamePrefix}}JsonTo{{returnType}} (ConvertTo-Json $LocalVarResult["Response"])
+        $LocalVarResult["Response"] = ConvertFrom-{{apiNamePrefix}}JsonTo{{returnType}} (ConvertTo-Json $LocalVarResult["Response"] -Depth 100)
 
         {{/vendorExtensions.x-ps-return-type-any-of}}
         if ($WithHttpInfo.IsPresent) {

--- a/samples/client/petstore/powershell/src/PSPetstore/Api/PSPetApi.ps1
+++ b/samples/client/petstore/powershell/src/PSPetstore/Api/PSPetApi.ps1
@@ -73,7 +73,7 @@ function Add-PSPet {
             throw "Error! The required parameter `Pet` missing when calling addPet."
         }
 
-        $LocalVarBodyParameter = $Pet | ConvertTo-Json
+        $LocalVarBodyParameter = $Pet | ConvertTo-Json -Depth 100
 
 
         $LocalVarResult = Invoke-PSApiClient -Method 'POST' `
@@ -505,7 +505,7 @@ function Update-PSPet {
             throw "Error! The required parameter `Pet` missing when calling updatePet."
         }
 
-        $LocalVarBodyParameter = $Pet | ConvertTo-Json
+        $LocalVarBodyParameter = $Pet | ConvertTo-Json -Depth 100
 
 
         $LocalVarResult = Invoke-PSApiClient -Method 'PUT' `

--- a/samples/client/petstore/powershell/src/PSPetstore/Api/PSStoreApi.ps1
+++ b/samples/client/petstore/powershell/src/PSPetstore/Api/PSStoreApi.ps1
@@ -293,7 +293,7 @@ function Invoke-PSPlaceOrder {
             throw "Error! The required parameter `Order` missing when calling placeOrder."
         }
 
-        $LocalVarBodyParameter = $Order | ConvertTo-Json
+        $LocalVarBodyParameter = $Order | ConvertTo-Json -Depth 100
 
         $LocalVarResult = Invoke-PSApiClient -Method 'POST' `
                                 -Uri $LocalVarUri `

--- a/samples/client/petstore/powershell/src/PSPetstore/Api/PSUserApi.ps1
+++ b/samples/client/petstore/powershell/src/PSPetstore/Api/PSUserApi.ps1
@@ -58,7 +58,7 @@ function New-PSUser {
             throw "Error! The required parameter `User` missing when calling createUser."
         }
 
-        $LocalVarBodyParameter = $User | ConvertTo-Json
+        $LocalVarBodyParameter = $User | ConvertTo-Json -Depth 100
 
         if ($Configuration["Cookie"]) {
             $LocalVarCookieParameters['auth_cookie'] = $Configuration["Cookie"]
@@ -137,7 +137,7 @@ function New-PSUsersWithArrayInput {
             throw "Error! The required parameter `User` missing when calling createUsersWithArrayInput."
         }
 
-        $LocalVarBodyParameter = $User | ConvertTo-Json
+        $LocalVarBodyParameter = $User | ConvertTo-Json -Depth 100
 
         if ($Configuration["Cookie"]) {
             $LocalVarCookieParameters['auth_cookie'] = $Configuration["Cookie"]
@@ -216,7 +216,7 @@ function New-PSUsersWithListInput {
             throw "Error! The required parameter `User` missing when calling createUsersWithListInput."
         }
 
-        $LocalVarBodyParameter = $User | ConvertTo-Json
+        $LocalVarBodyParameter = $User | ConvertTo-Json -Depth 100
 
         if ($Configuration["Cookie"]) {
             $LocalVarCookieParameters['auth_cookie'] = $Configuration["Cookie"]
@@ -623,7 +623,7 @@ function Update-PSUser {
             throw "Error! The required parameter `User` missing when calling updateUser."
         }
 
-        $LocalVarBodyParameter = $User | ConvertTo-Json
+        $LocalVarBodyParameter = $User | ConvertTo-Json -Depth 100
 
         if ($Configuration["Cookie"]) {
             $LocalVarCookieParameters['auth_cookie'] = $Configuration["Cookie"]


### PR DESCRIPTION
ConvertTo-Josn unable to process the nested objects which are more than two level inside, it treats the whole object as string. Parameter Depth is used to control the nested element processing.

Problem :-
```
PS C:> $response.ActualInstance.Results[0].Organization.GetType().Name
String
```
Correct One:
```
PS C:> $response.ActualInstance.Results[0].Organization.GetType()
PSCustomObject
```


<!-- Please check the completed items below -->
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [ ] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/config/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [X] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
@wing328 