### PR TITLE
[typescript-redux-query]fixed array requests

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-redux-query/apis.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-redux-query/apis.mustache
@@ -19,7 +19,7 @@ import {
 {{#allParams.0}}
 export interface {{operationIdCamelCase}}Request {
     {{#allParams}}
-    {{paramName}}{{^required}}{{^isListContainer}}?{{/isListContainer}}{{/required}}: {{#isEnum}}{{{datatypeWithEnum}}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}};
+    {{paramName}}{{^required}}?{{/required}}: {{#isEnum}}{{{datatypeWithEnum}}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}};
     {{/allParams}}
 }
 
@@ -60,7 +60,7 @@ function {{nickname}}Raw<T>({{#allParams.0}}requestParameters: {{operationIdCame
         queryParameters['{{baseName}}'] = requestParameters.{{paramName}};
         {{/isCollectionFormatMulti}}
         {{^isCollectionFormatMulti}}
-        queryParameters['{{baseName}}'] = requestParameters.{{paramName}}.join(runtime.COLLECTION_FORMATS["{{collectionFormat}}"]);
+        queryParameters['{{baseName}}'] = requestParameters.{{paramName}}?.join(runtime.COLLECTION_FORMATS["{{collectionFormat}}"]);
         {{/isCollectionFormatMulti}}
     }
 
@@ -97,7 +97,7 @@ function {{nickname}}Raw<T>({{#allParams.0}}requestParameters: {{operationIdCame
     {{#headerParams}}
     {{#isListContainer}}
     if (requestParameters.{{paramName}}) {
-        headerParameters['{{baseName}}'] = requestParameters.{{paramName}}.join(runtime.COLLECTION_FORMATS["{{collectionFormat}}"]);
+        headerParameters['{{baseName}}'] = requestParameters.{{paramName}}?.join(runtime.COLLECTION_FORMATS["{{collectionFormat}}"]);
     }
 
     {{/isListContainer}}
@@ -144,7 +144,7 @@ function {{nickname}}Raw<T>({{#allParams.0}}requestParameters: {{operationIdCame
         })
         {{/isCollectionFormatMulti}}
         {{^isCollectionFormatMulti}}
-        formData.append('{{baseName}}', requestParameters.{{paramName}}.join(runtime.COLLECTION_FORMATS["{{collectionFormat}}"]));
+        formData.append('{{baseName}}', requestParameters.{{paramName}}?.join(runtime.COLLECTION_FORMATS["{{collectionFormat}}"]));
         {{/isCollectionFormatMulti}}
     }
 
@@ -171,7 +171,7 @@ function {{nickname}}Raw<T>({{#allParams.0}}requestParameters: {{operationIdCame
         {{#hasBodyParam}}
         {{#bodyParam}}
         {{#isContainer}}
-        body: queryParameters || requestParameters.{{paramName}}{{#isListContainer}}{{#items}}{{^isPrimitiveType}}.map({{datatype}}ToJSON){{/isPrimitiveType}}{{/items}}{{/isListContainer}},
+        body: queryParameters || requestParameters.{{paramName}}{{#isListContainer}}{{#items}}{{^isPrimitiveType}}?.map({{datatype}}ToJSON){{/isPrimitiveType}}{{/items}}{{/isListContainer}},
         {{/isContainer}}
         {{^isContainer}}
         {{^isPrimitiveType}}

--- a/modules/openapi-generator/src/main/resources/typescript-redux-query/apis.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-redux-query/apis.mustache
@@ -19,7 +19,7 @@ import {
 {{#allParams.0}}
 export interface {{operationIdCamelCase}}Request {
     {{#allParams}}
-    {{paramName}}{{^required}}?{{/required}}: {{#isEnum}}{{{datatypeWithEnum}}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}};
+    {{paramName}}{{^required}}{{^isListContainer}}?{{/isListContainer}}{{/required}}: {{#isEnum}}{{{datatypeWithEnum}}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}};
     {{/allParams}}
 }
 

--- a/samples/client/petstore/typescript-redux-query/builds/with-npm-version/src/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-redux-query/builds/with-npm-version/src/apis/PetApi.ts
@@ -175,7 +175,7 @@ function findPetsByStatusRaw<T>(requestParameters: FindPetsByStatusRequest, requ
 
 
     if (requestParameters.status) {
-        queryParameters['status'] = requestParameters.status.join(runtime.COLLECTION_FORMATS["csv"]);
+        queryParameters['status'] = requestParameters.status?.join(runtime.COLLECTION_FORMATS["csv"]);
     }
 
     const headerParameters = {};
@@ -230,7 +230,7 @@ function findPetsByTagsRaw<T>(requestParameters: FindPetsByTagsRequest, requestC
 
 
     if (requestParameters.tags) {
-        queryParameters['tags'] = requestParameters.tags.join(runtime.COLLECTION_FORMATS["csv"]);
+        queryParameters['tags'] = requestParameters.tags?.join(runtime.COLLECTION_FORMATS["csv"]);
     }
 
     const headerParameters = {};

--- a/samples/client/petstore/typescript-redux-query/builds/with-npm-version/src/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-redux-query/builds/with-npm-version/src/apis/UserApi.ts
@@ -131,7 +131,7 @@ function createUsersWithArrayInputRaw<T>(requestParameters: CreateUsersWithArray
             method: 'POST',
             headers: headerParameters,
         },
-        body: queryParameters || requestParameters.body.map(UserToJSON),
+        body: queryParameters || requestParameters.body?.map(UserToJSON),
     };
 
     const { transform: requestTransform } = requestConfig;
@@ -178,7 +178,7 @@ function createUsersWithListInputRaw<T>(requestParameters: CreateUsersWithListIn
             method: 'POST',
             headers: headerParameters,
         },
-        body: queryParameters || requestParameters.body.map(UserToJSON),
+        body: queryParameters || requestParameters.body?.map(UserToJSON),
     };
 
     const { transform: requestTransform } = requestConfig;


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
When we have requests that have an array, we get the following error with typescript
```
Object is possibly 'undefined'.  TS2532

    261 |             headers: headerParameters,
    262 |         },
  > 263 |         body: queryParameters || requestParameters.theArrayParam.map(theArrayParamToJSON),
        |                                  ^
    264 |     };
    265 | 
    266 |     const { transform: requestTransform } = requestConfig;
```
there are two ways to fix it, and I don't know which is better. Either the one on the PR or adding a ? to every call of the array to have something like this:

`body: queryParameters || requestParameters.theArrayParam?.map(theArrayParamToJSON),`

by the way, regenerating the samples didn't change the output. I guess this case isn't covered by the petstore example

@TiFu (2017/07) @taxpon (2017/07) @sebastianhaas (2017/07) @kenisteward (2017/07) @Vrolijkx (2017/09) @macjohnny (2018/01) @topce (2018/10) @akehir (2019/07) @petejohansonxo (2019/11) @amakhrov (2020/02)

<!-- Please check the completed items below -->
### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [X] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [X] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
