### PR TITLE
[GO][SERVER] Add custom return code

### DIFF
--- a/modules/openapi-generator/src/main/resources/go-server/api.mustache
+++ b/modules/openapi-generator/src/main/resources/go-server/api.mustache
@@ -21,5 +21,5 @@ type {{classname}}Router interface { {{#operations}}{{#operation}}
 // while the service implementation can ignored with the .openapi-generator-ignore file 
 // and updated with the logic required for the API.
 type {{classname}}Servicer interface { {{#operations}}{{#operation}}
-	{{operationId}}(context.Context{{#allParams}}, {{dataType}}{{/allParams}}) (interface{}, error){{/operation}}{{/operations}}
+	{{operationId}}(context.Context{{#allParams}}, {{dataType}}{{/allParams}}) (Response, error){{/operation}}{{/operations}}
 }{{/apis}}{{/apiInfo}}

--- a/modules/openapi-generator/src/main/resources/go-server/controller-api.mustache
+++ b/modules/openapi-generator/src/main/resources/go-server/controller-api.mustache
@@ -94,9 +94,8 @@ func (c *{{classname}}Controller) {{nickname}}(w http.ResponseWriter, r *http.Re
 	{{/isBodyParam}}{{/allParams}}
 	result, err := c.service.{{nickname}}(r.Context(){{#allParams}}, {{#isBodyParam}}*{{/isBodyParam}}{{paramName}}{{/allParams}})
 	if err != nil {
-		w.WriteHeader(500)
+		EncodeJSONResponse(err.Error(), &result.Code, w)
 		return
-	}
-	
-	EncodeJSONResponse(result, nil, w)
+	}	
+	EncodeJSONResponse(result.Body, &result.Code, w)
 }{{/operation}}{{/operations}}

--- a/modules/openapi-generator/src/main/resources/go-server/routers.mustache
+++ b/modules/openapi-generator/src/main/resources/go-server/routers.mustache
@@ -21,6 +21,12 @@ type Route struct {
 	HandlerFunc http.HandlerFunc
 }
 
+// A Response defines the Message and reponse Code for an api response.
+type Response struct {
+	Body interface{}
+	Code int
+}
+
 // Routes are a collection of defined api endpoints
 type Routes []Route
 

--- a/modules/openapi-generator/src/main/resources/go-server/service.mustache
+++ b/modules/openapi-generator/src/main/resources/go-server/service.mustache
@@ -19,8 +19,8 @@ func New{{classname}}Service() {{classname}}Servicer {
 }{{#operations}}{{#operation}}
 
 // {{nickname}} - {{summary}}
-func (s *{{classname}}Service) {{nickname}}(ctx context.Context{{#allParams}}, {{paramName}} {{dataType}}{{/allParams}}) (interface{}, error) {
+func (s *{{classname}}Service) {{nickname}}(ctx context.Context{{#allParams}}, {{paramName}} {{dataType}}{{/allParams}}) (Response, error) {
 	// TODO - update {{nickname}} with the required logic for this service method.
 	// Add {{classFilename}}_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
-	return nil, errors.New("service method '{{nickname}}' not implemented")
+	return Response{}, errors.New("service method '{{nickname}}' not implemented")
 }{{/operation}}{{/operations}}

--- a/modules/openapi-generator/src/main/resources/go-server/service.mustache
+++ b/modules/openapi-generator/src/main/resources/go-server/service.mustache
@@ -22,5 +22,5 @@ func New{{classname}}Service() {{classname}}Servicer {
 func (s *{{classname}}Service) {{nickname}}(ctx context.Context{{#allParams}}, {{paramName}} {{dataType}}{{/allParams}}) (Response, error) {
 	// TODO - update {{nickname}} with the required logic for this service method.
 	// Add {{classFilename}}_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
-	return Response{}, errors.New("service method '{{nickname}}' not implemented")
+	return Response{Code:500}, errors.New("service method '{{nickname}}' not implemented")
 }{{/operation}}{{/operations}}

--- a/samples/server/petstore/go-api-server/go/api.go
+++ b/samples/server/petstore/go-api-server/go/api.go
@@ -58,14 +58,14 @@ type UserApiRouter interface {
 // while the service implementation can ignored with the .openapi-generator-ignore file 
 // and updated with the logic required for the API.
 type PetApiServicer interface { 
-	AddPet(context.Context, Pet) (interface{}, error)
-	DeletePet(context.Context, int64, string) (interface{}, error)
-	FindPetsByStatus(context.Context, []string) (interface{}, error)
-	FindPetsByTags(context.Context, []string) (interface{}, error)
-	GetPetById(context.Context, int64) (interface{}, error)
-	UpdatePet(context.Context, Pet) (interface{}, error)
-	UpdatePetWithForm(context.Context, int64, string, string) (interface{}, error)
-	UploadFile(context.Context, int64, string, *os.File) (interface{}, error)
+	AddPet(context.Context, Pet) (Response, error)
+	DeletePet(context.Context, int64, string) (Response, error)
+	FindPetsByStatus(context.Context, []string) (Response, error)
+	FindPetsByTags(context.Context, []string) (Response, error)
+	GetPetById(context.Context, int64) (Response, error)
+	UpdatePet(context.Context, Pet) (Response, error)
+	UpdatePetWithForm(context.Context, int64, string, string) (Response, error)
+	UploadFile(context.Context, int64, string, *os.File) (Response, error)
 }
 
 
@@ -74,10 +74,10 @@ type PetApiServicer interface {
 // while the service implementation can ignored with the .openapi-generator-ignore file 
 // and updated with the logic required for the API.
 type StoreApiServicer interface { 
-	DeleteOrder(context.Context, string) (interface{}, error)
-	GetInventory(context.Context) (interface{}, error)
-	GetOrderById(context.Context, int64) (interface{}, error)
-	PlaceOrder(context.Context, Order) (interface{}, error)
+	DeleteOrder(context.Context, string) (Response, error)
+	GetInventory(context.Context) (Response, error)
+	GetOrderById(context.Context, int64) (Response, error)
+	PlaceOrder(context.Context, Order) (Response, error)
 }
 
 
@@ -86,12 +86,12 @@ type StoreApiServicer interface {
 // while the service implementation can ignored with the .openapi-generator-ignore file 
 // and updated with the logic required for the API.
 type UserApiServicer interface { 
-	CreateUser(context.Context, User) (interface{}, error)
-	CreateUsersWithArrayInput(context.Context, []User) (interface{}, error)
-	CreateUsersWithListInput(context.Context, []User) (interface{}, error)
-	DeleteUser(context.Context, string) (interface{}, error)
-	GetUserByName(context.Context, string) (interface{}, error)
-	LoginUser(context.Context, string, string) (interface{}, error)
-	LogoutUser(context.Context) (interface{}, error)
-	UpdateUser(context.Context, string, User) (interface{}, error)
+	CreateUser(context.Context, User) (Response, error)
+	CreateUsersWithArrayInput(context.Context, []User) (Response, error)
+	CreateUsersWithListInput(context.Context, []User) (Response, error)
+	DeleteUser(context.Context, string) (Response, error)
+	GetUserByName(context.Context, string) (Response, error)
+	LoginUser(context.Context, string, string) (Response, error)
+	LogoutUser(context.Context) (Response, error)
+	UpdateUser(context.Context, string, User) (Response, error)
 }

--- a/samples/server/petstore/go-api-server/go/api_pet.go
+++ b/samples/server/petstore/go-api-server/go/api_pet.go
@@ -91,11 +91,10 @@ func (c *PetApiController) AddPet(w http.ResponseWriter, r *http.Request) {
 	
 	result, err := c.service.AddPet(r.Context(), *pet)
 	if err != nil {
-		w.WriteHeader(500)
+		EncodeJSONResponse(err.Error(), &result.Code, w)
 		return
-	}
-	
-	EncodeJSONResponse(result, nil, w)
+	}	
+	EncodeJSONResponse(result.Body, &result.Code, w)
 }
 
 // DeletePet - Deletes a pet
@@ -109,11 +108,10 @@ func (c *PetApiController) DeletePet(w http.ResponseWriter, r *http.Request) {
 	apiKey := r.Header.Get("apiKey")
 	result, err := c.service.DeletePet(r.Context(), petId, apiKey)
 	if err != nil {
-		w.WriteHeader(500)
+		EncodeJSONResponse(err.Error(), &result.Code, w)
 		return
-	}
-	
-	EncodeJSONResponse(result, nil, w)
+	}	
+	EncodeJSONResponse(result.Body, &result.Code, w)
 }
 
 // FindPetsByStatus - Finds Pets by status
@@ -122,11 +120,10 @@ func (c *PetApiController) FindPetsByStatus(w http.ResponseWriter, r *http.Reque
 	status := strings.Split(query.Get("status"), ",")
 	result, err := c.service.FindPetsByStatus(r.Context(), status)
 	if err != nil {
-		w.WriteHeader(500)
+		EncodeJSONResponse(err.Error(), &result.Code, w)
 		return
-	}
-	
-	EncodeJSONResponse(result, nil, w)
+	}	
+	EncodeJSONResponse(result.Body, &result.Code, w)
 }
 
 // FindPetsByTags - Finds Pets by tags
@@ -135,11 +132,10 @@ func (c *PetApiController) FindPetsByTags(w http.ResponseWriter, r *http.Request
 	tags := strings.Split(query.Get("tags"), ",")
 	result, err := c.service.FindPetsByTags(r.Context(), tags)
 	if err != nil {
-		w.WriteHeader(500)
+		EncodeJSONResponse(err.Error(), &result.Code, w)
 		return
-	}
-	
-	EncodeJSONResponse(result, nil, w)
+	}	
+	EncodeJSONResponse(result.Body, &result.Code, w)
 }
 
 // GetPetById - Find pet by ID
@@ -152,11 +148,10 @@ func (c *PetApiController) GetPetById(w http.ResponseWriter, r *http.Request) {
 	}
 	result, err := c.service.GetPetById(r.Context(), petId)
 	if err != nil {
-		w.WriteHeader(500)
+		EncodeJSONResponse(err.Error(), &result.Code, w)
 		return
-	}
-	
-	EncodeJSONResponse(result, nil, w)
+	}	
+	EncodeJSONResponse(result.Body, &result.Code, w)
 }
 
 // UpdatePet - Update an existing pet
@@ -169,11 +164,10 @@ func (c *PetApiController) UpdatePet(w http.ResponseWriter, r *http.Request) {
 	
 	result, err := c.service.UpdatePet(r.Context(), *pet)
 	if err != nil {
-		w.WriteHeader(500)
+		EncodeJSONResponse(err.Error(), &result.Code, w)
 		return
-	}
-	
-	EncodeJSONResponse(result, nil, w)
+	}	
+	EncodeJSONResponse(result.Body, &result.Code, w)
 }
 
 // UpdatePetWithForm - Updates a pet in the store with form data
@@ -194,11 +188,10 @@ func (c *PetApiController) UpdatePetWithForm(w http.ResponseWriter, r *http.Requ
 	status := r.FormValue("status")
 	result, err := c.service.UpdatePetWithForm(r.Context(), petId, name, status)
 	if err != nil {
-		w.WriteHeader(500)
+		EncodeJSONResponse(err.Error(), &result.Code, w)
 		return
-	}
-	
-	EncodeJSONResponse(result, nil, w)
+	}	
+	EncodeJSONResponse(result.Body, &result.Code, w)
 }
 
 // UploadFile - uploads an image
@@ -224,9 +217,8 @@ func (c *PetApiController) UploadFile(w http.ResponseWriter, r *http.Request) {
 	
 	result, err := c.service.UploadFile(r.Context(), petId, additionalMetadata, file)
 	if err != nil {
-		w.WriteHeader(500)
+		EncodeJSONResponse(err.Error(), &result.Code, w)
 		return
-	}
-	
-	EncodeJSONResponse(result, nil, w)
+	}	
+	EncodeJSONResponse(result.Body, &result.Code, w)
 }

--- a/samples/server/petstore/go-api-server/go/api_pet_service.go
+++ b/samples/server/petstore/go-api-server/go/api_pet_service.go
@@ -30,54 +30,54 @@ func NewPetApiService() PetApiServicer {
 func (s *PetApiService) AddPet(ctx context.Context, pet Pet) (Response, error) {
 	// TODO - update AddPet with the required logic for this service method.
 	// Add api_pet_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
-	return Response{}, errors.New("service method 'AddPet' not implemented")
+	return Response{Code:500}, errors.New("service method 'AddPet' not implemented")
 }
 
 // DeletePet - Deletes a pet
 func (s *PetApiService) DeletePet(ctx context.Context, petId int64, apiKey string) (Response, error) {
 	// TODO - update DeletePet with the required logic for this service method.
 	// Add api_pet_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
-	return Response{}, errors.New("service method 'DeletePet' not implemented")
+	return Response{Code:500}, errors.New("service method 'DeletePet' not implemented")
 }
 
 // FindPetsByStatus - Finds Pets by status
 func (s *PetApiService) FindPetsByStatus(ctx context.Context, status []string) (Response, error) {
 	// TODO - update FindPetsByStatus with the required logic for this service method.
 	// Add api_pet_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
-	return Response{}, errors.New("service method 'FindPetsByStatus' not implemented")
+	return Response{Code:500}, errors.New("service method 'FindPetsByStatus' not implemented")
 }
 
 // FindPetsByTags - Finds Pets by tags
 func (s *PetApiService) FindPetsByTags(ctx context.Context, tags []string) (Response, error) {
 	// TODO - update FindPetsByTags with the required logic for this service method.
 	// Add api_pet_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
-	return Response{}, errors.New("service method 'FindPetsByTags' not implemented")
+	return Response{Code:500}, errors.New("service method 'FindPetsByTags' not implemented")
 }
 
 // GetPetById - Find pet by ID
 func (s *PetApiService) GetPetById(ctx context.Context, petId int64) (Response, error) {
 	// TODO - update GetPetById with the required logic for this service method.
 	// Add api_pet_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
-	return Response{}, errors.New("service method 'GetPetById' not implemented")
+	return Response{Code:500}, errors.New("service method 'GetPetById' not implemented")
 }
 
 // UpdatePet - Update an existing pet
 func (s *PetApiService) UpdatePet(ctx context.Context, pet Pet) (Response, error) {
 	// TODO - update UpdatePet with the required logic for this service method.
 	// Add api_pet_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
-	return Response{}, errors.New("service method 'UpdatePet' not implemented")
+	return Response{Code:500}, errors.New("service method 'UpdatePet' not implemented")
 }
 
 // UpdatePetWithForm - Updates a pet in the store with form data
 func (s *PetApiService) UpdatePetWithForm(ctx context.Context, petId int64, name string, status string) (Response, error) {
 	// TODO - update UpdatePetWithForm with the required logic for this service method.
 	// Add api_pet_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
-	return Response{}, errors.New("service method 'UpdatePetWithForm' not implemented")
+	return Response{Code:500}, errors.New("service method 'UpdatePetWithForm' not implemented")
 }
 
 // UploadFile - uploads an image
 func (s *PetApiService) UploadFile(ctx context.Context, petId int64, additionalMetadata string, file *os.File) (Response, error) {
 	// TODO - update UploadFile with the required logic for this service method.
 	// Add api_pet_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
-	return Response{}, errors.New("service method 'UploadFile' not implemented")
+	return Response{Code:500}, errors.New("service method 'UploadFile' not implemented")
 }

--- a/samples/server/petstore/go-api-server/go/api_pet_service.go
+++ b/samples/server/petstore/go-api-server/go/api_pet_service.go
@@ -27,57 +27,57 @@ func NewPetApiService() PetApiServicer {
 }
 
 // AddPet - Add a new pet to the store
-func (s *PetApiService) AddPet(ctx context.Context, pet Pet) (interface{}, error) {
+func (s *PetApiService) AddPet(ctx context.Context, pet Pet) (Response, error) {
 	// TODO - update AddPet with the required logic for this service method.
 	// Add api_pet_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
-	return nil, errors.New("service method 'AddPet' not implemented")
+	return Response{}, errors.New("service method 'AddPet' not implemented")
 }
 
 // DeletePet - Deletes a pet
-func (s *PetApiService) DeletePet(ctx context.Context, petId int64, apiKey string) (interface{}, error) {
+func (s *PetApiService) DeletePet(ctx context.Context, petId int64, apiKey string) (Response, error) {
 	// TODO - update DeletePet with the required logic for this service method.
 	// Add api_pet_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
-	return nil, errors.New("service method 'DeletePet' not implemented")
+	return Response{}, errors.New("service method 'DeletePet' not implemented")
 }
 
 // FindPetsByStatus - Finds Pets by status
-func (s *PetApiService) FindPetsByStatus(ctx context.Context, status []string) (interface{}, error) {
+func (s *PetApiService) FindPetsByStatus(ctx context.Context, status []string) (Response, error) {
 	// TODO - update FindPetsByStatus with the required logic for this service method.
 	// Add api_pet_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
-	return nil, errors.New("service method 'FindPetsByStatus' not implemented")
+	return Response{}, errors.New("service method 'FindPetsByStatus' not implemented")
 }
 
 // FindPetsByTags - Finds Pets by tags
-func (s *PetApiService) FindPetsByTags(ctx context.Context, tags []string) (interface{}, error) {
+func (s *PetApiService) FindPetsByTags(ctx context.Context, tags []string) (Response, error) {
 	// TODO - update FindPetsByTags with the required logic for this service method.
 	// Add api_pet_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
-	return nil, errors.New("service method 'FindPetsByTags' not implemented")
+	return Response{}, errors.New("service method 'FindPetsByTags' not implemented")
 }
 
 // GetPetById - Find pet by ID
-func (s *PetApiService) GetPetById(ctx context.Context, petId int64) (interface{}, error) {
+func (s *PetApiService) GetPetById(ctx context.Context, petId int64) (Response, error) {
 	// TODO - update GetPetById with the required logic for this service method.
 	// Add api_pet_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
-	return nil, errors.New("service method 'GetPetById' not implemented")
+	return Response{}, errors.New("service method 'GetPetById' not implemented")
 }
 
 // UpdatePet - Update an existing pet
-func (s *PetApiService) UpdatePet(ctx context.Context, pet Pet) (interface{}, error) {
+func (s *PetApiService) UpdatePet(ctx context.Context, pet Pet) (Response, error) {
 	// TODO - update UpdatePet with the required logic for this service method.
 	// Add api_pet_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
-	return nil, errors.New("service method 'UpdatePet' not implemented")
+	return Response{}, errors.New("service method 'UpdatePet' not implemented")
 }
 
 // UpdatePetWithForm - Updates a pet in the store with form data
-func (s *PetApiService) UpdatePetWithForm(ctx context.Context, petId int64, name string, status string) (interface{}, error) {
+func (s *PetApiService) UpdatePetWithForm(ctx context.Context, petId int64, name string, status string) (Response, error) {
 	// TODO - update UpdatePetWithForm with the required logic for this service method.
 	// Add api_pet_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
-	return nil, errors.New("service method 'UpdatePetWithForm' not implemented")
+	return Response{}, errors.New("service method 'UpdatePetWithForm' not implemented")
 }
 
 // UploadFile - uploads an image
-func (s *PetApiService) UploadFile(ctx context.Context, petId int64, additionalMetadata string, file *os.File) (interface{}, error) {
+func (s *PetApiService) UploadFile(ctx context.Context, petId int64, additionalMetadata string, file *os.File) (Response, error) {
 	// TODO - update UploadFile with the required logic for this service method.
 	// Add api_pet_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
-	return nil, errors.New("service method 'UploadFile' not implemented")
+	return Response{}, errors.New("service method 'UploadFile' not implemented")
 }

--- a/samples/server/petstore/go-api-server/go/api_store.go
+++ b/samples/server/petstore/go-api-server/go/api_store.go
@@ -63,22 +63,20 @@ func (c *StoreApiController) DeleteOrder(w http.ResponseWriter, r *http.Request)
 	orderId := params["orderId"]
 	result, err := c.service.DeleteOrder(r.Context(), orderId)
 	if err != nil {
-		w.WriteHeader(500)
+		EncodeJSONResponse(err.Error(), &result.Code, w)
 		return
-	}
-	
-	EncodeJSONResponse(result, nil, w)
+	}	
+	EncodeJSONResponse(result.Body, &result.Code, w)
 }
 
 // GetInventory - Returns pet inventories by status
 func (c *StoreApiController) GetInventory(w http.ResponseWriter, r *http.Request) { 
 	result, err := c.service.GetInventory(r.Context())
 	if err != nil {
-		w.WriteHeader(500)
+		EncodeJSONResponse(err.Error(), &result.Code, w)
 		return
-	}
-	
-	EncodeJSONResponse(result, nil, w)
+	}	
+	EncodeJSONResponse(result.Body, &result.Code, w)
 }
 
 // GetOrderById - Find purchase order by ID
@@ -91,11 +89,10 @@ func (c *StoreApiController) GetOrderById(w http.ResponseWriter, r *http.Request
 	}
 	result, err := c.service.GetOrderById(r.Context(), orderId)
 	if err != nil {
-		w.WriteHeader(500)
+		EncodeJSONResponse(err.Error(), &result.Code, w)
 		return
-	}
-	
-	EncodeJSONResponse(result, nil, w)
+	}	
+	EncodeJSONResponse(result.Body, &result.Code, w)
 }
 
 // PlaceOrder - Place an order for a pet
@@ -108,9 +105,8 @@ func (c *StoreApiController) PlaceOrder(w http.ResponseWriter, r *http.Request) 
 	
 	result, err := c.service.PlaceOrder(r.Context(), *order)
 	if err != nil {
-		w.WriteHeader(500)
+		EncodeJSONResponse(err.Error(), &result.Code, w)
 		return
-	}
-	
-	EncodeJSONResponse(result, nil, w)
+	}	
+	EncodeJSONResponse(result.Body, &result.Code, w)
 }

--- a/samples/server/petstore/go-api-server/go/api_store_service.go
+++ b/samples/server/petstore/go-api-server/go/api_store_service.go
@@ -29,26 +29,26 @@ func NewStoreApiService() StoreApiServicer {
 func (s *StoreApiService) DeleteOrder(ctx context.Context, orderId string) (Response, error) {
 	// TODO - update DeleteOrder with the required logic for this service method.
 	// Add api_store_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
-	return Response{}, errors.New("service method 'DeleteOrder' not implemented")
+	return Response{Code:500}, errors.New("service method 'DeleteOrder' not implemented")
 }
 
 // GetInventory - Returns pet inventories by status
 func (s *StoreApiService) GetInventory(ctx context.Context) (Response, error) {
 	// TODO - update GetInventory with the required logic for this service method.
 	// Add api_store_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
-	return Response{}, errors.New("service method 'GetInventory' not implemented")
+	return Response{Code:500}, errors.New("service method 'GetInventory' not implemented")
 }
 
 // GetOrderById - Find purchase order by ID
 func (s *StoreApiService) GetOrderById(ctx context.Context, orderId int64) (Response, error) {
 	// TODO - update GetOrderById with the required logic for this service method.
 	// Add api_store_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
-	return Response{}, errors.New("service method 'GetOrderById' not implemented")
+	return Response{Code:500}, errors.New("service method 'GetOrderById' not implemented")
 }
 
 // PlaceOrder - Place an order for a pet
 func (s *StoreApiService) PlaceOrder(ctx context.Context, order Order) (Response, error) {
 	// TODO - update PlaceOrder with the required logic for this service method.
 	// Add api_store_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
-	return Response{}, errors.New("service method 'PlaceOrder' not implemented")
+	return Response{Code:500}, errors.New("service method 'PlaceOrder' not implemented")
 }

--- a/samples/server/petstore/go-api-server/go/api_store_service.go
+++ b/samples/server/petstore/go-api-server/go/api_store_service.go
@@ -26,29 +26,29 @@ func NewStoreApiService() StoreApiServicer {
 }
 
 // DeleteOrder - Delete purchase order by ID
-func (s *StoreApiService) DeleteOrder(ctx context.Context, orderId string) (interface{}, error) {
+func (s *StoreApiService) DeleteOrder(ctx context.Context, orderId string) (Response, error) {
 	// TODO - update DeleteOrder with the required logic for this service method.
 	// Add api_store_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
-	return nil, errors.New("service method 'DeleteOrder' not implemented")
+	return Response{}, errors.New("service method 'DeleteOrder' not implemented")
 }
 
 // GetInventory - Returns pet inventories by status
-func (s *StoreApiService) GetInventory(ctx context.Context) (interface{}, error) {
+func (s *StoreApiService) GetInventory(ctx context.Context) (Response, error) {
 	// TODO - update GetInventory with the required logic for this service method.
 	// Add api_store_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
-	return nil, errors.New("service method 'GetInventory' not implemented")
+	return Response{}, errors.New("service method 'GetInventory' not implemented")
 }
 
 // GetOrderById - Find purchase order by ID
-func (s *StoreApiService) GetOrderById(ctx context.Context, orderId int64) (interface{}, error) {
+func (s *StoreApiService) GetOrderById(ctx context.Context, orderId int64) (Response, error) {
 	// TODO - update GetOrderById with the required logic for this service method.
 	// Add api_store_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
-	return nil, errors.New("service method 'GetOrderById' not implemented")
+	return Response{}, errors.New("service method 'GetOrderById' not implemented")
 }
 
 // PlaceOrder - Place an order for a pet
-func (s *StoreApiService) PlaceOrder(ctx context.Context, order Order) (interface{}, error) {
+func (s *StoreApiService) PlaceOrder(ctx context.Context, order Order) (Response, error) {
 	// TODO - update PlaceOrder with the required logic for this service method.
 	// Add api_store_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
-	return nil, errors.New("service method 'PlaceOrder' not implemented")
+	return Response{}, errors.New("service method 'PlaceOrder' not implemented")
 }

--- a/samples/server/petstore/go-api-server/go/api_user.go
+++ b/samples/server/petstore/go-api-server/go/api_user.go
@@ -91,11 +91,10 @@ func (c *UserApiController) CreateUser(w http.ResponseWriter, r *http.Request) {
 	
 	result, err := c.service.CreateUser(r.Context(), *user)
 	if err != nil {
-		w.WriteHeader(500)
+		EncodeJSONResponse(err.Error(), &result.Code, w)
 		return
-	}
-	
-	EncodeJSONResponse(result, nil, w)
+	}	
+	EncodeJSONResponse(result.Body, &result.Code, w)
 }
 
 // CreateUsersWithArrayInput - Creates list of users with given input array
@@ -108,11 +107,10 @@ func (c *UserApiController) CreateUsersWithArrayInput(w http.ResponseWriter, r *
 	
 	result, err := c.service.CreateUsersWithArrayInput(r.Context(), *user)
 	if err != nil {
-		w.WriteHeader(500)
+		EncodeJSONResponse(err.Error(), &result.Code, w)
 		return
-	}
-	
-	EncodeJSONResponse(result, nil, w)
+	}	
+	EncodeJSONResponse(result.Body, &result.Code, w)
 }
 
 // CreateUsersWithListInput - Creates list of users with given input array
@@ -125,11 +123,10 @@ func (c *UserApiController) CreateUsersWithListInput(w http.ResponseWriter, r *h
 	
 	result, err := c.service.CreateUsersWithListInput(r.Context(), *user)
 	if err != nil {
-		w.WriteHeader(500)
+		EncodeJSONResponse(err.Error(), &result.Code, w)
 		return
-	}
-	
-	EncodeJSONResponse(result, nil, w)
+	}	
+	EncodeJSONResponse(result.Body, &result.Code, w)
 }
 
 // DeleteUser - Delete user
@@ -138,11 +135,10 @@ func (c *UserApiController) DeleteUser(w http.ResponseWriter, r *http.Request) {
 	username := params["username"]
 	result, err := c.service.DeleteUser(r.Context(), username)
 	if err != nil {
-		w.WriteHeader(500)
+		EncodeJSONResponse(err.Error(), &result.Code, w)
 		return
-	}
-	
-	EncodeJSONResponse(result, nil, w)
+	}	
+	EncodeJSONResponse(result.Body, &result.Code, w)
 }
 
 // GetUserByName - Get user by user name
@@ -151,11 +147,10 @@ func (c *UserApiController) GetUserByName(w http.ResponseWriter, r *http.Request
 	username := params["username"]
 	result, err := c.service.GetUserByName(r.Context(), username)
 	if err != nil {
-		w.WriteHeader(500)
+		EncodeJSONResponse(err.Error(), &result.Code, w)
 		return
-	}
-	
-	EncodeJSONResponse(result, nil, w)
+	}	
+	EncodeJSONResponse(result.Body, &result.Code, w)
 }
 
 // LoginUser - Logs user into the system
@@ -165,22 +160,20 @@ func (c *UserApiController) LoginUser(w http.ResponseWriter, r *http.Request) {
 	password := query.Get("password")
 	result, err := c.service.LoginUser(r.Context(), username, password)
 	if err != nil {
-		w.WriteHeader(500)
+		EncodeJSONResponse(err.Error(), &result.Code, w)
 		return
-	}
-	
-	EncodeJSONResponse(result, nil, w)
+	}	
+	EncodeJSONResponse(result.Body, &result.Code, w)
 }
 
 // LogoutUser - Logs out current logged in user session
 func (c *UserApiController) LogoutUser(w http.ResponseWriter, r *http.Request) { 
 	result, err := c.service.LogoutUser(r.Context())
 	if err != nil {
-		w.WriteHeader(500)
+		EncodeJSONResponse(err.Error(), &result.Code, w)
 		return
-	}
-	
-	EncodeJSONResponse(result, nil, w)
+	}	
+	EncodeJSONResponse(result.Body, &result.Code, w)
 }
 
 // UpdateUser - Updated user
@@ -195,9 +188,8 @@ func (c *UserApiController) UpdateUser(w http.ResponseWriter, r *http.Request) {
 	
 	result, err := c.service.UpdateUser(r.Context(), username, *user)
 	if err != nil {
-		w.WriteHeader(500)
+		EncodeJSONResponse(err.Error(), &result.Code, w)
 		return
-	}
-	
-	EncodeJSONResponse(result, nil, w)
+	}	
+	EncodeJSONResponse(result.Body, &result.Code, w)
 }

--- a/samples/server/petstore/go-api-server/go/api_user_service.go
+++ b/samples/server/petstore/go-api-server/go/api_user_service.go
@@ -26,57 +26,57 @@ func NewUserApiService() UserApiServicer {
 }
 
 // CreateUser - Create user
-func (s *UserApiService) CreateUser(ctx context.Context, user User) (interface{}, error) {
+func (s *UserApiService) CreateUser(ctx context.Context, user User) (Response, error) {
 	// TODO - update CreateUser with the required logic for this service method.
 	// Add api_user_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
-	return nil, errors.New("service method 'CreateUser' not implemented")
+	return Response{}, errors.New("service method 'CreateUser' not implemented")
 }
 
 // CreateUsersWithArrayInput - Creates list of users with given input array
-func (s *UserApiService) CreateUsersWithArrayInput(ctx context.Context, user []User) (interface{}, error) {
+func (s *UserApiService) CreateUsersWithArrayInput(ctx context.Context, user []User) (Response, error) {
 	// TODO - update CreateUsersWithArrayInput with the required logic for this service method.
 	// Add api_user_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
-	return nil, errors.New("service method 'CreateUsersWithArrayInput' not implemented")
+	return Response{}, errors.New("service method 'CreateUsersWithArrayInput' not implemented")
 }
 
 // CreateUsersWithListInput - Creates list of users with given input array
-func (s *UserApiService) CreateUsersWithListInput(ctx context.Context, user []User) (interface{}, error) {
+func (s *UserApiService) CreateUsersWithListInput(ctx context.Context, user []User) (Response, error) {
 	// TODO - update CreateUsersWithListInput with the required logic for this service method.
 	// Add api_user_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
-	return nil, errors.New("service method 'CreateUsersWithListInput' not implemented")
+	return Response{}, errors.New("service method 'CreateUsersWithListInput' not implemented")
 }
 
 // DeleteUser - Delete user
-func (s *UserApiService) DeleteUser(ctx context.Context, username string) (interface{}, error) {
+func (s *UserApiService) DeleteUser(ctx context.Context, username string) (Response, error) {
 	// TODO - update DeleteUser with the required logic for this service method.
 	// Add api_user_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
-	return nil, errors.New("service method 'DeleteUser' not implemented")
+	return Response{}, errors.New("service method 'DeleteUser' not implemented")
 }
 
 // GetUserByName - Get user by user name
-func (s *UserApiService) GetUserByName(ctx context.Context, username string) (interface{}, error) {
+func (s *UserApiService) GetUserByName(ctx context.Context, username string) (Response, error) {
 	// TODO - update GetUserByName with the required logic for this service method.
 	// Add api_user_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
-	return nil, errors.New("service method 'GetUserByName' not implemented")
+	return Response{}, errors.New("service method 'GetUserByName' not implemented")
 }
 
 // LoginUser - Logs user into the system
-func (s *UserApiService) LoginUser(ctx context.Context, username string, password string) (interface{}, error) {
+func (s *UserApiService) LoginUser(ctx context.Context, username string, password string) (Response, error) {
 	// TODO - update LoginUser with the required logic for this service method.
 	// Add api_user_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
-	return nil, errors.New("service method 'LoginUser' not implemented")
+	return Response{}, errors.New("service method 'LoginUser' not implemented")
 }
 
 // LogoutUser - Logs out current logged in user session
-func (s *UserApiService) LogoutUser(ctx context.Context) (interface{}, error) {
+func (s *UserApiService) LogoutUser(ctx context.Context) (Response, error) {
 	// TODO - update LogoutUser with the required logic for this service method.
 	// Add api_user_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
-	return nil, errors.New("service method 'LogoutUser' not implemented")
+	return Response{}, errors.New("service method 'LogoutUser' not implemented")
 }
 
 // UpdateUser - Updated user
-func (s *UserApiService) UpdateUser(ctx context.Context, username string, user User) (interface{}, error) {
+func (s *UserApiService) UpdateUser(ctx context.Context, username string, user User) (Response, error) {
 	// TODO - update UpdateUser with the required logic for this service method.
 	// Add api_user_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
-	return nil, errors.New("service method 'UpdateUser' not implemented")
+	return Response{}, errors.New("service method 'UpdateUser' not implemented")
 }

--- a/samples/server/petstore/go-api-server/go/api_user_service.go
+++ b/samples/server/petstore/go-api-server/go/api_user_service.go
@@ -29,54 +29,54 @@ func NewUserApiService() UserApiServicer {
 func (s *UserApiService) CreateUser(ctx context.Context, user User) (Response, error) {
 	// TODO - update CreateUser with the required logic for this service method.
 	// Add api_user_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
-	return Response{}, errors.New("service method 'CreateUser' not implemented")
+	return Response{Code:500}, errors.New("service method 'CreateUser' not implemented")
 }
 
 // CreateUsersWithArrayInput - Creates list of users with given input array
 func (s *UserApiService) CreateUsersWithArrayInput(ctx context.Context, user []User) (Response, error) {
 	// TODO - update CreateUsersWithArrayInput with the required logic for this service method.
 	// Add api_user_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
-	return Response{}, errors.New("service method 'CreateUsersWithArrayInput' not implemented")
+	return Response{Code:500}, errors.New("service method 'CreateUsersWithArrayInput' not implemented")
 }
 
 // CreateUsersWithListInput - Creates list of users with given input array
 func (s *UserApiService) CreateUsersWithListInput(ctx context.Context, user []User) (Response, error) {
 	// TODO - update CreateUsersWithListInput with the required logic for this service method.
 	// Add api_user_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
-	return Response{}, errors.New("service method 'CreateUsersWithListInput' not implemented")
+	return Response{Code:500}, errors.New("service method 'CreateUsersWithListInput' not implemented")
 }
 
 // DeleteUser - Delete user
 func (s *UserApiService) DeleteUser(ctx context.Context, username string) (Response, error) {
 	// TODO - update DeleteUser with the required logic for this service method.
 	// Add api_user_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
-	return Response{}, errors.New("service method 'DeleteUser' not implemented")
+	return Response{Code:500}, errors.New("service method 'DeleteUser' not implemented")
 }
 
 // GetUserByName - Get user by user name
 func (s *UserApiService) GetUserByName(ctx context.Context, username string) (Response, error) {
 	// TODO - update GetUserByName with the required logic for this service method.
 	// Add api_user_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
-	return Response{}, errors.New("service method 'GetUserByName' not implemented")
+	return Response{Code:500}, errors.New("service method 'GetUserByName' not implemented")
 }
 
 // LoginUser - Logs user into the system
 func (s *UserApiService) LoginUser(ctx context.Context, username string, password string) (Response, error) {
 	// TODO - update LoginUser with the required logic for this service method.
 	// Add api_user_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
-	return Response{}, errors.New("service method 'LoginUser' not implemented")
+	return Response{Code:500}, errors.New("service method 'LoginUser' not implemented")
 }
 
 // LogoutUser - Logs out current logged in user session
 func (s *UserApiService) LogoutUser(ctx context.Context) (Response, error) {
 	// TODO - update LogoutUser with the required logic for this service method.
 	// Add api_user_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
-	return Response{}, errors.New("service method 'LogoutUser' not implemented")
+	return Response{Code:500}, errors.New("service method 'LogoutUser' not implemented")
 }
 
 // UpdateUser - Updated user
 func (s *UserApiService) UpdateUser(ctx context.Context, username string, user User) (Response, error) {
 	// TODO - update UpdateUser with the required logic for this service method.
 	// Add api_user_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
-	return Response{}, errors.New("service method 'UpdateUser' not implemented")
+	return Response{Code:500}, errors.New("service method 'UpdateUser' not implemented")
 }

--- a/samples/server/petstore/go-api-server/go/routers.go
+++ b/samples/server/petstore/go-api-server/go/routers.go
@@ -26,6 +26,12 @@ type Route struct {
 	HandlerFunc http.HandlerFunc
 }
 
+// A Response defines the Message and reponse Code for an api response.
+type Response struct {
+	Body interface{}
+	Code int
+}
+
 // Routes are a collection of defined api endpoints
 type Routes []Route
 


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
Hi, in the go server, we can only return 500 and 200 error code whether we have an error or not.
The implementation return a variable of type interface{} which contain the body message.

I suggest to change this interface to a struct wich contain the Body message and a return code as well.

```
// A Response defines the Message and reponse Code for an api response.
type Response struct {
	Body interface{}
	Code int
}
```

So the logic is the following.

```
if err != nil {
	EncodeJSONResponse(err.Error(), &result.Code, w)
	return
}	
EncodeJSONResponse(result.Body, &result.Code, w)
```

- If we have an error parsing the request (body or parameters), we still have a 500 return error.
- If not, we enter our implementation function.
- If the implementation return an error, we encode the response with the error message as discussed in #7165 , and with the error code provided (500 by default).
- If no error is encoutered, we Encode the response with the custom code (if nil code = 200 by default).


----

I think being able to return custom code (202,204 etc..) is mandatory for a project aiming standardisation.

For example im trying to implement standard APIs defined with OpenAPI and need to be able to make the difference between 202 and 204 return type.
https://forge.etsi.org/swagger/ui/?url=https://forge.etsi.org/gitlab/mec/gs015-bandwith-mgmt-api/raw/master/BwManagementApi.yaml#/

@antihax (2017/11) @grokify (2018/07) @kemokemo (2018/09) @bkabrda (2019/07) @wing328
Thanks
<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
