### PR TITLE
[C][Client][Clang Static Analyzer] Remove the useless variable when assembling URL

### DIFF
--- a/modules/openapi-generator/src/main/resources/C-libcurl/apiClient.c.mustache
+++ b/modules/openapi-generator/src/main/resources/C-libcurl/apiClient.c.mustache
@@ -183,14 +183,9 @@ char *assembleTargetUrl(char    *basePath,
 
     int operationParameterLength = 0;
     int basePathLength = strlen(basePath);
-    bool slashNeedsToBeAppendedToBasePath = false;
 
     if(operationParameter != NULL) {
         operationParameterLength = (1 + strlen(operationParameter));
-    }
-    if(basePath[strlen(basePath) - 1] != '/') {
-        slashNeedsToBeAppendedToBasePath = true;
-        basePathLength++;
     }
 
     char *targetUrl =

--- a/samples/client/petstore/c/src/apiClient.c
+++ b/samples/client/petstore/c/src/apiClient.c
@@ -137,14 +137,9 @@ char *assembleTargetUrl(char    *basePath,
 
     int operationParameterLength = 0;
     int basePathLength = strlen(basePath);
-    bool slashNeedsToBeAppendedToBasePath = false;
 
     if(operationParameter != NULL) {
         operationParameterLength = (1 + strlen(operationParameter));
-    }
-    if(basePath[strlen(basePath) - 1] != '/') {
-        slashNeedsToBeAppendedToBasePath = true;
-        basePathLength++;
     }
 
     char *targetUrl =


### PR DESCRIPTION
@wing328  @zhemant @michelealbano

This problem is found by code static check tool (Clang Static Analyzer)
Bug Group | Bug Type ▾ | File | Function/Method | Line | Path Length |  
-- | -- | -- | -- | -- | -- | --
Dead store | Dead assignment | src/apiClient.c | assembleTargetUrl | 146 | 1 | 

The root cause is:
The variable ```slashNeedsToBeAppendedToBasePath``` is not used.
So I removed the variable ```slashNeedsToBeAppendedToBasePath``` and releated code.
 


- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [X] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [X] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.