### PR TITLE
Fixes #6942: Added ability to prepend a basePath to typescript-redux-query generators

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-redux-query/apis.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-redux-query/apis.mustache
@@ -157,7 +157,7 @@ function {{nickname}}Raw<T>({{#allParams.0}}requestParameters: {{operationIdCame
     {{/isListContainer}}
     {{/formParams}}
     const config: QueryConfig<T> = {
-        url: `{{{path}}}`{{#pathParams}}.replace(`{${"{{baseName}}"}}`, encodeURIComponent(String(requestParameters.{{paramName}}))){{/pathParams}},
+        url: `${runtime.Configuration.basePath}{{{path}}}`{{#pathParams}}.replace(`{${"{{baseName}}"}}`, encodeURIComponent(String(requestParameters.{{paramName}}))){{/pathParams}},
         meta,
         update: requestConfig.update,
         queryKey: requestConfig.queryKey,

--- a/modules/openapi-generator/src/main/resources/typescript-redux-query/runtime.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-redux-query/runtime.mustache
@@ -5,6 +5,12 @@ import { Meta, OptimisticUpdate, QueryKey, QueryOptions, Rollback, TransformStra
 
 export const BASE_PATH = "{{{basePath}}}".replace(/\/+$/, "");
 
+export const Configuration = {
+    basePath: '', // This is the value that will be prepended to all endpoints.  For compatibility with
+                  // previous versions, the default is an empty string.  Other generators typically use
+                  // BASE_PATH as the default.
+};
+
 export interface TypedQueryConfig<TState, TBody> {
     force?: boolean;
     meta?: Meta;

--- a/samples/client/petstore/typescript-redux-query/builds/with-npm-version/src/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-redux-query/builds/with-npm-version/src/apis/PetApi.ts
@@ -82,7 +82,7 @@ function addPetRaw<T>(requestParameters: AddPetRequest, requestConfig: runtime.T
 
     meta.authType = ['oauth', ["write:pets", "read:pets"]];
     const config: QueryConfig<T> = {
-        url: `/pet`,
+        url: `${runtime.Configuration.basePath}/pet`,
         meta,
         update: requestConfig.update,
         queryKey: requestConfig.queryKey,
@@ -132,7 +132,7 @@ function deletePetRaw<T>(requestParameters: DeletePetRequest, requestConfig: run
 
     meta.authType = ['oauth', ["write:pets", "read:pets"]];
     const config: QueryConfig<T> = {
-        url: `/pet/{petId}`.replace(`{${"petId"}}`, encodeURIComponent(String(requestParameters.petId))),
+        url: `${runtime.Configuration.basePath}/pet/{petId}`.replace(`{${"petId"}}`, encodeURIComponent(String(requestParameters.petId))),
         meta,
         update: requestConfig.update,
         queryKey: requestConfig.queryKey,
@@ -185,7 +185,7 @@ function findPetsByStatusRaw<T>(requestParameters: FindPetsByStatusRequest, requ
 
     meta.authType = ['oauth', ["write:pets", "read:pets"]];
     const config: QueryConfig<T> = {
-        url: `/pet/findByStatus`,
+        url: `${runtime.Configuration.basePath}/pet/findByStatus`,
         meta,
         update: requestConfig.update,
         queryKey: requestConfig.queryKey,
@@ -240,7 +240,7 @@ function findPetsByTagsRaw<T>(requestParameters: FindPetsByTagsRequest, requestC
 
     meta.authType = ['oauth', ["write:pets", "read:pets"]];
     const config: QueryConfig<T> = {
-        url: `/pet/findByTags`,
+        url: `${runtime.Configuration.basePath}/pet/findByTags`,
         meta,
         update: requestConfig.update,
         queryKey: requestConfig.queryKey,
@@ -289,7 +289,7 @@ function getPetByIdRaw<T>(requestParameters: GetPetByIdRequest, requestConfig: r
 
     meta.authType = ['api_key', 'header'];
     const config: QueryConfig<T> = {
-        url: `/pet/{petId}`.replace(`{${"petId"}}`, encodeURIComponent(String(requestParameters.petId))),
+        url: `${runtime.Configuration.basePath}/pet/{petId}`.replace(`{${"petId"}}`, encodeURIComponent(String(requestParameters.petId))),
         meta,
         update: requestConfig.update,
         queryKey: requestConfig.queryKey,
@@ -339,7 +339,7 @@ function updatePetRaw<T>(requestParameters: UpdatePetRequest, requestConfig: run
 
     meta.authType = ['oauth', ["write:pets", "read:pets"]];
     const config: QueryConfig<T> = {
-        url: `/pet`,
+        url: `${runtime.Configuration.basePath}/pet`,
         meta,
         update: requestConfig.update,
         queryKey: requestConfig.queryKey,
@@ -394,7 +394,7 @@ function updatePetWithFormRaw<T>(requestParameters: UpdatePetWithFormRequest, re
     }
 
     const config: QueryConfig<T> = {
-        url: `/pet/{petId}`.replace(`{${"petId"}}`, encodeURIComponent(String(requestParameters.petId))),
+        url: `${runtime.Configuration.basePath}/pet/{petId}`.replace(`{${"petId"}}`, encodeURIComponent(String(requestParameters.petId))),
         meta,
         update: requestConfig.update,
         queryKey: requestConfig.queryKey,
@@ -449,7 +449,7 @@ function uploadFileRaw<T>(requestParameters: UploadFileRequest, requestConfig: r
     }
 
     const config: QueryConfig<T> = {
-        url: `/pet/{petId}/uploadImage`.replace(`{${"petId"}}`, encodeURIComponent(String(requestParameters.petId))),
+        url: `${runtime.Configuration.basePath}/pet/{petId}/uploadImage`.replace(`{${"petId"}}`, encodeURIComponent(String(requestParameters.petId))),
         meta,
         update: requestConfig.update,
         queryKey: requestConfig.queryKey,

--- a/samples/client/petstore/typescript-redux-query/builds/with-npm-version/src/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript-redux-query/builds/with-npm-version/src/apis/StoreApi.ts
@@ -52,7 +52,7 @@ function deleteOrderRaw<T>(requestParameters: DeleteOrderRequest, requestConfig:
     const { meta = {} } = requestConfig;
 
     const config: QueryConfig<T> = {
-        url: `/store/order/{orderId}`.replace(`{${"orderId"}}`, encodeURIComponent(String(requestParameters.orderId))),
+        url: `${runtime.Configuration.basePath}/store/order/{orderId}`.replace(`{${"orderId"}}`, encodeURIComponent(String(requestParameters.orderId))),
         meta,
         update: requestConfig.update,
         queryKey: requestConfig.queryKey,
@@ -96,7 +96,7 @@ function getInventoryRaw<T>( requestConfig: runtime.TypedQueryConfig<T, { [key: 
 
     meta.authType = ['api_key', 'header'];
     const config: QueryConfig<T> = {
-        url: `/store/inventory`,
+        url: `${runtime.Configuration.basePath}/store/inventory`,
         meta,
         update: requestConfig.update,
         queryKey: requestConfig.queryKey,
@@ -143,7 +143,7 @@ function getOrderByIdRaw<T>(requestParameters: GetOrderByIdRequest, requestConfi
     const { meta = {} } = requestConfig;
 
     const config: QueryConfig<T> = {
-        url: `/store/order/{orderId}`.replace(`{${"orderId"}}`, encodeURIComponent(String(requestParameters.orderId))),
+        url: `${runtime.Configuration.basePath}/store/order/{orderId}`.replace(`{${"orderId"}}`, encodeURIComponent(String(requestParameters.orderId))),
         meta,
         update: requestConfig.update,
         queryKey: requestConfig.queryKey,
@@ -192,7 +192,7 @@ function placeOrderRaw<T>(requestParameters: PlaceOrderRequest, requestConfig: r
     const { meta = {} } = requestConfig;
 
     const config: QueryConfig<T> = {
-        url: `/store/order`,
+        url: `${runtime.Configuration.basePath}/store/order`,
         meta,
         update: requestConfig.update,
         queryKey: requestConfig.queryKey,

--- a/samples/client/petstore/typescript-redux-query/builds/with-npm-version/src/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-redux-query/builds/with-npm-version/src/apis/UserApi.ts
@@ -72,7 +72,7 @@ function createUserRaw<T>(requestParameters: CreateUserRequest, requestConfig: r
     const { meta = {} } = requestConfig;
 
     const config: QueryConfig<T> = {
-        url: `/user`,
+        url: `${runtime.Configuration.basePath}/user`,
         meta,
         update: requestConfig.update,
         queryKey: requestConfig.queryKey,
@@ -120,7 +120,7 @@ function createUsersWithArrayInputRaw<T>(requestParameters: CreateUsersWithArray
     const { meta = {} } = requestConfig;
 
     const config: QueryConfig<T> = {
-        url: `/user/createWithArray`,
+        url: `${runtime.Configuration.basePath}/user/createWithArray`,
         meta,
         update: requestConfig.update,
         queryKey: requestConfig.queryKey,
@@ -167,7 +167,7 @@ function createUsersWithListInputRaw<T>(requestParameters: CreateUsersWithListIn
     const { meta = {} } = requestConfig;
 
     const config: QueryConfig<T> = {
-        url: `/user/createWithList`,
+        url: `${runtime.Configuration.basePath}/user/createWithList`,
         meta,
         update: requestConfig.update,
         queryKey: requestConfig.queryKey,
@@ -213,7 +213,7 @@ function deleteUserRaw<T>(requestParameters: DeleteUserRequest, requestConfig: r
     const { meta = {} } = requestConfig;
 
     const config: QueryConfig<T> = {
-        url: `/user/{username}`.replace(`{${"username"}}`, encodeURIComponent(String(requestParameters.username))),
+        url: `${runtime.Configuration.basePath}/user/{username}`.replace(`{${"username"}}`, encodeURIComponent(String(requestParameters.username))),
         meta,
         update: requestConfig.update,
         queryKey: requestConfig.queryKey,
@@ -259,7 +259,7 @@ function getUserByNameRaw<T>(requestParameters: GetUserByNameRequest, requestCon
     const { meta = {} } = requestConfig;
 
     const config: QueryConfig<T> = {
-        url: `/user/{username}`.replace(`{${"username"}}`, encodeURIComponent(String(requestParameters.username))),
+        url: `${runtime.Configuration.basePath}/user/{username}`.replace(`{${"username"}}`, encodeURIComponent(String(requestParameters.username))),
         meta,
         update: requestConfig.update,
         queryKey: requestConfig.queryKey,
@@ -320,7 +320,7 @@ function loginUserRaw<T>(requestParameters: LoginUserRequest, requestConfig: run
     const { meta = {} } = requestConfig;
 
     const config: QueryConfig<T> = {
-        url: `/user/login`,
+        url: `${runtime.Configuration.basePath}/user/login`,
         meta,
         update: requestConfig.update,
         queryKey: requestConfig.queryKey,
@@ -362,7 +362,7 @@ function logoutUserRaw<T>( requestConfig: runtime.TypedQueryConfig<T, void> = {}
     const { meta = {} } = requestConfig;
 
     const config: QueryConfig<T> = {
-        url: `/user/logout`,
+        url: `${runtime.Configuration.basePath}/user/logout`,
         meta,
         update: requestConfig.update,
         queryKey: requestConfig.queryKey,
@@ -414,7 +414,7 @@ function updateUserRaw<T>(requestParameters: UpdateUserRequest, requestConfig: r
     const { meta = {} } = requestConfig;
 
     const config: QueryConfig<T> = {
-        url: `/user/{username}`.replace(`{${"username"}}`, encodeURIComponent(String(requestParameters.username))),
+        url: `${runtime.Configuration.basePath}/user/{username}`.replace(`{${"username"}}`, encodeURIComponent(String(requestParameters.username))),
         meta,
         update: requestConfig.update,
         queryKey: requestConfig.queryKey,

--- a/samples/client/petstore/typescript-redux-query/builds/with-npm-version/src/runtime.ts
+++ b/samples/client/petstore/typescript-redux-query/builds/with-npm-version/src/runtime.ts
@@ -16,6 +16,12 @@ import { Meta, OptimisticUpdate, QueryKey, QueryOptions, Rollback, TransformStra
 
 export const BASE_PATH = "http://petstore.swagger.io/v2".replace(/\/+$/, "");
 
+export const Configuration = {
+    basePath: '', // This is the value that will be prepended to all endpoints.  For compatibility with
+                  // previous versions, the default is an empty string.  Other generators typically use
+                  // BASE_PATH as the default.
+};
+
 export interface TypedQueryConfig<TState, TBody> {
     force?: boolean;
     meta?: Meta;


### PR DESCRIPTION
Added a new Configuration object that has attributes that can be used to alter the behaviour of the query config generators.  In particular, added a basePath field which can be used to prepend to the urls in the query configs.  The old behaviour only used relative paths for the urls which means cross domain support was not possible.

Left the default basePath as an empty string to keep existing behaviour the same.

