### PR TITLE
[Typescript-redux-query] Fix issue on api template when we have non empty header

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-redux-query/apis.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-redux-query/apis.mustache
@@ -3,7 +3,7 @@
 
 import { HttpMethods, QueryConfig, ResponseBody, ResponseText } from 'redux-query';
 import * as runtime from '../runtime';
-
+import { HttpHeaders } from '../../runtime';
 {{#imports.0}}
 import {
     {{#imports}}

--- a/modules/openapi-generator/src/main/resources/typescript-redux-query/apis.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-redux-query/apis.mustache
@@ -82,7 +82,7 @@ function {{nickname}}Raw<T>({{#allParams.0}}requestParameters: {{operationIdCame
 
     {{/isListContainer}}
     {{/queryParams}}
-    const headerParameters = {};
+    const headerParameters : HttpHeaders = {};
 
     {{#bodyParam}}
     {{^consumes}}

--- a/modules/openapi-generator/src/main/resources/typescript-redux-query/apis.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-redux-query/apis.mustache
@@ -3,7 +3,6 @@
 
 import { HttpMethods, QueryConfig, ResponseBody, ResponseText } from 'redux-query';
 import * as runtime from '../runtime';
-import { HttpHeaders } from '../../runtime';
 {{#imports.0}}
 import {
     {{#imports}}
@@ -82,7 +81,7 @@ function {{nickname}}Raw<T>({{#allParams.0}}requestParameters: {{operationIdCame
 
     {{/isListContainer}}
     {{/queryParams}}
-    const headerParameters : HttpHeaders = {};
+    const headerParameters : runtime.HttpHeaders = {};
 
     {{#bodyParam}}
     {{^consumes}}

--- a/modules/openapi-generator/src/main/resources/typescript-redux-query/runtime.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-redux-query/runtime.mustache
@@ -33,6 +33,8 @@ export const COLLECTION_FORMATS = {
 
 export type ModelPropertyNaming = 'camelCase' | 'snake_case' | 'PascalCase' | 'original';
 
+export type HttpHeaders = { [key: string]: string };
+
 export function exists(json: any, key: string) {
     const value = json[key];
     return value !== null && value !== undefined;

--- a/samples/client/petstore/typescript-redux-query/builds/with-npm-version/src/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-redux-query/builds/with-npm-version/src/apis/PetApi.ts
@@ -73,7 +73,7 @@ function addPetRaw<T>(requestParameters: AddPetRequest, requestConfig: runtime.T
     let queryParameters = null;
 
 
-    const headerParameters = {};
+        const headerParameters : runtime.HttpHeaders = {};
 
     headerParameters['Content-Type'] = 'application/json';
 
@@ -121,7 +121,7 @@ function deletePetRaw<T>(requestParameters: DeletePetRequest, requestConfig: run
     let queryParameters = null;
 
 
-    const headerParameters = {};
+        const headerParameters : runtime.HttpHeaders = {};
 
     if (requestParameters.apiKey !== undefined && requestParameters.apiKey !== null) {
         headerParameters['api_key'] = String(requestParameters.apiKey);
@@ -178,7 +178,7 @@ function findPetsByStatusRaw<T>(requestParameters: FindPetsByStatusRequest, requ
         queryParameters['status'] = requestParameters.status.join(runtime.COLLECTION_FORMATS["csv"]);
     }
 
-    const headerParameters = {};
+        const headerParameters : runtime.HttpHeaders = {};
 
 
     const { meta = {} } = requestConfig;
@@ -233,7 +233,7 @@ function findPetsByTagsRaw<T>(requestParameters: FindPetsByTagsRequest, requestC
         queryParameters['tags'] = requestParameters.tags.join(runtime.COLLECTION_FORMATS["csv"]);
     }
 
-    const headerParameters = {};
+        const headerParameters : runtime.HttpHeaders = {};
 
 
     const { meta = {} } = requestConfig;
@@ -282,7 +282,7 @@ function getPetByIdRaw<T>(requestParameters: GetPetByIdRequest, requestConfig: r
     let queryParameters = null;
 
 
-    const headerParameters = {};
+        const headerParameters : runtime.HttpHeaders = {};
 
 
     const { meta = {} } = requestConfig;
@@ -330,7 +330,7 @@ function updatePetRaw<T>(requestParameters: UpdatePetRequest, requestConfig: run
     let queryParameters = null;
 
 
-    const headerParameters = {};
+        const headerParameters : runtime.HttpHeaders = {};
 
     headerParameters['Content-Type'] = 'application/json';
 
@@ -378,7 +378,7 @@ function updatePetWithFormRaw<T>(requestParameters: UpdatePetWithFormRequest, re
     let queryParameters = null;
 
 
-    const headerParameters = {};
+        const headerParameters : runtime.HttpHeaders = {};
 
 
     const { meta = {} } = requestConfig;
@@ -433,7 +433,7 @@ function uploadFileRaw<T>(requestParameters: UploadFileRequest, requestConfig: r
     let queryParameters = null;
 
 
-    const headerParameters = {};
+        const headerParameters : runtime.HttpHeaders = {};
 
 
     const { meta = {} } = requestConfig;

--- a/samples/client/petstore/typescript-redux-query/builds/with-npm-version/src/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-redux-query/builds/with-npm-version/src/apis/PetApi.ts
@@ -14,7 +14,6 @@
 
 import { HttpMethods, QueryConfig, ResponseBody, ResponseText } from 'redux-query';
 import * as runtime from '../runtime';
-
 import {
     ModelApiResponse,
     ModelApiResponseFromJSON,
@@ -73,7 +72,7 @@ function addPetRaw<T>(requestParameters: AddPetRequest, requestConfig: runtime.T
     let queryParameters = null;
 
 
-        const headerParameters : runtime.HttpHeaders = {};
+    const headerParameters : runtime.HttpHeaders = {};
 
     headerParameters['Content-Type'] = 'application/json';
 
@@ -121,7 +120,7 @@ function deletePetRaw<T>(requestParameters: DeletePetRequest, requestConfig: run
     let queryParameters = null;
 
 
-        const headerParameters : runtime.HttpHeaders = {};
+    const headerParameters : runtime.HttpHeaders = {};
 
     if (requestParameters.apiKey !== undefined && requestParameters.apiKey !== null) {
         headerParameters['api_key'] = String(requestParameters.apiKey);
@@ -178,7 +177,7 @@ function findPetsByStatusRaw<T>(requestParameters: FindPetsByStatusRequest, requ
         queryParameters['status'] = requestParameters.status.join(runtime.COLLECTION_FORMATS["csv"]);
     }
 
-        const headerParameters : runtime.HttpHeaders = {};
+    const headerParameters : runtime.HttpHeaders = {};
 
 
     const { meta = {} } = requestConfig;
@@ -233,7 +232,7 @@ function findPetsByTagsRaw<T>(requestParameters: FindPetsByTagsRequest, requestC
         queryParameters['tags'] = requestParameters.tags.join(runtime.COLLECTION_FORMATS["csv"]);
     }
 
-        const headerParameters : runtime.HttpHeaders = {};
+    const headerParameters : runtime.HttpHeaders = {};
 
 
     const { meta = {} } = requestConfig;
@@ -282,7 +281,7 @@ function getPetByIdRaw<T>(requestParameters: GetPetByIdRequest, requestConfig: r
     let queryParameters = null;
 
 
-        const headerParameters : runtime.HttpHeaders = {};
+    const headerParameters : runtime.HttpHeaders = {};
 
 
     const { meta = {} } = requestConfig;
@@ -330,7 +329,7 @@ function updatePetRaw<T>(requestParameters: UpdatePetRequest, requestConfig: run
     let queryParameters = null;
 
 
-        const headerParameters : runtime.HttpHeaders = {};
+    const headerParameters : runtime.HttpHeaders = {};
 
     headerParameters['Content-Type'] = 'application/json';
 
@@ -378,7 +377,7 @@ function updatePetWithFormRaw<T>(requestParameters: UpdatePetWithFormRequest, re
     let queryParameters = null;
 
 
-        const headerParameters : runtime.HttpHeaders = {};
+    const headerParameters : runtime.HttpHeaders = {};
 
 
     const { meta = {} } = requestConfig;
@@ -433,7 +432,7 @@ function uploadFileRaw<T>(requestParameters: UploadFileRequest, requestConfig: r
     let queryParameters = null;
 
 
-        const headerParameters : runtime.HttpHeaders = {};
+    const headerParameters : runtime.HttpHeaders = {};
 
 
     const { meta = {} } = requestConfig;

--- a/samples/client/petstore/typescript-redux-query/builds/with-npm-version/src/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript-redux-query/builds/with-npm-version/src/apis/StoreApi.ts
@@ -46,7 +46,7 @@ function deleteOrderRaw<T>(requestParameters: DeleteOrderRequest, requestConfig:
     let queryParameters = null;
 
 
-    const headerParameters = {};
+        const headerParameters : runtime.HttpHeaders = {};
 
 
     const { meta = {} } = requestConfig;
@@ -89,7 +89,7 @@ function getInventoryRaw<T>( requestConfig: runtime.TypedQueryConfig<T, { [key: 
     let queryParameters = null;
 
 
-    const headerParameters = {};
+        const headerParameters : runtime.HttpHeaders = {};
 
 
     const { meta = {} } = requestConfig;
@@ -137,7 +137,7 @@ function getOrderByIdRaw<T>(requestParameters: GetOrderByIdRequest, requestConfi
     let queryParameters = null;
 
 
-    const headerParameters = {};
+        const headerParameters : runtime.HttpHeaders = {};
 
 
     const { meta = {} } = requestConfig;
@@ -184,7 +184,7 @@ function placeOrderRaw<T>(requestParameters: PlaceOrderRequest, requestConfig: r
     let queryParameters = null;
 
 
-    const headerParameters = {};
+        const headerParameters : runtime.HttpHeaders = {};
 
     headerParameters['Content-Type'] = 'application/json';
 

--- a/samples/client/petstore/typescript-redux-query/builds/with-npm-version/src/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript-redux-query/builds/with-npm-version/src/apis/StoreApi.ts
@@ -14,7 +14,6 @@
 
 import { HttpMethods, QueryConfig, ResponseBody, ResponseText } from 'redux-query';
 import * as runtime from '../runtime';
-
 import {
     Order,
     OrderFromJSON,
@@ -46,7 +45,7 @@ function deleteOrderRaw<T>(requestParameters: DeleteOrderRequest, requestConfig:
     let queryParameters = null;
 
 
-        const headerParameters : runtime.HttpHeaders = {};
+    const headerParameters : runtime.HttpHeaders = {};
 
 
     const { meta = {} } = requestConfig;
@@ -89,7 +88,7 @@ function getInventoryRaw<T>( requestConfig: runtime.TypedQueryConfig<T, { [key: 
     let queryParameters = null;
 
 
-        const headerParameters : runtime.HttpHeaders = {};
+    const headerParameters : runtime.HttpHeaders = {};
 
 
     const { meta = {} } = requestConfig;
@@ -137,7 +136,7 @@ function getOrderByIdRaw<T>(requestParameters: GetOrderByIdRequest, requestConfi
     let queryParameters = null;
 
 
-        const headerParameters : runtime.HttpHeaders = {};
+    const headerParameters : runtime.HttpHeaders = {};
 
 
     const { meta = {} } = requestConfig;
@@ -184,7 +183,7 @@ function placeOrderRaw<T>(requestParameters: PlaceOrderRequest, requestConfig: r
     let queryParameters = null;
 
 
-        const headerParameters : runtime.HttpHeaders = {};
+    const headerParameters : runtime.HttpHeaders = {};
 
     headerParameters['Content-Type'] = 'application/json';
 

--- a/samples/client/petstore/typescript-redux-query/builds/with-npm-version/src/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-redux-query/builds/with-npm-version/src/apis/UserApi.ts
@@ -14,7 +14,6 @@
 
 import { HttpMethods, QueryConfig, ResponseBody, ResponseText } from 'redux-query';
 import * as runtime from '../runtime';
-
 import {
     User,
     UserFromJSON,
@@ -64,7 +63,7 @@ function createUserRaw<T>(requestParameters: CreateUserRequest, requestConfig: r
     let queryParameters = null;
 
 
-        const headerParameters : runtime.HttpHeaders = {};
+    const headerParameters : runtime.HttpHeaders = {};
 
     headerParameters['Content-Type'] = 'application/json';
 
@@ -112,7 +111,7 @@ function createUsersWithArrayInputRaw<T>(requestParameters: CreateUsersWithArray
     let queryParameters = null;
 
 
-        const headerParameters : runtime.HttpHeaders = {};
+    const headerParameters : runtime.HttpHeaders = {};
 
     headerParameters['Content-Type'] = 'application/json';
 
@@ -159,7 +158,7 @@ function createUsersWithListInputRaw<T>(requestParameters: CreateUsersWithListIn
     let queryParameters = null;
 
 
-        const headerParameters : runtime.HttpHeaders = {};
+    const headerParameters : runtime.HttpHeaders = {};
 
     headerParameters['Content-Type'] = 'application/json';
 
@@ -207,7 +206,7 @@ function deleteUserRaw<T>(requestParameters: DeleteUserRequest, requestConfig: r
     let queryParameters = null;
 
 
-        const headerParameters : runtime.HttpHeaders = {};
+    const headerParameters : runtime.HttpHeaders = {};
 
 
     const { meta = {} } = requestConfig;
@@ -253,7 +252,7 @@ function getUserByNameRaw<T>(requestParameters: GetUserByNameRequest, requestCon
     let queryParameters = null;
 
 
-        const headerParameters : runtime.HttpHeaders = {};
+    const headerParameters : runtime.HttpHeaders = {};
 
 
     const { meta = {} } = requestConfig;
@@ -314,7 +313,7 @@ function loginUserRaw<T>(requestParameters: LoginUserRequest, requestConfig: run
         queryParameters['password'] = requestParameters.password;
     }
 
-        const headerParameters : runtime.HttpHeaders = {};
+    const headerParameters : runtime.HttpHeaders = {};
 
 
     const { meta = {} } = requestConfig;
@@ -356,7 +355,7 @@ function logoutUserRaw<T>( requestConfig: runtime.TypedQueryConfig<T, void> = {}
     let queryParameters = null;
 
 
-        const headerParameters : runtime.HttpHeaders = {};
+    const headerParameters : runtime.HttpHeaders = {};
 
 
     const { meta = {} } = requestConfig;
@@ -406,7 +405,7 @@ function updateUserRaw<T>(requestParameters: UpdateUserRequest, requestConfig: r
     let queryParameters = null;
 
 
-        const headerParameters : runtime.HttpHeaders = {};
+    const headerParameters : runtime.HttpHeaders = {};
 
     headerParameters['Content-Type'] = 'application/json';
 

--- a/samples/client/petstore/typescript-redux-query/builds/with-npm-version/src/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-redux-query/builds/with-npm-version/src/apis/UserApi.ts
@@ -64,7 +64,7 @@ function createUserRaw<T>(requestParameters: CreateUserRequest, requestConfig: r
     let queryParameters = null;
 
 
-    const headerParameters = {};
+        const headerParameters : runtime.HttpHeaders = {};
 
     headerParameters['Content-Type'] = 'application/json';
 
@@ -112,7 +112,7 @@ function createUsersWithArrayInputRaw<T>(requestParameters: CreateUsersWithArray
     let queryParameters = null;
 
 
-    const headerParameters = {};
+        const headerParameters : runtime.HttpHeaders = {};
 
     headerParameters['Content-Type'] = 'application/json';
 
@@ -159,7 +159,7 @@ function createUsersWithListInputRaw<T>(requestParameters: CreateUsersWithListIn
     let queryParameters = null;
 
 
-    const headerParameters = {};
+        const headerParameters : runtime.HttpHeaders = {};
 
     headerParameters['Content-Type'] = 'application/json';
 
@@ -207,7 +207,7 @@ function deleteUserRaw<T>(requestParameters: DeleteUserRequest, requestConfig: r
     let queryParameters = null;
 
 
-    const headerParameters = {};
+        const headerParameters : runtime.HttpHeaders = {};
 
 
     const { meta = {} } = requestConfig;
@@ -253,7 +253,7 @@ function getUserByNameRaw<T>(requestParameters: GetUserByNameRequest, requestCon
     let queryParameters = null;
 
 
-    const headerParameters = {};
+        const headerParameters : runtime.HttpHeaders = {};
 
 
     const { meta = {} } = requestConfig;
@@ -314,7 +314,7 @@ function loginUserRaw<T>(requestParameters: LoginUserRequest, requestConfig: run
         queryParameters['password'] = requestParameters.password;
     }
 
-    const headerParameters = {};
+        const headerParameters : runtime.HttpHeaders = {};
 
 
     const { meta = {} } = requestConfig;
@@ -356,7 +356,7 @@ function logoutUserRaw<T>( requestConfig: runtime.TypedQueryConfig<T, void> = {}
     let queryParameters = null;
 
 
-    const headerParameters = {};
+        const headerParameters : runtime.HttpHeaders = {};
 
 
     const { meta = {} } = requestConfig;
@@ -406,7 +406,7 @@ function updateUserRaw<T>(requestParameters: UpdateUserRequest, requestConfig: r
     let queryParameters = null;
 
 
-    const headerParameters = {};
+        const headerParameters : runtime.HttpHeaders = {};
 
     headerParameters['Content-Type'] = 'application/json';
 

--- a/samples/client/petstore/typescript-redux-query/builds/with-npm-version/src/runtime.ts
+++ b/samples/client/petstore/typescript-redux-query/builds/with-npm-version/src/runtime.ts
@@ -44,6 +44,8 @@ export const COLLECTION_FORMATS = {
 
 export type ModelPropertyNaming = 'camelCase' | 'snake_case' | 'PascalCase' | 'original';
 
+export type HttpHeaders = { [key: string]: string };
+
 export function exists(json: any, key: string) {
     const value = json[key];
     return value !== null && value !== undefined;


### PR DESCRIPTION
Hi, 
When we generate the code with typescript-redux-query template the code has an issue when we have anything in the header with this error : 
 

> Element implicitly has an 'any' type because expression of type '"Content-Type"' can't be used to index type '{}'.
>   Property 'Content-Type' does not exist on type '{}'

to fix this i just added a httpheader type on the object headerParameters

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
