### PR TITLE
avoid 'servers not defined in the spec' warn-spam on maven console (#6837)

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/URLPathUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/URLPathUtils.java
@@ -210,7 +210,7 @@ public class URLPathUtils {
                 once(LOGGER).warn("'scheme' not defined in the spec (2.0). Default to [http] for server URL [{}]", url);
             } else if (url.startsWith("/")) {
                 url = LOCAL_HOST + url;
-                once(LOGGER).warn("'host' (OAS 2.0) or 'servers' (OAS 3.0) not defined in the spec. Default to [{}] for server URL [{}]", LOCAL_HOST, url);
+                once(LOGGER).info("'host' (OAS 2.0) or 'servers' (OAS 3.0) not defined in the spec. Default to [{}] for server URL [{}]", LOCAL_HOST, url);
             } else if (!url.matches("[a-zA-Z][0-9a-zA-Z.+\\-]+://.+")) {
                 // Add http scheme for urls without a scheme.
                 // 2.0 spec is restricted to the following schemes: "http", "https", "ws", "wss"


### PR DESCRIPTION
fixes #6837 

avoid 'servers not defined in the spec' warn-spam on maven console

@bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04) @lwlee2608 (2019/10) @bkabrda (2020/01)
