### PR TITLE
Remove dot in golang type

### DIFF
--- a/modules/openapi-generator/src/main/resources/go-server/model.mustache
+++ b/modules/openapi-generator/src/main/resources/go-server/model.mustache
@@ -5,9 +5,9 @@ package {{packageName}}
 {{/-first}}	"{{import}}"{{#-last}}
 )
 {{/-last}}{{/imports}}{{#model}}{{#isEnum}}{{#description}}// {{{classname}}} : {{{description}}}{{/description}}
-type {{{name}}} {{^format}}{{dataType}}{{/format}}{{#format}}{{{format}}}{{/format}}
+type {{{classname}}} {{^format}}{{dataType}}{{/format}}{{#format}}{{{format}}}{{/format}}
 
-// List of {{{name}}}
+// List of {{{classname}}}
 const (
 	{{#allowableValues}}
 	{{#enumVars}}

--- a/samples/server/petstore/go-api-server/go.sum
+++ b/samples/server/petstore/go-api-server/go.sum
@@ -1,0 +1,2 @@
+github.com/gorilla/mux v1.7.3 h1:gnP5JzjVOuiZD07fKKToCAOjS0yOpj/qPETTXCCS6hw=
+github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
Hello, in the golang server, the model template seems to be broken when we use dot in openapi tags.
For example, for this Openapi input : https://forge.etsi.org/rep/mec/gs011-app-enablement-api/blob/master/MecAppSupportApi.yaml 

 The current output is : 

```
package openapi
// DestinationInterfaceInterfaceType : Type of the interface
type DestinationInterface.InterfaceType string

// List of DestinationInterface.InterfaceType
const (
	DESTINATIONINTERFACEINTERFACETYPE_TUNNEL DestinationInterfaceInterfaceType = "TUNNEL"
	DESTINATIONINTERFACEINTERFACETYPE_MAC DestinationInterfaceInterfaceType = "MAC"
	DESTINATIONINTERFACEINTERFACETYPE_IP DestinationInterfaceInterfaceType = "IP"
)
```
I change from {{{name}}} to {{{classname}}}, to have the enum matching the declaration ( i.e, removing the dot)
PS : I generated to sample example but their is no case matching my problem in it.

@antihax (2017/11) @grokify (2018/07) @kemokemo (2018/09) @bkabrda (2019/07) @wing328

Thanks

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
