### PR TITLE
[typescript-fetch]: Revert "[typescript-fetch] Support deepObject query params (#6075)"

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptFetchClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptFetchClientCodegen.java
@@ -247,21 +247,7 @@ public class TypeScriptFetchClientCodegen extends AbstractTypeScriptClientCodege
         this.addOperationObjectResponseInformation(operations);
         this.addOperationPrefixParameterInterfacesInformation(operations);
         this.escapeOperationIds(operations);
-        this.addDeepObjectVendorExtension(operations);
         return operations;
-    }
-
-    private void addDeepObjectVendorExtension(Map<String, Object> operations) {
-        Map<String, Object> _operations = (Map<String, Object>) operations.get("operations");
-        List<CodegenOperation> operationList = (List<CodegenOperation>) _operations.get("operation");
-
-        for (CodegenOperation op : operationList) {
-            for (CodegenParameter param : op.queryParams) {
-                if (param.style != null && param.style.equals("deepObject")) {
-                    param.vendorExtensions.put("x-codegen-isDeepObject", true);
-                }
-            }
-        }
     }
 
     private void escapeOperationIds(Map<String, Object> operations) {

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/apis.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/apis.mustache
@@ -122,12 +122,7 @@ export class {{classname}} extends runtime.BaseAPI {
             queryParameters['{{baseName}}'] = (requestParameters.{{paramName}} as any).toISOString().substr(0,10);
             {{/isDate}}
             {{^isDate}}
-            {{#vendorExtensions.x-codegen-isDeepObject}}
-            queryParameters['{{baseName}}'] = runtime.querystring(requestParameters.{{paramName}} as unknown as runtime.HTTPQuery, '{{baseName}}');
-            {{/vendorExtensions.x-codegen-isDeepObject}}
-            {{^vendorExtensions.x-codegen-isDeepObject}}
             queryParameters['{{baseName}}'] = requestParameters.{{paramName}};
-            {{/vendorExtensions.x-codegen-isDeepObject}}
             {{/isDate}}
             {{/isDateTime}}
         }


### PR DESCRIPTION
This reverts commit 354f195ec09293cfd731b72e67c3cc977b8c0894.

It became superfluous due to some other changes in runtime and changing
of the queryParameters in d9a6f4d

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/config/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
