### PR TITLE
Goclient fix read close

### DIFF
--- a/modules/openapi-generator/src/main/resources/go-experimental/api.mustache
+++ b/modules/openapi-generator/src/main/resources/go-experimental/api.mustache
@@ -274,7 +274,6 @@ func (r api{{operationId}}Request) Execute() ({{#returnType}}{{{.}}}, {{/returnT
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return {{#returnType}}localVarReturnValue, {{/returnType}}localVarHTTPResponse, err
 	}

--- a/modules/openapi-generator/src/main/resources/go/api.mustache
+++ b/modules/openapi-generator/src/main/resources/go/api.mustache
@@ -308,7 +308,6 @@ func (a *{{{classname}}}Service) {{{nickname}}}(ctx _context.Context{{#hasParams
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return {{#returnType}}localVarReturnValue, {{/returnType}}localVarHTTPResponse, err
 	}

--- a/samples/client/petstore/go-experimental/go-petstore/.openapi-generator/VERSION
+++ b/samples/client/petstore/go-experimental/go-petstore/.openapi-generator/VERSION
@@ -1,1 +1,1 @@
-5.0.0-SNAPSHOT
+5.0.0-beta

--- a/samples/client/petstore/go-experimental/go-petstore/api_another_fake.go
+++ b/samples/client/petstore/go-experimental/go-petstore/api_another_fake.go
@@ -108,7 +108,6 @@ func (r apiCall123TestSpecialTagsRequest) Execute() (Client, *_nethttp.Response,
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}

--- a/samples/client/petstore/go-experimental/go-petstore/api_fake.go
+++ b/samples/client/petstore/go-experimental/go-petstore/api_fake.go
@@ -111,7 +111,6 @@ func (r apiCreateXmlItemRequest) Execute() (*_nethttp.Response, error) {
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarHTTPResponse, err
 	}
@@ -206,7 +205,6 @@ func (r apiFakeOuterBooleanSerializeRequest) Execute() (bool, *_nethttp.Response
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
@@ -310,7 +308,6 @@ func (r apiFakeOuterCompositeSerializeRequest) Execute() (OuterComposite, *_neth
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
@@ -414,7 +411,6 @@ func (r apiFakeOuterNumberSerializeRequest) Execute() (float32, *_nethttp.Respon
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
@@ -518,7 +514,6 @@ func (r apiFakeOuterStringSerializeRequest) Execute() (string, *_nethttp.Respons
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
@@ -626,7 +621,6 @@ func (r apiTestBodyWithFileSchemaRequest) Execute() (*_nethttp.Response, error) 
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarHTTPResponse, err
 	}
@@ -735,7 +729,6 @@ func (r apiTestBodyWithQueryParamsRequest) Execute() (*_nethttp.Response, error)
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarHTTPResponse, err
 	}
@@ -834,7 +827,6 @@ func (r apiTestClientModelRequest) Execute() (Client, *_nethttp.Response, error)
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
@@ -1087,7 +1079,6 @@ func (r apiTestEndpointParametersRequest) Execute() (*_nethttp.Response, error) 
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarHTTPResponse, err
 	}
@@ -1246,7 +1237,6 @@ func (r apiTestEnumParametersRequest) Execute() (*_nethttp.Response, error) {
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarHTTPResponse, err
 	}
@@ -1393,7 +1383,6 @@ func (r apiTestGroupParametersRequest) Execute() (*_nethttp.Response, error) {
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarHTTPResponse, err
 	}
@@ -1491,7 +1480,6 @@ func (r apiTestInlineAdditionalPropertiesRequest) Execute() (*_nethttp.Response,
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarHTTPResponse, err
 	}
@@ -1599,7 +1587,6 @@ func (r apiTestJsonFormDataRequest) Execute() (*_nethttp.Response, error) {
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarHTTPResponse, err
 	}
@@ -1751,7 +1738,6 @@ func (r apiTestQueryParameterCollectionFormatRequest) Execute() (*_nethttp.Respo
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarHTTPResponse, err
 	}

--- a/samples/client/petstore/go-experimental/go-petstore/api_fake_classname_tags123.go
+++ b/samples/client/petstore/go-experimental/go-petstore/api_fake_classname_tags123.go
@@ -122,7 +122,6 @@ func (r apiTestClassnameRequest) Execute() (Client, *_nethttp.Response, error) {
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}

--- a/samples/client/petstore/go-experimental/go-petstore/api_pet.go
+++ b/samples/client/petstore/go-experimental/go-petstore/api_pet.go
@@ -109,7 +109,6 @@ func (r apiAddPetRequest) Execute() (*_nethttp.Response, error) {
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarHTTPResponse, err
 	}
@@ -209,7 +208,6 @@ func (r apiDeletePetRequest) Execute() (*_nethttp.Response, error) {
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarHTTPResponse, err
 	}
@@ -307,7 +305,6 @@ func (r apiFindPetsByStatusRequest) Execute() ([]Pet, *_nethttp.Response, error)
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
@@ -414,7 +411,6 @@ func (r apiFindPetsByTagsRequest) Execute() ([]Pet, *_nethttp.Response, error) {
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
@@ -529,7 +525,6 @@ func (r apiGetPetByIdRequest) Execute() (Pet, *_nethttp.Response, error) {
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
@@ -636,7 +631,6 @@ func (r apiUpdatePetRequest) Execute() (*_nethttp.Response, error) {
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarHTTPResponse, err
 	}
@@ -745,7 +739,6 @@ func (r apiUpdatePetWithFormRequest) Execute() (*_nethttp.Response, error) {
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarHTTPResponse, err
 	}
@@ -862,7 +855,6 @@ func (r apiUploadFileRequest) Execute() (ApiResponse, *_nethttp.Response, error)
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
@@ -989,7 +981,6 @@ func (r apiUploadFileWithRequiredFileRequest) Execute() (ApiResponse, *_nethttp.
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}

--- a/samples/client/petstore/go-experimental/go-petstore/api_store.go
+++ b/samples/client/petstore/go-experimental/go-petstore/api_store.go
@@ -102,7 +102,6 @@ func (r apiDeleteOrderRequest) Execute() (*_nethttp.Response, error) {
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarHTTPResponse, err
 	}
@@ -203,7 +202,6 @@ func (r apiGetInventoryRequest) Execute() (map[string]int32, *_nethttp.Response,
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
@@ -310,7 +308,6 @@ func (r apiGetOrderByIdRequest) Execute() (Order, *_nethttp.Response, error) {
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
@@ -417,7 +414,6 @@ func (r apiPlaceOrderRequest) Execute() (Order, *_nethttp.Response, error) {
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}

--- a/samples/client/petstore/go-experimental/go-petstore/api_user.go
+++ b/samples/client/petstore/go-experimental/go-petstore/api_user.go
@@ -109,7 +109,6 @@ func (r apiCreateUserRequest) Execute() (*_nethttp.Response, error) {
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarHTTPResponse, err
 	}
@@ -207,7 +206,6 @@ func (r apiCreateUsersWithArrayInputRequest) Execute() (*_nethttp.Response, erro
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarHTTPResponse, err
 	}
@@ -305,7 +303,6 @@ func (r apiCreateUsersWithListInputRequest) Execute() (*_nethttp.Response, error
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarHTTPResponse, err
 	}
@@ -397,7 +394,6 @@ func (r apiDeleteUserRequest) Execute() (*_nethttp.Response, error) {
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarHTTPResponse, err
 	}
@@ -488,7 +484,6 @@ func (r apiGetUserByNameRequest) Execute() (User, *_nethttp.Response, error) {
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
@@ -605,7 +600,6 @@ func (r apiLoginUserRequest) Execute() (string, *_nethttp.Response, error) {
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
@@ -700,7 +694,6 @@ func (r apiLogoutUserRequest) Execute() (*_nethttp.Response, error) {
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarHTTPResponse, err
 	}
@@ -804,7 +797,6 @@ func (r apiUpdateUserRequest) Execute() (*_nethttp.Response, error) {
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarHTTPResponse, err
 	}

--- a/samples/client/petstore/go/go-petstore-withXml/.openapi-generator/VERSION
+++ b/samples/client/petstore/go/go-petstore-withXml/.openapi-generator/VERSION
@@ -1,1 +1,1 @@
-5.0.0-SNAPSHOT
+5.0.0-beta

--- a/samples/client/petstore/go/go-petstore-withXml/api_another_fake.go
+++ b/samples/client/petstore/go/go-petstore-withXml/api_another_fake.go
@@ -78,7 +78,6 @@ func (a *AnotherFakeApiService) Call123TestSpecialTags(ctx _context.Context, bod
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}

--- a/samples/client/petstore/go/go-petstore-withXml/api_fake.go
+++ b/samples/client/petstore/go/go-petstore-withXml/api_fake.go
@@ -79,7 +79,6 @@ func (a *FakeApiService) CreateXmlItem(ctx _context.Context, xmlItem XmlItem) (*
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarHTTPResponse, err
 	}
@@ -157,7 +156,6 @@ func (a *FakeApiService) FakeOuterBooleanSerialize(ctx _context.Context, localVa
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
@@ -248,7 +246,6 @@ func (a *FakeApiService) FakeOuterCompositeSerialize(ctx _context.Context, local
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
@@ -335,7 +332,6 @@ func (a *FakeApiService) FakeOuterNumberSerialize(ctx _context.Context, localVar
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
@@ -422,7 +418,6 @@ func (a *FakeApiService) FakeOuterStringSerialize(ctx _context.Context, localVar
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
@@ -498,7 +493,6 @@ func (a *FakeApiService) TestBodyWithFileSchema(ctx _context.Context, body FileS
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarHTTPResponse, err
 	}
@@ -566,7 +560,6 @@ func (a *FakeApiService) TestBodyWithQueryParams(ctx _context.Context, query str
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarHTTPResponse, err
 	}
@@ -635,7 +628,6 @@ func (a *FakeApiService) TestClientModel(ctx _context.Context, body Client) (Cli
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
@@ -795,7 +787,6 @@ func (a *FakeApiService) TestEndpointParameters(ctx _context.Context, number flo
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarHTTPResponse, err
 	}
@@ -904,7 +895,6 @@ func (a *FakeApiService) TestEnumParameters(ctx _context.Context, localVarOption
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarHTTPResponse, err
 	}
@@ -994,7 +984,6 @@ func (a *FakeApiService) TestGroupParameters(ctx _context.Context, requiredStrin
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarHTTPResponse, err
 	}
@@ -1060,7 +1049,6 @@ func (a *FakeApiService) TestInlineAdditionalProperties(ctx _context.Context, pa
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarHTTPResponse, err
 	}
@@ -1127,7 +1115,6 @@ func (a *FakeApiService) TestJsonFormData(ctx _context.Context, param string, pa
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarHTTPResponse, err
 	}
@@ -1211,7 +1198,6 @@ func (a *FakeApiService) TestQueryParameterCollectionFormat(ctx _context.Context
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarHTTPResponse, err
 	}

--- a/samples/client/petstore/go/go-petstore-withXml/api_fake_classname_tags123.go
+++ b/samples/client/petstore/go/go-petstore-withXml/api_fake_classname_tags123.go
@@ -90,7 +90,6 @@ func (a *FakeClassnameTags123ApiService) TestClassname(ctx _context.Context, bod
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}

--- a/samples/client/petstore/go/go-petstore-withXml/api_pet.go
+++ b/samples/client/petstore/go/go-petstore-withXml/api_pet.go
@@ -78,7 +78,6 @@ func (a *PetApiService) AddPet(ctx _context.Context, body Pet) (*_nethttp.Respon
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarHTTPResponse, err
 	}
@@ -154,7 +153,6 @@ func (a *PetApiService) DeletePet(ctx _context.Context, petId int64, localVarOpt
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarHTTPResponse, err
 	}
@@ -222,7 +220,6 @@ func (a *PetApiService) FindPetsByStatus(ctx _context.Context, status []string) 
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
@@ -299,7 +296,6 @@ func (a *PetApiService) FindPetsByTags(ctx _context.Context, tags []string) ([]P
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
@@ -389,7 +385,6 @@ func (a *PetApiService) GetPetById(ctx _context.Context, petId int64) (Pet, *_ne
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
@@ -464,7 +459,6 @@ func (a *PetApiService) UpdatePet(ctx _context.Context, body Pet) (*_nethttp.Res
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarHTTPResponse, err
 	}
@@ -545,7 +539,6 @@ func (a *PetApiService) UpdatePetWithForm(ctx _context.Context, petId int64, loc
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarHTTPResponse, err
 	}
@@ -640,7 +633,6 @@ func (a *PetApiService) UploadFile(ctx _context.Context, petId int64, localVarOp
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
@@ -736,7 +728,6 @@ func (a *PetApiService) UploadFileWithRequiredFile(ctx _context.Context, petId i
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}

--- a/samples/client/petstore/go/go-petstore-withXml/api_store.go
+++ b/samples/client/petstore/go/go-petstore-withXml/api_store.go
@@ -77,7 +77,6 @@ func (a *StoreApiService) DeleteOrder(ctx _context.Context, orderId string) (*_n
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarHTTPResponse, err
 	}
@@ -155,7 +154,6 @@ func (a *StoreApiService) GetInventory(ctx _context.Context) (map[string]int32, 
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
@@ -239,7 +237,6 @@ func (a *StoreApiService) GetOrderById(ctx _context.Context, orderId int64) (Ord
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
@@ -316,7 +313,6 @@ func (a *StoreApiService) PlaceOrder(ctx _context.Context, body Order) (Order, *
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}

--- a/samples/client/petstore/go/go-petstore-withXml/api_user.go
+++ b/samples/client/petstore/go/go-petstore-withXml/api_user.go
@@ -77,7 +77,6 @@ func (a *UserApiService) CreateUser(ctx _context.Context, body User) (*_nethttp.
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarHTTPResponse, err
 	}
@@ -143,7 +142,6 @@ func (a *UserApiService) CreateUsersWithArrayInput(ctx _context.Context, body []
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarHTTPResponse, err
 	}
@@ -209,7 +207,6 @@ func (a *UserApiService) CreateUsersWithListInput(ctx _context.Context, body []U
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarHTTPResponse, err
 	}
@@ -276,7 +273,6 @@ func (a *UserApiService) DeleteUser(ctx _context.Context, username string) (*_ne
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarHTTPResponse, err
 	}
@@ -344,7 +340,6 @@ func (a *UserApiService) GetUserByName(ctx _context.Context, username string) (U
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
@@ -422,7 +417,6 @@ func (a *UserApiService) LoginUser(ctx _context.Context, username string, passwo
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
@@ -494,7 +488,6 @@ func (a *UserApiService) LogoutUser(ctx _context.Context) (*_nethttp.Response, e
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarHTTPResponse, err
 	}
@@ -564,7 +557,6 @@ func (a *UserApiService) UpdateUser(ctx _context.Context, username string, body 
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarHTTPResponse, err
 	}

--- a/samples/client/petstore/go/go-petstore/.openapi-generator/VERSION
+++ b/samples/client/petstore/go/go-petstore/.openapi-generator/VERSION
@@ -1,1 +1,1 @@
-5.0.0-SNAPSHOT
+5.0.0-beta

--- a/samples/client/petstore/go/go-petstore/api_another_fake.go
+++ b/samples/client/petstore/go/go-petstore/api_another_fake.go
@@ -77,7 +77,6 @@ func (a *AnotherFakeApiService) Call123TestSpecialTags(ctx _context.Context, bod
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}

--- a/samples/client/petstore/go/go-petstore/api_fake.go
+++ b/samples/client/petstore/go/go-petstore/api_fake.go
@@ -78,7 +78,6 @@ func (a *FakeApiService) CreateXmlItem(ctx _context.Context, xmlItem XmlItem) (*
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarHTTPResponse, err
 	}
@@ -156,7 +155,6 @@ func (a *FakeApiService) FakeOuterBooleanSerialize(ctx _context.Context, localVa
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
@@ -247,7 +245,6 @@ func (a *FakeApiService) FakeOuterCompositeSerialize(ctx _context.Context, local
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
@@ -334,7 +331,6 @@ func (a *FakeApiService) FakeOuterNumberSerialize(ctx _context.Context, localVar
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
@@ -421,7 +417,6 @@ func (a *FakeApiService) FakeOuterStringSerialize(ctx _context.Context, localVar
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
@@ -497,7 +492,6 @@ func (a *FakeApiService) TestBodyWithFileSchema(ctx _context.Context, body FileS
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarHTTPResponse, err
 	}
@@ -565,7 +559,6 @@ func (a *FakeApiService) TestBodyWithQueryParams(ctx _context.Context, query str
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarHTTPResponse, err
 	}
@@ -634,7 +627,6 @@ func (a *FakeApiService) TestClientModel(ctx _context.Context, body Client) (Cli
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
@@ -794,7 +786,6 @@ func (a *FakeApiService) TestEndpointParameters(ctx _context.Context, number flo
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarHTTPResponse, err
 	}
@@ -903,7 +894,6 @@ func (a *FakeApiService) TestEnumParameters(ctx _context.Context, localVarOption
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarHTTPResponse, err
 	}
@@ -993,7 +983,6 @@ func (a *FakeApiService) TestGroupParameters(ctx _context.Context, requiredStrin
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarHTTPResponse, err
 	}
@@ -1059,7 +1048,6 @@ func (a *FakeApiService) TestInlineAdditionalProperties(ctx _context.Context, pa
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarHTTPResponse, err
 	}
@@ -1126,7 +1114,6 @@ func (a *FakeApiService) TestJsonFormData(ctx _context.Context, param string, pa
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarHTTPResponse, err
 	}
@@ -1210,7 +1197,6 @@ func (a *FakeApiService) TestQueryParameterCollectionFormat(ctx _context.Context
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarHTTPResponse, err
 	}

--- a/samples/client/petstore/go/go-petstore/api_fake_classname_tags123.go
+++ b/samples/client/petstore/go/go-petstore/api_fake_classname_tags123.go
@@ -89,7 +89,6 @@ func (a *FakeClassnameTags123ApiService) TestClassname(ctx _context.Context, bod
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}

--- a/samples/client/petstore/go/go-petstore/api_pet.go
+++ b/samples/client/petstore/go/go-petstore/api_pet.go
@@ -77,7 +77,6 @@ func (a *PetApiService) AddPet(ctx _context.Context, body Pet) (*_nethttp.Respon
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarHTTPResponse, err
 	}
@@ -153,7 +152,6 @@ func (a *PetApiService) DeletePet(ctx _context.Context, petId int64, localVarOpt
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarHTTPResponse, err
 	}
@@ -221,7 +219,6 @@ func (a *PetApiService) FindPetsByStatus(ctx _context.Context, status []string) 
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
@@ -298,7 +295,6 @@ func (a *PetApiService) FindPetsByTags(ctx _context.Context, tags []string) ([]P
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
@@ -388,7 +384,6 @@ func (a *PetApiService) GetPetById(ctx _context.Context, petId int64) (Pet, *_ne
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
@@ -463,7 +458,6 @@ func (a *PetApiService) UpdatePet(ctx _context.Context, body Pet) (*_nethttp.Res
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarHTTPResponse, err
 	}
@@ -544,7 +538,6 @@ func (a *PetApiService) UpdatePetWithForm(ctx _context.Context, petId int64, loc
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarHTTPResponse, err
 	}
@@ -639,7 +632,6 @@ func (a *PetApiService) UploadFile(ctx _context.Context, petId int64, localVarOp
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
@@ -735,7 +727,6 @@ func (a *PetApiService) UploadFileWithRequiredFile(ctx _context.Context, petId i
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}

--- a/samples/client/petstore/go/go-petstore/api_store.go
+++ b/samples/client/petstore/go/go-petstore/api_store.go
@@ -76,7 +76,6 @@ func (a *StoreApiService) DeleteOrder(ctx _context.Context, orderId string) (*_n
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarHTTPResponse, err
 	}
@@ -154,7 +153,6 @@ func (a *StoreApiService) GetInventory(ctx _context.Context) (map[string]int32, 
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
@@ -238,7 +236,6 @@ func (a *StoreApiService) GetOrderById(ctx _context.Context, orderId int64) (Ord
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
@@ -315,7 +312,6 @@ func (a *StoreApiService) PlaceOrder(ctx _context.Context, body Order) (Order, *
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}

--- a/samples/client/petstore/go/go-petstore/api_user.go
+++ b/samples/client/petstore/go/go-petstore/api_user.go
@@ -76,7 +76,6 @@ func (a *UserApiService) CreateUser(ctx _context.Context, body User) (*_nethttp.
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarHTTPResponse, err
 	}
@@ -142,7 +141,6 @@ func (a *UserApiService) CreateUsersWithArrayInput(ctx _context.Context, body []
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarHTTPResponse, err
 	}
@@ -208,7 +206,6 @@ func (a *UserApiService) CreateUsersWithListInput(ctx _context.Context, body []U
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarHTTPResponse, err
 	}
@@ -275,7 +272,6 @@ func (a *UserApiService) DeleteUser(ctx _context.Context, username string) (*_ne
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarHTTPResponse, err
 	}
@@ -343,7 +339,6 @@ func (a *UserApiService) GetUserByName(ctx _context.Context, username string) (U
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
@@ -421,7 +416,6 @@ func (a *UserApiService) LoginUser(ctx _context.Context, username string, passwo
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
@@ -493,7 +487,6 @@ func (a *UserApiService) LogoutUser(ctx _context.Context) (*_nethttp.Response, e
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarHTTPResponse, err
 	}
@@ -563,7 +556,6 @@ func (a *UserApiService) UpdateUser(ctx _context.Context, username string, body 
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarHTTPResponse, err
 	}

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/.openapi-generator/VERSION
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/.openapi-generator/VERSION
@@ -1,1 +1,1 @@
-5.0.0-SNAPSHOT
+5.0.0-beta

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/api_another_fake.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/api_another_fake.go
@@ -108,7 +108,6 @@ func (r apiCall123TestSpecialTagsRequest) Execute() (Client, *_nethttp.Response,
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/api_default.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/api_default.go
@@ -95,7 +95,6 @@ func (r apiFooGetRequest) Execute() (InlineResponseDefault, *_nethttp.Response, 
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/api_fake.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/api_fake.go
@@ -98,7 +98,6 @@ func (r apiFakeHealthGetRequest) Execute() (HealthCheckResult, *_nethttp.Respons
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
@@ -202,7 +201,6 @@ func (r apiFakeOuterBooleanSerializeRequest) Execute() (bool, *_nethttp.Response
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
@@ -306,7 +304,6 @@ func (r apiFakeOuterCompositeSerializeRequest) Execute() (OuterComposite, *_neth
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
@@ -410,7 +407,6 @@ func (r apiFakeOuterNumberSerializeRequest) Execute() (float32, *_nethttp.Respon
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
@@ -514,7 +510,6 @@ func (r apiFakeOuterStringSerializeRequest) Execute() (string, *_nethttp.Respons
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
@@ -622,7 +617,6 @@ func (r apiTestBodyWithFileSchemaRequest) Execute() (*_nethttp.Response, error) 
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarHTTPResponse, err
 	}
@@ -731,7 +725,6 @@ func (r apiTestBodyWithQueryParamsRequest) Execute() (*_nethttp.Response, error)
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarHTTPResponse, err
 	}
@@ -830,7 +823,6 @@ func (r apiTestClientModelRequest) Execute() (Client, *_nethttp.Response, error)
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
@@ -1084,7 +1076,6 @@ func (r apiTestEndpointParametersRequest) Execute() (*_nethttp.Response, error) 
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarHTTPResponse, err
 	}
@@ -1251,7 +1242,6 @@ func (r apiTestEnumParametersRequest) Execute() (*_nethttp.Response, error) {
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarHTTPResponse, err
 	}
@@ -1398,7 +1388,6 @@ func (r apiTestGroupParametersRequest) Execute() (*_nethttp.Response, error) {
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarHTTPResponse, err
 	}
@@ -1496,7 +1485,6 @@ func (r apiTestInlineAdditionalPropertiesRequest) Execute() (*_nethttp.Response,
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarHTTPResponse, err
 	}
@@ -1604,7 +1592,6 @@ func (r apiTestJsonFormDataRequest) Execute() (*_nethttp.Response, error) {
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarHTTPResponse, err
 	}
@@ -1766,7 +1753,6 @@ func (r apiTestQueryParameterCollectionFormatRequest) Execute() (*_nethttp.Respo
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarHTTPResponse, err
 	}

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/api_fake_classname_tags123.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/api_fake_classname_tags123.go
@@ -122,7 +122,6 @@ func (r apiTestClassnameRequest) Execute() (Client, *_nethttp.Response, error) {
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/api_pet.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/api_pet.go
@@ -109,7 +109,6 @@ func (r apiAddPetRequest) Execute() (*_nethttp.Response, error) {
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarHTTPResponse, err
 	}
@@ -209,7 +208,6 @@ func (r apiDeletePetRequest) Execute() (*_nethttp.Response, error) {
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarHTTPResponse, err
 	}
@@ -307,7 +305,6 @@ func (r apiFindPetsByStatusRequest) Execute() ([]Pet, *_nethttp.Response, error)
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
@@ -414,7 +411,6 @@ func (r apiFindPetsByTagsRequest) Execute() ([]Pet, *_nethttp.Response, error) {
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
@@ -529,7 +525,6 @@ func (r apiGetPetByIdRequest) Execute() (Pet, *_nethttp.Response, error) {
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
@@ -636,7 +631,6 @@ func (r apiUpdatePetRequest) Execute() (*_nethttp.Response, error) {
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarHTTPResponse, err
 	}
@@ -745,7 +739,6 @@ func (r apiUpdatePetWithFormRequest) Execute() (*_nethttp.Response, error) {
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarHTTPResponse, err
 	}
@@ -862,7 +855,6 @@ func (r apiUploadFileRequest) Execute() (ApiResponse, *_nethttp.Response, error)
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
@@ -989,7 +981,6 @@ func (r apiUploadFileWithRequiredFileRequest) Execute() (ApiResponse, *_nethttp.
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/api_store.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/api_store.go
@@ -102,7 +102,6 @@ func (r apiDeleteOrderRequest) Execute() (*_nethttp.Response, error) {
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarHTTPResponse, err
 	}
@@ -203,7 +202,6 @@ func (r apiGetInventoryRequest) Execute() (map[string]int32, *_nethttp.Response,
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
@@ -310,7 +308,6 @@ func (r apiGetOrderByIdRequest) Execute() (Order, *_nethttp.Response, error) {
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
@@ -417,7 +414,6 @@ func (r apiPlaceOrderRequest) Execute() (Order, *_nethttp.Response, error) {
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/api_user.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/api_user.go
@@ -109,7 +109,6 @@ func (r apiCreateUserRequest) Execute() (*_nethttp.Response, error) {
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarHTTPResponse, err
 	}
@@ -207,7 +206,6 @@ func (r apiCreateUsersWithArrayInputRequest) Execute() (*_nethttp.Response, erro
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarHTTPResponse, err
 	}
@@ -305,7 +303,6 @@ func (r apiCreateUsersWithListInputRequest) Execute() (*_nethttp.Response, error
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarHTTPResponse, err
 	}
@@ -397,7 +394,6 @@ func (r apiDeleteUserRequest) Execute() (*_nethttp.Response, error) {
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarHTTPResponse, err
 	}
@@ -488,7 +484,6 @@ func (r apiGetUserByNameRequest) Execute() (User, *_nethttp.Response, error) {
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
@@ -605,7 +600,6 @@ func (r apiLoginUserRequest) Execute() (string, *_nethttp.Response, error) {
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
@@ -700,7 +694,6 @@ func (r apiLogoutUserRequest) Execute() (*_nethttp.Response, error) {
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarHTTPResponse, err
 	}
@@ -804,7 +797,6 @@ func (r apiUpdateUserRequest) Execute() (*_nethttp.Response, error) {
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarHTTPResponse, err
 	}

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_200_response.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_200_response.go
@@ -17,10 +17,7 @@ import (
 type Model200Response struct {
 	Name *int32 `json:"name,omitempty"`
 	Class *string `json:"class,omitempty"`
-	AdditionalProperties map[string]interface{}
 }
-
-type _Model200Response Model200Response
 
 // NewModel200Response instantiates a new Model200Response object
 // This constructor will assign default values to properties that have it defined,
@@ -111,30 +108,7 @@ func (o Model200Response) MarshalJSON() ([]byte, error) {
 	if o.Class != nil {
 		toSerialize["class"] = o.Class
 	}
-
-	for key, value := range o.AdditionalProperties {
-		toSerialize[key] = value
-	}
-
 	return json.Marshal(toSerialize)
-}
-
-func (o *Model200Response) UnmarshalJSON(bytes []byte) (err error) {
-	varModel200Response := _Model200Response{}
-
-	if err = json.Unmarshal(bytes, &varModel200Response); err == nil {
-		*o = Model200Response(varModel200Response)
-	}
-
-	additionalProperties := make(map[string]interface{})
-
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
-		delete(additionalProperties, "name")
-		delete(additionalProperties, "class")
-		o.AdditionalProperties = additionalProperties
-	}
-
-	return err
 }
 
 type NullableModel200Response struct {

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model__special_model_name_.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model__special_model_name_.go
@@ -16,10 +16,7 @@ import (
 // SpecialModelName struct for SpecialModelName
 type SpecialModelName struct {
 	SpecialPropertyName *int64 `json:"$special[property.name],omitempty"`
-	AdditionalProperties map[string]interface{}
 }
-
-type _SpecialModelName SpecialModelName
 
 // NewSpecialModelName instantiates a new SpecialModelName object
 // This constructor will assign default values to properties that have it defined,
@@ -75,29 +72,7 @@ func (o SpecialModelName) MarshalJSON() ([]byte, error) {
 	if o.SpecialPropertyName != nil {
 		toSerialize["$special[property.name]"] = o.SpecialPropertyName
 	}
-
-	for key, value := range o.AdditionalProperties {
-		toSerialize[key] = value
-	}
-
 	return json.Marshal(toSerialize)
-}
-
-func (o *SpecialModelName) UnmarshalJSON(bytes []byte) (err error) {
-	varSpecialModelName := _SpecialModelName{}
-
-	if err = json.Unmarshal(bytes, &varSpecialModelName); err == nil {
-		*o = SpecialModelName(varSpecialModelName)
-	}
-
-	additionalProperties := make(map[string]interface{})
-
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
-		delete(additionalProperties, "$special[property.name]")
-		o.AdditionalProperties = additionalProperties
-	}
-
-	return err
 }
 
 type NullableSpecialModelName struct {

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_additional_properties_class.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_additional_properties_class.go
@@ -17,10 +17,7 @@ import (
 type AdditionalPropertiesClass struct {
 	MapProperty *map[string]string `json:"map_property,omitempty"`
 	MapOfMapProperty *map[string]map[string]string `json:"map_of_map_property,omitempty"`
-	AdditionalProperties map[string]interface{}
 }
-
-type _AdditionalPropertiesClass AdditionalPropertiesClass
 
 // NewAdditionalPropertiesClass instantiates a new AdditionalPropertiesClass object
 // This constructor will assign default values to properties that have it defined,
@@ -111,30 +108,7 @@ func (o AdditionalPropertiesClass) MarshalJSON() ([]byte, error) {
 	if o.MapOfMapProperty != nil {
 		toSerialize["map_of_map_property"] = o.MapOfMapProperty
 	}
-
-	for key, value := range o.AdditionalProperties {
-		toSerialize[key] = value
-	}
-
 	return json.Marshal(toSerialize)
-}
-
-func (o *AdditionalPropertiesClass) UnmarshalJSON(bytes []byte) (err error) {
-	varAdditionalPropertiesClass := _AdditionalPropertiesClass{}
-
-	if err = json.Unmarshal(bytes, &varAdditionalPropertiesClass); err == nil {
-		*o = AdditionalPropertiesClass(varAdditionalPropertiesClass)
-	}
-
-	additionalProperties := make(map[string]interface{})
-
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
-		delete(additionalProperties, "map_property")
-		delete(additionalProperties, "map_of_map_property")
-		o.AdditionalProperties = additionalProperties
-	}
-
-	return err
 }
 
 type NullableAdditionalPropertiesClass struct {

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_animal.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_animal.go
@@ -17,10 +17,7 @@ import (
 type Animal struct {
 	ClassName string `json:"className"`
 	Color *string `json:"color,omitempty"`
-	AdditionalProperties map[string]interface{}
 }
-
-type _Animal Animal
 
 // NewAnimal instantiates a new Animal object
 // This constructor will assign default values to properties that have it defined,
@@ -108,30 +105,7 @@ func (o Animal) MarshalJSON() ([]byte, error) {
 	if o.Color != nil {
 		toSerialize["color"] = o.Color
 	}
-
-	for key, value := range o.AdditionalProperties {
-		toSerialize[key] = value
-	}
-
 	return json.Marshal(toSerialize)
-}
-
-func (o *Animal) UnmarshalJSON(bytes []byte) (err error) {
-	varAnimal := _Animal{}
-
-	if err = json.Unmarshal(bytes, &varAnimal); err == nil {
-		*o = Animal(varAnimal)
-	}
-
-	additionalProperties := make(map[string]interface{})
-
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
-		delete(additionalProperties, "className")
-		delete(additionalProperties, "color")
-		o.AdditionalProperties = additionalProperties
-	}
-
-	return err
 }
 
 type NullableAnimal struct {

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_api_response.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_api_response.go
@@ -18,10 +18,7 @@ type ApiResponse struct {
 	Code *int32 `json:"code,omitempty"`
 	Type *string `json:"type,omitempty"`
 	Message *string `json:"message,omitempty"`
-	AdditionalProperties map[string]interface{}
 }
-
-type _ApiResponse ApiResponse
 
 // NewApiResponse instantiates a new ApiResponse object
 // This constructor will assign default values to properties that have it defined,
@@ -147,31 +144,7 @@ func (o ApiResponse) MarshalJSON() ([]byte, error) {
 	if o.Message != nil {
 		toSerialize["message"] = o.Message
 	}
-
-	for key, value := range o.AdditionalProperties {
-		toSerialize[key] = value
-	}
-
 	return json.Marshal(toSerialize)
-}
-
-func (o *ApiResponse) UnmarshalJSON(bytes []byte) (err error) {
-	varApiResponse := _ApiResponse{}
-
-	if err = json.Unmarshal(bytes, &varApiResponse); err == nil {
-		*o = ApiResponse(varApiResponse)
-	}
-
-	additionalProperties := make(map[string]interface{})
-
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
-		delete(additionalProperties, "code")
-		delete(additionalProperties, "type")
-		delete(additionalProperties, "message")
-		o.AdditionalProperties = additionalProperties
-	}
-
-	return err
 }
 
 type NullableApiResponse struct {

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_apple.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_apple.go
@@ -16,10 +16,7 @@ import (
 // Apple struct for Apple
 type Apple struct {
 	Cultivar *string `json:"cultivar,omitempty"`
-	AdditionalProperties map[string]interface{}
 }
-
-type _Apple Apple
 
 // NewApple instantiates a new Apple object
 // This constructor will assign default values to properties that have it defined,
@@ -75,29 +72,7 @@ func (o Apple) MarshalJSON() ([]byte, error) {
 	if o.Cultivar != nil {
 		toSerialize["cultivar"] = o.Cultivar
 	}
-
-	for key, value := range o.AdditionalProperties {
-		toSerialize[key] = value
-	}
-
 	return json.Marshal(toSerialize)
-}
-
-func (o *Apple) UnmarshalJSON(bytes []byte) (err error) {
-	varApple := _Apple{}
-
-	if err = json.Unmarshal(bytes, &varApple); err == nil {
-		*o = Apple(varApple)
-	}
-
-	additionalProperties := make(map[string]interface{})
-
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
-		delete(additionalProperties, "cultivar")
-		o.AdditionalProperties = additionalProperties
-	}
-
-	return err
 }
 
 type NullableApple struct {

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_apple_req.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_apple_req.go
@@ -17,10 +17,7 @@ import (
 type AppleReq struct {
 	Cultivar string `json:"cultivar"`
 	Mealy *bool `json:"mealy,omitempty"`
-	AdditionalProperties map[string]interface{}
 }
-
-type _AppleReq AppleReq
 
 // NewAppleReq instantiates a new AppleReq object
 // This constructor will assign default values to properties that have it defined,
@@ -104,30 +101,7 @@ func (o AppleReq) MarshalJSON() ([]byte, error) {
 	if o.Mealy != nil {
 		toSerialize["mealy"] = o.Mealy
 	}
-
-	for key, value := range o.AdditionalProperties {
-		toSerialize[key] = value
-	}
-
 	return json.Marshal(toSerialize)
-}
-
-func (o *AppleReq) UnmarshalJSON(bytes []byte) (err error) {
-	varAppleReq := _AppleReq{}
-
-	if err = json.Unmarshal(bytes, &varAppleReq); err == nil {
-		*o = AppleReq(varAppleReq)
-	}
-
-	additionalProperties := make(map[string]interface{})
-
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
-		delete(additionalProperties, "cultivar")
-		delete(additionalProperties, "mealy")
-		o.AdditionalProperties = additionalProperties
-	}
-
-	return err
 }
 
 type NullableAppleReq struct {

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_array_of_array_of_number_only.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_array_of_array_of_number_only.go
@@ -16,10 +16,7 @@ import (
 // ArrayOfArrayOfNumberOnly struct for ArrayOfArrayOfNumberOnly
 type ArrayOfArrayOfNumberOnly struct {
 	ArrayArrayNumber *[][]float32 `json:"ArrayArrayNumber,omitempty"`
-	AdditionalProperties map[string]interface{}
 }
-
-type _ArrayOfArrayOfNumberOnly ArrayOfArrayOfNumberOnly
 
 // NewArrayOfArrayOfNumberOnly instantiates a new ArrayOfArrayOfNumberOnly object
 // This constructor will assign default values to properties that have it defined,
@@ -75,29 +72,7 @@ func (o ArrayOfArrayOfNumberOnly) MarshalJSON() ([]byte, error) {
 	if o.ArrayArrayNumber != nil {
 		toSerialize["ArrayArrayNumber"] = o.ArrayArrayNumber
 	}
-
-	for key, value := range o.AdditionalProperties {
-		toSerialize[key] = value
-	}
-
 	return json.Marshal(toSerialize)
-}
-
-func (o *ArrayOfArrayOfNumberOnly) UnmarshalJSON(bytes []byte) (err error) {
-	varArrayOfArrayOfNumberOnly := _ArrayOfArrayOfNumberOnly{}
-
-	if err = json.Unmarshal(bytes, &varArrayOfArrayOfNumberOnly); err == nil {
-		*o = ArrayOfArrayOfNumberOnly(varArrayOfArrayOfNumberOnly)
-	}
-
-	additionalProperties := make(map[string]interface{})
-
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
-		delete(additionalProperties, "ArrayArrayNumber")
-		o.AdditionalProperties = additionalProperties
-	}
-
-	return err
 }
 
 type NullableArrayOfArrayOfNumberOnly struct {

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_array_of_number_only.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_array_of_number_only.go
@@ -16,10 +16,7 @@ import (
 // ArrayOfNumberOnly struct for ArrayOfNumberOnly
 type ArrayOfNumberOnly struct {
 	ArrayNumber *[]float32 `json:"ArrayNumber,omitempty"`
-	AdditionalProperties map[string]interface{}
 }
-
-type _ArrayOfNumberOnly ArrayOfNumberOnly
 
 // NewArrayOfNumberOnly instantiates a new ArrayOfNumberOnly object
 // This constructor will assign default values to properties that have it defined,
@@ -75,29 +72,7 @@ func (o ArrayOfNumberOnly) MarshalJSON() ([]byte, error) {
 	if o.ArrayNumber != nil {
 		toSerialize["ArrayNumber"] = o.ArrayNumber
 	}
-
-	for key, value := range o.AdditionalProperties {
-		toSerialize[key] = value
-	}
-
 	return json.Marshal(toSerialize)
-}
-
-func (o *ArrayOfNumberOnly) UnmarshalJSON(bytes []byte) (err error) {
-	varArrayOfNumberOnly := _ArrayOfNumberOnly{}
-
-	if err = json.Unmarshal(bytes, &varArrayOfNumberOnly); err == nil {
-		*o = ArrayOfNumberOnly(varArrayOfNumberOnly)
-	}
-
-	additionalProperties := make(map[string]interface{})
-
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
-		delete(additionalProperties, "ArrayNumber")
-		o.AdditionalProperties = additionalProperties
-	}
-
-	return err
 }
 
 type NullableArrayOfNumberOnly struct {

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_array_test_.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_array_test_.go
@@ -18,10 +18,7 @@ type ArrayTest struct {
 	ArrayOfString *[]string `json:"array_of_string,omitempty"`
 	ArrayArrayOfInteger *[][]int64 `json:"array_array_of_integer,omitempty"`
 	ArrayArrayOfModel *[][]ReadOnlyFirst `json:"array_array_of_model,omitempty"`
-	AdditionalProperties map[string]interface{}
 }
-
-type _ArrayTest ArrayTest
 
 // NewArrayTest instantiates a new ArrayTest object
 // This constructor will assign default values to properties that have it defined,
@@ -147,31 +144,7 @@ func (o ArrayTest) MarshalJSON() ([]byte, error) {
 	if o.ArrayArrayOfModel != nil {
 		toSerialize["array_array_of_model"] = o.ArrayArrayOfModel
 	}
-
-	for key, value := range o.AdditionalProperties {
-		toSerialize[key] = value
-	}
-
 	return json.Marshal(toSerialize)
-}
-
-func (o *ArrayTest) UnmarshalJSON(bytes []byte) (err error) {
-	varArrayTest := _ArrayTest{}
-
-	if err = json.Unmarshal(bytes, &varArrayTest); err == nil {
-		*o = ArrayTest(varArrayTest)
-	}
-
-	additionalProperties := make(map[string]interface{})
-
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
-		delete(additionalProperties, "array_of_string")
-		delete(additionalProperties, "array_array_of_integer")
-		delete(additionalProperties, "array_array_of_model")
-		o.AdditionalProperties = additionalProperties
-	}
-
-	return err
 }
 
 type NullableArrayTest struct {

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_banana.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_banana.go
@@ -16,10 +16,7 @@ import (
 // Banana struct for Banana
 type Banana struct {
 	LengthCm *float32 `json:"lengthCm,omitempty"`
-	AdditionalProperties map[string]interface{}
 }
-
-type _Banana Banana
 
 // NewBanana instantiates a new Banana object
 // This constructor will assign default values to properties that have it defined,
@@ -75,29 +72,7 @@ func (o Banana) MarshalJSON() ([]byte, error) {
 	if o.LengthCm != nil {
 		toSerialize["lengthCm"] = o.LengthCm
 	}
-
-	for key, value := range o.AdditionalProperties {
-		toSerialize[key] = value
-	}
-
 	return json.Marshal(toSerialize)
-}
-
-func (o *Banana) UnmarshalJSON(bytes []byte) (err error) {
-	varBanana := _Banana{}
-
-	if err = json.Unmarshal(bytes, &varBanana); err == nil {
-		*o = Banana(varBanana)
-	}
-
-	additionalProperties := make(map[string]interface{})
-
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
-		delete(additionalProperties, "lengthCm")
-		o.AdditionalProperties = additionalProperties
-	}
-
-	return err
 }
 
 type NullableBanana struct {

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_banana_req.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_banana_req.go
@@ -17,10 +17,7 @@ import (
 type BananaReq struct {
 	LengthCm float32 `json:"lengthCm"`
 	Sweet *bool `json:"sweet,omitempty"`
-	AdditionalProperties map[string]interface{}
 }
-
-type _BananaReq BananaReq
 
 // NewBananaReq instantiates a new BananaReq object
 // This constructor will assign default values to properties that have it defined,
@@ -104,30 +101,7 @@ func (o BananaReq) MarshalJSON() ([]byte, error) {
 	if o.Sweet != nil {
 		toSerialize["sweet"] = o.Sweet
 	}
-
-	for key, value := range o.AdditionalProperties {
-		toSerialize[key] = value
-	}
-
 	return json.Marshal(toSerialize)
-}
-
-func (o *BananaReq) UnmarshalJSON(bytes []byte) (err error) {
-	varBananaReq := _BananaReq{}
-
-	if err = json.Unmarshal(bytes, &varBananaReq); err == nil {
-		*o = BananaReq(varBananaReq)
-	}
-
-	additionalProperties := make(map[string]interface{})
-
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
-		delete(additionalProperties, "lengthCm")
-		delete(additionalProperties, "sweet")
-		o.AdditionalProperties = additionalProperties
-	}
-
-	return err
 }
 
 type NullableBananaReq struct {

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_capitalization.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_capitalization.go
@@ -22,10 +22,7 @@ type Capitalization struct {
 	SCAETHFlowPoints *string `json:"SCA_ETH_Flow_Points,omitempty"`
 	// Name of the pet 
 	ATT_NAME *string `json:"ATT_NAME,omitempty"`
-	AdditionalProperties map[string]interface{}
 }
-
-type _Capitalization Capitalization
 
 // NewCapitalization instantiates a new Capitalization object
 // This constructor will assign default values to properties that have it defined,
@@ -256,34 +253,7 @@ func (o Capitalization) MarshalJSON() ([]byte, error) {
 	if o.ATT_NAME != nil {
 		toSerialize["ATT_NAME"] = o.ATT_NAME
 	}
-
-	for key, value := range o.AdditionalProperties {
-		toSerialize[key] = value
-	}
-
 	return json.Marshal(toSerialize)
-}
-
-func (o *Capitalization) UnmarshalJSON(bytes []byte) (err error) {
-	varCapitalization := _Capitalization{}
-
-	if err = json.Unmarshal(bytes, &varCapitalization); err == nil {
-		*o = Capitalization(varCapitalization)
-	}
-
-	additionalProperties := make(map[string]interface{})
-
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
-		delete(additionalProperties, "smallCamel")
-		delete(additionalProperties, "CapitalCamel")
-		delete(additionalProperties, "small_Snake")
-		delete(additionalProperties, "Capital_Snake")
-		delete(additionalProperties, "SCA_ETH_Flow_Points")
-		delete(additionalProperties, "ATT_NAME")
-		o.AdditionalProperties = additionalProperties
-	}
-
-	return err
 }
 
 type NullableCapitalization struct {

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_cat.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_cat.go
@@ -11,18 +11,13 @@ package petstore
 
 import (
 	"encoding/json"
-	"reflect"
-	"strings"
 )
 
 // Cat struct for Cat
 type Cat struct {
 	Animal
 	Declawed *bool `json:"declawed,omitempty"`
-	AdditionalProperties map[string]interface{}
 }
-
-type _Cat Cat
 
 // NewCat instantiates a new Cat object
 // This constructor will assign default values to properties that have it defined,
@@ -86,66 +81,7 @@ func (o Cat) MarshalJSON() ([]byte, error) {
 	if o.Declawed != nil {
 		toSerialize["declawed"] = o.Declawed
 	}
-
-	for key, value := range o.AdditionalProperties {
-		toSerialize[key] = value
-	}
-
 	return json.Marshal(toSerialize)
-}
-
-func (o *Cat) UnmarshalJSON(bytes []byte) (err error) {
-	type CatWithoutEmbeddedStruct struct {
-		Declawed *bool `json:"declawed,omitempty"`
-	}
-
-	varCatWithoutEmbeddedStruct := CatWithoutEmbeddedStruct{}
-
-	err = json.Unmarshal(bytes, &varCatWithoutEmbeddedStruct)
-	if err == nil {
-		varCat := _Cat{}
-		varCat.Declawed = varCatWithoutEmbeddedStruct.Declawed
-		*o = Cat(varCat)
-	} else {
-		return err
-	}
-
-	varCat := _Cat{}
-
-	err = json.Unmarshal(bytes, &varCat)
-	if err == nil {
-		o.Animal = varCat.Animal
-	} else {
-		return err
-	}
-
-	additionalProperties := make(map[string]interface{})
-
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
-		delete(additionalProperties, "declawed")
-
-		// remove fields from embedded structs
-		reflectAnimal := reflect.ValueOf(o.Animal)
-		for i := 0; i < reflectAnimal.Type().NumField(); i++ {
-			t := reflectAnimal.Type().Field(i)
-
-			if jsonTag := t.Tag.Get("json"); jsonTag != "" {
-				fieldName := ""
-				if commaIdx := strings.Index(jsonTag, ","); commaIdx > 0 {
-					fieldName = jsonTag[:commaIdx]
-				} else {
-					fieldName = jsonTag
-				}
-				if fieldName != "AdditionalProperties" {
-					delete(additionalProperties, fieldName)
-				}
-			}
-		}
-
-		o.AdditionalProperties = additionalProperties
-	}
-
-	return err
 }
 
 type NullableCat struct {

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_cat_all_of.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_cat_all_of.go
@@ -16,10 +16,7 @@ import (
 // CatAllOf struct for CatAllOf
 type CatAllOf struct {
 	Declawed *bool `json:"declawed,omitempty"`
-	AdditionalProperties map[string]interface{}
 }
-
-type _CatAllOf CatAllOf
 
 // NewCatAllOf instantiates a new CatAllOf object
 // This constructor will assign default values to properties that have it defined,
@@ -75,29 +72,7 @@ func (o CatAllOf) MarshalJSON() ([]byte, error) {
 	if o.Declawed != nil {
 		toSerialize["declawed"] = o.Declawed
 	}
-
-	for key, value := range o.AdditionalProperties {
-		toSerialize[key] = value
-	}
-
 	return json.Marshal(toSerialize)
-}
-
-func (o *CatAllOf) UnmarshalJSON(bytes []byte) (err error) {
-	varCatAllOf := _CatAllOf{}
-
-	if err = json.Unmarshal(bytes, &varCatAllOf); err == nil {
-		*o = CatAllOf(varCatAllOf)
-	}
-
-	additionalProperties := make(map[string]interface{})
-
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
-		delete(additionalProperties, "declawed")
-		o.AdditionalProperties = additionalProperties
-	}
-
-	return err
 }
 
 type NullableCatAllOf struct {

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_category.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_category.go
@@ -17,10 +17,7 @@ import (
 type Category struct {
 	Id *int64 `json:"id,omitempty"`
 	Name string `json:"name"`
-	AdditionalProperties map[string]interface{}
 }
-
-type _Category Category
 
 // NewCategory instantiates a new Category object
 // This constructor will assign default values to properties that have it defined,
@@ -106,30 +103,7 @@ func (o Category) MarshalJSON() ([]byte, error) {
 	if true {
 		toSerialize["name"] = o.Name
 	}
-
-	for key, value := range o.AdditionalProperties {
-		toSerialize[key] = value
-	}
-
 	return json.Marshal(toSerialize)
-}
-
-func (o *Category) UnmarshalJSON(bytes []byte) (err error) {
-	varCategory := _Category{}
-
-	if err = json.Unmarshal(bytes, &varCategory); err == nil {
-		*o = Category(varCategory)
-	}
-
-	additionalProperties := make(map[string]interface{})
-
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
-		delete(additionalProperties, "id")
-		delete(additionalProperties, "name")
-		o.AdditionalProperties = additionalProperties
-	}
-
-	return err
 }
 
 type NullableCategory struct {

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_class_model.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_class_model.go
@@ -16,10 +16,7 @@ import (
 // ClassModel Model for testing model with \"_class\" property
 type ClassModel struct {
 	Class *string `json:"_class,omitempty"`
-	AdditionalProperties map[string]interface{}
 }
-
-type _ClassModel ClassModel
 
 // NewClassModel instantiates a new ClassModel object
 // This constructor will assign default values to properties that have it defined,
@@ -75,29 +72,7 @@ func (o ClassModel) MarshalJSON() ([]byte, error) {
 	if o.Class != nil {
 		toSerialize["_class"] = o.Class
 	}
-
-	for key, value := range o.AdditionalProperties {
-		toSerialize[key] = value
-	}
-
 	return json.Marshal(toSerialize)
-}
-
-func (o *ClassModel) UnmarshalJSON(bytes []byte) (err error) {
-	varClassModel := _ClassModel{}
-
-	if err = json.Unmarshal(bytes, &varClassModel); err == nil {
-		*o = ClassModel(varClassModel)
-	}
-
-	additionalProperties := make(map[string]interface{})
-
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
-		delete(additionalProperties, "_class")
-		o.AdditionalProperties = additionalProperties
-	}
-
-	return err
 }
 
 type NullableClassModel struct {

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_client.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_client.go
@@ -16,10 +16,7 @@ import (
 // Client struct for Client
 type Client struct {
 	Client *string `json:"client,omitempty"`
-	AdditionalProperties map[string]interface{}
 }
-
-type _Client Client
 
 // NewClient instantiates a new Client object
 // This constructor will assign default values to properties that have it defined,
@@ -75,29 +72,7 @@ func (o Client) MarshalJSON() ([]byte, error) {
 	if o.Client != nil {
 		toSerialize["client"] = o.Client
 	}
-
-	for key, value := range o.AdditionalProperties {
-		toSerialize[key] = value
-	}
-
 	return json.Marshal(toSerialize)
-}
-
-func (o *Client) UnmarshalJSON(bytes []byte) (err error) {
-	varClient := _Client{}
-
-	if err = json.Unmarshal(bytes, &varClient); err == nil {
-		*o = Client(varClient)
-	}
-
-	additionalProperties := make(map[string]interface{})
-
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
-		delete(additionalProperties, "client")
-		o.AdditionalProperties = additionalProperties
-	}
-
-	return err
 }
 
 type NullableClient struct {

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_dog.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_dog.go
@@ -11,18 +11,13 @@ package petstore
 
 import (
 	"encoding/json"
-	"reflect"
-	"strings"
 )
 
 // Dog struct for Dog
 type Dog struct {
 	Animal
 	Breed *string `json:"breed,omitempty"`
-	AdditionalProperties map[string]interface{}
 }
-
-type _Dog Dog
 
 // NewDog instantiates a new Dog object
 // This constructor will assign default values to properties that have it defined,
@@ -86,66 +81,7 @@ func (o Dog) MarshalJSON() ([]byte, error) {
 	if o.Breed != nil {
 		toSerialize["breed"] = o.Breed
 	}
-
-	for key, value := range o.AdditionalProperties {
-		toSerialize[key] = value
-	}
-
 	return json.Marshal(toSerialize)
-}
-
-func (o *Dog) UnmarshalJSON(bytes []byte) (err error) {
-	type DogWithoutEmbeddedStruct struct {
-		Breed *string `json:"breed,omitempty"`
-	}
-
-	varDogWithoutEmbeddedStruct := DogWithoutEmbeddedStruct{}
-
-	err = json.Unmarshal(bytes, &varDogWithoutEmbeddedStruct)
-	if err == nil {
-		varDog := _Dog{}
-		varDog.Breed = varDogWithoutEmbeddedStruct.Breed
-		*o = Dog(varDog)
-	} else {
-		return err
-	}
-
-	varDog := _Dog{}
-
-	err = json.Unmarshal(bytes, &varDog)
-	if err == nil {
-		o.Animal = varDog.Animal
-	} else {
-		return err
-	}
-
-	additionalProperties := make(map[string]interface{})
-
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
-		delete(additionalProperties, "breed")
-
-		// remove fields from embedded structs
-		reflectAnimal := reflect.ValueOf(o.Animal)
-		for i := 0; i < reflectAnimal.Type().NumField(); i++ {
-			t := reflectAnimal.Type().Field(i)
-
-			if jsonTag := t.Tag.Get("json"); jsonTag != "" {
-				fieldName := ""
-				if commaIdx := strings.Index(jsonTag, ","); commaIdx > 0 {
-					fieldName = jsonTag[:commaIdx]
-				} else {
-					fieldName = jsonTag
-				}
-				if fieldName != "AdditionalProperties" {
-					delete(additionalProperties, fieldName)
-				}
-			}
-		}
-
-		o.AdditionalProperties = additionalProperties
-	}
-
-	return err
 }
 
 type NullableDog struct {

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_dog_all_of.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_dog_all_of.go
@@ -16,10 +16,7 @@ import (
 // DogAllOf struct for DogAllOf
 type DogAllOf struct {
 	Breed *string `json:"breed,omitempty"`
-	AdditionalProperties map[string]interface{}
 }
-
-type _DogAllOf DogAllOf
 
 // NewDogAllOf instantiates a new DogAllOf object
 // This constructor will assign default values to properties that have it defined,
@@ -75,29 +72,7 @@ func (o DogAllOf) MarshalJSON() ([]byte, error) {
 	if o.Breed != nil {
 		toSerialize["breed"] = o.Breed
 	}
-
-	for key, value := range o.AdditionalProperties {
-		toSerialize[key] = value
-	}
-
 	return json.Marshal(toSerialize)
-}
-
-func (o *DogAllOf) UnmarshalJSON(bytes []byte) (err error) {
-	varDogAllOf := _DogAllOf{}
-
-	if err = json.Unmarshal(bytes, &varDogAllOf); err == nil {
-		*o = DogAllOf(varDogAllOf)
-	}
-
-	additionalProperties := make(map[string]interface{})
-
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
-		delete(additionalProperties, "breed")
-		o.AdditionalProperties = additionalProperties
-	}
-
-	return err
 }
 
 type NullableDogAllOf struct {

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_enum_arrays.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_enum_arrays.go
@@ -17,10 +17,7 @@ import (
 type EnumArrays struct {
 	JustSymbol *string `json:"just_symbol,omitempty"`
 	ArrayEnum *[]string `json:"array_enum,omitempty"`
-	AdditionalProperties map[string]interface{}
 }
-
-type _EnumArrays EnumArrays
 
 // NewEnumArrays instantiates a new EnumArrays object
 // This constructor will assign default values to properties that have it defined,
@@ -111,30 +108,7 @@ func (o EnumArrays) MarshalJSON() ([]byte, error) {
 	if o.ArrayEnum != nil {
 		toSerialize["array_enum"] = o.ArrayEnum
 	}
-
-	for key, value := range o.AdditionalProperties {
-		toSerialize[key] = value
-	}
-
 	return json.Marshal(toSerialize)
-}
-
-func (o *EnumArrays) UnmarshalJSON(bytes []byte) (err error) {
-	varEnumArrays := _EnumArrays{}
-
-	if err = json.Unmarshal(bytes, &varEnumArrays); err == nil {
-		*o = EnumArrays(varEnumArrays)
-	}
-
-	additionalProperties := make(map[string]interface{})
-
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
-		delete(additionalProperties, "just_symbol")
-		delete(additionalProperties, "array_enum")
-		o.AdditionalProperties = additionalProperties
-	}
-
-	return err
 }
 
 type NullableEnumArrays struct {

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_enum_test_.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_enum_test_.go
@@ -23,10 +23,7 @@ type EnumTest struct {
 	OuterEnumInteger *OuterEnumInteger `json:"outerEnumInteger,omitempty"`
 	OuterEnumDefaultValue *OuterEnumDefaultValue `json:"outerEnumDefaultValue,omitempty"`
 	OuterEnumIntegerDefaultValue *OuterEnumIntegerDefaultValue `json:"outerEnumIntegerDefaultValue,omitempty"`
-	AdditionalProperties map[string]interface{}
 }
-
-type _EnumTest EnumTest
 
 // NewEnumTest instantiates a new EnumTest object
 // This constructor will assign default values to properties that have it defined,
@@ -338,36 +335,7 @@ func (o EnumTest) MarshalJSON() ([]byte, error) {
 	if o.OuterEnumIntegerDefaultValue != nil {
 		toSerialize["outerEnumIntegerDefaultValue"] = o.OuterEnumIntegerDefaultValue
 	}
-
-	for key, value := range o.AdditionalProperties {
-		toSerialize[key] = value
-	}
-
 	return json.Marshal(toSerialize)
-}
-
-func (o *EnumTest) UnmarshalJSON(bytes []byte) (err error) {
-	varEnumTest := _EnumTest{}
-
-	if err = json.Unmarshal(bytes, &varEnumTest); err == nil {
-		*o = EnumTest(varEnumTest)
-	}
-
-	additionalProperties := make(map[string]interface{})
-
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
-		delete(additionalProperties, "enum_string")
-		delete(additionalProperties, "enum_string_required")
-		delete(additionalProperties, "enum_integer")
-		delete(additionalProperties, "enum_number")
-		delete(additionalProperties, "outerEnum")
-		delete(additionalProperties, "outerEnumInteger")
-		delete(additionalProperties, "outerEnumDefaultValue")
-		delete(additionalProperties, "outerEnumIntegerDefaultValue")
-		o.AdditionalProperties = additionalProperties
-	}
-
-	return err
 }
 
 type NullableEnumTest struct {

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_file.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_file.go
@@ -17,10 +17,7 @@ import (
 type File struct {
 	// Test capitalization
 	SourceURI *string `json:"sourceURI,omitempty"`
-	AdditionalProperties map[string]interface{}
 }
-
-type _File File
 
 // NewFile instantiates a new File object
 // This constructor will assign default values to properties that have it defined,
@@ -76,29 +73,7 @@ func (o File) MarshalJSON() ([]byte, error) {
 	if o.SourceURI != nil {
 		toSerialize["sourceURI"] = o.SourceURI
 	}
-
-	for key, value := range o.AdditionalProperties {
-		toSerialize[key] = value
-	}
-
 	return json.Marshal(toSerialize)
-}
-
-func (o *File) UnmarshalJSON(bytes []byte) (err error) {
-	varFile := _File{}
-
-	if err = json.Unmarshal(bytes, &varFile); err == nil {
-		*o = File(varFile)
-	}
-
-	additionalProperties := make(map[string]interface{})
-
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
-		delete(additionalProperties, "sourceURI")
-		o.AdditionalProperties = additionalProperties
-	}
-
-	return err
 }
 
 type NullableFile struct {

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_file_schema_test_class.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_file_schema_test_class.go
@@ -17,10 +17,7 @@ import (
 type FileSchemaTestClass struct {
 	File *File `json:"file,omitempty"`
 	Files *[]File `json:"files,omitempty"`
-	AdditionalProperties map[string]interface{}
 }
-
-type _FileSchemaTestClass FileSchemaTestClass
 
 // NewFileSchemaTestClass instantiates a new FileSchemaTestClass object
 // This constructor will assign default values to properties that have it defined,
@@ -111,30 +108,7 @@ func (o FileSchemaTestClass) MarshalJSON() ([]byte, error) {
 	if o.Files != nil {
 		toSerialize["files"] = o.Files
 	}
-
-	for key, value := range o.AdditionalProperties {
-		toSerialize[key] = value
-	}
-
 	return json.Marshal(toSerialize)
-}
-
-func (o *FileSchemaTestClass) UnmarshalJSON(bytes []byte) (err error) {
-	varFileSchemaTestClass := _FileSchemaTestClass{}
-
-	if err = json.Unmarshal(bytes, &varFileSchemaTestClass); err == nil {
-		*o = FileSchemaTestClass(varFileSchemaTestClass)
-	}
-
-	additionalProperties := make(map[string]interface{})
-
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
-		delete(additionalProperties, "file")
-		delete(additionalProperties, "files")
-		o.AdditionalProperties = additionalProperties
-	}
-
-	return err
 }
 
 type NullableFileSchemaTestClass struct {

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_foo.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_foo.go
@@ -16,10 +16,7 @@ import (
 // Foo struct for Foo
 type Foo struct {
 	Bar *string `json:"bar,omitempty"`
-	AdditionalProperties map[string]interface{}
 }
-
-type _Foo Foo
 
 // NewFoo instantiates a new Foo object
 // This constructor will assign default values to properties that have it defined,
@@ -79,29 +76,7 @@ func (o Foo) MarshalJSON() ([]byte, error) {
 	if o.Bar != nil {
 		toSerialize["bar"] = o.Bar
 	}
-
-	for key, value := range o.AdditionalProperties {
-		toSerialize[key] = value
-	}
-
 	return json.Marshal(toSerialize)
-}
-
-func (o *Foo) UnmarshalJSON(bytes []byte) (err error) {
-	varFoo := _Foo{}
-
-	if err = json.Unmarshal(bytes, &varFoo); err == nil {
-		*o = Foo(varFoo)
-	}
-
-	additionalProperties := make(map[string]interface{})
-
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
-		delete(additionalProperties, "bar")
-		o.AdditionalProperties = additionalProperties
-	}
-
-	return err
 }
 
 type NullableFoo struct {

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_format_test_.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_format_test_.go
@@ -34,10 +34,7 @@ type FormatTest struct {
 	PatternWithDigits *string `json:"pattern_with_digits,omitempty"`
 	// A string starting with 'image_' (case insensitive) and one to three digits following i.e. Image_01.
 	PatternWithDigitsAndDelimiter *string `json:"pattern_with_digits_and_delimiter,omitempty"`
-	AdditionalProperties map[string]interface{}
 }
-
-type _FormatTest FormatTest
 
 // NewFormatTest instantiates a new FormatTest object
 // This constructor will assign default values to properties that have it defined,
@@ -555,43 +552,7 @@ func (o FormatTest) MarshalJSON() ([]byte, error) {
 	if o.PatternWithDigitsAndDelimiter != nil {
 		toSerialize["pattern_with_digits_and_delimiter"] = o.PatternWithDigitsAndDelimiter
 	}
-
-	for key, value := range o.AdditionalProperties {
-		toSerialize[key] = value
-	}
-
 	return json.Marshal(toSerialize)
-}
-
-func (o *FormatTest) UnmarshalJSON(bytes []byte) (err error) {
-	varFormatTest := _FormatTest{}
-
-	if err = json.Unmarshal(bytes, &varFormatTest); err == nil {
-		*o = FormatTest(varFormatTest)
-	}
-
-	additionalProperties := make(map[string]interface{})
-
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
-		delete(additionalProperties, "integer")
-		delete(additionalProperties, "int32")
-		delete(additionalProperties, "int64")
-		delete(additionalProperties, "number")
-		delete(additionalProperties, "float")
-		delete(additionalProperties, "double")
-		delete(additionalProperties, "string")
-		delete(additionalProperties, "byte")
-		delete(additionalProperties, "binary")
-		delete(additionalProperties, "date")
-		delete(additionalProperties, "dateTime")
-		delete(additionalProperties, "uuid")
-		delete(additionalProperties, "password")
-		delete(additionalProperties, "pattern_with_digits")
-		delete(additionalProperties, "pattern_with_digits_and_delimiter")
-		o.AdditionalProperties = additionalProperties
-	}
-
-	return err
 }
 
 type NullableFormatTest struct {

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_has_only_read_only.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_has_only_read_only.go
@@ -17,10 +17,7 @@ import (
 type HasOnlyReadOnly struct {
 	Bar *string `json:"bar,omitempty"`
 	Foo *string `json:"foo,omitempty"`
-	AdditionalProperties map[string]interface{}
 }
-
-type _HasOnlyReadOnly HasOnlyReadOnly
 
 // NewHasOnlyReadOnly instantiates a new HasOnlyReadOnly object
 // This constructor will assign default values to properties that have it defined,
@@ -111,30 +108,7 @@ func (o HasOnlyReadOnly) MarshalJSON() ([]byte, error) {
 	if o.Foo != nil {
 		toSerialize["foo"] = o.Foo
 	}
-
-	for key, value := range o.AdditionalProperties {
-		toSerialize[key] = value
-	}
-
 	return json.Marshal(toSerialize)
-}
-
-func (o *HasOnlyReadOnly) UnmarshalJSON(bytes []byte) (err error) {
-	varHasOnlyReadOnly := _HasOnlyReadOnly{}
-
-	if err = json.Unmarshal(bytes, &varHasOnlyReadOnly); err == nil {
-		*o = HasOnlyReadOnly(varHasOnlyReadOnly)
-	}
-
-	additionalProperties := make(map[string]interface{})
-
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
-		delete(additionalProperties, "bar")
-		delete(additionalProperties, "foo")
-		o.AdditionalProperties = additionalProperties
-	}
-
-	return err
 }
 
 type NullableHasOnlyReadOnly struct {

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_health_check_result.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_health_check_result.go
@@ -16,10 +16,7 @@ import (
 // HealthCheckResult Just a string to inform instance is up and running. Make it nullable in hope to get it as pointer in generated model.
 type HealthCheckResult struct {
 	NullableMessage NullableString `json:"NullableMessage,omitempty"`
-	AdditionalProperties map[string]interface{}
 }
-
-type _HealthCheckResult HealthCheckResult
 
 // NewHealthCheckResult instantiates a new HealthCheckResult object
 // This constructor will assign default values to properties that have it defined,
@@ -85,29 +82,7 @@ func (o HealthCheckResult) MarshalJSON() ([]byte, error) {
 	if o.NullableMessage.IsSet() {
 		toSerialize["NullableMessage"] = o.NullableMessage.Get()
 	}
-
-	for key, value := range o.AdditionalProperties {
-		toSerialize[key] = value
-	}
-
 	return json.Marshal(toSerialize)
-}
-
-func (o *HealthCheckResult) UnmarshalJSON(bytes []byte) (err error) {
-	varHealthCheckResult := _HealthCheckResult{}
-
-	if err = json.Unmarshal(bytes, &varHealthCheckResult); err == nil {
-		*o = HealthCheckResult(varHealthCheckResult)
-	}
-
-	additionalProperties := make(map[string]interface{})
-
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
-		delete(additionalProperties, "NullableMessage")
-		o.AdditionalProperties = additionalProperties
-	}
-
-	return err
 }
 
 type NullableHealthCheckResult struct {

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_inline_object.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_inline_object.go
@@ -19,10 +19,7 @@ type InlineObject struct {
 	Name *string `json:"name,omitempty"`
 	// Updated status of the pet
 	Status *string `json:"status,omitempty"`
-	AdditionalProperties map[string]interface{}
 }
-
-type _InlineObject InlineObject
 
 // NewInlineObject instantiates a new InlineObject object
 // This constructor will assign default values to properties that have it defined,
@@ -113,30 +110,7 @@ func (o InlineObject) MarshalJSON() ([]byte, error) {
 	if o.Status != nil {
 		toSerialize["status"] = o.Status
 	}
-
-	for key, value := range o.AdditionalProperties {
-		toSerialize[key] = value
-	}
-
 	return json.Marshal(toSerialize)
-}
-
-func (o *InlineObject) UnmarshalJSON(bytes []byte) (err error) {
-	varInlineObject := _InlineObject{}
-
-	if err = json.Unmarshal(bytes, &varInlineObject); err == nil {
-		*o = InlineObject(varInlineObject)
-	}
-
-	additionalProperties := make(map[string]interface{})
-
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
-		delete(additionalProperties, "name")
-		delete(additionalProperties, "status")
-		o.AdditionalProperties = additionalProperties
-	}
-
-	return err
 }
 
 type NullableInlineObject struct {

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_inline_object_1.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_inline_object_1.go
@@ -20,10 +20,7 @@ type InlineObject1 struct {
 	AdditionalMetadata *string `json:"additionalMetadata,omitempty"`
 	// file to upload
 	File **os.File `json:"file,omitempty"`
-	AdditionalProperties map[string]interface{}
 }
-
-type _InlineObject1 InlineObject1
 
 // NewInlineObject1 instantiates a new InlineObject1 object
 // This constructor will assign default values to properties that have it defined,
@@ -114,30 +111,7 @@ func (o InlineObject1) MarshalJSON() ([]byte, error) {
 	if o.File != nil {
 		toSerialize["file"] = o.File
 	}
-
-	for key, value := range o.AdditionalProperties {
-		toSerialize[key] = value
-	}
-
 	return json.Marshal(toSerialize)
-}
-
-func (o *InlineObject1) UnmarshalJSON(bytes []byte) (err error) {
-	varInlineObject1 := _InlineObject1{}
-
-	if err = json.Unmarshal(bytes, &varInlineObject1); err == nil {
-		*o = InlineObject1(varInlineObject1)
-	}
-
-	additionalProperties := make(map[string]interface{})
-
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
-		delete(additionalProperties, "additionalMetadata")
-		delete(additionalProperties, "file")
-		o.AdditionalProperties = additionalProperties
-	}
-
-	return err
 }
 
 type NullableInlineObject1 struct {

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_inline_object_2.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_inline_object_2.go
@@ -19,10 +19,7 @@ type InlineObject2 struct {
 	EnumFormStringArray *[]string `json:"enum_form_string_array,omitempty"`
 	// Form parameter enum test (string)
 	EnumFormString *string `json:"enum_form_string,omitempty"`
-	AdditionalProperties map[string]interface{}
 }
-
-type _InlineObject2 InlineObject2
 
 // NewInlineObject2 instantiates a new InlineObject2 object
 // This constructor will assign default values to properties that have it defined,
@@ -117,30 +114,7 @@ func (o InlineObject2) MarshalJSON() ([]byte, error) {
 	if o.EnumFormString != nil {
 		toSerialize["enum_form_string"] = o.EnumFormString
 	}
-
-	for key, value := range o.AdditionalProperties {
-		toSerialize[key] = value
-	}
-
 	return json.Marshal(toSerialize)
-}
-
-func (o *InlineObject2) UnmarshalJSON(bytes []byte) (err error) {
-	varInlineObject2 := _InlineObject2{}
-
-	if err = json.Unmarshal(bytes, &varInlineObject2); err == nil {
-		*o = InlineObject2(varInlineObject2)
-	}
-
-	additionalProperties := make(map[string]interface{})
-
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
-		delete(additionalProperties, "enum_form_string_array")
-		delete(additionalProperties, "enum_form_string")
-		o.AdditionalProperties = additionalProperties
-	}
-
-	return err
 }
 
 type NullableInlineObject2 struct {

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_inline_object_3.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_inline_object_3.go
@@ -45,10 +45,7 @@ type InlineObject3 struct {
 	Password *string `json:"password,omitempty"`
 	// None
 	Callback *string `json:"callback,omitempty"`
-	AdditionalProperties map[string]interface{}
 }
-
-type _InlineObject3 InlineObject3
 
 // NewInlineObject3 instantiates a new InlineObject3 object
 // This constructor will assign default values to properties that have it defined,
@@ -531,42 +528,7 @@ func (o InlineObject3) MarshalJSON() ([]byte, error) {
 	if o.Callback != nil {
 		toSerialize["callback"] = o.Callback
 	}
-
-	for key, value := range o.AdditionalProperties {
-		toSerialize[key] = value
-	}
-
 	return json.Marshal(toSerialize)
-}
-
-func (o *InlineObject3) UnmarshalJSON(bytes []byte) (err error) {
-	varInlineObject3 := _InlineObject3{}
-
-	if err = json.Unmarshal(bytes, &varInlineObject3); err == nil {
-		*o = InlineObject3(varInlineObject3)
-	}
-
-	additionalProperties := make(map[string]interface{})
-
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
-		delete(additionalProperties, "integer")
-		delete(additionalProperties, "int32")
-		delete(additionalProperties, "int64")
-		delete(additionalProperties, "number")
-		delete(additionalProperties, "float")
-		delete(additionalProperties, "double")
-		delete(additionalProperties, "string")
-		delete(additionalProperties, "pattern_without_delimiter")
-		delete(additionalProperties, "byte")
-		delete(additionalProperties, "binary")
-		delete(additionalProperties, "date")
-		delete(additionalProperties, "dateTime")
-		delete(additionalProperties, "password")
-		delete(additionalProperties, "callback")
-		o.AdditionalProperties = additionalProperties
-	}
-
-	return err
 }
 
 type NullableInlineObject3 struct {

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_inline_object_4.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_inline_object_4.go
@@ -19,10 +19,7 @@ type InlineObject4 struct {
 	Param string `json:"param"`
 	// field2
 	Param2 string `json:"param2"`
-	AdditionalProperties map[string]interface{}
 }
-
-type _InlineObject4 InlineObject4
 
 // NewInlineObject4 instantiates a new InlineObject4 object
 // This constructor will assign default values to properties that have it defined,
@@ -99,30 +96,7 @@ func (o InlineObject4) MarshalJSON() ([]byte, error) {
 	if true {
 		toSerialize["param2"] = o.Param2
 	}
-
-	for key, value := range o.AdditionalProperties {
-		toSerialize[key] = value
-	}
-
 	return json.Marshal(toSerialize)
-}
-
-func (o *InlineObject4) UnmarshalJSON(bytes []byte) (err error) {
-	varInlineObject4 := _InlineObject4{}
-
-	if err = json.Unmarshal(bytes, &varInlineObject4); err == nil {
-		*o = InlineObject4(varInlineObject4)
-	}
-
-	additionalProperties := make(map[string]interface{})
-
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
-		delete(additionalProperties, "param")
-		delete(additionalProperties, "param2")
-		o.AdditionalProperties = additionalProperties
-	}
-
-	return err
 }
 
 type NullableInlineObject4 struct {

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_inline_object_5.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_inline_object_5.go
@@ -20,10 +20,7 @@ type InlineObject5 struct {
 	AdditionalMetadata *string `json:"additionalMetadata,omitempty"`
 	// file to upload
 	RequiredFile *os.File `json:"requiredFile"`
-	AdditionalProperties map[string]interface{}
 }
-
-type _InlineObject5 InlineObject5
 
 // NewInlineObject5 instantiates a new InlineObject5 object
 // This constructor will assign default values to properties that have it defined,
@@ -107,30 +104,7 @@ func (o InlineObject5) MarshalJSON() ([]byte, error) {
 	if true {
 		toSerialize["requiredFile"] = o.RequiredFile
 	}
-
-	for key, value := range o.AdditionalProperties {
-		toSerialize[key] = value
-	}
-
 	return json.Marshal(toSerialize)
-}
-
-func (o *InlineObject5) UnmarshalJSON(bytes []byte) (err error) {
-	varInlineObject5 := _InlineObject5{}
-
-	if err = json.Unmarshal(bytes, &varInlineObject5); err == nil {
-		*o = InlineObject5(varInlineObject5)
-	}
-
-	additionalProperties := make(map[string]interface{})
-
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
-		delete(additionalProperties, "additionalMetadata")
-		delete(additionalProperties, "requiredFile")
-		o.AdditionalProperties = additionalProperties
-	}
-
-	return err
 }
 
 type NullableInlineObject5 struct {

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_inline_response_default.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_inline_response_default.go
@@ -16,10 +16,7 @@ import (
 // InlineResponseDefault struct for InlineResponseDefault
 type InlineResponseDefault struct {
 	String *Foo `json:"string,omitempty"`
-	AdditionalProperties map[string]interface{}
 }
-
-type _InlineResponseDefault InlineResponseDefault
 
 // NewInlineResponseDefault instantiates a new InlineResponseDefault object
 // This constructor will assign default values to properties that have it defined,
@@ -75,29 +72,7 @@ func (o InlineResponseDefault) MarshalJSON() ([]byte, error) {
 	if o.String != nil {
 		toSerialize["string"] = o.String
 	}
-
-	for key, value := range o.AdditionalProperties {
-		toSerialize[key] = value
-	}
-
 	return json.Marshal(toSerialize)
-}
-
-func (o *InlineResponseDefault) UnmarshalJSON(bytes []byte) (err error) {
-	varInlineResponseDefault := _InlineResponseDefault{}
-
-	if err = json.Unmarshal(bytes, &varInlineResponseDefault); err == nil {
-		*o = InlineResponseDefault(varInlineResponseDefault)
-	}
-
-	additionalProperties := make(map[string]interface{})
-
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
-		delete(additionalProperties, "string")
-		o.AdditionalProperties = additionalProperties
-	}
-
-	return err
 }
 
 type NullableInlineResponseDefault struct {

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_list.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_list.go
@@ -16,10 +16,7 @@ import (
 // List struct for List
 type List struct {
 	Var123List *string `json:"123-list,omitempty"`
-	AdditionalProperties map[string]interface{}
 }
-
-type _List List
 
 // NewList instantiates a new List object
 // This constructor will assign default values to properties that have it defined,
@@ -75,29 +72,7 @@ func (o List) MarshalJSON() ([]byte, error) {
 	if o.Var123List != nil {
 		toSerialize["123-list"] = o.Var123List
 	}
-
-	for key, value := range o.AdditionalProperties {
-		toSerialize[key] = value
-	}
-
 	return json.Marshal(toSerialize)
-}
-
-func (o *List) UnmarshalJSON(bytes []byte) (err error) {
-	varList := _List{}
-
-	if err = json.Unmarshal(bytes, &varList); err == nil {
-		*o = List(varList)
-	}
-
-	additionalProperties := make(map[string]interface{})
-
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
-		delete(additionalProperties, "123-list")
-		o.AdditionalProperties = additionalProperties
-	}
-
-	return err
 }
 
 type NullableList struct {

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_map_test_.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_map_test_.go
@@ -19,10 +19,7 @@ type MapTest struct {
 	MapOfEnumString *map[string]string `json:"map_of_enum_string,omitempty"`
 	DirectMap *map[string]bool `json:"direct_map,omitempty"`
 	IndirectMap *map[string]bool `json:"indirect_map,omitempty"`
-	AdditionalProperties map[string]interface{}
 }
-
-type _MapTest MapTest
 
 // NewMapTest instantiates a new MapTest object
 // This constructor will assign default values to properties that have it defined,
@@ -183,32 +180,7 @@ func (o MapTest) MarshalJSON() ([]byte, error) {
 	if o.IndirectMap != nil {
 		toSerialize["indirect_map"] = o.IndirectMap
 	}
-
-	for key, value := range o.AdditionalProperties {
-		toSerialize[key] = value
-	}
-
 	return json.Marshal(toSerialize)
-}
-
-func (o *MapTest) UnmarshalJSON(bytes []byte) (err error) {
-	varMapTest := _MapTest{}
-
-	if err = json.Unmarshal(bytes, &varMapTest); err == nil {
-		*o = MapTest(varMapTest)
-	}
-
-	additionalProperties := make(map[string]interface{})
-
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
-		delete(additionalProperties, "map_map_of_string")
-		delete(additionalProperties, "map_of_enum_string")
-		delete(additionalProperties, "direct_map")
-		delete(additionalProperties, "indirect_map")
-		o.AdditionalProperties = additionalProperties
-	}
-
-	return err
 }
 
 type NullableMapTest struct {

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_mixed_properties_and_additional_properties_class.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_mixed_properties_and_additional_properties_class.go
@@ -19,10 +19,7 @@ type MixedPropertiesAndAdditionalPropertiesClass struct {
 	Uuid *string `json:"uuid,omitempty"`
 	DateTime *time.Time `json:"dateTime,omitempty"`
 	Map *map[string]Animal `json:"map,omitempty"`
-	AdditionalProperties map[string]interface{}
 }
-
-type _MixedPropertiesAndAdditionalPropertiesClass MixedPropertiesAndAdditionalPropertiesClass
 
 // NewMixedPropertiesAndAdditionalPropertiesClass instantiates a new MixedPropertiesAndAdditionalPropertiesClass object
 // This constructor will assign default values to properties that have it defined,
@@ -148,31 +145,7 @@ func (o MixedPropertiesAndAdditionalPropertiesClass) MarshalJSON() ([]byte, erro
 	if o.Map != nil {
 		toSerialize["map"] = o.Map
 	}
-
-	for key, value := range o.AdditionalProperties {
-		toSerialize[key] = value
-	}
-
 	return json.Marshal(toSerialize)
-}
-
-func (o *MixedPropertiesAndAdditionalPropertiesClass) UnmarshalJSON(bytes []byte) (err error) {
-	varMixedPropertiesAndAdditionalPropertiesClass := _MixedPropertiesAndAdditionalPropertiesClass{}
-
-	if err = json.Unmarshal(bytes, &varMixedPropertiesAndAdditionalPropertiesClass); err == nil {
-		*o = MixedPropertiesAndAdditionalPropertiesClass(varMixedPropertiesAndAdditionalPropertiesClass)
-	}
-
-	additionalProperties := make(map[string]interface{})
-
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
-		delete(additionalProperties, "uuid")
-		delete(additionalProperties, "dateTime")
-		delete(additionalProperties, "map")
-		o.AdditionalProperties = additionalProperties
-	}
-
-	return err
 }
 
 type NullableMixedPropertiesAndAdditionalPropertiesClass struct {

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_name.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_name.go
@@ -19,10 +19,7 @@ type Name struct {
 	SnakeCase *int32 `json:"snake_case,omitempty"`
 	Property *string `json:"property,omitempty"`
 	Var123Number *int32 `json:"123Number,omitempty"`
-	AdditionalProperties map[string]interface{}
 }
-
-type _Name Name
 
 // NewName instantiates a new Name object
 // This constructor will assign default values to properties that have it defined,
@@ -176,32 +173,7 @@ func (o Name) MarshalJSON() ([]byte, error) {
 	if o.Var123Number != nil {
 		toSerialize["123Number"] = o.Var123Number
 	}
-
-	for key, value := range o.AdditionalProperties {
-		toSerialize[key] = value
-	}
-
 	return json.Marshal(toSerialize)
-}
-
-func (o *Name) UnmarshalJSON(bytes []byte) (err error) {
-	varName := _Name{}
-
-	if err = json.Unmarshal(bytes, &varName); err == nil {
-		*o = Name(varName)
-	}
-
-	additionalProperties := make(map[string]interface{})
-
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
-		delete(additionalProperties, "name")
-		delete(additionalProperties, "snake_case")
-		delete(additionalProperties, "property")
-		delete(additionalProperties, "123Number")
-		o.AdditionalProperties = additionalProperties
-	}
-
-	return err
 }
 
 type NullableName struct {

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_number_only.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_number_only.go
@@ -16,10 +16,7 @@ import (
 // NumberOnly struct for NumberOnly
 type NumberOnly struct {
 	JustNumber *float32 `json:"JustNumber,omitempty"`
-	AdditionalProperties map[string]interface{}
 }
-
-type _NumberOnly NumberOnly
 
 // NewNumberOnly instantiates a new NumberOnly object
 // This constructor will assign default values to properties that have it defined,
@@ -75,29 +72,7 @@ func (o NumberOnly) MarshalJSON() ([]byte, error) {
 	if o.JustNumber != nil {
 		toSerialize["JustNumber"] = o.JustNumber
 	}
-
-	for key, value := range o.AdditionalProperties {
-		toSerialize[key] = value
-	}
-
 	return json.Marshal(toSerialize)
-}
-
-func (o *NumberOnly) UnmarshalJSON(bytes []byte) (err error) {
-	varNumberOnly := _NumberOnly{}
-
-	if err = json.Unmarshal(bytes, &varNumberOnly); err == nil {
-		*o = NumberOnly(varNumberOnly)
-	}
-
-	additionalProperties := make(map[string]interface{})
-
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
-		delete(additionalProperties, "JustNumber")
-		o.AdditionalProperties = additionalProperties
-	}
-
-	return err
 }
 
 type NullableNumberOnly struct {

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_order.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_order.go
@@ -23,10 +23,7 @@ type Order struct {
 	// Order Status
 	Status *string `json:"status,omitempty"`
 	Complete *bool `json:"complete,omitempty"`
-	AdditionalProperties map[string]interface{}
 }
-
-type _Order Order
 
 // NewOrder instantiates a new Order object
 // This constructor will assign default values to properties that have it defined,
@@ -261,34 +258,7 @@ func (o Order) MarshalJSON() ([]byte, error) {
 	if o.Complete != nil {
 		toSerialize["complete"] = o.Complete
 	}
-
-	for key, value := range o.AdditionalProperties {
-		toSerialize[key] = value
-	}
-
 	return json.Marshal(toSerialize)
-}
-
-func (o *Order) UnmarshalJSON(bytes []byte) (err error) {
-	varOrder := _Order{}
-
-	if err = json.Unmarshal(bytes, &varOrder); err == nil {
-		*o = Order(varOrder)
-	}
-
-	additionalProperties := make(map[string]interface{})
-
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
-		delete(additionalProperties, "id")
-		delete(additionalProperties, "petId")
-		delete(additionalProperties, "quantity")
-		delete(additionalProperties, "shipDate")
-		delete(additionalProperties, "status")
-		delete(additionalProperties, "complete")
-		o.AdditionalProperties = additionalProperties
-	}
-
-	return err
 }
 
 type NullableOrder struct {

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_outer_composite.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_outer_composite.go
@@ -18,10 +18,7 @@ type OuterComposite struct {
 	MyNumber *float32 `json:"my_number,omitempty"`
 	MyString *string `json:"my_string,omitempty"`
 	MyBoolean *bool `json:"my_boolean,omitempty"`
-	AdditionalProperties map[string]interface{}
 }
-
-type _OuterComposite OuterComposite
 
 // NewOuterComposite instantiates a new OuterComposite object
 // This constructor will assign default values to properties that have it defined,
@@ -147,31 +144,7 @@ func (o OuterComposite) MarshalJSON() ([]byte, error) {
 	if o.MyBoolean != nil {
 		toSerialize["my_boolean"] = o.MyBoolean
 	}
-
-	for key, value := range o.AdditionalProperties {
-		toSerialize[key] = value
-	}
-
 	return json.Marshal(toSerialize)
-}
-
-func (o *OuterComposite) UnmarshalJSON(bytes []byte) (err error) {
-	varOuterComposite := _OuterComposite{}
-
-	if err = json.Unmarshal(bytes, &varOuterComposite); err == nil {
-		*o = OuterComposite(varOuterComposite)
-	}
-
-	additionalProperties := make(map[string]interface{})
-
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
-		delete(additionalProperties, "my_number")
-		delete(additionalProperties, "my_string")
-		delete(additionalProperties, "my_boolean")
-		o.AdditionalProperties = additionalProperties
-	}
-
-	return err
 }
 
 type NullableOuterComposite struct {

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_pet.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_pet.go
@@ -22,10 +22,7 @@ type Pet struct {
 	Tags *[]Tag `json:"tags,omitempty"`
 	// pet status in the store
 	Status *string `json:"status,omitempty"`
-	AdditionalProperties map[string]interface{}
 }
-
-type _Pet Pet
 
 // NewPet instantiates a new Pet object
 // This constructor will assign default values to properties that have it defined,
@@ -242,34 +239,7 @@ func (o Pet) MarshalJSON() ([]byte, error) {
 	if o.Status != nil {
 		toSerialize["status"] = o.Status
 	}
-
-	for key, value := range o.AdditionalProperties {
-		toSerialize[key] = value
-	}
-
 	return json.Marshal(toSerialize)
-}
-
-func (o *Pet) UnmarshalJSON(bytes []byte) (err error) {
-	varPet := _Pet{}
-
-	if err = json.Unmarshal(bytes, &varPet); err == nil {
-		*o = Pet(varPet)
-	}
-
-	additionalProperties := make(map[string]interface{})
-
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
-		delete(additionalProperties, "id")
-		delete(additionalProperties, "category")
-		delete(additionalProperties, "name")
-		delete(additionalProperties, "photoUrls")
-		delete(additionalProperties, "tags")
-		delete(additionalProperties, "status")
-		o.AdditionalProperties = additionalProperties
-	}
-
-	return err
 }
 
 type NullablePet struct {

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_read_only_first.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_read_only_first.go
@@ -17,10 +17,7 @@ import (
 type ReadOnlyFirst struct {
 	Bar *string `json:"bar,omitempty"`
 	Baz *string `json:"baz,omitempty"`
-	AdditionalProperties map[string]interface{}
 }
-
-type _ReadOnlyFirst ReadOnlyFirst
 
 // NewReadOnlyFirst instantiates a new ReadOnlyFirst object
 // This constructor will assign default values to properties that have it defined,
@@ -111,30 +108,7 @@ func (o ReadOnlyFirst) MarshalJSON() ([]byte, error) {
 	if o.Baz != nil {
 		toSerialize["baz"] = o.Baz
 	}
-
-	for key, value := range o.AdditionalProperties {
-		toSerialize[key] = value
-	}
-
 	return json.Marshal(toSerialize)
-}
-
-func (o *ReadOnlyFirst) UnmarshalJSON(bytes []byte) (err error) {
-	varReadOnlyFirst := _ReadOnlyFirst{}
-
-	if err = json.Unmarshal(bytes, &varReadOnlyFirst); err == nil {
-		*o = ReadOnlyFirst(varReadOnlyFirst)
-	}
-
-	additionalProperties := make(map[string]interface{})
-
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
-		delete(additionalProperties, "bar")
-		delete(additionalProperties, "baz")
-		o.AdditionalProperties = additionalProperties
-	}
-
-	return err
 }
 
 type NullableReadOnlyFirst struct {

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_return.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_return.go
@@ -16,10 +16,7 @@ import (
 // Return Model for testing reserved words
 type Return struct {
 	Return *int32 `json:"return,omitempty"`
-	AdditionalProperties map[string]interface{}
 }
-
-type _Return Return
 
 // NewReturn instantiates a new Return object
 // This constructor will assign default values to properties that have it defined,
@@ -75,29 +72,7 @@ func (o Return) MarshalJSON() ([]byte, error) {
 	if o.Return != nil {
 		toSerialize["return"] = o.Return
 	}
-
-	for key, value := range o.AdditionalProperties {
-		toSerialize[key] = value
-	}
-
 	return json.Marshal(toSerialize)
-}
-
-func (o *Return) UnmarshalJSON(bytes []byte) (err error) {
-	varReturn := _Return{}
-
-	if err = json.Unmarshal(bytes, &varReturn); err == nil {
-		*o = Return(varReturn)
-	}
-
-	additionalProperties := make(map[string]interface{})
-
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
-		delete(additionalProperties, "return")
-		o.AdditionalProperties = additionalProperties
-	}
-
-	return err
 }
 
 type NullableReturn struct {

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_tag.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_tag.go
@@ -17,10 +17,7 @@ import (
 type Tag struct {
 	Id *int64 `json:"id,omitempty"`
 	Name *string `json:"name,omitempty"`
-	AdditionalProperties map[string]interface{}
 }
-
-type _Tag Tag
 
 // NewTag instantiates a new Tag object
 // This constructor will assign default values to properties that have it defined,
@@ -111,30 +108,7 @@ func (o Tag) MarshalJSON() ([]byte, error) {
 	if o.Name != nil {
 		toSerialize["name"] = o.Name
 	}
-
-	for key, value := range o.AdditionalProperties {
-		toSerialize[key] = value
-	}
-
 	return json.Marshal(toSerialize)
-}
-
-func (o *Tag) UnmarshalJSON(bytes []byte) (err error) {
-	varTag := _Tag{}
-
-	if err = json.Unmarshal(bytes, &varTag); err == nil {
-		*o = Tag(varTag)
-	}
-
-	additionalProperties := make(map[string]interface{})
-
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
-		delete(additionalProperties, "id")
-		delete(additionalProperties, "name")
-		o.AdditionalProperties = additionalProperties
-	}
-
-	return err
 }
 
 type NullableTag struct {

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_user.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_user.go
@@ -32,10 +32,7 @@ type User struct {
 	ArbitraryTypeValue interface{} `json:"arbitraryTypeValue,omitempty"`
 	// test code generation for any type Value can be any type - string, number, boolean, array, object or the 'null' value.
 	ArbitraryNullableTypeValue interface{} `json:"arbitraryNullableTypeValue,omitempty"`
-	AdditionalProperties map[string]interface{}
 }
-
-type _User User
 
 // NewUser instantiates a new User object
 // This constructor will assign default values to properties that have it defined,
@@ -479,40 +476,7 @@ func (o User) MarshalJSON() ([]byte, error) {
 	if o.ArbitraryNullableTypeValue != nil {
 		toSerialize["arbitraryNullableTypeValue"] = o.ArbitraryNullableTypeValue
 	}
-
-	for key, value := range o.AdditionalProperties {
-		toSerialize[key] = value
-	}
-
 	return json.Marshal(toSerialize)
-}
-
-func (o *User) UnmarshalJSON(bytes []byte) (err error) {
-	varUser := _User{}
-
-	if err = json.Unmarshal(bytes, &varUser); err == nil {
-		*o = User(varUser)
-	}
-
-	additionalProperties := make(map[string]interface{})
-
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
-		delete(additionalProperties, "id")
-		delete(additionalProperties, "username")
-		delete(additionalProperties, "firstName")
-		delete(additionalProperties, "lastName")
-		delete(additionalProperties, "email")
-		delete(additionalProperties, "password")
-		delete(additionalProperties, "phone")
-		delete(additionalProperties, "userStatus")
-		delete(additionalProperties, "arbitraryObject")
-		delete(additionalProperties, "arbitraryNullableObject")
-		delete(additionalProperties, "arbitraryTypeValue")
-		delete(additionalProperties, "arbitraryNullableTypeValue")
-		o.AdditionalProperties = additionalProperties
-	}
-
-	return err
 }
 
 type NullableUser struct {

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_whale.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_whale.go
@@ -18,10 +18,7 @@ type Whale struct {
 	HasBaleen *bool `json:"hasBaleen,omitempty"`
 	HasTeeth *bool `json:"hasTeeth,omitempty"`
 	ClassName string `json:"className"`
-	AdditionalProperties map[string]interface{}
 }
-
-type _Whale Whale
 
 // NewWhale instantiates a new Whale object
 // This constructor will assign default values to properties that have it defined,
@@ -140,31 +137,7 @@ func (o Whale) MarshalJSON() ([]byte, error) {
 	if true {
 		toSerialize["className"] = o.ClassName
 	}
-
-	for key, value := range o.AdditionalProperties {
-		toSerialize[key] = value
-	}
-
 	return json.Marshal(toSerialize)
-}
-
-func (o *Whale) UnmarshalJSON(bytes []byte) (err error) {
-	varWhale := _Whale{}
-
-	if err = json.Unmarshal(bytes, &varWhale); err == nil {
-		*o = Whale(varWhale)
-	}
-
-	additionalProperties := make(map[string]interface{})
-
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
-		delete(additionalProperties, "hasBaleen")
-		delete(additionalProperties, "hasTeeth")
-		delete(additionalProperties, "className")
-		o.AdditionalProperties = additionalProperties
-	}
-
-	return err
 }
 
 type NullableWhale struct {

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_zebra.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_zebra.go
@@ -17,10 +17,7 @@ import (
 type Zebra struct {
 	Type *string `json:"type,omitempty"`
 	ClassName string `json:"className"`
-	AdditionalProperties map[string]interface{}
 }
-
-type _Zebra Zebra
 
 // NewZebra instantiates a new Zebra object
 // This constructor will assign default values to properties that have it defined,
@@ -104,30 +101,7 @@ func (o Zebra) MarshalJSON() ([]byte, error) {
 	if true {
 		toSerialize["className"] = o.ClassName
 	}
-
-	for key, value := range o.AdditionalProperties {
-		toSerialize[key] = value
-	}
-
 	return json.Marshal(toSerialize)
-}
-
-func (o *Zebra) UnmarshalJSON(bytes []byte) (err error) {
-	varZebra := _Zebra{}
-
-	if err = json.Unmarshal(bytes, &varZebra); err == nil {
-		*o = Zebra(varZebra)
-	}
-
-	additionalProperties := make(map[string]interface{})
-
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
-		delete(additionalProperties, "type")
-		delete(additionalProperties, "className")
-		o.AdditionalProperties = additionalProperties
-	}
-
-	return err
 }
 
 type NullableZebra struct {

--- a/samples/openapi3/client/petstore/go/go-petstore/.openapi-generator/VERSION
+++ b/samples/openapi3/client/petstore/go/go-petstore/.openapi-generator/VERSION
@@ -1,1 +1,1 @@
-5.0.0-SNAPSHOT
+5.0.0-beta

--- a/samples/openapi3/client/petstore/go/go-petstore/api_another_fake.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/api_another_fake.go
@@ -77,7 +77,6 @@ func (a *AnotherFakeApiService) Call123TestSpecialTags(ctx _context.Context, cli
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}

--- a/samples/openapi3/client/petstore/go/go-petstore/api_default.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/api_default.go
@@ -73,7 +73,6 @@ func (a *DefaultApiService) FooGet(ctx _context.Context) (InlineResponseDefault,
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}

--- a/samples/openapi3/client/petstore/go/go-petstore/api_fake.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/api_fake.go
@@ -76,7 +76,6 @@ func (a *FakeApiService) FakeHealthGet(ctx _context.Context) (HealthCheckResult,
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
@@ -166,7 +165,6 @@ func (a *FakeApiService) FakeHttpSignatureTest(ctx _context.Context, pet Pet, lo
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarHTTPResponse, err
 	}
@@ -244,7 +242,6 @@ func (a *FakeApiService) FakeOuterBooleanSerialize(ctx _context.Context, localVa
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
@@ -335,7 +332,6 @@ func (a *FakeApiService) FakeOuterCompositeSerialize(ctx _context.Context, local
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
@@ -422,7 +418,6 @@ func (a *FakeApiService) FakeOuterNumberSerialize(ctx _context.Context, localVar
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
@@ -509,7 +504,6 @@ func (a *FakeApiService) FakeOuterStringSerialize(ctx _context.Context, localVar
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
@@ -585,7 +579,6 @@ func (a *FakeApiService) TestBodyWithFileSchema(ctx _context.Context, fileSchema
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarHTTPResponse, err
 	}
@@ -653,7 +646,6 @@ func (a *FakeApiService) TestBodyWithQueryParams(ctx _context.Context, query str
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarHTTPResponse, err
 	}
@@ -722,7 +714,6 @@ func (a *FakeApiService) TestClientModel(ctx _context.Context, client Client) (C
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
@@ -882,7 +873,6 @@ func (a *FakeApiService) TestEndpointParameters(ctx _context.Context, number flo
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarHTTPResponse, err
 	}
@@ -999,7 +989,6 @@ func (a *FakeApiService) TestEnumParameters(ctx _context.Context, localVarOption
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarHTTPResponse, err
 	}
@@ -1089,7 +1078,6 @@ func (a *FakeApiService) TestGroupParameters(ctx _context.Context, requiredStrin
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarHTTPResponse, err
 	}
@@ -1155,7 +1143,6 @@ func (a *FakeApiService) TestInlineAdditionalProperties(ctx _context.Context, re
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarHTTPResponse, err
 	}
@@ -1222,7 +1209,6 @@ func (a *FakeApiService) TestJsonFormData(ctx _context.Context, param string, pa
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarHTTPResponse, err
 	}
@@ -1316,7 +1302,6 @@ func (a *FakeApiService) TestQueryParameterCollectionFormat(ctx _context.Context
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarHTTPResponse, err
 	}

--- a/samples/openapi3/client/petstore/go/go-petstore/api_fake_classname_tags123.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/api_fake_classname_tags123.go
@@ -89,7 +89,6 @@ func (a *FakeClassnameTags123ApiService) TestClassname(ctx _context.Context, cli
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}

--- a/samples/openapi3/client/petstore/go/go-petstore/api_pet.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/api_pet.go
@@ -77,7 +77,6 @@ func (a *PetApiService) AddPet(ctx _context.Context, pet Pet) (*_nethttp.Respons
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarHTTPResponse, err
 	}
@@ -153,7 +152,6 @@ func (a *PetApiService) DeletePet(ctx _context.Context, petId int64, localVarOpt
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarHTTPResponse, err
 	}
@@ -221,7 +219,6 @@ func (a *PetApiService) FindPetsByStatus(ctx _context.Context, status []string) 
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
@@ -298,7 +295,6 @@ func (a *PetApiService) FindPetsByTags(ctx _context.Context, tags []string) ([]P
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
@@ -388,7 +384,6 @@ func (a *PetApiService) GetPetById(ctx _context.Context, petId int64) (Pet, *_ne
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
@@ -463,7 +458,6 @@ func (a *PetApiService) UpdatePet(ctx _context.Context, pet Pet) (*_nethttp.Resp
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarHTTPResponse, err
 	}
@@ -544,7 +538,6 @@ func (a *PetApiService) UpdatePetWithForm(ctx _context.Context, petId int64, loc
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarHTTPResponse, err
 	}
@@ -639,7 +632,6 @@ func (a *PetApiService) UploadFile(ctx _context.Context, petId int64, localVarOp
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
@@ -735,7 +727,6 @@ func (a *PetApiService) UploadFileWithRequiredFile(ctx _context.Context, petId i
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}

--- a/samples/openapi3/client/petstore/go/go-petstore/api_store.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/api_store.go
@@ -76,7 +76,6 @@ func (a *StoreApiService) DeleteOrder(ctx _context.Context, orderId string) (*_n
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarHTTPResponse, err
 	}
@@ -154,7 +153,6 @@ func (a *StoreApiService) GetInventory(ctx _context.Context) (map[string]int32, 
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
@@ -238,7 +236,6 @@ func (a *StoreApiService) GetOrderById(ctx _context.Context, orderId int64) (Ord
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
@@ -315,7 +312,6 @@ func (a *StoreApiService) PlaceOrder(ctx _context.Context, order Order) (Order, 
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}

--- a/samples/openapi3/client/petstore/go/go-petstore/api_user.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/api_user.go
@@ -76,7 +76,6 @@ func (a *UserApiService) CreateUser(ctx _context.Context, user User) (*_nethttp.
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarHTTPResponse, err
 	}
@@ -142,7 +141,6 @@ func (a *UserApiService) CreateUsersWithArrayInput(ctx _context.Context, user []
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarHTTPResponse, err
 	}
@@ -208,7 +206,6 @@ func (a *UserApiService) CreateUsersWithListInput(ctx _context.Context, user []U
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarHTTPResponse, err
 	}
@@ -275,7 +272,6 @@ func (a *UserApiService) DeleteUser(ctx _context.Context, username string) (*_ne
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarHTTPResponse, err
 	}
@@ -343,7 +339,6 @@ func (a *UserApiService) GetUserByName(ctx _context.Context, username string) (U
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
@@ -421,7 +416,6 @@ func (a *UserApiService) LoginUser(ctx _context.Context, username string, passwo
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
@@ -493,7 +487,6 @@ func (a *UserApiService) LogoutUser(ctx _context.Context) (*_nethttp.Response, e
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarHTTPResponse, err
 	}
@@ -563,7 +556,6 @@ func (a *UserApiService) UpdateUser(ctx _context.Context, username string, user 
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
 	if err != nil {
 		return localVarHTTPResponse, err
 	}

--- a/samples/server/petstore/go-api-server/.openapi-generator/VERSION
+++ b/samples/server/petstore/go-api-server/.openapi-generator/VERSION
@@ -1,1 +1,1 @@
-5.0.0-SNAPSHOT
+5.0.0-beta

--- a/samples/server/petstore/go-gin-api-server/.openapi-generator/VERSION
+++ b/samples/server/petstore/go-gin-api-server/.openapi-generator/VERSION
@@ -1,1 +1,1 @@
-5.0.0-SNAPSHOT
+5.0.0-beta


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
With the generated go client, the body response is read and closed inside the function, which is not returned. It is impossible to get the body from the returned value.
I suggest to not close the body and let the user do it with the returned value.

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
