### PR TITLE
[Protobuf] Make it possible to override field numbers using x-protobuf-index

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ProtobufSchemaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ProtobufSchemaCodegen.java
@@ -28,7 +28,6 @@ import org.openapitools.codegen.meta.Stability;
 import org.openapitools.codegen.meta.features.DocumentationFeature;
 import org.openapitools.codegen.meta.features.SecurityFeature;
 import org.openapitools.codegen.meta.features.WireFormatFeature;
-import org.openapitools.codegen.utils.ProcessUtils;
 import org.openapitools.codegen.utils.ModelUtils;
 
 import org.apache.commons.lang3.StringUtils;
@@ -216,13 +215,12 @@ public class ProtobufSchemaCodegen extends DefaultCodegen implements CodegenConf
     public Map<String, Object> postProcessModels(Map<String, Object> objs) {
         objs = postProcessModelsEnum(objs);
         List<Object> models = (List<Object>) objs.get("models");
-        // add x-index to properties
-        ProcessUtils.addIndexToProperties(models, 1);
 
         for (Object _mo : models) {
             Map<String, Object> mo = (Map<String, Object>) _mo;
             CodegenModel cm = (CodegenModel) mo.get("model");
 
+            int index = 1;
             for (CodegenProperty var : cm.vars) {
                 // add x-protobuf-type: repeated if it's an array
                 if (Boolean.TRUE.equals(var.isListContainer)) {
@@ -247,6 +245,10 @@ public class ProtobufSchemaCodegen extends DefaultCodegen implements CodegenConf
                         enumIndex++;
                     }
                 }
+
+                // Add x-protobuf-index, unless already specified
+                var.vendorExtensions.putIfAbsent("x-protobuf-index", index);
+                index++;
             }
         }
         return objs;
@@ -422,7 +424,7 @@ public class ProtobufSchemaCodegen extends DefaultCodegen implements CodegenConf
                     }
                 }
 
-                p.vendorExtensions.put("x-index", index);
+                p.vendorExtensions.putIfAbsent("x-protobuf-index", index);
                 index++;
             }
 

--- a/modules/openapi-generator/src/main/resources/protobuf-schema/api.mustache
+++ b/modules/openapi-generator/src/main/resources/protobuf-schema/api.mustache
@@ -30,7 +30,7 @@ message {{operationId}}Request {
   {{#description}}
   // {{{.}}}
   {{/description}}
-  {{#vendorExtensions.x-protobuf-type}}{{.}} {{/vendorExtensions.x-protobuf-type}}{{vendorExtensions.x-protobuf-data-type}} {{paramName}} = {{vendorExtensions.x-index}};
+  {{#vendorExtensions.x-protobuf-type}}{{.}} {{/vendorExtensions.x-protobuf-type}}{{vendorExtensions.x-protobuf-data-type}} {{paramName}} = {{vendorExtensions.x-protobuf-index}};
   {{/allParams}}
 
 }

--- a/modules/openapi-generator/src/main/resources/protobuf-schema/model.mustache
+++ b/modules/openapi-generator/src/main/resources/protobuf-schema/model.mustache
@@ -18,7 +18,7 @@ message {{classname}} {
   // {{{.}}}
   {{/description}}
   {{^isEnum}}
-  {{#vendorExtensions.x-protobuf-type}}{{.}} {{/vendorExtensions.x-protobuf-type}}{{vendorExtensions.x-protobuf-data-type}} {{name}} = {{vendorExtensions.x-index}}{{#vendorExtensions.x-protobuf-packed}} [packed=true]{{/vendorExtensions.x-protobuf-packed}};
+  {{#vendorExtensions.x-protobuf-type}}{{.}} {{/vendorExtensions.x-protobuf-type}}{{vendorExtensions.x-protobuf-data-type}} {{name}} = {{vendorExtensions.x-protobuf-index}}{{#vendorExtensions.x-protobuf-packed}} [packed=true]{{/vendorExtensions.x-protobuf-packed}};
   {{/isEnum}}
   {{#isEnum}}
   enum {{name}} {


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
As described in issue https://github.com/OpenAPITools/openapi-generator/issues/6756 .
Cc: @dobl1 .

The protobuf generator currently does not guarantee that generated field numbers are preserved across multiple generations: it always generates them as a sequence from 0 to `n` (through the `x-index` vendor extension). If fields are re-ordered, added, or deleted, field numbers will almost always shift. This is a big deal, as field numbers are part of the binary interface of protobuf serialization format.

This change is making it possible to specify protobuf field numbers using the vendor extension `x-protobuf-index`. This is an opt-in feature at field level: if `x-protobuf-index` is not specified, then the current behavior based on `x-index` still applies. In other words: this is backward compatible.

For example, the following data definition:
```yaml
Pet:
  type: object
  properties:
    id:
      type: integer
      x-protobuf-index: 3
    name:
      type: string
      x-protobuf-index: 1
```
... will generate the below protobuf message:
```protobuf
message Pet {
  int64 id = 3;
  string name = 1;
}
```

I do not expect this pull-request to be merged as-is, I rather see it as a conversation-starter: do you agree with the general approach ? How would you suggest I improve the implementation ? I'd rather get feedback before investing time in writing automated tests, for example. For now, I've just manually validated the behavior on a toy example.

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [ ] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [ ] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
