### PR TITLE
[go-server] Modified go-server templates to allow services to receive http request's context.

### DIFF
--- a/modules/openapi-generator/src/main/resources/go-server/api.mustache
+++ b/modules/openapi-generator/src/main/resources/go-server/api.mustache
@@ -2,6 +2,7 @@
 package {{packageName}}
 
 import (
+	"context"
 	"net/http"{{#apiInfo}}{{#apis}}{{#imports}}
 	"{{import}}"{{/imports}}{{/apis}}{{/apiInfo}}
 )
@@ -20,5 +21,5 @@ type {{classname}}Router interface { {{#operations}}{{#operation}}
 // while the service implementation can ignored with the .openapi-generator-ignore file 
 // and updated with the logic required for the API.
 type {{classname}}Servicer interface { {{#operations}}{{#operation}}
-	{{operationId}}({{#allParams}}{{dataType}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) (interface{}, error){{/operation}}{{/operations}}
+	{{operationId}}(context.Context{{#allParams}}, {{dataType}}{{/allParams}}) (interface{}, error){{/operation}}{{/operations}}
 }{{/apis}}{{/apiInfo}}

--- a/modules/openapi-generator/src/main/resources/go-server/controller-api.mustache
+++ b/modules/openapi-generator/src/main/resources/go-server/controller-api.mustache
@@ -92,7 +92,7 @@ func (c *{{classname}}Controller) {{nickname}}(w http.ResponseWriter, r *http.Re
 		return
 	}
 	{{/isBodyParam}}{{/allParams}}
-	result, err := c.service.{{nickname}}({{#allParams}}{{#isBodyParam}}*{{/isBodyParam}}{{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}})
+	result, err := c.service.{{nickname}}(r.Context(){{#allParams}}, {{#isBodyParam}}*{{/isBodyParam}}{{paramName}}{{/allParams}})
 	if err != nil {
 		w.WriteHeader(500)
 		return

--- a/modules/openapi-generator/src/main/resources/go-server/service.mustache
+++ b/modules/openapi-generator/src/main/resources/go-server/service.mustache
@@ -2,6 +2,7 @@
 package {{packageName}}
 
 import (
+	"context"
 	"errors"{{#imports}}
 	"{{import}}"{{/imports}}
 )
@@ -18,7 +19,7 @@ func New{{classname}}Service() {{classname}}Servicer {
 }{{#operations}}{{#operation}}
 
 // {{nickname}} - {{summary}}
-func (s *{{classname}}Service) {{nickname}}({{#allParams}}{{paramName}} {{dataType}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) (interface{}, error) {
+func (s *{{classname}}Service) {{nickname}}(ctx context.Context{{#allParams}}, {{paramName}} {{dataType}}{{/allParams}}) (interface{}, error) {
 	// TODO - update {{nickname}} with the required logic for this service method.
 	// Add {{classFilename}}_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
 	return nil, errors.New("service method '{{nickname}}' not implemented")

--- a/samples/server/petstore/go-api-server/go/api.go
+++ b/samples/server/petstore/go-api-server/go/api.go
@@ -10,6 +10,7 @@
 package petstoreserver
 
 import (
+	"context"
 	"net/http"
 	"os"
 )
@@ -57,14 +58,14 @@ type UserApiRouter interface {
 // while the service implementation can ignored with the .openapi-generator-ignore file 
 // and updated with the logic required for the API.
 type PetApiServicer interface { 
-	AddPet(Pet) (interface{}, error)
-	DeletePet(int64, string) (interface{}, error)
-	FindPetsByStatus([]string) (interface{}, error)
-	FindPetsByTags([]string) (interface{}, error)
-	GetPetById(int64) (interface{}, error)
-	UpdatePet(Pet) (interface{}, error)
-	UpdatePetWithForm(int64, string, string) (interface{}, error)
-	UploadFile(int64, string, *os.File) (interface{}, error)
+	AddPet(context.Context, Pet) (interface{}, error)
+	DeletePet(context.Context, int64, string) (interface{}, error)
+	FindPetsByStatus(context.Context, []string) (interface{}, error)
+	FindPetsByTags(context.Context, []string) (interface{}, error)
+	GetPetById(context.Context, int64) (interface{}, error)
+	UpdatePet(context.Context, Pet) (interface{}, error)
+	UpdatePetWithForm(context.Context, int64, string, string) (interface{}, error)
+	UploadFile(context.Context, int64, string, *os.File) (interface{}, error)
 }
 
 
@@ -73,10 +74,10 @@ type PetApiServicer interface {
 // while the service implementation can ignored with the .openapi-generator-ignore file 
 // and updated with the logic required for the API.
 type StoreApiServicer interface { 
-	DeleteOrder(string) (interface{}, error)
-	GetInventory() (interface{}, error)
-	GetOrderById(int64) (interface{}, error)
-	PlaceOrder(Order) (interface{}, error)
+	DeleteOrder(context.Context, string) (interface{}, error)
+	GetInventory(context.Context) (interface{}, error)
+	GetOrderById(context.Context, int64) (interface{}, error)
+	PlaceOrder(context.Context, Order) (interface{}, error)
 }
 
 
@@ -85,12 +86,12 @@ type StoreApiServicer interface {
 // while the service implementation can ignored with the .openapi-generator-ignore file 
 // and updated with the logic required for the API.
 type UserApiServicer interface { 
-	CreateUser(User) (interface{}, error)
-	CreateUsersWithArrayInput([]User) (interface{}, error)
-	CreateUsersWithListInput([]User) (interface{}, error)
-	DeleteUser(string) (interface{}, error)
-	GetUserByName(string) (interface{}, error)
-	LoginUser(string, string) (interface{}, error)
-	LogoutUser() (interface{}, error)
-	UpdateUser(string, User) (interface{}, error)
+	CreateUser(context.Context, User) (interface{}, error)
+	CreateUsersWithArrayInput(context.Context, []User) (interface{}, error)
+	CreateUsersWithListInput(context.Context, []User) (interface{}, error)
+	DeleteUser(context.Context, string) (interface{}, error)
+	GetUserByName(context.Context, string) (interface{}, error)
+	LoginUser(context.Context, string, string) (interface{}, error)
+	LogoutUser(context.Context) (interface{}, error)
+	UpdateUser(context.Context, string, User) (interface{}, error)
 }

--- a/samples/server/petstore/go-api-server/go/api_pet.go
+++ b/samples/server/petstore/go-api-server/go/api_pet.go
@@ -89,7 +89,7 @@ func (c *PetApiController) AddPet(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	
-	result, err := c.service.AddPet(*pet)
+	result, err := c.service.AddPet(r.Context(), *pet)
 	if err != nil {
 		w.WriteHeader(500)
 		return
@@ -107,7 +107,7 @@ func (c *PetApiController) DeletePet(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	apiKey := r.Header.Get("apiKey")
-	result, err := c.service.DeletePet(petId, apiKey)
+	result, err := c.service.DeletePet(r.Context(), petId, apiKey)
 	if err != nil {
 		w.WriteHeader(500)
 		return
@@ -120,7 +120,7 @@ func (c *PetApiController) DeletePet(w http.ResponseWriter, r *http.Request) {
 func (c *PetApiController) FindPetsByStatus(w http.ResponseWriter, r *http.Request) { 
 	query := r.URL.Query()
 	status := strings.Split(query.Get("status"), ",")
-	result, err := c.service.FindPetsByStatus(status)
+	result, err := c.service.FindPetsByStatus(r.Context(), status)
 	if err != nil {
 		w.WriteHeader(500)
 		return
@@ -133,7 +133,7 @@ func (c *PetApiController) FindPetsByStatus(w http.ResponseWriter, r *http.Reque
 func (c *PetApiController) FindPetsByTags(w http.ResponseWriter, r *http.Request) { 
 	query := r.URL.Query()
 	tags := strings.Split(query.Get("tags"), ",")
-	result, err := c.service.FindPetsByTags(tags)
+	result, err := c.service.FindPetsByTags(r.Context(), tags)
 	if err != nil {
 		w.WriteHeader(500)
 		return
@@ -150,7 +150,7 @@ func (c *PetApiController) GetPetById(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(500)
 		return
 	}
-	result, err := c.service.GetPetById(petId)
+	result, err := c.service.GetPetById(r.Context(), petId)
 	if err != nil {
 		w.WriteHeader(500)
 		return
@@ -167,7 +167,7 @@ func (c *PetApiController) UpdatePet(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	
-	result, err := c.service.UpdatePet(*pet)
+	result, err := c.service.UpdatePet(r.Context(), *pet)
 	if err != nil {
 		w.WriteHeader(500)
 		return
@@ -192,7 +192,7 @@ func (c *PetApiController) UpdatePetWithForm(w http.ResponseWriter, r *http.Requ
 	}
 	name := r.FormValue("name")
 	status := r.FormValue("status")
-	result, err := c.service.UpdatePetWithForm(petId, name, status)
+	result, err := c.service.UpdatePetWithForm(r.Context(), petId, name, status)
 	if err != nil {
 		w.WriteHeader(500)
 		return
@@ -222,7 +222,7 @@ func (c *PetApiController) UploadFile(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	
-	result, err := c.service.UploadFile(petId, additionalMetadata, file)
+	result, err := c.service.UploadFile(r.Context(), petId, additionalMetadata, file)
 	if err != nil {
 		w.WriteHeader(500)
 		return

--- a/samples/server/petstore/go-api-server/go/api_pet_service.go
+++ b/samples/server/petstore/go-api-server/go/api_pet_service.go
@@ -10,6 +10,7 @@
 package petstoreserver
 
 import (
+	"context"
 	"errors"
 	"os"
 )
@@ -26,56 +27,56 @@ func NewPetApiService() PetApiServicer {
 }
 
 // AddPet - Add a new pet to the store
-func (s *PetApiService) AddPet(pet Pet) (interface{}, error) {
+func (s *PetApiService) AddPet(ctx context.Context, pet Pet) (interface{}, error) {
 	// TODO - update AddPet with the required logic for this service method.
 	// Add api_pet_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
 	return nil, errors.New("service method 'AddPet' not implemented")
 }
 
 // DeletePet - Deletes a pet
-func (s *PetApiService) DeletePet(petId int64, apiKey string) (interface{}, error) {
+func (s *PetApiService) DeletePet(ctx context.Context, petId int64, apiKey string) (interface{}, error) {
 	// TODO - update DeletePet with the required logic for this service method.
 	// Add api_pet_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
 	return nil, errors.New("service method 'DeletePet' not implemented")
 }
 
 // FindPetsByStatus - Finds Pets by status
-func (s *PetApiService) FindPetsByStatus(status []string) (interface{}, error) {
+func (s *PetApiService) FindPetsByStatus(ctx context.Context, status []string) (interface{}, error) {
 	// TODO - update FindPetsByStatus with the required logic for this service method.
 	// Add api_pet_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
 	return nil, errors.New("service method 'FindPetsByStatus' not implemented")
 }
 
 // FindPetsByTags - Finds Pets by tags
-func (s *PetApiService) FindPetsByTags(tags []string) (interface{}, error) {
+func (s *PetApiService) FindPetsByTags(ctx context.Context, tags []string) (interface{}, error) {
 	// TODO - update FindPetsByTags with the required logic for this service method.
 	// Add api_pet_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
 	return nil, errors.New("service method 'FindPetsByTags' not implemented")
 }
 
 // GetPetById - Find pet by ID
-func (s *PetApiService) GetPetById(petId int64) (interface{}, error) {
+func (s *PetApiService) GetPetById(ctx context.Context, petId int64) (interface{}, error) {
 	// TODO - update GetPetById with the required logic for this service method.
 	// Add api_pet_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
 	return nil, errors.New("service method 'GetPetById' not implemented")
 }
 
 // UpdatePet - Update an existing pet
-func (s *PetApiService) UpdatePet(pet Pet) (interface{}, error) {
+func (s *PetApiService) UpdatePet(ctx context.Context, pet Pet) (interface{}, error) {
 	// TODO - update UpdatePet with the required logic for this service method.
 	// Add api_pet_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
 	return nil, errors.New("service method 'UpdatePet' not implemented")
 }
 
 // UpdatePetWithForm - Updates a pet in the store with form data
-func (s *PetApiService) UpdatePetWithForm(petId int64, name string, status string) (interface{}, error) {
+func (s *PetApiService) UpdatePetWithForm(ctx context.Context, petId int64, name string, status string) (interface{}, error) {
 	// TODO - update UpdatePetWithForm with the required logic for this service method.
 	// Add api_pet_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
 	return nil, errors.New("service method 'UpdatePetWithForm' not implemented")
 }
 
 // UploadFile - uploads an image
-func (s *PetApiService) UploadFile(petId int64, additionalMetadata string, file *os.File) (interface{}, error) {
+func (s *PetApiService) UploadFile(ctx context.Context, petId int64, additionalMetadata string, file *os.File) (interface{}, error) {
 	// TODO - update UploadFile with the required logic for this service method.
 	// Add api_pet_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
 	return nil, errors.New("service method 'UploadFile' not implemented")

--- a/samples/server/petstore/go-api-server/go/api_store.go
+++ b/samples/server/petstore/go-api-server/go/api_store.go
@@ -61,7 +61,7 @@ func (c *StoreApiController) Routes() Routes {
 func (c *StoreApiController) DeleteOrder(w http.ResponseWriter, r *http.Request) { 
 	params := mux.Vars(r)
 	orderId := params["orderId"]
-	result, err := c.service.DeleteOrder(orderId)
+	result, err := c.service.DeleteOrder(r.Context(), orderId)
 	if err != nil {
 		w.WriteHeader(500)
 		return
@@ -72,7 +72,7 @@ func (c *StoreApiController) DeleteOrder(w http.ResponseWriter, r *http.Request)
 
 // GetInventory - Returns pet inventories by status
 func (c *StoreApiController) GetInventory(w http.ResponseWriter, r *http.Request) { 
-	result, err := c.service.GetInventory()
+	result, err := c.service.GetInventory(r.Context())
 	if err != nil {
 		w.WriteHeader(500)
 		return
@@ -89,7 +89,7 @@ func (c *StoreApiController) GetOrderById(w http.ResponseWriter, r *http.Request
 		w.WriteHeader(500)
 		return
 	}
-	result, err := c.service.GetOrderById(orderId)
+	result, err := c.service.GetOrderById(r.Context(), orderId)
 	if err != nil {
 		w.WriteHeader(500)
 		return
@@ -106,7 +106,7 @@ func (c *StoreApiController) PlaceOrder(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 	
-	result, err := c.service.PlaceOrder(*order)
+	result, err := c.service.PlaceOrder(r.Context(), *order)
 	if err != nil {
 		w.WriteHeader(500)
 		return

--- a/samples/server/petstore/go-api-server/go/api_store_service.go
+++ b/samples/server/petstore/go-api-server/go/api_store_service.go
@@ -10,6 +10,7 @@
 package petstoreserver
 
 import (
+	"context"
 	"errors"
 )
 
@@ -25,28 +26,28 @@ func NewStoreApiService() StoreApiServicer {
 }
 
 // DeleteOrder - Delete purchase order by ID
-func (s *StoreApiService) DeleteOrder(orderId string) (interface{}, error) {
+func (s *StoreApiService) DeleteOrder(ctx context.Context, orderId string) (interface{}, error) {
 	// TODO - update DeleteOrder with the required logic for this service method.
 	// Add api_store_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
 	return nil, errors.New("service method 'DeleteOrder' not implemented")
 }
 
 // GetInventory - Returns pet inventories by status
-func (s *StoreApiService) GetInventory() (interface{}, error) {
+func (s *StoreApiService) GetInventory(ctx context.Context) (interface{}, error) {
 	// TODO - update GetInventory with the required logic for this service method.
 	// Add api_store_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
 	return nil, errors.New("service method 'GetInventory' not implemented")
 }
 
 // GetOrderById - Find purchase order by ID
-func (s *StoreApiService) GetOrderById(orderId int64) (interface{}, error) {
+func (s *StoreApiService) GetOrderById(ctx context.Context, orderId int64) (interface{}, error) {
 	// TODO - update GetOrderById with the required logic for this service method.
 	// Add api_store_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
 	return nil, errors.New("service method 'GetOrderById' not implemented")
 }
 
 // PlaceOrder - Place an order for a pet
-func (s *StoreApiService) PlaceOrder(order Order) (interface{}, error) {
+func (s *StoreApiService) PlaceOrder(ctx context.Context, order Order) (interface{}, error) {
 	// TODO - update PlaceOrder with the required logic for this service method.
 	// Add api_store_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
 	return nil, errors.New("service method 'PlaceOrder' not implemented")

--- a/samples/server/petstore/go-api-server/go/api_user.go
+++ b/samples/server/petstore/go-api-server/go/api_user.go
@@ -89,7 +89,7 @@ func (c *UserApiController) CreateUser(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	
-	result, err := c.service.CreateUser(*user)
+	result, err := c.service.CreateUser(r.Context(), *user)
 	if err != nil {
 		w.WriteHeader(500)
 		return
@@ -106,7 +106,7 @@ func (c *UserApiController) CreateUsersWithArrayInput(w http.ResponseWriter, r *
 		return
 	}
 	
-	result, err := c.service.CreateUsersWithArrayInput(*user)
+	result, err := c.service.CreateUsersWithArrayInput(r.Context(), *user)
 	if err != nil {
 		w.WriteHeader(500)
 		return
@@ -123,7 +123,7 @@ func (c *UserApiController) CreateUsersWithListInput(w http.ResponseWriter, r *h
 		return
 	}
 	
-	result, err := c.service.CreateUsersWithListInput(*user)
+	result, err := c.service.CreateUsersWithListInput(r.Context(), *user)
 	if err != nil {
 		w.WriteHeader(500)
 		return
@@ -136,7 +136,7 @@ func (c *UserApiController) CreateUsersWithListInput(w http.ResponseWriter, r *h
 func (c *UserApiController) DeleteUser(w http.ResponseWriter, r *http.Request) { 
 	params := mux.Vars(r)
 	username := params["username"]
-	result, err := c.service.DeleteUser(username)
+	result, err := c.service.DeleteUser(r.Context(), username)
 	if err != nil {
 		w.WriteHeader(500)
 		return
@@ -149,7 +149,7 @@ func (c *UserApiController) DeleteUser(w http.ResponseWriter, r *http.Request) {
 func (c *UserApiController) GetUserByName(w http.ResponseWriter, r *http.Request) { 
 	params := mux.Vars(r)
 	username := params["username"]
-	result, err := c.service.GetUserByName(username)
+	result, err := c.service.GetUserByName(r.Context(), username)
 	if err != nil {
 		w.WriteHeader(500)
 		return
@@ -163,7 +163,7 @@ func (c *UserApiController) LoginUser(w http.ResponseWriter, r *http.Request) {
 	query := r.URL.Query()
 	username := query.Get("username")
 	password := query.Get("password")
-	result, err := c.service.LoginUser(username, password)
+	result, err := c.service.LoginUser(r.Context(), username, password)
 	if err != nil {
 		w.WriteHeader(500)
 		return
@@ -174,7 +174,7 @@ func (c *UserApiController) LoginUser(w http.ResponseWriter, r *http.Request) {
 
 // LogoutUser - Logs out current logged in user session
 func (c *UserApiController) LogoutUser(w http.ResponseWriter, r *http.Request) { 
-	result, err := c.service.LogoutUser()
+	result, err := c.service.LogoutUser(r.Context())
 	if err != nil {
 		w.WriteHeader(500)
 		return
@@ -193,7 +193,7 @@ func (c *UserApiController) UpdateUser(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	
-	result, err := c.service.UpdateUser(username, *user)
+	result, err := c.service.UpdateUser(r.Context(), username, *user)
 	if err != nil {
 		w.WriteHeader(500)
 		return

--- a/samples/server/petstore/go-api-server/go/api_user_service.go
+++ b/samples/server/petstore/go-api-server/go/api_user_service.go
@@ -10,6 +10,7 @@
 package petstoreserver
 
 import (
+	"context"
 	"errors"
 )
 
@@ -25,56 +26,56 @@ func NewUserApiService() UserApiServicer {
 }
 
 // CreateUser - Create user
-func (s *UserApiService) CreateUser(user User) (interface{}, error) {
+func (s *UserApiService) CreateUser(ctx context.Context, user User) (interface{}, error) {
 	// TODO - update CreateUser with the required logic for this service method.
 	// Add api_user_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
 	return nil, errors.New("service method 'CreateUser' not implemented")
 }
 
 // CreateUsersWithArrayInput - Creates list of users with given input array
-func (s *UserApiService) CreateUsersWithArrayInput(user []User) (interface{}, error) {
+func (s *UserApiService) CreateUsersWithArrayInput(ctx context.Context, user []User) (interface{}, error) {
 	// TODO - update CreateUsersWithArrayInput with the required logic for this service method.
 	// Add api_user_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
 	return nil, errors.New("service method 'CreateUsersWithArrayInput' not implemented")
 }
 
 // CreateUsersWithListInput - Creates list of users with given input array
-func (s *UserApiService) CreateUsersWithListInput(user []User) (interface{}, error) {
+func (s *UserApiService) CreateUsersWithListInput(ctx context.Context, user []User) (interface{}, error) {
 	// TODO - update CreateUsersWithListInput with the required logic for this service method.
 	// Add api_user_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
 	return nil, errors.New("service method 'CreateUsersWithListInput' not implemented")
 }
 
 // DeleteUser - Delete user
-func (s *UserApiService) DeleteUser(username string) (interface{}, error) {
+func (s *UserApiService) DeleteUser(ctx context.Context, username string) (interface{}, error) {
 	// TODO - update DeleteUser with the required logic for this service method.
 	// Add api_user_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
 	return nil, errors.New("service method 'DeleteUser' not implemented")
 }
 
 // GetUserByName - Get user by user name
-func (s *UserApiService) GetUserByName(username string) (interface{}, error) {
+func (s *UserApiService) GetUserByName(ctx context.Context, username string) (interface{}, error) {
 	// TODO - update GetUserByName with the required logic for this service method.
 	// Add api_user_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
 	return nil, errors.New("service method 'GetUserByName' not implemented")
 }
 
 // LoginUser - Logs user into the system
-func (s *UserApiService) LoginUser(username string, password string) (interface{}, error) {
+func (s *UserApiService) LoginUser(ctx context.Context, username string, password string) (interface{}, error) {
 	// TODO - update LoginUser with the required logic for this service method.
 	// Add api_user_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
 	return nil, errors.New("service method 'LoginUser' not implemented")
 }
 
 // LogoutUser - Logs out current logged in user session
-func (s *UserApiService) LogoutUser() (interface{}, error) {
+func (s *UserApiService) LogoutUser(ctx context.Context) (interface{}, error) {
 	// TODO - update LogoutUser with the required logic for this service method.
 	// Add api_user_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
 	return nil, errors.New("service method 'LogoutUser' not implemented")
 }
 
 // UpdateUser - Updated user
-func (s *UserApiService) UpdateUser(username string, user User) (interface{}, error) {
+func (s *UserApiService) UpdateUser(ctx context.Context, username string, user User) (interface{}, error) {
 	// TODO - update UpdateUser with the required logic for this service method.
 	// Add api_user_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
 	return nil, errors.New("service method 'UpdateUser' not implemented")


### PR DESCRIPTION
Modifiled go-server templates.

close #6657 

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

### Description

- Added `context.Context` arguments to below templates
  - api.mustache
  - controller-api.mustache
  - service.mustache
- Updated `go-api-server` sample by running `./bin/generate-samples.sh`

<!-- Please check the completed items below -->
### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [X] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
