### PR TITLE
[cpp-restsdk] Enabling forward declarations also for cpp-restsdk generator

### DIFF
--- a/modules/openapi-generator/src/main/resources/cpp-rest-sdk-client/model-header.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-rest-sdk-client/model-header.mustache
@@ -20,6 +20,10 @@
 namespace {{this}} {
 {{/modelNamespaceDeclarations}}
 
+{{#vendorExtensions.x-has-forward-declarations}}
+{{#vendorExtensions.x-forward-declarations}}{{.}}
+{{/vendorExtensions.x-forward-declarations}}
+{{/vendorExtensions.x-has-forward-declarations}}
 {{#isEnum}}
 class {{declspec}} {{classname}}
     : public {{#parent}}{{{parent}}}{{/parent}}{{^parent}}ModelBase{{/parent}}


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
### Summary
Enabling forward class declarations also for cpp-restsdk generator as introduced in #6654 

### Details
This PR modifies only the templates used for cpp-restsdk and is a simple copy&paste from #6654. The petstore sample client does not change since it does not contain circular references.

### Technical commitee
@ravinikam @stkrwork @etherealjoy @martindelille @muttleyxd

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
