### PR TITLE
[DART] Fix 2d list generated deserilization

### DIFF
--- a/modules/openapi-generator/src/main/resources/dart2/class.mustache
+++ b/modules/openapi-generator/src/main/resources/dart2/class.mustache
@@ -37,7 +37,20 @@ class {{classname}} {
       {{#isListContainer}}
     {{name}} = (json['{{baseName}}'] == null) ?
       null :
+    {{#items.isListContainer}}
+      (json['{{baseName}}'] as List).map(
+        (e) => e == null ? null :
+      {{#items.complexType}}
+          {{items.complexType}}.listFromJson(json['{{baseName}}'])
+      {{/items.complexType}}
+      {{^items.complexType}}
+          (e as List).cast<{{items.items.dataType}}>()
+      {{/items.complexType}}
+      ).toList();
+    {{/items.isListContainer}}
+    {{^items.isListContainer}}
       {{complexType}}.listFromJson(json['{{baseName}}']);
+    {{/items.isListContainer}}
       {{/isListContainer}}
       {{^isListContainer}}
       {{#isMapContainer}}


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
This PR fixes the `fromJson` method for classes with nested lists like `List<List<>>`.  Thus it fixes #2567.
I know the fix is not perfect. The generation will probably break with `List<List<List<>>>` and more dimensions. For fixing this I don't see any easy solution. Feel free to comment ideas into this direction.

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/config/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@ircecho (2017/07) @swipesight (2018/09) @jaumard (2018/09) @athornz (2019/12) @amondnet (2019/12)
