### PR TITLE
Add isAdditionalPropertiesTrue

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenModel.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenModel.java
@@ -129,6 +129,11 @@ public class CodegenModel implements IJsonSchemaValidationProperties {
      */
     public String additionalPropertiesType;
 
+    /**
+     * True if additionalProperties is not defined or it's set to true
+     */
+    public boolean isAdditionalPropertiesTrue;
+
     private Integer maxProperties;
     private Integer minProperties;
     private boolean uniqueItems;

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenModel.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenModel.java
@@ -130,7 +130,7 @@ public class CodegenModel implements IJsonSchemaValidationProperties {
     public String additionalPropertiesType;
 
     /**
-     * True if additionalProperties is not defined or it's set to true
+     * True if additionalProperties is set to true (boolean value)
      */
     public boolean isAdditionalPropertiesTrue;
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -2483,19 +2483,6 @@ public class DefaultCodegen implements CodegenConfig {
         // remove duplicated properties
         m.removeAllDuplicatedProperty();
 
-        // post process model properties
-        if (m.vars != null) {
-            for (CodegenProperty prop : m.vars) {
-                postProcessModelProperty(m, prop);
-            }
-            m.hasVars = m.vars.size() > 0;
-        }
-        if (m.allVars != null) {
-            for (CodegenProperty prop : m.allVars) {
-                postProcessModelProperty(m, prop);
-            }
-        }
-
         // set isDiscriminator on the discriminator property
         if (m.discriminator != null) {
             String discPropName = m.discriminator.getPropertyBaseName();
@@ -2523,6 +2510,19 @@ public class DefaultCodegen implements CodegenConfig {
             };
             Collections.sort(m.vars, comparator);
             Collections.sort(m.allVars, comparator);
+        }
+
+        // post process model properties
+        if (m.vars != null) {
+            for (CodegenProperty prop : m.vars) {
+                postProcessModelProperty(m, prop);
+            }
+            m.hasVars = m.vars.size() > 0;
+        }
+        if (m.allVars != null) {
+            for (CodegenProperty prop : m.allVars) {
+                postProcessModelProperty(m, prop);
+            }
         }
 
         return m;

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -2512,6 +2512,19 @@ public class DefaultCodegen implements CodegenConfig {
             Collections.sort(m.allVars, comparator);
         }
 
+        // process 'additionalProperties'
+        if (schema.getAdditionalProperties() == null) {
+            m.isAdditionalPropertiesTrue = false; // TODO fix the old (incorrect) behaviour (likely with an option)
+        } else if (schema.getAdditionalProperties() instanceof Boolean) {
+            if (Boolean.TRUE.equals(schema.getAdditionalProperties())) {
+                m.isAdditionalPropertiesTrue = true;
+            } else {
+                m.isAdditionalPropertiesTrue = false;
+            }
+        } else {
+            m.isAdditionalPropertiesTrue = false;
+        }
+
         // post process model properties
         if (m.vars != null) {
             for (CodegenProperty prop : m.vars) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/GoClientExperimentalCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/GoClientExperimentalCodegen.java
@@ -222,11 +222,6 @@ public class GoClientExperimentalCodegen extends GoClientCodegen {
                 if (model.anyOf != null && !model.anyOf.isEmpty()) {
                     imports.add(createMapping("import", "fmt"));
                 }
-
-                // add x-additional-properties
-                if ("map[string]map[string]interface{}".equals(model.parent)) {
-                    model.vendorExtensions.put("x-additional-properties", true);
-                }
             }
         }
         return objs;

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/GoClientExperimentalCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/GoClientExperimentalCodegen.java
@@ -39,9 +39,6 @@ public class GoClientExperimentalCodegen extends GoClientCodegen {
 
     public GoClientExperimentalCodegen() {
         super();
-
-        supportsAdditionalPropertiesWithComposedSchema = false;
-
         outputFolder = "generated-code/go-experimental";
         embeddedTemplateDir = templateDir = "go-experimental";
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/GoClientExperimentalCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/GoClientExperimentalCodegen.java
@@ -39,6 +39,9 @@ public class GoClientExperimentalCodegen extends GoClientCodegen {
 
     public GoClientExperimentalCodegen() {
         super();
+
+        supportsAdditionalPropertiesWithComposedSchema = false;
+
         outputFolder = "generated-code/go-experimental";
         embeddedTemplateDir = templateDir = "go-experimental";
 

--- a/modules/openapi-generator/src/main/resources/go-experimental/model_simple.mustache
+++ b/modules/openapi-generator/src/main/resources/go-experimental/model_simple.mustache
@@ -13,15 +13,15 @@ type {{classname}} struct {
 {{/description}}
 	{{name}} {{^required}}{{^isNullable}}*{{/isNullable}}{{/required}}{{{dataType}}} `json:"{{baseName}}{{^required}},omitempty{{/required}}"{{#withXml}} xml:"{{baseName}}{{#isXmlAttribute}},attr{{/isXmlAttribute}}"{{/withXml}}{{#vendorExtensions.x-go-custom-tag}} {{{.}}}{{/vendorExtensions.x-go-custom-tag}}`
 {{/vars}}
-{{#vendorExtensions.x-additional-properties}}
+{{#isAdditionalPropertiesTrue}}
 	AdditionalProperties map[string]interface{}
-{{/vendorExtensions.x-additional-properties}}
+{{/isAdditionalPropertiesTrue}}
 }
 
-{{#vendorExtensions.x-additional-properties}}
+{{#isAdditionalPropertiesTrue}}
 type _{{{classname}}} {{{classname}}}
 
-{{/vendorExtensions.x-additional-properties}}
+{{/isAdditionalPropertiesTrue}}
 // New{{classname}} instantiates a new {{classname}} object
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
@@ -253,17 +253,17 @@ func (o {{classname}}) MarshalJSON() ([]byte, error) {
 	}
 	{{/isNullable}}
 	{{/vars}}
-	{{#vendorExtensions.x-additional-properties}}
+	{{#isAdditionalPropertiesTrue}}
 
 	for key, value := range o.AdditionalProperties {
 		toSerialize[key] = value
 	}
 
-	{{/vendorExtensions.x-additional-properties}}
+	{{/isAdditionalPropertiesTrue}}
 	return json.Marshal(toSerialize)
 }
 
-{{#vendorExtensions.x-additional-properties}}
+{{#isAdditionalPropertiesTrue}}
 func (o *{{{classname}}}) UnmarshalJSON(bytes []byte) (err error) {
 	var{{{classname}}} := _{{{classname}}}{}
 
@@ -283,5 +283,5 @@ func (o *{{{classname}}}) UnmarshalJSON(bytes []byte) (err error) {
 	return err
 }
 
-{{/vendorExtensions.x-additional-properties}}
+{{/isAdditionalPropertiesTrue}}
 {{>nullable_model}}

--- a/samples/client/petstore/go-experimental/go-petstore/model_additional_properties_any_type.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_additional_properties_any_type.go
@@ -16,10 +16,7 @@ import (
 // AdditionalPropertiesAnyType struct for AdditionalPropertiesAnyType
 type AdditionalPropertiesAnyType struct {
 	Name *string `json:"name,omitempty"`
-	AdditionalProperties map[string]interface{}
 }
-
-type _AdditionalPropertiesAnyType AdditionalPropertiesAnyType
 
 // NewAdditionalPropertiesAnyType instantiates a new AdditionalPropertiesAnyType object
 // This constructor will assign default values to properties that have it defined,
@@ -75,29 +72,7 @@ func (o AdditionalPropertiesAnyType) MarshalJSON() ([]byte, error) {
 	if o.Name != nil {
 		toSerialize["name"] = o.Name
 	}
-
-	for key, value := range o.AdditionalProperties {
-		toSerialize[key] = value
-	}
-
 	return json.Marshal(toSerialize)
-}
-
-func (o *AdditionalPropertiesAnyType) UnmarshalJSON(bytes []byte) (err error) {
-	varAdditionalPropertiesAnyType := _AdditionalPropertiesAnyType{}
-
-	if err = json.Unmarshal(bytes, &varAdditionalPropertiesAnyType); err == nil {
-		*o = AdditionalPropertiesAnyType(varAdditionalPropertiesAnyType)
-	}
-
-	additionalProperties := make(map[string]interface{})
-
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
-		delete(additionalProperties, "name")
-		o.AdditionalProperties = additionalProperties
-	}
-
-	return err
 }
 
 type NullableAdditionalPropertiesAnyType struct {

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_nullable_class.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_nullable_class.go
@@ -28,10 +28,7 @@ type NullableClass struct {
 	ObjectNullableProp map[string]map[string]interface{} `json:"object_nullable_prop,omitempty"`
 	ObjectAndItemsNullableProp map[string]map[string]interface{} `json:"object_and_items_nullable_prop,omitempty"`
 	ObjectItemsNullable *map[string]map[string]interface{} `json:"object_items_nullable,omitempty"`
-	AdditionalProperties map[string]interface{}
 }
-
-type _NullableClass NullableClass
 
 // NewNullableClass instantiates a new NullableClass object
 // This constructor will assign default values to properties that have it defined,
@@ -536,40 +533,7 @@ func (o NullableClass) MarshalJSON() ([]byte, error) {
 	if o.ObjectItemsNullable != nil {
 		toSerialize["object_items_nullable"] = o.ObjectItemsNullable
 	}
-
-	for key, value := range o.AdditionalProperties {
-		toSerialize[key] = value
-	}
-
 	return json.Marshal(toSerialize)
-}
-
-func (o *NullableClass) UnmarshalJSON(bytes []byte) (err error) {
-	varNullableClass := _NullableClass{}
-
-	if err = json.Unmarshal(bytes, &varNullableClass); err == nil {
-		*o = NullableClass(varNullableClass)
-	}
-
-	additionalProperties := make(map[string]interface{})
-
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
-		delete(additionalProperties, "integer_prop")
-		delete(additionalProperties, "number_prop")
-		delete(additionalProperties, "boolean_prop")
-		delete(additionalProperties, "string_prop")
-		delete(additionalProperties, "date_prop")
-		delete(additionalProperties, "datetime_prop")
-		delete(additionalProperties, "array_nullable_prop")
-		delete(additionalProperties, "array_and_items_nullable_prop")
-		delete(additionalProperties, "array_items_nullable")
-		delete(additionalProperties, "object_nullable_prop")
-		delete(additionalProperties, "object_and_items_nullable_prop")
-		delete(additionalProperties, "object_items_nullable")
-		o.AdditionalProperties = additionalProperties
-	}
-
-	return err
 }
 
 type NullableNullableClass struct {


### PR DESCRIPTION
- Added isAdditionalPropertiesTrue to indicate whether `additionalProperties` in the spec is set to true
- Updated go-experimental template to use isAdditionalPropertiesTrue

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/config/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

cc @antihax (2017/11) @grokify (2018/07) @kemokemo (2018/09) @bkabrda (2019/07)

cc @OpenAPITools/generator-core-team 
