### PR TITLE
[Java][pkmst] Fix string comparison

### DIFF
--- a/modules/openapi-generator/src/main/resources/java-pkmst/logging/httpLoggingFilter.mustache
+++ b/modules/openapi-generator/src/main/resources/java-pkmst/logging/httpLoggingFilter.mustache
@@ -70,7 +70,7 @@ public class HttpLoggingFilter implements Filter {
         chain.doFilter(bufferedRequest, bufferedResponse);
         long elapsedTime = System.currentTimeMillis() - start;
         String respContent = null;
-        if (bufferedResponse.getContent() == null || bufferedResponse.getContent() == "") {
+        if (bufferedResponse.getContent() == null || "".equals(bufferedResponse.getContent())) {
           respContent = "No data";
         } else {
           respContent = bufferedResponse.getContent();

--- a/samples/server/petstore/java-pkmst/src/main/java/com/prokarma/pkmst/logging/HttpLoggingFilter.java
+++ b/samples/server/petstore/java-pkmst/src/main/java/com/prokarma/pkmst/logging/HttpLoggingFilter.java
@@ -70,7 +70,7 @@ public class HttpLoggingFilter implements Filter {
         chain.doFilter(bufferedRequest, bufferedResponse);
         long elapsedTime = System.currentTimeMillis() - start;
         String respContent = null;
-        if (bufferedResponse.getContent() == null || bufferedResponse.getContent() == "") {
+        if (bufferedResponse.getContent() == null || "".equals(bufferedResponse.getContent())) {
           respContent = "No data";
         } else {
           respContent = bufferedResponse.getContent();


### PR DESCRIPTION
Fix string comparison using `.equals()`

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

cc @bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04) @lwlee2608 (2019/10) @bkabrda (2020/01)



