### PR TITLE
[JS] Fix paramToString handling for non primitive types

### DIFF
--- a/modules/openapi-generator/src/main/resources/Javascript/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Javascript/ApiClient.mustache
@@ -119,7 +119,26 @@
     if (param instanceof Date) {
       return param.toJSON();
     }
+    if (this.canBeJsonified(param)) {
+      return JSON.stringify(param);
+    }
     return param.toString();
+  };
+
+{{#emitJSDoc}}  /**
+    * Returns a boolean indicating if the parameter could be JSON.stringified
+    * @param param The actual parameter
+    * @returns {Boolean} Flag indicating if <code>param</code> can be JSON.stringified
+    */
+{{/emitJSDoc}}  exports.prototype.canBeJsonified = function(str) {
+    if (typeof str !== 'string' && typeof str !== 'object') return false;
+    try {
+      const type = str.toString();
+      return type === '[object Object]'
+          || type === '[object Array]';
+    } catch (err) {
+      return false;
+    }
   };
 
 {{#emitJSDoc}}

--- a/modules/openapi-generator/src/main/resources/Javascript/es6/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Javascript/es6/ApiClient.mustache
@@ -108,9 +108,28 @@ class ApiClient {
         if (param instanceof Date) {
             return param.toJSON();
         }
+        if (ApiClient.canBeJsonified(param)) {
+            return JSON.stringify(param);
+        }
 
         return param.toString();
     }
+
+    {{#emitJSDoc}}/**
+    * Returns a boolean indicating if the parameter could be JSON.stringified
+    * @param param The actual parameter
+    * @returns {Boolean} Flag indicating if <code>param</code> can be JSON.stringified
+    */{{/emitJSDoc}}
+    static canBeJsonified(str) {
+        if (typeof str !== 'string' && typeof str !== 'object') return false;
+        try {
+            const type = str.toString();
+            return type === '[object Object]'
+                || type === '[object Array]';
+        } catch (err) {
+            return false;
+        }
+    };
 
     {{#emitJSDoc}}
    /**

--- a/samples/client/petstore/javascript-es6/src/ApiClient.js
+++ b/samples/client/petstore/javascript-es6/src/ApiClient.js
@@ -109,9 +109,28 @@ class ApiClient {
         if (param instanceof Date) {
             return param.toJSON();
         }
+        if (ApiClient.canBeJsonified(param)) {
+            return JSON.stringify(param);
+        }
 
         return param.toString();
     }
+
+    /**
+    * Returns a boolean indicating if the parameter could be JSON.stringified
+    * @param param The actual parameter
+    * @returns {Boolean} Flag indicating if <code>param</code> can be JSON.stringified
+    */
+    static canBeJsonified(str) {
+        if (typeof str !== 'string' && typeof str !== 'object') return false;
+        try {
+            const type = str.toString();
+            return type === '[object Object]'
+                || type === '[object Array]';
+        } catch (err) {
+            return false;
+        }
+    };
 
    /**
     * Builds full URL by appending the given path to the base URL and replacing path parameter place-holders with parameter values.

--- a/samples/client/petstore/javascript-promise-es6/src/ApiClient.js
+++ b/samples/client/petstore/javascript-promise-es6/src/ApiClient.js
@@ -109,9 +109,28 @@ class ApiClient {
         if (param instanceof Date) {
             return param.toJSON();
         }
+        if (ApiClient.canBeJsonified(param)) {
+            return JSON.stringify(param);
+        }
 
         return param.toString();
     }
+
+    /**
+    * Returns a boolean indicating if the parameter could be JSON.stringified
+    * @param param The actual parameter
+    * @returns {Boolean} Flag indicating if <code>param</code> can be JSON.stringified
+    */
+    static canBeJsonified(str) {
+        if (typeof str !== 'string' && typeof str !== 'object') return false;
+        try {
+            const type = str.toString();
+            return type === '[object Object]'
+                || type === '[object Array]';
+        } catch (err) {
+            return false;
+        }
+    };
 
    /**
     * Builds full URL by appending the given path to the base URL and replacing path parameter place-holders with parameter values.


### PR DESCRIPTION
Fixing the handling of non primitive types in paramToString (#7171)

Small change adding a helper method that checks if a parameter could be JSON-ified then modified paramToString to use JSON.stringify if the helper returns true.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [X] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [X] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

cc @CodeNinjai @frol @cliffano @wing328