### PR TITLE
[kotlin][client] fix retrofit dependencies

### DIFF
--- a/modules/openapi-generator/src/main/resources/kotlin-client/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/build.gradle.mustache
@@ -41,9 +41,6 @@ test {
 
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
-    {{#hasOAuthMethods}}
-    compile "org.apache.oltu.oauth2:org.apache.oltu.oauth2.client:1.0.0"
-    {{/hasOAuthMethods}}
     {{#moshi}}
     {{^moshiCodeGen}}
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
@@ -84,12 +81,15 @@ dependencies {
     {{/modeCodeGen}}
     {{/moshi}}
     compile "com.squareup.okhttp3:okhttp:4.2.2"
-    compile "com.squareup.okhttp3:logging-interceptor:4.4.0"
     {{/jvm-okhttp4}}
     {{#threetenbp}}
     compile "org.threeten:threetenbp:1.4.0"
     {{/threetenbp}}
     {{#jvm-retrofit2}}
+    {{#hasOAuthMethods}}
+    compile "org.apache.oltu.oauth2:org.apache.oltu.oauth2.client:1.0.0"
+    {{/hasOAuthMethods}}
+    compile "com.squareup.okhttp3:logging-interceptor:4.4.0"
     {{#useRxJava}}
     compile "io.reactivex:rxjava:$rxJavaVersion"
     compile "com.squareup.retrofit2:adapter-rxjava:$retrofitVersion"

--- a/samples/client/petstore/kotlin-gson/build.gradle
+++ b/samples/client/petstore/kotlin-gson/build.gradle
@@ -29,10 +29,8 @@ test {
 
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
-    compile "org.apache.oltu.oauth2:org.apache.oltu.oauth2.client:1.0.0"
     compile "com.google.code.gson:gson:2.8.6"
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
     compile "com.squareup.okhttp3:okhttp:4.2.2"
-    compile "com.squareup.okhttp3:logging-interceptor:4.4.0"
     testCompile "io.kotlintest:kotlintest-runner-junit5:3.1.0"
 }

--- a/samples/client/petstore/kotlin-jackson/build.gradle
+++ b/samples/client/petstore/kotlin-jackson/build.gradle
@@ -29,12 +29,10 @@ test {
 
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
-    compile "org.apache.oltu.oauth2:org.apache.oltu.oauth2.client:1.0.0"
     compile "com.fasterxml.jackson.module:jackson-module-kotlin:2.10.2"
     compile "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.10.2"
     compile "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.10.2"
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
     compile "com.squareup.okhttp3:okhttp:4.2.2"
-    compile "com.squareup.okhttp3:logging-interceptor:4.4.0"
     testCompile "io.kotlintest:kotlintest-runner-junit5:3.1.0"
 }

--- a/samples/client/petstore/kotlin-json-request-string/build.gradle
+++ b/samples/client/petstore/kotlin-json-request-string/build.gradle
@@ -29,11 +29,9 @@ test {
 
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
-    compile "org.apache.oltu.oauth2:org.apache.oltu.oauth2.client:1.0.0"
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
     compile "com.squareup.moshi:moshi-kotlin:1.9.2"
     compile "com.squareup.moshi:moshi-adapters:1.9.2"
     compile "com.squareup.okhttp3:okhttp:4.2.2"
-    compile "com.squareup.okhttp3:logging-interceptor:4.4.0"
     testCompile "io.kotlintest:kotlintest-runner-junit5:3.1.0"
 }

--- a/samples/client/petstore/kotlin-jvm-okhttp4-coroutines/build.gradle
+++ b/samples/client/petstore/kotlin-jvm-okhttp4-coroutines/build.gradle
@@ -29,10 +29,8 @@ test {
 
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
-    compile "org.apache.oltu.oauth2:org.apache.oltu.oauth2.client:1.0.0"
     compile "com.google.code.gson:gson:2.8.6"
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
     compile "com.squareup.okhttp3:okhttp:4.2.2"
-    compile "com.squareup.okhttp3:logging-interceptor:4.4.0"
     testCompile "io.kotlintest:kotlintest-runner-junit5:3.1.0"
 }

--- a/samples/client/petstore/kotlin-moshi-codegen/build.gradle
+++ b/samples/client/petstore/kotlin-moshi-codegen/build.gradle
@@ -30,11 +30,9 @@ test {
 
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
-    compile "org.apache.oltu.oauth2:org.apache.oltu.oauth2.client:1.0.0"
     compile "com.squareup.moshi:moshi-adapters:1.9.2"
     compile "com.squareup.moshi:moshi:1.9.2"
     kapt "com.squareup.moshi:moshi-kotlin-codegen:1.9.2"
     compile "com.squareup.okhttp3:okhttp:4.2.2"
-    compile "com.squareup.okhttp3:logging-interceptor:4.4.0"
     testCompile "io.kotlintest:kotlintest-runner-junit5:3.1.0"
 }

--- a/samples/client/petstore/kotlin-nonpublic/build.gradle
+++ b/samples/client/petstore/kotlin-nonpublic/build.gradle
@@ -29,11 +29,9 @@ test {
 
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
-    compile "org.apache.oltu.oauth2:org.apache.oltu.oauth2.client:1.0.0"
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
     compile "com.squareup.moshi:moshi-kotlin:1.9.2"
     compile "com.squareup.moshi:moshi-adapters:1.9.2"
     compile "com.squareup.okhttp3:okhttp:4.2.2"
-    compile "com.squareup.okhttp3:logging-interceptor:4.4.0"
     testCompile "io.kotlintest:kotlintest-runner-junit5:3.1.0"
 }

--- a/samples/client/petstore/kotlin-nullable/build.gradle
+++ b/samples/client/petstore/kotlin-nullable/build.gradle
@@ -29,11 +29,9 @@ test {
 
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
-    compile "org.apache.oltu.oauth2:org.apache.oltu.oauth2.client:1.0.0"
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
     compile "com.squareup.moshi:moshi-kotlin:1.9.2"
     compile "com.squareup.moshi:moshi-adapters:1.9.2"
     compile "com.squareup.okhttp3:okhttp:4.2.2"
-    compile "com.squareup.okhttp3:logging-interceptor:4.4.0"
     testCompile "io.kotlintest:kotlintest-runner-junit5:3.1.0"
 }

--- a/samples/client/petstore/kotlin-okhttp3/build.gradle
+++ b/samples/client/petstore/kotlin-okhttp3/build.gradle
@@ -29,7 +29,6 @@ test {
 
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
-    compile "org.apache.oltu.oauth2:org.apache.oltu.oauth2.client:1.0.0"
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
     compile "com.squareup.moshi:moshi-kotlin:1.9.2"
     compile "com.squareup.moshi:moshi-adapters:1.9.2"

--- a/samples/client/petstore/kotlin-retrofit2/build.gradle
+++ b/samples/client/petstore/kotlin-retrofit2/build.gradle
@@ -30,10 +30,11 @@ test {
 
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
-    compile "org.apache.oltu.oauth2:org.apache.oltu.oauth2.client:1.0.0"
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
     compile "com.squareup.moshi:moshi-kotlin:1.9.2"
     compile "com.squareup.moshi:moshi-adapters:1.9.2"
+    compile "org.apache.oltu.oauth2:org.apache.oltu.oauth2.client:1.0.0"
+    compile "com.squareup.okhttp3:logging-interceptor:4.4.0"
     compile "com.squareup.retrofit2:retrofit:$retrofitVersion"
     compile "com.squareup.retrofit2:converter-moshi:$retrofitVersion"
     compile "com.squareup.retrofit2:converter-scalars:$retrofitVersion"

--- a/samples/client/petstore/kotlin-string/build.gradle
+++ b/samples/client/petstore/kotlin-string/build.gradle
@@ -29,11 +29,9 @@ test {
 
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
-    compile "org.apache.oltu.oauth2:org.apache.oltu.oauth2.client:1.0.0"
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
     compile "com.squareup.moshi:moshi-kotlin:1.9.2"
     compile "com.squareup.moshi:moshi-adapters:1.9.2"
     compile "com.squareup.okhttp3:okhttp:4.2.2"
-    compile "com.squareup.okhttp3:logging-interceptor:4.4.0"
     testCompile "io.kotlintest:kotlintest-runner-junit5:3.1.0"
 }

--- a/samples/client/petstore/kotlin-threetenbp/build.gradle
+++ b/samples/client/petstore/kotlin-threetenbp/build.gradle
@@ -29,12 +29,10 @@ test {
 
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
-    compile "org.apache.oltu.oauth2:org.apache.oltu.oauth2.client:1.0.0"
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
     compile "com.squareup.moshi:moshi-kotlin:1.9.2"
     compile "com.squareup.moshi:moshi-adapters:1.9.2"
     compile "com.squareup.okhttp3:okhttp:4.2.2"
-    compile "com.squareup.okhttp3:logging-interceptor:4.4.0"
     compile "org.threeten:threetenbp:1.4.0"
     testCompile "io.kotlintest:kotlintest-runner-junit5:3.1.0"
 }

--- a/samples/client/petstore/kotlin/build.gradle
+++ b/samples/client/petstore/kotlin/build.gradle
@@ -29,11 +29,9 @@ test {
 
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
-    compile "org.apache.oltu.oauth2:org.apache.oltu.oauth2.client:1.0.0"
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
     compile "com.squareup.moshi:moshi-kotlin:1.9.2"
     compile "com.squareup.moshi:moshi-adapters:1.9.2"
     compile "com.squareup.okhttp3:okhttp:4.2.2"
-    compile "com.squareup.okhttp3:logging-interceptor:4.4.0"
     testCompile "io.kotlintest:kotlintest-runner-junit5:3.1.0"
 }


### PR DESCRIPTION
There were some dependencies introduced in https://github.com/OpenAPITools/openapi-generator/pull/6585 when using the retrofit library, that accidentally were added also when using the okhttp library.

This PR fixes that, by attributing the right dependencies to the right libraries.

### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [X] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/config/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [X] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@jimschubert (2017/09) ❤️, @dr4ke616 (2018/08) @karismann (2019/03) @Zomzog (2019/04) @andrewemery (2019/10) @4brunu (2019/11) @yutaka0m (2020/03)