### PR TITLE
[REQ] Added enumClassPrefix option to Go server generation

### DIFF
--- a/docs/generators/go-server.md
+++ b/docs/generators/go-server.md
@@ -11,6 +11,7 @@ sidebar_label: go-server
 |packageVersion|Go package version.| |1.0.0|
 |serverPort|The network port the generated server binds to| |8080|
 |sourceFolder|source folder for generated code| |go|
+|enumClassPrefix|Prefix enum with class name| |false|
 
 ## IMPORT MAPPING
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/GoServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/GoServerCodegen.java
@@ -188,7 +188,7 @@ public class GoServerCodegen extends AbstractGoCodegen {
         if (additionalProperties.containsKey(CodegenConstants.ENUM_CLASS_PREFIX)) {
             setEnumClassPrefix(Boolean.parseBoolean(additionalProperties.get(CodegenConstants.ENUM_CLASS_PREFIX).toString()));
             if (enumClassPrefix) {
-                additionalProperties.put(CodegenConstants.ENUM_CLASS_PREFIX, "true");
+                additionalProperties.put(CodegenConstants.ENUM_CLASS_PREFIX, true);
             }
         }
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/GoServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/GoServerCodegen.java
@@ -104,7 +104,7 @@ public class GoServerCodegen extends AbstractGoCodegen {
 
         /*
          * Service templates.  You can write services for each Api file with the apiTemplateFiles map.
-            These services are skeletons built to implement the logic of your api using the 
+            These services are skeletons built to implement the logic of your api using the
             expected parameters and response.
          */
         apiTemplateFiles.put(
@@ -183,6 +183,13 @@ public class GoServerCodegen extends AbstractGoCodegen {
             this.setFeatureCORS(convertPropertyToBooleanAndWriteBack("featureCORS"));
         } else {
             additionalProperties.put("featureCORS", corsFeatureEnabled);
+        }
+
+        if (additionalProperties.containsKey(CodegenConstants.ENUM_CLASS_PREFIX)) {
+            setEnumClassPrefix(Boolean.parseBoolean(additionalProperties.get(CodegenConstants.ENUM_CLASS_PREFIX).toString()));
+            if (enumClassPrefix) {
+                additionalProperties.put(CodegenConstants.ENUM_CLASS_PREFIX, "true");
+            }
         }
 
         modelPackage = packageName;

--- a/modules/openapi-generator/src/main/resources/go-server/model.mustache
+++ b/modules/openapi-generator/src/main/resources/go-server/model.mustache
@@ -11,7 +11,7 @@ type {{{name}}} {{^format}}{{dataType}}{{/format}}{{#format}}{{{format}}}{{/form
 const (
 	{{#allowableValues}}
 	{{#enumVars}}
-	{{name}} {{{classname}}} = {{{value}}}
+	{{#enumClassPrefix}}{{{classname.toUpperCase}}}_{{/enumClassPrefix}}{{name}} {{{classname}}} = {{{value}}}
 	{{/enumVars}}
 	{{/allowableValues}}
 ){{/isEnum}}{{^isEnum}}{{#description}}


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
Added "enumClassPrefix" option for Go server generation. Ported existing functionality already made available in the Go client generation so that the constant terms for enum values can be prefixed with the enum name itself. This is useful when you have multiple enum definitions that have some values that are shared between the enum sets.

Fix #6907 

<!-- Please check the completed items below -->
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [X] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [X] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@antihax (2017/11) @grokify (2018/07) @kemokemo (2018/09) @bkabrda (2019/07)