### PR TITLE
[Go] fix unmarshal for models with parents

### DIFF
--- a/bin/configs/go-experimental-go-petstore.yaml
+++ b/bin/configs/go-experimental-go-petstore.yaml
@@ -5,3 +5,4 @@ templateDir: modules/openapi-generator/src/main/resources/go-experimental
 additionalProperties:
   enumClassPrefix: "true"
   packageName: petstore
+  disallowAdditionalPropertiesIfNotPresent: false

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/GoClientExperimentalCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/GoClientExperimentalCodegen.java
@@ -242,6 +242,13 @@ public class GoClientExperimentalCodegen extends GoClientCodegen {
                 if (model.anyOf != null && !model.anyOf.isEmpty()) {
                     imports.add(createMapping("import", "fmt"));
                 }
+
+                // additionalProperties: true and parent
+                if (model.isAdditionalPropertiesTrue && model.parent != null && Boolean.FALSE.equals(model.isMapModel)) {
+                    imports.add(createMapping("import", "reflect"));
+                    imports.add(createMapping("import", "strings"));
+                }
+
             }
         }
         return objs;

--- a/modules/openapi-generator/src/main/resources/go-experimental/model_simple.mustache
+++ b/modules/openapi-generator/src/main/resources/go-experimental/model_simple.mustache
@@ -319,7 +319,7 @@ func (o *{{{classname}}}) UnmarshalJSON(bytes []byte) (err error) {
 				} else {
 					fieldName = jsonTag
 				}
-				if fieldName != "AdditoinalProperties" {
+				if fieldName != "AdditionalProperties" {
 					delete(additionalProperties, fieldName)
 				}
 			}

--- a/modules/openapi-generator/src/main/resources/go-experimental/model_simple.mustache
+++ b/modules/openapi-generator/src/main/resources/go-experimental/model_simple.mustache
@@ -265,6 +265,52 @@ func (o {{classname}}) MarshalJSON() ([]byte, error) {
 
 {{#isAdditionalPropertiesTrue}}
 func (o *{{{classname}}}) UnmarshalJSON(bytes []byte) (err error) {
+{{#parent}}
+{{^isMapModel}}
+	type {{classname}}WithoutEmbeddedStruct struct {
+	{{#vars}}
+	{{^-first}}
+	{{/-first}}
+	{{#description}}
+		// {{{description}}}
+	{{/description}}
+		{{name}} {{^required}}{{^isNullable}}*{{/isNullable}}{{/required}}{{{dataType}}} `json:"{{baseName}}{{^required}},omitempty{{/required}}"{{#withXml}} xml:"{{baseName}}{{#isXmlAttribute}},attr{{/isXmlAttribute}}"{{/withXml}}{{#vendorExtensions.x-go-custom-tag}} {{{.}}}{{/vendorExtensions.x-go-custom-tag}}`
+	{{/vars}}
+	}
+
+	var{{{classname}}}WithoutEmbeddedStruct := {{{classname}}}WithoutEmbeddedStruct{}
+
+	err = json.Unmarshal(bytes, &var{{{classname}}}WithoutEmbeddedStruct)
+	if err == nil {
+		var{{{classname}}} := _{{{classname}}}{}
+		{{#vars}}
+		var{{{classname}}}.{{{name}}} = var{{{classname}}}WithoutEmbeddedStruct.{{{name}}}
+		{{/vars}}
+		*o = {{{classname}}}(var{{{classname}}})
+	} else {
+		return err
+	}
+
+	var{{{classname}}} := _{{{classname}}}{}
+
+	err = json.Unmarshal(bytes, &var{{{classname}}})
+	if err == nil {
+		o.{{{parent}}} = var{{{classname}}}.{{{parent}}}
+	} else {
+		return err
+	}
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		{{#vars}}
+		delete(additionalProperties, "{{{baseName}}}")
+		{{/vars}}
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
+{{/isMapModel}}
+{{#isMapModel}}
 	var{{{classname}}} := _{{{classname}}}{}
 
 	if err = json.Unmarshal(bytes, &var{{{classname}}}); err == nil {
@@ -281,6 +327,26 @@ func (o *{{{classname}}}) UnmarshalJSON(bytes []byte) (err error) {
 	}
 
 	return err
+{{/isMapModel}}
+{{/parent}}
+{{^parent}}
+	var{{{classname}}} := _{{{classname}}}{}
+
+	if err = json.Unmarshal(bytes, &var{{{classname}}}); err == nil {
+		*o = {{{classname}}}(var{{{classname}}})
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		{{#vars}}
+		delete(additionalProperties, "{{{baseName}}}")
+		{{/vars}}
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
+{{/parent}}
 }
 
 {{/isAdditionalPropertiesTrue}}

--- a/modules/openapi-generator/src/main/resources/go-experimental/model_simple.mustache
+++ b/modules/openapi-generator/src/main/resources/go-experimental/model_simple.mustache
@@ -299,12 +299,32 @@ func (o *{{{classname}}}) UnmarshalJSON(bytes []byte) (err error) {
 	} else {
 		return err
 	}
+
 	additionalProperties := make(map[string]interface{})
 
 	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
 		{{#vars}}
 		delete(additionalProperties, "{{{baseName}}}")
 		{{/vars}}
+
+		// remove fields from embedded structs
+		reflect{{{parent}}} := reflect.ValueOf(o.{{{parent}}})
+		for i := 0; i < reflect{{{parent}}}.Type().NumField(); i++ {
+			t := reflect{{{parent}}}.Type().Field(i)
+
+			if jsonTag := t.Tag.Get("json"); jsonTag != "" {
+				fieldName := ""
+				if commaIdx := strings.Index(jsonTag, ","); commaIdx > 0 {
+					fieldName = jsonTag[:commaIdx]
+				} else {
+					fieldName = jsonTag
+				}
+				if fieldName != "AdditoinalProperties" {
+					delete(additionalProperties, fieldName)
+				}
+			}
+		}
+
 		o.AdditionalProperties = additionalProperties
 	}
 

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_200_response.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_200_response.go
@@ -17,7 +17,10 @@ import (
 type Model200Response struct {
 	Name *int32 `json:"name,omitempty"`
 	Class *string `json:"class,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _Model200Response Model200Response
 
 // NewModel200Response instantiates a new Model200Response object
 // This constructor will assign default values to properties that have it defined,
@@ -108,7 +111,30 @@ func (o Model200Response) MarshalJSON() ([]byte, error) {
 	if o.Class != nil {
 		toSerialize["class"] = o.Class
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return json.Marshal(toSerialize)
+}
+
+func (o *Model200Response) UnmarshalJSON(bytes []byte) (err error) {
+	varModel200Response := _Model200Response{}
+
+	if err = json.Unmarshal(bytes, &varModel200Response); err == nil {
+		*o = Model200Response(varModel200Response)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "name")
+		delete(additionalProperties, "class")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableModel200Response struct {

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model__special_model_name_.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model__special_model_name_.go
@@ -16,7 +16,10 @@ import (
 // SpecialModelName struct for SpecialModelName
 type SpecialModelName struct {
 	SpecialPropertyName *int64 `json:"$special[property.name],omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _SpecialModelName SpecialModelName
 
 // NewSpecialModelName instantiates a new SpecialModelName object
 // This constructor will assign default values to properties that have it defined,
@@ -72,7 +75,29 @@ func (o SpecialModelName) MarshalJSON() ([]byte, error) {
 	if o.SpecialPropertyName != nil {
 		toSerialize["$special[property.name]"] = o.SpecialPropertyName
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return json.Marshal(toSerialize)
+}
+
+func (o *SpecialModelName) UnmarshalJSON(bytes []byte) (err error) {
+	varSpecialModelName := _SpecialModelName{}
+
+	if err = json.Unmarshal(bytes, &varSpecialModelName); err == nil {
+		*o = SpecialModelName(varSpecialModelName)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "$special[property.name]")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableSpecialModelName struct {

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_additional_properties_class.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_additional_properties_class.go
@@ -17,7 +17,10 @@ import (
 type AdditionalPropertiesClass struct {
 	MapProperty *map[string]string `json:"map_property,omitempty"`
 	MapOfMapProperty *map[string]map[string]string `json:"map_of_map_property,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _AdditionalPropertiesClass AdditionalPropertiesClass
 
 // NewAdditionalPropertiesClass instantiates a new AdditionalPropertiesClass object
 // This constructor will assign default values to properties that have it defined,
@@ -108,7 +111,30 @@ func (o AdditionalPropertiesClass) MarshalJSON() ([]byte, error) {
 	if o.MapOfMapProperty != nil {
 		toSerialize["map_of_map_property"] = o.MapOfMapProperty
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return json.Marshal(toSerialize)
+}
+
+func (o *AdditionalPropertiesClass) UnmarshalJSON(bytes []byte) (err error) {
+	varAdditionalPropertiesClass := _AdditionalPropertiesClass{}
+
+	if err = json.Unmarshal(bytes, &varAdditionalPropertiesClass); err == nil {
+		*o = AdditionalPropertiesClass(varAdditionalPropertiesClass)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "map_property")
+		delete(additionalProperties, "map_of_map_property")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableAdditionalPropertiesClass struct {

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_animal.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_animal.go
@@ -17,7 +17,10 @@ import (
 type Animal struct {
 	ClassName string `json:"className"`
 	Color *string `json:"color,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _Animal Animal
 
 // NewAnimal instantiates a new Animal object
 // This constructor will assign default values to properties that have it defined,
@@ -105,7 +108,30 @@ func (o Animal) MarshalJSON() ([]byte, error) {
 	if o.Color != nil {
 		toSerialize["color"] = o.Color
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return json.Marshal(toSerialize)
+}
+
+func (o *Animal) UnmarshalJSON(bytes []byte) (err error) {
+	varAnimal := _Animal{}
+
+	if err = json.Unmarshal(bytes, &varAnimal); err == nil {
+		*o = Animal(varAnimal)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "className")
+		delete(additionalProperties, "color")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableAnimal struct {

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_api_response.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_api_response.go
@@ -18,7 +18,10 @@ type ApiResponse struct {
 	Code *int32 `json:"code,omitempty"`
 	Type *string `json:"type,omitempty"`
 	Message *string `json:"message,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _ApiResponse ApiResponse
 
 // NewApiResponse instantiates a new ApiResponse object
 // This constructor will assign default values to properties that have it defined,
@@ -144,7 +147,31 @@ func (o ApiResponse) MarshalJSON() ([]byte, error) {
 	if o.Message != nil {
 		toSerialize["message"] = o.Message
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return json.Marshal(toSerialize)
+}
+
+func (o *ApiResponse) UnmarshalJSON(bytes []byte) (err error) {
+	varApiResponse := _ApiResponse{}
+
+	if err = json.Unmarshal(bytes, &varApiResponse); err == nil {
+		*o = ApiResponse(varApiResponse)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "code")
+		delete(additionalProperties, "type")
+		delete(additionalProperties, "message")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableApiResponse struct {

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_apple.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_apple.go
@@ -16,7 +16,10 @@ import (
 // Apple struct for Apple
 type Apple struct {
 	Cultivar *string `json:"cultivar,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _Apple Apple
 
 // NewApple instantiates a new Apple object
 // This constructor will assign default values to properties that have it defined,
@@ -72,7 +75,29 @@ func (o Apple) MarshalJSON() ([]byte, error) {
 	if o.Cultivar != nil {
 		toSerialize["cultivar"] = o.Cultivar
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return json.Marshal(toSerialize)
+}
+
+func (o *Apple) UnmarshalJSON(bytes []byte) (err error) {
+	varApple := _Apple{}
+
+	if err = json.Unmarshal(bytes, &varApple); err == nil {
+		*o = Apple(varApple)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "cultivar")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableApple struct {

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_apple_req.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_apple_req.go
@@ -17,7 +17,10 @@ import (
 type AppleReq struct {
 	Cultivar string `json:"cultivar"`
 	Mealy *bool `json:"mealy,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _AppleReq AppleReq
 
 // NewAppleReq instantiates a new AppleReq object
 // This constructor will assign default values to properties that have it defined,
@@ -101,7 +104,30 @@ func (o AppleReq) MarshalJSON() ([]byte, error) {
 	if o.Mealy != nil {
 		toSerialize["mealy"] = o.Mealy
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return json.Marshal(toSerialize)
+}
+
+func (o *AppleReq) UnmarshalJSON(bytes []byte) (err error) {
+	varAppleReq := _AppleReq{}
+
+	if err = json.Unmarshal(bytes, &varAppleReq); err == nil {
+		*o = AppleReq(varAppleReq)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "cultivar")
+		delete(additionalProperties, "mealy")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableAppleReq struct {

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_array_of_array_of_number_only.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_array_of_array_of_number_only.go
@@ -16,7 +16,10 @@ import (
 // ArrayOfArrayOfNumberOnly struct for ArrayOfArrayOfNumberOnly
 type ArrayOfArrayOfNumberOnly struct {
 	ArrayArrayNumber *[][]float32 `json:"ArrayArrayNumber,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _ArrayOfArrayOfNumberOnly ArrayOfArrayOfNumberOnly
 
 // NewArrayOfArrayOfNumberOnly instantiates a new ArrayOfArrayOfNumberOnly object
 // This constructor will assign default values to properties that have it defined,
@@ -72,7 +75,29 @@ func (o ArrayOfArrayOfNumberOnly) MarshalJSON() ([]byte, error) {
 	if o.ArrayArrayNumber != nil {
 		toSerialize["ArrayArrayNumber"] = o.ArrayArrayNumber
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return json.Marshal(toSerialize)
+}
+
+func (o *ArrayOfArrayOfNumberOnly) UnmarshalJSON(bytes []byte) (err error) {
+	varArrayOfArrayOfNumberOnly := _ArrayOfArrayOfNumberOnly{}
+
+	if err = json.Unmarshal(bytes, &varArrayOfArrayOfNumberOnly); err == nil {
+		*o = ArrayOfArrayOfNumberOnly(varArrayOfArrayOfNumberOnly)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "ArrayArrayNumber")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableArrayOfArrayOfNumberOnly struct {

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_array_of_number_only.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_array_of_number_only.go
@@ -16,7 +16,10 @@ import (
 // ArrayOfNumberOnly struct for ArrayOfNumberOnly
 type ArrayOfNumberOnly struct {
 	ArrayNumber *[]float32 `json:"ArrayNumber,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _ArrayOfNumberOnly ArrayOfNumberOnly
 
 // NewArrayOfNumberOnly instantiates a new ArrayOfNumberOnly object
 // This constructor will assign default values to properties that have it defined,
@@ -72,7 +75,29 @@ func (o ArrayOfNumberOnly) MarshalJSON() ([]byte, error) {
 	if o.ArrayNumber != nil {
 		toSerialize["ArrayNumber"] = o.ArrayNumber
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return json.Marshal(toSerialize)
+}
+
+func (o *ArrayOfNumberOnly) UnmarshalJSON(bytes []byte) (err error) {
+	varArrayOfNumberOnly := _ArrayOfNumberOnly{}
+
+	if err = json.Unmarshal(bytes, &varArrayOfNumberOnly); err == nil {
+		*o = ArrayOfNumberOnly(varArrayOfNumberOnly)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "ArrayNumber")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableArrayOfNumberOnly struct {

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_array_test_.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_array_test_.go
@@ -18,7 +18,10 @@ type ArrayTest struct {
 	ArrayOfString *[]string `json:"array_of_string,omitempty"`
 	ArrayArrayOfInteger *[][]int64 `json:"array_array_of_integer,omitempty"`
 	ArrayArrayOfModel *[][]ReadOnlyFirst `json:"array_array_of_model,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _ArrayTest ArrayTest
 
 // NewArrayTest instantiates a new ArrayTest object
 // This constructor will assign default values to properties that have it defined,
@@ -144,7 +147,31 @@ func (o ArrayTest) MarshalJSON() ([]byte, error) {
 	if o.ArrayArrayOfModel != nil {
 		toSerialize["array_array_of_model"] = o.ArrayArrayOfModel
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return json.Marshal(toSerialize)
+}
+
+func (o *ArrayTest) UnmarshalJSON(bytes []byte) (err error) {
+	varArrayTest := _ArrayTest{}
+
+	if err = json.Unmarshal(bytes, &varArrayTest); err == nil {
+		*o = ArrayTest(varArrayTest)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "array_of_string")
+		delete(additionalProperties, "array_array_of_integer")
+		delete(additionalProperties, "array_array_of_model")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableArrayTest struct {

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_banana_req.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_banana_req.go
@@ -17,7 +17,10 @@ import (
 type BananaReq struct {
 	LengthCm float32 `json:"lengthCm"`
 	Sweet *bool `json:"sweet,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _BananaReq BananaReq
 
 // NewBananaReq instantiates a new BananaReq object
 // This constructor will assign default values to properties that have it defined,
@@ -101,7 +104,30 @@ func (o BananaReq) MarshalJSON() ([]byte, error) {
 	if o.Sweet != nil {
 		toSerialize["sweet"] = o.Sweet
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return json.Marshal(toSerialize)
+}
+
+func (o *BananaReq) UnmarshalJSON(bytes []byte) (err error) {
+	varBananaReq := _BananaReq{}
+
+	if err = json.Unmarshal(bytes, &varBananaReq); err == nil {
+		*o = BananaReq(varBananaReq)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "lengthCm")
+		delete(additionalProperties, "sweet")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableBananaReq struct {

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_capitalization.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_capitalization.go
@@ -22,7 +22,10 @@ type Capitalization struct {
 	SCAETHFlowPoints *string `json:"SCA_ETH_Flow_Points,omitempty"`
 	// Name of the pet 
 	ATT_NAME *string `json:"ATT_NAME,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _Capitalization Capitalization
 
 // NewCapitalization instantiates a new Capitalization object
 // This constructor will assign default values to properties that have it defined,
@@ -253,7 +256,34 @@ func (o Capitalization) MarshalJSON() ([]byte, error) {
 	if o.ATT_NAME != nil {
 		toSerialize["ATT_NAME"] = o.ATT_NAME
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return json.Marshal(toSerialize)
+}
+
+func (o *Capitalization) UnmarshalJSON(bytes []byte) (err error) {
+	varCapitalization := _Capitalization{}
+
+	if err = json.Unmarshal(bytes, &varCapitalization); err == nil {
+		*o = Capitalization(varCapitalization)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "smallCamel")
+		delete(additionalProperties, "CapitalCamel")
+		delete(additionalProperties, "small_Snake")
+		delete(additionalProperties, "Capital_Snake")
+		delete(additionalProperties, "SCA_ETH_Flow_Points")
+		delete(additionalProperties, "ATT_NAME")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableCapitalization struct {

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_cat.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_cat.go
@@ -17,7 +17,10 @@ import (
 type Cat struct {
 	Animal
 	Declawed *bool `json:"declawed,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _Cat Cat
 
 // NewCat instantiates a new Cat object
 // This constructor will assign default values to properties that have it defined,
@@ -81,7 +84,29 @@ func (o Cat) MarshalJSON() ([]byte, error) {
 	if o.Declawed != nil {
 		toSerialize["declawed"] = o.Declawed
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return json.Marshal(toSerialize)
+}
+
+func (o *Cat) UnmarshalJSON(bytes []byte) (err error) {
+	varCat := _Cat{}
+
+	if err = json.Unmarshal(bytes, &varCat); err == nil {
+		*o = Cat(varCat)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "declawed")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableCat struct {

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_cat.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_cat.go
@@ -93,12 +93,29 @@ func (o Cat) MarshalJSON() ([]byte, error) {
 }
 
 func (o *Cat) UnmarshalJSON(bytes []byte) (err error) {
-	varCat := _Cat{}
-
-	if err = json.Unmarshal(bytes, &varCat); err == nil {
-		*o = Cat(varCat)
+	type CatWithoutEmbeddedStruct struct {
+		Declawed *bool `json:"declawed,omitempty"`
 	}
 
+	varCatWithoutEmbeddedStruct := CatWithoutEmbeddedStruct{}
+
+	err = json.Unmarshal(bytes, &varCatWithoutEmbeddedStruct)
+	if err == nil {
+		varCat := _Cat{}
+		varCat.Declawed = varCatWithoutEmbeddedStruct.Declawed
+		*o = Cat(varCat)
+	} else {
+		return err
+	}
+
+	varCat := _Cat{}
+
+	err = json.Unmarshal(bytes, &varCat)
+	if err == nil {
+		o.Animal = varCat.Animal
+	} else {
+		return err
+	}
 	additionalProperties := make(map[string]interface{})
 
 	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_cat.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_cat.go
@@ -136,7 +136,7 @@ func (o *Cat) UnmarshalJSON(bytes []byte) (err error) {
 				} else {
 					fieldName = jsonTag
 				}
-				if fieldName != "AdditoinalProperties" {
+				if fieldName != "AdditionalProperties" {
 					delete(additionalProperties, fieldName)
 				}
 			}

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_cat_all_of.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_cat_all_of.go
@@ -16,7 +16,10 @@ import (
 // CatAllOf struct for CatAllOf
 type CatAllOf struct {
 	Declawed *bool `json:"declawed,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _CatAllOf CatAllOf
 
 // NewCatAllOf instantiates a new CatAllOf object
 // This constructor will assign default values to properties that have it defined,
@@ -72,7 +75,29 @@ func (o CatAllOf) MarshalJSON() ([]byte, error) {
 	if o.Declawed != nil {
 		toSerialize["declawed"] = o.Declawed
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return json.Marshal(toSerialize)
+}
+
+func (o *CatAllOf) UnmarshalJSON(bytes []byte) (err error) {
+	varCatAllOf := _CatAllOf{}
+
+	if err = json.Unmarshal(bytes, &varCatAllOf); err == nil {
+		*o = CatAllOf(varCatAllOf)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "declawed")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableCatAllOf struct {

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_category.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_category.go
@@ -17,7 +17,10 @@ import (
 type Category struct {
 	Id *int64 `json:"id,omitempty"`
 	Name string `json:"name"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _Category Category
 
 // NewCategory instantiates a new Category object
 // This constructor will assign default values to properties that have it defined,
@@ -103,7 +106,30 @@ func (o Category) MarshalJSON() ([]byte, error) {
 	if true {
 		toSerialize["name"] = o.Name
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return json.Marshal(toSerialize)
+}
+
+func (o *Category) UnmarshalJSON(bytes []byte) (err error) {
+	varCategory := _Category{}
+
+	if err = json.Unmarshal(bytes, &varCategory); err == nil {
+		*o = Category(varCategory)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "name")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableCategory struct {

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_class_model.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_class_model.go
@@ -16,7 +16,10 @@ import (
 // ClassModel Model for testing model with \"_class\" property
 type ClassModel struct {
 	Class *string `json:"_class,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _ClassModel ClassModel
 
 // NewClassModel instantiates a new ClassModel object
 // This constructor will assign default values to properties that have it defined,
@@ -72,7 +75,29 @@ func (o ClassModel) MarshalJSON() ([]byte, error) {
 	if o.Class != nil {
 		toSerialize["_class"] = o.Class
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return json.Marshal(toSerialize)
+}
+
+func (o *ClassModel) UnmarshalJSON(bytes []byte) (err error) {
+	varClassModel := _ClassModel{}
+
+	if err = json.Unmarshal(bytes, &varClassModel); err == nil {
+		*o = ClassModel(varClassModel)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "_class")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableClassModel struct {

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_client.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_client.go
@@ -16,7 +16,10 @@ import (
 // Client struct for Client
 type Client struct {
 	Client *string `json:"client,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _Client Client
 
 // NewClient instantiates a new Client object
 // This constructor will assign default values to properties that have it defined,
@@ -72,7 +75,29 @@ func (o Client) MarshalJSON() ([]byte, error) {
 	if o.Client != nil {
 		toSerialize["client"] = o.Client
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return json.Marshal(toSerialize)
+}
+
+func (o *Client) UnmarshalJSON(bytes []byte) (err error) {
+	varClient := _Client{}
+
+	if err = json.Unmarshal(bytes, &varClient); err == nil {
+		*o = Client(varClient)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "client")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableClient struct {

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_dog.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_dog.go
@@ -17,7 +17,10 @@ import (
 type Dog struct {
 	Animal
 	Breed *string `json:"breed,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _Dog Dog
 
 // NewDog instantiates a new Dog object
 // This constructor will assign default values to properties that have it defined,
@@ -81,7 +84,29 @@ func (o Dog) MarshalJSON() ([]byte, error) {
 	if o.Breed != nil {
 		toSerialize["breed"] = o.Breed
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return json.Marshal(toSerialize)
+}
+
+func (o *Dog) UnmarshalJSON(bytes []byte) (err error) {
+	varDog := _Dog{}
+
+	if err = json.Unmarshal(bytes, &varDog); err == nil {
+		*o = Dog(varDog)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "breed")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableDog struct {

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_dog.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_dog.go
@@ -11,6 +11,8 @@ package petstore
 
 import (
 	"encoding/json"
+	"reflect"
+	"strings"
 )
 
 // Dog struct for Dog
@@ -116,10 +118,30 @@ func (o *Dog) UnmarshalJSON(bytes []byte) (err error) {
 	} else {
 		return err
 	}
+
 	additionalProperties := make(map[string]interface{})
 
 	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
 		delete(additionalProperties, "breed")
+
+		// remove fields from embedded structs
+		reflectAnimal := reflect.ValueOf(o.Animal)
+		for i := 0; i < reflectAnimal.Type().NumField(); i++ {
+			t := reflectAnimal.Type().Field(i)
+
+			if jsonTag := t.Tag.Get("json"); jsonTag != "" {
+				fieldName := ""
+				if commaIdx := strings.Index(jsonTag, ","); commaIdx > 0 {
+					fieldName = jsonTag[:commaIdx]
+				} else {
+					fieldName = jsonTag
+				}
+				if fieldName != "AdditoinalProperties" {
+					delete(additionalProperties, fieldName)
+				}
+			}
+		}
+
 		o.AdditionalProperties = additionalProperties
 	}
 

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_dog.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_dog.go
@@ -93,12 +93,29 @@ func (o Dog) MarshalJSON() ([]byte, error) {
 }
 
 func (o *Dog) UnmarshalJSON(bytes []byte) (err error) {
-	varDog := _Dog{}
-
-	if err = json.Unmarshal(bytes, &varDog); err == nil {
-		*o = Dog(varDog)
+	type DogWithoutEmbeddedStruct struct {
+		Breed *string `json:"breed,omitempty"`
 	}
 
+	varDogWithoutEmbeddedStruct := DogWithoutEmbeddedStruct{}
+
+	err = json.Unmarshal(bytes, &varDogWithoutEmbeddedStruct)
+	if err == nil {
+		varDog := _Dog{}
+		varDog.Breed = varDogWithoutEmbeddedStruct.Breed
+		*o = Dog(varDog)
+	} else {
+		return err
+	}
+
+	varDog := _Dog{}
+
+	err = json.Unmarshal(bytes, &varDog)
+	if err == nil {
+		o.Animal = varDog.Animal
+	} else {
+		return err
+	}
 	additionalProperties := make(map[string]interface{})
 
 	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_dog.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_dog.go
@@ -136,7 +136,7 @@ func (o *Dog) UnmarshalJSON(bytes []byte) (err error) {
 				} else {
 					fieldName = jsonTag
 				}
-				if fieldName != "AdditoinalProperties" {
+				if fieldName != "AdditionalProperties" {
 					delete(additionalProperties, fieldName)
 				}
 			}

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_dog_all_of.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_dog_all_of.go
@@ -16,7 +16,10 @@ import (
 // DogAllOf struct for DogAllOf
 type DogAllOf struct {
 	Breed *string `json:"breed,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _DogAllOf DogAllOf
 
 // NewDogAllOf instantiates a new DogAllOf object
 // This constructor will assign default values to properties that have it defined,
@@ -72,7 +75,29 @@ func (o DogAllOf) MarshalJSON() ([]byte, error) {
 	if o.Breed != nil {
 		toSerialize["breed"] = o.Breed
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return json.Marshal(toSerialize)
+}
+
+func (o *DogAllOf) UnmarshalJSON(bytes []byte) (err error) {
+	varDogAllOf := _DogAllOf{}
+
+	if err = json.Unmarshal(bytes, &varDogAllOf); err == nil {
+		*o = DogAllOf(varDogAllOf)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "breed")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableDogAllOf struct {

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_enum_arrays.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_enum_arrays.go
@@ -17,7 +17,10 @@ import (
 type EnumArrays struct {
 	JustSymbol *string `json:"just_symbol,omitempty"`
 	ArrayEnum *[]string `json:"array_enum,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _EnumArrays EnumArrays
 
 // NewEnumArrays instantiates a new EnumArrays object
 // This constructor will assign default values to properties that have it defined,
@@ -108,7 +111,30 @@ func (o EnumArrays) MarshalJSON() ([]byte, error) {
 	if o.ArrayEnum != nil {
 		toSerialize["array_enum"] = o.ArrayEnum
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return json.Marshal(toSerialize)
+}
+
+func (o *EnumArrays) UnmarshalJSON(bytes []byte) (err error) {
+	varEnumArrays := _EnumArrays{}
+
+	if err = json.Unmarshal(bytes, &varEnumArrays); err == nil {
+		*o = EnumArrays(varEnumArrays)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "just_symbol")
+		delete(additionalProperties, "array_enum")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableEnumArrays struct {

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_enum_test_.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_enum_test_.go
@@ -23,7 +23,10 @@ type EnumTest struct {
 	OuterEnumInteger *OuterEnumInteger `json:"outerEnumInteger,omitempty"`
 	OuterEnumDefaultValue *OuterEnumDefaultValue `json:"outerEnumDefaultValue,omitempty"`
 	OuterEnumIntegerDefaultValue *OuterEnumIntegerDefaultValue `json:"outerEnumIntegerDefaultValue,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _EnumTest EnumTest
 
 // NewEnumTest instantiates a new EnumTest object
 // This constructor will assign default values to properties that have it defined,
@@ -335,7 +338,36 @@ func (o EnumTest) MarshalJSON() ([]byte, error) {
 	if o.OuterEnumIntegerDefaultValue != nil {
 		toSerialize["outerEnumIntegerDefaultValue"] = o.OuterEnumIntegerDefaultValue
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return json.Marshal(toSerialize)
+}
+
+func (o *EnumTest) UnmarshalJSON(bytes []byte) (err error) {
+	varEnumTest := _EnumTest{}
+
+	if err = json.Unmarshal(bytes, &varEnumTest); err == nil {
+		*o = EnumTest(varEnumTest)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "enum_string")
+		delete(additionalProperties, "enum_string_required")
+		delete(additionalProperties, "enum_integer")
+		delete(additionalProperties, "enum_number")
+		delete(additionalProperties, "outerEnum")
+		delete(additionalProperties, "outerEnumInteger")
+		delete(additionalProperties, "outerEnumDefaultValue")
+		delete(additionalProperties, "outerEnumIntegerDefaultValue")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableEnumTest struct {

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_file.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_file.go
@@ -17,7 +17,10 @@ import (
 type File struct {
 	// Test capitalization
 	SourceURI *string `json:"sourceURI,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _File File
 
 // NewFile instantiates a new File object
 // This constructor will assign default values to properties that have it defined,
@@ -73,7 +76,29 @@ func (o File) MarshalJSON() ([]byte, error) {
 	if o.SourceURI != nil {
 		toSerialize["sourceURI"] = o.SourceURI
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return json.Marshal(toSerialize)
+}
+
+func (o *File) UnmarshalJSON(bytes []byte) (err error) {
+	varFile := _File{}
+
+	if err = json.Unmarshal(bytes, &varFile); err == nil {
+		*o = File(varFile)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "sourceURI")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableFile struct {

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_file_schema_test_class.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_file_schema_test_class.go
@@ -17,7 +17,10 @@ import (
 type FileSchemaTestClass struct {
 	File *File `json:"file,omitempty"`
 	Files *[]File `json:"files,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _FileSchemaTestClass FileSchemaTestClass
 
 // NewFileSchemaTestClass instantiates a new FileSchemaTestClass object
 // This constructor will assign default values to properties that have it defined,
@@ -108,7 +111,30 @@ func (o FileSchemaTestClass) MarshalJSON() ([]byte, error) {
 	if o.Files != nil {
 		toSerialize["files"] = o.Files
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return json.Marshal(toSerialize)
+}
+
+func (o *FileSchemaTestClass) UnmarshalJSON(bytes []byte) (err error) {
+	varFileSchemaTestClass := _FileSchemaTestClass{}
+
+	if err = json.Unmarshal(bytes, &varFileSchemaTestClass); err == nil {
+		*o = FileSchemaTestClass(varFileSchemaTestClass)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "file")
+		delete(additionalProperties, "files")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableFileSchemaTestClass struct {

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_foo.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_foo.go
@@ -16,7 +16,10 @@ import (
 // Foo struct for Foo
 type Foo struct {
 	Bar *string `json:"bar,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _Foo Foo
 
 // NewFoo instantiates a new Foo object
 // This constructor will assign default values to properties that have it defined,
@@ -76,7 +79,29 @@ func (o Foo) MarshalJSON() ([]byte, error) {
 	if o.Bar != nil {
 		toSerialize["bar"] = o.Bar
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return json.Marshal(toSerialize)
+}
+
+func (o *Foo) UnmarshalJSON(bytes []byte) (err error) {
+	varFoo := _Foo{}
+
+	if err = json.Unmarshal(bytes, &varFoo); err == nil {
+		*o = Foo(varFoo)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "bar")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableFoo struct {

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_format_test_.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_format_test_.go
@@ -34,7 +34,10 @@ type FormatTest struct {
 	PatternWithDigits *string `json:"pattern_with_digits,omitempty"`
 	// A string starting with 'image_' (case insensitive) and one to three digits following i.e. Image_01.
 	PatternWithDigitsAndDelimiter *string `json:"pattern_with_digits_and_delimiter,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _FormatTest FormatTest
 
 // NewFormatTest instantiates a new FormatTest object
 // This constructor will assign default values to properties that have it defined,
@@ -552,7 +555,43 @@ func (o FormatTest) MarshalJSON() ([]byte, error) {
 	if o.PatternWithDigitsAndDelimiter != nil {
 		toSerialize["pattern_with_digits_and_delimiter"] = o.PatternWithDigitsAndDelimiter
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return json.Marshal(toSerialize)
+}
+
+func (o *FormatTest) UnmarshalJSON(bytes []byte) (err error) {
+	varFormatTest := _FormatTest{}
+
+	if err = json.Unmarshal(bytes, &varFormatTest); err == nil {
+		*o = FormatTest(varFormatTest)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "integer")
+		delete(additionalProperties, "int32")
+		delete(additionalProperties, "int64")
+		delete(additionalProperties, "number")
+		delete(additionalProperties, "float")
+		delete(additionalProperties, "double")
+		delete(additionalProperties, "string")
+		delete(additionalProperties, "byte")
+		delete(additionalProperties, "binary")
+		delete(additionalProperties, "date")
+		delete(additionalProperties, "dateTime")
+		delete(additionalProperties, "uuid")
+		delete(additionalProperties, "password")
+		delete(additionalProperties, "pattern_with_digits")
+		delete(additionalProperties, "pattern_with_digits_and_delimiter")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableFormatTest struct {

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_has_only_read_only.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_has_only_read_only.go
@@ -17,7 +17,10 @@ import (
 type HasOnlyReadOnly struct {
 	Bar *string `json:"bar,omitempty"`
 	Foo *string `json:"foo,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _HasOnlyReadOnly HasOnlyReadOnly
 
 // NewHasOnlyReadOnly instantiates a new HasOnlyReadOnly object
 // This constructor will assign default values to properties that have it defined,
@@ -108,7 +111,30 @@ func (o HasOnlyReadOnly) MarshalJSON() ([]byte, error) {
 	if o.Foo != nil {
 		toSerialize["foo"] = o.Foo
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return json.Marshal(toSerialize)
+}
+
+func (o *HasOnlyReadOnly) UnmarshalJSON(bytes []byte) (err error) {
+	varHasOnlyReadOnly := _HasOnlyReadOnly{}
+
+	if err = json.Unmarshal(bytes, &varHasOnlyReadOnly); err == nil {
+		*o = HasOnlyReadOnly(varHasOnlyReadOnly)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "bar")
+		delete(additionalProperties, "foo")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableHasOnlyReadOnly struct {

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_health_check_result.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_health_check_result.go
@@ -16,7 +16,10 @@ import (
 // HealthCheckResult Just a string to inform instance is up and running. Make it nullable in hope to get it as pointer in generated model.
 type HealthCheckResult struct {
 	NullableMessage NullableString `json:"NullableMessage,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _HealthCheckResult HealthCheckResult
 
 // NewHealthCheckResult instantiates a new HealthCheckResult object
 // This constructor will assign default values to properties that have it defined,
@@ -82,7 +85,29 @@ func (o HealthCheckResult) MarshalJSON() ([]byte, error) {
 	if o.NullableMessage.IsSet() {
 		toSerialize["NullableMessage"] = o.NullableMessage.Get()
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return json.Marshal(toSerialize)
+}
+
+func (o *HealthCheckResult) UnmarshalJSON(bytes []byte) (err error) {
+	varHealthCheckResult := _HealthCheckResult{}
+
+	if err = json.Unmarshal(bytes, &varHealthCheckResult); err == nil {
+		*o = HealthCheckResult(varHealthCheckResult)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "NullableMessage")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableHealthCheckResult struct {

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_inline_object.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_inline_object.go
@@ -19,7 +19,10 @@ type InlineObject struct {
 	Name *string `json:"name,omitempty"`
 	// Updated status of the pet
 	Status *string `json:"status,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _InlineObject InlineObject
 
 // NewInlineObject instantiates a new InlineObject object
 // This constructor will assign default values to properties that have it defined,
@@ -110,7 +113,30 @@ func (o InlineObject) MarshalJSON() ([]byte, error) {
 	if o.Status != nil {
 		toSerialize["status"] = o.Status
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return json.Marshal(toSerialize)
+}
+
+func (o *InlineObject) UnmarshalJSON(bytes []byte) (err error) {
+	varInlineObject := _InlineObject{}
+
+	if err = json.Unmarshal(bytes, &varInlineObject); err == nil {
+		*o = InlineObject(varInlineObject)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "name")
+		delete(additionalProperties, "status")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableInlineObject struct {

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_inline_object_1.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_inline_object_1.go
@@ -20,7 +20,10 @@ type InlineObject1 struct {
 	AdditionalMetadata *string `json:"additionalMetadata,omitempty"`
 	// file to upload
 	File **os.File `json:"file,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _InlineObject1 InlineObject1
 
 // NewInlineObject1 instantiates a new InlineObject1 object
 // This constructor will assign default values to properties that have it defined,
@@ -111,7 +114,30 @@ func (o InlineObject1) MarshalJSON() ([]byte, error) {
 	if o.File != nil {
 		toSerialize["file"] = o.File
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return json.Marshal(toSerialize)
+}
+
+func (o *InlineObject1) UnmarshalJSON(bytes []byte) (err error) {
+	varInlineObject1 := _InlineObject1{}
+
+	if err = json.Unmarshal(bytes, &varInlineObject1); err == nil {
+		*o = InlineObject1(varInlineObject1)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "additionalMetadata")
+		delete(additionalProperties, "file")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableInlineObject1 struct {

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_inline_object_2.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_inline_object_2.go
@@ -19,7 +19,10 @@ type InlineObject2 struct {
 	EnumFormStringArray *[]string `json:"enum_form_string_array,omitempty"`
 	// Form parameter enum test (string)
 	EnumFormString *string `json:"enum_form_string,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _InlineObject2 InlineObject2
 
 // NewInlineObject2 instantiates a new InlineObject2 object
 // This constructor will assign default values to properties that have it defined,
@@ -114,7 +117,30 @@ func (o InlineObject2) MarshalJSON() ([]byte, error) {
 	if o.EnumFormString != nil {
 		toSerialize["enum_form_string"] = o.EnumFormString
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return json.Marshal(toSerialize)
+}
+
+func (o *InlineObject2) UnmarshalJSON(bytes []byte) (err error) {
+	varInlineObject2 := _InlineObject2{}
+
+	if err = json.Unmarshal(bytes, &varInlineObject2); err == nil {
+		*o = InlineObject2(varInlineObject2)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "enum_form_string_array")
+		delete(additionalProperties, "enum_form_string")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableInlineObject2 struct {

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_inline_object_3.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_inline_object_3.go
@@ -45,7 +45,10 @@ type InlineObject3 struct {
 	Password *string `json:"password,omitempty"`
 	// None
 	Callback *string `json:"callback,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _InlineObject3 InlineObject3
 
 // NewInlineObject3 instantiates a new InlineObject3 object
 // This constructor will assign default values to properties that have it defined,
@@ -528,7 +531,42 @@ func (o InlineObject3) MarshalJSON() ([]byte, error) {
 	if o.Callback != nil {
 		toSerialize["callback"] = o.Callback
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return json.Marshal(toSerialize)
+}
+
+func (o *InlineObject3) UnmarshalJSON(bytes []byte) (err error) {
+	varInlineObject3 := _InlineObject3{}
+
+	if err = json.Unmarshal(bytes, &varInlineObject3); err == nil {
+		*o = InlineObject3(varInlineObject3)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "integer")
+		delete(additionalProperties, "int32")
+		delete(additionalProperties, "int64")
+		delete(additionalProperties, "number")
+		delete(additionalProperties, "float")
+		delete(additionalProperties, "double")
+		delete(additionalProperties, "string")
+		delete(additionalProperties, "pattern_without_delimiter")
+		delete(additionalProperties, "byte")
+		delete(additionalProperties, "binary")
+		delete(additionalProperties, "date")
+		delete(additionalProperties, "dateTime")
+		delete(additionalProperties, "password")
+		delete(additionalProperties, "callback")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableInlineObject3 struct {

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_inline_object_4.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_inline_object_4.go
@@ -19,7 +19,10 @@ type InlineObject4 struct {
 	Param string `json:"param"`
 	// field2
 	Param2 string `json:"param2"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _InlineObject4 InlineObject4
 
 // NewInlineObject4 instantiates a new InlineObject4 object
 // This constructor will assign default values to properties that have it defined,
@@ -96,7 +99,30 @@ func (o InlineObject4) MarshalJSON() ([]byte, error) {
 	if true {
 		toSerialize["param2"] = o.Param2
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return json.Marshal(toSerialize)
+}
+
+func (o *InlineObject4) UnmarshalJSON(bytes []byte) (err error) {
+	varInlineObject4 := _InlineObject4{}
+
+	if err = json.Unmarshal(bytes, &varInlineObject4); err == nil {
+		*o = InlineObject4(varInlineObject4)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "param")
+		delete(additionalProperties, "param2")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableInlineObject4 struct {

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_inline_object_5.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_inline_object_5.go
@@ -20,7 +20,10 @@ type InlineObject5 struct {
 	AdditionalMetadata *string `json:"additionalMetadata,omitempty"`
 	// file to upload
 	RequiredFile *os.File `json:"requiredFile"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _InlineObject5 InlineObject5
 
 // NewInlineObject5 instantiates a new InlineObject5 object
 // This constructor will assign default values to properties that have it defined,
@@ -104,7 +107,30 @@ func (o InlineObject5) MarshalJSON() ([]byte, error) {
 	if true {
 		toSerialize["requiredFile"] = o.RequiredFile
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return json.Marshal(toSerialize)
+}
+
+func (o *InlineObject5) UnmarshalJSON(bytes []byte) (err error) {
+	varInlineObject5 := _InlineObject5{}
+
+	if err = json.Unmarshal(bytes, &varInlineObject5); err == nil {
+		*o = InlineObject5(varInlineObject5)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "additionalMetadata")
+		delete(additionalProperties, "requiredFile")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableInlineObject5 struct {

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_inline_response_default.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_inline_response_default.go
@@ -16,7 +16,10 @@ import (
 // InlineResponseDefault struct for InlineResponseDefault
 type InlineResponseDefault struct {
 	String *Foo `json:"string,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _InlineResponseDefault InlineResponseDefault
 
 // NewInlineResponseDefault instantiates a new InlineResponseDefault object
 // This constructor will assign default values to properties that have it defined,
@@ -72,7 +75,29 @@ func (o InlineResponseDefault) MarshalJSON() ([]byte, error) {
 	if o.String != nil {
 		toSerialize["string"] = o.String
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return json.Marshal(toSerialize)
+}
+
+func (o *InlineResponseDefault) UnmarshalJSON(bytes []byte) (err error) {
+	varInlineResponseDefault := _InlineResponseDefault{}
+
+	if err = json.Unmarshal(bytes, &varInlineResponseDefault); err == nil {
+		*o = InlineResponseDefault(varInlineResponseDefault)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "string")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableInlineResponseDefault struct {

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_list.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_list.go
@@ -16,7 +16,10 @@ import (
 // List struct for List
 type List struct {
 	Var123List *string `json:"123-list,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _List List
 
 // NewList instantiates a new List object
 // This constructor will assign default values to properties that have it defined,
@@ -72,7 +75,29 @@ func (o List) MarshalJSON() ([]byte, error) {
 	if o.Var123List != nil {
 		toSerialize["123-list"] = o.Var123List
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return json.Marshal(toSerialize)
+}
+
+func (o *List) UnmarshalJSON(bytes []byte) (err error) {
+	varList := _List{}
+
+	if err = json.Unmarshal(bytes, &varList); err == nil {
+		*o = List(varList)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "123-list")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableList struct {

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_map_test_.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_map_test_.go
@@ -19,7 +19,10 @@ type MapTest struct {
 	MapOfEnumString *map[string]string `json:"map_of_enum_string,omitempty"`
 	DirectMap *map[string]bool `json:"direct_map,omitempty"`
 	IndirectMap *map[string]bool `json:"indirect_map,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _MapTest MapTest
 
 // NewMapTest instantiates a new MapTest object
 // This constructor will assign default values to properties that have it defined,
@@ -180,7 +183,32 @@ func (o MapTest) MarshalJSON() ([]byte, error) {
 	if o.IndirectMap != nil {
 		toSerialize["indirect_map"] = o.IndirectMap
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return json.Marshal(toSerialize)
+}
+
+func (o *MapTest) UnmarshalJSON(bytes []byte) (err error) {
+	varMapTest := _MapTest{}
+
+	if err = json.Unmarshal(bytes, &varMapTest); err == nil {
+		*o = MapTest(varMapTest)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "map_map_of_string")
+		delete(additionalProperties, "map_of_enum_string")
+		delete(additionalProperties, "direct_map")
+		delete(additionalProperties, "indirect_map")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableMapTest struct {

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_mixed_properties_and_additional_properties_class.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_mixed_properties_and_additional_properties_class.go
@@ -19,7 +19,10 @@ type MixedPropertiesAndAdditionalPropertiesClass struct {
 	Uuid *string `json:"uuid,omitempty"`
 	DateTime *time.Time `json:"dateTime,omitempty"`
 	Map *map[string]Animal `json:"map,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _MixedPropertiesAndAdditionalPropertiesClass MixedPropertiesAndAdditionalPropertiesClass
 
 // NewMixedPropertiesAndAdditionalPropertiesClass instantiates a new MixedPropertiesAndAdditionalPropertiesClass object
 // This constructor will assign default values to properties that have it defined,
@@ -145,7 +148,31 @@ func (o MixedPropertiesAndAdditionalPropertiesClass) MarshalJSON() ([]byte, erro
 	if o.Map != nil {
 		toSerialize["map"] = o.Map
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return json.Marshal(toSerialize)
+}
+
+func (o *MixedPropertiesAndAdditionalPropertiesClass) UnmarshalJSON(bytes []byte) (err error) {
+	varMixedPropertiesAndAdditionalPropertiesClass := _MixedPropertiesAndAdditionalPropertiesClass{}
+
+	if err = json.Unmarshal(bytes, &varMixedPropertiesAndAdditionalPropertiesClass); err == nil {
+		*o = MixedPropertiesAndAdditionalPropertiesClass(varMixedPropertiesAndAdditionalPropertiesClass)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "uuid")
+		delete(additionalProperties, "dateTime")
+		delete(additionalProperties, "map")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableMixedPropertiesAndAdditionalPropertiesClass struct {

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_name.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_name.go
@@ -19,7 +19,10 @@ type Name struct {
 	SnakeCase *int32 `json:"snake_case,omitempty"`
 	Property *string `json:"property,omitempty"`
 	Var123Number *int32 `json:"123Number,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _Name Name
 
 // NewName instantiates a new Name object
 // This constructor will assign default values to properties that have it defined,
@@ -173,7 +176,32 @@ func (o Name) MarshalJSON() ([]byte, error) {
 	if o.Var123Number != nil {
 		toSerialize["123Number"] = o.Var123Number
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return json.Marshal(toSerialize)
+}
+
+func (o *Name) UnmarshalJSON(bytes []byte) (err error) {
+	varName := _Name{}
+
+	if err = json.Unmarshal(bytes, &varName); err == nil {
+		*o = Name(varName)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "name")
+		delete(additionalProperties, "snake_case")
+		delete(additionalProperties, "property")
+		delete(additionalProperties, "123Number")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableName struct {

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_number_only.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_number_only.go
@@ -16,7 +16,10 @@ import (
 // NumberOnly struct for NumberOnly
 type NumberOnly struct {
 	JustNumber *float32 `json:"JustNumber,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _NumberOnly NumberOnly
 
 // NewNumberOnly instantiates a new NumberOnly object
 // This constructor will assign default values to properties that have it defined,
@@ -72,7 +75,29 @@ func (o NumberOnly) MarshalJSON() ([]byte, error) {
 	if o.JustNumber != nil {
 		toSerialize["JustNumber"] = o.JustNumber
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return json.Marshal(toSerialize)
+}
+
+func (o *NumberOnly) UnmarshalJSON(bytes []byte) (err error) {
+	varNumberOnly := _NumberOnly{}
+
+	if err = json.Unmarshal(bytes, &varNumberOnly); err == nil {
+		*o = NumberOnly(varNumberOnly)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "JustNumber")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableNumberOnly struct {

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_order.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_order.go
@@ -23,7 +23,10 @@ type Order struct {
 	// Order Status
 	Status *string `json:"status,omitempty"`
 	Complete *bool `json:"complete,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _Order Order
 
 // NewOrder instantiates a new Order object
 // This constructor will assign default values to properties that have it defined,
@@ -258,7 +261,34 @@ func (o Order) MarshalJSON() ([]byte, error) {
 	if o.Complete != nil {
 		toSerialize["complete"] = o.Complete
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return json.Marshal(toSerialize)
+}
+
+func (o *Order) UnmarshalJSON(bytes []byte) (err error) {
+	varOrder := _Order{}
+
+	if err = json.Unmarshal(bytes, &varOrder); err == nil {
+		*o = Order(varOrder)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "petId")
+		delete(additionalProperties, "quantity")
+		delete(additionalProperties, "shipDate")
+		delete(additionalProperties, "status")
+		delete(additionalProperties, "complete")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableOrder struct {

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_outer_composite.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_outer_composite.go
@@ -18,7 +18,10 @@ type OuterComposite struct {
 	MyNumber *float32 `json:"my_number,omitempty"`
 	MyString *string `json:"my_string,omitempty"`
 	MyBoolean *bool `json:"my_boolean,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _OuterComposite OuterComposite
 
 // NewOuterComposite instantiates a new OuterComposite object
 // This constructor will assign default values to properties that have it defined,
@@ -144,7 +147,31 @@ func (o OuterComposite) MarshalJSON() ([]byte, error) {
 	if o.MyBoolean != nil {
 		toSerialize["my_boolean"] = o.MyBoolean
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return json.Marshal(toSerialize)
+}
+
+func (o *OuterComposite) UnmarshalJSON(bytes []byte) (err error) {
+	varOuterComposite := _OuterComposite{}
+
+	if err = json.Unmarshal(bytes, &varOuterComposite); err == nil {
+		*o = OuterComposite(varOuterComposite)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "my_number")
+		delete(additionalProperties, "my_string")
+		delete(additionalProperties, "my_boolean")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableOuterComposite struct {

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_pet.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_pet.go
@@ -22,7 +22,10 @@ type Pet struct {
 	Tags *[]Tag `json:"tags,omitempty"`
 	// pet status in the store
 	Status *string `json:"status,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _Pet Pet
 
 // NewPet instantiates a new Pet object
 // This constructor will assign default values to properties that have it defined,
@@ -239,7 +242,34 @@ func (o Pet) MarshalJSON() ([]byte, error) {
 	if o.Status != nil {
 		toSerialize["status"] = o.Status
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return json.Marshal(toSerialize)
+}
+
+func (o *Pet) UnmarshalJSON(bytes []byte) (err error) {
+	varPet := _Pet{}
+
+	if err = json.Unmarshal(bytes, &varPet); err == nil {
+		*o = Pet(varPet)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "category")
+		delete(additionalProperties, "name")
+		delete(additionalProperties, "photoUrls")
+		delete(additionalProperties, "tags")
+		delete(additionalProperties, "status")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullablePet struct {

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_read_only_first.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_read_only_first.go
@@ -17,7 +17,10 @@ import (
 type ReadOnlyFirst struct {
 	Bar *string `json:"bar,omitempty"`
 	Baz *string `json:"baz,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _ReadOnlyFirst ReadOnlyFirst
 
 // NewReadOnlyFirst instantiates a new ReadOnlyFirst object
 // This constructor will assign default values to properties that have it defined,
@@ -108,7 +111,30 @@ func (o ReadOnlyFirst) MarshalJSON() ([]byte, error) {
 	if o.Baz != nil {
 		toSerialize["baz"] = o.Baz
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return json.Marshal(toSerialize)
+}
+
+func (o *ReadOnlyFirst) UnmarshalJSON(bytes []byte) (err error) {
+	varReadOnlyFirst := _ReadOnlyFirst{}
+
+	if err = json.Unmarshal(bytes, &varReadOnlyFirst); err == nil {
+		*o = ReadOnlyFirst(varReadOnlyFirst)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "bar")
+		delete(additionalProperties, "baz")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableReadOnlyFirst struct {

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_return.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_return.go
@@ -16,7 +16,10 @@ import (
 // Return Model for testing reserved words
 type Return struct {
 	Return *int32 `json:"return,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _Return Return
 
 // NewReturn instantiates a new Return object
 // This constructor will assign default values to properties that have it defined,
@@ -72,7 +75,29 @@ func (o Return) MarshalJSON() ([]byte, error) {
 	if o.Return != nil {
 		toSerialize["return"] = o.Return
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return json.Marshal(toSerialize)
+}
+
+func (o *Return) UnmarshalJSON(bytes []byte) (err error) {
+	varReturn := _Return{}
+
+	if err = json.Unmarshal(bytes, &varReturn); err == nil {
+		*o = Return(varReturn)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "return")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableReturn struct {

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_tag.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_tag.go
@@ -17,7 +17,10 @@ import (
 type Tag struct {
 	Id *int64 `json:"id,omitempty"`
 	Name *string `json:"name,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _Tag Tag
 
 // NewTag instantiates a new Tag object
 // This constructor will assign default values to properties that have it defined,
@@ -108,7 +111,30 @@ func (o Tag) MarshalJSON() ([]byte, error) {
 	if o.Name != nil {
 		toSerialize["name"] = o.Name
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return json.Marshal(toSerialize)
+}
+
+func (o *Tag) UnmarshalJSON(bytes []byte) (err error) {
+	varTag := _Tag{}
+
+	if err = json.Unmarshal(bytes, &varTag); err == nil {
+		*o = Tag(varTag)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "name")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableTag struct {

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_user.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_user.go
@@ -32,7 +32,10 @@ type User struct {
 	ArbitraryTypeValue interface{} `json:"arbitraryTypeValue,omitempty"`
 	// test code generation for any type Value can be any type - string, number, boolean, array, object or the 'null' value.
 	ArbitraryNullableTypeValue interface{} `json:"arbitraryNullableTypeValue,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _User User
 
 // NewUser instantiates a new User object
 // This constructor will assign default values to properties that have it defined,
@@ -476,7 +479,40 @@ func (o User) MarshalJSON() ([]byte, error) {
 	if o.ArbitraryNullableTypeValue != nil {
 		toSerialize["arbitraryNullableTypeValue"] = o.ArbitraryNullableTypeValue
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return json.Marshal(toSerialize)
+}
+
+func (o *User) UnmarshalJSON(bytes []byte) (err error) {
+	varUser := _User{}
+
+	if err = json.Unmarshal(bytes, &varUser); err == nil {
+		*o = User(varUser)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "username")
+		delete(additionalProperties, "firstName")
+		delete(additionalProperties, "lastName")
+		delete(additionalProperties, "email")
+		delete(additionalProperties, "password")
+		delete(additionalProperties, "phone")
+		delete(additionalProperties, "userStatus")
+		delete(additionalProperties, "arbitraryObject")
+		delete(additionalProperties, "arbitraryNullableObject")
+		delete(additionalProperties, "arbitraryTypeValue")
+		delete(additionalProperties, "arbitraryNullableTypeValue")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableUser struct {

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_whale.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_whale.go
@@ -18,7 +18,10 @@ type Whale struct {
 	HasBaleen *bool `json:"hasBaleen,omitempty"`
 	HasTeeth *bool `json:"hasTeeth,omitempty"`
 	ClassName string `json:"className"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _Whale Whale
 
 // NewWhale instantiates a new Whale object
 // This constructor will assign default values to properties that have it defined,
@@ -137,7 +140,31 @@ func (o Whale) MarshalJSON() ([]byte, error) {
 	if true {
 		toSerialize["className"] = o.ClassName
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return json.Marshal(toSerialize)
+}
+
+func (o *Whale) UnmarshalJSON(bytes []byte) (err error) {
+	varWhale := _Whale{}
+
+	if err = json.Unmarshal(bytes, &varWhale); err == nil {
+		*o = Whale(varWhale)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "hasBaleen")
+		delete(additionalProperties, "hasTeeth")
+		delete(additionalProperties, "className")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableWhale struct {

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_zebra.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_zebra.go
@@ -17,7 +17,10 @@ import (
 type Zebra struct {
 	Type *string `json:"type,omitempty"`
 	ClassName string `json:"className"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _Zebra Zebra
 
 // NewZebra instantiates a new Zebra object
 // This constructor will assign default values to properties that have it defined,
@@ -101,7 +104,30 @@ func (o Zebra) MarshalJSON() ([]byte, error) {
 	if true {
 		toSerialize["className"] = o.ClassName
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return json.Marshal(toSerialize)
+}
+
+func (o *Zebra) UnmarshalJSON(bytes []byte) (err error) {
+	varZebra := _Zebra{}
+
+	if err = json.Unmarshal(bytes, &varZebra); err == nil {
+		*o = Zebra(varZebra)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "type")
+		delete(additionalProperties, "className")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableZebra struct {

--- a/samples/openapi3/client/petstore/go-experimental/model_test.go
+++ b/samples/openapi3/client/petstore/go-experimental/model_test.go
@@ -1,34 +1,43 @@
 package main
 
 import (
+	"encoding/json"
 	"testing"
-    "encoding/json"
-	"github.com/stretchr/testify/assert"
+
 	sw "./go-petstore"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestBanana(t *testing.T) {
-    assert := assert.New(t)
+	assert := assert.New(t)
 
-    lengthCm := float32(2.3)
-    lengthCm2 := float32(2.4)
-    newBanana := (sw.Banana{LengthCm: &lengthCm})
-    newBanana.LengthCm = &lengthCm2
-    assert.Equal(newBanana.LengthCm, &lengthCm2, "Banana LengthCm should be equal")
+	lengthCm := float32(2.3)
+	lengthCm2 := float32(2.4)
+	newBanana := (sw.Banana{LengthCm: &lengthCm})
+	newBanana.LengthCm = &lengthCm2
+	assert.Equal(newBanana.LengthCm, &lengthCm2, "Banana LengthCm should be equal")
 
-    // test additioanl properties
-    jsonBanana:= `{"fruits":["apple","peach"],"lengthCm":3.1}`
-    jsonMap := make(map[string]interface{})
-    json.Unmarshal([]byte(jsonBanana), &jsonMap)
+	// test additioanl properties
+	jsonBanana := `{"fruits":["apple","peach"],"lengthCm":3.1}`
+	jsonMap := make(map[string]interface{})
+	json.Unmarshal([]byte(jsonBanana), &jsonMap)
 
-    newBanana2 := (sw.Banana{})
-    lengthCm3 := float32(3.1)
-    json.Unmarshal([]byte(jsonBanana), &newBanana2)
-    assert.Equal(newBanana2.LengthCm, &lengthCm3, "Banana2 LengthCm should be equal")
-    assert.Equal(newBanana2.AdditionalProperties["fruits"], jsonMap["fruits"], "Banana2 AdditonalProperties should be equal")
+	newBanana2 := (sw.Banana{})
+	lengthCm3 := float32(3.1)
+	json.Unmarshal([]byte(jsonBanana), &newBanana2)
+	assert.Equal(newBanana2.LengthCm, &lengthCm3, "Banana2 LengthCm should be equal")
+	assert.Equal(newBanana2.AdditionalProperties["fruits"], jsonMap["fruits"], "Banana2 AdditonalProperties should be equal")
 
-    newBanana2Json, _ := json.Marshal(newBanana2)
-    assert.Equal(string(newBanana2Json), jsonBanana, "Banana2 JSON string should be equal")
-
+	newBanana2Json, _ := json.Marshal(newBanana2)
+	assert.Equal(string(newBanana2Json), jsonBanana, "Banana2 JSON string should be equal")
 }
 
+func TestDog(t *testing.T) {
+	assert := assert.New(t)
+	newDog := (sw.Dog{})
+	jsonDog := `{"breed":"Shepherd","className":"dog","color":"white"}`
+	json.Unmarshal([]byte(jsonDog), &newDog)
+	breedString := "Shepherd"
+	//assert.Nil(newDog)
+	assert.Equal(*newDog.Breed, breedString, "Breed should be `Shepherd`")
+}


### PR DESCRIPTION
- Bugfix for models with parents (embedded struct) and `additionalProperties: true` to properly unmarshal.

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/config/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

cc @antihax (2017/11) @grokify (2018/07) @kemokemo (2018/09) @bkabrda (2019/07)


