### PR TITLE
Add result in 500 status code

### DIFF
--- a/modules/openapi-generator/src/main/resources/go-server/controller-api.mustache
+++ b/modules/openapi-generator/src/main/resources/go-server/controller-api.mustache
@@ -95,7 +95,7 @@ func (c *{{classname}}Controller) {{nickname}}(w http.ResponseWriter, r *http.Re
 	result, err := c.service.{{nickname}}({{#allParams}}{{#isBodyParam}}*{{/isBodyParam}}{{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}})
 	if err != nil {
 		statusCode := 500
-		EncodeJSONResponse(result, &statusCode, w)
+		EncodeJSONResponse(err.Error(), &statusCode, w)
 		return
 	}
 	

--- a/modules/openapi-generator/src/main/resources/go-server/controller-api.mustache
+++ b/modules/openapi-generator/src/main/resources/go-server/controller-api.mustache
@@ -94,7 +94,8 @@ func (c *{{classname}}Controller) {{nickname}}(w http.ResponseWriter, r *http.Re
 	{{/isBodyParam}}{{/allParams}}
 	result, err := c.service.{{nickname}}({{#allParams}}{{#isBodyParam}}*{{/isBodyParam}}{{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}})
 	if err != nil {
-		w.WriteHeader(500)
+		statusCode := 500
+		EncodeJSONResponse(result, &statusCode, w)
 		return
 	}
 	

--- a/samples/server/petstore/go-api-server/.openapi-generator/VERSION
+++ b/samples/server/petstore/go-api-server/.openapi-generator/VERSION
@@ -1,1 +1,1 @@
-5.0.0-SNAPSHOT
+5.0.0-beta

--- a/samples/server/petstore/go-api-server/.openapi-generator/VERSION
+++ b/samples/server/petstore/go-api-server/.openapi-generator/VERSION
@@ -1,1 +1,1 @@
-5.0.0-beta
+5.0.0-SNAPSHOT

--- a/samples/server/petstore/go-api-server/go/api_pet.go
+++ b/samples/server/petstore/go-api-server/go/api_pet.go
@@ -92,7 +92,7 @@ func (c *PetApiController) AddPet(w http.ResponseWriter, r *http.Request) {
 	result, err := c.service.AddPet(*pet)
 	if err != nil {
 		statusCode := 500
-		EncodeJSONResponse(result, &statusCode, w)
+		EncodeJSONResponse(err.Error(), &statusCode, w)
 		return
 	}
 	
@@ -111,7 +111,7 @@ func (c *PetApiController) DeletePet(w http.ResponseWriter, r *http.Request) {
 	result, err := c.service.DeletePet(petId, apiKey)
 	if err != nil {
 		statusCode := 500
-		EncodeJSONResponse(result, &statusCode, w)
+		EncodeJSONResponse(err.Error(), &statusCode, w)
 		return
 	}
 	
@@ -125,7 +125,7 @@ func (c *PetApiController) FindPetsByStatus(w http.ResponseWriter, r *http.Reque
 	result, err := c.service.FindPetsByStatus(status)
 	if err != nil {
 		statusCode := 500
-		EncodeJSONResponse(result, &statusCode, w)
+		EncodeJSONResponse(err.Error(), &statusCode, w)
 		return
 	}
 	
@@ -139,7 +139,7 @@ func (c *PetApiController) FindPetsByTags(w http.ResponseWriter, r *http.Request
 	result, err := c.service.FindPetsByTags(tags)
 	if err != nil {
 		statusCode := 500
-		EncodeJSONResponse(result, &statusCode, w)
+		EncodeJSONResponse(err.Error(), &statusCode, w)
 		return
 	}
 	
@@ -157,7 +157,7 @@ func (c *PetApiController) GetPetById(w http.ResponseWriter, r *http.Request) {
 	result, err := c.service.GetPetById(petId)
 	if err != nil {
 		statusCode := 500
-		EncodeJSONResponse(result, &statusCode, w)
+		EncodeJSONResponse(err.Error(), &statusCode, w)
 		return
 	}
 	
@@ -175,7 +175,7 @@ func (c *PetApiController) UpdatePet(w http.ResponseWriter, r *http.Request) {
 	result, err := c.service.UpdatePet(*pet)
 	if err != nil {
 		statusCode := 500
-		EncodeJSONResponse(result, &statusCode, w)
+		EncodeJSONResponse(err.Error(), &statusCode, w)
 		return
 	}
 	
@@ -201,7 +201,7 @@ func (c *PetApiController) UpdatePetWithForm(w http.ResponseWriter, r *http.Requ
 	result, err := c.service.UpdatePetWithForm(petId, name, status)
 	if err != nil {
 		statusCode := 500
-		EncodeJSONResponse(result, &statusCode, w)
+		EncodeJSONResponse(err.Error(), &statusCode, w)
 		return
 	}
 	
@@ -232,7 +232,7 @@ func (c *PetApiController) UploadFile(w http.ResponseWriter, r *http.Request) {
 	result, err := c.service.UploadFile(petId, additionalMetadata, file)
 	if err != nil {
 		statusCode := 500
-		EncodeJSONResponse(result, &statusCode, w)
+		EncodeJSONResponse(err.Error(), &statusCode, w)
 		return
 	}
 	

--- a/samples/server/petstore/go-api-server/go/api_pet.go
+++ b/samples/server/petstore/go-api-server/go/api_pet.go
@@ -91,7 +91,8 @@ func (c *PetApiController) AddPet(w http.ResponseWriter, r *http.Request) {
 	
 	result, err := c.service.AddPet(*pet)
 	if err != nil {
-		w.WriteHeader(500)
+		statusCode := 500
+		EncodeJSONResponse(result, &statusCode, w)
 		return
 	}
 	
@@ -109,7 +110,8 @@ func (c *PetApiController) DeletePet(w http.ResponseWriter, r *http.Request) {
 	apiKey := r.Header.Get("apiKey")
 	result, err := c.service.DeletePet(petId, apiKey)
 	if err != nil {
-		w.WriteHeader(500)
+		statusCode := 500
+		EncodeJSONResponse(result, &statusCode, w)
 		return
 	}
 	
@@ -122,7 +124,8 @@ func (c *PetApiController) FindPetsByStatus(w http.ResponseWriter, r *http.Reque
 	status := strings.Split(query.Get("status"), ",")
 	result, err := c.service.FindPetsByStatus(status)
 	if err != nil {
-		w.WriteHeader(500)
+		statusCode := 500
+		EncodeJSONResponse(result, &statusCode, w)
 		return
 	}
 	
@@ -135,7 +138,8 @@ func (c *PetApiController) FindPetsByTags(w http.ResponseWriter, r *http.Request
 	tags := strings.Split(query.Get("tags"), ",")
 	result, err := c.service.FindPetsByTags(tags)
 	if err != nil {
-		w.WriteHeader(500)
+		statusCode := 500
+		EncodeJSONResponse(result, &statusCode, w)
 		return
 	}
 	
@@ -152,7 +156,8 @@ func (c *PetApiController) GetPetById(w http.ResponseWriter, r *http.Request) {
 	}
 	result, err := c.service.GetPetById(petId)
 	if err != nil {
-		w.WriteHeader(500)
+		statusCode := 500
+		EncodeJSONResponse(result, &statusCode, w)
 		return
 	}
 	
@@ -169,7 +174,8 @@ func (c *PetApiController) UpdatePet(w http.ResponseWriter, r *http.Request) {
 	
 	result, err := c.service.UpdatePet(*pet)
 	if err != nil {
-		w.WriteHeader(500)
+		statusCode := 500
+		EncodeJSONResponse(result, &statusCode, w)
 		return
 	}
 	
@@ -194,7 +200,8 @@ func (c *PetApiController) UpdatePetWithForm(w http.ResponseWriter, r *http.Requ
 	status := r.FormValue("status")
 	result, err := c.service.UpdatePetWithForm(petId, name, status)
 	if err != nil {
-		w.WriteHeader(500)
+		statusCode := 500
+		EncodeJSONResponse(result, &statusCode, w)
 		return
 	}
 	
@@ -224,7 +231,8 @@ func (c *PetApiController) UploadFile(w http.ResponseWriter, r *http.Request) {
 	
 	result, err := c.service.UploadFile(petId, additionalMetadata, file)
 	if err != nil {
-		w.WriteHeader(500)
+		statusCode := 500
+		EncodeJSONResponse(result, &statusCode, w)
 		return
 	}
 	

--- a/samples/server/petstore/go-api-server/go/api_store.go
+++ b/samples/server/petstore/go-api-server/go/api_store.go
@@ -64,7 +64,7 @@ func (c *StoreApiController) DeleteOrder(w http.ResponseWriter, r *http.Request)
 	result, err := c.service.DeleteOrder(orderId)
 	if err != nil {
 		statusCode := 500
-		EncodeJSONResponse(result, &statusCode, w)
+		EncodeJSONResponse(err.Error(), &statusCode, w)
 		return
 	}
 	
@@ -76,7 +76,7 @@ func (c *StoreApiController) GetInventory(w http.ResponseWriter, r *http.Request
 	result, err := c.service.GetInventory()
 	if err != nil {
 		statusCode := 500
-		EncodeJSONResponse(result, &statusCode, w)
+		EncodeJSONResponse(err.Error(), &statusCode, w)
 		return
 	}
 	
@@ -94,7 +94,7 @@ func (c *StoreApiController) GetOrderById(w http.ResponseWriter, r *http.Request
 	result, err := c.service.GetOrderById(orderId)
 	if err != nil {
 		statusCode := 500
-		EncodeJSONResponse(result, &statusCode, w)
+		EncodeJSONResponse(err.Error(), &statusCode, w)
 		return
 	}
 	
@@ -112,7 +112,7 @@ func (c *StoreApiController) PlaceOrder(w http.ResponseWriter, r *http.Request) 
 	result, err := c.service.PlaceOrder(*order)
 	if err != nil {
 		statusCode := 500
-		EncodeJSONResponse(result, &statusCode, w)
+		EncodeJSONResponse(err.Error(), &statusCode, w)
 		return
 	}
 	

--- a/samples/server/petstore/go-api-server/go/api_store.go
+++ b/samples/server/petstore/go-api-server/go/api_store.go
@@ -63,7 +63,8 @@ func (c *StoreApiController) DeleteOrder(w http.ResponseWriter, r *http.Request)
 	orderId := params["orderId"]
 	result, err := c.service.DeleteOrder(orderId)
 	if err != nil {
-		w.WriteHeader(500)
+		statusCode := 500
+		EncodeJSONResponse(result, &statusCode, w)
 		return
 	}
 	
@@ -74,7 +75,8 @@ func (c *StoreApiController) DeleteOrder(w http.ResponseWriter, r *http.Request)
 func (c *StoreApiController) GetInventory(w http.ResponseWriter, r *http.Request) { 
 	result, err := c.service.GetInventory()
 	if err != nil {
-		w.WriteHeader(500)
+		statusCode := 500
+		EncodeJSONResponse(result, &statusCode, w)
 		return
 	}
 	
@@ -91,7 +93,8 @@ func (c *StoreApiController) GetOrderById(w http.ResponseWriter, r *http.Request
 	}
 	result, err := c.service.GetOrderById(orderId)
 	if err != nil {
-		w.WriteHeader(500)
+		statusCode := 500
+		EncodeJSONResponse(result, &statusCode, w)
 		return
 	}
 	
@@ -108,7 +111,8 @@ func (c *StoreApiController) PlaceOrder(w http.ResponseWriter, r *http.Request) 
 	
 	result, err := c.service.PlaceOrder(*order)
 	if err != nil {
-		w.WriteHeader(500)
+		statusCode := 500
+		EncodeJSONResponse(result, &statusCode, w)
 		return
 	}
 	

--- a/samples/server/petstore/go-api-server/go/api_user.go
+++ b/samples/server/petstore/go-api-server/go/api_user.go
@@ -92,7 +92,7 @@ func (c *UserApiController) CreateUser(w http.ResponseWriter, r *http.Request) {
 	result, err := c.service.CreateUser(*user)
 	if err != nil {
 		statusCode := 500
-		EncodeJSONResponse(result, &statusCode, w)
+		EncodeJSONResponse(err.Error(), &statusCode, w)
 		return
 	}
 	
@@ -110,7 +110,7 @@ func (c *UserApiController) CreateUsersWithArrayInput(w http.ResponseWriter, r *
 	result, err := c.service.CreateUsersWithArrayInput(*user)
 	if err != nil {
 		statusCode := 500
-		EncodeJSONResponse(result, &statusCode, w)
+		EncodeJSONResponse(err.Error(), &statusCode, w)
 		return
 	}
 	
@@ -128,7 +128,7 @@ func (c *UserApiController) CreateUsersWithListInput(w http.ResponseWriter, r *h
 	result, err := c.service.CreateUsersWithListInput(*user)
 	if err != nil {
 		statusCode := 500
-		EncodeJSONResponse(result, &statusCode, w)
+		EncodeJSONResponse(err.Error(), &statusCode, w)
 		return
 	}
 	
@@ -142,7 +142,7 @@ func (c *UserApiController) DeleteUser(w http.ResponseWriter, r *http.Request) {
 	result, err := c.service.DeleteUser(username)
 	if err != nil {
 		statusCode := 500
-		EncodeJSONResponse(result, &statusCode, w)
+		EncodeJSONResponse(err.Error(), &statusCode, w)
 		return
 	}
 	
@@ -156,7 +156,7 @@ func (c *UserApiController) GetUserByName(w http.ResponseWriter, r *http.Request
 	result, err := c.service.GetUserByName(username)
 	if err != nil {
 		statusCode := 500
-		EncodeJSONResponse(result, &statusCode, w)
+		EncodeJSONResponse(err.Error(), &statusCode, w)
 		return
 	}
 	
@@ -171,7 +171,7 @@ func (c *UserApiController) LoginUser(w http.ResponseWriter, r *http.Request) {
 	result, err := c.service.LoginUser(username, password)
 	if err != nil {
 		statusCode := 500
-		EncodeJSONResponse(result, &statusCode, w)
+		EncodeJSONResponse(err.Error(), &statusCode, w)
 		return
 	}
 	
@@ -183,7 +183,7 @@ func (c *UserApiController) LogoutUser(w http.ResponseWriter, r *http.Request) {
 	result, err := c.service.LogoutUser()
 	if err != nil {
 		statusCode := 500
-		EncodeJSONResponse(result, &statusCode, w)
+		EncodeJSONResponse(err.Error(), &statusCode, w)
 		return
 	}
 	
@@ -203,7 +203,7 @@ func (c *UserApiController) UpdateUser(w http.ResponseWriter, r *http.Request) {
 	result, err := c.service.UpdateUser(username, *user)
 	if err != nil {
 		statusCode := 500
-		EncodeJSONResponse(result, &statusCode, w)
+		EncodeJSONResponse(err.Error(), &statusCode, w)
 		return
 	}
 	

--- a/samples/server/petstore/go-api-server/go/api_user.go
+++ b/samples/server/petstore/go-api-server/go/api_user.go
@@ -91,7 +91,8 @@ func (c *UserApiController) CreateUser(w http.ResponseWriter, r *http.Request) {
 	
 	result, err := c.service.CreateUser(*user)
 	if err != nil {
-		w.WriteHeader(500)
+		statusCode := 500
+		EncodeJSONResponse(result, &statusCode, w)
 		return
 	}
 	
@@ -108,7 +109,8 @@ func (c *UserApiController) CreateUsersWithArrayInput(w http.ResponseWriter, r *
 	
 	result, err := c.service.CreateUsersWithArrayInput(*user)
 	if err != nil {
-		w.WriteHeader(500)
+		statusCode := 500
+		EncodeJSONResponse(result, &statusCode, w)
 		return
 	}
 	
@@ -125,7 +127,8 @@ func (c *UserApiController) CreateUsersWithListInput(w http.ResponseWriter, r *h
 	
 	result, err := c.service.CreateUsersWithListInput(*user)
 	if err != nil {
-		w.WriteHeader(500)
+		statusCode := 500
+		EncodeJSONResponse(result, &statusCode, w)
 		return
 	}
 	
@@ -138,7 +141,8 @@ func (c *UserApiController) DeleteUser(w http.ResponseWriter, r *http.Request) {
 	username := params["username"]
 	result, err := c.service.DeleteUser(username)
 	if err != nil {
-		w.WriteHeader(500)
+		statusCode := 500
+		EncodeJSONResponse(result, &statusCode, w)
 		return
 	}
 	
@@ -151,7 +155,8 @@ func (c *UserApiController) GetUserByName(w http.ResponseWriter, r *http.Request
 	username := params["username"]
 	result, err := c.service.GetUserByName(username)
 	if err != nil {
-		w.WriteHeader(500)
+		statusCode := 500
+		EncodeJSONResponse(result, &statusCode, w)
 		return
 	}
 	
@@ -165,7 +170,8 @@ func (c *UserApiController) LoginUser(w http.ResponseWriter, r *http.Request) {
 	password := query.Get("password")
 	result, err := c.service.LoginUser(username, password)
 	if err != nil {
-		w.WriteHeader(500)
+		statusCode := 500
+		EncodeJSONResponse(result, &statusCode, w)
 		return
 	}
 	
@@ -176,7 +182,8 @@ func (c *UserApiController) LoginUser(w http.ResponseWriter, r *http.Request) {
 func (c *UserApiController) LogoutUser(w http.ResponseWriter, r *http.Request) { 
 	result, err := c.service.LogoutUser()
 	if err != nil {
-		w.WriteHeader(500)
+		statusCode := 500
+		EncodeJSONResponse(result, &statusCode, w)
 		return
 	}
 	
@@ -195,7 +202,8 @@ func (c *UserApiController) UpdateUser(w http.ResponseWriter, r *http.Request) {
 	
 	result, err := c.service.UpdateUser(username, *user)
 	if err != nil {
-		w.WriteHeader(500)
+		statusCode := 500
+		EncodeJSONResponse(result, &statusCode, w)
 		return
 	}
 	


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
Hi, in the Go server, we can only have Status code 200 or 500 wether our implementation function return an error or not.

In case or error (err!=nil), the server write the status code 500 without any messages .



```
result, err := c.service.AddPet(*pet)
	if err != nil {
		w.WriteHeader(500)
		return
	}	
	EncodeJSONResponse(result, nil, w)
```

In many cases, their can be several types of error in our implementation, and i wouldlike to return the  error message to the client.
I suggest to Encode the response with the result variable, with the statuscode 500, which will let us write responses in case of error.

```
        if err != nil {
		statusCode := 500
		EncodeJSONResponse(result, &statusCode, w)
		return
	}

```


@antihax (2017/11) @grokify (2018/07) @kemokemo (2018/09) @bkabrda (2019/07) @wing328 

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
