### PR TITLE
[C][Client][Clang Static Analyzer] Fix memory leak in apiClient_invoke

### DIFF
--- a/modules/openapi-generator/src/main/resources/C-libcurl/apiClient.c.mustache
+++ b/modules/openapi-generator/src/main/resources/C-libcurl/apiClient.c.mustache
@@ -300,6 +300,8 @@ void apiClient_invoke(apiClient_t    *apiClient,
                             (char *) listEntry->data);
                     headers = curl_slist_append(headers,
                                                 buffContent);
+                    free(buffContent);
+                    buffContent = NULL;
                 }
             }
         } else {
@@ -313,8 +315,8 @@ void apiClient_invoke(apiClient_t    *apiClient,
         }
 
         if(formParameters != NULL) {
-            if(strstr(buffContent,
-                      "application/x-www-form-urlencoded") != NULL)
+            if(contentType &&
+               findStrInStrList(contentType, "application/x-www-form-urlencoded") != NULL)
             {
                 long parameterLength = 0;
                 long keyPairLength = 0;
@@ -356,7 +358,8 @@ void apiClient_invoke(apiClient_t    *apiClient,
                 curl_easy_setopt(handle, CURLOPT_POSTFIELDS,
                                  formString);
             }
-            if(strstr(buffContent, "multipart/form-data") != NULL) {
+            if(contentType &&
+               findStrInStrList(contentType, "multipart/form-data") != NULL) {
                 mime = curl_mime_init(handle);
                 list_ForEach(listEntry, formParameters) {
                     keyValuePair_t *keyValuePair =

--- a/modules/openapi-generator/src/main/resources/C-libcurl/list.c.mustache
+++ b/modules/openapi-generator/src/main/resources/C-libcurl/list.c.mustache
@@ -1,6 +1,7 @@
 #include <stddef.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include <string.h>
 
 #include "../include/list.h"
 static listEntry_t *listEntry_create(void *data) {
@@ -165,4 +166,20 @@ listEntry_t *list_getElementAt(list_t *list, long indexOfElement) {
 
         return currentListEntry;
     }
+}
+
+char* findStrInStrList(list_t *strList, const char *str)
+{
+    if (!strList || !str) {
+        return NULL;
+    }
+
+    listEntry_t* listEntry = NULL;
+    list_ForEach(listEntry, strList) {
+        if (strstr((char*)listEntry->data, str) != NULL) {
+            return (char*)listEntry->data;
+        }
+    }
+
+    return NULL;
 }

--- a/modules/openapi-generator/src/main/resources/C-libcurl/list.h.mustache
+++ b/modules/openapi-generator/src/main/resources/C-libcurl/list.h.mustache
@@ -36,4 +36,6 @@ void list_iterateThroughListBackward(list_t* list, void (*operationToPerform)(li
 
 void listEntry_printAsInt(listEntry_t* listEntry, void *additionalData);
 void listEntry_free(listEntry_t *listEntry, void *additionalData);
+
+char* findStrInStrList(list_t* strList, const char* str);
 #endif // INCLUDE_LIST_H

--- a/samples/client/petstore/c/include/list.h
+++ b/samples/client/petstore/c/include/list.h
@@ -36,4 +36,6 @@ void list_iterateThroughListBackward(list_t* list, void (*operationToPerform)(li
 
 void listEntry_printAsInt(listEntry_t* listEntry, void *additionalData);
 void listEntry_free(listEntry_t *listEntry, void *additionalData);
+
+char* findStrInStrList(list_t* strList, const char* str);
 #endif // INCLUDE_LIST_H

--- a/samples/client/petstore/c/src/apiClient.c
+++ b/samples/client/petstore/c/src/apiClient.c
@@ -254,6 +254,8 @@ void apiClient_invoke(apiClient_t    *apiClient,
                             (char *) listEntry->data);
                     headers = curl_slist_append(headers,
                                                 buffContent);
+                    free(buffContent);
+                    buffContent = NULL;
                 }
             }
         } else {
@@ -267,8 +269,8 @@ void apiClient_invoke(apiClient_t    *apiClient,
         }
 
         if(formParameters != NULL) {
-            if(strstr(buffContent,
-                      "application/x-www-form-urlencoded") != NULL)
+            if(contentType &&
+               findStrInStrList(contentType, "application/x-www-form-urlencoded") != NULL)
             {
                 long parameterLength = 0;
                 long keyPairLength = 0;
@@ -310,7 +312,8 @@ void apiClient_invoke(apiClient_t    *apiClient,
                 curl_easy_setopt(handle, CURLOPT_POSTFIELDS,
                                  formString);
             }
-            if(strstr(buffContent, "multipart/form-data") != NULL) {
+            if(contentType &&
+               findStrInStrList(contentType, "multipart/form-data") != NULL) {
                 mime = curl_mime_init(handle);
                 list_ForEach(listEntry, formParameters) {
                     keyValuePair_t *keyValuePair =

--- a/samples/client/petstore/c/src/list.c
+++ b/samples/client/petstore/c/src/list.c
@@ -1,6 +1,7 @@
 #include <stddef.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include <string.h>
 
 #include "../include/list.h"
 static listEntry_t *listEntry_create(void *data) {
@@ -165,4 +166,20 @@ listEntry_t *list_getElementAt(list_t *list, long indexOfElement) {
 
         return currentListEntry;
     }
+}
+
+char* findStrInStrList(list_t *strList, const char *str)
+{
+    if (!strList || !str) {
+        return NULL;
+    }
+
+    listEntry_t* listEntry = NULL;
+    list_ForEach(listEntry, strList) {
+        if (strstr((char*)listEntry->data, str) != NULL) {
+            return (char*)listEntry->data;
+        }
+    }
+
+    return NULL;
 }


### PR DESCRIPTION
The 2 problems are found by code static check tool (Clang Static Analyzer)
Bug Group | Bug Type ▾ | File | Function/Method | Line | Path Length |  
-- | -- | -- | -- | -- | -- | --
API | Argument with 'nonnull' attribute passed null | src/apiClient.c | apiClient_invoke | 275 | 12 | 
Memory error | Memory leak | src/apiClient.c | apiClient_invoke | 257 | 18 | 

```c
           list_ForEach(listEntry, contentType) {
                if(strstr((char *) listEntry->data,
                          "xml") == NULL)
                {   
                    buffContent =     //<==== The pointer pointing the previous bufContnet memory is lost 
                        malloc(strlen(
                                   "Content-Type: ") + strlen(
                                   (char *)
                                   listEntry->data) +
                               1);     
                    sprintf(buffContent, "%s%s",
                            "Content-Type: ",
                            (char *) listEntry->data);
                    headers = curl_slist_append(headers,
                                                buffContent);


                  // need to free the memory of bufContnet here
               }   
            }   
```


```c
        if(formParameters != NULL) {
             if(strstr(buffContent,     // <=== buffContent only includes the current content type, it is not enough, we need traverse in list contentType 
                       "application/x-www-form-urlencoded") != NULL)
```


- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [X] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [X] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@wing328 @zhemant @michelealbano