### PR TITLE
[typescript-fetch] adds support for serializing an array of objects into formData

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-fetch/apis.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/apis.mustache
@@ -231,7 +231,12 @@ export class {{classname}} extends runtime.BaseAPI {
             })
             {{/isCollectionFormatMulti}}
             {{^isCollectionFormatMulti}}
-            formParams.append('{{baseName}}', requestParameters.{{paramName}}.join(runtime.COLLECTION_FORMATS["{{collectionFormat}}"]));
+                // Serialize array of objects as needed
+                if (typeof requestParameters.{{paramName}}[0] === 'object' && requestParameters.{{paramName}}[0] !== null) {
+                    runtime.serializeArrayObjectsToFormData(formParams, "{{paramName}}", requestParameters.{{paramName}})
+                } else {
+                    formParams.append('{{baseName}}', requestParameters.{{paramName}}.join(runtime.COLLECTION_FORMATS["{{collectionFormat}}"]));
+                }
             {{/isCollectionFormatMulti}}
         }
 

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/runtime.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/runtime.mustache
@@ -303,3 +303,42 @@ export class TextApiResponse {
         return await this.raw.text();
     };
 }
+
+/**
+ * Serializes an array's contents into the properties within the supplied formData instance.
+ * @param {FormData} formData - formData instance
+ * @param {string} paramName - name of the parameter (form value) being serialized
+ * @param {Array} arr - array of objects to be serialized
+ */
+export function serializeArrayObjectsToFormData(formData: FormData, paramName: string, arr: any[]) {
+    arr.forEach(elem => {
+        appendFormData(formData, elem, `${paramName}[]`)
+    });
+}
+
+/**
+ * Appends the data from an object to the supplied formData instance
+ * See: https://stackoverflow.com/a/43101878
+ * @param {FormData} formData - instance of FormData object
+ * @param {any} data - data (object?) to post to form data
+ */
+export function appendFormData(formData: FormData, data: any, previousKey?: string) {
+  if (data instanceof Object) {
+    Object.keys(data).forEach(key => {
+      const value = data[key];
+      if (value instanceof Object && !Array.isArray(value)) {
+        return appendFormData(formData, value, key);
+      }
+      if (previousKey) {
+        key = `${previousKey}[${key}]`;
+      }
+      if (Array.isArray(value)) {
+        value.forEach(val => {
+          formData.append(`${key}[]`, val);
+        });
+      } else {
+        formData.append(key, value);
+      }
+    });
+  }
+}

--- a/samples/client/petstore/typescript-fetch/builds/default/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/runtime.ts
@@ -314,3 +314,42 @@ export class TextApiResponse {
         return await this.raw.text();
     };
 }
+
+/**
+ * Serializes an array's contents into the properties within the supplied formData instance.
+ * @param {FormData} formData - formData instance
+ * @param {string} paramName - name of the parameter (form value) being serialized
+ * @param {Array} arr - array of objects to be serialized
+ */
+export function serializeArrayObjectsToFormData(formData: FormData, paramName: string, arr: any[]) {
+    arr.forEach(elem => {
+        appendFormData(formData, elem, `${paramName}[]`)
+    });
+}
+
+/**
+ * Appends the data from an object to the supplied formData instance
+ * See: https://stackoverflow.com/a/43101878
+ * @param {FormData} formData - instance of FormData object
+ * @param {any} data - data (object?) to post to form data
+ */
+export function appendFormData(formData: FormData, data: any, previousKey?: string) {
+  if (data instanceof Object) {
+    Object.keys(data).forEach(key => {
+      const value = data[key];
+      if (value instanceof Object && !Array.isArray(value)) {
+        return appendFormData(formData, value, key);
+      }
+      if (previousKey) {
+        key = `${previousKey}[${key}]`;
+      }
+      if (Array.isArray(value)) {
+        value.forEach(val => {
+          formData.append(`${key}[]`, val);
+        });
+      } else {
+        formData.append(key, value);
+      }
+    });
+  }
+}

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/runtime.ts
@@ -314,3 +314,42 @@ export class TextApiResponse {
         return await this.raw.text();
     };
 }
+
+/**
+ * Serializes an array's contents into the properties within the supplied formData instance.
+ * @param {FormData} formData - formData instance
+ * @param {string} paramName - name of the parameter (form value) being serialized
+ * @param {Array} arr - array of objects to be serialized
+ */
+export function serializeArrayObjectsToFormData(formData: FormData, paramName: string, arr: any[]) {
+    arr.forEach(elem => {
+        appendFormData(formData, elem, `${paramName}[]`)
+    });
+}
+
+/**
+ * Appends the data from an object to the supplied formData instance
+ * See: https://stackoverflow.com/a/43101878
+ * @param {FormData} formData - instance of FormData object
+ * @param {any} data - data (object?) to post to form data
+ */
+export function appendFormData(formData: FormData, data: any, previousKey?: string) {
+  if (data instanceof Object) {
+    Object.keys(data).forEach(key => {
+      const value = data[key];
+      if (value instanceof Object && !Array.isArray(value)) {
+        return appendFormData(formData, value, key);
+      }
+      if (previousKey) {
+        key = `${previousKey}[${key}]`;
+      }
+      if (Array.isArray(value)) {
+        value.forEach(val => {
+          formData.append(`${key}[]`, val);
+        });
+      } else {
+        formData.append(key, value);
+      }
+    });
+  }
+}

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/runtime.ts
@@ -314,3 +314,42 @@ export class TextApiResponse {
         return await this.raw.text();
     };
 }
+
+/**
+ * Serializes an array's contents into the properties within the supplied formData instance.
+ * @param {FormData} formData - formData instance
+ * @param {string} paramName - name of the parameter (form value) being serialized
+ * @param {Array} arr - array of objects to be serialized
+ */
+export function serializeArrayObjectsToFormData(formData: FormData, paramName: string, arr: any[]) {
+    arr.forEach(elem => {
+        appendFormData(formData, elem, `${paramName}[]`)
+    });
+}
+
+/**
+ * Appends the data from an object to the supplied formData instance
+ * See: https://stackoverflow.com/a/43101878
+ * @param {FormData} formData - instance of FormData object
+ * @param {any} data - data (object?) to post to form data
+ */
+export function appendFormData(formData: FormData, data: any, previousKey?: string) {
+  if (data instanceof Object) {
+    Object.keys(data).forEach(key => {
+      const value = data[key];
+      if (value instanceof Object && !Array.isArray(value)) {
+        return appendFormData(formData, value, key);
+      }
+      if (previousKey) {
+        key = `${previousKey}[${key}]`;
+      }
+      if (Array.isArray(value)) {
+        value.forEach(val => {
+          formData.append(`${key}[]`, val);
+        });
+      } else {
+        formData.append(key, value);
+      }
+    });
+  }
+}

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/runtime.ts
@@ -314,3 +314,42 @@ export class TextApiResponse {
         return await this.raw.text();
     };
 }
+
+/**
+ * Serializes an array's contents into the properties within the supplied formData instance.
+ * @param {FormData} formData - formData instance
+ * @param {string} paramName - name of the parameter (form value) being serialized
+ * @param {Array} arr - array of objects to be serialized
+ */
+export function serializeArrayObjectsToFormData(formData: FormData, paramName: string, arr: any[]) {
+    arr.forEach(elem => {
+        appendFormData(formData, elem, `${paramName}[]`)
+    });
+}
+
+/**
+ * Appends the data from an object to the supplied formData instance
+ * See: https://stackoverflow.com/a/43101878
+ * @param {FormData} formData - instance of FormData object
+ * @param {any} data - data (object?) to post to form data
+ */
+export function appendFormData(formData: FormData, data: any, previousKey?: string) {
+  if (data instanceof Object) {
+    Object.keys(data).forEach(key => {
+      const value = data[key];
+      if (value instanceof Object && !Array.isArray(value)) {
+        return appendFormData(formData, value, key);
+      }
+      if (previousKey) {
+        key = `${previousKey}[${key}]`;
+      }
+      if (Array.isArray(value)) {
+        value.forEach(val => {
+          formData.append(`${key}[]`, val);
+        });
+      } else {
+        formData.append(key, value);
+      }
+    });
+  }
+}

--- a/samples/client/petstore/typescript-fetch/builds/typescript-three-plus/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/typescript-three-plus/src/runtime.ts
@@ -314,3 +314,42 @@ export class TextApiResponse {
         return await this.raw.text();
     };
 }
+
+/**
+ * Serializes an array's contents into the properties within the supplied formData instance.
+ * @param {FormData} formData - formData instance
+ * @param {string} paramName - name of the parameter (form value) being serialized
+ * @param {Array} arr - array of objects to be serialized
+ */
+export function serializeArrayObjectsToFormData(formData: FormData, paramName: string, arr: any[]) {
+    arr.forEach(elem => {
+        appendFormData(formData, elem, `${paramName}[]`)
+    });
+}
+
+/**
+ * Appends the data from an object to the supplied formData instance
+ * See: https://stackoverflow.com/a/43101878
+ * @param {FormData} formData - instance of FormData object
+ * @param {any} data - data (object?) to post to form data
+ */
+export function appendFormData(formData: FormData, data: any, previousKey?: string) {
+  if (data instanceof Object) {
+    Object.keys(data).forEach(key => {
+      const value = data[key];
+      if (value instanceof Object && !Array.isArray(value)) {
+        return appendFormData(formData, value, key);
+      }
+      if (previousKey) {
+        key = `${previousKey}[${key}]`;
+      }
+      if (Array.isArray(value)) {
+        value.forEach(val => {
+          formData.append(`${key}[]`, val);
+        });
+      } else {
+        formData.append(key, value);
+      }
+    });
+  }
+}

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/runtime.ts
@@ -314,3 +314,42 @@ export class TextApiResponse {
         return await this.raw.text();
     };
 }
+
+/**
+ * Serializes an array's contents into the properties within the supplied formData instance.
+ * @param {FormData} formData - formData instance
+ * @param {string} paramName - name of the parameter (form value) being serialized
+ * @param {Array} arr - array of objects to be serialized
+ */
+export function serializeArrayObjectsToFormData(formData: FormData, paramName: string, arr: any[]) {
+    arr.forEach(elem => {
+        appendFormData(formData, elem, `${paramName}[]`)
+    });
+}
+
+/**
+ * Appends the data from an object to the supplied formData instance
+ * See: https://stackoverflow.com/a/43101878
+ * @param {FormData} formData - instance of FormData object
+ * @param {any} data - data (object?) to post to form data
+ */
+export function appendFormData(formData: FormData, data: any, previousKey?: string) {
+  if (data instanceof Object) {
+    Object.keys(data).forEach(key => {
+      const value = data[key];
+      if (value instanceof Object && !Array.isArray(value)) {
+        return appendFormData(formData, value, key);
+      }
+      if (previousKey) {
+        key = `${previousKey}[${key}]`;
+      }
+      if (Array.isArray(value)) {
+        value.forEach(val => {
+          formData.append(`${key}[]`, val);
+        });
+      } else {
+        formData.append(key, value);
+      }
+    });
+  }
+}

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/runtime.ts
@@ -314,3 +314,42 @@ export class TextApiResponse {
         return await this.raw.text();
     };
 }
+
+/**
+ * Serializes an array's contents into the properties within the supplied formData instance.
+ * @param {FormData} formData - formData instance
+ * @param {string} paramName - name of the parameter (form value) being serialized
+ * @param {Array} arr - array of objects to be serialized
+ */
+export function serializeArrayObjectsToFormData(formData: FormData, paramName: string, arr: any[]) {
+    arr.forEach(elem => {
+        appendFormData(formData, elem, `${paramName}[]`)
+    });
+}
+
+/**
+ * Appends the data from an object to the supplied formData instance
+ * See: https://stackoverflow.com/a/43101878
+ * @param {FormData} formData - instance of FormData object
+ * @param {any} data - data (object?) to post to form data
+ */
+export function appendFormData(formData: FormData, data: any, previousKey?: string) {
+  if (data instanceof Object) {
+    Object.keys(data).forEach(key => {
+      const value = data[key];
+      if (value instanceof Object && !Array.isArray(value)) {
+        return appendFormData(formData, value, key);
+      }
+      if (previousKey) {
+        key = `${previousKey}[${key}]`;
+      }
+      if (Array.isArray(value)) {
+        value.forEach(val => {
+          formData.append(`${key}[]`, val);
+        });
+      } else {
+        formData.append(key, value);
+      }
+    });
+  }
+}


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

**Description**
This is a template-only change for the typescript-fetch generator.

It includes the addition of two methods to the `runtime.ts` file for serializing an array of objects stored `requestParameters` into the `formData` instance.

**Problem**
Previously, a `.join()` would be called on a particular parameter within `requestParameter` regardless of whether or not it contained an array of objects or an array of strings. This resulted a string of  ` [object Object] ` strings getting inserted into  a key within the `formData` instance.

**Solution**
This change allows for an array of objects to be inserted into the `formData` instance by iterating over each object and its properties and appending it into the properly named `formData` key to preserve its nesting (as an array of objects)

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
