### PR TITLE
[csharp-netcore] Adding response headers to the ApiException

### DIFF
--- a/modules/openapi-generator/src/main/resources/csharp-netcore/ApiException.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/ApiException.mustache
@@ -22,6 +22,12 @@ namespace {{packageName}}.Client
         public object ErrorContent { get; private set; }
 
         /// <summary>
+        /// Gets or sets the HTTP headers
+        /// </summary>
+        /// <value>HTTP headers</value>
+        public Multimap<string, string> Headers { get; private set; }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="ApiException"/> class.
         /// </summary>
         public ApiException() {}
@@ -42,10 +48,12 @@ namespace {{packageName}}.Client
         /// <param name="errorCode">HTTP status code.</param>
         /// <param name="message">Error message.</param>
         /// <param name="errorContent">Error content.</param>
-        public ApiException(int errorCode, string message, object errorContent = null) : base(message)
+        /// <param name="headers">HTTP Headers.</param>
+        public ApiException(int errorCode, string message, object errorContent = null, Multimap<string, string> headers =  null) : base(message)
         {
             this.ErrorCode = errorCode;
             this.ErrorContent = errorContent;
+            this.Headers = headers;
         }
     }
 

--- a/modules/openapi-generator/src/main/resources/csharp-netcore/Configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/Configuration.mustache
@@ -47,7 +47,7 @@ namespace {{packageName}}.Client
             {
                 return new ApiException(status,
                     string.Format("Error calling {0}: {1}", methodName, response.RawContent),
-                    response.RawContent);
+                    response.RawContent, response.Headers);
             }
             {{^netStandard}}if (status == 0)
             {

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Client/ApiException.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Client/ApiException.cs
@@ -31,6 +31,12 @@ namespace Org.OpenAPITools.Client
         public object ErrorContent { get; private set; }
 
         /// <summary>
+        /// Gets or sets the HTTP headers
+        /// </summary>
+        /// <value>HTTP headers</value>
+        public Multimap<string, string> Headers { get; private set; }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="ApiException"/> class.
         /// </summary>
         public ApiException() {}
@@ -51,10 +57,12 @@ namespace Org.OpenAPITools.Client
         /// <param name="errorCode">HTTP status code.</param>
         /// <param name="message">Error message.</param>
         /// <param name="errorContent">Error content.</param>
-        public ApiException(int errorCode, string message, object errorContent = null) : base(message)
+        /// <param name="headers">HTTP Headers.</param>
+        public ApiException(int errorCode, string message, object errorContent = null, Multimap<string, string> headers =  null) : base(message)
         {
             this.ErrorCode = errorCode;
             this.ErrorContent = errorContent;
+            this.Headers = headers;
         }
     }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Client/Configuration.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Client/Configuration.cs
@@ -54,7 +54,7 @@ namespace Org.OpenAPITools.Client
             {
                 return new ApiException(status,
                     string.Format("Error calling {0}: {1}", methodName, response.RawContent),
-                    response.RawContent);
+                    response.RawContent, response.Headers);
             }
             
             return null;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Client/ApiException.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Client/ApiException.cs
@@ -31,6 +31,12 @@ namespace Org.OpenAPITools.Client
         public object ErrorContent { get; private set; }
 
         /// <summary>
+        /// Gets or sets the HTTP headers
+        /// </summary>
+        /// <value>HTTP headers</value>
+        public Multimap<string, string> Headers { get; private set; }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="ApiException"/> class.
         /// </summary>
         public ApiException() {}
@@ -51,10 +57,12 @@ namespace Org.OpenAPITools.Client
         /// <param name="errorCode">HTTP status code.</param>
         /// <param name="message">Error message.</param>
         /// <param name="errorContent">Error content.</param>
-        public ApiException(int errorCode, string message, object errorContent = null) : base(message)
+        /// <param name="headers">HTTP Headers.</param>
+        public ApiException(int errorCode, string message, object errorContent = null, Multimap<string, string> headers =  null) : base(message)
         {
             this.ErrorCode = errorCode;
             this.ErrorContent = errorContent;
+            this.Headers = headers;
         }
     }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Client/Configuration.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Client/Configuration.cs
@@ -54,7 +54,7 @@ namespace Org.OpenAPITools.Client
             {
                 return new ApiException(status,
                     string.Format("Error calling {0}: {1}", methodName, response.RawContent),
-                    response.RawContent);
+                    response.RawContent, response.Headers);
             }
             if (status == 0)
             {


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

* Adding HTTP response headers to the ApiException.
<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@mandrean (2017/08) @frankyjuang (2019/09) @shibayan (2020/02)