### PR TITLE
[PS] Replace x-additional-properties with isAdditionalPropertiesTrue

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PowerShellClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PowerShellClientCodegen.java
@@ -953,11 +953,6 @@ public class PowerShellClientCodegen extends DefaultCodegen implements CodegenCo
                 model.isNullable = true;
                 model.anyOf.remove("ModelNull");
             }
-
-            // add vendor extension for additonalProperties: true
-            if ("null<String, SystemCollectionsHashtable>".equals(model.parent)) {
-                model.vendorExtensions.put("x-additional-properties", true);
-            }
         }
 
         return objs;

--- a/modules/openapi-generator/src/main/resources/powershell/model_simple.mustache
+++ b/modules/openapi-generator/src/main/resources/powershell/model_simple.mustache
@@ -223,24 +223,24 @@ function ConvertFrom-{{{apiNamePrefix}}}JsonTo{{{classname}}} {
         $PSBoundParameters | Out-DebugParameter | Write-Debug
 
         $JsonParameters = ConvertFrom-Json -InputObject $Json
-        {{#vendorExtensions.x-additional-properties}}
+        {{#isAdditionalPropertiesTrue}}
         ${{{apiNamePrefix}}}{{{classname}}}AdditionalProperties = @{}
-        {{/vendorExtensions.x-additional-properties}}
+        {{/isAdditionalPropertiesTrue}}
 
         # check if Json contains properties not defined in {{{apiNamePrefix}}}{{{classname}}}
         $AllProperties = ({{#allVars}}"{{{baseName}}}"{{^-last}}, {{/-last}}{{/allVars}})
         foreach ($name in $JsonParameters.PsObject.Properties.Name) {
-            {{^vendorExtensions.x-additional-properties}}
+            {{^isAdditionalPropertiesTrue}}
             if (!($AllProperties.Contains($name))) {
                 throw "Error! JSON key '$name' not found in the properties: $($AllProperties)"
             }
-            {{/vendorExtensions.x-additional-properties}}
-            {{#vendorExtensions.x-additional-properties}}
+            {{/isAdditionalPropertiesTrue}}
+            {{#isAdditionalPropertiesTrue}}
             # store undefined properties in additionalProperties
             if (!($AllProperties.Contains($name))) {
                 ${{{apiNamePrefix}}}{{{classname}}}AdditionalProperties[$name] = $JsonParameters.PSobject.Properties[$name].value
             }
-            {{/vendorExtensions.x-additional-properties}}
+            {{/isAdditionalPropertiesTrue}}
         }
 
         {{#requiredVars}}
@@ -271,9 +271,9 @@ function ConvertFrom-{{{apiNamePrefix}}}JsonTo{{{classname}}} {
             "<<baseName>>" = ${<<name>>}
             <</allVars>>
             <<={{ }}=>>
-            {{#vendorExtensions.x-additional-properties}}
+            {{#isAdditionalPropertiesTrue}}
             "AdditionalProperties" = ${{{apiNamePrefix}}}{{{classname}}}AdditionalProperties
-            {{/vendorExtensions.x-additional-properties}}
+            {{/isAdditionalPropertiesTrue}}
         }
 
         return $PSO


### PR DESCRIPTION
Replace x-additional-properties with isAdditionalPropertiesTrue

Tested locally to confirm the change.

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/config/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
