### PR TITLE
[online] Fix for version conflicts with springfox/boot

### DIFF
--- a/modules/openapi-generator-online/pom.xml
+++ b/modules/openapi-generator-online/pom.xml
@@ -15,8 +15,8 @@
         <java.version>1.8</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
-        <spring-boot-version>2.0.7.RELEASE</spring-boot-version>
-        <springfox-version>2.8.0</springfox-version>
+        <spring-boot-version>2.2.9.RELEASE</spring-boot-version>
+        <springfox-version>3.0.0</springfox-version>
         <junit-version>4.13</junit-version>
         <jackson-version>2.10.2</jackson-version>
     </properties>
@@ -105,12 +105,16 @@
             <version>${springfox-version}</version>
             <exclusions>
                 <exclusion>
-                <groupId>io.swagger</groupId>
-                <artifactId>swagger-annotations</artifactId>
-            </exclusion>
+                    <groupId>io.swagger</groupId>
+                    <artifactId>swagger-annotations</artifactId>
+                </exclusion>
                 <exclusion>
                     <groupId>io.swagger</groupId>
                     <artifactId>swagger-models</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/modules/openapi-generator-online/src/main/java/org/openapitools/codegen/online/OpenAPI2SpringBoot.java
+++ b/modules/openapi-generator-online/src/main/java/org/openapitools/codegen/online/OpenAPI2SpringBoot.java
@@ -23,6 +23,7 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.web.filter.ForwardedHeaderFilter;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
@@ -59,5 +60,10 @@ public class OpenAPI2SpringBoot implements CommandLineRunner {
                 registry.addMapping("/**").allowedOrigins("*").allowedHeaders("Content-Type");
             }
         };
+    }
+
+    @Bean
+    ForwardedHeaderFilter forwardedHeaderFilter() {
+        return new ForwardedHeaderFilter();
     }
 }

--- a/modules/openapi-generator-online/src/test/java/org/openapitools/codegen/online/api/GenApiControllerTest.java
+++ b/modules/openapi-generator-online/src/test/java/org/openapitools/codegen/online/api/GenApiControllerTest.java
@@ -22,7 +22,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WebMvcTest(GenApiController.class)
 public class GenApiControllerTest {
 
-    private static final String OPENAPI_URL = "http://petstore.swagger.io/v2/swagger.json";
+    private static final String OPENAPI_URL = "https://raw.githubusercontent.com/OpenAPITools/openapi-generator/v4.3.1/modules/openapi-generator/src/test/resources/petstore.json";
     private static final String UUID_REGEX = "[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-4[a-fA-F0-9]{3}-[89aAbB][a-fA-F0-9]{3}-[a-fA-F0-9]{12}";
 
     @Autowired
@@ -43,7 +43,7 @@ public class GenApiControllerTest {
     public void getLanguages(String type, String expected) throws Exception {
         mockMvc.perform(get("/api/gen/" + type))
                 .andExpect(status().isOk())
-                .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8))
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.[*]").value(hasItem(expected)));
     }
 
@@ -72,7 +72,7 @@ public class GenApiControllerTest {
     private void getOptions(String type, String name) throws Exception {
         mockMvc.perform(get("/api/gen/" + type + "/" + name))
                 .andExpect(status().isOk())
-                .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8))
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.sortParamsByRequiredFlag.opt").value("sortParamsByRequiredFlag"));
     }
 
@@ -88,10 +88,10 @@ public class GenApiControllerTest {
 
     private void generateAndDownload(String type, String name) throws Exception {
         String result = mockMvc.perform(post("http://test.com:1234/api/gen/" + type + "/" + name)
-                .contentType(MediaType.APPLICATION_JSON_UTF8)
+                .contentType(MediaType.APPLICATION_JSON)
                 .content("{\"openAPIUrl\": \"" + OPENAPI_URL + "\"}"))
                 .andExpect(status().isOk())
-                .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8))
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.code").value(matchesPattern(UUID_REGEX)))
                 .andExpect(jsonPath("$.link").value(matchesPattern("http\\:\\/\\/test.com\\:1234\\/api\\/gen\\/download\\/" + UUID_REGEX)))
                 .andReturn().getResponse().getContentAsString();
@@ -107,13 +107,13 @@ public class GenApiControllerTest {
     @Test
     public void generateWIthForwardedHeaders() throws Exception {
         String result = mockMvc.perform(post("http://test.com:1234/api/gen/clients/java")
-                .contentType(MediaType.APPLICATION_JSON_UTF8)
+                .contentType(MediaType.APPLICATION_JSON)
                 .header("X-Forwarded-Proto", "https")
                 .header("X-Forwarded-Host", "forwarded.com")
                 .header("X-Forwarded-Port", "5678")
                 .content("{\"openAPIUrl\": \"" + OPENAPI_URL + "\"}"))
                 .andExpect(status().isOk())
-                .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8))
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.code").value(matchesPattern(UUID_REGEX)))
                 .andExpect(jsonPath("$.link").value(matchesPattern("https\\:\\/\\/forwarded.com\\:5678\\/api\\/gen\\/download\\/" + UUID_REGEX)))
                 .andReturn().getResponse().getContentAsString();


### PR DESCRIPTION
From [slack](https://openapi-generator.slack.com/archives/CLSB0U0R5/p1595950538195500)… generation via online is broken due to errors.

For example:

```
curl -X POST "https://api-latest-master.openapi-generator.tech/api/gen/clients/csharp" -H "Accept: */*" -H "Content-Type: application/json" -d "{ \"openAPIUrl\": \"https://raw.githubusercontent.com/OpenAPITools/openapi-generator/master/modules/openapi-generator/src/test/resources/2_0/petstore.yaml\"}"
```

Results in an error:

```
{"timestamp":"2020-07-31T13:05:33.674Z","status":500,"error":"Internal Server Error","message":"Could not initialize class io.swagger.v3.parser.OpenAPIV3Parser","path":"/api/gen/clients/csharp"}
```

The online project was pulling in Jackson 2.9 deps which are not all ABI compatible with the 2.10 version we pull in with the newer swagger-parser. guava and snakeyaml were also old and potentially causing issues.

I've updated springboot to 2.2.9.RELEASE and springfox to 3.0.0 to address the version conflicts. The springboot bump from 2.0 to 2.2 requires providing bean `ForwardedHeaderFilter` because newer SpringBoot does not enable X-Forwarded- support by default and the property-based native or framework configuration does not work for `X-Forwarded-Host` and `X-Forwarded-Port` as we use and test for.


## Release Notes

* [online] Upgraded springboot to 2.2.9.RELEASE
* [online] Upgraded springfox to 3.0.0


cc @OpenAPITools/generator-core-team 

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
