### PR TITLE
[docker] Update builder images, and change java:8 to openjdk:8

### DIFF
--- a/.hub.cli.dockerfile
+++ b/.hub.cli.dockerfile
@@ -3,10 +3,7 @@
 ##
 ## You can build _just_ this part with:
 ##     docker --target builder -t container-name:builder -f .hub.cli.dockerfile .
-FROM jimschubert/8-jdk-alpine-mvn:1.0 as builder
-
-RUN set -x && \
-    apk add --no-cache bash
+FROM jimschubert/8-jdk-alpine-mvn:bash-2.0 as builder
 
 ENV GEN_DIR /opt/openapi-generator
 WORKDIR ${GEN_DIR}

--- a/.hub.online.dockerfile
+++ b/.hub.online.dockerfile
@@ -3,10 +3,7 @@
 ##
 ## You can build _just_ this part with:
 ##     docker --target builder -t container-name:builder -f .hub.online.dockerfile .
-FROM jimschubert/8-jdk-alpine-mvn:1.0 as builder
-
-RUN set -x && \
-    apk add --no-cache bash
+FROM jimschubert/8-jdk-alpine-mvn:bash-2.0 as builder
 
 ENV GEN_DIR /opt/openapi-generator
 WORKDIR ${GEN_DIR}

--- a/modules/openapi-generator-cli/Dockerfile
+++ b/modules/openapi-generator-cli/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8-jre-alpine
+FROM openjdk:8-jre-alpine
 
 RUN apk add --no-cache bash
 


### PR DESCRIPTION
Related to #7001, this updates the images for CLI + Online to use the consistent base image of `openjdk:8-jre-alpine` (`java:8-*` is no longer maintained).

This also updates `.hub.cli.dockerfile` and `.hub.online.dockerfile` (which are used in our Docker Hub automated builds) to use my `jimschubert/8-jdk-alpine-mvn:bash-2.0` as the base builder image. This image is rebuilt weekly and has bash pre-installed in the image. This isn't a huge deal as it is a builder image and we don't have build slowness on Docker Hub, but it's best to stay up to date.

This _does not_ touch the Dockerfile discussed in #7001 because there's already work from a contributor there. Plus, that Dockerfile isn't used for anything other than local development. We don't have insight into how often people use that Dockerfile or whether they prefer it over `run-in-docker.sh` in the project root, which effectively does the same thing.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
