### PR TITLE
Fix allOf with only one child schema (no discriminator)

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
@@ -1241,6 +1241,11 @@ public class ModelUtils {
                         // not a parent since discriminator.propertyName is not set
                         hasAmbiguousParents = true;
                         refedWithoutDiscriminator.add(parentName);
+
+                        // TOOD to be removed in 6.x release
+                        LOGGER.warn("[deprecated] inheritance without use of 'discriminator.propertyName' has been deprecated" +
+                                        " in the 5.x release. Composed schema name: {}. Title: {}",
+                                composedSchema.getName(), composedSchema.getTitle());
                     }
                 } else {
                     // not a ref, doing nothing, except counting the number of times the 'null' type
@@ -1253,21 +1258,6 @@ public class ModelUtils {
                     }
                 }
             }
-            if (refedWithoutDiscriminator.size() == 1 && nullSchemaChildrenCount == 1) {
-                // One schema is a $ref and the other is the 'null' type, so the parent is obvious.
-                // In this particular case there is no need to specify a discriminator.
-                hasAmbiguousParents = false;
-            }
-        }
-
-        // parent name only makes sense when there is a single obvious parent
-        if (refedWithoutDiscriminator.size() == 1) {
-            if (hasAmbiguousParents) {
-                LOGGER.warn("[deprecated] inheritance without use of 'discriminator.propertyName' is deprecated " +
-                                "and will be removed in a future release. Generating model for composed schema name: {}. Title: {}",
-                        composedSchema.getName(), composedSchema.getTitle());
-            }
-            return refedWithoutDiscriminator.get(0);
         }
 
         return null;

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
@@ -1222,8 +1222,6 @@ public class ModelUtils {
     public static String getParentName(ComposedSchema composedSchema, Map<String, Schema> allSchemas) {
         List<Schema> interfaces = getInterfaces(composedSchema);
         int nullSchemaChildrenCount = 0;
-        boolean hasAmbiguousParents = false;
-        List<String> refedWithoutDiscriminator = new ArrayList<>();
 
         if (interfaces != null && !interfaces.isEmpty()) {
             for (Schema schema : interfaces) {
@@ -1239,8 +1237,6 @@ public class ModelUtils {
                         return parentName;
                     } else {
                         // not a parent since discriminator.propertyName is not set
-                        hasAmbiguousParents = true;
-                        refedWithoutDiscriminator.add(parentName);
 
                         // TOOD to be removed in 6.x release
                         LOGGER.warn("[deprecated] inheritance without use of 'discriminator.propertyName' has been deprecated" +

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
@@ -1372,9 +1372,9 @@ public class DefaultCodegenTest {
         Schema schema = openAPI.getComponents().getSchemas().get("NewMessageEventCoreNoOwnProps");
         codegen.setOpenAPI(openAPI);
         CodegenModel model = codegen.fromModel("NewMessageEventCoreNoOwnProps", schema);
-        Assert.assertEquals(getNames(model.getVars()), Collections.emptyList());
-        Assert.assertEquals(model.parent, "MessageEventCore");
-        Assert.assertEquals(model.allParents, Collections.singletonList("MessageEventCore"));
+        Assert.assertEquals(getNames(model.getVars()), Arrays.asList("id","message"));
+        Assert.assertNull(model.parent);
+        Assert.assertNull(model.allParents);
     }
 
     class CodegenWithMultipleInheritance extends DefaultCodegen {

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaInheritanceTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaInheritanceTest.java
@@ -25,6 +25,7 @@ import io.swagger.v3.oas.models.media.Discriminator;
 import io.swagger.v3.oas.models.media.ObjectSchema;
 import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.media.StringSchema;
+import java.util.Collections;
 import org.apache.commons.lang3.StringUtils;
 import org.openapitools.codegen.CodegenModel;
 import org.openapitools.codegen.CodegenProperty;
@@ -57,8 +58,8 @@ public class JavaInheritanceTest {
 
         Assert.assertEquals(cm.name, "sample");
         Assert.assertEquals(cm.classname, "Sample");
-        Assert.assertEquals(cm.parent, "Base");
-        Assert.assertEquals(cm.imports, Sets.newHashSet("Base"));
+        Assert.assertNull(cm.parent);
+        Assert.assertEquals(cm.imports, Collections.emptySet());
     }
 
     @Test(description = "convert a composed model with discriminator")


### PR DESCRIPTION
Fix allOf with only one child schema (no discriminator)

<!-- Please check the completed items below -->
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [ ] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/config/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [ ] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
