### PR TITLE
Fix string comparison in Python generator's abstract class

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPythonConnexionServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPythonConnexionServerCodegen.java
@@ -43,7 +43,7 @@ import java.util.*;
 import static org.openapitools.codegen.utils.StringUtils.camelize;
 import static org.openapitools.codegen.utils.StringUtils.underscore;
 
-abstract public class AbstractPythonConnexionServerCodegen extends DefaultCodegen implements CodegenConfig {
+public abstract class AbstractPythonConnexionServerCodegen extends DefaultCodegen implements CodegenConfig {
     private static final Logger LOGGER = LoggerFactory.getLogger(AbstractPythonConnexionServerCodegen.class);
 
     public static final String CONTROLLER_PACKAGE = "controllerPackage";

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPythonConnexionServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPythonConnexionServerCodegen.java
@@ -43,8 +43,8 @@ import java.util.*;
 import static org.openapitools.codegen.utils.StringUtils.camelize;
 import static org.openapitools.codegen.utils.StringUtils.underscore;
 
-public class PythonAbstractConnexionServerCodegen extends DefaultCodegen implements CodegenConfig {
-    private static final Logger LOGGER = LoggerFactory.getLogger(PythonAbstractConnexionServerCodegen.class);
+abstract public class AbstractPythonConnexionServerCodegen extends DefaultCodegen implements CodegenConfig {
+    private static final Logger LOGGER = LoggerFactory.getLogger(AbstractPythonConnexionServerCodegen.class);
 
     public static final String CONTROLLER_PACKAGE = "controllerPackage";
     public static final String DEFAULT_CONTROLLER = "defaultController";
@@ -64,7 +64,7 @@ public class PythonAbstractConnexionServerCodegen extends DefaultCodegen impleme
     protected boolean useNose = Boolean.FALSE;
     protected String pythonSrcRoot;
 
-    public PythonAbstractConnexionServerCodegen(String templateDirectory, boolean fixBodyNameValue) {
+    public AbstractPythonConnexionServerCodegen(String templateDirectory, boolean fixBodyNameValue) {
         super();
 
         modifyFeatureSet(features -> features.includeDocumentationFeatures(DocumentationFeature.Readme));

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonAbstractConnexionServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonAbstractConnexionServerCodegen.java
@@ -248,7 +248,7 @@ public class PythonAbstractConnexionServerCodegen extends DefaultCodegen impleme
             pySrcRoot = val.replaceAll("[/\\\\]+$", "");
         }
 
-        if (pySrcRoot.isEmpty() || pySrcRoot == ".") {
+        if (pySrcRoot.isEmpty() || ".".equals(pySrcRoot)) {
             this.pythonSrcRoot = "";
         } else {
             this.pythonSrcRoot = pySrcRoot + File.separator;

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonAiohttpConnexionServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonAiohttpConnexionServerCodegen.java
@@ -22,7 +22,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.EnumSet;
 
-public class PythonAiohttpConnexionServerCodegen extends PythonAbstractConnexionServerCodegen {
+public class PythonAiohttpConnexionServerCodegen extends AbstractPythonConnexionServerCodegen {
     private static final Logger LOGGER = LoggerFactory.getLogger(PythonAiohttpConnexionServerCodegen.class);
 
     public PythonAiohttpConnexionServerCodegen() {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonBluePlanetServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonBluePlanetServerCodegen.java
@@ -24,7 +24,7 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.util.EnumSet;
 
-public class PythonBluePlanetServerCodegen extends PythonAbstractConnexionServerCodegen {
+public class PythonBluePlanetServerCodegen extends AbstractPythonConnexionServerCodegen {
     private static final Logger LOGGER = LoggerFactory.getLogger(PythonBluePlanetServerCodegen.class);
 
     protected String modelDocPath = "";

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonFlaskConnexionServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonFlaskConnexionServerCodegen.java
@@ -22,7 +22,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 
-public class PythonFlaskConnexionServerCodegen extends PythonAbstractConnexionServerCodegen {
+public class PythonFlaskConnexionServerCodegen extends AbstractPythonConnexionServerCodegen {
     private static final Logger LOGGER = LoggerFactory.getLogger(PythonFlaskConnexionServerCodegen.class);
 
     public PythonFlaskConnexionServerCodegen() {


### PR DESCRIPTION
- Fix string comparison
- rename PythonAbstractConnexionServerCodegen.java to AbstractPythonConnexionServerCodegen.java

cc @taxpon (2017/07) @frol (2017/07) @mbohlool (2017/07) @cbornet (2017/09) @kenjones-cisco (2017/11) @tomplus (2018/10) @Jyhess (2019/01) @arun-nalla (2019/11) @spacether (2019/11)

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
