### PR TITLE
[Java][jersey2] Fix null payload

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/ApiClient.mustache
@@ -874,9 +874,9 @@ public class ApiClient {
     } else {
       // We let jersey handle the serialization
       if (isBodyNullable) { // payload is nullable
-        entity = Entity.entity(obj == null ? Entity.text("null") : obj, contentType);
+        entity = Entity.entity(obj == null ? "null" : obj, contentType);
       } else {
-        entity = Entity.entity(obj == null ? Entity.text("") : obj, contentType);
+        entity = Entity.entity(obj == null ? "" : obj, contentType);
       }
     }
     return entity;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/ApiClient.java
@@ -791,9 +791,9 @@ public class ApiClient {
     } else {
       // We let jersey handle the serialization
       if (isBodyNullable) { // payload is nullable
-        entity = Entity.entity(obj == null ? Entity.text("null") : obj, contentType);
+        entity = Entity.entity(obj == null ? "null" : obj, contentType);
       } else {
-        entity = Entity.entity(obj == null ? Entity.text("") : obj, contentType);
+        entity = Entity.entity(obj == null ? "" : obj, contentType);
       }
     }
     return entity;

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/ApiClient.java
@@ -870,9 +870,9 @@ public class ApiClient {
     } else {
       // We let jersey handle the serialization
       if (isBodyNullable) { // payload is nullable
-        entity = Entity.entity(obj == null ? Entity.text("null") : obj, contentType);
+        entity = Entity.entity(obj == null ? "null" : obj, contentType);
       } else {
-        entity = Entity.entity(obj == null ? Entity.text("") : obj, contentType);
+        entity = Entity.entity(obj == null ? "" : obj, contentType);
       }
     }
     return entity;


### PR DESCRIPTION
Fix null payload
- when body (non-nullable) is null, send empty string
- when body is nullable and null, send "null"
- tested locally with tcpdump to verify the HTTP request

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/config/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

cc @bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04) @lwlee2608 (2019/10) @bkabrda (2020/01)


