### PR TITLE
Update apiInvoker.mustache

### DIFF
--- a/modules/openapi-generator/src/main/resources/scala-akka-client/apiInvoker.mustache
+++ b/modules/openapi-generator/src/main/resources/scala-akka-client/apiInvoker.mustache
@@ -103,11 +103,11 @@ class ApiInvoker(formats: Formats)(implicit system: ActorSystem) extends CustomC
     request: HttpRequest =>
       credentialsSeq.foldLeft(request) {
         case (req, BasicCredentials(login, password)) =>
-          req.withHeaders(Authorization(BasicHttpCredentials(login, password)))
+          req.addHeader(Authorization(BasicHttpCredentials(login, password)))
         case (req, ApiKeyCredentials(keyValue, keyName, ApiKeyLocations.HEADER)) =>
-          req.withHeaders(RawHeader(keyName, keyValue.value))
+          req.addHeader(RawHeader(keyName, keyValue.value))
         case (req, BearerToken(token)) =>
-            req.withHeaders(RawHeader("Authorization", s"Bearer $token"))
+            req.addHeader(RawHeader("Authorization", s"Bearer $token"))
         case (req, _) => req
       }
   }


### PR DESCRIPTION
Issue Fix for #7258 

In scala-akka-client code that is getting generated, addAuthentication method is called after setting headers using header parameter in the below mentioned line
addAuthentication(request.credentials)(
      httpRequest.withHeaders(headers(request.headerParams))
    )

However, in addAuthentication method, we are using withHeaders method that overwrites the headers set using header parameters. So, I am proposing to
change the addAuthentication method be replacing withHeaders() method to addHeader() to add authentication header to the list of already existing headers.

### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [ ] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [ ] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
