### PR TITLE
[C][Client][Clang Static Analyzer] Fix uninitialized argument value

### DIFF
--- a/modules/openapi-generator/src/main/resources/C-libcurl/api-body.mustache
+++ b/modules/openapi-generator/src/main/resources/C-libcurl/api-body.mustache
@@ -193,7 +193,7 @@ end:
     {{#headerParams}}
 
     // header parameters
-    char *keyHeader_{{{paramName}}};
+    char *keyHeader_{{{paramName}}} = NULL;
     {{#isPrimitiveType}}{{#isNumber}}{{{dataType}}}{{/isNumber}}{{#isLong}}{{{dataType}}}{{/isLong}}{{#isInteger}}{{{dataType}}}{{/isInteger}}{{#isDouble}}{{{dataType}}}{{/isDouble}}{{#isFloat}}{{{dataType}}}{{/isFloat}}{{#isBoolean}}{{dataType}}{{/isBoolean}}{{#isEnum}}{{#isString}}{{projectName}}_{{operationId}}_{{baseName}}_e{{/isString}}{{/isEnum}}{{^isEnum}}{{#isString}}{{{dataType}}} *{{/isString}}{{/isEnum}}{{#isByteArray}}{{{dataType}}}{{/isByteArray}}{{#isDate}}{{{dataType}}}{{/isDate}}{{#isDateTime}}{{{dataType}}}{{/isDateTime}}{{#isFile}}{{{dataType}}}{{/isFile}}{{/isPrimitiveType}}{{^isPrimitiveType}}{{#isModel}}{{#isEnum}}{{datatypeWithEnum}}_e{{/isEnum}}{{^isEnum}}{{{dataType}}}_t *{{/isEnum}}{{/isModel}}{{^isModel}}{{#isEnum}}{{datatypeWithEnum}}_e{{/isEnum}}{{/isModel}}{{#isUuid}}{{dataType}} *{{/isUuid}}{{#isEmail}}{{dataType}}{{/isEmail}}{{/isPrimitiveType}} valueHeader_{{{paramName}}};
     keyValuePair_t *keyPairHeader_{{paramName}} = 0;
     if ({{paramName}}) {
@@ -242,12 +242,12 @@ end:
 
     // form parameters
     {{#isFile}}
-    char *keyForm_{{paramName}};
+    char *keyForm_{{paramName}} = NULL;
     {{{dataType}}} valueForm_{{paramName}};
     keyValuePair_t *keyPairForm_{{paramName}} = 0;
     {{/isFile}}
     {{^isFile}}
-    char *keyForm_{{paramName}};
+    char *keyForm_{{paramName}} = NULL;
     {{#isPrimitiveType}}{{#isNumber}}{{{dataType}}}{{/isNumber}}{{#isLong}}{{{dataType}}}{{/isLong}}{{#isInteger}}{{{dataType}}}{{/isInteger}}{{#isDouble}}{{{dataType}}}{{/isDouble}}{{#isFloat}}{{{dataType}}}{{/isFloat}}{{#isBoolean}}{{dataType}}{{/isBoolean}}{{#isEnum}}{{#isString}}{{projectName}}_{{operationId}}_{{baseName}}_e{{/isString}}{{/isEnum}}{{^isEnum}}{{#isString}}{{{dataType}}} *{{/isString}}{{/isEnum}}{{#isByteArray}}{{{dataType}}}{{/isByteArray}}{{#isDate}}{{{dataType}}}{{/isDate}}{{#isDateTime}}{{{dataType}}}{{/isDateTime}}{{#isFile}}{{{dataType}}}{{/isFile}}{{/isPrimitiveType}}{{^isPrimitiveType}}{{#isModel}}{{#isEnum}}{{datatypeWithEnum}}_e{{/isEnum}}{{^isEnum}}{{{dataType}}}_t *{{/isEnum}}{{/isModel}}{{^isModel}}{{#isEnum}}{{datatypeWithEnum}}_e{{/isEnum}}{{/isModel}}{{#isUuid}}{{dataType}} *{{/isUuid}}{{#isEmail}}{{dataType}}{{/isEmail}}{{/isPrimitiveType}} valueForm_{{paramName}};
     keyValuePair_t *keyPairForm_{{paramName}} = 0;
     {{/isFile}}
@@ -272,9 +272,9 @@ end:
     // Body Param
     {{#isListContainer}}
     //notstring
-    cJSON *localVar_{{paramName}};
-    cJSON *localVarItemJSON_{{paramName}};
-    cJSON *localVarSingleItemJSON_{{paramName}};
+    cJSON *localVar_{{paramName}} = NULL;
+    cJSON *localVarItemJSON_{{paramName}} = NULL;
+    cJSON *localVarSingleItemJSON_{{paramName}} = NULL;
     if ({{paramName}} != NULL)
     {
         localVarItemJSON_{{paramName}} = cJSON_CreateObject();
@@ -300,7 +300,7 @@ end:
     }
     {{/isListContainer}}
     {{^isListContainer}}
-    cJSON *localVarSingleItemJSON_{{paramName}};
+    cJSON *localVarSingleItemJSON_{{paramName}} = NULL;
     if ({{paramName}} != NULL)
     {
         //string
@@ -399,23 +399,41 @@ end:
     {{/pathParams}}
     {{#headerParams}}
     {{#isString}}
-    free(keyHeader_{{{paramName}}});
+    if (keyHeader_{{{paramName}}}) {
+        free(keyHeader_{{{paramName}}});
+        keyHeader_{{{paramName}}} = NULL;
+    }
     free(valueHeader_{{{paramName}}});
     {{/isString}}
     {{^isString}}
-    free(keyHeader_{{{paramName}}});
+    if (keyHeader_{{{paramName}}}) {
+        free(keyHeader_{{{paramName}}});
+        keyHeader_{{{paramName}}} = NULL;
+    }
     {{/isString}}
     free(keyPairHeader_{{paramName}});
     {{/headerParams}}
     {{#bodyParams}}
     {{#isListContainer}}
-    cJSON_Delete(localVarItemJSON_{{paramName}});
-    cJSON_Delete(localVarSingleItemJSON_{{paramName}});
-    cJSON_Delete(localVar_{{paramName}});
+    if (localVarItemJSON_{{paramName}}) {
+        cJSON_Delete(localVarItemJSON_{{paramName}});
+        localVarItemJSON_{{paramName}} = NULL;
+    }
+    if (localVarSingleItemJSON_{{paramName}}) {
+        cJSON_Delete(localVarSingleItemJSON_{{paramName}});
+        localVarSingleItemJSON_{{paramName}} = NULL;
+    }
+    if (localVar_{{paramName}}) {
+        cJSON_Delete(localVar_{{paramName}});
+        localVar_{{paramName}} = NULL;
+    }
     free(localVarBodyParameters);
     {{/isListContainer}}
     {{^isListContainer}}
-    cJSON_Delete(localVarSingleItemJSON_{{paramName}});
+    if (localVarSingleItemJSON_{{paramName}}) {
+        cJSON_Delete(localVarSingleItemJSON_{{paramName}});
+        localVarSingleItemJSON_{{paramName}} = NULL;
+    }
     free(localVarBodyParameters);
     {{/isListContainer}}
     {{/bodyParams}}
@@ -451,19 +469,28 @@ end:
     {{/queryParams}}
     {{#formParams}}
     {{#isFile}}
-    free(keyForm_{{{paramName}}});
+    if (keyForm_{{{paramName}}}) {
+        free(keyForm_{{{paramName}}});
+        keyForm_{{{paramName}}} = NULL;
+    }
 //    free(fileVar_{{paramName}}->data);
 //    free(fileVar_{{paramName}});
     free(keyPairForm_{{paramName}});
     {{/isFile}}
     {{^isFile}}
     {{#isString}}
-    free(keyForm_{{{paramName}}});
+    if (keyForm_{{{paramName}}}) {
+        free(keyForm_{{{paramName}}});
+        keyForm_{{{paramName}}} = NULL;
+    }
     free(valueForm_{{{paramName}}});
     free(keyPairForm_{{paramName}});
     {{/isString}}
     {{^isString}}
-    free(keyForm_{{{paramName}}});
+    if (keyForm_{{{paramName}}}) {
+        free(keyForm_{{{paramName}}});
+        keyForm_{{{paramName}}} = NULL;
+    }
     free(keyPairForm_{{paramName}});
     {{/isString}}
     {{/isFile}}
@@ -492,23 +519,41 @@ end:
     {{/pathParams}}
     {{#headerParams}}
     {{#isString}}
-    free(keyHeader_{{{paramName}}});
+    if (keyHeader_{{{paramName}}}) {
+        free(keyHeader_{{{paramName}}});
+        keyHeader_{{{paramName}}} = NULL;
+    }
     free(valueHeader_{{{paramName}}});
     {{/isString}}
     {{^isString}}
-    free(keyHeader_{{{paramName}}});
+    if (keyHeader_{{{paramName}}}) {
+        free(keyHeader_{{{paramName}}});
+        keyHeader_{{{paramName}}} = NULL;
+    }
     {{/isString}}
     free(keyPairHeader_{{paramName}});
     {{/headerParams}}
     {{#bodyParams}}
     {{#isListContainer}}
-    cJSON_Delete(localVarItemJSON_{{paramName}});
-    cJSON_Delete(localVarSingleItemJSON_{{paramName}});
-    cJSON_Delete(localVar_{{paramName}});
+    if (localVarItemJSON_{{paramName}}) {
+        cJSON_Delete(localVarItemJSON_{{paramName}});
+        localVarItemJSON_{{paramName}} = NULL;
+    }
+    if (localVarSingleItemJSON_{{paramName}}) {
+        cJSON_Delete(localVarSingleItemJSON_{{paramName}});
+        localVarSingleItemJSON_{{paramName}} = NULL;
+    }
+    if (localVar_{{paramName}}) {
+        cJSON_Delete(localVar_{{paramName}});
+        localVar_{{paramName}} = NULL;
+    }
     free(localVarBodyParameters);
     {{/isListContainer}}
     {{^isListContainer}}
-    cJSON_Delete(localVarSingleItemJSON_{{paramName}});
+    if (localVarSingleItemJSON_{{paramName}}) {
+        cJSON_Delete(localVarSingleItemJSON_{{paramName}});
+        localVarSingleItemJSON_{{paramName}} = NULL;
+    }
     free(localVarBodyParameters);
     {{/isListContainer}}
     {{/bodyParams}}
@@ -542,18 +587,27 @@ end:
     {{/queryParams}}
     {{#formParams}}
     {{#isFile}}
-    free(keyForm_{{{paramName}}});
+    if (keyForm_{{{paramName}}}) {
+        free(keyForm_{{{paramName}}});
+        keyForm_{{{paramName}}} = NULL;
+    }
 //    free(fileVar_{{paramName}}->data);
 //    free(fileVar_{{paramName}});
     {{/isFile}}
     {{^isFile}}
     {{#isString}}
-    free(keyForm_{{{paramName}}});
+    if (keyForm_{{{paramName}}}) {
+        free(keyForm_{{{paramName}}});
+        keyForm_{{{paramName}}} = NULL;
+    }
     free(valueForm_{{{paramName}}});
     keyValuePair_free(keyPairForm_{{{paramName}}});
     {{/isString}}
     {{^isString}}
-    free(keyForm_{{{paramName}}});
+    if (keyForm_{{{paramName}}}) {
+        free(keyForm_{{{paramName}}});
+        keyForm_{{{paramName}}} = NULL;
+    }
     free(keyPairForm_{{paramName}});
     {{/isString}}
     {{/isFile}}

--- a/samples/client/petstore/c/api/PetAPI.c
+++ b/samples/client/petstore/c/api/PetAPI.c
@@ -76,7 +76,7 @@ PetAPI_addPet(apiClient_t *apiClient, pet_t * body )
 
 
     // Body Param
-    cJSON *localVarSingleItemJSON_body;
+    cJSON *localVarSingleItemJSON_body = NULL;
     if (body != NULL)
     {
         //string
@@ -111,7 +111,10 @@ end:
     
     list_free(localVarContentType);
     free(localVarPath);
-    cJSON_Delete(localVarSingleItemJSON_body);
+    if (localVarSingleItemJSON_body) {
+        cJSON_Delete(localVarSingleItemJSON_body);
+        localVarSingleItemJSON_body = NULL;
+    }
     free(localVarBodyParameters);
 
 }
@@ -151,7 +154,7 @@ PetAPI_deletePet(apiClient_t *apiClient, long petId , char * api_key )
 
 
     // header parameters
-    char *keyHeader_api_key;
+    char *keyHeader_api_key = NULL;
     char * valueHeader_api_key;
     keyValuePair_t *keyPairHeader_api_key = 0;
     if (api_key) {
@@ -188,7 +191,10 @@ end:
     
     free(localVarPath);
     free(localVarToReplace_petId);
-    free(keyHeader_api_key);
+    if (keyHeader_api_key) {
+        free(keyHeader_api_key);
+        keyHeader_api_key = NULL;
+    }
     free(valueHeader_api_key);
     free(keyPairHeader_api_key);
 
@@ -463,7 +469,7 @@ PetAPI_updatePet(apiClient_t *apiClient, pet_t * body )
 
 
     // Body Param
-    cJSON *localVarSingleItemJSON_body;
+    cJSON *localVarSingleItemJSON_body = NULL;
     if (body != NULL)
     {
         //string
@@ -504,7 +510,10 @@ end:
     
     list_free(localVarContentType);
     free(localVarPath);
-    cJSON_Delete(localVarSingleItemJSON_body);
+    if (localVarSingleItemJSON_body) {
+        cJSON_Delete(localVarSingleItemJSON_body);
+        localVarSingleItemJSON_body = NULL;
+    }
     free(localVarBodyParameters);
 
 }
@@ -544,7 +553,7 @@ PetAPI_updatePetWithForm(apiClient_t *apiClient, long petId , char * name , char
 
 
     // form parameters
-    char *keyForm_name;
+    char *keyForm_name = NULL;
     char * valueForm_name;
     keyValuePair_t *keyPairForm_name = 0;
     if (name != NULL)
@@ -556,7 +565,7 @@ PetAPI_updatePetWithForm(apiClient_t *apiClient, long petId , char * name , char
     }
 
     // form parameters
-    char *keyForm_status;
+    char *keyForm_status = NULL;
     char * valueForm_status;
     keyValuePair_t *keyPairForm_status = 0;
     if (status != NULL)
@@ -594,10 +603,16 @@ end:
     list_free(localVarContentType);
     free(localVarPath);
     free(localVarToReplace_petId);
-    free(keyForm_name);
+    if (keyForm_name) {
+        free(keyForm_name);
+        keyForm_name = NULL;
+    }
     free(valueForm_name);
     keyValuePair_free(keyPairForm_name);
-    free(keyForm_status);
+    if (keyForm_status) {
+        free(keyForm_status);
+        keyForm_status = NULL;
+    }
     free(valueForm_status);
     keyValuePair_free(keyPairForm_status);
 
@@ -638,7 +653,7 @@ PetAPI_uploadFile(apiClient_t *apiClient, long petId , char * additionalMetadata
 
 
     // form parameters
-    char *keyForm_additionalMetadata;
+    char *keyForm_additionalMetadata = NULL;
     char * valueForm_additionalMetadata;
     keyValuePair_t *keyPairForm_additionalMetadata = 0;
     if (additionalMetadata != NULL)
@@ -650,7 +665,7 @@ PetAPI_uploadFile(apiClient_t *apiClient, long petId , char * additionalMetadata
     }
 
     // form parameters
-    char *keyForm_file;
+    char *keyForm_file = NULL;
     binary_t* valueForm_file;
     keyValuePair_t *keyPairForm_file = 0;
     if (file != NULL)
@@ -696,10 +711,16 @@ PetAPI_uploadFile(apiClient_t *apiClient, long petId , char * additionalMetadata
     list_free(localVarContentType);
     free(localVarPath);
     free(localVarToReplace_petId);
-    free(keyForm_additionalMetadata);
+    if (keyForm_additionalMetadata) {
+        free(keyForm_additionalMetadata);
+        keyForm_additionalMetadata = NULL;
+    }
     free(valueForm_additionalMetadata);
     free(keyPairForm_additionalMetadata);
-    free(keyForm_file);
+    if (keyForm_file) {
+        free(keyForm_file);
+        keyForm_file = NULL;
+    }
 //    free(fileVar_file->data);
 //    free(fileVar_file);
     free(keyPairForm_file);

--- a/samples/client/petstore/c/api/StoreAPI.c
+++ b/samples/client/petstore/c/api/StoreAPI.c
@@ -244,7 +244,7 @@ StoreAPI_placeOrder(apiClient_t *apiClient, order_t * body )
 
 
     // Body Param
-    cJSON *localVarSingleItemJSON_body;
+    cJSON *localVarSingleItemJSON_body = NULL;
     if (body != NULL)
     {
         //string
@@ -289,7 +289,10 @@ StoreAPI_placeOrder(apiClient_t *apiClient, order_t * body )
     list_free(localVarHeaderType);
     
     free(localVarPath);
-    cJSON_Delete(localVarSingleItemJSON_body);
+    if (localVarSingleItemJSON_body) {
+        cJSON_Delete(localVarSingleItemJSON_body);
+        localVarSingleItemJSON_body = NULL;
+    }
     free(localVarBodyParameters);
     return elementToReturn;
 end:

--- a/samples/client/petstore/c/api/UserAPI.c
+++ b/samples/client/petstore/c/api/UserAPI.c
@@ -35,7 +35,7 @@ UserAPI_createUser(apiClient_t *apiClient, user_t * body )
 
 
     // Body Param
-    cJSON *localVarSingleItemJSON_body;
+    cJSON *localVarSingleItemJSON_body = NULL;
     if (body != NULL)
     {
         //string
@@ -68,7 +68,10 @@ end:
     
     
     free(localVarPath);
-    cJSON_Delete(localVarSingleItemJSON_body);
+    if (localVarSingleItemJSON_body) {
+        cJSON_Delete(localVarSingleItemJSON_body);
+        localVarSingleItemJSON_body = NULL;
+    }
     free(localVarBodyParameters);
 
 }
@@ -95,9 +98,9 @@ UserAPI_createUsersWithArrayInput(apiClient_t *apiClient, list_t * body )
 
     // Body Param
     //notstring
-    cJSON *localVar_body;
-    cJSON *localVarItemJSON_body;
-    cJSON *localVarSingleItemJSON_body;
+    cJSON *localVar_body = NULL;
+    cJSON *localVarItemJSON_body = NULL;
+    cJSON *localVarSingleItemJSON_body = NULL;
     if (body != NULL)
     {
         localVarItemJSON_body = cJSON_CreateObject();
@@ -147,9 +150,18 @@ end:
     
     
     free(localVarPath);
-    cJSON_Delete(localVarItemJSON_body);
-    cJSON_Delete(localVarSingleItemJSON_body);
-    cJSON_Delete(localVar_body);
+    if (localVarItemJSON_body) {
+        cJSON_Delete(localVarItemJSON_body);
+        localVarItemJSON_body = NULL;
+    }
+    if (localVarSingleItemJSON_body) {
+        cJSON_Delete(localVarSingleItemJSON_body);
+        localVarSingleItemJSON_body = NULL;
+    }
+    if (localVar_body) {
+        cJSON_Delete(localVar_body);
+        localVar_body = NULL;
+    }
     free(localVarBodyParameters);
 
 }
@@ -176,9 +188,9 @@ UserAPI_createUsersWithListInput(apiClient_t *apiClient, list_t * body )
 
     // Body Param
     //notstring
-    cJSON *localVar_body;
-    cJSON *localVarItemJSON_body;
-    cJSON *localVarSingleItemJSON_body;
+    cJSON *localVar_body = NULL;
+    cJSON *localVarItemJSON_body = NULL;
+    cJSON *localVarSingleItemJSON_body = NULL;
     if (body != NULL)
     {
         localVarItemJSON_body = cJSON_CreateObject();
@@ -228,9 +240,18 @@ end:
     
     
     free(localVarPath);
-    cJSON_Delete(localVarItemJSON_body);
-    cJSON_Delete(localVarSingleItemJSON_body);
-    cJSON_Delete(localVar_body);
+    if (localVarItemJSON_body) {
+        cJSON_Delete(localVarItemJSON_body);
+        localVarItemJSON_body = NULL;
+    }
+    if (localVarSingleItemJSON_body) {
+        cJSON_Delete(localVarSingleItemJSON_body);
+        localVarSingleItemJSON_body = NULL;
+    }
+    if (localVar_body) {
+        cJSON_Delete(localVar_body);
+        localVar_body = NULL;
+    }
     free(localVarBodyParameters);
 
 }
@@ -564,7 +585,7 @@ UserAPI_updateUser(apiClient_t *apiClient, char * username , user_t * body )
 
 
     // Body Param
-    cJSON *localVarSingleItemJSON_body;
+    cJSON *localVarSingleItemJSON_body = NULL;
     if (body != NULL)
     {
         //string
@@ -601,7 +622,10 @@ end:
     
     free(localVarPath);
     free(localVarToReplace_username);
-    cJSON_Delete(localVarSingleItemJSON_body);
+    if (localVarSingleItemJSON_body) {
+        cJSON_Delete(localVarSingleItemJSON_body);
+        localVarSingleItemJSON_body = NULL;
+    }
     free(localVarBodyParameters);
 
 }


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
These problems are found by code static check tool (Clang Static Analyzer)

Take example:

```c
    char *keyForm_status; //<-- keyForm_status is uninitialized
...
    free(keyForm_status);  //<-- if the memory of keyForm_status is not allocated by malloc/calloc, it will coredump here. 
```

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@wing328 @zhemant @michelealbano