### PR TITLE
[php] Exclude composer.lock in root gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -174,7 +174,14 @@ samples/client/petstore/python-asyncio/.pytest_cache/
 samples/client/petstore/python-tornado/.venv/
 
 # PHP
+samples/client/petstore/php/OpenAPIClient-php/composer.lock
+samples/openapi3/server/petstore/php-symfony/SymfonyBundle-php/composer.lock
+samples/openapi3/server/petstore/php-ze-ph/composer.lock
+samples/server/petstore/php-laravel/lib/composer.lock
 samples/server/petstore/php-lumen/lib/composer.lock
+samples/server/petstore/php-slim4/composer.lock
+samples/server/petstore/php-symfony/SymfonyBundle-php/composer.lock
+samples/server/petstore/php-ze-ph/composer.lock
 
 # ts
 samples/client/petstore/typescript-angular2/npm/npm-debug.log

--- a/modules/openapi-generator/src/main/resources/php-laravel/gitignore
+++ b/modules/openapi-generator/src/main/resources/php-laravel/gitignore
@@ -13,4 +13,4 @@ yarn-error.log
 
 # Commit your application's lock file https://getcomposer.org/doc/01-basic-usage.md#commit-your-composer-lock-file-to-version-control
 # You may choose to ignore a library lock file http://getcomposer.org/doc/02-libraries.md#lock-file
-composer.lock
+# composer.lock

--- a/modules/openapi-generator/src/main/resources/php-slim4-server/gitignore
+++ b/modules/openapi-generator/src/main/resources/php-slim4-server/gitignore
@@ -5,7 +5,7 @@ composer.phar
 
 # Commit your application's lock file https://getcomposer.org/doc/01-basic-usage.md#commit-your-composer-lock-file-to-version-control
 # You may choose to ignore a library lock file http://getcomposer.org/doc/02-libraries.md#lock-file
-composer.lock
+# composer.lock
 
 # phplint tool creates cache file which is not necessary in a codebase
 /.phplint-cache

--- a/modules/openapi-generator/src/main/resources/php-symfony/gitignore
+++ b/modules/openapi-generator/src/main/resources/php-symfony/gitignore
@@ -31,7 +31,7 @@
 
 # Commit your application's lock file https://getcomposer.org/doc/01-basic-usage.md#commit-your-composer-lock-file-to-version-control
 # You may choose to ignore a library lock file http://getcomposer.org/doc/02-libraries.md#lock-file
-composer.lock
+# composer.lock
 
 # Assets and user uploads
 /web/bundles/

--- a/modules/openapi-generator/src/main/resources/php/gitignore
+++ b/modules/openapi-generator/src/main/resources/php/gitignore
@@ -5,7 +5,7 @@ composer.phar
 
 # Commit your application's lock file https://getcomposer.org/doc/01-basic-usage.md#commit-your-composer-lock-file-to-version-control
 # You may choose to ignore a library lock file http://getcomposer.org/doc/02-libraries.md#lock-file
-composer.lock
+# composer.lock
 
 # php-cs-fixer cache
 .php_cs.cache

--- a/samples/client/petstore/php/OpenAPIClient-php/.gitignore
+++ b/samples/client/petstore/php/OpenAPIClient-php/.gitignore
@@ -5,7 +5,7 @@ composer.phar
 
 # Commit your application's lock file https://getcomposer.org/doc/01-basic-usage.md#commit-your-composer-lock-file-to-version-control
 # You may choose to ignore a library lock file http://getcomposer.org/doc/02-libraries.md#lock-file
-composer.lock
+# composer.lock
 
 # php-cs-fixer cache
 .php_cs.cache

--- a/samples/server/petstore/php-laravel/lib/.gitignore
+++ b/samples/server/petstore/php-laravel/lib/.gitignore
@@ -13,4 +13,4 @@ yarn-error.log
 
 # Commit your application's lock file https://getcomposer.org/doc/01-basic-usage.md#commit-your-composer-lock-file-to-version-control
 # You may choose to ignore a library lock file http://getcomposer.org/doc/02-libraries.md#lock-file
-composer.lock
+# composer.lock

--- a/samples/server/petstore/php-slim4/.gitignore
+++ b/samples/server/petstore/php-slim4/.gitignore
@@ -5,7 +5,7 @@ composer.phar
 
 # Commit your application's lock file https://getcomposer.org/doc/01-basic-usage.md#commit-your-composer-lock-file-to-version-control
 # You may choose to ignore a library lock file http://getcomposer.org/doc/02-libraries.md#lock-file
-composer.lock
+# composer.lock
 
 # phplint tool creates cache file which is not necessary in a codebase
 /.phplint-cache

--- a/samples/server/petstore/php-symfony/SymfonyBundle-php/.gitignore
+++ b/samples/server/petstore/php-symfony/SymfonyBundle-php/.gitignore
@@ -31,7 +31,7 @@
 
 # Commit your application's lock file https://getcomposer.org/doc/01-basic-usage.md#commit-your-composer-lock-file-to-version-control
 # You may choose to ignore a library lock file http://getcomposer.org/doc/02-libraries.md#lock-file
-composer.lock
+# composer.lock
 
 # Assets and user uploads
 /web/bundles/


### PR DESCRIPTION
`composer.lock` may produce CI errors when you need to test build against different PHP versions. However users most likely want to commit this file, so I think it's better to exclude it only in root `.gitignore`.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@jebentier @dkarlovi @mandrean @jfastnacht @ackintosh @renepardon