### PR TITLE
[Java][jersey2]Fix gradle HttpSignatureAuth dependencies

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/build.gradle.mustache
@@ -137,9 +137,9 @@ ext {
     {{#hasOAuthMethods}}
     scribejava_apis_version = "6.9.0"
     {{/hasOAuthMethods}}
-    {{#hasHttpBasicMethods}}
-    tomitribe_http_signatures_version = "1.3"
-    {{/hasHttpBasicMethods}}
+    {{#hasHttpSignatureMethods}}
+    tomitribe_http_signatures_version = "1.5"
+    {{/hasHttpSignatureMethods}}
 }
 
 dependencies {
@@ -161,9 +161,9 @@ dependencies {
     {{#hasOAuthMethods}}
     compile "com.github.scribejava:scribejava-apis:$scribejava_apis_version"
     {{/hasOAuthMethods}}
-    {{#hasHttpBasicMethods}}
+    {{#hasHttpSignatureMethods}}
     compile "org.tomitribe:tomitribe-http-signatures:$tomitribe_http_signatures_version"
-    {{/hasHttpBasicMethods}}
+    {{/hasHttpSignatureMethods}}
     {{#supportJava6}}
     compile "commons-io:commons-io:$commons_io_version"
     compile "org.apache.commons:commons-lang3:$commons_lang3_version"

--- a/samples/client/petstore/java/jersey2-java8/build.gradle
+++ b/samples/client/petstore/java/jersey2-java8/build.gradle
@@ -101,7 +101,6 @@ ext {
     jersey_version = "2.27"
     junit_version = "4.13"
     scribejava_apis_version = "6.9.0"
-    tomitribe_http_signatures_version = "1.3"
 }
 
 dependencies {
@@ -116,7 +115,6 @@ dependencies {
     compile "org.openapitools:jackson-databind-nullable:$jackson_databind_nullable_version"
     compile "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jackson_version"
     compile "com.github.scribejava:scribejava-apis:$scribejava_apis_version"
-    compile "org.tomitribe:tomitribe-http-signatures:$tomitribe_http_signatures_version"
     compile 'javax.annotation:javax.annotation-api:1.3.2'
     testCompile "junit:junit:$junit_version"
 }

--- a/samples/openapi3/client/petstore/java/jersey2-java8/build.gradle
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/build.gradle
@@ -101,7 +101,7 @@ ext {
     jersey_version = "2.27"
     junit_version = "4.13"
     scribejava_apis_version = "6.9.0"
-    tomitribe_http_signatures_version = "1.3"
+    tomitribe_http_signatures_version = "1.5"
 }
 
 dependencies {


### PR DESCRIPTION
* Corrects tag for including HttpSignatureAuth in gradle builds
* Updates version of org.tomitribe:tomitribe-http-signatures in
gradle template to match version from maven template
* Updates samples

### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [ ] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [ ] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
