### PR TITLE
[kotlin][client] fix warning Extension is shadowed by a member

### DIFF
--- a/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-okhttp/infrastructure/ResponseExtensions.kt.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-okhttp/infrastructure/ResponseExtensions.kt.mustache
@@ -10,6 +10,7 @@ import okhttp3.Response
 /**
  * Provides an extension to evaluation whether the response is a 3xx code
  */
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
 {{#nonPublicApi}}internal {{/nonPublicApi}}val Response.isRedirect : Boolean get() = this.code{{#jvm-okhttp3}}(){{/jvm-okhttp3}} in 300..399
 
 /**

--- a/samples/client/petstore/kotlin-gson/src/main/kotlin/org/openapitools/client/infrastructure/ResponseExtensions.kt
+++ b/samples/client/petstore/kotlin-gson/src/main/kotlin/org/openapitools/client/infrastructure/ResponseExtensions.kt
@@ -10,6 +10,7 @@ val Response.isInformational : Boolean get() = this.code in 100..199
 /**
  * Provides an extension to evaluation whether the response is a 3xx code
  */
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
 val Response.isRedirect : Boolean get() = this.code in 300..399
 
 /**

--- a/samples/client/petstore/kotlin-jackson/src/main/kotlin/org/openapitools/client/infrastructure/ResponseExtensions.kt
+++ b/samples/client/petstore/kotlin-jackson/src/main/kotlin/org/openapitools/client/infrastructure/ResponseExtensions.kt
@@ -10,6 +10,7 @@ val Response.isInformational : Boolean get() = this.code in 100..199
 /**
  * Provides an extension to evaluation whether the response is a 3xx code
  */
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
 val Response.isRedirect : Boolean get() = this.code in 300..399
 
 /**

--- a/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/infrastructure/ResponseExtensions.kt
+++ b/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/infrastructure/ResponseExtensions.kt
@@ -10,6 +10,7 @@ val Response.isInformational : Boolean get() = this.code in 100..199
 /**
  * Provides an extension to evaluation whether the response is a 3xx code
  */
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
 val Response.isRedirect : Boolean get() = this.code in 300..399
 
 /**

--- a/samples/client/petstore/kotlin-jvm-okhttp4-coroutines/src/main/kotlin/org/openapitools/client/infrastructure/ResponseExtensions.kt
+++ b/samples/client/petstore/kotlin-jvm-okhttp4-coroutines/src/main/kotlin/org/openapitools/client/infrastructure/ResponseExtensions.kt
@@ -10,6 +10,7 @@ val Response.isInformational : Boolean get() = this.code in 100..199
 /**
  * Provides an extension to evaluation whether the response is a 3xx code
  */
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
 val Response.isRedirect : Boolean get() = this.code in 300..399
 
 /**

--- a/samples/client/petstore/kotlin-moshi-codegen/src/main/kotlin/org/openapitools/client/infrastructure/ResponseExtensions.kt
+++ b/samples/client/petstore/kotlin-moshi-codegen/src/main/kotlin/org/openapitools/client/infrastructure/ResponseExtensions.kt
@@ -10,6 +10,7 @@ val Response.isInformational : Boolean get() = this.code in 100..199
 /**
  * Provides an extension to evaluation whether the response is a 3xx code
  */
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
 val Response.isRedirect : Boolean get() = this.code in 300..399
 
 /**

--- a/samples/client/petstore/kotlin-nonpublic/src/main/kotlin/org/openapitools/client/infrastructure/ResponseExtensions.kt
+++ b/samples/client/petstore/kotlin-nonpublic/src/main/kotlin/org/openapitools/client/infrastructure/ResponseExtensions.kt
@@ -10,6 +10,7 @@ internal val Response.isInformational : Boolean get() = this.code in 100..199
 /**
  * Provides an extension to evaluation whether the response is a 3xx code
  */
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
 internal val Response.isRedirect : Boolean get() = this.code in 300..399
 
 /**

--- a/samples/client/petstore/kotlin-nullable/src/main/kotlin/org/openapitools/client/infrastructure/ResponseExtensions.kt
+++ b/samples/client/petstore/kotlin-nullable/src/main/kotlin/org/openapitools/client/infrastructure/ResponseExtensions.kt
@@ -10,6 +10,7 @@ val Response.isInformational : Boolean get() = this.code in 100..199
 /**
  * Provides an extension to evaluation whether the response is a 3xx code
  */
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
 val Response.isRedirect : Boolean get() = this.code in 300..399
 
 /**

--- a/samples/client/petstore/kotlin-okhttp3/src/main/kotlin/org/openapitools/client/infrastructure/ResponseExtensions.kt
+++ b/samples/client/petstore/kotlin-okhttp3/src/main/kotlin/org/openapitools/client/infrastructure/ResponseExtensions.kt
@@ -10,6 +10,7 @@ val Response.isInformational : Boolean get() = this.code() in 100..199
 /**
  * Provides an extension to evaluation whether the response is a 3xx code
  */
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
 val Response.isRedirect : Boolean get() = this.code() in 300..399
 
 /**

--- a/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/infrastructure/ResponseExtensions.kt
+++ b/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/infrastructure/ResponseExtensions.kt
@@ -10,6 +10,7 @@ val Response.isInformational : Boolean get() = this.code in 100..199
 /**
  * Provides an extension to evaluation whether the response is a 3xx code
  */
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
 val Response.isRedirect : Boolean get() = this.code in 300..399
 
 /**

--- a/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/infrastructure/ResponseExtensions.kt
+++ b/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/infrastructure/ResponseExtensions.kt
@@ -10,6 +10,7 @@ val Response.isInformational : Boolean get() = this.code in 100..199
 /**
  * Provides an extension to evaluation whether the response is a 3xx code
  */
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
 val Response.isRedirect : Boolean get() = this.code in 300..399
 
 /**

--- a/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/infrastructure/ResponseExtensions.kt
+++ b/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/infrastructure/ResponseExtensions.kt
@@ -10,6 +10,7 @@ val Response.isInformational : Boolean get() = this.code in 100..199
 /**
  * Provides an extension to evaluation whether the response is a 3xx code
  */
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
 val Response.isRedirect : Boolean get() = this.code in 300..399
 
 /**


### PR DESCRIPTION
Currently the kotlin client generator `ResponseExtensions.kt` shows the following warning.
`infrastructure/ResponseExtensions.kt: (13, 23): Extension is shadowed by a member: public final val isRedirect: Boolean`

This PR silents this warning.

<!-- Please check the completed items below -->
### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [X] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [X] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@jimschubert (2017/09) ❤️, @dr4ke616 (2018/08) @karismann (2019/03) @Zomzog (2019/04) @andrewemery (2019/10) @4brunu (2019/11) @yutaka0m (2020/03)