### PR TITLE
Configure useOneOfInterfaces and addOneOfInterfaceImports via additional-properties

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConstants.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConstants.java
@@ -351,4 +351,7 @@ public class CodegenConstants {
 
     public static final String REMOVE_ENUM_VALUE_PREFIX = "removeEnumValuePrefix";
     public static final String REMOVE_ENUM_VALUE_PREFIX_DESC = "Remove the common prefix of enum values";
+
+    public static final String USE_ONE_OF_INTERFACES = "useOneOfInterfaces";
+    public static final String ADD_ONE_OF_INTERFACE_IMPORTS = "addOneOfInterfaceImports";
 }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -306,6 +306,16 @@ public class DefaultCodegen implements CodegenConfig {
             this.setRemoveEnumValuePrefix(Boolean.valueOf(additionalProperties
                     .get(CodegenConstants.REMOVE_ENUM_VALUE_PREFIX).toString()));
         }
+
+        if (additionalProperties.containsKey(CodegenConstants.USE_ONE_OF_INTERFACES)) {
+            this.setUseOneOfInterfaces(Boolean.valueOf(additionalProperties
+                    .get(CodegenConstants.USE_ONE_OF_INTERFACES).toString()));
+        }
+
+        if (additionalProperties.containsKey(CodegenConstants.ADD_ONE_OF_INTERFACE_IMPORTS)) {
+            this.setAddOneOfInterfaceImports(Boolean.valueOf(additionalProperties
+                    .get(CodegenConstants.ADD_ONE_OF_INTERFACE_IMPORTS).toString()));
+        }
     }
 
     /***
@@ -1123,6 +1133,10 @@ public class DefaultCodegen implements CodegenConfig {
 
     public void setUseOneOfInterfaces(Boolean useOneOfInterfaces) {
         this.useOneOfInterfaces = useOneOfInterfaces;
+    }
+
+    public void setAddOneOfInterfaceImports(Boolean addOneOfInterfaceImports) {
+        this.addOneOfInterfaceImports = addOneOfInterfaceImports;
     }
 
     /**


### PR DESCRIPTION
This can actually lead to us deleting the faulty javascript-apollo generator I wrote earlier.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [ ] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/config/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [ ] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
