### PR TITLE
[Java][jersey2] Add jersey injection dependencies

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/build.gradle.mustache
@@ -146,6 +146,7 @@ dependencies {
     compile "io.swagger:swagger-annotations:$swagger_annotations_version"
     compile "com.google.code.findbugs:jsr305:3.0.2"
     compile "org.glassfish.jersey.core:jersey-client:$jersey_version"
+    compile "org.glassfish.jersey.inject:jersey-hk2:$jersey_version"
     compile "org.glassfish.jersey.media:jersey-media-multipart:$jersey_version"
     compile "org.glassfish.jersey.media:jersey-media-json-jackson:$jersey_version"
     compile "com.fasterxml.jackson.core:jackson-core:$jackson_version"

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/build.sbt.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/build.sbt.mustache
@@ -10,9 +10,10 @@ lazy val root = (project in file(".")).
     resolvers += Resolver.mavenLocal,
     libraryDependencies ++= Seq(
       "io.swagger" % "swagger-annotations" % "1.5.22",
-      "org.glassfish.jersey.core" % "jersey-client" % {{#supportJava6}}"2.6"{{/supportJava6}}{{^supportJava6}}"2.25.1"{{/supportJava6}},
-      "org.glassfish.jersey.media" % "jersey-media-multipart" % {{#supportJava6}}"2.6"{{/supportJava6}}{{^supportJava6}}"2.25.1"{{/supportJava6}},
-      "org.glassfish.jersey.media" % "jersey-media-json-jackson" % {{#supportJava6}}"2.6"{{/supportJava6}}{{^supportJava6}}"2.25.1"{{/supportJava6}},
+      "org.glassfish.jersey.core" % "jersey-client" % {{#supportJava6}}"2.6"{{/supportJava6}}{{^supportJava6}}"2.27"{{/supportJava6}},{{^supportJava6}}
+      "org.glassfish.jersey.inject" % "jersey-hk2" % "2.27",{{/supportJava6}}
+      "org.glassfish.jersey.media" % "jersey-media-multipart" % {{#supportJava6}}"2.6"{{/supportJava6}}{{^supportJava6}}"2.27"{{/supportJava6}},
+      "org.glassfish.jersey.media" % "jersey-media-json-jackson" % {{#supportJava6}}"2.6"{{/supportJava6}}{{^supportJava6}}"2.27"{{/supportJava6}},
       "com.fasterxml.jackson.core" % "jackson-core" % "2.10.4" % "compile",
       "com.fasterxml.jackson.core" % "jackson-annotations" % "2.10.4" % "compile",
       "com.fasterxml.jackson.core" % "jackson-databind" % "2.10.4" % "compile",

--- a/samples/client/petstore/java/jersey2-java8/build.gradle
+++ b/samples/client/petstore/java/jersey2-java8/build.gradle
@@ -107,6 +107,7 @@ dependencies {
     compile "io.swagger:swagger-annotations:$swagger_annotations_version"
     compile "com.google.code.findbugs:jsr305:3.0.2"
     compile "org.glassfish.jersey.core:jersey-client:$jersey_version"
+    compile "org.glassfish.jersey.inject:jersey-hk2:$jersey_version"
     compile "org.glassfish.jersey.media:jersey-media-multipart:$jersey_version"
     compile "org.glassfish.jersey.media:jersey-media-json-jackson:$jersey_version"
     compile "com.fasterxml.jackson.core:jackson-core:$jackson_version"

--- a/samples/client/petstore/java/jersey2-java8/build.sbt
+++ b/samples/client/petstore/java/jersey2-java8/build.sbt
@@ -10,9 +10,10 @@ lazy val root = (project in file(".")).
     resolvers += Resolver.mavenLocal,
     libraryDependencies ++= Seq(
       "io.swagger" % "swagger-annotations" % "1.5.22",
-      "org.glassfish.jersey.core" % "jersey-client" % "2.25.1",
-      "org.glassfish.jersey.media" % "jersey-media-multipart" % "2.25.1",
-      "org.glassfish.jersey.media" % "jersey-media-json-jackson" % "2.25.1",
+      "org.glassfish.jersey.core" % "jersey-client" % "2.27",
+      "org.glassfish.jersey.inject" % "jersey-hk2" % "2.27",
+      "org.glassfish.jersey.media" % "jersey-media-multipart" % "2.27",
+      "org.glassfish.jersey.media" % "jersey-media-json-jackson" % "2.27",
       "com.fasterxml.jackson.core" % "jackson-core" % "2.10.4" % "compile",
       "com.fasterxml.jackson.core" % "jackson-annotations" % "2.10.4" % "compile",
       "com.fasterxml.jackson.core" % "jackson-databind" % "2.10.4" % "compile",

--- a/samples/openapi3/client/petstore/java/jersey2-java8-special-characters/build.gradle
+++ b/samples/openapi3/client/petstore/java/jersey2-java8-special-characters/build.gradle
@@ -106,6 +106,7 @@ dependencies {
     compile "io.swagger:swagger-annotations:$swagger_annotations_version"
     compile "com.google.code.findbugs:jsr305:3.0.2"
     compile "org.glassfish.jersey.core:jersey-client:$jersey_version"
+    compile "org.glassfish.jersey.inject:jersey-hk2:$jersey_version"
     compile "org.glassfish.jersey.media:jersey-media-multipart:$jersey_version"
     compile "org.glassfish.jersey.media:jersey-media-json-jackson:$jersey_version"
     compile "com.fasterxml.jackson.core:jackson-core:$jackson_version"

--- a/samples/openapi3/client/petstore/java/jersey2-java8-special-characters/build.sbt
+++ b/samples/openapi3/client/petstore/java/jersey2-java8-special-characters/build.sbt
@@ -10,9 +10,10 @@ lazy val root = (project in file(".")).
     resolvers += Resolver.mavenLocal,
     libraryDependencies ++= Seq(
       "io.swagger" % "swagger-annotations" % "1.5.22",
-      "org.glassfish.jersey.core" % "jersey-client" % "2.25.1",
-      "org.glassfish.jersey.media" % "jersey-media-multipart" % "2.25.1",
-      "org.glassfish.jersey.media" % "jersey-media-json-jackson" % "2.25.1",
+      "org.glassfish.jersey.core" % "jersey-client" % "2.27",
+      "org.glassfish.jersey.inject" % "jersey-hk2" % "2.27",
+      "org.glassfish.jersey.media" % "jersey-media-multipart" % "2.27",
+      "org.glassfish.jersey.media" % "jersey-media-json-jackson" % "2.27",
       "com.fasterxml.jackson.core" % "jackson-core" % "2.10.4" % "compile",
       "com.fasterxml.jackson.core" % "jackson-annotations" % "2.10.4" % "compile",
       "com.fasterxml.jackson.core" % "jackson-databind" % "2.10.4" % "compile",

--- a/samples/openapi3/client/petstore/java/jersey2-java8/build.gradle
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/build.gradle
@@ -108,6 +108,7 @@ dependencies {
     compile "io.swagger:swagger-annotations:$swagger_annotations_version"
     compile "com.google.code.findbugs:jsr305:3.0.2"
     compile "org.glassfish.jersey.core:jersey-client:$jersey_version"
+    compile "org.glassfish.jersey.inject:jersey-hk2:$jersey_version"
     compile "org.glassfish.jersey.media:jersey-media-multipart:$jersey_version"
     compile "org.glassfish.jersey.media:jersey-media-json-jackson:$jersey_version"
     compile "com.fasterxml.jackson.core:jackson-core:$jackson_version"

--- a/samples/openapi3/client/petstore/java/jersey2-java8/build.sbt
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/build.sbt
@@ -10,9 +10,10 @@ lazy val root = (project in file(".")).
     resolvers += Resolver.mavenLocal,
     libraryDependencies ++= Seq(
       "io.swagger" % "swagger-annotations" % "1.5.22",
-      "org.glassfish.jersey.core" % "jersey-client" % "2.25.1",
-      "org.glassfish.jersey.media" % "jersey-media-multipart" % "2.25.1",
-      "org.glassfish.jersey.media" % "jersey-media-json-jackson" % "2.25.1",
+      "org.glassfish.jersey.core" % "jersey-client" % "2.27",
+      "org.glassfish.jersey.inject" % "jersey-hk2" % "2.27",
+      "org.glassfish.jersey.media" % "jersey-media-multipart" % "2.27",
+      "org.glassfish.jersey.media" % "jersey-media-json-jackson" % "2.27",
       "com.fasterxml.jackson.core" % "jackson-core" % "2.10.4" % "compile",
       "com.fasterxml.jackson.core" % "jackson-annotations" % "2.10.4" % "compile",
       "com.fasterxml.jackson.core" % "jackson-databind" % "2.10.4" % "compile",


### PR DESCRIPTION
Adds the jersey injection dependency to gradle and sbt to match
the maven dependency.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [ ] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [ ] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
