### PR TITLE
[ci] Verify supported JDK versions on master push

### DIFF
--- a/.github/workflows/check-supported-versions.yaml
+++ b/.github/workflows/check-supported-versions.yaml
@@ -1,0 +1,80 @@
+name: Check Supported Java Versions
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    name: Build on JDK ${{ matrix.java }} and ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        java: [8, 11]
+        os: [ubuntu-latest]
+        include:
+          - java: 8
+            os: windows-latest
+          - java: 13
+            os: ubuntu-latest
+            # Need to update to Gradle version with v13 support in modules/openapi-generator-gradle-plugin/pom.xml
+            flags: -am -pl modules/openapi-generator-cli
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Set up JDK ${{ matrix.java }}
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java }}
+
+      - uses: actions/cache@v1
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('pom.xml', 'modules/**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('modules/openapi-generator-gradle-plugin/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Build with Maven
+        shell: bash
+        run: mvn -nsu -B --quiet -Djacoco.skip=true -Dorg.slf4j.simpleLogger.defaultLogLevel=error --no-transfer-progress clean install --file pom.xml ${{ matrix.flags }}
+
+      - name: Test gradle
+        shell: bash
+        run: gradle -b modules/openapi-generator-gradle-plugin/samples/local-spec/build.gradle buildGoSdk --stacktrace
+
+      - name: Upload Maven build artifact
+        uses: actions/upload-artifact@v1
+        if: matrix.java == '8'
+        with:
+          name: artifact
+          path: modules/openapi-generator-cli/target/openapi-generator-cli.jar
+
+  verify:
+    name: Verifies integrity of the commit on ${{ matrix.os }}
+    needs: build
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+      - name: Download build artifact
+        uses: actions/download-artifact@v1
+        with:
+          name: artifact
+      - name: Run Ensures Script
+        run: |
+          mkdir -p modules/openapi-generator-cli/target/
+          mv artifact/openapi-generator-cli.jar modules/openapi-generator-cli/target/
+          ./bin/utils/ensure-up-to-date

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 [![Windows Test](https://ci.appveyor.com/api/projects/status/github/openapitools/openapi-generator?branch=master&svg=true&passingText=Windows%20Test%20-%20OK&failingText=Windows%20Test%20-%20Fails)](https://ci.appveyor.com/project/WilliamCheng/openapi-generator-wh2wu)
 [![JDK11 Build](https://cloud.drone.io/api/badges/OpenAPITools/openapi-generator/status.svg?ref=refs/heads/master)](https://cloud.drone.io/OpenAPITools/openapi-generator)
 [![iOS Build Status](https://app.bitrise.io/app/4a2b10a819d12b67/status.svg?token=859FMDR8QHwabCzwvZK6vQ&branch=master)](https://app.bitrise.io/app/4a2b10a819d12b67)
+![Check Supported Java Versions](https://github.com/openapi-generator/openapi-generator/workflows/Check%20Supported%20Java%20Versions/badge.svg)
 
 </div>
 


### PR DESCRIPTION
This sets up a GitHub Workflow to verify JDK 8 (Linux, Windows), 11 (Linux), and 13 (Linux) on pushes to master. It also verifies that the ensure-up-to-date script works in both Linux and Windows.

This is applied to pushes to master only, because GitHub Workflows currently don't support run cancellation.

JDK 13 skips building the Maven and Gradle plugins for simplicity since the version of Gradle we use to build the Gradle plugin does not support JDK 13 and the Maven plugin is compiled and released using JDK 8. This supported version check is provided for those contributing generators and other functionality aside from plugins. we may add back in plugin checks to JDK 13 once our Gradle dependency is updated.

cc @OpenAPITools/generator-core-team 

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
