### PR TITLE
[PS] add nullable body support

### DIFF
--- a/modules/openapi-generator/src/main/resources/powershell/api.mustache
+++ b/modules/openapi-generator/src/main/resources/powershell/api.mustache
@@ -221,7 +221,8 @@ function {{{vendorExtensions.x-powershell-method-name}}} {
                                 -QueryParameters $LocalVarQueryParameters `
                                 -FormParameters $LocalVarFormParameters `
                                 -CookieParameters $LocalVarCookieParameters `
-                                -ReturnType "{{#returnType}}{{{.}}}{{/returnType}}"
+                                -ReturnType "{{#returnType}}{{{.}}}{{/returnType}}" `
+                                -IsBodyNullable {{#bodyParam}}{{#isNullable}}$true{{/isNullable}}{{^isNullable}}$false{{/isNullable}}{{/bodyParam}}{{^bodyParam}}$false{{/bodyParam}}
 
         {{#vendorExtensions.x-ps-return-type-one-of}}
         # process oneOf response

--- a/modules/openapi-generator/src/main/resources/powershell/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/powershell/api_client.mustache
@@ -26,7 +26,9 @@ function Invoke-{{{apiNamePrefix}}}ApiClient {
         [string]$Method,
         [Parameter(Mandatory)]
         [AllowEmptyString()]
-        [string]$ReturnType
+        [string]$ReturnType,
+        [Parameter(Mandatory)]
+        [bool]$IsBodyNullable
     )
 
     'Calling method: Invoke-{{{apiNamePrefix}}}ApiClient' | Write-Debug
@@ -85,8 +87,11 @@ function Invoke-{{{apiNamePrefix}}}ApiClient {
         $RequestBody = $FormParameters
     }
 
-    if ($Body) {
+    if ($Body -or $IsBodyNullable) {
         $RequestBody = $Body
+        if ([string]::IsNullOrEmpty($RequestBody) -and $IsBodyNullable -eq $true) {
+            $RequestBody = "null"
+        }
     }
 
     {{#hasHttpSignatureMethods}}

--- a/samples/client/petstore/powershell/Test1.ps1
+++ b/samples/client/petstore/powershell/Test1.ps1
@@ -27,13 +27,14 @@ $Id = 38369
     ) -Status Available
     
     #Write-Host $pet
-    $Result = Add-PSPet -Pet $pet
+    #$Result = Add-PSPet -Pet $pet
+    $Result = Add-PSPet -Pet $null
     Set-PSConfigurationApiKey -Id "api_key" -ApiKey "zzZZZZZZZZZZZZZ"
     $Result2 = Get-PSPetById -petId ($Id) -Verbose -WithHttpInfo #-testHeader "testing only" -testQuery "testing something here"
     Write-Host $Result2["Headers"]["Content-Type"]
-    $Result3 = Get-PSPetById -petId ($Id) -Verbose -WithHttpInfo -ReturnType "application/xml" #-testHeader "testing only" -testQuery "testing something here"
-    Write-Host $Result3["Headers"]["Content-Type"]
-    Write-Host $Result3["Response"]
+    #$Result3 = Get-PSPetById -petId ($Id) -Verbose -WithHttpInfo -ReturnType "application/xml" #-testHeader "testing only" -testQuery "testing something here"
+    #Write-Host $Result3["Headers"]["Content-Type"]
+    #Write-Host $Result3["Response"]
 #} catch {
 #    Write-Host ("Exception occured when calling '': {0}" -f ($_.ErrorDetails | ConvertFrom-Json))
 #    Write-Host ("Response headers: {0}" -f ($_.Exception.Response.Headers | ConvertTo-Json))

--- a/samples/client/petstore/powershell/src/PSPetstore/Api/PSPetApi.ps1
+++ b/samples/client/petstore/powershell/src/PSPetstore/Api/PSPetApi.ps1
@@ -85,7 +85,8 @@ function Add-PSPet {
                                 -QueryParameters $LocalVarQueryParameters `
                                 -FormParameters $LocalVarFormParameters `
                                 -CookieParameters $LocalVarCookieParameters `
-                                -ReturnType "Pet"
+                                -ReturnType "Pet" `
+                                -IsBodyNullable $false
 
         if ($WithHttpInfo.IsPresent) {
             return $LocalVarResult
@@ -165,7 +166,8 @@ function Remove-Pet {
                                 -QueryParameters $LocalVarQueryParameters `
                                 -FormParameters $LocalVarFormParameters `
                                 -CookieParameters $LocalVarCookieParameters `
-                                -ReturnType ""
+                                -ReturnType "" `
+                                -IsBodyNullable $false
 
         if ($WithHttpInfo.IsPresent) {
             return $LocalVarResult
@@ -252,7 +254,8 @@ function Find-PSPetsByStatus {
                                 -QueryParameters $LocalVarQueryParameters `
                                 -FormParameters $LocalVarFormParameters `
                                 -CookieParameters $LocalVarCookieParameters `
-                                -ReturnType "Pet[]"
+                                -ReturnType "Pet[]" `
+                                -IsBodyNullable $false
 
         if ($WithHttpInfo.IsPresent) {
             return $LocalVarResult
@@ -338,7 +341,8 @@ function Find-PSPetsByTags {
                                 -QueryParameters $LocalVarQueryParameters `
                                 -FormParameters $LocalVarFormParameters `
                                 -CookieParameters $LocalVarCookieParameters `
-                                -ReturnType "Pet[]"
+                                -ReturnType "Pet[]" `
+                                -IsBodyNullable $false
 
         if ($WithHttpInfo.IsPresent) {
             return $LocalVarResult
@@ -427,7 +431,8 @@ function Get-PSPetById {
                                 -QueryParameters $LocalVarQueryParameters `
                                 -FormParameters $LocalVarFormParameters `
                                 -CookieParameters $LocalVarCookieParameters `
-                                -ReturnType "Pet"
+                                -ReturnType "Pet" `
+                                -IsBodyNullable $false
 
         if ($WithHttpInfo.IsPresent) {
             return $LocalVarResult
@@ -517,7 +522,8 @@ function Update-PSPet {
                                 -QueryParameters $LocalVarQueryParameters `
                                 -FormParameters $LocalVarFormParameters `
                                 -CookieParameters $LocalVarCookieParameters `
-                                -ReturnType "Pet"
+                                -ReturnType "Pet" `
+                                -IsBodyNullable $false
 
         if ($WithHttpInfo.IsPresent) {
             return $LocalVarResult
@@ -610,7 +616,8 @@ function Update-PSPetWithForm {
                                 -QueryParameters $LocalVarQueryParameters `
                                 -FormParameters $LocalVarFormParameters `
                                 -CookieParameters $LocalVarCookieParameters `
-                                -ReturnType ""
+                                -ReturnType "" `
+                                -IsBodyNullable $false
 
         if ($WithHttpInfo.IsPresent) {
             return $LocalVarResult
@@ -706,7 +713,8 @@ function Invoke-PSUploadFile {
                                 -QueryParameters $LocalVarQueryParameters `
                                 -FormParameters $LocalVarFormParameters `
                                 -CookieParameters $LocalVarCookieParameters `
-                                -ReturnType "ApiResponse"
+                                -ReturnType "ApiResponse" `
+                                -IsBodyNullable $false
 
         if ($WithHttpInfo.IsPresent) {
             return $LocalVarResult

--- a/samples/client/petstore/powershell/src/PSPetstore/Api/PSStoreApi.ps1
+++ b/samples/client/petstore/powershell/src/PSPetstore/Api/PSStoreApi.ps1
@@ -64,7 +64,8 @@ function Remove-PSOrder {
                                 -QueryParameters $LocalVarQueryParameters `
                                 -FormParameters $LocalVarFormParameters `
                                 -CookieParameters $LocalVarCookieParameters `
-                                -ReturnType ""
+                                -ReturnType "" `
+                                -IsBodyNullable $false
 
         if ($WithHttpInfo.IsPresent) {
             return $LocalVarResult
@@ -131,7 +132,8 @@ function Get-PSInventory {
                                 -QueryParameters $LocalVarQueryParameters `
                                 -FormParameters $LocalVarFormParameters `
                                 -CookieParameters $LocalVarCookieParameters `
-                                -ReturnType "System.Collections.Hashtable"
+                                -ReturnType "System.Collections.Hashtable" `
+                                -IsBodyNullable $false
 
         if ($WithHttpInfo.IsPresent) {
             return $LocalVarResult
@@ -215,7 +217,8 @@ function Get-PSOrderById {
                                 -QueryParameters $LocalVarQueryParameters `
                                 -FormParameters $LocalVarFormParameters `
                                 -CookieParameters $LocalVarCookieParameters `
-                                -ReturnType "Order"
+                                -ReturnType "Order" `
+                                -IsBodyNullable $false
 
         if ($WithHttpInfo.IsPresent) {
             return $LocalVarResult
@@ -304,7 +307,8 @@ function Invoke-PSPlaceOrder {
                                 -QueryParameters $LocalVarQueryParameters `
                                 -FormParameters $LocalVarFormParameters `
                                 -CookieParameters $LocalVarCookieParameters `
-                                -ReturnType "Order"
+                                -ReturnType "Order" `
+                                -IsBodyNullable $false
 
         if ($WithHttpInfo.IsPresent) {
             return $LocalVarResult

--- a/samples/client/petstore/powershell/src/PSPetstore/Api/PSUserApi.ps1
+++ b/samples/client/petstore/powershell/src/PSPetstore/Api/PSUserApi.ps1
@@ -74,7 +74,8 @@ function New-PSUser {
                                 -QueryParameters $LocalVarQueryParameters `
                                 -FormParameters $LocalVarFormParameters `
                                 -CookieParameters $LocalVarCookieParameters `
-                                -ReturnType ""
+                                -ReturnType "" `
+                                -IsBodyNullable $false
 
         if ($WithHttpInfo.IsPresent) {
             return $LocalVarResult
@@ -153,7 +154,8 @@ function New-PSUsersWithArrayInput {
                                 -QueryParameters $LocalVarQueryParameters `
                                 -FormParameters $LocalVarFormParameters `
                                 -CookieParameters $LocalVarCookieParameters `
-                                -ReturnType ""
+                                -ReturnType "" `
+                                -IsBodyNullable $false
 
         if ($WithHttpInfo.IsPresent) {
             return $LocalVarResult
@@ -232,7 +234,8 @@ function New-PSUsersWithListInput {
                                 -QueryParameters $LocalVarQueryParameters `
                                 -FormParameters $LocalVarFormParameters `
                                 -CookieParameters $LocalVarCookieParameters `
-                                -ReturnType ""
+                                -ReturnType "" `
+                                -IsBodyNullable $false
 
         if ($WithHttpInfo.IsPresent) {
             return $LocalVarResult
@@ -306,7 +309,8 @@ function Remove-PSUser {
                                 -QueryParameters $LocalVarQueryParameters `
                                 -FormParameters $LocalVarFormParameters `
                                 -CookieParameters $LocalVarCookieParameters `
-                                -ReturnType ""
+                                -ReturnType "" `
+                                -IsBodyNullable $false
 
         if ($WithHttpInfo.IsPresent) {
             return $LocalVarResult
@@ -390,7 +394,8 @@ function Get-PSUserByName {
                                 -QueryParameters $LocalVarQueryParameters `
                                 -FormParameters $LocalVarFormParameters `
                                 -CookieParameters $LocalVarCookieParameters `
-                                -ReturnType "User"
+                                -ReturnType "User" `
+                                -IsBodyNullable $false
 
         if ($WithHttpInfo.IsPresent) {
             return $LocalVarResult
@@ -486,7 +491,8 @@ function Invoke-PSLoginUser {
                                 -QueryParameters $LocalVarQueryParameters `
                                 -FormParameters $LocalVarFormParameters `
                                 -CookieParameters $LocalVarCookieParameters `
-                                -ReturnType "String"
+                                -ReturnType "String" `
+                                -IsBodyNullable $false
 
         if ($WithHttpInfo.IsPresent) {
             return $LocalVarResult
@@ -550,7 +556,8 @@ function Invoke-PSLogoutUser {
                                 -QueryParameters $LocalVarQueryParameters `
                                 -FormParameters $LocalVarFormParameters `
                                 -CookieParameters $LocalVarCookieParameters `
-                                -ReturnType ""
+                                -ReturnType "" `
+                                -IsBodyNullable $false
 
         if ($WithHttpInfo.IsPresent) {
             return $LocalVarResult
@@ -639,7 +646,8 @@ function Update-PSUser {
                                 -QueryParameters $LocalVarQueryParameters `
                                 -FormParameters $LocalVarFormParameters `
                                 -CookieParameters $LocalVarCookieParameters `
-                                -ReturnType ""
+                                -ReturnType "" `
+                                -IsBodyNullable $false
 
         if ($WithHttpInfo.IsPresent) {
             return $LocalVarResult

--- a/samples/client/petstore/powershell/src/PSPetstore/Private/PSApiClient.ps1
+++ b/samples/client/petstore/powershell/src/PSPetstore/Private/PSApiClient.ps1
@@ -32,7 +32,9 @@ function Invoke-PSApiClient {
         [string]$Method,
         [Parameter(Mandatory)]
         [AllowEmptyString()]
-        [string]$ReturnType
+        [string]$ReturnType,
+        [Parameter(Mandatory)]
+        [bool]$IsBodyNullable
     )
 
     'Calling method: Invoke-PSApiClient' | Write-Debug
@@ -91,8 +93,11 @@ function Invoke-PSApiClient {
         $RequestBody = $FormParameters
     }
 
-    if ($Body) {
+    if ($Body -or $IsBodyNullable) {
         $RequestBody = $Body
+        if ([string]::IsNullOrEmpty($RequestBody) -and $IsBodyNullable -eq $true) {
+            $RequestBody = "null"
+        }
     }
 
     if ($SkipCertificateCheck -eq $true) {


### PR DESCRIPTION
- added nullable body support
- tested locally to confirm "null" in the HTTP request body
 
<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/config/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [ ] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
