### PR TITLE
[C][Client][Clang Static Analyzer] Fix memory leak before function returns

### DIFF
--- a/modules/openapi-generator/src/main/resources/C-libcurl/api-body.mustache
+++ b/modules/openapi-generator/src/main/resources/C-libcurl/api-body.mustache
@@ -470,6 +470,7 @@ end:
     {{/formParams}}
     return elementToReturn;
 end:
+    free(localVarPath);
     return NULL;
     {{/returnType}}
     {{^returnType}}

--- a/samples/client/petstore/c/api/PetAPI.c
+++ b/samples/client/petstore/c/api/PetAPI.c
@@ -271,6 +271,7 @@ PetAPI_findPetsByStatus(apiClient_t *apiClient, list_t * status )
     free(localVarPath);
     return elementToReturn;
 end:
+    free(localVarPath);
     return NULL;
 
 }
@@ -352,6 +353,7 @@ PetAPI_findPetsByTags(apiClient_t *apiClient, list_t * tags )
     free(localVarPath);
     return elementToReturn;
 end:
+    free(localVarPath);
     return NULL;
 
 }
@@ -435,6 +437,7 @@ PetAPI_getPetById(apiClient_t *apiClient, long petId )
     free(localVarToReplace_petId);
     return elementToReturn;
 end:
+    free(localVarPath);
     return NULL;
 
 }
@@ -702,6 +705,7 @@ PetAPI_uploadFile(apiClient_t *apiClient, long petId , char * additionalMetadata
     free(keyPairForm_file);
     return elementToReturn;
 end:
+    free(localVarPath);
     return NULL;
 
 }

--- a/samples/client/petstore/c/api/StoreAPI.c
+++ b/samples/client/petstore/c/api/StoreAPI.c
@@ -134,6 +134,7 @@ StoreAPI_getInventory(apiClient_t *apiClient)
     free(localVarPath);
     return elementToReturn;
 end:
+    free(localVarPath);
     return NULL;
 
 }
@@ -217,6 +218,7 @@ StoreAPI_getOrderById(apiClient_t *apiClient, long orderId )
     free(localVarToReplace_orderId);
     return elementToReturn;
 end:
+    free(localVarPath);
     return NULL;
 
 }
@@ -291,6 +293,7 @@ StoreAPI_placeOrder(apiClient_t *apiClient, order_t * body )
     free(localVarBodyParameters);
     return elementToReturn;
 end:
+    free(localVarPath);
     return NULL;
 
 }

--- a/samples/client/petstore/c/api/UserAPI.c
+++ b/samples/client/petstore/c/api/UserAPI.c
@@ -372,6 +372,7 @@ UserAPI_getUserByName(apiClient_t *apiClient, char * username )
     free(localVarToReplace_username);
     return elementToReturn;
 end:
+    free(localVarPath);
     return NULL;
 
 }
@@ -477,6 +478,7 @@ UserAPI_loginUser(apiClient_t *apiClient, char * username , char * password )
     }
     return elementToReturn;
 end:
+    free(localVarPath);
     return NULL;
 
 }


### PR DESCRIPTION
The problem is found by code static check tool (Clang Static Analyzer)

Bug Group | Bug Type ▾ | File | Function/Method | Line | Path Length |  
-- | -- | -- | -- | -- | -- | --
Memory error | Memory leak | api/PetAPI.c | PetAPI_uploadFile | 705 | 5 |

```c

    long sizeOfPath = strlen("/pet/{petId}/uploadImage")+1;
    char *localVarPath = malloc(sizeOfPath);

    if(petId == 0){
        goto end;
    }
...
    free(localVarPath);
...
    return elementToReturn;
end:
    return NULL;  // <-- The localVarPath is not freed, so memory will leak if the function returns from here
```

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
@wing328 @zhemant @michelealbano
