### PR TITLE
fix http bear auth documentation for go clinets

### DIFF
--- a/modules/openapi-generator/src/main/resources/go-experimental/README.mustache
+++ b/modules/openapi-generator/src/main/resources/go-experimental/README.mustache
@@ -105,6 +105,17 @@ Note, each API key must be added to a map of `map[string]APIKey` where the key i
 
 {{/isApiKey}}
 {{#isBasic}}
+{{#isBasicBearer}}
+- **Type**: HTTP Bearer token authentication
+
+Example
+
+```golang
+auth := context.WithValue(context.Background(), sw.ContextAccessToken, "BEARERTOKENSTRING")
+r, err := client.Service.Operation(auth, args)
+```
+
+{{/isBasicBearer}}
 {{#isBasicBasic}}
 - **Type**: HTTP basic authentication
 

--- a/modules/openapi-generator/src/main/resources/go/README.mustache
+++ b/modules/openapi-generator/src/main/resources/go/README.mustache
@@ -64,7 +64,7 @@ Class | Method | HTTP request | Description
 Example
 
 ```golang
-auth := context.WithValue(context.Background(), sw.ContextAPIKey, sw.APIKey{
+auth := context.WithValue(context.Background(), {{packageName}}.ContextAPIKey, {{packageName}}.APIKey{
     Key: "APIKEY",
     Prefix: "Bearer", // Omit if not necessary.
 })
@@ -72,19 +72,33 @@ r, err := client.Service.Operation(auth, args)
 ```
 
 {{/isApiKey}}
-{{#isBasic}}- **Type**: HTTP basic authentication
+{{#isHttpSignature}}
+Not supported.
+
+{{/isHttpSignature}}
+{{#isBasicBasic}}- **Type**: HTTP basic authentication
 
 Example
 
 ```golang
-auth := context.WithValue(context.Background(), sw.ContextBasicAuth, sw.BasicAuth{
+auth := context.WithValue(context.Background(), {{packageName}}.ContextBasicAuth, {{packageName}}.BasicAuth{
     UserName: "username",
     Password: "password",
 })
 r, err := client.Service.Operation(auth, args)
 ```
 
-{{/isBasic}}
+{{/isBasicBasic}}
+{{#isBasicBearer}}- **Type**: HTTP Bearer token authentication
+
+Example
+
+```golang
+auth := context.WithValue(context.Background(), {{packageName}}.ContextAccessToken, "BEARERTOKENSTRING")
+r, err := client.Service.Operation(auth, args)
+```
+
+{{/isBasicBearer}}
 {{#isOAuth}}
 
 - **Type**: OAuth
@@ -97,7 +111,7 @@ r, err := client.Service.Operation(auth, args)
 Example
 
 ```golang
-auth := context.WithValue(context.Background(), sw.ContextAccessToken, "ACCESSTOKENSTRING")
+auth := context.WithValue(context.Background(), {{packageName}}.ContextAccessToken, "ACCESSTOKENSTRING")
 r, err := client.Service.Operation(auth, args)
 ```
 
@@ -109,7 +123,7 @@ import "golang.org/x/oauth2"
 /* Perform OAuth2 round trip request and obtain a token */
 
 tokenSource := oauth2cfg.TokenSource(createContext(httpClient), &token)
-auth := context.WithValue(oauth2.NoContext, sw.ContextOAuth2, tokenSource)
+auth := context.WithValue(oauth2.NoContext, {{packageName}}.ContextOAuth2, tokenSource)
 r, err := client.Service.Operation(auth, args)
 ```
 
@@ -120,7 +134,7 @@ r, err := client.Service.Operation(auth, args)
 Example
 
 ```golang
-auth := context.WithValue(context.Background(), sw.ContextAWSv4, sw.AWSv4{
+auth := context.WithValue(context.Background(), {{packageName}}.ContextAWSv4, {{packageName}}.AWSv4{
     AccessKey: "ACCESSKEYSTRING",
     SecretKey: "SECRETKEYSTRING",
 })

--- a/samples/client/petstore/go/go-petstore-withXml/README.md
+++ b/samples/client/petstore/go/go-petstore-withXml/README.md
@@ -134,7 +134,7 @@ Class | Method | HTTP request | Description
 Example
 
 ```golang
-auth := context.WithValue(context.Background(), sw.ContextAPIKey, sw.APIKey{
+auth := context.WithValue(context.Background(), petstore.ContextAPIKey, petstore.APIKey{
     Key: "APIKEY",
     Prefix: "Bearer", // Omit if not necessary.
 })
@@ -149,7 +149,7 @@ r, err := client.Service.Operation(auth, args)
 Example
 
 ```golang
-auth := context.WithValue(context.Background(), sw.ContextAPIKey, sw.APIKey{
+auth := context.WithValue(context.Background(), petstore.ContextAPIKey, petstore.APIKey{
     Key: "APIKEY",
     Prefix: "Bearer", // Omit if not necessary.
 })
@@ -164,7 +164,7 @@ r, err := client.Service.Operation(auth, args)
 Example
 
 ```golang
-auth := context.WithValue(context.Background(), sw.ContextBasicAuth, sw.BasicAuth{
+auth := context.WithValue(context.Background(), petstore.ContextBasicAuth, petstore.BasicAuth{
     UserName: "username",
     Password: "password",
 })
@@ -185,7 +185,7 @@ r, err := client.Service.Operation(auth, args)
 Example
 
 ```golang
-auth := context.WithValue(context.Background(), sw.ContextAccessToken, "ACCESSTOKENSTRING")
+auth := context.WithValue(context.Background(), petstore.ContextAccessToken, "ACCESSTOKENSTRING")
 r, err := client.Service.Operation(auth, args)
 ```
 
@@ -197,7 +197,7 @@ import "golang.org/x/oauth2"
 /* Perform OAuth2 round trip request and obtain a token */
 
 tokenSource := oauth2cfg.TokenSource(createContext(httpClient), &token)
-auth := context.WithValue(oauth2.NoContext, sw.ContextOAuth2, tokenSource)
+auth := context.WithValue(oauth2.NoContext, petstore.ContextOAuth2, tokenSource)
 r, err := client.Service.Operation(auth, args)
 ```
 

--- a/samples/client/petstore/go/go-petstore/README.md
+++ b/samples/client/petstore/go/go-petstore/README.md
@@ -134,7 +134,7 @@ Class | Method | HTTP request | Description
 Example
 
 ```golang
-auth := context.WithValue(context.Background(), sw.ContextAPIKey, sw.APIKey{
+auth := context.WithValue(context.Background(), petstore.ContextAPIKey, petstore.APIKey{
     Key: "APIKEY",
     Prefix: "Bearer", // Omit if not necessary.
 })
@@ -149,7 +149,7 @@ r, err := client.Service.Operation(auth, args)
 Example
 
 ```golang
-auth := context.WithValue(context.Background(), sw.ContextAPIKey, sw.APIKey{
+auth := context.WithValue(context.Background(), petstore.ContextAPIKey, petstore.APIKey{
     Key: "APIKEY",
     Prefix: "Bearer", // Omit if not necessary.
 })
@@ -164,7 +164,7 @@ r, err := client.Service.Operation(auth, args)
 Example
 
 ```golang
-auth := context.WithValue(context.Background(), sw.ContextBasicAuth, sw.BasicAuth{
+auth := context.WithValue(context.Background(), petstore.ContextBasicAuth, petstore.BasicAuth{
     UserName: "username",
     Password: "password",
 })
@@ -185,7 +185,7 @@ r, err := client.Service.Operation(auth, args)
 Example
 
 ```golang
-auth := context.WithValue(context.Background(), sw.ContextAccessToken, "ACCESSTOKENSTRING")
+auth := context.WithValue(context.Background(), petstore.ContextAccessToken, "ACCESSTOKENSTRING")
 r, err := client.Service.Operation(auth, args)
 ```
 
@@ -197,7 +197,7 @@ import "golang.org/x/oauth2"
 /* Perform OAuth2 round trip request and obtain a token */
 
 tokenSource := oauth2cfg.TokenSource(createContext(httpClient), &token)
-auth := context.WithValue(oauth2.NoContext, sw.ContextOAuth2, tokenSource)
+auth := context.WithValue(oauth2.NoContext, petstore.ContextOAuth2, tokenSource)
 r, err := client.Service.Operation(auth, args)
 ```
 

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/README.md
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/README.md
@@ -199,6 +199,15 @@ Note, each API key must be added to a map of `map[string]APIKey` where the key i
 
 ### bearer_test
 
+- **Type**: HTTP Bearer token authentication
+
+Example
+
+```golang
+auth := context.WithValue(context.Background(), sw.ContextAccessToken, "BEARERTOKENSTRING")
+r, err := client.Service.Operation(auth, args)
+```
+
 
 ### http_basic_test
 

--- a/samples/openapi3/client/petstore/go/go-petstore/README.md
+++ b/samples/openapi3/client/petstore/go/go-petstore/README.md
@@ -137,7 +137,7 @@ Class | Method | HTTP request | Description
 Example
 
 ```golang
-auth := context.WithValue(context.Background(), sw.ContextAPIKey, sw.APIKey{
+auth := context.WithValue(context.Background(), petstore.ContextAPIKey, petstore.APIKey{
     Key: "APIKEY",
     Prefix: "Bearer", // Omit if not necessary.
 })
@@ -152,7 +152,7 @@ r, err := client.Service.Operation(auth, args)
 Example
 
 ```golang
-auth := context.WithValue(context.Background(), sw.ContextAPIKey, sw.APIKey{
+auth := context.WithValue(context.Background(), petstore.ContextAPIKey, petstore.APIKey{
     Key: "APIKEY",
     Prefix: "Bearer", // Omit if not necessary.
 })
@@ -162,15 +162,12 @@ r, err := client.Service.Operation(auth, args)
 
 ## bearer_test
 
-- **Type**: HTTP basic authentication
+- **Type**: HTTP Bearer token authentication
 
 Example
 
 ```golang
-auth := context.WithValue(context.Background(), sw.ContextBasicAuth, sw.BasicAuth{
-    UserName: "username",
-    Password: "password",
-})
+auth := context.WithValue(context.Background(), petstore.ContextAccessToken, "BEARERTOKENSTRING")
 r, err := client.Service.Operation(auth, args)
 ```
 
@@ -182,7 +179,7 @@ r, err := client.Service.Operation(auth, args)
 Example
 
 ```golang
-auth := context.WithValue(context.Background(), sw.ContextBasicAuth, sw.BasicAuth{
+auth := context.WithValue(context.Background(), petstore.ContextBasicAuth, petstore.BasicAuth{
     UserName: "username",
     Password: "password",
 })
@@ -192,17 +189,7 @@ r, err := client.Service.Operation(auth, args)
 
 ## http_signature_test
 
-- **Type**: HTTP basic authentication
-
-Example
-
-```golang
-auth := context.WithValue(context.Background(), sw.ContextBasicAuth, sw.BasicAuth{
-    UserName: "username",
-    Password: "password",
-})
-r, err := client.Service.Operation(auth, args)
-```
+Not supported.
 
 
 ## petstore_auth
@@ -218,7 +205,7 @@ r, err := client.Service.Operation(auth, args)
 Example
 
 ```golang
-auth := context.WithValue(context.Background(), sw.ContextAccessToken, "ACCESSTOKENSTRING")
+auth := context.WithValue(context.Background(), petstore.ContextAccessToken, "ACCESSTOKENSTRING")
 r, err := client.Service.Operation(auth, args)
 ```
 
@@ -230,7 +217,7 @@ import "golang.org/x/oauth2"
 /* Perform OAuth2 round trip request and obtain a token */
 
 tokenSource := oauth2cfg.TokenSource(createContext(httpClient), &token)
-auth := context.WithValue(oauth2.NoContext, sw.ContextOAuth2, tokenSource)
+auth := context.WithValue(oauth2.NoContext, petstore.ContextOAuth2, tokenSource)
 r, err := client.Service.Operation(auth, args)
 ```
 


### PR DESCRIPTION
Auth documentation for the following config is not generated correctly for go clients:

```yaml
    GoogleOpenIdAuth:
      type: http
      scheme: bearer
      bearerFormat: JWT
```

It should use AccessToken as the auth config, but what we have right now is BasicAuth.

Also properly document http_signature scheme as unsupported.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
