### PR TITLE
[C#][netcore] remove supportsUWP from template

### DIFF
--- a/modules/openapi-generator/src/main/resources/csharp-netcore/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/ApiClient.mustache
@@ -6,9 +6,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 {{^netStandard}}
-{{^supportsUWP}}
 using System.Web;
-{{/supportsUWP}}
 {{/netStandard}}
 using System.Linq;
 using System.Net;

--- a/modules/openapi-generator/src/main/resources/csharp-netcore/Configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/Configuration.mustache
@@ -345,10 +345,8 @@ namespace {{packageName}}.Client
         {
             String report = "C# SDK ({{{packageName}}}) Debug Report:\n";
             {{^netStandard}}
-            {{^supportsUWP}}
             report += "    OS: " + System.Environment.OSVersion + "\n";
             report += "    .NET Framework Version: " + System.Environment.Version  + "\n";
-            {{/supportsUWP}}
             {{/netStandard}}
             {{#netStandard}}
             report += "    OS: " + System.Runtime.InteropServices.RuntimeInformation.OSDescription + "\n";


### PR DESCRIPTION
- remove `supportsUWP` from template as it's not supported in csharp-netcore.
- users are advised to use `csharp` generator instead.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

cc @mandrean (2017/08) @frankyjuang (2019/09) @shibayan (2020/02)


