### PR TITLE
fix: update base image to maven supported

### DIFF
--- a/.hub.cli.dockerfile
+++ b/.hub.cli.dockerfile
@@ -3,10 +3,7 @@
 ##
 ## You can build _just_ this part with:
 ##     docker --target builder -t container-name:builder -f .hub.cli.dockerfile .
-FROM jimschubert/8-jdk-alpine-mvn:1.0 as builder
-
-RUN set -x && \
-    apk add --no-cache bash
+FROM maven:3.6.3-jdk-11-openj9 as builder
 
 ENV GEN_DIR /opt/openapi-generator
 WORKDIR ${GEN_DIR}
@@ -18,11 +15,10 @@ RUN mvn -am -pl "modules/openapi-generator-cli" package
 ## The final (release) image
 ## The resulting container here only needs the target jar
 ## and ca-certificates (to be able to query HTTPS hosted specs)
-FROM openjdk:8-jre-alpine
+FROM openjdk:11.0.8-jre-slim-buster
 
 ENV GEN_DIR /opt/openapi-generator
 
-RUN apk --no-cache add ca-certificates bash
 RUN mkdir -p ${GEN_DIR}/modules/openapi-generator-cli/target
 
 WORKDIR ${GEN_DIR}/modules/openapi-generator-cli/target

--- a/.hub.online.dockerfile
+++ b/.hub.online.dockerfile
@@ -3,10 +3,7 @@
 ##
 ## You can build _just_ this part with:
 ##     docker --target builder -t container-name:builder -f .hub.online.dockerfile .
-FROM jimschubert/8-jdk-alpine-mvn:1.0 as builder
-
-RUN set -x && \
-    apk add --no-cache bash
+FROM maven:3.6.3-jdk-11-openj9 as builder
 
 ENV GEN_DIR /opt/openapi-generator
 WORKDIR ${GEN_DIR}
@@ -17,7 +14,7 @@ RUN mvn -am -pl "modules/openapi-generator-online" package
 
 ## The final (release) image
 ## The resulting container here only needs the target jar
-FROM openjdk:8-jre-alpine
+FROM openjdk:11.0.8-jre-slim-buster
 
 ENV GEN_DIR /opt/openapi-generator
 ENV TARGET_DIR /generator

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,4 @@
-FROM jimschubert/8-jdk-alpine-mvn:1.0
-
-RUN set -x && \
-    apk add --no-cache bash
+FROM maven:3.6.3-jdk-11-openj9
 
 ENV GEN_DIR /opt/openapi-generator
 WORKDIR ${GEN_DIR}
@@ -29,6 +26,6 @@ RUN mvn -am -pl "modules/openapi-generator-cli" package
 COPY docker-entrypoint.sh /usr/local/bin/
 RUN ln -s /usr/local/bin/docker-entrypoint.sh /usr/local/bin/openapi-generator
 
-ENTRYPOINT ["docker-entrypoint.sh"]
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
 
 CMD ["help"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM maven:3-jdk-8
+FROM maven:3.6.3-jdk-11-openj9
 
 ENV GEN_DIR /opt/openapi-generator
 WORKDIR ${GEN_DIR}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM maven:3.6.3-jdk-11-openj9
+FROM maven:3-jdk-8
 
 ENV GEN_DIR /opt/openapi-generator
 WORKDIR ${GEN_DIR}


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

Switch base image from jimschubert/8-jdk-alpine-mvn:1.0 to
maven:3.6.3-jdk-11-openj9.

The jimschubert/8-jdk-alpine-mvn:1.0 is not managed by
any project, it has a very old (alpine 3.4) base image
with many CVE security flaw.

Swap to the image managed by the Maven apache project.

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [ ] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
