### PR TITLE
[Java][jaxrs] Add getter to ApiException templates

### DIFF
--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/ApiException.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/ApiException.mustache
@@ -1,10 +1,32 @@
 package {{apiPackage}};
 
+/**
+ * The exception that can be used to store the HTTP status code returned by an API response.
+ */
 {{>generatedAnnotation}}
-public class ApiException extends Exception{
+public class ApiException extends Exception {
+
+    /** The HTTP status code. */
     private int code;
-    public ApiException (int code, String msg) {
+
+    /**
+     * Constructor.
+     *
+     * @param code The HTTP status code.
+     * @param msg The error message.
+     */
+    public ApiException(int code, String msg) {
         super(msg);
         this.code = code;
     }
+
+    /**
+     * Get the HTTP status code.
+     *
+     * @return The HTTP status code.
+     */
+    public int getCode() {
+        return code;
+    }
+
 }

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy/ApiException.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy/ApiException.mustache
@@ -1,10 +1,32 @@
 package {{apiPackage}};
 
+/**
+ * The exception that can be used to store the HTTP status code returned by an API response.
+ */
 {{>generatedAnnotation}}
-public class ApiException extends Exception{
+public class ApiException extends Exception {
+
+    /** The HTTP status code. */
     private int code;
-    public ApiException (int code, String msg) {
+
+    /**
+     * Constructor.
+     *
+     * @param code The HTTP status code.
+     * @param msg The error message.
+     */
+    public ApiException(int code, String msg) {
         super(msg);
         this.code = code;
     }
+
+    /**
+     * Get the HTTP status code.
+     *
+     * @return The HTTP status code.
+     */
+    public int getCode() {
+        return code;
+    }
+
 }

--- a/modules/openapi-generator/src/main/resources/JavaSpring/apiException.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/apiException.mustache
@@ -1,10 +1,32 @@
 package {{apiPackage}};
 
+/**
+ * The exception that can be used to store the HTTP status code returned by an API response.
+ */
 {{>generatedAnnotation}}
-public class ApiException extends Exception{
+public class ApiException extends Exception {
+
+    /** The HTTP status code. */
     private int code;
-    public ApiException (int code, String msg) {
+
+    /**
+     * Constructor.
+     *
+     * @param code The HTTP status code.
+     * @param msg The error message.
+     */
+    public ApiException(int code, String msg) {
         super(msg);
         this.code = code;
     }
+
+    /**
+     * Get the HTTP status code.
+     *
+     * @return The HTTP status code.
+     */
+    public int getCode() {
+        return code;
+    }
+
 }

--- a/modules/openapi-generator/src/main/resources/java-msf4j-server/ApiException.mustache
+++ b/modules/openapi-generator/src/main/resources/java-msf4j-server/ApiException.mustache
@@ -1,10 +1,32 @@
 package {{apiPackage}};
 
+/**
+ * The exception that can be used to store the HTTP status code returned by an API response.
+ */
 {{>generatedAnnotation}}
-public class ApiException extends Exception{
+public class ApiException extends Exception {
+
+    /** The HTTP status code. */
     private int code;
-    public ApiException (int code, String msg) {
+
+    /**
+     * Constructor.
+     *
+     * @param code The HTTP status code.
+     * @param msg The error message.
+     */
+    public ApiException(int code, String msg) {
         super(msg);
         this.code = code;
     }
+
+    /**
+     * Get the HTTP status code.
+     *
+     * @return The HTTP status code.
+     */
+    public int getCode() {
+        return code;
+    }
+
 }

--- a/samples/server/petstore/java-msf4j/src/gen/java/org/openapitools/api/ApiException.java
+++ b/samples/server/petstore/java-msf4j/src/gen/java/org/openapitools/api/ApiException.java
@@ -1,10 +1,32 @@
 package org.openapitools.api;
 
+/**
+ * The exception that can be used to store the HTTP status code returned by an API response.
+ */
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaMSF4JServerCodegen")
-public class ApiException extends Exception{
+public class ApiException extends Exception {
+
+    /** The HTTP status code. */
     private int code;
-    public ApiException (int code, String msg) {
+
+    /**
+     * Constructor.
+     *
+     * @param code The HTTP status code.
+     * @param msg The error message.
+     */
+    public ApiException(int code, String msg) {
         super(msg);
         this.code = code;
     }
+
+    /**
+     * Get the HTTP status code.
+     *
+     * @return The HTTP status code.
+     */
+    public int getCode() {
+        return code;
+    }
+
 }

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/api/ApiException.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/api/ApiException.java
@@ -1,10 +1,32 @@
 package org.openapitools.api;
 
+/**
+ * The exception that can be used to store the HTTP status code returned by an API response.
+ */
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJerseyServerCodegen")
-public class ApiException extends Exception{
+public class ApiException extends Exception {
+
+    /** The HTTP status code. */
     private int code;
-    public ApiException (int code, String msg) {
+
+    /**
+     * Constructor.
+     *
+     * @param code The HTTP status code.
+     * @param msg The error message.
+     */
+    public ApiException(int code, String msg) {
         super(msg);
         this.code = code;
     }
+
+    /**
+     * Get the HTTP status code.
+     *
+     * @return The HTTP status code.
+     */
+    public int getCode() {
+        return code;
+    }
+
 }

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/api/ApiException.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/api/ApiException.java
@@ -1,10 +1,32 @@
 package org.openapitools.api;
 
+/**
+ * The exception that can be used to store the HTTP status code returned by an API response.
+ */
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJerseyServerCodegen")
-public class ApiException extends Exception{
+public class ApiException extends Exception {
+
+    /** The HTTP status code. */
     private int code;
-    public ApiException (int code, String msg) {
+
+    /**
+     * Constructor.
+     *
+     * @param code The HTTP status code.
+     * @param msg The error message.
+     */
+    public ApiException(int code, String msg) {
         super(msg);
         this.code = code;
     }
+
+    /**
+     * Get the HTTP status code.
+     *
+     * @return The HTTP status code.
+     */
+    public int getCode() {
+        return code;
+    }
+
 }

--- a/samples/server/petstore/jaxrs-resteasy/default/src/gen/java/org/openapitools/api/ApiException.java
+++ b/samples/server/petstore/jaxrs-resteasy/default/src/gen/java/org/openapitools/api/ApiException.java
@@ -1,10 +1,32 @@
 package org.openapitools.api;
 
+/**
+ * The exception that can be used to store the HTTP status code returned by an API response.
+ */
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaResteasyServerCodegen")
-public class ApiException extends Exception{
+public class ApiException extends Exception {
+
+    /** The HTTP status code. */
     private int code;
-    public ApiException (int code, String msg) {
+
+    /**
+     * Constructor.
+     *
+     * @param code The HTTP status code.
+     * @param msg The error message.
+     */
+    public ApiException(int code, String msg) {
         super(msg);
         this.code = code;
     }
+
+    /**
+     * Get the HTTP status code.
+     *
+     * @return The HTTP status code.
+     */
+    public int getCode() {
+        return code;
+    }
+
 }

--- a/samples/server/petstore/jaxrs-resteasy/joda/src/gen/java/org/openapitools/api/ApiException.java
+++ b/samples/server/petstore/jaxrs-resteasy/joda/src/gen/java/org/openapitools/api/ApiException.java
@@ -1,10 +1,32 @@
 package org.openapitools.api;
 
+/**
+ * The exception that can be used to store the HTTP status code returned by an API response.
+ */
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaResteasyServerCodegen")
-public class ApiException extends Exception{
+public class ApiException extends Exception {
+
+    /** The HTTP status code. */
     private int code;
-    public ApiException (int code, String msg) {
+
+    /**
+     * Constructor.
+     *
+     * @param code The HTTP status code.
+     * @param msg The error message.
+     */
+    public ApiException(int code, String msg) {
         super(msg);
         this.code = code;
     }
+
+    /**
+     * Get the HTTP status code.
+     *
+     * @return The HTTP status code.
+     */
+    public int getCode() {
+        return code;
+    }
+
 }

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/api/ApiException.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/api/ApiException.java
@@ -1,10 +1,32 @@
 package org.openapitools.api;
 
+/**
+ * The exception that can be used to store the HTTP status code returned by an API response.
+ */
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJerseyServerCodegen")
-public class ApiException extends Exception{
+public class ApiException extends Exception {
+
+    /** The HTTP status code. */
     private int code;
-    public ApiException (int code, String msg) {
+
+    /**
+     * Constructor.
+     *
+     * @param code The HTTP status code.
+     * @param msg The error message.
+     */
+    public ApiException(int code, String msg) {
         super(msg);
         this.code = code;
     }
+
+    /**
+     * Get the HTTP status code.
+     *
+     * @return The HTTP status code.
+     */
+    public int getCode() {
+        return code;
+    }
+
 }

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/api/ApiException.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/api/ApiException.java
@@ -1,10 +1,32 @@
 package org.openapitools.api;
 
+/**
+ * The exception that can be used to store the HTTP status code returned by an API response.
+ */
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJerseyServerCodegen")
-public class ApiException extends Exception{
+public class ApiException extends Exception {
+
+    /** The HTTP status code. */
     private int code;
-    public ApiException (int code, String msg) {
+
+    /**
+     * Constructor.
+     *
+     * @param code The HTTP status code.
+     * @param msg The error message.
+     */
+    public ApiException(int code, String msg) {
         super(msg);
         this.code = code;
     }
+
+    /**
+     * Get the HTTP status code.
+     *
+     * @return The HTTP status code.
+     */
+    public int getCode() {
+        return code;
+    }
+
 }

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/api/ApiException.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/api/ApiException.java
@@ -1,10 +1,32 @@
 package org.openapitools.api;
 
+/**
+ * The exception that can be used to store the HTTP status code returned by an API response.
+ */
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJerseyServerCodegen")
-public class ApiException extends Exception{
+public class ApiException extends Exception {
+
+    /** The HTTP status code. */
     private int code;
-    public ApiException (int code, String msg) {
+
+    /**
+     * Constructor.
+     *
+     * @param code The HTTP status code.
+     * @param msg The error message.
+     */
+    public ApiException(int code, String msg) {
         super(msg);
         this.code = code;
     }
+
+    /**
+     * Get the HTTP status code.
+     *
+     * @return The HTTP status code.
+     */
+    public int getCode() {
+        return code;
+    }
+
 }

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/api/ApiException.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/api/ApiException.java
@@ -1,10 +1,32 @@
 package org.openapitools.api;
 
+/**
+ * The exception that can be used to store the HTTP status code returned by an API response.
+ */
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJerseyServerCodegen")
-public class ApiException extends Exception{
+public class ApiException extends Exception {
+
+    /** The HTTP status code. */
     private int code;
-    public ApiException (int code, String msg) {
+
+    /**
+     * Constructor.
+     *
+     * @param code The HTTP status code.
+     * @param msg The error message.
+     */
+    public ApiException(int code, String msg) {
         super(msg);
         this.code = code;
     }
+
+    /**
+     * Get the HTTP status code.
+     *
+     * @return The HTTP status code.
+     */
+    public int getCode() {
+        return code;
+    }
+
 }


### PR DESCRIPTION
Fixes #6830 

Basically a few `ApiException` templates for Java servers were missing a getter for the `code` field.  
Before the fix the generated class was:

```java
package org.openapitools.api;

@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaResteasyServerCodegen", date = "2020-07-01T16:12:55.083+02:00[Europe/Paris]")
public class ApiException extends Exception{
    private int code;
    public ApiException (int code, String msg) {
        super(msg);
        this.code = code;
    }
}
```

With the fix it becomes:

```java
package org.openapitools.api;

@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaResteasyServerCodegen", date = "2020-08-06T22:46:58.073+02:00[Europe/Paris]")
public class ApiException extends Exception {

    private int code;

    public ApiException(int code, String msg) {
        super(msg);
        this.code = code;
    }

    public int getCode() {
        return code;
    }

}
```

### Validation

I compiled the `cli` jar and generated the new class with the same command as in the issue description, then compiled the generated code.

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

Technical committee: @bbdouglas @sreeshas  @jfiala  @lukoyanov @cbornet @jeff9finger @karismann @Zomzog @lwlee2608 @bkabrda