### PR TITLE
[aspnetcore] Typo issues in docs and generated code

### DIFF
--- a/docs/generators/aspnetcore.md
+++ b/docs/generators/aspnetcore.md
@@ -18,7 +18,7 @@ sidebar_label: aspnetcore
 |modelClassModifier|Model Class Modifier can be nothing or partial| |partial|
 |newtonsoftVersion|Version for Microsoft.AspNetCore.Mvc.NewtonsoftJson for ASP.NET Core 3.0+| |3.0.0|
 |operationIsAsync|Set methods to async or sync (default).| |false|
-|operationModifier|Operation Modifier can be virtual, abstract or partial| |virtual|
+|operationModifier|Operation Modifier can be virtual or abstract| |virtual|
 |operationResultTask|Set methods result to Task&lt;&gt;.| |false|
 |packageAuthors|Specifies Authors property in the .NET Core project file.| |OpenAPI|
 |packageCopyright|Specifies an AssemblyCopyright for the .NET Framework global assembly attributes stored in the AssemblyInfo file.| |No Copyright|

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AspNetCoreServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AspNetCoreServerCodegen.java
@@ -70,7 +70,7 @@ public class AspNetCoreServerCodegen extends AbstractCSharpCodegen {
     protected CliOption swashbuckleVersion = new CliOption(SWASHBUCKLE_VERSION, "Swashbuckle version: 3.0.0, 4.0.0, 5.0.0");
     protected CliOption aspnetCoreVersion = new CliOption(ASPNET_CORE_VERSION, "ASP.NET Core version: 3.1, 3.0, 2.2, 2.1, 2.0 (deprecated)");
     private CliOption classModifier = new CliOption(CLASS_MODIFIER, "Class Modifier can be empty, abstract");
-    private CliOption operationModifier = new CliOption(OPERATION_MODIFIER, "Operation Modifier can be virtual, abstract or partial");
+    private CliOption operationModifier = new CliOption(OPERATION_MODIFIER, "Operation Modifier can be virtual or abstract");
     private CliOption modelClassModifier = new CliOption(MODEL_CLASS_MODIFIER, "Model Class Modifier can be nothing or partial");
     private boolean generateBody = true;
     private CliOption buildTarget = new CliOption("buildTarget", "Target to build an application or library");

--- a/modules/openapi-generator/src/main/resources/aspnetcore/3.0/Program.mustache
+++ b/modules/openapi-generator/src/main/resources/aspnetcore/3.0/Program.mustache
@@ -14,7 +14,7 @@ namespace {{packageName}}
         /// <param name="args"></param>
         public static void Main(string[] args)
         {
-            CreateWebHostBuilder(args).Build().Run();
+            CreateHostBuilder(args).Build().Run();
         }
 
         /// <summary>
@@ -22,7 +22,7 @@ namespace {{packageName}}
         /// </summary>
         /// <param name="args"></param>
         /// <returns>IHostBuilder</returns>
-        public static IHostBuilder CreateWebHostBuilder(string[] args) =>
+        public static IHostBuilder CreateHostBuilder(string[] args) =>
             Host.CreateDefaultBuilder(args)
                 .ConfigureWebHostDefaults(webBuilder =>
                 {

--- a/samples/server/petstore/aspnetcore-3.0/src/Org.OpenAPITools/Program.cs
+++ b/samples/server/petstore/aspnetcore-3.0/src/Org.OpenAPITools/Program.cs
@@ -14,7 +14,7 @@ namespace Org.OpenAPITools
         /// <param name="args"></param>
         public static void Main(string[] args)
         {
-            CreateWebHostBuilder(args).Build().Run();
+            CreateHostBuilder(args).Build().Run();
         }
 
         /// <summary>
@@ -22,7 +22,7 @@ namespace Org.OpenAPITools
         /// </summary>
         /// <param name="args"></param>
         /// <returns>IHostBuilder</returns>
-        public static IHostBuilder CreateWebHostBuilder(string[] args) =>
+        public static IHostBuilder CreateHostBuilder(string[] args) =>
             Host.CreateDefaultBuilder(args)
                 .ConfigureWebHostDefaults(webBuilder =>
                 {

--- a/samples/server/petstore/aspnetcore-3.1/src/Org.OpenAPITools/Program.cs
+++ b/samples/server/petstore/aspnetcore-3.1/src/Org.OpenAPITools/Program.cs
@@ -14,7 +14,7 @@ namespace Org.OpenAPITools
         /// <param name="args"></param>
         public static void Main(string[] args)
         {
-            CreateWebHostBuilder(args).Build().Run();
+            CreateHostBuilder(args).Build().Run();
         }
 
         /// <summary>
@@ -22,7 +22,7 @@ namespace Org.OpenAPITools
         /// </summary>
         /// <param name="args"></param>
         /// <returns>IHostBuilder</returns>
-        public static IHostBuilder CreateWebHostBuilder(string[] args) =>
+        public static IHostBuilder CreateHostBuilder(string[] args) =>
             Host.CreateDefaultBuilder(args)
                 .ConfigureWebHostDefaults(webBuilder =>
                 {


### PR DESCRIPTION
There are two small typo fixes in this issue:
- a doc typo #4829
- a method typo #7093

@mandrean 
@frankyjuang 
@shibayan 

<!-- Please check the completed items below -->
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [X] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [X] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
