### PR TITLE
Sttp - wrap query params

### DIFF
--- a/modules/openapi-generator/src/main/resources/scala-sttp/api.mustache
+++ b/modules/openapi-generator/src/main/resources/scala-sttp/api.mustache
@@ -22,7 +22,7 @@ class {{classname}}(baseUrl: String) {
 {{/javadocRenderer}}
   def {{operationId}}({{>methodParameters}}): Request[{{#separateErrorChannel}}Either[ResponseError[Exception], {{>operationReturnType}}]{{/separateErrorChannel}}{{^separateErrorChannel}}{{>operationReturnType}}{{/separateErrorChannel}}, Nothing] =
     basicRequest
-      .method(Method.{{httpMethod.toUpperCase}}, uri"$baseUrl{{{path}}}{{#queryParams.0}}?{{#queryParams}}{{baseName}}=${{{paramName}}}{{^-last}}&{{/-last}}{{/queryParams}}{{/queryParams.0}}{{#isApiKey}}{{#isKeyInQuery}}{{^queryParams.0}}?{{/queryParams.0}}{{#queryParams.0}}&{{/queryParams.0}}{{keyParamName}}=${apiKey.value}&{{/isKeyInQuery}}{{/isApiKey}}")
+      .method(Method.{{httpMethod.toUpperCase}}, uri"$baseUrl{{{path}}}{{#queryParams.0}}?{{#queryParams}}{{baseName}}=${ {{{paramName}}} }{{^-last}}&{{/-last}}{{/queryParams}}{{/queryParams.0}}{{#isApiKey}}{{#isKeyInQuery}}{{^queryParams.0}}?{{/queryParams.0}}{{#queryParams.0}}&{{/queryParams.0}}{{keyParamName}}=${apiKey.value}&{{/isKeyInQuery}}{{/isApiKey}}")
       .contentType({{#consumes.0}}"{{{mediaType}}}"{{/consumes.0}}{{^consumes}}"application/json"{{/consumes}}){{#headerParams}}
       .header({{>paramCreation}}){{/headerParams}}{{#authMethods}}{{#isBasic}}{{#isBasicBasic}}
       .auth.withCredentials(username, password){{/isBasicBasic}}{{#isBasicBearer}}

--- a/modules/openapi-generator/src/main/resources/scala-sttp/paramQueryCreation.mustache
+++ b/modules/openapi-generator/src/main/resources/scala-sttp/paramQueryCreation.mustache
@@ -1,1 +1,0 @@
-{{#isContainer}}${ formatQueryArray("{{{baseName}}}",{{{paramName}}}{{#collectionFormat}}, {{collectionFormat.toUpperCase}}{{/collectionFormat}}) }{{/isContainer}}{{^isContainer}}{{baseName}}=${ {{{paramName}}} }{{/isContainer}}

--- a/samples/client/petstore/scala-sttp/src/main/scala/org/openapitools/client/api/PetApi.scala
+++ b/samples/client/petstore/scala-sttp/src/main/scala/org/openapitools/client/api/PetApi.scala
@@ -67,7 +67,7 @@ class PetApi(baseUrl: String) {
   def findPetsByStatus(status: Seq[String]
 ): Request[Either[ResponseError[Exception], Seq[Pet]], Nothing] =
     basicRequest
-      .method(Method.GET, uri"$baseUrl/pet/findByStatus?status=$status")
+      .method(Method.GET, uri"$baseUrl/pet/findByStatus?status=${ status }")
       .contentType("application/json")
       .response(asJson[Seq[Pet]])
 
@@ -83,7 +83,7 @@ class PetApi(baseUrl: String) {
   def findPetsByTags(tags: Seq[String]
 ): Request[Either[ResponseError[Exception], Seq[Pet]], Nothing] =
     basicRequest
-      .method(Method.GET, uri"$baseUrl/pet/findByTags?tags=$tags")
+      .method(Method.GET, uri"$baseUrl/pet/findByTags?tags=${ tags }")
       .contentType("application/json")
       .response(asJson[Seq[Pet]])
 

--- a/samples/client/petstore/scala-sttp/src/main/scala/org/openapitools/client/api/UserApi.scala
+++ b/samples/client/petstore/scala-sttp/src/main/scala/org/openapitools/client/api/UserApi.scala
@@ -129,7 +129,7 @@ class UserApi(baseUrl: String) {
   def loginUser(username: String, password: String
 ): Request[Either[ResponseError[Exception], String], Nothing] =
     basicRequest
-      .method(Method.GET, uri"$baseUrl/user/login?username=$username&password=$password")
+      .method(Method.GET, uri"$baseUrl/user/login?username=${ username }&password=${ password }")
       .contentType("application/json")
       .response(asJson[String])
 


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
This fixes #6883 

Provided solution generates additional spaces around `paramName`.

Alternative solution to fix this would be to create a custom lambda to wrap arbitrary expression in curly braces in sttp generator and register it within `additionalProperties`.

<!-- Please check the completed items below -->
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [X] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/config/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [X] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@clasnake (2017/07), @jimschubert (2017/09) , @shijinkui (2018/01), @ramzimaalej (2018/03), @chameleon82 (2020/03), @Bouillie (2020/04)
