### PR TITLE
[C][Client][Clang Static Analyzer] Remove the useless free operation for buffContent

### DIFF
--- a/modules/openapi-generator/src/main/resources/C-libcurl/apiClient.c.mustache
+++ b/modules/openapi-generator/src/main/resources/C-libcurl/apiClient.c.mustache
@@ -520,10 +520,6 @@ void apiClient_invoke(apiClient_t    *apiClient,
 
         free(targetUrl);
 
-        if(contentType != NULL) {
-            free(buffContent);
-        }
-
         if(res == CURLE_OK) {
             curl_easy_getinfo(handle, CURLINFO_RESPONSE_CODE, &apiClient->response_code);
         } else {

--- a/samples/client/petstore/c/src/apiClient.c
+++ b/samples/client/petstore/c/src/apiClient.c
@@ -437,10 +437,6 @@ void apiClient_invoke(apiClient_t    *apiClient,
 
         free(targetUrl);
 
-        if(contentType != NULL) {
-            free(buffContent);
-        }
-
         if(res == CURLE_OK) {
             curl_easy_getinfo(handle, CURLINFO_RESPONSE_CODE, &apiClient->response_code);
         } else {


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
This is a defect introduced by my PR https://github.com/OpenAPITools/openapi-generator/pull/7285

```c
            list_ForEach(listEntry, contentType) {
                if(strstr((char *) listEntry->data,
                          "xml") == NULL)
                {
                    buffContent =
                        malloc(strlen(
                                   "Content-Type: ") + strlen(
                                   (char *)
                                   listEntry->data) +
                               1);
                    ...
                    free(buffContent);  // <-- I add code to free "buffContent" in PR 7285
                    buffContent = NULL;
                }
...

        if(contentType != NULL) {.   // <-- but I forgot to remove this code, so it will coredump here because buffContent is freed before.	
            free(buffContent);	
        }

```


<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@wing328 @zhemant @michelealbano