### PR TITLE
Don't escape values provided by user via additionalModelTypeAnnotations

### DIFF
--- a/modules/openapi-generator/src/main/resources/JavaSpring/additionalModelTypeAnnotations.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/additionalModelTypeAnnotations.mustache
@@ -1,2 +1,2 @@
-{{#additionalModelTypeAnnotations}}{{.}}
+{{#additionalModelTypeAnnotations}}{{{.}}}
 {{/additionalModelTypeAnnotations}}


### PR DESCRIPTION
This fixes #5533. I've corrected template only for spring, but I add add fixes for other generators as well if desided.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [X] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/config/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [ ] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
