### PR TITLE
[Typescript] Import path is invalid in windows.

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptClientCodegen.java
@@ -295,7 +295,7 @@ public class TypeScriptClientCodegen extends DefaultCodegen implements CodegenCo
         // Add additional filename information for model imports in the apis
         List<Map<String, Object>> imports = (List<Map<String, Object>>) operations.get("imports");
         for (Map<String, Object> im : imports) {
-            im.put("filename", ((String) im.get("import")).replace(".", File.separator));
+            im.put("filename", ((String) im.get("import")).replace(".", "/"));
             im.put("classname", getModelnameFromModelFilename(im.get("import").toString()));
         }
         


### PR DESCRIPTION
Fixes #7174. Please review.

Use `/` instead of `File.Separator`. `File.Separator` is `/` in Windows.

A target method is `postProcessOperationsWithModels` of openapi-generator\modules\openapi-generator\src\main\java\org\openapitools\codegen\languages\TypeScriptClientCodegen.java.

Before
```java
im.put("filename", ((String) im.get("import")).replace(".", File.Separator));
```

After
```java
im.put("filename", ((String) im.get("import")).replace(".", "/"));
```

By this, OpenAPI generator generated valid import path in typescript.

Expected Code
```typescript
import { Pet } from '../models/Pet';
```

Actual Code
```typescript
import { Pet } from '..\models\Pet';
```
