### PR TITLE
[Swift5] Fix Datetime default value

### DIFF
--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/AdditionalPropertiesClass.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/AdditionalPropertiesClass.swift
@@ -12,7 +12,7 @@ public struct AdditionalPropertiesClass: Codable {
     public var mapString: [String: String]?
     public var mapMapString: [String: [String: String]]?
 
-    public init(mapString: [String: String]?, mapMapString: [String: [String: String]]?) {
+    public init(mapString: [String: String]? = nil, mapMapString: [String: [String: String]]? = nil) {
         self.mapString = mapString
         self.mapMapString = mapMapString
     }

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/Animal.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/Animal.swift
@@ -12,7 +12,7 @@ public struct Animal: Codable {
     public var className: String
     public var color: String? = "red"
 
-    public init(className: String, color: String?) {
+    public init(className: String, color: String? = nil) {
         self.className = className
         self.color = color
     }

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/ApiResponse.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/ApiResponse.swift
@@ -13,7 +13,7 @@ public struct ApiResponse: Codable {
     public var type: String?
     public var message: String?
 
-    public init(code: Int?, type: String?, message: String?) {
+    public init(code: Int? = nil, type: String? = nil, message: String? = nil) {
         self.code = code
         self.type = type
         self.message = message

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfArrayOfNumberOnly.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfArrayOfNumberOnly.swift
@@ -11,7 +11,7 @@ public struct ArrayOfArrayOfNumberOnly: Codable {
 
     public var arrayArrayNumber: [[Double]]?
 
-    public init(arrayArrayNumber: [[Double]]?) {
+    public init(arrayArrayNumber: [[Double]]? = nil) {
         self.arrayArrayNumber = arrayArrayNumber
     }
 

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfNumberOnly.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfNumberOnly.swift
@@ -11,7 +11,7 @@ public struct ArrayOfNumberOnly: Codable {
 
     public var arrayNumber: [Double]?
 
-    public init(arrayNumber: [Double]?) {
+    public init(arrayNumber: [Double]? = nil) {
         self.arrayNumber = arrayNumber
     }
 

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/ArrayTest.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/ArrayTest.swift
@@ -13,7 +13,7 @@ public struct ArrayTest: Codable {
     public var arrayArrayOfInteger: [[Int64]]?
     public var arrayArrayOfModel: [[ReadOnlyFirst]]?
 
-    public init(arrayOfString: [String]?, arrayArrayOfInteger: [[Int64]]?, arrayArrayOfModel: [[ReadOnlyFirst]]?) {
+    public init(arrayOfString: [String]? = nil, arrayArrayOfInteger: [[Int64]]? = nil, arrayArrayOfModel: [[ReadOnlyFirst]]? = nil) {
         self.arrayOfString = arrayOfString
         self.arrayArrayOfInteger = arrayArrayOfInteger
         self.arrayArrayOfModel = arrayArrayOfModel

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/Capitalization.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/Capitalization.swift
@@ -17,7 +17,7 @@ public struct Capitalization: Codable {
     /** Name of the pet  */
     public var ATT_NAME: String?
 
-    public init(smallCamel: String?, capitalCamel: String?, smallSnake: String?, capitalSnake: String?, sCAETHFlowPoints: String?, ATT_NAME: String?) {
+    public init(smallCamel: String? = nil, capitalCamel: String? = nil, smallSnake: String? = nil, capitalSnake: String? = nil, sCAETHFlowPoints: String? = nil, ATT_NAME: String? = nil) {
         self.smallCamel = smallCamel
         self.capitalCamel = capitalCamel
         self.smallSnake = smallSnake

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/Cat.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/Cat.swift
@@ -13,7 +13,7 @@ public struct Cat: Codable {
     public var color: String? = "red"
     public var declawed: Bool?
 
-    public init(className: String, color: String?, declawed: Bool?) {
+    public init(className: String, color: String? = nil, declawed: Bool? = nil) {
         self.className = className
         self.color = color
         self.declawed = declawed

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/CatAllOf.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/CatAllOf.swift
@@ -11,7 +11,7 @@ public struct CatAllOf: Codable {
 
     public var declawed: Bool?
 
-    public init(declawed: Bool?) {
+    public init(declawed: Bool? = nil) {
         self.declawed = declawed
     }
 

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/Category.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/Category.swift
@@ -12,7 +12,7 @@ public struct Category: Codable {
     public var id: Int64?
     public var name: String = "default-name"
 
-    public init(id: Int64?, name: String) {
+    public init(id: Int64? = nil, name: String) {
         self.id = id
         self.name = name
     }

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/ClassModel.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/ClassModel.swift
@@ -12,7 +12,7 @@ public struct ClassModel: Codable {
 
     public var _class: String?
 
-    public init(_class: String?) {
+    public init(_class: String? = nil) {
         self._class = _class
     }
 

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/Client.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/Client.swift
@@ -11,7 +11,7 @@ public struct Client: Codable {
 
     public var client: String?
 
-    public init(client: String?) {
+    public init(client: String? = nil) {
         self.client = client
     }
 

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/Dog.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/Dog.swift
@@ -13,7 +13,7 @@ public struct Dog: Codable {
     public var color: String? = "red"
     public var breed: String?
 
-    public init(className: String, color: String?, breed: String?) {
+    public init(className: String, color: String? = nil, breed: String? = nil) {
         self.className = className
         self.color = color
         self.breed = breed

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/DogAllOf.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/DogAllOf.swift
@@ -11,7 +11,7 @@ public struct DogAllOf: Codable {
 
     public var breed: String?
 
-    public init(breed: String?) {
+    public init(breed: String? = nil) {
         self.breed = breed
     }
 

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/EnumArrays.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/EnumArrays.swift
@@ -20,7 +20,7 @@ public struct EnumArrays: Codable {
     public var justSymbol: JustSymbol?
     public var arrayEnum: [ArrayEnum]?
 
-    public init(justSymbol: JustSymbol?, arrayEnum: [ArrayEnum]?) {
+    public init(justSymbol: JustSymbol? = nil, arrayEnum: [ArrayEnum]? = nil) {
         self.justSymbol = justSymbol
         self.arrayEnum = arrayEnum
     }

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/EnumTest.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/EnumTest.swift
@@ -33,7 +33,7 @@ public struct EnumTest: Codable {
     public var enumNumber: EnumNumber?
     public var outerEnum: OuterEnum?
 
-    public init(enumString: EnumString?, enumStringRequired: EnumStringRequired, enumInteger: EnumInteger?, enumNumber: EnumNumber?, outerEnum: OuterEnum?) {
+    public init(enumString: EnumString? = nil, enumStringRequired: EnumStringRequired, enumInteger: EnumInteger? = nil, enumNumber: EnumNumber? = nil, outerEnum: OuterEnum? = nil) {
         self.enumString = enumString
         self.enumStringRequired = enumStringRequired
         self.enumInteger = enumInteger

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/File.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/File.swift
@@ -13,7 +13,7 @@ public struct File: Codable {
     /** Test capitalization */
     public var sourceURI: String?
 
-    public init(sourceURI: String?) {
+    public init(sourceURI: String? = nil) {
         self.sourceURI = sourceURI
     }
 

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/FileSchemaTestClass.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/FileSchemaTestClass.swift
@@ -12,7 +12,7 @@ public struct FileSchemaTestClass: Codable {
     public var file: File?
     public var files: [File]?
 
-    public init(file: File?, files: [File]?) {
+    public init(file: File? = nil, files: [File]? = nil) {
         self.file = file
         self.files = files
     }

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/FormatTest.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/FormatTest.swift
@@ -23,7 +23,7 @@ public struct FormatTest: Codable {
     public var uuid: UUID?
     public var password: String
 
-    public init(integer: Int?, int32: Int?, int64: Int64?, number: Double, float: Float?, double: Double?, string: String?, byte: Data, binary: URL?, date: Date, dateTime: Date?, uuid: UUID?, password: String) {
+    public init(integer: Int? = nil, int32: Int? = nil, int64: Int64? = nil, number: Double, float: Float? = nil, double: Double? = nil, string: String? = nil, byte: Data, binary: URL? = nil, date: Date, dateTime: Date? = nil, uuid: UUID? = nil, password: String) {
         self.integer = integer
         self.int32 = int32
         self.int64 = int64

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/HasOnlyReadOnly.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/HasOnlyReadOnly.swift
@@ -12,7 +12,7 @@ public struct HasOnlyReadOnly: Codable {
     public var bar: String?
     public var foo: String?
 
-    public init(bar: String?, foo: String?) {
+    public init(bar: String? = nil, foo: String? = nil) {
         self.bar = bar
         self.foo = foo
     }

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/List.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/List.swift
@@ -11,7 +11,7 @@ public struct List: Codable {
 
     public var _123list: String?
 
-    public init(_123list: String?) {
+    public init(_123list: String? = nil) {
         self._123list = _123list
     }
 

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/MapTest.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/MapTest.swift
@@ -18,7 +18,7 @@ public struct MapTest: Codable {
     public var directMap: [String: Bool]?
     public var indirectMap: StringBooleanMap?
 
-    public init(mapMapOfString: [String: [String: String]]?, mapOfEnumString: [String: String]?, directMap: [String: Bool]?, indirectMap: StringBooleanMap?) {
+    public init(mapMapOfString: [String: [String: String]]? = nil, mapOfEnumString: [String: String]? = nil, directMap: [String: Bool]? = nil, indirectMap: StringBooleanMap? = nil) {
         self.mapMapOfString = mapMapOfString
         self.mapOfEnumString = mapOfEnumString
         self.directMap = directMap

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/MixedPropertiesAndAdditionalPropertiesClass.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/MixedPropertiesAndAdditionalPropertiesClass.swift
@@ -13,7 +13,7 @@ public struct MixedPropertiesAndAdditionalPropertiesClass: Codable {
     public var dateTime: Date?
     public var map: [String: Animal]?
 
-    public init(uuid: UUID?, dateTime: Date?, map: [String: Animal]?) {
+    public init(uuid: UUID? = nil, dateTime: Date? = nil, map: [String: Animal]? = nil) {
         self.uuid = uuid
         self.dateTime = dateTime
         self.map = map

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/Model200Response.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/Model200Response.swift
@@ -13,7 +13,7 @@ public struct Model200Response: Codable {
     public var name: Int?
     public var _class: String?
 
-    public init(name: Int?, _class: String?) {
+    public init(name: Int? = nil, _class: String? = nil) {
         self.name = name
         self._class = _class
     }

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/Name.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/Name.swift
@@ -15,7 +15,7 @@ public struct Name: Codable {
     public var property: String?
     public var _123number: Int?
 
-    public init(name: Int, snakeCase: Int?, property: String?, _123number: Int?) {
+    public init(name: Int, snakeCase: Int? = nil, property: String? = nil, _123number: Int? = nil) {
         self.name = name
         self.snakeCase = snakeCase
         self.property = property

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/NumberOnly.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/NumberOnly.swift
@@ -11,7 +11,7 @@ public struct NumberOnly: Codable {
 
     public var justNumber: Double?
 
-    public init(justNumber: Double?) {
+    public init(justNumber: Double? = nil) {
         self.justNumber = justNumber
     }
 

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/Order.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/Order.swift
@@ -22,7 +22,7 @@ public struct Order: Codable {
     public var status: Status?
     public var complete: Bool? = false
 
-    public init(id: Int64?, petId: Int64?, quantity: Int?, shipDate: Date?, status: Status?, complete: Bool?) {
+    public init(id: Int64? = nil, petId: Int64? = nil, quantity: Int? = nil, shipDate: Date? = nil, status: Status? = nil, complete: Bool? = nil) {
         self.id = id
         self.petId = petId
         self.quantity = quantity

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/OuterComposite.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/OuterComposite.swift
@@ -13,7 +13,7 @@ public struct OuterComposite: Codable {
     public var myString: String?
     public var myBoolean: Bool?
 
-    public init(myNumber: Double?, myString: String?, myBoolean: Bool?) {
+    public init(myNumber: Double? = nil, myString: String? = nil, myBoolean: Bool? = nil) {
         self.myNumber = myNumber
         self.myString = myString
         self.myBoolean = myBoolean

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/Pet.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/Pet.swift
@@ -22,7 +22,7 @@ public struct Pet: Codable {
     /** pet status in the store */
     public var status: Status?
 
-    public init(id: Int64?, category: Category?, name: String, photoUrls: [String], tags: [Tag]?, status: Status?) {
+    public init(id: Int64? = nil, category: Category? = nil, name: String, photoUrls: [String], tags: [Tag]? = nil, status: Status? = nil) {
         self.id = id
         self.category = category
         self.name = name

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/ReadOnlyFirst.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/ReadOnlyFirst.swift
@@ -12,7 +12,7 @@ public struct ReadOnlyFirst: Codable {
     public var bar: String?
     public var baz: String?
 
-    public init(bar: String?, baz: String?) {
+    public init(bar: String? = nil, baz: String? = nil) {
         self.bar = bar
         self.baz = baz
     }

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/Return.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/Return.swift
@@ -12,7 +12,7 @@ public struct Return: Codable {
 
     public var _return: Int?
 
-    public init(_return: Int?) {
+    public init(_return: Int? = nil) {
         self._return = _return
     }
 

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/SpecialModelName.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/SpecialModelName.swift
@@ -11,7 +11,7 @@ public struct SpecialModelName: Codable {
 
     public var specialPropertyName: Int64?
 
-    public init(specialPropertyName: Int64?) {
+    public init(specialPropertyName: Int64? = nil) {
         self.specialPropertyName = specialPropertyName
     }
 

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/Tag.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/Tag.swift
@@ -12,7 +12,7 @@ public struct Tag: Codable {
     public var id: Int64?
     public var name: String?
 
-    public init(id: Int64?, name: String?) {
+    public init(id: Int64? = nil, name: String? = nil) {
         self.id = id
         self.name = name
     }

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/User.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/User.swift
@@ -19,7 +19,7 @@ public struct User: Codable {
     /** User Status */
     public var userStatus: Int?
 
-    public init(id: Int64?, username: String?, firstName: String?, lastName: String?, email: String?, password: String?, phone: String?, userStatus: Int?) {
+    public init(id: Int64? = nil, username: String? = nil, firstName: String? = nil, lastName: String? = nil, email: String? = nil, password: String? = nil, phone: String? = nil, userStatus: Int? = nil) {
         self.id = id
         self.username = username
         self.firstName = firstName

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/AdditionalPropertiesClass.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/AdditionalPropertiesClass.swift
@@ -12,7 +12,7 @@ public struct AdditionalPropertiesClass: Codable {
     public var mapString: [String: String]?
     public var mapMapString: [String: [String: String]]?
 
-    public init(mapString: [String: String]?, mapMapString: [String: [String: String]]?) {
+    public init(mapString: [String: String]? = nil, mapMapString: [String: [String: String]]? = nil) {
         self.mapString = mapString
         self.mapMapString = mapMapString
     }

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/Animal.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/Animal.swift
@@ -12,7 +12,7 @@ public struct Animal: Codable {
     public var className: String
     public var color: String? = "red"
 
-    public init(className: String, color: String?) {
+    public init(className: String, color: String? = nil) {
         self.className = className
         self.color = color
     }

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/ApiResponse.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/ApiResponse.swift
@@ -13,7 +13,7 @@ public struct ApiResponse: Codable {
     public var type: String?
     public var message: String?
 
-    public init(code: Int?, type: String?, message: String?) {
+    public init(code: Int? = nil, type: String? = nil, message: String? = nil) {
         self.code = code
         self.type = type
         self.message = message

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfArrayOfNumberOnly.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfArrayOfNumberOnly.swift
@@ -11,7 +11,7 @@ public struct ArrayOfArrayOfNumberOnly: Codable {
 
     public var arrayArrayNumber: [[Double]]?
 
-    public init(arrayArrayNumber: [[Double]]?) {
+    public init(arrayArrayNumber: [[Double]]? = nil) {
         self.arrayArrayNumber = arrayArrayNumber
     }
 

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfNumberOnly.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfNumberOnly.swift
@@ -11,7 +11,7 @@ public struct ArrayOfNumberOnly: Codable {
 
     public var arrayNumber: [Double]?
 
-    public init(arrayNumber: [Double]?) {
+    public init(arrayNumber: [Double]? = nil) {
         self.arrayNumber = arrayNumber
     }
 

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/ArrayTest.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/ArrayTest.swift
@@ -13,7 +13,7 @@ public struct ArrayTest: Codable {
     public var arrayArrayOfInteger: [[Int64]]?
     public var arrayArrayOfModel: [[ReadOnlyFirst]]?
 
-    public init(arrayOfString: [String]?, arrayArrayOfInteger: [[Int64]]?, arrayArrayOfModel: [[ReadOnlyFirst]]?) {
+    public init(arrayOfString: [String]? = nil, arrayArrayOfInteger: [[Int64]]? = nil, arrayArrayOfModel: [[ReadOnlyFirst]]? = nil) {
         self.arrayOfString = arrayOfString
         self.arrayArrayOfInteger = arrayArrayOfInteger
         self.arrayArrayOfModel = arrayArrayOfModel

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/Capitalization.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/Capitalization.swift
@@ -17,7 +17,7 @@ public struct Capitalization: Codable {
     /** Name of the pet  */
     public var ATT_NAME: String?
 
-    public init(smallCamel: String?, capitalCamel: String?, smallSnake: String?, capitalSnake: String?, sCAETHFlowPoints: String?, ATT_NAME: String?) {
+    public init(smallCamel: String? = nil, capitalCamel: String? = nil, smallSnake: String? = nil, capitalSnake: String? = nil, sCAETHFlowPoints: String? = nil, ATT_NAME: String? = nil) {
         self.smallCamel = smallCamel
         self.capitalCamel = capitalCamel
         self.smallSnake = smallSnake

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/Cat.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/Cat.swift
@@ -13,7 +13,7 @@ public struct Cat: Codable {
     public var color: String? = "red"
     public var declawed: Bool?
 
-    public init(className: String, color: String?, declawed: Bool?) {
+    public init(className: String, color: String? = nil, declawed: Bool? = nil) {
         self.className = className
         self.color = color
         self.declawed = declawed

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/CatAllOf.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/CatAllOf.swift
@@ -11,7 +11,7 @@ public struct CatAllOf: Codable {
 
     public var declawed: Bool?
 
-    public init(declawed: Bool?) {
+    public init(declawed: Bool? = nil) {
         self.declawed = declawed
     }
 

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/Category.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/Category.swift
@@ -12,7 +12,7 @@ public struct Category: Codable {
     public var id: Int64?
     public var name: String = "default-name"
 
-    public init(id: Int64?, name: String) {
+    public init(id: Int64? = nil, name: String) {
         self.id = id
         self.name = name
     }

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/ClassModel.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/ClassModel.swift
@@ -12,7 +12,7 @@ public struct ClassModel: Codable {
 
     public var _class: String?
 
-    public init(_class: String?) {
+    public init(_class: String? = nil) {
         self._class = _class
     }
 

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/Client.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/Client.swift
@@ -11,7 +11,7 @@ public struct Client: Codable {
 
     public var client: String?
 
-    public init(client: String?) {
+    public init(client: String? = nil) {
         self.client = client
     }
 

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/Dog.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/Dog.swift
@@ -13,7 +13,7 @@ public struct Dog: Codable {
     public var color: String? = "red"
     public var breed: String?
 
-    public init(className: String, color: String?, breed: String?) {
+    public init(className: String, color: String? = nil, breed: String? = nil) {
         self.className = className
         self.color = color
         self.breed = breed

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/DogAllOf.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/DogAllOf.swift
@@ -11,7 +11,7 @@ public struct DogAllOf: Codable {
 
     public var breed: String?
 
-    public init(breed: String?) {
+    public init(breed: String? = nil) {
         self.breed = breed
     }
 

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/EnumArrays.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/EnumArrays.swift
@@ -20,7 +20,7 @@ public struct EnumArrays: Codable {
     public var justSymbol: JustSymbol?
     public var arrayEnum: [ArrayEnum]?
 
-    public init(justSymbol: JustSymbol?, arrayEnum: [ArrayEnum]?) {
+    public init(justSymbol: JustSymbol? = nil, arrayEnum: [ArrayEnum]? = nil) {
         self.justSymbol = justSymbol
         self.arrayEnum = arrayEnum
     }

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/EnumTest.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/EnumTest.swift
@@ -33,7 +33,7 @@ public struct EnumTest: Codable {
     public var enumNumber: EnumNumber?
     public var outerEnum: OuterEnum?
 
-    public init(enumString: EnumString?, enumStringRequired: EnumStringRequired, enumInteger: EnumInteger?, enumNumber: EnumNumber?, outerEnum: OuterEnum?) {
+    public init(enumString: EnumString? = nil, enumStringRequired: EnumStringRequired, enumInteger: EnumInteger? = nil, enumNumber: EnumNumber? = nil, outerEnum: OuterEnum? = nil) {
         self.enumString = enumString
         self.enumStringRequired = enumStringRequired
         self.enumInteger = enumInteger

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/File.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/File.swift
@@ -13,7 +13,7 @@ public struct File: Codable {
     /** Test capitalization */
     public var sourceURI: String?
 
-    public init(sourceURI: String?) {
+    public init(sourceURI: String? = nil) {
         self.sourceURI = sourceURI
     }
 

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/FileSchemaTestClass.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/FileSchemaTestClass.swift
@@ -12,7 +12,7 @@ public struct FileSchemaTestClass: Codable {
     public var file: File?
     public var files: [File]?
 
-    public init(file: File?, files: [File]?) {
+    public init(file: File? = nil, files: [File]? = nil) {
         self.file = file
         self.files = files
     }

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/FormatTest.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/FormatTest.swift
@@ -23,7 +23,7 @@ public struct FormatTest: Codable {
     public var uuid: UUID?
     public var password: String
 
-    public init(integer: Int?, int32: Int?, int64: Int64?, number: Double, float: Float?, double: Double?, string: String?, byte: Data, binary: URL?, date: Date, dateTime: Date?, uuid: UUID?, password: String) {
+    public init(integer: Int? = nil, int32: Int? = nil, int64: Int64? = nil, number: Double, float: Float? = nil, double: Double? = nil, string: String? = nil, byte: Data, binary: URL? = nil, date: Date, dateTime: Date? = nil, uuid: UUID? = nil, password: String) {
         self.integer = integer
         self.int32 = int32
         self.int64 = int64

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/HasOnlyReadOnly.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/HasOnlyReadOnly.swift
@@ -12,7 +12,7 @@ public struct HasOnlyReadOnly: Codable {
     public var bar: String?
     public var foo: String?
 
-    public init(bar: String?, foo: String?) {
+    public init(bar: String? = nil, foo: String? = nil) {
         self.bar = bar
         self.foo = foo
     }

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/List.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/List.swift
@@ -11,7 +11,7 @@ public struct List: Codable {
 
     public var _123list: String?
 
-    public init(_123list: String?) {
+    public init(_123list: String? = nil) {
         self._123list = _123list
     }
 

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/MapTest.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/MapTest.swift
@@ -18,7 +18,7 @@ public struct MapTest: Codable {
     public var directMap: [String: Bool]?
     public var indirectMap: StringBooleanMap?
 
-    public init(mapMapOfString: [String: [String: String]]?, mapOfEnumString: [String: String]?, directMap: [String: Bool]?, indirectMap: StringBooleanMap?) {
+    public init(mapMapOfString: [String: [String: String]]? = nil, mapOfEnumString: [String: String]? = nil, directMap: [String: Bool]? = nil, indirectMap: StringBooleanMap? = nil) {
         self.mapMapOfString = mapMapOfString
         self.mapOfEnumString = mapOfEnumString
         self.directMap = directMap

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/MixedPropertiesAndAdditionalPropertiesClass.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/MixedPropertiesAndAdditionalPropertiesClass.swift
@@ -13,7 +13,7 @@ public struct MixedPropertiesAndAdditionalPropertiesClass: Codable {
     public var dateTime: Date?
     public var map: [String: Animal]?
 
-    public init(uuid: UUID?, dateTime: Date?, map: [String: Animal]?) {
+    public init(uuid: UUID? = nil, dateTime: Date? = nil, map: [String: Animal]? = nil) {
         self.uuid = uuid
         self.dateTime = dateTime
         self.map = map

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/Model200Response.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/Model200Response.swift
@@ -13,7 +13,7 @@ public struct Model200Response: Codable {
     public var name: Int?
     public var _class: String?
 
-    public init(name: Int?, _class: String?) {
+    public init(name: Int? = nil, _class: String? = nil) {
         self.name = name
         self._class = _class
     }

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/Name.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/Name.swift
@@ -15,7 +15,7 @@ public struct Name: Codable {
     public var property: String?
     public var _123number: Int?
 
-    public init(name: Int, snakeCase: Int?, property: String?, _123number: Int?) {
+    public init(name: Int, snakeCase: Int? = nil, property: String? = nil, _123number: Int? = nil) {
         self.name = name
         self.snakeCase = snakeCase
         self.property = property

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/NumberOnly.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/NumberOnly.swift
@@ -11,7 +11,7 @@ public struct NumberOnly: Codable {
 
     public var justNumber: Double?
 
-    public init(justNumber: Double?) {
+    public init(justNumber: Double? = nil) {
         self.justNumber = justNumber
     }
 

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/Order.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/Order.swift
@@ -22,7 +22,7 @@ public struct Order: Codable {
     public var status: Status?
     public var complete: Bool? = false
 
-    public init(id: Int64?, petId: Int64?, quantity: Int?, shipDate: Date?, status: Status?, complete: Bool?) {
+    public init(id: Int64? = nil, petId: Int64? = nil, quantity: Int? = nil, shipDate: Date? = nil, status: Status? = nil, complete: Bool? = nil) {
         self.id = id
         self.petId = petId
         self.quantity = quantity

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/OuterComposite.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/OuterComposite.swift
@@ -13,7 +13,7 @@ public struct OuterComposite: Codable {
     public var myString: String?
     public var myBoolean: Bool?
 
-    public init(myNumber: Double?, myString: String?, myBoolean: Bool?) {
+    public init(myNumber: Double? = nil, myString: String? = nil, myBoolean: Bool? = nil) {
         self.myNumber = myNumber
         self.myString = myString
         self.myBoolean = myBoolean

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/Pet.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/Pet.swift
@@ -22,7 +22,7 @@ public struct Pet: Codable {
     /** pet status in the store */
     public var status: Status?
 
-    public init(id: Int64?, category: Category?, name: String, photoUrls: [String], tags: [Tag]?, status: Status?) {
+    public init(id: Int64? = nil, category: Category? = nil, name: String, photoUrls: [String], tags: [Tag]? = nil, status: Status? = nil) {
         self.id = id
         self.category = category
         self.name = name

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/ReadOnlyFirst.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/ReadOnlyFirst.swift
@@ -12,7 +12,7 @@ public struct ReadOnlyFirst: Codable {
     public var bar: String?
     public var baz: String?
 
-    public init(bar: String?, baz: String?) {
+    public init(bar: String? = nil, baz: String? = nil) {
         self.bar = bar
         self.baz = baz
     }

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/Return.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/Return.swift
@@ -12,7 +12,7 @@ public struct Return: Codable {
 
     public var _return: Int?
 
-    public init(_return: Int?) {
+    public init(_return: Int? = nil) {
         self._return = _return
     }
 

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/SpecialModelName.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/SpecialModelName.swift
@@ -11,7 +11,7 @@ public struct SpecialModelName: Codable {
 
     public var specialPropertyName: Int64?
 
-    public init(specialPropertyName: Int64?) {
+    public init(specialPropertyName: Int64? = nil) {
         self.specialPropertyName = specialPropertyName
     }
 

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/Tag.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/Tag.swift
@@ -12,7 +12,7 @@ public struct Tag: Codable {
     public var id: Int64?
     public var name: String?
 
-    public init(id: Int64?, name: String?) {
+    public init(id: Int64? = nil, name: String? = nil) {
         self.id = id
         self.name = name
     }

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/User.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/User.swift
@@ -19,7 +19,7 @@ public struct User: Codable {
     /** User Status */
     public var userStatus: Int?
 
-    public init(id: Int64?, username: String?, firstName: String?, lastName: String?, email: String?, password: String?, phone: String?, userStatus: Int?) {
+    public init(id: Int64? = nil, username: String? = nil, firstName: String? = nil, lastName: String? = nil, email: String? = nil, password: String? = nil, phone: String? = nil, userStatus: Int? = nil) {
         self.id = id
         self.username = username
         self.firstName = firstName

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/AdditionalPropertiesClass.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/AdditionalPropertiesClass.swift
@@ -12,7 +12,7 @@ public struct AdditionalPropertiesClass: Codable {
     public var mapString: [String: String]?
     public var mapMapString: [String: [String: String]]?
 
-    public init(mapString: [String: String]?, mapMapString: [String: [String: String]]?) {
+    public init(mapString: [String: String]? = nil, mapMapString: [String: [String: String]]? = nil) {
         self.mapString = mapString
         self.mapMapString = mapMapString
     }

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/Animal.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/Animal.swift
@@ -12,7 +12,7 @@ public struct Animal: Codable {
     public var className: String
     public var color: String? = "red"
 
-    public init(className: String, color: String?) {
+    public init(className: String, color: String? = nil) {
         self.className = className
         self.color = color
     }

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/ApiResponse.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/ApiResponse.swift
@@ -13,7 +13,7 @@ public struct ApiResponse: Codable {
     public var type: String?
     public var message: String?
 
-    public init(code: Int?, type: String?, message: String?) {
+    public init(code: Int? = nil, type: String? = nil, message: String? = nil) {
         self.code = code
         self.type = type
         self.message = message

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfArrayOfNumberOnly.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfArrayOfNumberOnly.swift
@@ -11,7 +11,7 @@ public struct ArrayOfArrayOfNumberOnly: Codable {
 
     public var arrayArrayNumber: [[Double]]?
 
-    public init(arrayArrayNumber: [[Double]]?) {
+    public init(arrayArrayNumber: [[Double]]? = nil) {
         self.arrayArrayNumber = arrayArrayNumber
     }
 

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfNumberOnly.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfNumberOnly.swift
@@ -11,7 +11,7 @@ public struct ArrayOfNumberOnly: Codable {
 
     public var arrayNumber: [Double]?
 
-    public init(arrayNumber: [Double]?) {
+    public init(arrayNumber: [Double]? = nil) {
         self.arrayNumber = arrayNumber
     }
 

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/ArrayTest.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/ArrayTest.swift
@@ -13,7 +13,7 @@ public struct ArrayTest: Codable {
     public var arrayArrayOfInteger: [[Int64]]?
     public var arrayArrayOfModel: [[ReadOnlyFirst]]?
 
-    public init(arrayOfString: [String]?, arrayArrayOfInteger: [[Int64]]?, arrayArrayOfModel: [[ReadOnlyFirst]]?) {
+    public init(arrayOfString: [String]? = nil, arrayArrayOfInteger: [[Int64]]? = nil, arrayArrayOfModel: [[ReadOnlyFirst]]? = nil) {
         self.arrayOfString = arrayOfString
         self.arrayArrayOfInteger = arrayArrayOfInteger
         self.arrayArrayOfModel = arrayArrayOfModel

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/Capitalization.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/Capitalization.swift
@@ -17,7 +17,7 @@ public struct Capitalization: Codable {
     /** Name of the pet  */
     public var ATT_NAME: String?
 
-    public init(smallCamel: String?, capitalCamel: String?, smallSnake: String?, capitalSnake: String?, sCAETHFlowPoints: String?, ATT_NAME: String?) {
+    public init(smallCamel: String? = nil, capitalCamel: String? = nil, smallSnake: String? = nil, capitalSnake: String? = nil, sCAETHFlowPoints: String? = nil, ATT_NAME: String? = nil) {
         self.smallCamel = smallCamel
         self.capitalCamel = capitalCamel
         self.smallSnake = smallSnake

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/Cat.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/Cat.swift
@@ -13,7 +13,7 @@ public struct Cat: Codable {
     public var color: String? = "red"
     public var declawed: Bool?
 
-    public init(className: String, color: String?, declawed: Bool?) {
+    public init(className: String, color: String? = nil, declawed: Bool? = nil) {
         self.className = className
         self.color = color
         self.declawed = declawed

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/CatAllOf.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/CatAllOf.swift
@@ -11,7 +11,7 @@ public struct CatAllOf: Codable {
 
     public var declawed: Bool?
 
-    public init(declawed: Bool?) {
+    public init(declawed: Bool? = nil) {
         self.declawed = declawed
     }
 

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/Category.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/Category.swift
@@ -12,7 +12,7 @@ public struct Category: Codable {
     public var id: Int64?
     public var name: String = "default-name"
 
-    public init(id: Int64?, name: String) {
+    public init(id: Int64? = nil, name: String) {
         self.id = id
         self.name = name
     }

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/ClassModel.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/ClassModel.swift
@@ -12,7 +12,7 @@ public struct ClassModel: Codable {
 
     public var _class: String?
 
-    public init(_class: String?) {
+    public init(_class: String? = nil) {
         self._class = _class
     }
 

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/Client.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/Client.swift
@@ -11,7 +11,7 @@ public struct Client: Codable {
 
     public var client: String?
 
-    public init(client: String?) {
+    public init(client: String? = nil) {
         self.client = client
     }
 

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/Dog.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/Dog.swift
@@ -13,7 +13,7 @@ public struct Dog: Codable {
     public var color: String? = "red"
     public var breed: String?
 
-    public init(className: String, color: String?, breed: String?) {
+    public init(className: String, color: String? = nil, breed: String? = nil) {
         self.className = className
         self.color = color
         self.breed = breed

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/DogAllOf.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/DogAllOf.swift
@@ -11,7 +11,7 @@ public struct DogAllOf: Codable {
 
     public var breed: String?
 
-    public init(breed: String?) {
+    public init(breed: String? = nil) {
         self.breed = breed
     }
 

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/EnumArrays.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/EnumArrays.swift
@@ -20,7 +20,7 @@ public struct EnumArrays: Codable {
     public var justSymbol: JustSymbol?
     public var arrayEnum: [ArrayEnum]?
 
-    public init(justSymbol: JustSymbol?, arrayEnum: [ArrayEnum]?) {
+    public init(justSymbol: JustSymbol? = nil, arrayEnum: [ArrayEnum]? = nil) {
         self.justSymbol = justSymbol
         self.arrayEnum = arrayEnum
     }

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/EnumTest.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/EnumTest.swift
@@ -33,7 +33,7 @@ public struct EnumTest: Codable {
     public var enumNumber: EnumNumber?
     public var outerEnum: OuterEnum?
 
-    public init(enumString: EnumString?, enumStringRequired: EnumStringRequired, enumInteger: EnumInteger?, enumNumber: EnumNumber?, outerEnum: OuterEnum?) {
+    public init(enumString: EnumString? = nil, enumStringRequired: EnumStringRequired, enumInteger: EnumInteger? = nil, enumNumber: EnumNumber? = nil, outerEnum: OuterEnum? = nil) {
         self.enumString = enumString
         self.enumStringRequired = enumStringRequired
         self.enumInteger = enumInteger

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/File.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/File.swift
@@ -13,7 +13,7 @@ public struct File: Codable {
     /** Test capitalization */
     public var sourceURI: String?
 
-    public init(sourceURI: String?) {
+    public init(sourceURI: String? = nil) {
         self.sourceURI = sourceURI
     }
 

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/FileSchemaTestClass.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/FileSchemaTestClass.swift
@@ -12,7 +12,7 @@ public struct FileSchemaTestClass: Codable {
     public var file: File?
     public var files: [File]?
 
-    public init(file: File?, files: [File]?) {
+    public init(file: File? = nil, files: [File]? = nil) {
         self.file = file
         self.files = files
     }

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/FormatTest.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/FormatTest.swift
@@ -23,7 +23,7 @@ public struct FormatTest: Codable {
     public var uuid: UUID?
     public var password: String
 
-    public init(integer: Int?, int32: Int?, int64: Int64?, number: Double, float: Float?, double: Double?, string: String?, byte: Data, binary: URL?, date: Date, dateTime: Date?, uuid: UUID?, password: String) {
+    public init(integer: Int? = nil, int32: Int? = nil, int64: Int64? = nil, number: Double, float: Float? = nil, double: Double? = nil, string: String? = nil, byte: Data, binary: URL? = nil, date: Date, dateTime: Date? = nil, uuid: UUID? = nil, password: String) {
         self.integer = integer
         self.int32 = int32
         self.int64 = int64

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/HasOnlyReadOnly.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/HasOnlyReadOnly.swift
@@ -12,7 +12,7 @@ public struct HasOnlyReadOnly: Codable {
     public var bar: String?
     public var foo: String?
 
-    public init(bar: String?, foo: String?) {
+    public init(bar: String? = nil, foo: String? = nil) {
         self.bar = bar
         self.foo = foo
     }

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/List.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/List.swift
@@ -11,7 +11,7 @@ public struct List: Codable {
 
     public var _123list: String?
 
-    public init(_123list: String?) {
+    public init(_123list: String? = nil) {
         self._123list = _123list
     }
 

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/MapTest.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/MapTest.swift
@@ -18,7 +18,7 @@ public struct MapTest: Codable {
     public var directMap: [String: Bool]?
     public var indirectMap: StringBooleanMap?
 
-    public init(mapMapOfString: [String: [String: String]]?, mapOfEnumString: [String: String]?, directMap: [String: Bool]?, indirectMap: StringBooleanMap?) {
+    public init(mapMapOfString: [String: [String: String]]? = nil, mapOfEnumString: [String: String]? = nil, directMap: [String: Bool]? = nil, indirectMap: StringBooleanMap? = nil) {
         self.mapMapOfString = mapMapOfString
         self.mapOfEnumString = mapOfEnumString
         self.directMap = directMap

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/MixedPropertiesAndAdditionalPropertiesClass.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/MixedPropertiesAndAdditionalPropertiesClass.swift
@@ -13,7 +13,7 @@ public struct MixedPropertiesAndAdditionalPropertiesClass: Codable {
     public var dateTime: Date?
     public var map: [String: Animal]?
 
-    public init(uuid: UUID?, dateTime: Date?, map: [String: Animal]?) {
+    public init(uuid: UUID? = nil, dateTime: Date? = nil, map: [String: Animal]? = nil) {
         self.uuid = uuid
         self.dateTime = dateTime
         self.map = map

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/Model200Response.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/Model200Response.swift
@@ -13,7 +13,7 @@ public struct Model200Response: Codable {
     public var name: Int?
     public var _class: String?
 
-    public init(name: Int?, _class: String?) {
+    public init(name: Int? = nil, _class: String? = nil) {
         self.name = name
         self._class = _class
     }

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/Name.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/Name.swift
@@ -15,7 +15,7 @@ public struct Name: Codable {
     public var property: String?
     public var _123number: Int?
 
-    public init(name: Int, snakeCase: Int?, property: String?, _123number: Int?) {
+    public init(name: Int, snakeCase: Int? = nil, property: String? = nil, _123number: Int? = nil) {
         self.name = name
         self.snakeCase = snakeCase
         self.property = property

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/NumberOnly.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/NumberOnly.swift
@@ -11,7 +11,7 @@ public struct NumberOnly: Codable {
 
     public var justNumber: Double?
 
-    public init(justNumber: Double?) {
+    public init(justNumber: Double? = nil) {
         self.justNumber = justNumber
     }
 

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/Order.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/Order.swift
@@ -22,7 +22,7 @@ public struct Order: Codable {
     public var status: Status?
     public var complete: Bool? = false
 
-    public init(id: Int64?, petId: Int64?, quantity: Int?, shipDate: Date?, status: Status?, complete: Bool?) {
+    public init(id: Int64? = nil, petId: Int64? = nil, quantity: Int? = nil, shipDate: Date? = nil, status: Status? = nil, complete: Bool? = nil) {
         self.id = id
         self.petId = petId
         self.quantity = quantity

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/OuterComposite.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/OuterComposite.swift
@@ -13,7 +13,7 @@ public struct OuterComposite: Codable {
     public var myString: String?
     public var myBoolean: Bool?
 
-    public init(myNumber: Double?, myString: String?, myBoolean: Bool?) {
+    public init(myNumber: Double? = nil, myString: String? = nil, myBoolean: Bool? = nil) {
         self.myNumber = myNumber
         self.myString = myString
         self.myBoolean = myBoolean

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/Pet.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/Pet.swift
@@ -22,7 +22,7 @@ public struct Pet: Codable {
     /** pet status in the store */
     public var status: Status?
 
-    public init(id: Int64?, category: Category?, name: String, photoUrls: [String], tags: [Tag]?, status: Status?) {
+    public init(id: Int64? = nil, category: Category? = nil, name: String, photoUrls: [String], tags: [Tag]? = nil, status: Status? = nil) {
         self.id = id
         self.category = category
         self.name = name

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/ReadOnlyFirst.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/ReadOnlyFirst.swift
@@ -12,7 +12,7 @@ public struct ReadOnlyFirst: Codable {
     public var bar: String?
     public var baz: String?
 
-    public init(bar: String?, baz: String?) {
+    public init(bar: String? = nil, baz: String? = nil) {
         self.bar = bar
         self.baz = baz
     }

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/Return.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/Return.swift
@@ -12,7 +12,7 @@ public struct Return: Codable {
 
     public var _return: Int?
 
-    public init(_return: Int?) {
+    public init(_return: Int? = nil) {
         self._return = _return
     }
 

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/SpecialModelName.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/SpecialModelName.swift
@@ -11,7 +11,7 @@ public struct SpecialModelName: Codable {
 
     public var specialPropertyName: Int64?
 
-    public init(specialPropertyName: Int64?) {
+    public init(specialPropertyName: Int64? = nil) {
         self.specialPropertyName = specialPropertyName
     }
 

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/Tag.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/Tag.swift
@@ -12,7 +12,7 @@ public struct Tag: Codable {
     public var id: Int64?
     public var name: String?
 
-    public init(id: Int64?, name: String?) {
+    public init(id: Int64? = nil, name: String? = nil) {
         self.id = id
         self.name = name
     }

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/User.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/User.swift
@@ -19,7 +19,7 @@ public struct User: Codable {
     /** User Status */
     public var userStatus: Int?
 
-    public init(id: Int64?, username: String?, firstName: String?, lastName: String?, email: String?, password: String?, phone: String?, userStatus: Int?) {
+    public init(id: Int64? = nil, username: String? = nil, firstName: String? = nil, lastName: String? = nil, email: String? = nil, password: String? = nil, phone: String? = nil, userStatus: Int? = nil) {
         self.id = id
         self.username = username
         self.firstName = firstName

--- a/samples/client/petstore/swift5/deprecated/PetstoreClient/Classes/OpenAPIs/Models/ApiResponse.swift
+++ b/samples/client/petstore/swift5/deprecated/PetstoreClient/Classes/OpenAPIs/Models/ApiResponse.swift
@@ -14,7 +14,7 @@ public struct ApiResponse: Codable {
     public var type: String?
     public var message: String?
 
-    public init(code: Int?, type: String?, message: String?) {
+    public init(code: Int? = nil, type: String? = nil, message: String? = nil) {
         self.code = code
         self.type = type
         self.message = message

--- a/samples/client/petstore/swift5/deprecated/PetstoreClient/Classes/OpenAPIs/Models/Category.swift
+++ b/samples/client/petstore/swift5/deprecated/PetstoreClient/Classes/OpenAPIs/Models/Category.swift
@@ -13,7 +13,7 @@ public struct Category: Codable {
     public var id: Int64?
     public var name: String?
 
-    public init(id: Int64?, name: String?) {
+    public init(id: Int64? = nil, name: String? = nil) {
         self.id = id
         self.name = name
     }

--- a/samples/client/petstore/swift5/deprecated/PetstoreClient/Classes/OpenAPIs/Models/InlineObject.swift
+++ b/samples/client/petstore/swift5/deprecated/PetstoreClient/Classes/OpenAPIs/Models/InlineObject.swift
@@ -14,7 +14,7 @@ public struct InlineObject: Codable {
     /** Updated status of the pet */
     public var status: String?
 
-    public init(name: String?, status: String?) {
+    public init(name: String? = nil, status: String? = nil) {
         self.name = name
         self.status = status
     }

--- a/samples/client/petstore/swift5/deprecated/PetstoreClient/Classes/OpenAPIs/Models/InlineObject1.swift
+++ b/samples/client/petstore/swift5/deprecated/PetstoreClient/Classes/OpenAPIs/Models/InlineObject1.swift
@@ -14,7 +14,7 @@ public struct InlineObject1: Codable {
     /** file to upload */
     public var file: URL?
 
-    public init(additionalMetadata: String?, file: URL?) {
+    public init(additionalMetadata: String? = nil, file: URL? = nil) {
         self.additionalMetadata = additionalMetadata
         self.file = file
     }

--- a/samples/client/petstore/swift5/deprecated/PetstoreClient/Classes/OpenAPIs/Models/Order.swift
+++ b/samples/client/petstore/swift5/deprecated/PetstoreClient/Classes/OpenAPIs/Models/Order.swift
@@ -24,7 +24,7 @@ public struct Order: Codable {
     public var status: Status?
     public var complete: Bool? = false
 
-    public init(id: Int64?, petId: Int64?, quantity: Int?, shipDate: Date?, status: Status?, complete: Bool?) {
+    public init(id: Int64? = nil, petId: Int64? = nil, quantity: Int? = nil, shipDate: Date? = nil, status: Status? = nil, complete: Bool? = nil) {
         self.id = id
         self.petId = petId
         self.quantity = quantity

--- a/samples/client/petstore/swift5/deprecated/PetstoreClient/Classes/OpenAPIs/Models/Pet.swift
+++ b/samples/client/petstore/swift5/deprecated/PetstoreClient/Classes/OpenAPIs/Models/Pet.swift
@@ -25,7 +25,7 @@ public struct Pet: Codable {
     /** pet status in the store */
     public var status: Status?
 
-    public init(id: Int64?, category: Category?, name: String?, photoUrls: [String], tags: [Tag]?, status: Status?) {
+    public init(id: Int64? = nil, category: Category? = nil, name: String?, photoUrls: [String], tags: [Tag]? = nil, status: Status? = nil) {
         self.id = id
         self.category = category
         self.name = name

--- a/samples/client/petstore/swift5/deprecated/PetstoreClient/Classes/OpenAPIs/Models/Tag.swift
+++ b/samples/client/petstore/swift5/deprecated/PetstoreClient/Classes/OpenAPIs/Models/Tag.swift
@@ -13,7 +13,7 @@ public struct Tag: Codable {
     public var id: Int64?
     public var name: String?
 
-    public init(id: Int64?, name: String?) {
+    public init(id: Int64? = nil, name: String? = nil) {
         self.id = id
         self.name = name
     }

--- a/samples/client/petstore/swift5/deprecated/PetstoreClient/Classes/OpenAPIs/Models/User.swift
+++ b/samples/client/petstore/swift5/deprecated/PetstoreClient/Classes/OpenAPIs/Models/User.swift
@@ -20,7 +20,7 @@ public struct User: Codable {
     /** User Status */
     public var userStatus: Int?
 
-    public init(id: Int64?, username: String?, firstName: String?, lastName: String?, email: String?, password: String?, phone: String?, userStatus: Int?) {
+    public init(id: Int64? = nil, username: String? = nil, firstName: String? = nil, lastName: String? = nil, email: String? = nil, password: String? = nil, phone: String? = nil, userStatus: Int? = nil) {
         self.id = id
         self.username = username
         self.firstName = firstName

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/AdditionalPropertiesClass.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/AdditionalPropertiesClass.swift
@@ -12,7 +12,7 @@ internal struct AdditionalPropertiesClass: Codable {
     internal var mapString: [String: String]?
     internal var mapMapString: [String: [String: String]]?
 
-    internal init(mapString: [String: String]?, mapMapString: [String: [String: String]]?) {
+    internal init(mapString: [String: String]? = nil, mapMapString: [String: [String: String]]? = nil) {
         self.mapString = mapString
         self.mapMapString = mapMapString
     }

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/Animal.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/Animal.swift
@@ -12,7 +12,7 @@ internal struct Animal: Codable {
     internal var className: String
     internal var color: String? = "red"
 
-    internal init(className: String, color: String?) {
+    internal init(className: String, color: String? = nil) {
         self.className = className
         self.color = color
     }

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/ApiResponse.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/ApiResponse.swift
@@ -13,7 +13,7 @@ internal struct ApiResponse: Codable {
     internal var type: String?
     internal var message: String?
 
-    internal init(code: Int?, type: String?, message: String?) {
+    internal init(code: Int? = nil, type: String? = nil, message: String? = nil) {
         self.code = code
         self.type = type
         self.message = message

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfArrayOfNumberOnly.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfArrayOfNumberOnly.swift
@@ -11,7 +11,7 @@ internal struct ArrayOfArrayOfNumberOnly: Codable {
 
     internal var arrayArrayNumber: [[Double]]?
 
-    internal init(arrayArrayNumber: [[Double]]?) {
+    internal init(arrayArrayNumber: [[Double]]? = nil) {
         self.arrayArrayNumber = arrayArrayNumber
     }
 

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfNumberOnly.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfNumberOnly.swift
@@ -11,7 +11,7 @@ internal struct ArrayOfNumberOnly: Codable {
 
     internal var arrayNumber: [Double]?
 
-    internal init(arrayNumber: [Double]?) {
+    internal init(arrayNumber: [Double]? = nil) {
         self.arrayNumber = arrayNumber
     }
 

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/ArrayTest.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/ArrayTest.swift
@@ -13,7 +13,7 @@ internal struct ArrayTest: Codable {
     internal var arrayArrayOfInteger: [[Int64]]?
     internal var arrayArrayOfModel: [[ReadOnlyFirst]]?
 
-    internal init(arrayOfString: [String]?, arrayArrayOfInteger: [[Int64]]?, arrayArrayOfModel: [[ReadOnlyFirst]]?) {
+    internal init(arrayOfString: [String]? = nil, arrayArrayOfInteger: [[Int64]]? = nil, arrayArrayOfModel: [[ReadOnlyFirst]]? = nil) {
         self.arrayOfString = arrayOfString
         self.arrayArrayOfInteger = arrayArrayOfInteger
         self.arrayArrayOfModel = arrayArrayOfModel

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/Capitalization.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/Capitalization.swift
@@ -17,7 +17,7 @@ internal struct Capitalization: Codable {
     /** Name of the pet  */
     internal var ATT_NAME: String?
 
-    internal init(smallCamel: String?, capitalCamel: String?, smallSnake: String?, capitalSnake: String?, sCAETHFlowPoints: String?, ATT_NAME: String?) {
+    internal init(smallCamel: String? = nil, capitalCamel: String? = nil, smallSnake: String? = nil, capitalSnake: String? = nil, sCAETHFlowPoints: String? = nil, ATT_NAME: String? = nil) {
         self.smallCamel = smallCamel
         self.capitalCamel = capitalCamel
         self.smallSnake = smallSnake

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/Cat.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/Cat.swift
@@ -13,7 +13,7 @@ internal struct Cat: Codable {
     internal var color: String? = "red"
     internal var declawed: Bool?
 
-    internal init(className: String, color: String?, declawed: Bool?) {
+    internal init(className: String, color: String? = nil, declawed: Bool? = nil) {
         self.className = className
         self.color = color
         self.declawed = declawed

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/CatAllOf.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/CatAllOf.swift
@@ -11,7 +11,7 @@ internal struct CatAllOf: Codable {
 
     internal var declawed: Bool?
 
-    internal init(declawed: Bool?) {
+    internal init(declawed: Bool? = nil) {
         self.declawed = declawed
     }
 

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/Category.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/Category.swift
@@ -12,7 +12,7 @@ internal struct Category: Codable {
     internal var id: Int64?
     internal var name: String = "default-name"
 
-    internal init(id: Int64?, name: String) {
+    internal init(id: Int64? = nil, name: String) {
         self.id = id
         self.name = name
     }

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/ClassModel.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/ClassModel.swift
@@ -12,7 +12,7 @@ internal struct ClassModel: Codable {
 
     internal var _class: String?
 
-    internal init(_class: String?) {
+    internal init(_class: String? = nil) {
         self._class = _class
     }
 

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/Client.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/Client.swift
@@ -11,7 +11,7 @@ internal struct Client: Codable {
 
     internal var client: String?
 
-    internal init(client: String?) {
+    internal init(client: String? = nil) {
         self.client = client
     }
 

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/Dog.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/Dog.swift
@@ -13,7 +13,7 @@ internal struct Dog: Codable {
     internal var color: String? = "red"
     internal var breed: String?
 
-    internal init(className: String, color: String?, breed: String?) {
+    internal init(className: String, color: String? = nil, breed: String? = nil) {
         self.className = className
         self.color = color
         self.breed = breed

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/DogAllOf.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/DogAllOf.swift
@@ -11,7 +11,7 @@ internal struct DogAllOf: Codable {
 
     internal var breed: String?
 
-    internal init(breed: String?) {
+    internal init(breed: String? = nil) {
         self.breed = breed
     }
 

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/EnumArrays.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/EnumArrays.swift
@@ -20,7 +20,7 @@ internal struct EnumArrays: Codable {
     internal var justSymbol: JustSymbol?
     internal var arrayEnum: [ArrayEnum]?
 
-    internal init(justSymbol: JustSymbol?, arrayEnum: [ArrayEnum]?) {
+    internal init(justSymbol: JustSymbol? = nil, arrayEnum: [ArrayEnum]? = nil) {
         self.justSymbol = justSymbol
         self.arrayEnum = arrayEnum
     }

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/EnumTest.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/EnumTest.swift
@@ -33,7 +33,7 @@ internal struct EnumTest: Codable {
     internal var enumNumber: EnumNumber?
     internal var outerEnum: OuterEnum?
 
-    internal init(enumString: EnumString?, enumStringRequired: EnumStringRequired, enumInteger: EnumInteger?, enumNumber: EnumNumber?, outerEnum: OuterEnum?) {
+    internal init(enumString: EnumString? = nil, enumStringRequired: EnumStringRequired, enumInteger: EnumInteger? = nil, enumNumber: EnumNumber? = nil, outerEnum: OuterEnum? = nil) {
         self.enumString = enumString
         self.enumStringRequired = enumStringRequired
         self.enumInteger = enumInteger

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/File.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/File.swift
@@ -13,7 +13,7 @@ internal struct File: Codable {
     /** Test capitalization */
     internal var sourceURI: String?
 
-    internal init(sourceURI: String?) {
+    internal init(sourceURI: String? = nil) {
         self.sourceURI = sourceURI
     }
 

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/FileSchemaTestClass.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/FileSchemaTestClass.swift
@@ -12,7 +12,7 @@ internal struct FileSchemaTestClass: Codable {
     internal var file: File?
     internal var files: [File]?
 
-    internal init(file: File?, files: [File]?) {
+    internal init(file: File? = nil, files: [File]? = nil) {
         self.file = file
         self.files = files
     }

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/FormatTest.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/FormatTest.swift
@@ -23,7 +23,7 @@ internal struct FormatTest: Codable {
     internal var uuid: UUID?
     internal var password: String
 
-    internal init(integer: Int?, int32: Int?, int64: Int64?, number: Double, float: Float?, double: Double?, string: String?, byte: Data, binary: URL?, date: Date, dateTime: Date?, uuid: UUID?, password: String) {
+    internal init(integer: Int? = nil, int32: Int? = nil, int64: Int64? = nil, number: Double, float: Float? = nil, double: Double? = nil, string: String? = nil, byte: Data, binary: URL? = nil, date: Date, dateTime: Date? = nil, uuid: UUID? = nil, password: String) {
         self.integer = integer
         self.int32 = int32
         self.int64 = int64

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/HasOnlyReadOnly.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/HasOnlyReadOnly.swift
@@ -12,7 +12,7 @@ internal struct HasOnlyReadOnly: Codable {
     internal var bar: String?
     internal var foo: String?
 
-    internal init(bar: String?, foo: String?) {
+    internal init(bar: String? = nil, foo: String? = nil) {
         self.bar = bar
         self.foo = foo
     }

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/List.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/List.swift
@@ -11,7 +11,7 @@ internal struct List: Codable {
 
     internal var _123list: String?
 
-    internal init(_123list: String?) {
+    internal init(_123list: String? = nil) {
         self._123list = _123list
     }
 

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/MapTest.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/MapTest.swift
@@ -18,7 +18,7 @@ internal struct MapTest: Codable {
     internal var directMap: [String: Bool]?
     internal var indirectMap: StringBooleanMap?
 
-    internal init(mapMapOfString: [String: [String: String]]?, mapOfEnumString: [String: String]?, directMap: [String: Bool]?, indirectMap: StringBooleanMap?) {
+    internal init(mapMapOfString: [String: [String: String]]? = nil, mapOfEnumString: [String: String]? = nil, directMap: [String: Bool]? = nil, indirectMap: StringBooleanMap? = nil) {
         self.mapMapOfString = mapMapOfString
         self.mapOfEnumString = mapOfEnumString
         self.directMap = directMap

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/MixedPropertiesAndAdditionalPropertiesClass.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/MixedPropertiesAndAdditionalPropertiesClass.swift
@@ -13,7 +13,7 @@ internal struct MixedPropertiesAndAdditionalPropertiesClass: Codable {
     internal var dateTime: Date?
     internal var map: [String: Animal]?
 
-    internal init(uuid: UUID?, dateTime: Date?, map: [String: Animal]?) {
+    internal init(uuid: UUID? = nil, dateTime: Date? = nil, map: [String: Animal]? = nil) {
         self.uuid = uuid
         self.dateTime = dateTime
         self.map = map

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/Model200Response.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/Model200Response.swift
@@ -13,7 +13,7 @@ internal struct Model200Response: Codable {
     internal var name: Int?
     internal var _class: String?
 
-    internal init(name: Int?, _class: String?) {
+    internal init(name: Int? = nil, _class: String? = nil) {
         self.name = name
         self._class = _class
     }

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/Name.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/Name.swift
@@ -15,7 +15,7 @@ internal struct Name: Codable {
     internal var property: String?
     internal var _123number: Int?
 
-    internal init(name: Int, snakeCase: Int?, property: String?, _123number: Int?) {
+    internal init(name: Int, snakeCase: Int? = nil, property: String? = nil, _123number: Int? = nil) {
         self.name = name
         self.snakeCase = snakeCase
         self.property = property

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/NumberOnly.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/NumberOnly.swift
@@ -11,7 +11,7 @@ internal struct NumberOnly: Codable {
 
     internal var justNumber: Double?
 
-    internal init(justNumber: Double?) {
+    internal init(justNumber: Double? = nil) {
         self.justNumber = justNumber
     }
 

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/Order.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/Order.swift
@@ -22,7 +22,7 @@ internal struct Order: Codable {
     internal var status: Status?
     internal var complete: Bool? = false
 
-    internal init(id: Int64?, petId: Int64?, quantity: Int?, shipDate: Date?, status: Status?, complete: Bool?) {
+    internal init(id: Int64? = nil, petId: Int64? = nil, quantity: Int? = nil, shipDate: Date? = nil, status: Status? = nil, complete: Bool? = nil) {
         self.id = id
         self.petId = petId
         self.quantity = quantity

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/OuterComposite.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/OuterComposite.swift
@@ -13,7 +13,7 @@ internal struct OuterComposite: Codable {
     internal var myString: String?
     internal var myBoolean: Bool?
 
-    internal init(myNumber: Double?, myString: String?, myBoolean: Bool?) {
+    internal init(myNumber: Double? = nil, myString: String? = nil, myBoolean: Bool? = nil) {
         self.myNumber = myNumber
         self.myString = myString
         self.myBoolean = myBoolean

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/Pet.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/Pet.swift
@@ -22,7 +22,7 @@ internal struct Pet: Codable {
     /** pet status in the store */
     internal var status: Status?
 
-    internal init(id: Int64?, category: Category?, name: String, photoUrls: [String], tags: [Tag]?, status: Status?) {
+    internal init(id: Int64? = nil, category: Category? = nil, name: String, photoUrls: [String], tags: [Tag]? = nil, status: Status? = nil) {
         self.id = id
         self.category = category
         self.name = name

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/ReadOnlyFirst.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/ReadOnlyFirst.swift
@@ -12,7 +12,7 @@ internal struct ReadOnlyFirst: Codable {
     internal var bar: String?
     internal var baz: String?
 
-    internal init(bar: String?, baz: String?) {
+    internal init(bar: String? = nil, baz: String? = nil) {
         self.bar = bar
         self.baz = baz
     }

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/Return.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/Return.swift
@@ -12,7 +12,7 @@ internal struct Return: Codable {
 
     internal var _return: Int?
 
-    internal init(_return: Int?) {
+    internal init(_return: Int? = nil) {
         self._return = _return
     }
 

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/SpecialModelName.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/SpecialModelName.swift
@@ -11,7 +11,7 @@ internal struct SpecialModelName: Codable {
 
     internal var specialPropertyName: Int64?
 
-    internal init(specialPropertyName: Int64?) {
+    internal init(specialPropertyName: Int64? = nil) {
         self.specialPropertyName = specialPropertyName
     }
 

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/Tag.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/Tag.swift
@@ -12,7 +12,7 @@ internal struct Tag: Codable {
     internal var id: Int64?
     internal var name: String?
 
-    internal init(id: Int64?, name: String?) {
+    internal init(id: Int64? = nil, name: String? = nil) {
         self.id = id
         self.name = name
     }

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/User.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/User.swift
@@ -19,7 +19,7 @@ internal struct User: Codable {
     /** User Status */
     internal var userStatus: Int?
 
-    internal init(id: Int64?, username: String?, firstName: String?, lastName: String?, email: String?, password: String?, phone: String?, userStatus: Int?) {
+    internal init(id: Int64? = nil, username: String? = nil, firstName: String? = nil, lastName: String? = nil, email: String? = nil, password: String? = nil, phone: String? = nil, userStatus: Int? = nil) {
         self.id = id
         self.username = username
         self.firstName = firstName

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/AdditionalPropertiesClass.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/AdditionalPropertiesClass.swift
@@ -12,7 +12,7 @@ import Foundation
     public var mapString: [String: String]?
     public var mapMapString: [String: [String: String]]?
 
-    public init(mapString: [String: String]?, mapMapString: [String: [String: String]]?) {
+    public init(mapString: [String: String]? = nil, mapMapString: [String: [String: String]]? = nil) {
         self.mapString = mapString
         self.mapMapString = mapMapString
     }

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/Animal.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/Animal.swift
@@ -12,7 +12,7 @@ import Foundation
     public var _className: String
     public var color: String? = "red"
 
-    public init(_className: String, color: String?) {
+    public init(_className: String, color: String? = nil) {
         self._className = _className
         self.color = color
     }

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/ApiResponse.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/ApiResponse.swift
@@ -18,7 +18,7 @@ import Foundation
     public var type: String?
     public var message: String?
 
-    public init(code: Int?, type: String?, message: String?) {
+    public init(code: Int? = nil, type: String? = nil, message: String? = nil) {
         self.code = code
         self.type = type
         self.message = message

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfArrayOfNumberOnly.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfArrayOfNumberOnly.swift
@@ -11,7 +11,7 @@ import Foundation
 
     public var arrayArrayNumber: [[Double]]?
 
-    public init(arrayArrayNumber: [[Double]]?) {
+    public init(arrayArrayNumber: [[Double]]? = nil) {
         self.arrayArrayNumber = arrayArrayNumber
     }
 

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfNumberOnly.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfNumberOnly.swift
@@ -11,7 +11,7 @@ import Foundation
 
     public var arrayNumber: [Double]?
 
-    public init(arrayNumber: [Double]?) {
+    public init(arrayNumber: [Double]? = nil) {
         self.arrayNumber = arrayNumber
     }
 

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/ArrayTest.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/ArrayTest.swift
@@ -13,7 +13,7 @@ import Foundation
     public var arrayArrayOfInteger: [[Int64]]?
     public var arrayArrayOfModel: [[ReadOnlyFirst]]?
 
-    public init(arrayOfString: [String]?, arrayArrayOfInteger: [[Int64]]?, arrayArrayOfModel: [[ReadOnlyFirst]]?) {
+    public init(arrayOfString: [String]? = nil, arrayArrayOfInteger: [[Int64]]? = nil, arrayArrayOfModel: [[ReadOnlyFirst]]? = nil) {
         self.arrayOfString = arrayOfString
         self.arrayArrayOfInteger = arrayArrayOfInteger
         self.arrayArrayOfModel = arrayArrayOfModel

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/Capitalization.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/Capitalization.swift
@@ -17,7 +17,7 @@ import Foundation
     /** Name of the pet  */
     public var ATT_NAME: String?
 
-    public init(smallCamel: String?, capitalCamel: String?, smallSnake: String?, capitalSnake: String?, sCAETHFlowPoints: String?, ATT_NAME: String?) {
+    public init(smallCamel: String? = nil, capitalCamel: String? = nil, smallSnake: String? = nil, capitalSnake: String? = nil, sCAETHFlowPoints: String? = nil, ATT_NAME: String? = nil) {
         self.smallCamel = smallCamel
         self.capitalCamel = capitalCamel
         self.smallSnake = smallSnake

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/Cat.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/Cat.swift
@@ -18,7 +18,7 @@ import Foundation
         }
     }
 
-    public init(_className: String, color: String?, declawed: Bool?) {
+    public init(_className: String, color: String? = nil, declawed: Bool? = nil) {
         self._className = _className
         self.color = color
         self.declawed = declawed

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/CatAllOf.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/CatAllOf.swift
@@ -16,7 +16,7 @@ import Foundation
         }
     }
 
-    public init(declawed: Bool?) {
+    public init(declawed: Bool? = nil) {
         self.declawed = declawed
     }
 

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/Category.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/Category.swift
@@ -17,7 +17,7 @@ import Foundation
     }
     public var name: String = "default-name"
 
-    public init(_id: Int64?, name: String) {
+    public init(_id: Int64? = nil, name: String) {
         self._id = _id
         self.name = name
     }

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/ClassModel.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/ClassModel.swift
@@ -13,7 +13,7 @@ import Foundation
 
     public var _class: String?
 
-    public init(_class: String?) {
+    public init(_class: String? = nil) {
         self._class = _class
     }
 

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/Client.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/Client.swift
@@ -11,7 +11,7 @@ import Foundation
 
     public var client: String?
 
-    public init(client: String?) {
+    public init(client: String? = nil) {
         self.client = client
     }
 

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/Dog.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/Dog.swift
@@ -13,7 +13,7 @@ import Foundation
     public var color: String? = "red"
     public var breed: String?
 
-    public init(_className: String, color: String?, breed: String?) {
+    public init(_className: String, color: String? = nil, breed: String? = nil) {
         self._className = _className
         self.color = color
         self.breed = breed

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/DogAllOf.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/DogAllOf.swift
@@ -11,7 +11,7 @@ import Foundation
 
     public var breed: String?
 
-    public init(breed: String?) {
+    public init(breed: String? = nil) {
         self.breed = breed
     }
 

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/EnumArrays.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/EnumArrays.swift
@@ -20,7 +20,7 @@ import Foundation
     public var justSymbol: JustSymbol?
     public var arrayEnum: [ArrayEnum]?
 
-    public init(justSymbol: JustSymbol?, arrayEnum: [ArrayEnum]?) {
+    public init(justSymbol: JustSymbol? = nil, arrayEnum: [ArrayEnum]? = nil) {
         self.justSymbol = justSymbol
         self.arrayEnum = arrayEnum
     }

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/EnumTest.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/EnumTest.swift
@@ -33,7 +33,7 @@ import Foundation
     public var enumNumber: EnumNumber?
     public var outerEnum: OuterEnum?
 
-    public init(enumString: EnumString?, enumStringRequired: EnumStringRequired, enumInteger: EnumInteger?, enumNumber: EnumNumber?, outerEnum: OuterEnum?) {
+    public init(enumString: EnumString? = nil, enumStringRequired: EnumStringRequired, enumInteger: EnumInteger? = nil, enumNumber: EnumNumber? = nil, outerEnum: OuterEnum? = nil) {
         self.enumString = enumString
         self.enumStringRequired = enumStringRequired
         self.enumInteger = enumInteger

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/File.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/File.swift
@@ -14,7 +14,7 @@ import Foundation
     /** Test capitalization */
     public var sourceURI: String?
 
-    public init(sourceURI: String?) {
+    public init(sourceURI: String? = nil) {
         self.sourceURI = sourceURI
     }
 

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/FileSchemaTestClass.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/FileSchemaTestClass.swift
@@ -12,7 +12,7 @@ import Foundation
     public var file: File?
     public var files: [File]?
 
-    public init(file: File?, files: [File]?) {
+    public init(file: File? = nil, files: [File]? = nil) {
         self.file = file
         self.files = files
     }

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/FormatTest.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/FormatTest.swift
@@ -48,7 +48,7 @@ import Foundation
     public var uuid: UUID?
     public var password: String
 
-    public init(integer: Int?, int32: Int?, int64: Int64?, number: Double, float: Float?, double: Double?, string: String?, byte: Data, binary: URL?, date: Date, dateTime: Date?, uuid: UUID?, password: String) {
+    public init(integer: Int? = nil, int32: Int? = nil, int64: Int64? = nil, number: Double, float: Float? = nil, double: Double? = nil, string: String? = nil, byte: Data, binary: URL? = nil, date: Date, dateTime: Date? = nil, uuid: UUID? = nil, password: String) {
         self.integer = integer
         self.int32 = int32
         self.int64 = int64

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/HasOnlyReadOnly.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/HasOnlyReadOnly.swift
@@ -12,7 +12,7 @@ import Foundation
     public var bar: String?
     public var foo: String?
 
-    public init(bar: String?, foo: String?) {
+    public init(bar: String? = nil, foo: String? = nil) {
         self.bar = bar
         self.foo = foo
     }

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/List.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/List.swift
@@ -11,7 +11,7 @@ import Foundation
 
     public var _123list: String?
 
-    public init(_123list: String?) {
+    public init(_123list: String? = nil) {
         self._123list = _123list
     }
 

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/MapTest.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/MapTest.swift
@@ -18,7 +18,7 @@ import Foundation
     public var directMap: [String: Bool]?
     public var indirectMap: StringBooleanMap?
 
-    public init(mapMapOfString: [String: [String: String]]?, mapOfEnumString: [String: String]?, directMap: [String: Bool]?, indirectMap: StringBooleanMap?) {
+    public init(mapMapOfString: [String: [String: String]]? = nil, mapOfEnumString: [String: String]? = nil, directMap: [String: Bool]? = nil, indirectMap: StringBooleanMap? = nil) {
         self.mapMapOfString = mapMapOfString
         self.mapOfEnumString = mapOfEnumString
         self.directMap = directMap

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/MixedPropertiesAndAdditionalPropertiesClass.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/MixedPropertiesAndAdditionalPropertiesClass.swift
@@ -13,7 +13,7 @@ import Foundation
     public var dateTime: Date?
     public var map: [String: Animal]?
 
-    public init(uuid: UUID?, dateTime: Date?, map: [String: Animal]?) {
+    public init(uuid: UUID? = nil, dateTime: Date? = nil, map: [String: Animal]? = nil) {
         self.uuid = uuid
         self.dateTime = dateTime
         self.map = map

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/Model200Response.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/Model200Response.swift
@@ -19,7 +19,7 @@ import Foundation
     }
     public var _class: String?
 
-    public init(name: Int?, _class: String?) {
+    public init(name: Int? = nil, _class: String? = nil) {
         self.name = name
         self._class = _class
     }

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/Name.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/Name.swift
@@ -26,7 +26,7 @@ import Foundation
         }
     }
 
-    public init(name: Int, snakeCase: Int?, property: String?, _123number: Int?) {
+    public init(name: Int, snakeCase: Int? = nil, property: String? = nil, _123number: Int? = nil) {
         self.name = name
         self.snakeCase = snakeCase
         self.property = property

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/NumberOnly.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/NumberOnly.swift
@@ -11,7 +11,7 @@ import Foundation
 
     public var justNumber: Double?
 
-    public init(justNumber: Double?) {
+    public init(justNumber: Double? = nil) {
         self.justNumber = justNumber
     }
 

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/Order.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/Order.swift
@@ -42,7 +42,7 @@ import Foundation
         }
     }
 
-    public init(_id: Int64?, petId: Int64?, quantity: Int?, shipDate: Date?, status: Status?, complete: Bool?) {
+    public init(_id: Int64? = nil, petId: Int64? = nil, quantity: Int? = nil, shipDate: Date? = nil, status: Status? = nil, complete: Bool? = nil) {
         self._id = _id
         self.petId = petId
         self.quantity = quantity

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/OuterComposite.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/OuterComposite.swift
@@ -18,7 +18,7 @@ import Foundation
         }
     }
 
-    public init(myNumber: Double?, myString: String?, myBoolean: Bool?) {
+    public init(myNumber: Double? = nil, myString: String? = nil, myBoolean: Bool? = nil) {
         self.myNumber = myNumber
         self.myString = myString
         self.myBoolean = myBoolean

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/Pet.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/Pet.swift
@@ -27,7 +27,7 @@ import Foundation
     /** pet status in the store */
     public var status: Status?
 
-    public init(_id: Int64?, category: Category?, name: String, photoUrls: [String], tags: [Tag]?, status: Status?) {
+    public init(_id: Int64? = nil, category: Category? = nil, name: String, photoUrls: [String], tags: [Tag]? = nil, status: Status? = nil) {
         self._id = _id
         self.category = category
         self.name = name

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/ReadOnlyFirst.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/ReadOnlyFirst.swift
@@ -12,7 +12,7 @@ import Foundation
     public var bar: String?
     public var baz: String?
 
-    public init(bar: String?, baz: String?) {
+    public init(bar: String? = nil, baz: String? = nil) {
         self.bar = bar
         self.baz = baz
     }

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/Return.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/Return.swift
@@ -18,7 +18,7 @@ import Foundation
         }
     }
 
-    public init(_return: Int?) {
+    public init(_return: Int? = nil) {
         self._return = _return
     }
 

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/SpecialModelName.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/SpecialModelName.swift
@@ -16,7 +16,7 @@ import Foundation
         }
     }
 
-    public init(specialPropertyName: Int64?) {
+    public init(specialPropertyName: Int64? = nil) {
         self.specialPropertyName = specialPropertyName
     }
 

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/Tag.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/Tag.swift
@@ -17,7 +17,7 @@ import Foundation
     }
     public var name: String?
 
-    public init(_id: Int64?, name: String?) {
+    public init(_id: Int64? = nil, name: String? = nil) {
         self._id = _id
         self.name = name
     }

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/User.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/User.swift
@@ -29,7 +29,7 @@ import Foundation
         }
     }
 
-    public init(_id: Int64?, username: String?, firstName: String?, lastName: String?, email: String?, password: String?, phone: String?, userStatus: Int?) {
+    public init(_id: Int64? = nil, username: String? = nil, firstName: String? = nil, lastName: String? = nil, email: String? = nil, password: String? = nil, phone: String? = nil, userStatus: Int? = nil) {
         self._id = _id
         self.username = username
         self.firstName = firstName

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/AdditionalPropertiesClass.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/AdditionalPropertiesClass.swift
@@ -12,7 +12,7 @@ public struct AdditionalPropertiesClass: Codable {
     public var mapString: [String: String]?
     public var mapMapString: [String: [String: String]]?
 
-    public init(mapString: [String: String]?, mapMapString: [String: [String: String]]?) {
+    public init(mapString: [String: String]? = nil, mapMapString: [String: [String: String]]? = nil) {
         self.mapString = mapString
         self.mapMapString = mapMapString
     }

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/Animal.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/Animal.swift
@@ -12,7 +12,7 @@ public struct Animal: Codable {
     public var className: String
     public var color: String? = "red"
 
-    public init(className: String, color: String?) {
+    public init(className: String, color: String? = nil) {
         self.className = className
         self.color = color
     }

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/ApiResponse.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/ApiResponse.swift
@@ -13,7 +13,7 @@ public struct ApiResponse: Codable {
     public var type: String?
     public var message: String?
 
-    public init(code: Int?, type: String?, message: String?) {
+    public init(code: Int? = nil, type: String? = nil, message: String? = nil) {
         self.code = code
         self.type = type
         self.message = message

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfArrayOfNumberOnly.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfArrayOfNumberOnly.swift
@@ -11,7 +11,7 @@ public struct ArrayOfArrayOfNumberOnly: Codable {
 
     public var arrayArrayNumber: [[Double]]?
 
-    public init(arrayArrayNumber: [[Double]]?) {
+    public init(arrayArrayNumber: [[Double]]? = nil) {
         self.arrayArrayNumber = arrayArrayNumber
     }
 

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfNumberOnly.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfNumberOnly.swift
@@ -11,7 +11,7 @@ public struct ArrayOfNumberOnly: Codable {
 
     public var arrayNumber: [Double]?
 
-    public init(arrayNumber: [Double]?) {
+    public init(arrayNumber: [Double]? = nil) {
         self.arrayNumber = arrayNumber
     }
 

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/ArrayTest.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/ArrayTest.swift
@@ -13,7 +13,7 @@ public struct ArrayTest: Codable {
     public var arrayArrayOfInteger: [[Int64]]?
     public var arrayArrayOfModel: [[ReadOnlyFirst]]?
 
-    public init(arrayOfString: [String]?, arrayArrayOfInteger: [[Int64]]?, arrayArrayOfModel: [[ReadOnlyFirst]]?) {
+    public init(arrayOfString: [String]? = nil, arrayArrayOfInteger: [[Int64]]? = nil, arrayArrayOfModel: [[ReadOnlyFirst]]? = nil) {
         self.arrayOfString = arrayOfString
         self.arrayArrayOfInteger = arrayArrayOfInteger
         self.arrayArrayOfModel = arrayArrayOfModel

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/Capitalization.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/Capitalization.swift
@@ -17,7 +17,7 @@ public struct Capitalization: Codable {
     /** Name of the pet  */
     public var ATT_NAME: String?
 
-    public init(smallCamel: String?, capitalCamel: String?, smallSnake: String?, capitalSnake: String?, sCAETHFlowPoints: String?, ATT_NAME: String?) {
+    public init(smallCamel: String? = nil, capitalCamel: String? = nil, smallSnake: String? = nil, capitalSnake: String? = nil, sCAETHFlowPoints: String? = nil, ATT_NAME: String? = nil) {
         self.smallCamel = smallCamel
         self.capitalCamel = capitalCamel
         self.smallSnake = smallSnake

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/Cat.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/Cat.swift
@@ -13,7 +13,7 @@ public struct Cat: Codable {
     public var color: String? = "red"
     public var declawed: Bool?
 
-    public init(className: String, color: String?, declawed: Bool?) {
+    public init(className: String, color: String? = nil, declawed: Bool? = nil) {
         self.className = className
         self.color = color
         self.declawed = declawed

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/CatAllOf.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/CatAllOf.swift
@@ -11,7 +11,7 @@ public struct CatAllOf: Codable {
 
     public var declawed: Bool?
 
-    public init(declawed: Bool?) {
+    public init(declawed: Bool? = nil) {
         self.declawed = declawed
     }
 

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/Category.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/Category.swift
@@ -12,7 +12,7 @@ public struct Category: Codable {
     public var id: Int64?
     public var name: String = "default-name"
 
-    public init(id: Int64?, name: String) {
+    public init(id: Int64? = nil, name: String) {
         self.id = id
         self.name = name
     }

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/ClassModel.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/ClassModel.swift
@@ -12,7 +12,7 @@ public struct ClassModel: Codable {
 
     public var _class: String?
 
-    public init(_class: String?) {
+    public init(_class: String? = nil) {
         self._class = _class
     }
 

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/Client.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/Client.swift
@@ -11,7 +11,7 @@ public struct Client: Codable {
 
     public var client: String?
 
-    public init(client: String?) {
+    public init(client: String? = nil) {
         self.client = client
     }
 

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/Dog.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/Dog.swift
@@ -13,7 +13,7 @@ public struct Dog: Codable {
     public var color: String? = "red"
     public var breed: String?
 
-    public init(className: String, color: String?, breed: String?) {
+    public init(className: String, color: String? = nil, breed: String? = nil) {
         self.className = className
         self.color = color
         self.breed = breed

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/DogAllOf.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/DogAllOf.swift
@@ -11,7 +11,7 @@ public struct DogAllOf: Codable {
 
     public var breed: String?
 
-    public init(breed: String?) {
+    public init(breed: String? = nil) {
         self.breed = breed
     }
 

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/EnumArrays.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/EnumArrays.swift
@@ -20,7 +20,7 @@ public struct EnumArrays: Codable {
     public var justSymbol: JustSymbol?
     public var arrayEnum: [ArrayEnum]?
 
-    public init(justSymbol: JustSymbol?, arrayEnum: [ArrayEnum]?) {
+    public init(justSymbol: JustSymbol? = nil, arrayEnum: [ArrayEnum]? = nil) {
         self.justSymbol = justSymbol
         self.arrayEnum = arrayEnum
     }

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/EnumTest.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/EnumTest.swift
@@ -33,7 +33,7 @@ public struct EnumTest: Codable {
     public var enumNumber: EnumNumber?
     public var outerEnum: OuterEnum?
 
-    public init(enumString: EnumString?, enumStringRequired: EnumStringRequired, enumInteger: EnumInteger?, enumNumber: EnumNumber?, outerEnum: OuterEnum?) {
+    public init(enumString: EnumString? = nil, enumStringRequired: EnumStringRequired, enumInteger: EnumInteger? = nil, enumNumber: EnumNumber? = nil, outerEnum: OuterEnum? = nil) {
         self.enumString = enumString
         self.enumStringRequired = enumStringRequired
         self.enumInteger = enumInteger

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/File.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/File.swift
@@ -13,7 +13,7 @@ public struct File: Codable {
     /** Test capitalization */
     public var sourceURI: String?
 
-    public init(sourceURI: String?) {
+    public init(sourceURI: String? = nil) {
         self.sourceURI = sourceURI
     }
 

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/FileSchemaTestClass.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/FileSchemaTestClass.swift
@@ -12,7 +12,7 @@ public struct FileSchemaTestClass: Codable {
     public var file: File?
     public var files: [File]?
 
-    public init(file: File?, files: [File]?) {
+    public init(file: File? = nil, files: [File]? = nil) {
         self.file = file
         self.files = files
     }

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/FormatTest.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/FormatTest.swift
@@ -23,7 +23,7 @@ public struct FormatTest: Codable {
     public var uuid: UUID?
     public var password: String
 
-    public init(integer: Int?, int32: Int?, int64: Int64?, number: Double, float: Float?, double: Double?, string: String?, byte: Data, binary: URL?, date: Date, dateTime: Date?, uuid: UUID?, password: String) {
+    public init(integer: Int? = nil, int32: Int? = nil, int64: Int64? = nil, number: Double, float: Float? = nil, double: Double? = nil, string: String? = nil, byte: Data, binary: URL? = nil, date: Date, dateTime: Date? = nil, uuid: UUID? = nil, password: String) {
         self.integer = integer
         self.int32 = int32
         self.int64 = int64

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/HasOnlyReadOnly.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/HasOnlyReadOnly.swift
@@ -12,7 +12,7 @@ public struct HasOnlyReadOnly: Codable {
     public var bar: String?
     public var foo: String?
 
-    public init(bar: String?, foo: String?) {
+    public init(bar: String? = nil, foo: String? = nil) {
         self.bar = bar
         self.foo = foo
     }

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/List.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/List.swift
@@ -11,7 +11,7 @@ public struct List: Codable {
 
     public var _123list: String?
 
-    public init(_123list: String?) {
+    public init(_123list: String? = nil) {
         self._123list = _123list
     }
 

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/MapTest.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/MapTest.swift
@@ -18,7 +18,7 @@ public struct MapTest: Codable {
     public var directMap: [String: Bool]?
     public var indirectMap: StringBooleanMap?
 
-    public init(mapMapOfString: [String: [String: String]]?, mapOfEnumString: [String: String]?, directMap: [String: Bool]?, indirectMap: StringBooleanMap?) {
+    public init(mapMapOfString: [String: [String: String]]? = nil, mapOfEnumString: [String: String]? = nil, directMap: [String: Bool]? = nil, indirectMap: StringBooleanMap? = nil) {
         self.mapMapOfString = mapMapOfString
         self.mapOfEnumString = mapOfEnumString
         self.directMap = directMap

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/MixedPropertiesAndAdditionalPropertiesClass.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/MixedPropertiesAndAdditionalPropertiesClass.swift
@@ -13,7 +13,7 @@ public struct MixedPropertiesAndAdditionalPropertiesClass: Codable {
     public var dateTime: Date?
     public var map: [String: Animal]?
 
-    public init(uuid: UUID?, dateTime: Date?, map: [String: Animal]?) {
+    public init(uuid: UUID? = nil, dateTime: Date? = nil, map: [String: Animal]? = nil) {
         self.uuid = uuid
         self.dateTime = dateTime
         self.map = map

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/Model200Response.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/Model200Response.swift
@@ -13,7 +13,7 @@ public struct Model200Response: Codable {
     public var name: Int?
     public var _class: String?
 
-    public init(name: Int?, _class: String?) {
+    public init(name: Int? = nil, _class: String? = nil) {
         self.name = name
         self._class = _class
     }

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/Name.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/Name.swift
@@ -15,7 +15,7 @@ public struct Name: Codable {
     public var property: String?
     public var _123number: Int?
 
-    public init(name: Int, snakeCase: Int?, property: String?, _123number: Int?) {
+    public init(name: Int, snakeCase: Int? = nil, property: String? = nil, _123number: Int? = nil) {
         self.name = name
         self.snakeCase = snakeCase
         self.property = property

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/NumberOnly.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/NumberOnly.swift
@@ -11,7 +11,7 @@ public struct NumberOnly: Codable {
 
     public var justNumber: Double?
 
-    public init(justNumber: Double?) {
+    public init(justNumber: Double? = nil) {
         self.justNumber = justNumber
     }
 

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/Order.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/Order.swift
@@ -22,7 +22,7 @@ public struct Order: Codable {
     public var status: Status?
     public var complete: Bool? = false
 
-    public init(id: Int64?, petId: Int64?, quantity: Int?, shipDate: Date?, status: Status?, complete: Bool?) {
+    public init(id: Int64? = nil, petId: Int64? = nil, quantity: Int? = nil, shipDate: Date? = nil, status: Status? = nil, complete: Bool? = nil) {
         self.id = id
         self.petId = petId
         self.quantity = quantity

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/OuterComposite.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/OuterComposite.swift
@@ -13,7 +13,7 @@ public struct OuterComposite: Codable {
     public var myString: String?
     public var myBoolean: Bool?
 
-    public init(myNumber: Double?, myString: String?, myBoolean: Bool?) {
+    public init(myNumber: Double? = nil, myString: String? = nil, myBoolean: Bool? = nil) {
         self.myNumber = myNumber
         self.myString = myString
         self.myBoolean = myBoolean

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/Pet.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/Pet.swift
@@ -22,7 +22,7 @@ public struct Pet: Codable {
     /** pet status in the store */
     public var status: Status?
 
-    public init(id: Int64?, category: Category?, name: String, photoUrls: [String], tags: [Tag]?, status: Status?) {
+    public init(id: Int64? = nil, category: Category? = nil, name: String, photoUrls: [String], tags: [Tag]? = nil, status: Status? = nil) {
         self.id = id
         self.category = category
         self.name = name

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/ReadOnlyFirst.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/ReadOnlyFirst.swift
@@ -12,7 +12,7 @@ public struct ReadOnlyFirst: Codable {
     public var bar: String?
     public var baz: String?
 
-    public init(bar: String?, baz: String?) {
+    public init(bar: String? = nil, baz: String? = nil) {
         self.bar = bar
         self.baz = baz
     }

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/Return.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/Return.swift
@@ -12,7 +12,7 @@ public struct Return: Codable {
 
     public var _return: Int?
 
-    public init(_return: Int?) {
+    public init(_return: Int? = nil) {
         self._return = _return
     }
 

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/SpecialModelName.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/SpecialModelName.swift
@@ -11,7 +11,7 @@ public struct SpecialModelName: Codable {
 
     public var specialPropertyName: Int64?
 
-    public init(specialPropertyName: Int64?) {
+    public init(specialPropertyName: Int64? = nil) {
         self.specialPropertyName = specialPropertyName
     }
 

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/Tag.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/Tag.swift
@@ -12,7 +12,7 @@ public struct Tag: Codable {
     public var id: Int64?
     public var name: String?
 
-    public init(id: Int64?, name: String?) {
+    public init(id: Int64? = nil, name: String? = nil) {
         self.id = id
         self.name = name
     }

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/User.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/User.swift
@@ -19,7 +19,7 @@ public struct User: Codable {
     /** User Status */
     public var userStatus: Int?
 
-    public init(id: Int64?, username: String?, firstName: String?, lastName: String?, email: String?, password: String?, phone: String?, userStatus: Int?) {
+    public init(id: Int64? = nil, username: String? = nil, firstName: String? = nil, lastName: String? = nil, email: String? = nil, password: String? = nil, phone: String? = nil, userStatus: Int? = nil) {
         self.id = id
         self.username = username
         self.firstName = firstName

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/AdditionalPropertiesClass.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/AdditionalPropertiesClass.swift
@@ -12,7 +12,7 @@ public struct AdditionalPropertiesClass: Codable {
     public private(set) var mapString: [String: String]?
     public private(set) var mapMapString: [String: [String: String]]?
 
-    public init(mapString: [String: String]?, mapMapString: [String: [String: String]]?) {
+    public init(mapString: [String: String]? = nil, mapMapString: [String: [String: String]]? = nil) {
         self.mapString = mapString
         self.mapMapString = mapMapString
     }

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/Animal.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/Animal.swift
@@ -12,7 +12,7 @@ public struct Animal: Codable {
     public private(set) var className: String
     public private(set) var color: String? = "red"
 
-    public init(className: String, color: String?) {
+    public init(className: String, color: String? = nil) {
         self.className = className
         self.color = color
     }

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/ApiResponse.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/ApiResponse.swift
@@ -13,7 +13,7 @@ public struct ApiResponse: Codable {
     public private(set) var type: String?
     public private(set) var message: String?
 
-    public init(code: Int?, type: String?, message: String?) {
+    public init(code: Int? = nil, type: String? = nil, message: String? = nil) {
         self.code = code
         self.type = type
         self.message = message

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfArrayOfNumberOnly.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfArrayOfNumberOnly.swift
@@ -11,7 +11,7 @@ public struct ArrayOfArrayOfNumberOnly: Codable {
 
     public private(set) var arrayArrayNumber: [[Double]]?
 
-    public init(arrayArrayNumber: [[Double]]?) {
+    public init(arrayArrayNumber: [[Double]]? = nil) {
         self.arrayArrayNumber = arrayArrayNumber
     }
 

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfNumberOnly.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfNumberOnly.swift
@@ -11,7 +11,7 @@ public struct ArrayOfNumberOnly: Codable {
 
     public private(set) var arrayNumber: [Double]?
 
-    public init(arrayNumber: [Double]?) {
+    public init(arrayNumber: [Double]? = nil) {
         self.arrayNumber = arrayNumber
     }
 

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/ArrayTest.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/ArrayTest.swift
@@ -13,7 +13,7 @@ public struct ArrayTest: Codable {
     public private(set) var arrayArrayOfInteger: [[Int64]]?
     public private(set) var arrayArrayOfModel: [[ReadOnlyFirst]]?
 
-    public init(arrayOfString: [String]?, arrayArrayOfInteger: [[Int64]]?, arrayArrayOfModel: [[ReadOnlyFirst]]?) {
+    public init(arrayOfString: [String]? = nil, arrayArrayOfInteger: [[Int64]]? = nil, arrayArrayOfModel: [[ReadOnlyFirst]]? = nil) {
         self.arrayOfString = arrayOfString
         self.arrayArrayOfInteger = arrayArrayOfInteger
         self.arrayArrayOfModel = arrayArrayOfModel

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/Capitalization.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/Capitalization.swift
@@ -17,7 +17,7 @@ public struct Capitalization: Codable {
     /** Name of the pet  */
     public private(set) var ATT_NAME: String?
 
-    public init(smallCamel: String?, capitalCamel: String?, smallSnake: String?, capitalSnake: String?, sCAETHFlowPoints: String?, ATT_NAME: String?) {
+    public init(smallCamel: String? = nil, capitalCamel: String? = nil, smallSnake: String? = nil, capitalSnake: String? = nil, sCAETHFlowPoints: String? = nil, ATT_NAME: String? = nil) {
         self.smallCamel = smallCamel
         self.capitalCamel = capitalCamel
         self.smallSnake = smallSnake

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/Cat.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/Cat.swift
@@ -13,7 +13,7 @@ public struct Cat: Codable {
     public private(set) var color: String? = "red"
     public private(set) var declawed: Bool?
 
-    public init(className: String, color: String?, declawed: Bool?) {
+    public init(className: String, color: String? = nil, declawed: Bool? = nil) {
         self.className = className
         self.color = color
         self.declawed = declawed

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/CatAllOf.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/CatAllOf.swift
@@ -11,7 +11,7 @@ public struct CatAllOf: Codable {
 
     public private(set) var declawed: Bool?
 
-    public init(declawed: Bool?) {
+    public init(declawed: Bool? = nil) {
         self.declawed = declawed
     }
 

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/Category.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/Category.swift
@@ -12,7 +12,7 @@ public struct Category: Codable {
     public private(set) var id: Int64?
     public private(set) var name: String = "default-name"
 
-    public init(id: Int64?, name: String) {
+    public init(id: Int64? = nil, name: String) {
         self.id = id
         self.name = name
     }

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/ClassModel.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/ClassModel.swift
@@ -12,7 +12,7 @@ public struct ClassModel: Codable {
 
     public private(set) var _class: String?
 
-    public init(_class: String?) {
+    public init(_class: String? = nil) {
         self._class = _class
     }
 

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/Client.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/Client.swift
@@ -11,7 +11,7 @@ public struct Client: Codable {
 
     public private(set) var client: String?
 
-    public init(client: String?) {
+    public init(client: String? = nil) {
         self.client = client
     }
 

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/Dog.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/Dog.swift
@@ -13,7 +13,7 @@ public struct Dog: Codable {
     public private(set) var color: String? = "red"
     public private(set) var breed: String?
 
-    public init(className: String, color: String?, breed: String?) {
+    public init(className: String, color: String? = nil, breed: String? = nil) {
         self.className = className
         self.color = color
         self.breed = breed

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/DogAllOf.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/DogAllOf.swift
@@ -11,7 +11,7 @@ public struct DogAllOf: Codable {
 
     public private(set) var breed: String?
 
-    public init(breed: String?) {
+    public init(breed: String? = nil) {
         self.breed = breed
     }
 

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/EnumArrays.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/EnumArrays.swift
@@ -20,7 +20,7 @@ public struct EnumArrays: Codable {
     public private(set) var justSymbol: JustSymbol?
     public private(set) var arrayEnum: [ArrayEnum]?
 
-    public init(justSymbol: JustSymbol?, arrayEnum: [ArrayEnum]?) {
+    public init(justSymbol: JustSymbol? = nil, arrayEnum: [ArrayEnum]? = nil) {
         self.justSymbol = justSymbol
         self.arrayEnum = arrayEnum
     }

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/EnumTest.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/EnumTest.swift
@@ -33,7 +33,7 @@ public struct EnumTest: Codable {
     public private(set) var enumNumber: EnumNumber?
     public private(set) var outerEnum: OuterEnum?
 
-    public init(enumString: EnumString?, enumStringRequired: EnumStringRequired, enumInteger: EnumInteger?, enumNumber: EnumNumber?, outerEnum: OuterEnum?) {
+    public init(enumString: EnumString? = nil, enumStringRequired: EnumStringRequired, enumInteger: EnumInteger? = nil, enumNumber: EnumNumber? = nil, outerEnum: OuterEnum? = nil) {
         self.enumString = enumString
         self.enumStringRequired = enumStringRequired
         self.enumInteger = enumInteger

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/File.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/File.swift
@@ -13,7 +13,7 @@ public struct File: Codable {
     /** Test capitalization */
     public private(set) var sourceURI: String?
 
-    public init(sourceURI: String?) {
+    public init(sourceURI: String? = nil) {
         self.sourceURI = sourceURI
     }
 

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/FileSchemaTestClass.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/FileSchemaTestClass.swift
@@ -12,7 +12,7 @@ public struct FileSchemaTestClass: Codable {
     public private(set) var file: File?
     public private(set) var files: [File]?
 
-    public init(file: File?, files: [File]?) {
+    public init(file: File? = nil, files: [File]? = nil) {
         self.file = file
         self.files = files
     }

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/FormatTest.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/FormatTest.swift
@@ -23,7 +23,7 @@ public struct FormatTest: Codable {
     public private(set) var uuid: UUID?
     public private(set) var password: String
 
-    public init(integer: Int?, int32: Int?, int64: Int64?, number: Double, float: Float?, double: Double?, string: String?, byte: Data, binary: URL?, date: Date, dateTime: Date?, uuid: UUID?, password: String) {
+    public init(integer: Int? = nil, int32: Int? = nil, int64: Int64? = nil, number: Double, float: Float? = nil, double: Double? = nil, string: String? = nil, byte: Data, binary: URL? = nil, date: Date, dateTime: Date? = nil, uuid: UUID? = nil, password: String) {
         self.integer = integer
         self.int32 = int32
         self.int64 = int64

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/HasOnlyReadOnly.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/HasOnlyReadOnly.swift
@@ -12,7 +12,7 @@ public struct HasOnlyReadOnly: Codable {
     public private(set) var bar: String?
     public private(set) var foo: String?
 
-    public init(bar: String?, foo: String?) {
+    public init(bar: String? = nil, foo: String? = nil) {
         self.bar = bar
         self.foo = foo
     }

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/List.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/List.swift
@@ -11,7 +11,7 @@ public struct List: Codable {
 
     public private(set) var _123list: String?
 
-    public init(_123list: String?) {
+    public init(_123list: String? = nil) {
         self._123list = _123list
     }
 

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/MapTest.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/MapTest.swift
@@ -18,7 +18,7 @@ public struct MapTest: Codable {
     public private(set) var directMap: [String: Bool]?
     public private(set) var indirectMap: StringBooleanMap?
 
-    public init(mapMapOfString: [String: [String: String]]?, mapOfEnumString: [String: String]?, directMap: [String: Bool]?, indirectMap: StringBooleanMap?) {
+    public init(mapMapOfString: [String: [String: String]]? = nil, mapOfEnumString: [String: String]? = nil, directMap: [String: Bool]? = nil, indirectMap: StringBooleanMap? = nil) {
         self.mapMapOfString = mapMapOfString
         self.mapOfEnumString = mapOfEnumString
         self.directMap = directMap

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/MixedPropertiesAndAdditionalPropertiesClass.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/MixedPropertiesAndAdditionalPropertiesClass.swift
@@ -13,7 +13,7 @@ public struct MixedPropertiesAndAdditionalPropertiesClass: Codable {
     public private(set) var dateTime: Date?
     public private(set) var map: [String: Animal]?
 
-    public init(uuid: UUID?, dateTime: Date?, map: [String: Animal]?) {
+    public init(uuid: UUID? = nil, dateTime: Date? = nil, map: [String: Animal]? = nil) {
         self.uuid = uuid
         self.dateTime = dateTime
         self.map = map

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/Model200Response.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/Model200Response.swift
@@ -13,7 +13,7 @@ public struct Model200Response: Codable {
     public private(set) var name: Int?
     public private(set) var _class: String?
 
-    public init(name: Int?, _class: String?) {
+    public init(name: Int? = nil, _class: String? = nil) {
         self.name = name
         self._class = _class
     }

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/Name.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/Name.swift
@@ -15,7 +15,7 @@ public struct Name: Codable {
     public private(set) var property: String?
     public private(set) var _123number: Int?
 
-    public init(name: Int, snakeCase: Int?, property: String?, _123number: Int?) {
+    public init(name: Int, snakeCase: Int? = nil, property: String? = nil, _123number: Int? = nil) {
         self.name = name
         self.snakeCase = snakeCase
         self.property = property

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/NumberOnly.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/NumberOnly.swift
@@ -11,7 +11,7 @@ public struct NumberOnly: Codable {
 
     public private(set) var justNumber: Double?
 
-    public init(justNumber: Double?) {
+    public init(justNumber: Double? = nil) {
         self.justNumber = justNumber
     }
 

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/Order.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/Order.swift
@@ -22,7 +22,7 @@ public struct Order: Codable {
     public private(set) var status: Status?
     public private(set) var complete: Bool? = false
 
-    public init(id: Int64?, petId: Int64?, quantity: Int?, shipDate: Date?, status: Status?, complete: Bool?) {
+    public init(id: Int64? = nil, petId: Int64? = nil, quantity: Int? = nil, shipDate: Date? = nil, status: Status? = nil, complete: Bool? = nil) {
         self.id = id
         self.petId = petId
         self.quantity = quantity

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/OuterComposite.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/OuterComposite.swift
@@ -13,7 +13,7 @@ public struct OuterComposite: Codable {
     public private(set) var myString: String?
     public private(set) var myBoolean: Bool?
 
-    public init(myNumber: Double?, myString: String?, myBoolean: Bool?) {
+    public init(myNumber: Double? = nil, myString: String? = nil, myBoolean: Bool? = nil) {
         self.myNumber = myNumber
         self.myString = myString
         self.myBoolean = myBoolean

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/Pet.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/Pet.swift
@@ -22,7 +22,7 @@ public struct Pet: Codable {
     /** pet status in the store */
     public private(set) var status: Status?
 
-    public init(id: Int64?, category: Category?, name: String, photoUrls: [String], tags: [Tag]?, status: Status?) {
+    public init(id: Int64? = nil, category: Category? = nil, name: String, photoUrls: [String], tags: [Tag]? = nil, status: Status? = nil) {
         self.id = id
         self.category = category
         self.name = name

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/ReadOnlyFirst.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/ReadOnlyFirst.swift
@@ -12,7 +12,7 @@ public struct ReadOnlyFirst: Codable {
     public private(set) var bar: String?
     public private(set) var baz: String?
 
-    public init(bar: String?, baz: String?) {
+    public init(bar: String? = nil, baz: String? = nil) {
         self.bar = bar
         self.baz = baz
     }

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/Return.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/Return.swift
@@ -12,7 +12,7 @@ public struct Return: Codable {
 
     public private(set) var _return: Int?
 
-    public init(_return: Int?) {
+    public init(_return: Int? = nil) {
         self._return = _return
     }
 

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/SpecialModelName.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/SpecialModelName.swift
@@ -11,7 +11,7 @@ public struct SpecialModelName: Codable {
 
     public private(set) var specialPropertyName: Int64?
 
-    public init(specialPropertyName: Int64?) {
+    public init(specialPropertyName: Int64? = nil) {
         self.specialPropertyName = specialPropertyName
     }
 

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/Tag.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/Tag.swift
@@ -12,7 +12,7 @@ public struct Tag: Codable {
     public private(set) var id: Int64?
     public private(set) var name: String?
 
-    public init(id: Int64?, name: String?) {
+    public init(id: Int64? = nil, name: String? = nil) {
         self.id = id
         self.name = name
     }

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/User.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/User.swift
@@ -19,7 +19,7 @@ public struct User: Codable {
     /** User Status */
     public private(set) var userStatus: Int?
 
-    public init(id: Int64?, username: String?, firstName: String?, lastName: String?, email: String?, password: String?, phone: String?, userStatus: Int?) {
+    public init(id: Int64? = nil, username: String? = nil, firstName: String? = nil, lastName: String? = nil, email: String? = nil, password: String? = nil, phone: String? = nil, userStatus: Int? = nil) {
         self.id = id
         self.username = username
         self.firstName = firstName

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/AdditionalPropertiesClass.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/AdditionalPropertiesClass.swift
@@ -12,7 +12,7 @@ public struct AdditionalPropertiesClass: Codable {
     public var mapString: [String: String]?
     public var mapMapString: [String: [String: String]]?
 
-    public init(mapString: [String: String]?, mapMapString: [String: [String: String]]?) {
+    public init(mapString: [String: String]? = nil, mapMapString: [String: [String: String]]? = nil) {
         self.mapString = mapString
         self.mapMapString = mapMapString
     }

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/Animal.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/Animal.swift
@@ -12,7 +12,7 @@ public struct Animal: Codable {
     public var className: String
     public var color: String? = "red"
 
-    public init(className: String, color: String?) {
+    public init(className: String, color: String? = nil) {
         self.className = className
         self.color = color
     }

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/ApiResponse.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/ApiResponse.swift
@@ -13,7 +13,7 @@ public struct ApiResponse: Codable {
     public var type: String?
     public var message: String?
 
-    public init(code: Int?, type: String?, message: String?) {
+    public init(code: Int? = nil, type: String? = nil, message: String? = nil) {
         self.code = code
         self.type = type
         self.message = message

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfArrayOfNumberOnly.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfArrayOfNumberOnly.swift
@@ -11,7 +11,7 @@ public struct ArrayOfArrayOfNumberOnly: Codable {
 
     public var arrayArrayNumber: [[Double]]?
 
-    public init(arrayArrayNumber: [[Double]]?) {
+    public init(arrayArrayNumber: [[Double]]? = nil) {
         self.arrayArrayNumber = arrayArrayNumber
     }
 

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfNumberOnly.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfNumberOnly.swift
@@ -11,7 +11,7 @@ public struct ArrayOfNumberOnly: Codable {
 
     public var arrayNumber: [Double]?
 
-    public init(arrayNumber: [Double]?) {
+    public init(arrayNumber: [Double]? = nil) {
         self.arrayNumber = arrayNumber
     }
 

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/ArrayTest.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/ArrayTest.swift
@@ -13,7 +13,7 @@ public struct ArrayTest: Codable {
     public var arrayArrayOfInteger: [[Int64]]?
     public var arrayArrayOfModel: [[ReadOnlyFirst]]?
 
-    public init(arrayOfString: [String]?, arrayArrayOfInteger: [[Int64]]?, arrayArrayOfModel: [[ReadOnlyFirst]]?) {
+    public init(arrayOfString: [String]? = nil, arrayArrayOfInteger: [[Int64]]? = nil, arrayArrayOfModel: [[ReadOnlyFirst]]? = nil) {
         self.arrayOfString = arrayOfString
         self.arrayArrayOfInteger = arrayArrayOfInteger
         self.arrayArrayOfModel = arrayArrayOfModel

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/Capitalization.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/Capitalization.swift
@@ -17,7 +17,7 @@ public struct Capitalization: Codable {
     /** Name of the pet  */
     public var ATT_NAME: String?
 
-    public init(smallCamel: String?, capitalCamel: String?, smallSnake: String?, capitalSnake: String?, sCAETHFlowPoints: String?, ATT_NAME: String?) {
+    public init(smallCamel: String? = nil, capitalCamel: String? = nil, smallSnake: String? = nil, capitalSnake: String? = nil, sCAETHFlowPoints: String? = nil, ATT_NAME: String? = nil) {
         self.smallCamel = smallCamel
         self.capitalCamel = capitalCamel
         self.smallSnake = smallSnake

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/Cat.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/Cat.swift
@@ -13,7 +13,7 @@ public struct Cat: Codable {
     public var color: String? = "red"
     public var declawed: Bool?
 
-    public init(className: String, color: String?, declawed: Bool?) {
+    public init(className: String, color: String? = nil, declawed: Bool? = nil) {
         self.className = className
         self.color = color
         self.declawed = declawed

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/CatAllOf.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/CatAllOf.swift
@@ -11,7 +11,7 @@ public struct CatAllOf: Codable {
 
     public var declawed: Bool?
 
-    public init(declawed: Bool?) {
+    public init(declawed: Bool? = nil) {
         self.declawed = declawed
     }
 

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/Category.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/Category.swift
@@ -12,7 +12,7 @@ public struct Category: Codable {
     public var id: Int64?
     public var name: String = "default-name"
 
-    public init(id: Int64?, name: String) {
+    public init(id: Int64? = nil, name: String) {
         self.id = id
         self.name = name
     }

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/ClassModel.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/ClassModel.swift
@@ -12,7 +12,7 @@ public struct ClassModel: Codable {
 
     public var _class: String?
 
-    public init(_class: String?) {
+    public init(_class: String? = nil) {
         self._class = _class
     }
 

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/Client.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/Client.swift
@@ -11,7 +11,7 @@ public struct Client: Codable {
 
     public var client: String?
 
-    public init(client: String?) {
+    public init(client: String? = nil) {
         self.client = client
     }
 

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/Dog.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/Dog.swift
@@ -13,7 +13,7 @@ public struct Dog: Codable {
     public var color: String? = "red"
     public var breed: String?
 
-    public init(className: String, color: String?, breed: String?) {
+    public init(className: String, color: String? = nil, breed: String? = nil) {
         self.className = className
         self.color = color
         self.breed = breed

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/DogAllOf.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/DogAllOf.swift
@@ -11,7 +11,7 @@ public struct DogAllOf: Codable {
 
     public var breed: String?
 
-    public init(breed: String?) {
+    public init(breed: String? = nil) {
         self.breed = breed
     }
 

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/EnumArrays.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/EnumArrays.swift
@@ -20,7 +20,7 @@ public struct EnumArrays: Codable {
     public var justSymbol: JustSymbol?
     public var arrayEnum: [ArrayEnum]?
 
-    public init(justSymbol: JustSymbol?, arrayEnum: [ArrayEnum]?) {
+    public init(justSymbol: JustSymbol? = nil, arrayEnum: [ArrayEnum]? = nil) {
         self.justSymbol = justSymbol
         self.arrayEnum = arrayEnum
     }

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/EnumTest.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/EnumTest.swift
@@ -33,7 +33,7 @@ public struct EnumTest: Codable {
     public var enumNumber: EnumNumber?
     public var outerEnum: OuterEnum?
 
-    public init(enumString: EnumString?, enumStringRequired: EnumStringRequired, enumInteger: EnumInteger?, enumNumber: EnumNumber?, outerEnum: OuterEnum?) {
+    public init(enumString: EnumString? = nil, enumStringRequired: EnumStringRequired, enumInteger: EnumInteger? = nil, enumNumber: EnumNumber? = nil, outerEnum: OuterEnum? = nil) {
         self.enumString = enumString
         self.enumStringRequired = enumStringRequired
         self.enumInteger = enumInteger

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/File.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/File.swift
@@ -13,7 +13,7 @@ public struct File: Codable {
     /** Test capitalization */
     public var sourceURI: String?
 
-    public init(sourceURI: String?) {
+    public init(sourceURI: String? = nil) {
         self.sourceURI = sourceURI
     }
 

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/FileSchemaTestClass.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/FileSchemaTestClass.swift
@@ -12,7 +12,7 @@ public struct FileSchemaTestClass: Codable {
     public var file: File?
     public var files: [File]?
 
-    public init(file: File?, files: [File]?) {
+    public init(file: File? = nil, files: [File]? = nil) {
         self.file = file
         self.files = files
     }

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/FormatTest.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/FormatTest.swift
@@ -23,7 +23,7 @@ public struct FormatTest: Codable {
     public var uuid: UUID?
     public var password: String
 
-    public init(integer: Int?, int32: Int?, int64: Int64?, number: Double, float: Float?, double: Double?, string: String?, byte: Data, binary: URL?, date: Date, dateTime: Date?, uuid: UUID?, password: String) {
+    public init(integer: Int? = nil, int32: Int? = nil, int64: Int64? = nil, number: Double, float: Float? = nil, double: Double? = nil, string: String? = nil, byte: Data, binary: URL? = nil, date: Date, dateTime: Date? = nil, uuid: UUID? = nil, password: String) {
         self.integer = integer
         self.int32 = int32
         self.int64 = int64

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/HasOnlyReadOnly.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/HasOnlyReadOnly.swift
@@ -12,7 +12,7 @@ public struct HasOnlyReadOnly: Codable {
     public var bar: String?
     public var foo: String?
 
-    public init(bar: String?, foo: String?) {
+    public init(bar: String? = nil, foo: String? = nil) {
         self.bar = bar
         self.foo = foo
     }

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/List.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/List.swift
@@ -11,7 +11,7 @@ public struct List: Codable {
 
     public var _123list: String?
 
-    public init(_123list: String?) {
+    public init(_123list: String? = nil) {
         self._123list = _123list
     }
 

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/MapTest.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/MapTest.swift
@@ -18,7 +18,7 @@ public struct MapTest: Codable {
     public var directMap: [String: Bool]?
     public var indirectMap: StringBooleanMap?
 
-    public init(mapMapOfString: [String: [String: String]]?, mapOfEnumString: [String: String]?, directMap: [String: Bool]?, indirectMap: StringBooleanMap?) {
+    public init(mapMapOfString: [String: [String: String]]? = nil, mapOfEnumString: [String: String]? = nil, directMap: [String: Bool]? = nil, indirectMap: StringBooleanMap? = nil) {
         self.mapMapOfString = mapMapOfString
         self.mapOfEnumString = mapOfEnumString
         self.directMap = directMap

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/MixedPropertiesAndAdditionalPropertiesClass.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/MixedPropertiesAndAdditionalPropertiesClass.swift
@@ -13,7 +13,7 @@ public struct MixedPropertiesAndAdditionalPropertiesClass: Codable {
     public var dateTime: Date?
     public var map: [String: Animal]?
 
-    public init(uuid: UUID?, dateTime: Date?, map: [String: Animal]?) {
+    public init(uuid: UUID? = nil, dateTime: Date? = nil, map: [String: Animal]? = nil) {
         self.uuid = uuid
         self.dateTime = dateTime
         self.map = map

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/Model200Response.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/Model200Response.swift
@@ -13,7 +13,7 @@ public struct Model200Response: Codable {
     public var name: Int?
     public var _class: String?
 
-    public init(name: Int?, _class: String?) {
+    public init(name: Int? = nil, _class: String? = nil) {
         self.name = name
         self._class = _class
     }

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/Name.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/Name.swift
@@ -15,7 +15,7 @@ public struct Name: Codable {
     public var property: String?
     public var _123number: Int?
 
-    public init(name: Int, snakeCase: Int?, property: String?, _123number: Int?) {
+    public init(name: Int, snakeCase: Int? = nil, property: String? = nil, _123number: Int? = nil) {
         self.name = name
         self.snakeCase = snakeCase
         self.property = property

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/NumberOnly.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/NumberOnly.swift
@@ -11,7 +11,7 @@ public struct NumberOnly: Codable {
 
     public var justNumber: Double?
 
-    public init(justNumber: Double?) {
+    public init(justNumber: Double? = nil) {
         self.justNumber = justNumber
     }
 

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/Order.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/Order.swift
@@ -22,7 +22,7 @@ public struct Order: Codable {
     public var status: Status?
     public var complete: Bool? = false
 
-    public init(id: Int64?, petId: Int64?, quantity: Int?, shipDate: Date?, status: Status?, complete: Bool?) {
+    public init(id: Int64? = nil, petId: Int64? = nil, quantity: Int? = nil, shipDate: Date? = nil, status: Status? = nil, complete: Bool? = nil) {
         self.id = id
         self.petId = petId
         self.quantity = quantity

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/OuterComposite.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/OuterComposite.swift
@@ -13,7 +13,7 @@ public struct OuterComposite: Codable {
     public var myString: String?
     public var myBoolean: Bool?
 
-    public init(myNumber: Double?, myString: String?, myBoolean: Bool?) {
+    public init(myNumber: Double? = nil, myString: String? = nil, myBoolean: Bool? = nil) {
         self.myNumber = myNumber
         self.myString = myString
         self.myBoolean = myBoolean

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/Pet.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/Pet.swift
@@ -22,7 +22,7 @@ public struct Pet: Codable {
     /** pet status in the store */
     public var status: Status?
 
-    public init(id: Int64?, category: Category?, name: String, photoUrls: [String], tags: [Tag]?, status: Status?) {
+    public init(id: Int64? = nil, category: Category? = nil, name: String, photoUrls: [String], tags: [Tag]? = nil, status: Status? = nil) {
         self.id = id
         self.category = category
         self.name = name

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/ReadOnlyFirst.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/ReadOnlyFirst.swift
@@ -12,7 +12,7 @@ public struct ReadOnlyFirst: Codable {
     public var bar: String?
     public var baz: String?
 
-    public init(bar: String?, baz: String?) {
+    public init(bar: String? = nil, baz: String? = nil) {
         self.bar = bar
         self.baz = baz
     }

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/Return.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/Return.swift
@@ -12,7 +12,7 @@ public struct Return: Codable {
 
     public var _return: Int?
 
-    public init(_return: Int?) {
+    public init(_return: Int? = nil) {
         self._return = _return
     }
 

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/SpecialModelName.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/SpecialModelName.swift
@@ -11,7 +11,7 @@ public struct SpecialModelName: Codable {
 
     public var specialPropertyName: Int64?
 
-    public init(specialPropertyName: Int64?) {
+    public init(specialPropertyName: Int64? = nil) {
         self.specialPropertyName = specialPropertyName
     }
 

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/Tag.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/Tag.swift
@@ -12,7 +12,7 @@ public struct Tag: Codable {
     public var id: Int64?
     public var name: String?
 
-    public init(id: Int64?, name: String?) {
+    public init(id: Int64? = nil, name: String? = nil) {
         self.id = id
         self.name = name
     }

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/User.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/User.swift
@@ -19,7 +19,7 @@ public struct User: Codable {
     /** User Status */
     public var userStatus: Int?
 
-    public init(id: Int64?, username: String?, firstName: String?, lastName: String?, email: String?, password: String?, phone: String?, userStatus: Int?) {
+    public init(id: Int64? = nil, username: String? = nil, firstName: String? = nil, lastName: String? = nil, email: String? = nil, password: String? = nil, phone: String? = nil, userStatus: Int? = nil) {
         self.id = id
         self.username = username
         self.firstName = firstName

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/AdditionalPropertiesClass.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/AdditionalPropertiesClass.swift
@@ -12,7 +12,7 @@ public struct AdditionalPropertiesClass: Codable {
     public var mapString: [String: String]?
     public var mapMapString: [String: [String: String]]?
 
-    public init(mapString: [String: String]?, mapMapString: [String: [String: String]]?) {
+    public init(mapString: [String: String]? = nil, mapMapString: [String: [String: String]]? = nil) {
         self.mapString = mapString
         self.mapMapString = mapMapString
     }

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/Animal.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/Animal.swift
@@ -12,7 +12,7 @@ public struct Animal: Codable {
     public var className: String
     public var color: String? = "red"
 
-    public init(className: String, color: String?) {
+    public init(className: String, color: String? = nil) {
         self.className = className
         self.color = color
     }

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/ApiResponse.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/ApiResponse.swift
@@ -13,7 +13,7 @@ public struct ApiResponse: Codable {
     public var type: String?
     public var message: String?
 
-    public init(code: Int?, type: String?, message: String?) {
+    public init(code: Int? = nil, type: String? = nil, message: String? = nil) {
         self.code = code
         self.type = type
         self.message = message

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfArrayOfNumberOnly.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfArrayOfNumberOnly.swift
@@ -11,7 +11,7 @@ public struct ArrayOfArrayOfNumberOnly: Codable {
 
     public var arrayArrayNumber: [[Double]]?
 
-    public init(arrayArrayNumber: [[Double]]?) {
+    public init(arrayArrayNumber: [[Double]]? = nil) {
         self.arrayArrayNumber = arrayArrayNumber
     }
 

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfNumberOnly.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfNumberOnly.swift
@@ -11,7 +11,7 @@ public struct ArrayOfNumberOnly: Codable {
 
     public var arrayNumber: [Double]?
 
-    public init(arrayNumber: [Double]?) {
+    public init(arrayNumber: [Double]? = nil) {
         self.arrayNumber = arrayNumber
     }
 

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/ArrayTest.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/ArrayTest.swift
@@ -13,7 +13,7 @@ public struct ArrayTest: Codable {
     public var arrayArrayOfInteger: [[Int64]]?
     public var arrayArrayOfModel: [[ReadOnlyFirst]]?
 
-    public init(arrayOfString: [String]?, arrayArrayOfInteger: [[Int64]]?, arrayArrayOfModel: [[ReadOnlyFirst]]?) {
+    public init(arrayOfString: [String]? = nil, arrayArrayOfInteger: [[Int64]]? = nil, arrayArrayOfModel: [[ReadOnlyFirst]]? = nil) {
         self.arrayOfString = arrayOfString
         self.arrayArrayOfInteger = arrayArrayOfInteger
         self.arrayArrayOfModel = arrayArrayOfModel

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/Capitalization.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/Capitalization.swift
@@ -17,7 +17,7 @@ public struct Capitalization: Codable {
     /** Name of the pet  */
     public var ATT_NAME: String?
 
-    public init(smallCamel: String?, capitalCamel: String?, smallSnake: String?, capitalSnake: String?, sCAETHFlowPoints: String?, ATT_NAME: String?) {
+    public init(smallCamel: String? = nil, capitalCamel: String? = nil, smallSnake: String? = nil, capitalSnake: String? = nil, sCAETHFlowPoints: String? = nil, ATT_NAME: String? = nil) {
         self.smallCamel = smallCamel
         self.capitalCamel = capitalCamel
         self.smallSnake = smallSnake

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/Cat.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/Cat.swift
@@ -13,7 +13,7 @@ public struct Cat: Codable {
     public var color: String? = "red"
     public var declawed: Bool?
 
-    public init(className: String, color: String?, declawed: Bool?) {
+    public init(className: String, color: String? = nil, declawed: Bool? = nil) {
         self.className = className
         self.color = color
         self.declawed = declawed

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/CatAllOf.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/CatAllOf.swift
@@ -11,7 +11,7 @@ public struct CatAllOf: Codable {
 
     public var declawed: Bool?
 
-    public init(declawed: Bool?) {
+    public init(declawed: Bool? = nil) {
         self.declawed = declawed
     }
 

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/Category.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/Category.swift
@@ -12,7 +12,7 @@ public struct Category: Codable {
     public var id: Int64?
     public var name: String = "default-name"
 
-    public init(id: Int64?, name: String) {
+    public init(id: Int64? = nil, name: String) {
         self.id = id
         self.name = name
     }

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/ClassModel.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/ClassModel.swift
@@ -12,7 +12,7 @@ public struct ClassModel: Codable {
 
     public var _class: String?
 
-    public init(_class: String?) {
+    public init(_class: String? = nil) {
         self._class = _class
     }
 

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/Client.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/Client.swift
@@ -11,7 +11,7 @@ public struct Client: Codable {
 
     public var client: String?
 
-    public init(client: String?) {
+    public init(client: String? = nil) {
         self.client = client
     }
 

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/Dog.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/Dog.swift
@@ -13,7 +13,7 @@ public struct Dog: Codable {
     public var color: String? = "red"
     public var breed: String?
 
-    public init(className: String, color: String?, breed: String?) {
+    public init(className: String, color: String? = nil, breed: String? = nil) {
         self.className = className
         self.color = color
         self.breed = breed

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/DogAllOf.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/DogAllOf.swift
@@ -11,7 +11,7 @@ public struct DogAllOf: Codable {
 
     public var breed: String?
 
-    public init(breed: String?) {
+    public init(breed: String? = nil) {
         self.breed = breed
     }
 

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/EnumArrays.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/EnumArrays.swift
@@ -20,7 +20,7 @@ public struct EnumArrays: Codable {
     public var justSymbol: JustSymbol?
     public var arrayEnum: [ArrayEnum]?
 
-    public init(justSymbol: JustSymbol?, arrayEnum: [ArrayEnum]?) {
+    public init(justSymbol: JustSymbol? = nil, arrayEnum: [ArrayEnum]? = nil) {
         self.justSymbol = justSymbol
         self.arrayEnum = arrayEnum
     }

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/EnumTest.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/EnumTest.swift
@@ -33,7 +33,7 @@ public struct EnumTest: Codable {
     public var enumNumber: EnumNumber?
     public var outerEnum: OuterEnum?
 
-    public init(enumString: EnumString?, enumStringRequired: EnumStringRequired, enumInteger: EnumInteger?, enumNumber: EnumNumber?, outerEnum: OuterEnum?) {
+    public init(enumString: EnumString? = nil, enumStringRequired: EnumStringRequired, enumInteger: EnumInteger? = nil, enumNumber: EnumNumber? = nil, outerEnum: OuterEnum? = nil) {
         self.enumString = enumString
         self.enumStringRequired = enumStringRequired
         self.enumInteger = enumInteger

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/File.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/File.swift
@@ -13,7 +13,7 @@ public struct File: Codable {
     /** Test capitalization */
     public var sourceURI: String?
 
-    public init(sourceURI: String?) {
+    public init(sourceURI: String? = nil) {
         self.sourceURI = sourceURI
     }
 

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/FileSchemaTestClass.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/FileSchemaTestClass.swift
@@ -12,7 +12,7 @@ public struct FileSchemaTestClass: Codable {
     public var file: File?
     public var files: [File]?
 
-    public init(file: File?, files: [File]?) {
+    public init(file: File? = nil, files: [File]? = nil) {
         self.file = file
         self.files = files
     }

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/FormatTest.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/FormatTest.swift
@@ -23,7 +23,7 @@ public struct FormatTest: Codable {
     public var uuid: UUID?
     public var password: String
 
-    public init(integer: Int?, int32: Int?, int64: Int64?, number: Double, float: Float?, double: Double?, string: String?, byte: Data, binary: URL?, date: Date, dateTime: Date?, uuid: UUID?, password: String) {
+    public init(integer: Int? = nil, int32: Int? = nil, int64: Int64? = nil, number: Double, float: Float? = nil, double: Double? = nil, string: String? = nil, byte: Data, binary: URL? = nil, date: Date, dateTime: Date? = nil, uuid: UUID? = nil, password: String) {
         self.integer = integer
         self.int32 = int32
         self.int64 = int64

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/HasOnlyReadOnly.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/HasOnlyReadOnly.swift
@@ -12,7 +12,7 @@ public struct HasOnlyReadOnly: Codable {
     public var bar: String?
     public var foo: String?
 
-    public init(bar: String?, foo: String?) {
+    public init(bar: String? = nil, foo: String? = nil) {
         self.bar = bar
         self.foo = foo
     }

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/List.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/List.swift
@@ -11,7 +11,7 @@ public struct List: Codable {
 
     public var _123list: String?
 
-    public init(_123list: String?) {
+    public init(_123list: String? = nil) {
         self._123list = _123list
     }
 

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/MapTest.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/MapTest.swift
@@ -18,7 +18,7 @@ public struct MapTest: Codable {
     public var directMap: [String: Bool]?
     public var indirectMap: StringBooleanMap?
 
-    public init(mapMapOfString: [String: [String: String]]?, mapOfEnumString: [String: String]?, directMap: [String: Bool]?, indirectMap: StringBooleanMap?) {
+    public init(mapMapOfString: [String: [String: String]]? = nil, mapOfEnumString: [String: String]? = nil, directMap: [String: Bool]? = nil, indirectMap: StringBooleanMap? = nil) {
         self.mapMapOfString = mapMapOfString
         self.mapOfEnumString = mapOfEnumString
         self.directMap = directMap

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/MixedPropertiesAndAdditionalPropertiesClass.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/MixedPropertiesAndAdditionalPropertiesClass.swift
@@ -13,7 +13,7 @@ public struct MixedPropertiesAndAdditionalPropertiesClass: Codable {
     public var dateTime: Date?
     public var map: [String: Animal]?
 
-    public init(uuid: UUID?, dateTime: Date?, map: [String: Animal]?) {
+    public init(uuid: UUID? = nil, dateTime: Date? = nil, map: [String: Animal]? = nil) {
         self.uuid = uuid
         self.dateTime = dateTime
         self.map = map

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/Model200Response.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/Model200Response.swift
@@ -13,7 +13,7 @@ public struct Model200Response: Codable {
     public var name: Int?
     public var _class: String?
 
-    public init(name: Int?, _class: String?) {
+    public init(name: Int? = nil, _class: String? = nil) {
         self.name = name
         self._class = _class
     }

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/Name.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/Name.swift
@@ -15,7 +15,7 @@ public struct Name: Codable {
     public var property: String?
     public var _123number: Int?
 
-    public init(name: Int, snakeCase: Int?, property: String?, _123number: Int?) {
+    public init(name: Int, snakeCase: Int? = nil, property: String? = nil, _123number: Int? = nil) {
         self.name = name
         self.snakeCase = snakeCase
         self.property = property

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/NumberOnly.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/NumberOnly.swift
@@ -11,7 +11,7 @@ public struct NumberOnly: Codable {
 
     public var justNumber: Double?
 
-    public init(justNumber: Double?) {
+    public init(justNumber: Double? = nil) {
         self.justNumber = justNumber
     }
 

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/Order.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/Order.swift
@@ -22,7 +22,7 @@ public struct Order: Codable {
     public var status: Status?
     public var complete: Bool? = false
 
-    public init(id: Int64?, petId: Int64?, quantity: Int?, shipDate: Date?, status: Status?, complete: Bool?) {
+    public init(id: Int64? = nil, petId: Int64? = nil, quantity: Int? = nil, shipDate: Date? = nil, status: Status? = nil, complete: Bool? = nil) {
         self.id = id
         self.petId = petId
         self.quantity = quantity

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/OuterComposite.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/OuterComposite.swift
@@ -13,7 +13,7 @@ public struct OuterComposite: Codable {
     public var myString: String?
     public var myBoolean: Bool?
 
-    public init(myNumber: Double?, myString: String?, myBoolean: Bool?) {
+    public init(myNumber: Double? = nil, myString: String? = nil, myBoolean: Bool? = nil) {
         self.myNumber = myNumber
         self.myString = myString
         self.myBoolean = myBoolean

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/Pet.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/Pet.swift
@@ -22,7 +22,7 @@ public struct Pet: Codable {
     /** pet status in the store */
     public var status: Status?
 
-    public init(id: Int64?, category: Category?, name: String, photoUrls: [String], tags: [Tag]?, status: Status?) {
+    public init(id: Int64? = nil, category: Category? = nil, name: String, photoUrls: [String], tags: [Tag]? = nil, status: Status? = nil) {
         self.id = id
         self.category = category
         self.name = name

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/ReadOnlyFirst.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/ReadOnlyFirst.swift
@@ -12,7 +12,7 @@ public struct ReadOnlyFirst: Codable {
     public var bar: String?
     public var baz: String?
 
-    public init(bar: String?, baz: String?) {
+    public init(bar: String? = nil, baz: String? = nil) {
         self.bar = bar
         self.baz = baz
     }

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/Return.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/Return.swift
@@ -12,7 +12,7 @@ public struct Return: Codable {
 
     public var _return: Int?
 
-    public init(_return: Int?) {
+    public init(_return: Int? = nil) {
         self._return = _return
     }
 

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/SpecialModelName.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/SpecialModelName.swift
@@ -11,7 +11,7 @@ public struct SpecialModelName: Codable {
 
     public var specialPropertyName: Int64?
 
-    public init(specialPropertyName: Int64?) {
+    public init(specialPropertyName: Int64? = nil) {
         self.specialPropertyName = specialPropertyName
     }
 

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/Tag.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/Tag.swift
@@ -12,7 +12,7 @@ public struct Tag: Codable {
     public var id: Int64?
     public var name: String?
 
-    public init(id: Int64?, name: String?) {
+    public init(id: Int64? = nil, name: String? = nil) {
         self.id = id
         self.name = name
     }

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/User.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/User.swift
@@ -19,7 +19,7 @@ public struct User: Codable {
     /** User Status */
     public var userStatus: Int?
 
-    public init(id: Int64?, username: String?, firstName: String?, lastName: String?, email: String?, password: String?, phone: String?, userStatus: Int?) {
+    public init(id: Int64? = nil, username: String? = nil, firstName: String? = nil, lastName: String? = nil, email: String? = nil, password: String? = nil, phone: String? = nil, userStatus: Int? = nil) {
         self.id = id
         self.username = username
         self.firstName = firstName

--- a/samples/client/petstore/swift5/urlsessionLibrary/PetstoreClient/Classes/OpenAPIs/Models/AdditionalPropertiesClass.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/PetstoreClient/Classes/OpenAPIs/Models/AdditionalPropertiesClass.swift
@@ -12,7 +12,7 @@ public struct AdditionalPropertiesClass: Codable {
     public var mapString: [String: String]?
     public var mapMapString: [String: [String: String]]?
 
-    public init(mapString: [String: String]?, mapMapString: [String: [String: String]]?) {
+    public init(mapString: [String: String]? = nil, mapMapString: [String: [String: String]]? = nil) {
         self.mapString = mapString
         self.mapMapString = mapMapString
     }

--- a/samples/client/petstore/swift5/urlsessionLibrary/PetstoreClient/Classes/OpenAPIs/Models/Animal.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/PetstoreClient/Classes/OpenAPIs/Models/Animal.swift
@@ -12,7 +12,7 @@ public struct Animal: Codable {
     public var className: String
     public var color: String? = "red"
 
-    public init(className: String, color: String?) {
+    public init(className: String, color: String? = nil) {
         self.className = className
         self.color = color
     }

--- a/samples/client/petstore/swift5/urlsessionLibrary/PetstoreClient/Classes/OpenAPIs/Models/ApiResponse.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/PetstoreClient/Classes/OpenAPIs/Models/ApiResponse.swift
@@ -13,7 +13,7 @@ public struct ApiResponse: Codable {
     public var type: String?
     public var message: String?
 
-    public init(code: Int?, type: String?, message: String?) {
+    public init(code: Int? = nil, type: String? = nil, message: String? = nil) {
         self.code = code
         self.type = type
         self.message = message

--- a/samples/client/petstore/swift5/urlsessionLibrary/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfArrayOfNumberOnly.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfArrayOfNumberOnly.swift
@@ -11,7 +11,7 @@ public struct ArrayOfArrayOfNumberOnly: Codable {
 
     public var arrayArrayNumber: [[Double]]?
 
-    public init(arrayArrayNumber: [[Double]]?) {
+    public init(arrayArrayNumber: [[Double]]? = nil) {
         self.arrayArrayNumber = arrayArrayNumber
     }
 

--- a/samples/client/petstore/swift5/urlsessionLibrary/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfNumberOnly.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfNumberOnly.swift
@@ -11,7 +11,7 @@ public struct ArrayOfNumberOnly: Codable {
 
     public var arrayNumber: [Double]?
 
-    public init(arrayNumber: [Double]?) {
+    public init(arrayNumber: [Double]? = nil) {
         self.arrayNumber = arrayNumber
     }
 

--- a/samples/client/petstore/swift5/urlsessionLibrary/PetstoreClient/Classes/OpenAPIs/Models/ArrayTest.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/PetstoreClient/Classes/OpenAPIs/Models/ArrayTest.swift
@@ -13,7 +13,7 @@ public struct ArrayTest: Codable {
     public var arrayArrayOfInteger: [[Int64]]?
     public var arrayArrayOfModel: [[ReadOnlyFirst]]?
 
-    public init(arrayOfString: [String]?, arrayArrayOfInteger: [[Int64]]?, arrayArrayOfModel: [[ReadOnlyFirst]]?) {
+    public init(arrayOfString: [String]? = nil, arrayArrayOfInteger: [[Int64]]? = nil, arrayArrayOfModel: [[ReadOnlyFirst]]? = nil) {
         self.arrayOfString = arrayOfString
         self.arrayArrayOfInteger = arrayArrayOfInteger
         self.arrayArrayOfModel = arrayArrayOfModel

--- a/samples/client/petstore/swift5/urlsessionLibrary/PetstoreClient/Classes/OpenAPIs/Models/Capitalization.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/PetstoreClient/Classes/OpenAPIs/Models/Capitalization.swift
@@ -17,7 +17,7 @@ public struct Capitalization: Codable {
     /** Name of the pet  */
     public var ATT_NAME: String?
 
-    public init(smallCamel: String?, capitalCamel: String?, smallSnake: String?, capitalSnake: String?, sCAETHFlowPoints: String?, ATT_NAME: String?) {
+    public init(smallCamel: String? = nil, capitalCamel: String? = nil, smallSnake: String? = nil, capitalSnake: String? = nil, sCAETHFlowPoints: String? = nil, ATT_NAME: String? = nil) {
         self.smallCamel = smallCamel
         self.capitalCamel = capitalCamel
         self.smallSnake = smallSnake

--- a/samples/client/petstore/swift5/urlsessionLibrary/PetstoreClient/Classes/OpenAPIs/Models/Cat.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/PetstoreClient/Classes/OpenAPIs/Models/Cat.swift
@@ -13,7 +13,7 @@ public struct Cat: Codable {
     public var color: String? = "red"
     public var declawed: Bool?
 
-    public init(className: String, color: String?, declawed: Bool?) {
+    public init(className: String, color: String? = nil, declawed: Bool? = nil) {
         self.className = className
         self.color = color
         self.declawed = declawed

--- a/samples/client/petstore/swift5/urlsessionLibrary/PetstoreClient/Classes/OpenAPIs/Models/CatAllOf.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/PetstoreClient/Classes/OpenAPIs/Models/CatAllOf.swift
@@ -11,7 +11,7 @@ public struct CatAllOf: Codable {
 
     public var declawed: Bool?
 
-    public init(declawed: Bool?) {
+    public init(declawed: Bool? = nil) {
         self.declawed = declawed
     }
 

--- a/samples/client/petstore/swift5/urlsessionLibrary/PetstoreClient/Classes/OpenAPIs/Models/Category.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/PetstoreClient/Classes/OpenAPIs/Models/Category.swift
@@ -12,7 +12,7 @@ public struct Category: Codable {
     public var id: Int64?
     public var name: String = "default-name"
 
-    public init(id: Int64?, name: String) {
+    public init(id: Int64? = nil, name: String) {
         self.id = id
         self.name = name
     }

--- a/samples/client/petstore/swift5/urlsessionLibrary/PetstoreClient/Classes/OpenAPIs/Models/ClassModel.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/PetstoreClient/Classes/OpenAPIs/Models/ClassModel.swift
@@ -12,7 +12,7 @@ public struct ClassModel: Codable {
 
     public var _class: String?
 
-    public init(_class: String?) {
+    public init(_class: String? = nil) {
         self._class = _class
     }
 

--- a/samples/client/petstore/swift5/urlsessionLibrary/PetstoreClient/Classes/OpenAPIs/Models/Client.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/PetstoreClient/Classes/OpenAPIs/Models/Client.swift
@@ -11,7 +11,7 @@ public struct Client: Codable {
 
     public var client: String?
 
-    public init(client: String?) {
+    public init(client: String? = nil) {
         self.client = client
     }
 

--- a/samples/client/petstore/swift5/urlsessionLibrary/PetstoreClient/Classes/OpenAPIs/Models/Dog.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/PetstoreClient/Classes/OpenAPIs/Models/Dog.swift
@@ -13,7 +13,7 @@ public struct Dog: Codable {
     public var color: String? = "red"
     public var breed: String?
 
-    public init(className: String, color: String?, breed: String?) {
+    public init(className: String, color: String? = nil, breed: String? = nil) {
         self.className = className
         self.color = color
         self.breed = breed

--- a/samples/client/petstore/swift5/urlsessionLibrary/PetstoreClient/Classes/OpenAPIs/Models/DogAllOf.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/PetstoreClient/Classes/OpenAPIs/Models/DogAllOf.swift
@@ -11,7 +11,7 @@ public struct DogAllOf: Codable {
 
     public var breed: String?
 
-    public init(breed: String?) {
+    public init(breed: String? = nil) {
         self.breed = breed
     }
 

--- a/samples/client/petstore/swift5/urlsessionLibrary/PetstoreClient/Classes/OpenAPIs/Models/EnumArrays.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/PetstoreClient/Classes/OpenAPIs/Models/EnumArrays.swift
@@ -20,7 +20,7 @@ public struct EnumArrays: Codable {
     public var justSymbol: JustSymbol?
     public var arrayEnum: [ArrayEnum]?
 
-    public init(justSymbol: JustSymbol?, arrayEnum: [ArrayEnum]?) {
+    public init(justSymbol: JustSymbol? = nil, arrayEnum: [ArrayEnum]? = nil) {
         self.justSymbol = justSymbol
         self.arrayEnum = arrayEnum
     }

--- a/samples/client/petstore/swift5/urlsessionLibrary/PetstoreClient/Classes/OpenAPIs/Models/EnumTest.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/PetstoreClient/Classes/OpenAPIs/Models/EnumTest.swift
@@ -33,7 +33,7 @@ public struct EnumTest: Codable {
     public var enumNumber: EnumNumber?
     public var outerEnum: OuterEnum?
 
-    public init(enumString: EnumString?, enumStringRequired: EnumStringRequired, enumInteger: EnumInteger?, enumNumber: EnumNumber?, outerEnum: OuterEnum?) {
+    public init(enumString: EnumString? = nil, enumStringRequired: EnumStringRequired, enumInteger: EnumInteger? = nil, enumNumber: EnumNumber? = nil, outerEnum: OuterEnum? = nil) {
         self.enumString = enumString
         self.enumStringRequired = enumStringRequired
         self.enumInteger = enumInteger

--- a/samples/client/petstore/swift5/urlsessionLibrary/PetstoreClient/Classes/OpenAPIs/Models/File.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/PetstoreClient/Classes/OpenAPIs/Models/File.swift
@@ -13,7 +13,7 @@ public struct File: Codable {
     /** Test capitalization */
     public var sourceURI: String?
 
-    public init(sourceURI: String?) {
+    public init(sourceURI: String? = nil) {
         self.sourceURI = sourceURI
     }
 

--- a/samples/client/petstore/swift5/urlsessionLibrary/PetstoreClient/Classes/OpenAPIs/Models/FileSchemaTestClass.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/PetstoreClient/Classes/OpenAPIs/Models/FileSchemaTestClass.swift
@@ -12,7 +12,7 @@ public struct FileSchemaTestClass: Codable {
     public var file: File?
     public var files: [File]?
 
-    public init(file: File?, files: [File]?) {
+    public init(file: File? = nil, files: [File]? = nil) {
         self.file = file
         self.files = files
     }

--- a/samples/client/petstore/swift5/urlsessionLibrary/PetstoreClient/Classes/OpenAPIs/Models/FormatTest.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/PetstoreClient/Classes/OpenAPIs/Models/FormatTest.swift
@@ -23,7 +23,7 @@ public struct FormatTest: Codable {
     public var uuid: UUID?
     public var password: String
 
-    public init(integer: Int?, int32: Int?, int64: Int64?, number: Double, float: Float?, double: Double?, string: String?, byte: Data, binary: URL?, date: Date, dateTime: Date?, uuid: UUID?, password: String) {
+    public init(integer: Int? = nil, int32: Int? = nil, int64: Int64? = nil, number: Double, float: Float? = nil, double: Double? = nil, string: String? = nil, byte: Data, binary: URL? = nil, date: Date, dateTime: Date? = nil, uuid: UUID? = nil, password: String) {
         self.integer = integer
         self.int32 = int32
         self.int64 = int64

--- a/samples/client/petstore/swift5/urlsessionLibrary/PetstoreClient/Classes/OpenAPIs/Models/HasOnlyReadOnly.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/PetstoreClient/Classes/OpenAPIs/Models/HasOnlyReadOnly.swift
@@ -12,7 +12,7 @@ public struct HasOnlyReadOnly: Codable {
     public var bar: String?
     public var foo: String?
 
-    public init(bar: String?, foo: String?) {
+    public init(bar: String? = nil, foo: String? = nil) {
         self.bar = bar
         self.foo = foo
     }

--- a/samples/client/petstore/swift5/urlsessionLibrary/PetstoreClient/Classes/OpenAPIs/Models/List.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/PetstoreClient/Classes/OpenAPIs/Models/List.swift
@@ -11,7 +11,7 @@ public struct List: Codable {
 
     public var _123list: String?
 
-    public init(_123list: String?) {
+    public init(_123list: String? = nil) {
         self._123list = _123list
     }
 

--- a/samples/client/petstore/swift5/urlsessionLibrary/PetstoreClient/Classes/OpenAPIs/Models/MapTest.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/PetstoreClient/Classes/OpenAPIs/Models/MapTest.swift
@@ -18,7 +18,7 @@ public struct MapTest: Codable {
     public var directMap: [String: Bool]?
     public var indirectMap: StringBooleanMap?
 
-    public init(mapMapOfString: [String: [String: String]]?, mapOfEnumString: [String: String]?, directMap: [String: Bool]?, indirectMap: StringBooleanMap?) {
+    public init(mapMapOfString: [String: [String: String]]? = nil, mapOfEnumString: [String: String]? = nil, directMap: [String: Bool]? = nil, indirectMap: StringBooleanMap? = nil) {
         self.mapMapOfString = mapMapOfString
         self.mapOfEnumString = mapOfEnumString
         self.directMap = directMap

--- a/samples/client/petstore/swift5/urlsessionLibrary/PetstoreClient/Classes/OpenAPIs/Models/MixedPropertiesAndAdditionalPropertiesClass.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/PetstoreClient/Classes/OpenAPIs/Models/MixedPropertiesAndAdditionalPropertiesClass.swift
@@ -13,7 +13,7 @@ public struct MixedPropertiesAndAdditionalPropertiesClass: Codable {
     public var dateTime: Date?
     public var map: [String: Animal]?
 
-    public init(uuid: UUID?, dateTime: Date?, map: [String: Animal]?) {
+    public init(uuid: UUID? = nil, dateTime: Date? = nil, map: [String: Animal]? = nil) {
         self.uuid = uuid
         self.dateTime = dateTime
         self.map = map

--- a/samples/client/petstore/swift5/urlsessionLibrary/PetstoreClient/Classes/OpenAPIs/Models/Model200Response.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/PetstoreClient/Classes/OpenAPIs/Models/Model200Response.swift
@@ -13,7 +13,7 @@ public struct Model200Response: Codable {
     public var name: Int?
     public var _class: String?
 
-    public init(name: Int?, _class: String?) {
+    public init(name: Int? = nil, _class: String? = nil) {
         self.name = name
         self._class = _class
     }

--- a/samples/client/petstore/swift5/urlsessionLibrary/PetstoreClient/Classes/OpenAPIs/Models/Name.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/PetstoreClient/Classes/OpenAPIs/Models/Name.swift
@@ -15,7 +15,7 @@ public struct Name: Codable {
     public var property: String?
     public var _123number: Int?
 
-    public init(name: Int, snakeCase: Int?, property: String?, _123number: Int?) {
+    public init(name: Int, snakeCase: Int? = nil, property: String? = nil, _123number: Int? = nil) {
         self.name = name
         self.snakeCase = snakeCase
         self.property = property

--- a/samples/client/petstore/swift5/urlsessionLibrary/PetstoreClient/Classes/OpenAPIs/Models/NumberOnly.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/PetstoreClient/Classes/OpenAPIs/Models/NumberOnly.swift
@@ -11,7 +11,7 @@ public struct NumberOnly: Codable {
 
     public var justNumber: Double?
 
-    public init(justNumber: Double?) {
+    public init(justNumber: Double? = nil) {
         self.justNumber = justNumber
     }
 

--- a/samples/client/petstore/swift5/urlsessionLibrary/PetstoreClient/Classes/OpenAPIs/Models/Order.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/PetstoreClient/Classes/OpenAPIs/Models/Order.swift
@@ -22,7 +22,7 @@ public struct Order: Codable {
     public var status: Status?
     public var complete: Bool? = false
 
-    public init(id: Int64?, petId: Int64?, quantity: Int?, shipDate: Date?, status: Status?, complete: Bool?) {
+    public init(id: Int64? = nil, petId: Int64? = nil, quantity: Int? = nil, shipDate: Date? = nil, status: Status? = nil, complete: Bool? = nil) {
         self.id = id
         self.petId = petId
         self.quantity = quantity

--- a/samples/client/petstore/swift5/urlsessionLibrary/PetstoreClient/Classes/OpenAPIs/Models/OuterComposite.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/PetstoreClient/Classes/OpenAPIs/Models/OuterComposite.swift
@@ -13,7 +13,7 @@ public struct OuterComposite: Codable {
     public var myString: String?
     public var myBoolean: Bool?
 
-    public init(myNumber: Double?, myString: String?, myBoolean: Bool?) {
+    public init(myNumber: Double? = nil, myString: String? = nil, myBoolean: Bool? = nil) {
         self.myNumber = myNumber
         self.myString = myString
         self.myBoolean = myBoolean

--- a/samples/client/petstore/swift5/urlsessionLibrary/PetstoreClient/Classes/OpenAPIs/Models/Pet.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/PetstoreClient/Classes/OpenAPIs/Models/Pet.swift
@@ -22,7 +22,7 @@ public struct Pet: Codable {
     /** pet status in the store */
     public var status: Status?
 
-    public init(id: Int64?, category: Category?, name: String, photoUrls: [String], tags: [Tag]?, status: Status?) {
+    public init(id: Int64? = nil, category: Category? = nil, name: String, photoUrls: [String], tags: [Tag]? = nil, status: Status? = nil) {
         self.id = id
         self.category = category
         self.name = name

--- a/samples/client/petstore/swift5/urlsessionLibrary/PetstoreClient/Classes/OpenAPIs/Models/ReadOnlyFirst.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/PetstoreClient/Classes/OpenAPIs/Models/ReadOnlyFirst.swift
@@ -12,7 +12,7 @@ public struct ReadOnlyFirst: Codable {
     public var bar: String?
     public var baz: String?
 
-    public init(bar: String?, baz: String?) {
+    public init(bar: String? = nil, baz: String? = nil) {
         self.bar = bar
         self.baz = baz
     }

--- a/samples/client/petstore/swift5/urlsessionLibrary/PetstoreClient/Classes/OpenAPIs/Models/Return.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/PetstoreClient/Classes/OpenAPIs/Models/Return.swift
@@ -12,7 +12,7 @@ public struct Return: Codable {
 
     public var _return: Int?
 
-    public init(_return: Int?) {
+    public init(_return: Int? = nil) {
         self._return = _return
     }
 

--- a/samples/client/petstore/swift5/urlsessionLibrary/PetstoreClient/Classes/OpenAPIs/Models/SpecialModelName.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/PetstoreClient/Classes/OpenAPIs/Models/SpecialModelName.swift
@@ -11,7 +11,7 @@ public struct SpecialModelName: Codable {
 
     public var specialPropertyName: Int64?
 
-    public init(specialPropertyName: Int64?) {
+    public init(specialPropertyName: Int64? = nil) {
         self.specialPropertyName = specialPropertyName
     }
 

--- a/samples/client/petstore/swift5/urlsessionLibrary/PetstoreClient/Classes/OpenAPIs/Models/Tag.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/PetstoreClient/Classes/OpenAPIs/Models/Tag.swift
@@ -12,7 +12,7 @@ public struct Tag: Codable {
     public var id: Int64?
     public var name: String?
 
-    public init(id: Int64?, name: String?) {
+    public init(id: Int64? = nil, name: String? = nil) {
         self.id = id
         self.name = name
     }

--- a/samples/client/petstore/swift5/urlsessionLibrary/PetstoreClient/Classes/OpenAPIs/Models/User.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/PetstoreClient/Classes/OpenAPIs/Models/User.swift
@@ -19,7 +19,7 @@ public struct User: Codable {
     /** User Status */
     public var userStatus: Int?
 
-    public init(id: Int64?, username: String?, firstName: String?, lastName: String?, email: String?, password: String?, phone: String?, userStatus: Int?) {
+    public init(id: Int64? = nil, username: String? = nil, firstName: String? = nil, lastName: String? = nil, email: String? = nil, password: String? = nil, phone: String? = nil, userStatus: Int? = nil) {
         self.id = id
         self.username = username
         self.firstName = firstName


### PR DESCRIPTION
This is a follow-up to #5256, which happens to affect the Swift5 code-gen.

If a default value is provided by the API spec for a date-time attribute, this PR fixes the generation code to build a correct Swift `Date` object.

To close #5256

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language: @4brunu