### PR TITLE
Fix string comparison in fsharp generator tests

### DIFF
--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/fsharp/FSharpServerCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/fsharp/FSharpServerCodegenTest.java
@@ -66,9 +66,9 @@ public class FSharpServerCodegenTest {
         
         Object[] keys = sorted.keySet().toArray();
         
-        Assert.assertTrue(keys[0] == "wheel");
-        Assert.assertTrue(keys[1] == "bike" || keys[1] == "car");
-        Assert.assertTrue(keys[2] == "bike" || keys[2] == "car");
+        Assert.assertTrue("wheel".equals(keys[0]));
+        Assert.assertTrue("bike".equals(keys[1]) || "car".equals(keys[1]));
+        Assert.assertTrue("bike".equals(keys[2]) || "car".equals(keys[2]));
         Assert.assertEquals(keys[3], "parent");
         Assert.assertEquals(keys[4], "child");
         


### PR DESCRIPTION
Fix string comparison in fsharp generator tests by using `.equals()`

<!-- Please check the completed items below -->
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [ ] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [ ] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

FYI @nmfisher