### PR TITLE
[typescript] Add default values for typescript types

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractTypeScriptClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractTypeScriptClientCodegen.java
@@ -464,10 +464,19 @@ public abstract class AbstractTypeScriptClientCodegen extends DefaultCodegen imp
     @Override
     public String toDefaultValue(Schema p) {
         if (ModelUtils.isBooleanSchema(p)) {
+            if (p.getDefault() != null) {
+                return p.getDefault().toString();
+            }
             return UNDEFINED_VALUE;
         } else if (ModelUtils.isDateSchema(p)) {
+            if (p.getDefault() != null) {
+                return p.getDefault().toString();
+            }
             return UNDEFINED_VALUE;
         } else if (ModelUtils.isDateTimeSchema(p)) {
+            if (p.getDefault() != null) {
+                return p.getDefault().toString();
+            }
             return UNDEFINED_VALUE;
         } else if (ModelUtils.isNumberSchema(p) || ModelUtils.isIntegerSchema(p)) {
             if (p.getDefault() != null) {

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/fetch/TypeScriptFetchModelTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/fetch/TypeScriptFetchModelTest.java
@@ -29,11 +29,15 @@ import org.openapitools.codegen.languages.TypeScriptFetchClientCodegen;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import java.time.LocalDate;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
-import java.time.format.DateTimeFormatter;
+import java.time.ZoneOffset;
 import java.util.Arrays;
+import java.util.Date;
 import java.util.HashMap;
+import java.util.Locale;
 
 /*
 import static io.swagger.codegen.CodegenConstants.IS_ENUM_EXT_NAME;
@@ -118,18 +122,20 @@ public class TypeScriptFetchModelTest {
     }
 
     @Test(description = "convert and check default values for a simple TypeScript Angular model")
-    public void simpleModelDefaultValuesTest() {
+    public void simpleModelDefaultValuesTest() throws ParseException {
         IntegerSchema integerSchema = new IntegerSchema().format(SchemaTypeUtil.INTEGER64_FORMAT);
         integerSchema.setDefault(1234);
 
         StringSchema stringSchema = new StringSchema();
         stringSchema.setDefault("Jack");
 
+        OffsetDateTime testOffsetDateTime = OffsetDateTime.of(LocalDateTime.of(2020, 1, 1, 12, 0), ZoneOffset.UTC);
         DateTimeSchema dateTimeSchema = new DateTimeSchema();
-        dateTimeSchema.setDefault(OffsetDateTime.parse("2020-01-01T12:00:00+01:00", DateTimeFormatter.ISO_OFFSET_DATE_TIME));
+        dateTimeSchema.setDefault(testOffsetDateTime);
 
+        Date testDate = Date.from(testOffsetDateTime.toInstant());
         DateSchema dateSchema = new DateSchema();
-        dateSchema.setDefault("2020-01-01");
+        dateSchema.setDefault(testDate);
 
         BooleanSchema booleanSchema = new BooleanSchema();
         booleanSchema.setDefault(true);
@@ -164,11 +170,11 @@ public class TypeScriptFetchModelTest {
 
         final CodegenProperty property3 = cm.vars.get(2);
         Assert.assertEquals(property3.baseName, "createdAt");
-        Assert.assertEquals(property3.defaultValue, "2020-01-01T12:00+01:00");
+        Assert.assertEquals(OffsetDateTime.parse(property3.defaultValue), testOffsetDateTime);
 
         final CodegenProperty property4 = cm.vars.get(3);
         Assert.assertEquals(property4.baseName, "birthDate");
-        Assert.assertEquals(property4.defaultValue, "Wed Jan 01 01:00:00 CET 2020");
+        Assert.assertEquals(new SimpleDateFormat("EEE MMM dd HH:mm:ss z yyyy", Locale.ENGLISH).parse(property4.defaultValue), testDate);
 
         final CodegenProperty property5 = cm.vars.get(4);
         Assert.assertEquals(property5.baseName, "active");

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/fetch/TypeScriptFetchModelTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/fetch/TypeScriptFetchModelTest.java
@@ -29,6 +29,9 @@ import org.openapitools.codegen.languages.TypeScriptFetchClientCodegen;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.HashMap;
 
@@ -49,6 +52,7 @@ public class TypeScriptFetchModelTest {
                 .addProperties("name", new StringSchema())
                 .addProperties("createdAt", new DateTimeSchema())
                 .addProperties("birthDate", new DateSchema())
+                .addProperties("active", new BooleanSchema())
                 .addRequiredItem("id")
                 .addRequiredItem("name");
 
@@ -60,7 +64,7 @@ public class TypeScriptFetchModelTest {
         Assert.assertEquals(cm.name, "sample");
         Assert.assertEquals(cm.classname, "Sample");
         Assert.assertEquals(cm.description, "a sample model");
-        Assert.assertEquals(cm.vars.size(), 4);
+        Assert.assertEquals(cm.vars.size(), 5);
 
         final CodegenProperty property1 = cm.vars.get(0);
         Assert.assertEquals(property1.baseName, "id");
@@ -98,9 +102,77 @@ public class TypeScriptFetchModelTest {
         Assert.assertEquals(property4.dataType, "Date");
         Assert.assertEquals(property4.name, "birthDate");
         Assert.assertEquals(property4.defaultValue, "undefined");
-        Assert.assertFalse(property4.hasMore);
+        Assert.assertTrue(property4.hasMore);
         Assert.assertFalse(property4.required);
         Assert.assertFalse(property4.isContainer);
+
+        final CodegenProperty property5 = cm.vars.get(4);
+        Assert.assertEquals(property5.baseName, "active");
+        Assert.assertEquals(property5.complexType, null);
+        Assert.assertEquals(property5.dataType, "boolean");
+        Assert.assertEquals(property5.name, "active");
+        Assert.assertEquals(property5.defaultValue, "undefined");
+        Assert.assertFalse(property5.hasMore);
+        Assert.assertFalse(property5.required);
+        Assert.assertFalse(property5.isContainer);
+    }
+
+    @Test(description = "convert and check default values for a simple TypeScript Angular model")
+    public void simpleModelDefaultValuesTest() {
+        IntegerSchema integerSchema = new IntegerSchema().format(SchemaTypeUtil.INTEGER64_FORMAT);
+        integerSchema.setDefault(1234);
+
+        StringSchema stringSchema = new StringSchema();
+        stringSchema.setDefault("Jack");
+
+        DateTimeSchema dateTimeSchema = new DateTimeSchema();
+        dateTimeSchema.setDefault(OffsetDateTime.parse("2020-01-01T12:00:00+01:00", DateTimeFormatter.ISO_OFFSET_DATE_TIME));
+
+        DateSchema dateSchema = new DateSchema();
+        dateSchema.setDefault("2020-01-01");
+
+        BooleanSchema booleanSchema = new BooleanSchema();
+        booleanSchema.setDefault(true);
+
+        final Schema model = new Schema()
+                .description("a sample model")
+                .addProperties("id", integerSchema)
+                .addProperties("name", stringSchema)
+                .addProperties("createdAt", dateTimeSchema)
+                .addProperties("birthDate", dateSchema)
+                .addProperties("active", booleanSchema)
+                .addRequiredItem("id")
+                .addRequiredItem("name");
+
+        final DefaultCodegen codegen = new TypeScriptFetchClientCodegen();
+        OpenAPI openAPI = TestUtils.createOpenAPIWithOneSchema("sample", model);
+        codegen.setOpenAPI(openAPI);
+        final CodegenModel cm = codegen.fromModel("sample", model);
+
+        Assert.assertEquals(cm.name, "sample");
+        Assert.assertEquals(cm.classname, "Sample");
+        Assert.assertEquals(cm.description, "a sample model");
+        Assert.assertEquals(cm.vars.size(), 5);
+
+        final CodegenProperty property1 = cm.vars.get(0);
+        Assert.assertEquals(property1.baseName, "id");
+        Assert.assertEquals(property1.defaultValue, "1234");
+
+        final CodegenProperty property2 = cm.vars.get(1);
+        Assert.assertEquals(property2.baseName, "name");
+        Assert.assertEquals(property2.defaultValue, "'Jack'");
+
+        final CodegenProperty property3 = cm.vars.get(2);
+        Assert.assertEquals(property3.baseName, "createdAt");
+        Assert.assertEquals(property3.defaultValue, "2020-01-01T12:00+01:00");
+
+        final CodegenProperty property4 = cm.vars.get(3);
+        Assert.assertEquals(property4.baseName, "birthDate");
+        Assert.assertEquals(property4.defaultValue, "Wed Jan 01 01:00:00 CET 2020");
+
+        final CodegenProperty property5 = cm.vars.get(4);
+        Assert.assertEquals(property5.baseName, "active");
+        Assert.assertEquals(property5.defaultValue, "true");
     }
 
     @Test(description = "convert a model with list property")
@@ -223,7 +295,7 @@ public class TypeScriptFetchModelTest {
     }
 
     @Test(description = "test enum array model")
-    public void enumArrayMdoelTest() {
+    public void enumArrayModelTest() {
         // TODO: update yaml file.
         final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml");
         final DefaultCodegen codegen = new TypeScriptFetchClientCodegen();
@@ -262,7 +334,7 @@ public class TypeScriptFetchModelTest {
     }
 
     @Test(description = "test enum model for values (numeric, string, etc)")
-    public void enumMdoelValueTest() {
+    public void enumModelValueTest() {
         final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml");
         final DefaultCodegen codegen = new TypeScriptFetchClientCodegen();
         codegen.processOpts();
@@ -297,7 +369,7 @@ public class TypeScriptFetchModelTest {
     @Test(description = "Add null safe additional property indexer when enabled")
     public void testNullSafeAdditionalProps() {
         final Schema model = new Schema()
-            .additionalProperties(new StringSchema());
+                .additionalProperties(new StringSchema());
         final DefaultCodegen codegen = new TypeScriptFetchClientCodegen();
         codegen.additionalProperties().put("nullSafeAdditionalProps", true);
         codegen.processOpts();
@@ -308,7 +380,7 @@ public class TypeScriptFetchModelTest {
     @Test(description = "Don't add null safe additional property indexer by default")
     public void testWithoutNullSafeAdditionalProps() {
         final Schema model = new Schema()
-            .additionalProperties(new StringSchema());
+                .additionalProperties(new StringSchema());
         final DefaultCodegen codegen = new TypeScriptFetchClientCodegen();
         codegen.processOpts();
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/typescriptangular/TypeScriptAngularModelTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/typescriptangular/TypeScriptAngularModelTest.java
@@ -21,7 +21,6 @@ import com.google.common.collect.Sets;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.media.*;
 import io.swagger.v3.parser.util.SchemaTypeUtil;
-import org.openapitools.codegen.CodegenConstants;
 import org.openapitools.codegen.CodegenModel;
 import org.openapitools.codegen.CodegenProperty;
 import org.openapitools.codegen.DefaultCodegen;
@@ -31,8 +30,13 @@ import org.openapitools.codegen.languages.TypeScriptFetchClientCodegen;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
-import java.time.format.DateTimeFormatter;
+import java.time.ZoneOffset;
+import java.util.Date;
+import java.util.Locale;
 
 @SuppressWarnings("static-method")
 public class TypeScriptAngularModelTest {
@@ -112,18 +116,20 @@ public class TypeScriptAngularModelTest {
     }
 
     @Test(description = "convert and check default values for a simple TypeScript Angular model")
-    public void simpleModelDefaultValuesTest() {
+    public void simpleModelDefaultValuesTest() throws ParseException {
         IntegerSchema integerSchema = new IntegerSchema().format(SchemaTypeUtil.INTEGER64_FORMAT);
         integerSchema.setDefault(1234);
 
         StringSchema stringSchema = new StringSchema();
         stringSchema.setDefault("Jack");
 
+        OffsetDateTime testOffsetDateTime = OffsetDateTime.of(LocalDateTime.of(2020, 1, 1, 12, 0), ZoneOffset.UTC);
         DateTimeSchema dateTimeSchema = new DateTimeSchema();
-        dateTimeSchema.setDefault(OffsetDateTime.parse("2020-01-01T12:00:00+01:00", DateTimeFormatter.ISO_OFFSET_DATE_TIME));
+        dateTimeSchema.setDefault(testOffsetDateTime);
 
+        Date testDate = Date.from(testOffsetDateTime.toInstant());
         DateSchema dateSchema = new DateSchema();
-        dateSchema.setDefault("2020-01-01");
+        dateSchema.setDefault(testDate);
 
         BooleanSchema booleanSchema = new BooleanSchema();
         booleanSchema.setDefault(true);
@@ -158,11 +164,11 @@ public class TypeScriptAngularModelTest {
 
         final CodegenProperty property3 = cm.vars.get(2);
         Assert.assertEquals(property3.baseName, "createdAt");
-        Assert.assertEquals(property3.defaultValue, "2020-01-01T12:00+01:00");
+        Assert.assertEquals(OffsetDateTime.parse(property3.defaultValue), testOffsetDateTime);
 
         final CodegenProperty property4 = cm.vars.get(3);
         Assert.assertEquals(property4.baseName, "birthDate");
-        Assert.assertEquals(property4.defaultValue, "Wed Jan 01 01:00:00 CET 2020");
+        Assert.assertEquals(new SimpleDateFormat("EEE MMM dd HH:mm:ss z yyyy", Locale.ENGLISH).parse(property4.defaultValue), testDate);
 
         final CodegenProperty property5 = cm.vars.get(4);
         Assert.assertEquals(property5.baseName, "active");

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/typescriptangular/TypeScriptAngularModelTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/typescriptangular/TypeScriptAngularModelTest.java
@@ -27,8 +27,12 @@ import org.openapitools.codegen.CodegenProperty;
 import org.openapitools.codegen.DefaultCodegen;
 import org.openapitools.codegen.TestUtils;
 import org.openapitools.codegen.languages.TypeScriptAngularClientCodegen;
+import org.openapitools.codegen.languages.TypeScriptFetchClientCodegen;
 import org.testng.Assert;
 import org.testng.annotations.Test;
+
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
 
 @SuppressWarnings("static-method")
 public class TypeScriptAngularModelTest {
@@ -41,6 +45,7 @@ public class TypeScriptAngularModelTest {
                 .addProperties("name", new StringSchema())
                 .addProperties("createdAt", new DateTimeSchema())
                 .addProperties("birthDate", new DateSchema())
+                .addProperties("active", new BooleanSchema())
                 .addRequiredItem("id")
                 .addRequiredItem("name");
         final DefaultCodegen codegen = new TypeScriptAngularClientCodegen();
@@ -51,7 +56,7 @@ public class TypeScriptAngularModelTest {
         Assert.assertEquals(cm.name, "sample");
         Assert.assertEquals(cm.classname, "Sample");
         Assert.assertEquals(cm.description, "a sample model");
-        Assert.assertEquals(cm.vars.size(), 4);
+        Assert.assertEquals(cm.vars.size(), 5);
 
         final CodegenProperty property1 = cm.vars.get(0);
         Assert.assertEquals(property1.baseName, "id");
@@ -91,9 +96,77 @@ public class TypeScriptAngularModelTest {
         Assert.assertEquals(property4.name, "birthDate");
         Assert.assertEquals(property4.baseType, "string");
         Assert.assertEquals(property4.defaultValue, "undefined");
-        Assert.assertFalse(property4.hasMore);
+        Assert.assertTrue(property4.hasMore);
         Assert.assertFalse(property4.required);
         Assert.assertFalse(property4.isContainer);
+
+        final CodegenProperty property5 = cm.vars.get(4);
+        Assert.assertEquals(property5.baseName, "active");
+        Assert.assertEquals(property5.complexType, null);
+        Assert.assertEquals(property5.dataType, "boolean");
+        Assert.assertEquals(property5.name, "active");
+        Assert.assertEquals(property5.defaultValue, "undefined");
+        Assert.assertFalse(property5.hasMore);
+        Assert.assertFalse(property5.required);
+        Assert.assertFalse(property5.isContainer);
+    }
+
+    @Test(description = "convert and check default values for a simple TypeScript Angular model")
+    public void simpleModelDefaultValuesTest() {
+        IntegerSchema integerSchema = new IntegerSchema().format(SchemaTypeUtil.INTEGER64_FORMAT);
+        integerSchema.setDefault(1234);
+
+        StringSchema stringSchema = new StringSchema();
+        stringSchema.setDefault("Jack");
+
+        DateTimeSchema dateTimeSchema = new DateTimeSchema();
+        dateTimeSchema.setDefault(OffsetDateTime.parse("2020-01-01T12:00:00+01:00", DateTimeFormatter.ISO_OFFSET_DATE_TIME));
+
+        DateSchema dateSchema = new DateSchema();
+        dateSchema.setDefault("2020-01-01");
+
+        BooleanSchema booleanSchema = new BooleanSchema();
+        booleanSchema.setDefault(true);
+
+        final Schema model = new Schema()
+                .description("a sample model")
+                .addProperties("id", integerSchema)
+                .addProperties("name", stringSchema)
+                .addProperties("createdAt", dateTimeSchema)
+                .addProperties("birthDate", dateSchema)
+                .addProperties("active", booleanSchema)
+                .addRequiredItem("id")
+                .addRequiredItem("name");
+
+        final DefaultCodegen codegen = new TypeScriptFetchClientCodegen();
+        OpenAPI openAPI = TestUtils.createOpenAPIWithOneSchema("sample", model);
+        codegen.setOpenAPI(openAPI);
+        final CodegenModel cm = codegen.fromModel("sample", model);
+
+        Assert.assertEquals(cm.name, "sample");
+        Assert.assertEquals(cm.classname, "Sample");
+        Assert.assertEquals(cm.description, "a sample model");
+        Assert.assertEquals(cm.vars.size(), 5);
+
+        final CodegenProperty property1 = cm.vars.get(0);
+        Assert.assertEquals(property1.baseName, "id");
+        Assert.assertEquals(property1.defaultValue, "1234");
+
+        final CodegenProperty property2 = cm.vars.get(1);
+        Assert.assertEquals(property2.baseName, "name");
+        Assert.assertEquals(property2.defaultValue, "'Jack'");
+
+        final CodegenProperty property3 = cm.vars.get(2);
+        Assert.assertEquals(property3.baseName, "createdAt");
+        Assert.assertEquals(property3.defaultValue, "2020-01-01T12:00+01:00");
+
+        final CodegenProperty property4 = cm.vars.get(3);
+        Assert.assertEquals(property4.baseName, "birthDate");
+        Assert.assertEquals(property4.defaultValue, "Wed Jan 01 01:00:00 CET 2020");
+
+        final CodegenProperty property5 = cm.vars.get(4);
+        Assert.assertEquals(property5.baseName, "active");
+        Assert.assertEquals(property5.defaultValue, "true");
     }
 
     @Test(description = "convert a model with list property")

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/typescriptangularjs/TypeScriptAngularJsModelTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/typescriptangularjs/TypeScriptAngularJsModelTest.java
@@ -30,8 +30,13 @@ import org.openapitools.codegen.languages.TypeScriptFetchClientCodegen;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
-import java.time.format.DateTimeFormatter;
+import java.time.ZoneOffset;
+import java.util.Date;
+import java.util.Locale;
 
 @SuppressWarnings("static-method")
 public class TypeScriptAngularJsModelTest {
@@ -109,18 +114,20 @@ public class TypeScriptAngularJsModelTest {
     }
 
     @Test(description = "convert and check default values for a simple TypeScript Angular model")
-    public void simpleModelDefaultValuesTest() {
+    public void simpleModelDefaultValuesTest() throws ParseException {
         IntegerSchema integerSchema = new IntegerSchema().format(SchemaTypeUtil.INTEGER64_FORMAT);
         integerSchema.setDefault(1234);
 
         StringSchema stringSchema = new StringSchema();
         stringSchema.setDefault("Jack");
 
+        OffsetDateTime testOffsetDateTime = OffsetDateTime.of(LocalDateTime.of(2020, 1, 1, 12, 0), ZoneOffset.UTC);
         DateTimeSchema dateTimeSchema = new DateTimeSchema();
-        dateTimeSchema.setDefault(OffsetDateTime.parse("2020-01-01T12:00:00+01:00", DateTimeFormatter.ISO_OFFSET_DATE_TIME));
+        dateTimeSchema.setDefault(testOffsetDateTime);
 
+        Date testDate = Date.from(testOffsetDateTime.toInstant());
         DateSchema dateSchema = new DateSchema();
-        dateSchema.setDefault("2020-01-01");
+        dateSchema.setDefault(testDate);
 
         BooleanSchema booleanSchema = new BooleanSchema();
         booleanSchema.setDefault(true);
@@ -155,11 +162,11 @@ public class TypeScriptAngularJsModelTest {
 
         final CodegenProperty property3 = cm.vars.get(2);
         Assert.assertEquals(property3.baseName, "createdAt");
-        Assert.assertEquals(property3.defaultValue, "2020-01-01T12:00+01:00");
+        Assert.assertEquals(OffsetDateTime.parse(property3.defaultValue), testOffsetDateTime);
 
         final CodegenProperty property4 = cm.vars.get(3);
         Assert.assertEquals(property4.baseName, "birthDate");
-        Assert.assertEquals(property4.defaultValue, "Wed Jan 01 01:00:00 CET 2020");
+        Assert.assertEquals(new SimpleDateFormat("EEE MMM dd HH:mm:ss z yyyy", Locale.ENGLISH).parse(property4.defaultValue), testDate);
 
         final CodegenProperty property5 = cm.vars.get(4);
         Assert.assertEquals(property5.baseName, "active");

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/typescriptangularjs/TypeScriptAngularJsModelTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/typescriptangularjs/TypeScriptAngularJsModelTest.java
@@ -26,8 +26,12 @@ import org.openapitools.codegen.CodegenProperty;
 import org.openapitools.codegen.DefaultCodegen;
 import org.openapitools.codegen.TestUtils;
 import org.openapitools.codegen.languages.TypeScriptAngularJsClientCodegen;
+import org.openapitools.codegen.languages.TypeScriptFetchClientCodegen;
 import org.testng.Assert;
 import org.testng.annotations.Test;
+
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
 
 @SuppressWarnings("static-method")
 public class TypeScriptAngularJsModelTest {
@@ -40,6 +44,7 @@ public class TypeScriptAngularJsModelTest {
                 .addProperties("name", new StringSchema())
                 .addProperties("createdAt", new DateTimeSchema())
                 .addProperties("birthDate", new DateSchema())
+                .addProperties("active", new BooleanSchema())
                 .addRequiredItem("id")
                 .addRequiredItem("name");
         final DefaultCodegen codegen = new TypeScriptAngularJsClientCodegen();
@@ -50,7 +55,7 @@ public class TypeScriptAngularJsModelTest {
         Assert.assertEquals(cm.name, "sample");
         Assert.assertEquals(cm.classname, "Sample");
         Assert.assertEquals(cm.description, "a sample model");
-        Assert.assertEquals(cm.vars.size(), 4);
+        Assert.assertEquals(cm.vars.size(), 5);
 
         final CodegenProperty property1 = cm.vars.get(0);
         Assert.assertEquals(property1.baseName, "id");
@@ -88,9 +93,77 @@ public class TypeScriptAngularJsModelTest {
         Assert.assertEquals(property4.dataType, "string");
         Assert.assertEquals(property4.name, "birthDate");
         Assert.assertEquals(property4.defaultValue, "undefined");
-        Assert.assertFalse(property4.hasMore);
+        Assert.assertTrue(property4.hasMore);
         Assert.assertFalse(property4.required);
         Assert.assertFalse(property4.isContainer);
+
+        final CodegenProperty property5 = cm.vars.get(4);
+        Assert.assertEquals(property5.baseName, "active");
+        Assert.assertEquals(property5.complexType, null);
+        Assert.assertEquals(property5.dataType, "boolean");
+        Assert.assertEquals(property5.name, "active");
+        Assert.assertEquals(property5.defaultValue, "undefined");
+        Assert.assertFalse(property5.hasMore);
+        Assert.assertFalse(property5.required);
+        Assert.assertFalse(property5.isContainer);
+    }
+
+    @Test(description = "convert and check default values for a simple TypeScript Angular model")
+    public void simpleModelDefaultValuesTest() {
+        IntegerSchema integerSchema = new IntegerSchema().format(SchemaTypeUtil.INTEGER64_FORMAT);
+        integerSchema.setDefault(1234);
+
+        StringSchema stringSchema = new StringSchema();
+        stringSchema.setDefault("Jack");
+
+        DateTimeSchema dateTimeSchema = new DateTimeSchema();
+        dateTimeSchema.setDefault(OffsetDateTime.parse("2020-01-01T12:00:00+01:00", DateTimeFormatter.ISO_OFFSET_DATE_TIME));
+
+        DateSchema dateSchema = new DateSchema();
+        dateSchema.setDefault("2020-01-01");
+
+        BooleanSchema booleanSchema = new BooleanSchema();
+        booleanSchema.setDefault(true);
+
+        final Schema model = new Schema()
+                .description("a sample model")
+                .addProperties("id", integerSchema)
+                .addProperties("name", stringSchema)
+                .addProperties("createdAt", dateTimeSchema)
+                .addProperties("birthDate", dateSchema)
+                .addProperties("active", booleanSchema)
+                .addRequiredItem("id")
+                .addRequiredItem("name");
+
+        final DefaultCodegen codegen = new TypeScriptFetchClientCodegen();
+        OpenAPI openAPI = TestUtils.createOpenAPIWithOneSchema("sample", model);
+        codegen.setOpenAPI(openAPI);
+        final CodegenModel cm = codegen.fromModel("sample", model);
+
+        Assert.assertEquals(cm.name, "sample");
+        Assert.assertEquals(cm.classname, "Sample");
+        Assert.assertEquals(cm.description, "a sample model");
+        Assert.assertEquals(cm.vars.size(), 5);
+
+        final CodegenProperty property1 = cm.vars.get(0);
+        Assert.assertEquals(property1.baseName, "id");
+        Assert.assertEquals(property1.defaultValue, "1234");
+
+        final CodegenProperty property2 = cm.vars.get(1);
+        Assert.assertEquals(property2.baseName, "name");
+        Assert.assertEquals(property2.defaultValue, "'Jack'");
+
+        final CodegenProperty property3 = cm.vars.get(2);
+        Assert.assertEquals(property3.baseName, "createdAt");
+        Assert.assertEquals(property3.defaultValue, "2020-01-01T12:00+01:00");
+
+        final CodegenProperty property4 = cm.vars.get(3);
+        Assert.assertEquals(property4.baseName, "birthDate");
+        Assert.assertEquals(property4.defaultValue, "Wed Jan 01 01:00:00 CET 2020");
+
+        final CodegenProperty property5 = cm.vars.get(4);
+        Assert.assertEquals(property5.baseName, "active");
+        Assert.assertEquals(property5.defaultValue, "true");
     }
 
     @Test(description = "convert a model with list property")

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/typescriptnode/TypeScriptNodeModelTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/typescriptnode/TypeScriptNodeModelTest.java
@@ -32,8 +32,13 @@ import org.openapitools.codegen.languages.TypeScriptNodeClientCodegen;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
-import java.time.format.DateTimeFormatter;
+import java.time.ZoneOffset;
+import java.util.Date;
+import java.util.Locale;
 
 @SuppressWarnings("static-method")
 public class TypeScriptNodeModelTest {
@@ -107,18 +112,20 @@ public class TypeScriptNodeModelTest {
     }
 
     @Test(description = "convert and check default values for a simple TypeScript Angular model")
-    public void simpleModelDefaultValuesTest() {
+    public void simpleModelDefaultValuesTest() throws ParseException {
         IntegerSchema integerSchema = new IntegerSchema().format(SchemaTypeUtil.INTEGER64_FORMAT);
         integerSchema.setDefault(1234);
 
         StringSchema stringSchema = new StringSchema();
         stringSchema.setDefault("Jack");
 
+        OffsetDateTime testOffsetDateTime = OffsetDateTime.of(LocalDateTime.of(2020, 1, 1, 12, 0), ZoneOffset.UTC);
         DateTimeSchema dateTimeSchema = new DateTimeSchema();
-        dateTimeSchema.setDefault(OffsetDateTime.parse("2020-01-01T12:00:00+01:00", DateTimeFormatter.ISO_OFFSET_DATE_TIME));
+        dateTimeSchema.setDefault(testOffsetDateTime);
 
+        Date testDate = Date.from(testOffsetDateTime.toInstant());
         DateSchema dateSchema = new DateSchema();
-        dateSchema.setDefault("2020-01-01");
+        dateSchema.setDefault(testDate);
 
         BooleanSchema booleanSchema = new BooleanSchema();
         booleanSchema.setDefault(true);
@@ -153,11 +160,11 @@ public class TypeScriptNodeModelTest {
 
         final CodegenProperty property3 = cm.vars.get(2);
         Assert.assertEquals(property3.baseName, "createdAt");
-        Assert.assertEquals(property3.defaultValue, "2020-01-01T12:00+01:00");
+        Assert.assertEquals(OffsetDateTime.parse(property3.defaultValue), testOffsetDateTime);
 
         final CodegenProperty property4 = cm.vars.get(3);
         Assert.assertEquals(property4.baseName, "birthDate");
-        Assert.assertEquals(property4.defaultValue, "Wed Jan 01 01:00:00 CET 2020");
+        Assert.assertEquals(new SimpleDateFormat("EEE MMM dd HH:mm:ss z yyyy", Locale.ENGLISH).parse(property4.defaultValue), testDate);
 
         final CodegenProperty property5 = cm.vars.get(4);
         Assert.assertEquals(property5.baseName, "active");

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/typescriptnode/TypeScriptNodeModelTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/typescriptnode/TypeScriptNodeModelTest.java
@@ -27,9 +27,13 @@ import org.openapitools.codegen.CodegenModel;
 import org.openapitools.codegen.CodegenProperty;
 import org.openapitools.codegen.DefaultCodegen;
 import org.openapitools.codegen.TestUtils;
+import org.openapitools.codegen.languages.TypeScriptFetchClientCodegen;
 import org.openapitools.codegen.languages.TypeScriptNodeClientCodegen;
 import org.testng.Assert;
 import org.testng.annotations.Test;
+
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
 
 @SuppressWarnings("static-method")
 public class TypeScriptNodeModelTest {
@@ -42,6 +46,7 @@ public class TypeScriptNodeModelTest {
                 .addProperties("name", new StringSchema())
                 .addProperties("createdAt", new DateTimeSchema())
                 .addProperties("birthDate", new DateSchema())
+                .addProperties("active", new BooleanSchema())
                 .addRequiredItem("id")
                 .addRequiredItem("name");
         final DefaultCodegen codegen = new TypeScriptNodeClientCodegen();
@@ -52,7 +57,7 @@ public class TypeScriptNodeModelTest {
         Assert.assertEquals(cm.name, "sample");
         Assert.assertEquals(cm.classname, "Sample");
         Assert.assertEquals(cm.description, "a sample model");
-        Assert.assertEquals(cm.vars.size(), 4);
+        Assert.assertEquals(cm.vars.size(), 5);
 
         final CodegenProperty property1 = cm.vars.get(0);
         Assert.assertEquals(property1.baseName, "id");
@@ -87,8 +92,76 @@ public class TypeScriptNodeModelTest {
         Assert.assertEquals(property4.dataType, "string");
         Assert.assertEquals(property4.name, "birthDate");
         Assert.assertEquals(property4.defaultValue, "undefined");
-        Assert.assertFalse(property4.hasMore);
+        Assert.assertTrue(property4.hasMore);
         Assert.assertFalse(property4.required);
+
+        final CodegenProperty property5 = cm.vars.get(4);
+        Assert.assertEquals(property5.baseName, "active");
+        Assert.assertEquals(property5.complexType, null);
+        Assert.assertEquals(property5.dataType, "boolean");
+        Assert.assertEquals(property5.name, "active");
+        Assert.assertEquals(property5.defaultValue, "undefined");
+        Assert.assertFalse(property5.hasMore);
+        Assert.assertFalse(property5.required);
+        Assert.assertFalse(property5.isContainer);
+    }
+
+    @Test(description = "convert and check default values for a simple TypeScript Angular model")
+    public void simpleModelDefaultValuesTest() {
+        IntegerSchema integerSchema = new IntegerSchema().format(SchemaTypeUtil.INTEGER64_FORMAT);
+        integerSchema.setDefault(1234);
+
+        StringSchema stringSchema = new StringSchema();
+        stringSchema.setDefault("Jack");
+
+        DateTimeSchema dateTimeSchema = new DateTimeSchema();
+        dateTimeSchema.setDefault(OffsetDateTime.parse("2020-01-01T12:00:00+01:00", DateTimeFormatter.ISO_OFFSET_DATE_TIME));
+
+        DateSchema dateSchema = new DateSchema();
+        dateSchema.setDefault("2020-01-01");
+
+        BooleanSchema booleanSchema = new BooleanSchema();
+        booleanSchema.setDefault(true);
+
+        final Schema model = new Schema()
+                .description("a sample model")
+                .addProperties("id", integerSchema)
+                .addProperties("name", stringSchema)
+                .addProperties("createdAt", dateTimeSchema)
+                .addProperties("birthDate", dateSchema)
+                .addProperties("active", booleanSchema)
+                .addRequiredItem("id")
+                .addRequiredItem("name");
+
+        final DefaultCodegen codegen = new TypeScriptFetchClientCodegen();
+        OpenAPI openAPI = TestUtils.createOpenAPIWithOneSchema("sample", model);
+        codegen.setOpenAPI(openAPI);
+        final CodegenModel cm = codegen.fromModel("sample", model);
+
+        Assert.assertEquals(cm.name, "sample");
+        Assert.assertEquals(cm.classname, "Sample");
+        Assert.assertEquals(cm.description, "a sample model");
+        Assert.assertEquals(cm.vars.size(), 5);
+
+        final CodegenProperty property1 = cm.vars.get(0);
+        Assert.assertEquals(property1.baseName, "id");
+        Assert.assertEquals(property1.defaultValue, "1234");
+
+        final CodegenProperty property2 = cm.vars.get(1);
+        Assert.assertEquals(property2.baseName, "name");
+        Assert.assertEquals(property2.defaultValue, "'Jack'");
+
+        final CodegenProperty property3 = cm.vars.get(2);
+        Assert.assertEquals(property3.baseName, "createdAt");
+        Assert.assertEquals(property3.defaultValue, "2020-01-01T12:00+01:00");
+
+        final CodegenProperty property4 = cm.vars.get(3);
+        Assert.assertEquals(property4.baseName, "birthDate");
+        Assert.assertEquals(property4.defaultValue, "Wed Jan 01 01:00:00 CET 2020");
+
+        final CodegenProperty property5 = cm.vars.get(4);
+        Assert.assertEquals(property5.baseName, "active");
+        Assert.assertEquals(property5.defaultValue, "true");
     }
 
     @Test(description = "convert a model with list property")


### PR DESCRIPTION
I was building my own mustache template for typescript client generation and ran into the issue of all boolean and date property defaultValue fields always beeing set to undefined. This PR adds the missing defaultValue handling for typescript generators.

* Added default values for DateTimeSchema, DateSchema and BooleanSchema.
* Added simple tests for default value parsing

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/config/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@TiFu (2017/07) @taxpon (2017/07) @sebastianhaas (2017/07) @kenisteward (2017/07) @Vrolijkx (2017/09) @macjohnny (2018/01) @topce (2018/10) @akehir (2019/07) @petejohansonxo (2019/11) @amakhrov (2020/02)
