### PR TITLE
[kotlin-spring] Optional delegate in ApiController constructor

### DIFF
--- a/modules/openapi-generator/src/main/resources/kotlin-spring/apiController.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/apiController.mustache
@@ -11,7 +11,7 @@ import java.util.Optional;
 <%={{ }}=%>
 {{#operations}}
 class {{classname}}Controller(
-        @org.springframework.beans.factory.annotation.Autowired(required = false) delegate: {{classname}}Delegate
+        @org.springframework.beans.factory.annotation.Autowired(required = false) delegate: {{classname}}Delegate?
 ) : {{classname}} {
     private val delegate: {{classname}}Delegate
 


### PR DESCRIPTION
If the delegate is optional, put it as optional in constructor

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
