### PR TITLE
added int32 type support for go-server

### DIFF
--- a/modules/openapi-generator/src/main/resources/go-server/controller-api.mustache
+++ b/modules/openapi-generator/src/main/resources/go-server/controller-api.mustache
@@ -41,32 +41,49 @@ func (c *{{classname}}Controller) {{nickname}}(w http.ResponseWriter, r *http.Re
 	{{/hasFormParams}}{{#hasPathParams}}
 	params := mux.Vars(r){{/hasPathParams}}{{#hasQueryParams}}
 	query := r.URL.Query(){{/hasQueryParams}}{{#allParams}}{{#isPathParam}}{{#isLong}}
-	{{paramName}}, err := parseIntParameter(params["{{paramName}}"])
+	{{paramName}}, err := parseInt64Parameter(params["{{paramName}}"])
+	if err != nil {
+		w.WriteHeader(500)
+		return
+	}{{/isLong}}{{#isInteger}}
+	{{paramName}}, err := parseInt32Parameter(params["{{paramName}}"])
 	if err != nil {
 		w.WriteHeader(500)
 		return
 	}
-	{{/isLong}}{{^isLong}}
-	{{paramName}} := params["{{paramName}}"]{{/isLong}}{{/isPathParam}}{{#isQueryParam}}{{#isLong}}
-	{{paramName}}, err := parseIntParameter(query.Get("{{paramName}}"))
+	{{/isInteger}}{{^isLong}}{{^isInteger}}
+	{{paramName}} := params["{{paramName}}"]{{/isInteger}}{{/isLong}}{{/isPathParam}}{{#isQueryParam}}{{#isLong}}
+	{{paramName}}, err := parseInt64Parameter(query.Get("{{paramName}}"))
 	if err != nil {
 		w.WriteHeader(500)
 		return
 	}
-	{{/isLong}}{{^isLong}}
-	{{paramName}} := {{#isListContainer}}strings.Split({{/isListContainer}}query.Get("{{paramName}}"){{#isListContainer}}, ","){{/isListContainer}}{{/isLong}}{{/isQueryParam}}{{#isFormParam}}{{#isFile}}
+	{{/isLong}}{{#isInteger}}
+	{{paramName}}, err := parseInt32Parameter(query.Get("{{paramName}}"))
+	if err != nil {
+		w.WriteHeader(500)
+		return
+	}
+	{{/isInteger}}{{^isLong}}{{^isInteger}}
+	{{paramName}} := {{#isListContainer}}strings.Split({{/isListContainer}}query.Get("{{paramName}}"){{#isListContainer}}, ","){{/isListContainer}}{{/isInteger}}{{/isLong}}{{/isQueryParam}}{{#isFormParam}}{{#isFile}}
 	{{paramName}}, err := ReadFormFileToTempFile(r, "{{paramName}}")
 	if err != nil {
 		w.WriteHeader(500)
 		return
 	}
 	{{/isFile}}{{#isLong}}
-	{{paramName}}, err := parseIntParameter( r.FormValue("{{paramName}}"))
+	{{paramName}}, err := parseInt64Parameter( r.FormValue("{{paramName}}"))
 	if err != nil {
 		w.WriteHeader(500)
 		return
 	}
-	{{/isLong}}{{^isFile}}{{^isLong}}
+	{{/isLong}}{{#isInteger}}
+	{{paramName}}, err := parseInt32Parameter( r.FormValue("{{paramName}}"))
+	if err != nil {
+		w.WriteHeader(500)
+		return
+	}
+	{{/isInteger}}{{^isFile}}{{^isLong}}
 	{{paramName}} := r.FormValue("{{paramName}}"){{/isLong}}{{/isFile}}{{/isFormParam}}{{#isHeaderParam}}
 	{{paramName}} := r.Header.Get("{{paramName}}"){{/isHeaderParam}}{{#isBodyParam}}
 	{{paramName}} := &{{dataType}}{}

--- a/modules/openapi-generator/src/main/resources/go-server/routers.mustache
+++ b/modules/openapi-generator/src/main/resources/go-server/routers.mustache
@@ -88,7 +88,16 @@ func ReadFormFileToTempFile(r *http.Request, key string) (*os.File, error) {
 	return file, nil
 }
 
-// parseIntParameter parses a sting parameter to an int64
-func parseIntParameter(param string) (int64, error) {
+// parseInt64Parameter parses a sting parameter to an int64
+func parseInt64Parameter(param string) (int64, error) {
 	return strconv.ParseInt(param, 10, 64)
+}
+
+// parseInt32Parameter parses a sting parameter to an int32
+func parseInt32Parameter(param string) (int32, error) {
+	val, err := strconv.ParseInt(param, 10, 32)
+	if err != nil {
+		return -1, err
+	}
+	return int32(val), nil
 }

--- a/samples/server/petstore/go-api-server/README.md
+++ b/samples/server/petstore/go-api-server/README.md
@@ -13,6 +13,7 @@ To see how to make this your own, look here:
 [README](https://openapi-generator.tech)
 
 - API version: 1.0.0
+- Build date: 2020-08-04T17:54:56.190+08:00[Asia/Hong_Kong]
 
 
 ### Running the server

--- a/samples/server/petstore/go-api-server/go/api_pet.go
+++ b/samples/server/petstore/go-api-server/go/api_pet.go
@@ -101,12 +101,11 @@ func (c *PetApiController) AddPet(w http.ResponseWriter, r *http.Request) {
 // DeletePet - Deletes a pet
 func (c *PetApiController) DeletePet(w http.ResponseWriter, r *http.Request) { 
 	params := mux.Vars(r)
-	petId, err := parseIntParameter(params["petId"])
+	petId, err := parseInt64Parameter(params["petId"])
 	if err != nil {
 		w.WriteHeader(500)
 		return
 	}
-	
 	apiKey := r.Header.Get("apiKey")
 	result, err := c.service.DeletePet(petId, apiKey)
 	if err != nil {
@@ -146,12 +145,11 @@ func (c *PetApiController) FindPetsByTags(w http.ResponseWriter, r *http.Request
 // GetPetById - Find pet by ID
 func (c *PetApiController) GetPetById(w http.ResponseWriter, r *http.Request) { 
 	params := mux.Vars(r)
-	petId, err := parseIntParameter(params["petId"])
+	petId, err := parseInt64Parameter(params["petId"])
 	if err != nil {
 		w.WriteHeader(500)
 		return
 	}
-	
 	result, err := c.service.GetPetById(petId)
 	if err != nil {
 		w.WriteHeader(500)
@@ -187,12 +185,11 @@ func (c *PetApiController) UpdatePetWithForm(w http.ResponseWriter, r *http.Requ
 	}
 	
 	params := mux.Vars(r)
-	petId, err := parseIntParameter(params["petId"])
+	petId, err := parseInt64Parameter(params["petId"])
 	if err != nil {
 		w.WriteHeader(500)
 		return
 	}
-	
 	name := r.FormValue("name")
 	status := r.FormValue("status")
 	result, err := c.service.UpdatePetWithForm(petId, name, status)
@@ -213,12 +210,11 @@ func (c *PetApiController) UploadFile(w http.ResponseWriter, r *http.Request) {
 	}
 	
 	params := mux.Vars(r)
-	petId, err := parseIntParameter(params["petId"])
+	petId, err := parseInt64Parameter(params["petId"])
 	if err != nil {
 		w.WriteHeader(500)
 		return
 	}
-	
 	additionalMetadata := r.FormValue("additionalMetadata")
 	file, err := ReadFormFileToTempFile(r, "file")
 	if err != nil {

--- a/samples/server/petstore/go-api-server/go/api_store.go
+++ b/samples/server/petstore/go-api-server/go/api_store.go
@@ -84,12 +84,11 @@ func (c *StoreApiController) GetInventory(w http.ResponseWriter, r *http.Request
 // GetOrderById - Find purchase order by ID
 func (c *StoreApiController) GetOrderById(w http.ResponseWriter, r *http.Request) { 
 	params := mux.Vars(r)
-	orderId, err := parseIntParameter(params["orderId"])
+	orderId, err := parseInt64Parameter(params["orderId"])
 	if err != nil {
 		w.WriteHeader(500)
 		return
 	}
-	
 	result, err := c.service.GetOrderById(orderId)
 	if err != nil {
 		w.WriteHeader(500)

--- a/samples/server/petstore/go-api-server/go/routers.go
+++ b/samples/server/petstore/go-api-server/go/routers.go
@@ -90,7 +90,16 @@ func ReadFormFileToTempFile(r *http.Request, key string) (*os.File, error) {
 	return file, nil
 }
 
-// parseIntParameter parses a sting parameter to an int64
-func parseIntParameter(param string) (int64, error) {
+// parseInt64Parameter parses a sting parameter to an int64
+func parseInt64Parameter(param string) (int64, error) {
 	return strconv.ParseInt(param, 10, 64)
+}
+
+// parseInt32Parameter parses a sting parameter to an int32
+func parseInt32Parameter(param string) (int32, error) {
+	val, err := strconv.ParseInt(param, 10, 32)
+	if err != nil {
+		return -1, err
+	}
+	return int32(val), nil
 }


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
