### PR TITLE
Add structPrefix support to go-experimental

### DIFF
--- a/modules/openapi-generator/src/main/resources/go-experimental/api.mustache
+++ b/modules/openapi-generator/src/main/resources/go-experimental/api.mustache
@@ -27,15 +27,15 @@ type {{classname}} interface {
   {{/notes}}
    * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().{{#pathParams}}
    * @param {{paramName}}{{#description}} {{{.}}}{{/description}}{{/pathParams}}
-   * @return Api{{operationId}}Request
+   * @return {{#structPrefix}}{{&classname}}{{/structPrefix}}Api{{operationId}}Request
    */
-  {{{nickname}}}(ctx _context.Context{{#pathParams}}, {{paramName}} {{{dataType}}}{{/pathParams}}) Api{{operationId}}Request
+  {{{nickname}}}(ctx _context.Context{{#pathParams}}, {{paramName}} {{{dataType}}}{{/pathParams}}) {{#structPrefix}}{{&classname}}{{/structPrefix}}Api{{operationId}}Request
 
   /*
    * {{nickname}}Execute executes the request{{#returnType}}
    * @return {{{.}}}{{/returnType}}
    */
-  {{nickname}}Execute(r Api{{operationId}}Request) ({{#returnType}}{{{.}}}, {{/returnType}}*_nethttp.Response, error)
+  {{nickname}}Execute(r {{#structPrefix}}{{&classname}}{{/structPrefix}}Api{{operationId}}Request) ({{#returnType}}{{{.}}}, {{/returnType}}*_nethttp.Response, error)
   {{/operation}}
 }
 {{/generateInterfaces}}
@@ -44,7 +44,7 @@ type {{classname}} interface {
 type {{classname}}Service service
 {{#operation}}
 
-type Api{{operationId}}Request struct {
+type {{#structPrefix}}{{&classname}}{{/structPrefix}}Api{{operationId}}Request struct {
 	ctx _context.Context{{#generateInterfaces}}
 	ApiService {{classname}}
 {{/generateInterfaces}}{{^generateInterfaces}}
@@ -55,13 +55,13 @@ type Api{{operationId}}Request struct {
 {{/allParams}}
 }
 {{#allParams}}{{^isPathParam}}
-func (r Api{{operationId}}Request) {{vendorExtensions.x-export-param-name}}({{paramName}} {{{dataType}}}) Api{{operationId}}Request {
+func (r {{#structPrefix}}{{&classname}}{{/structPrefix}}Api{{operationId}}Request) {{vendorExtensions.x-export-param-name}}({{paramName}} {{{dataType}}}) {{#structPrefix}}{{&classname}}{{/structPrefix}}Api{{operationId}}Request {
 	r.{{paramName}} = &{{paramName}}
 	return r
 }{{/isPathParam}}{{/allParams}}
 
-func (r Api{{operationId}}Request) Execute() ({{#returnType}}{{{.}}}, {{/returnType}}*_nethttp.Response, error) {
-    return r.ApiService.{{nickname}}Execute(r)
+func (r {{#structPrefix}}{{&classname}}{{/structPrefix}}Api{{operationId}}Request) Execute() ({{#returnType}}{{{.}}}, {{/returnType}}*_nethttp.Response, error) {
+	return r.ApiService.{{nickname}}Execute(r)
 }
 
 /*
@@ -71,10 +71,10 @@ func (r Api{{operationId}}Request) Execute() ({{#returnType}}{{{.}}}, {{/returnT
 {{/notes}}
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().{{#pathParams}}
  * @param {{paramName}}{{#description}} {{{.}}}{{/description}}{{/pathParams}}
- * @return Api{{operationId}}Request
+ * @return {{#structPrefix}}{{&classname}}{{/structPrefix}}Api{{operationId}}Request
  */
-func (a *{{{classname}}}Service) {{{nickname}}}(ctx _context.Context{{#pathParams}}, {{paramName}} {{{dataType}}}{{/pathParams}}) Api{{operationId}}Request {
-	return Api{{operationId}}Request{
+func (a *{{{classname}}}Service) {{{nickname}}}(ctx _context.Context{{#pathParams}}, {{paramName}} {{{dataType}}}{{/pathParams}}) {{#structPrefix}}{{&classname}}{{/structPrefix}}Api{{operationId}}Request {
+	return {{#structPrefix}}{{&classname}}{{/structPrefix}}Api{{operationId}}Request{
 		ApiService: a,
 		ctx: ctx,{{#pathParams}}
 		{{paramName}}: {{paramName}},{{/pathParams}}
@@ -85,7 +85,7 @@ func (a *{{{classname}}}Service) {{{nickname}}}(ctx _context.Context{{#pathParam
  * Execute executes the request{{#returnType}}
  * @return {{{.}}}{{/returnType}}
  */
-func (a *{{{classname}}}Service) {{nickname}}Execute(r Api{{operationId}}Request) ({{#returnType}}{{{.}}}, {{/returnType}}*_nethttp.Response, error) {
+func (a *{{{classname}}}Service) {{nickname}}Execute(r {{#structPrefix}}{{&classname}}{{/structPrefix}}Api{{operationId}}Request) ({{#returnType}}{{{.}}}, {{/returnType}}*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.Method{{httpMethod}}
 		localVarPostBody     interface{}

--- a/samples/client/petstore/go-experimental/go-petstore/api_another_fake.go
+++ b/samples/client/petstore/go-experimental/go-petstore/api_another_fake.go
@@ -53,7 +53,7 @@ func (r ApiCall123TestSpecialTagsRequest) Body(body Client) ApiCall123TestSpecia
 }
 
 func (r ApiCall123TestSpecialTagsRequest) Execute() (Client, *_nethttp.Response, error) {
-    return r.ApiService.Call123TestSpecialTagsExecute(r)
+	return r.ApiService.Call123TestSpecialTagsExecute(r)
 }
 
 /*

--- a/samples/client/petstore/go-experimental/go-petstore/api_fake.go
+++ b/samples/client/petstore/go-experimental/go-petstore/api_fake.go
@@ -229,7 +229,7 @@ func (r ApiCreateXmlItemRequest) XmlItem(xmlItem XmlItem) ApiCreateXmlItemReques
 }
 
 func (r ApiCreateXmlItemRequest) Execute() (*_nethttp.Response, error) {
-    return r.ApiService.CreateXmlItemExecute(r)
+	return r.ApiService.CreateXmlItemExecute(r)
 }
 
 /*
@@ -329,7 +329,7 @@ func (r ApiFakeOuterBooleanSerializeRequest) Body(body bool) ApiFakeOuterBoolean
 }
 
 func (r ApiFakeOuterBooleanSerializeRequest) Execute() (bool, *_nethttp.Response, error) {
-    return r.ApiService.FakeOuterBooleanSerializeExecute(r)
+	return r.ApiService.FakeOuterBooleanSerializeExecute(r)
 }
 
 /*
@@ -437,7 +437,7 @@ func (r ApiFakeOuterCompositeSerializeRequest) Body(body OuterComposite) ApiFake
 }
 
 func (r ApiFakeOuterCompositeSerializeRequest) Execute() (OuterComposite, *_nethttp.Response, error) {
-    return r.ApiService.FakeOuterCompositeSerializeExecute(r)
+	return r.ApiService.FakeOuterCompositeSerializeExecute(r)
 }
 
 /*
@@ -545,7 +545,7 @@ func (r ApiFakeOuterNumberSerializeRequest) Body(body float32) ApiFakeOuterNumbe
 }
 
 func (r ApiFakeOuterNumberSerializeRequest) Execute() (float32, *_nethttp.Response, error) {
-    return r.ApiService.FakeOuterNumberSerializeExecute(r)
+	return r.ApiService.FakeOuterNumberSerializeExecute(r)
 }
 
 /*
@@ -653,7 +653,7 @@ func (r ApiFakeOuterStringSerializeRequest) Body(body string) ApiFakeOuterString
 }
 
 func (r ApiFakeOuterStringSerializeRequest) Execute() (string, *_nethttp.Response, error) {
-    return r.ApiService.FakeOuterStringSerializeExecute(r)
+	return r.ApiService.FakeOuterStringSerializeExecute(r)
 }
 
 /*
@@ -761,7 +761,7 @@ func (r ApiTestBodyWithFileSchemaRequest) Body(body FileSchemaTestClass) ApiTest
 }
 
 func (r ApiTestBodyWithFileSchemaRequest) Execute() (*_nethttp.Response, error) {
-    return r.ApiService.TestBodyWithFileSchemaExecute(r)
+	return r.ApiService.TestBodyWithFileSchemaExecute(r)
 }
 
 /*
@@ -866,7 +866,7 @@ func (r ApiTestBodyWithQueryParamsRequest) Body(body User) ApiTestBodyWithQueryP
 }
 
 func (r ApiTestBodyWithQueryParamsRequest) Execute() (*_nethttp.Response, error) {
-    return r.ApiService.TestBodyWithQueryParamsExecute(r)
+	return r.ApiService.TestBodyWithQueryParamsExecute(r)
 }
 
 /*
@@ -969,7 +969,7 @@ func (r ApiTestClientModelRequest) Body(body Client) ApiTestClientModelRequest {
 }
 
 func (r ApiTestClientModelRequest) Execute() (Client, *_nethttp.Response, error) {
-    return r.ApiService.TestClientModelExecute(r)
+	return r.ApiService.TestClientModelExecute(r)
 }
 
 /*
@@ -1145,7 +1145,7 @@ func (r ApiTestEndpointParametersRequest) Callback(callback string) ApiTestEndpo
 }
 
 func (r ApiTestEndpointParametersRequest) Execute() (*_nethttp.Response, error) {
-    return r.ApiService.TestEndpointParametersExecute(r)
+	return r.ApiService.TestEndpointParametersExecute(r)
 }
 
 /*
@@ -1344,7 +1344,7 @@ func (r ApiTestEnumParametersRequest) EnumFormString(enumFormString string) ApiT
 }
 
 func (r ApiTestEnumParametersRequest) Execute() (*_nethttp.Response, error) {
-    return r.ApiService.TestEnumParametersExecute(r)
+	return r.ApiService.TestEnumParametersExecute(r)
 }
 
 /*
@@ -1488,7 +1488,7 @@ func (r ApiTestGroupParametersRequest) Int64Group(int64Group int64) ApiTestGroup
 }
 
 func (r ApiTestGroupParametersRequest) Execute() (*_nethttp.Response, error) {
-    return r.ApiService.TestGroupParametersExecute(r)
+	return r.ApiService.TestGroupParametersExecute(r)
 }
 
 /*
@@ -1604,7 +1604,7 @@ func (r ApiTestInlineAdditionalPropertiesRequest) Param(param map[string]string)
 }
 
 func (r ApiTestInlineAdditionalPropertiesRequest) Execute() (*_nethttp.Response, error) {
-    return r.ApiService.TestInlineAdditionalPropertiesExecute(r)
+	return r.ApiService.TestInlineAdditionalPropertiesExecute(r)
 }
 
 /*
@@ -1708,7 +1708,7 @@ func (r ApiTestJsonFormDataRequest) Param2(param2 string) ApiTestJsonFormDataReq
 }
 
 func (r ApiTestJsonFormDataRequest) Execute() (*_nethttp.Response, error) {
-    return r.ApiService.TestJsonFormDataExecute(r)
+	return r.ApiService.TestJsonFormDataExecute(r)
 }
 
 /*
@@ -1830,7 +1830,7 @@ func (r ApiTestQueryParameterCollectionFormatRequest) Context(context []string) 
 }
 
 func (r ApiTestQueryParameterCollectionFormatRequest) Execute() (*_nethttp.Response, error) {
-    return r.ApiService.TestQueryParameterCollectionFormatExecute(r)
+	return r.ApiService.TestQueryParameterCollectionFormatExecute(r)
 }
 
 /*

--- a/samples/client/petstore/go-experimental/go-petstore/api_fake_classname_tags123.go
+++ b/samples/client/petstore/go-experimental/go-petstore/api_fake_classname_tags123.go
@@ -53,7 +53,7 @@ func (r ApiTestClassnameRequest) Body(body Client) ApiTestClassnameRequest {
 }
 
 func (r ApiTestClassnameRequest) Execute() (Client, *_nethttp.Response, error) {
-    return r.ApiService.TestClassnameExecute(r)
+	return r.ApiService.TestClassnameExecute(r)
 }
 
 /*

--- a/samples/client/petstore/go-experimental/go-petstore/api_pet.go
+++ b/samples/client/petstore/go-experimental/go-petstore/api_pet.go
@@ -162,7 +162,7 @@ func (r ApiAddPetRequest) Body(body Pet) ApiAddPetRequest {
 }
 
 func (r ApiAddPetRequest) Execute() (*_nethttp.Response, error) {
-    return r.ApiService.AddPetExecute(r)
+	return r.ApiService.AddPetExecute(r)
 }
 
 /*
@@ -262,7 +262,7 @@ func (r ApiDeletePetRequest) ApiKey(apiKey string) ApiDeletePetRequest {
 }
 
 func (r ApiDeletePetRequest) Execute() (*_nethttp.Response, error) {
-    return r.ApiService.DeletePetExecute(r)
+	return r.ApiService.DeletePetExecute(r)
 }
 
 /*
@@ -362,7 +362,7 @@ func (r ApiFindPetsByStatusRequest) Status(status []string) ApiFindPetsByStatusR
 }
 
 func (r ApiFindPetsByStatusRequest) Execute() ([]Pet, *_nethttp.Response, error) {
-    return r.ApiService.FindPetsByStatusExecute(r)
+	return r.ApiService.FindPetsByStatusExecute(r)
 }
 
 /*
@@ -472,7 +472,7 @@ func (r ApiFindPetsByTagsRequest) Tags(tags []string) ApiFindPetsByTagsRequest {
 }
 
 func (r ApiFindPetsByTagsRequest) Execute() ([]Pet, *_nethttp.Response, error) {
-    return r.ApiService.FindPetsByTagsExecute(r)
+	return r.ApiService.FindPetsByTagsExecute(r)
 }
 
 /*
@@ -578,7 +578,7 @@ type ApiGetPetByIdRequest struct {
 
 
 func (r ApiGetPetByIdRequest) Execute() (Pet, *_nethttp.Response, error) {
-    return r.ApiService.GetPetByIdExecute(r)
+	return r.ApiService.GetPetByIdExecute(r)
 }
 
 /*
@@ -701,7 +701,7 @@ func (r ApiUpdatePetRequest) Body(body Pet) ApiUpdatePetRequest {
 }
 
 func (r ApiUpdatePetRequest) Execute() (*_nethttp.Response, error) {
-    return r.ApiService.UpdatePetExecute(r)
+	return r.ApiService.UpdatePetExecute(r)
 }
 
 /*
@@ -806,7 +806,7 @@ func (r ApiUpdatePetWithFormRequest) Status(status string) ApiUpdatePetWithFormR
 }
 
 func (r ApiUpdatePetWithFormRequest) Execute() (*_nethttp.Response, error) {
-    return r.ApiService.UpdatePetWithFormExecute(r)
+	return r.ApiService.UpdatePetWithFormExecute(r)
 }
 
 /*
@@ -915,7 +915,7 @@ func (r ApiUploadFileRequest) File(file *os.File) ApiUploadFileRequest {
 }
 
 func (r ApiUploadFileRequest) Execute() (ApiResponse, *_nethttp.Response, error) {
-    return r.ApiService.UploadFileExecute(r)
+	return r.ApiService.UploadFileExecute(r)
 }
 
 /*
@@ -1043,7 +1043,7 @@ func (r ApiUploadFileWithRequiredFileRequest) AdditionalMetadata(additionalMetad
 }
 
 func (r ApiUploadFileWithRequiredFileRequest) Execute() (ApiResponse, *_nethttp.Response, error) {
-    return r.ApiService.UploadFileWithRequiredFileExecute(r)
+	return r.ApiService.UploadFileWithRequiredFileExecute(r)
 }
 
 /*

--- a/samples/client/petstore/go-experimental/go-petstore/api_store.go
+++ b/samples/client/petstore/go-experimental/go-petstore/api_store.go
@@ -92,7 +92,7 @@ type ApiDeleteOrderRequest struct {
 
 
 func (r ApiDeleteOrderRequest) Execute() (*_nethttp.Response, error) {
-    return r.ApiService.DeleteOrderExecute(r)
+	return r.ApiService.DeleteOrderExecute(r)
 }
 
 /*
@@ -185,7 +185,7 @@ type ApiGetInventoryRequest struct {
 
 
 func (r ApiGetInventoryRequest) Execute() (map[string]int32, *_nethttp.Response, error) {
-    return r.ApiService.GetInventoryExecute(r)
+	return r.ApiService.GetInventoryExecute(r)
 }
 
 /*
@@ -301,7 +301,7 @@ type ApiGetOrderByIdRequest struct {
 
 
 func (r ApiGetOrderByIdRequest) Execute() (Order, *_nethttp.Response, error) {
-    return r.ApiService.GetOrderByIdExecute(r)
+	return r.ApiService.GetOrderByIdExecute(r)
 }
 
 /*
@@ -416,7 +416,7 @@ func (r ApiPlaceOrderRequest) Body(body Order) ApiPlaceOrderRequest {
 }
 
 func (r ApiPlaceOrderRequest) Execute() (Order, *_nethttp.Response, error) {
-    return r.ApiService.PlaceOrderExecute(r)
+	return r.ApiService.PlaceOrderExecute(r)
 }
 
 /*

--- a/samples/client/petstore/go-experimental/go-petstore/api_user.go
+++ b/samples/client/petstore/go-experimental/go-petstore/api_user.go
@@ -144,7 +144,7 @@ func (r ApiCreateUserRequest) Body(body User) ApiCreateUserRequest {
 }
 
 func (r ApiCreateUserRequest) Execute() (*_nethttp.Response, error) {
-    return r.ApiService.CreateUserExecute(r)
+	return r.ApiService.CreateUserExecute(r)
 }
 
 /*
@@ -244,7 +244,7 @@ func (r ApiCreateUsersWithArrayInputRequest) Body(body []User) ApiCreateUsersWit
 }
 
 func (r ApiCreateUsersWithArrayInputRequest) Execute() (*_nethttp.Response, error) {
-    return r.ApiService.CreateUsersWithArrayInputExecute(r)
+	return r.ApiService.CreateUsersWithArrayInputExecute(r)
 }
 
 /*
@@ -343,7 +343,7 @@ func (r ApiCreateUsersWithListInputRequest) Body(body []User) ApiCreateUsersWith
 }
 
 func (r ApiCreateUsersWithListInputRequest) Execute() (*_nethttp.Response, error) {
-    return r.ApiService.CreateUsersWithListInputExecute(r)
+	return r.ApiService.CreateUsersWithListInputExecute(r)
 }
 
 /*
@@ -438,7 +438,7 @@ type ApiDeleteUserRequest struct {
 
 
 func (r ApiDeleteUserRequest) Execute() (*_nethttp.Response, error) {
-    return r.ApiService.DeleteUserExecute(r)
+	return r.ApiService.DeleteUserExecute(r)
 }
 
 /*
@@ -532,7 +532,7 @@ type ApiGetUserByNameRequest struct {
 
 
 func (r ApiGetUserByNameRequest) Execute() (User, *_nethttp.Response, error) {
-    return r.ApiService.GetUserByNameExecute(r)
+	return r.ApiService.GetUserByNameExecute(r)
 }
 
 /*
@@ -645,7 +645,7 @@ func (r ApiLoginUserRequest) Password(password string) ApiLoginUserRequest {
 }
 
 func (r ApiLoginUserRequest) Execute() (string, *_nethttp.Response, error) {
-    return r.ApiService.LoginUserExecute(r)
+	return r.ApiService.LoginUserExecute(r)
 }
 
 /*
@@ -753,7 +753,7 @@ type ApiLogoutUserRequest struct {
 
 
 func (r ApiLogoutUserRequest) Execute() (*_nethttp.Response, error) {
-    return r.ApiService.LogoutUserExecute(r)
+	return r.ApiService.LogoutUserExecute(r)
 }
 
 /*
@@ -848,7 +848,7 @@ func (r ApiUpdateUserRequest) Body(body User) ApiUpdateUserRequest {
 }
 
 func (r ApiUpdateUserRequest) Execute() (*_nethttp.Response, error) {
-    return r.ApiService.UpdateUserExecute(r)
+	return r.ApiService.UpdateUserExecute(r)
 }
 
 /*

--- a/samples/openapi3/client/extensions/x-auth-id-alias/go-experimental/api_usage.go
+++ b/samples/openapi3/client/extensions/x-auth-id-alias/go-experimental/api_usage.go
@@ -24,29 +24,34 @@ var (
 // UsageApiService UsageApi service
 type UsageApiService service
 
-type apiAnyKeyRequest struct {
+type ApiAnyKeyRequest struct {
 	ctx _context.Context
-	apiService *UsageApiService
+	ApiService *UsageApiService
+}
+
+
+func (r ApiAnyKeyRequest) Execute() (map[string]interface{}, *_nethttp.Response, error) {
+	return r.ApiService.AnyKeyExecute(r)
 }
 
 /*
-AnyKey Use any API key
-Use any API key
+ * AnyKey Use any API key
+ * Use any API key
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-@return apiAnyKeyRequest
-*/
-func (a *UsageApiService) AnyKey(ctx _context.Context) apiAnyKeyRequest {
-	return apiAnyKeyRequest{
-		apiService: a,
+ * @return ApiAnyKeyRequest
+ */
+func (a *UsageApiService) AnyKey(ctx _context.Context) ApiAnyKeyRequest {
+	return ApiAnyKeyRequest{
+		ApiService: a,
 		ctx: ctx,
 	}
 }
 
 /*
-Execute executes the request
-@return map[string]interface{}
-*/
-func (r apiAnyKeyRequest) Execute() (map[string]interface{}, *_nethttp.Response, error) {
+ * Execute executes the request
+ * @return map[string]interface{}
+ */
+func (a *UsageApiService) AnyKeyExecute(r ApiAnyKeyRequest) (map[string]interface{}, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
@@ -56,7 +61,7 @@ func (r apiAnyKeyRequest) Execute() (map[string]interface{}, *_nethttp.Response,
 		localVarReturnValue  map[string]interface{}
 	)
 
-	localBasePath, err := r.apiService.client.cfg.ServerURLWithContext(r.ctx, "UsageApiService.AnyKey")
+	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "UsageApiService.AnyKey")
 	if err != nil {
 		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
@@ -112,12 +117,12 @@ func (r apiAnyKeyRequest) Execute() (map[string]interface{}, *_nethttp.Response,
 			}
 		}
 	}
-	req, err := r.apiService.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
+	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return localVarReturnValue, nil, err
 	}
 
-	localVarHTTPResponse, err := r.apiService.client.callAPI(req)
+	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
@@ -136,7 +141,7 @@ func (r apiAnyKeyRequest) Execute() (map[string]interface{}, *_nethttp.Response,
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	err = r.apiService.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -147,29 +152,35 @@ func (r apiAnyKeyRequest) Execute() (map[string]interface{}, *_nethttp.Response,
 
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
-type apiBothKeysRequest struct {
+
+type ApiBothKeysRequest struct {
 	ctx _context.Context
-	apiService *UsageApiService
+	ApiService *UsageApiService
+}
+
+
+func (r ApiBothKeysRequest) Execute() (map[string]interface{}, *_nethttp.Response, error) {
+	return r.ApiService.BothKeysExecute(r)
 }
 
 /*
-BothKeys Use both API keys
-Use both API keys
+ * BothKeys Use both API keys
+ * Use both API keys
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-@return apiBothKeysRequest
-*/
-func (a *UsageApiService) BothKeys(ctx _context.Context) apiBothKeysRequest {
-	return apiBothKeysRequest{
-		apiService: a,
+ * @return ApiBothKeysRequest
+ */
+func (a *UsageApiService) BothKeys(ctx _context.Context) ApiBothKeysRequest {
+	return ApiBothKeysRequest{
+		ApiService: a,
 		ctx: ctx,
 	}
 }
 
 /*
-Execute executes the request
-@return map[string]interface{}
-*/
-func (r apiBothKeysRequest) Execute() (map[string]interface{}, *_nethttp.Response, error) {
+ * Execute executes the request
+ * @return map[string]interface{}
+ */
+func (a *UsageApiService) BothKeysExecute(r ApiBothKeysRequest) (map[string]interface{}, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
@@ -179,7 +190,7 @@ func (r apiBothKeysRequest) Execute() (map[string]interface{}, *_nethttp.Respons
 		localVarReturnValue  map[string]interface{}
 	)
 
-	localBasePath, err := r.apiService.client.cfg.ServerURLWithContext(r.ctx, "UsageApiService.BothKeys")
+	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "UsageApiService.BothKeys")
 	if err != nil {
 		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
@@ -235,12 +246,12 @@ func (r apiBothKeysRequest) Execute() (map[string]interface{}, *_nethttp.Respons
 			}
 		}
 	}
-	req, err := r.apiService.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
+	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return localVarReturnValue, nil, err
 	}
 
-	localVarHTTPResponse, err := r.apiService.client.callAPI(req)
+	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
@@ -259,7 +270,7 @@ func (r apiBothKeysRequest) Execute() (map[string]interface{}, *_nethttp.Respons
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	err = r.apiService.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -270,29 +281,35 @@ func (r apiBothKeysRequest) Execute() (map[string]interface{}, *_nethttp.Respons
 
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
-type apiKeyInHeaderRequest struct {
+
+type ApiKeyInHeaderRequest struct {
 	ctx _context.Context
-	apiService *UsageApiService
+	ApiService *UsageApiService
+}
+
+
+func (r ApiKeyInHeaderRequest) Execute() (map[string]interface{}, *_nethttp.Response, error) {
+	return r.ApiService.KeyInHeaderExecute(r)
 }
 
 /*
-KeyInHeader Use API key in header
-Use API key in header
+ * KeyInHeader Use API key in header
+ * Use API key in header
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-@return apiKeyInHeaderRequest
-*/
-func (a *UsageApiService) KeyInHeader(ctx _context.Context) apiKeyInHeaderRequest {
-	return apiKeyInHeaderRequest{
-		apiService: a,
+ * @return ApiKeyInHeaderRequest
+ */
+func (a *UsageApiService) KeyInHeader(ctx _context.Context) ApiKeyInHeaderRequest {
+	return ApiKeyInHeaderRequest{
+		ApiService: a,
 		ctx: ctx,
 	}
 }
 
 /*
-Execute executes the request
-@return map[string]interface{}
-*/
-func (r apiKeyInHeaderRequest) Execute() (map[string]interface{}, *_nethttp.Response, error) {
+ * Execute executes the request
+ * @return map[string]interface{}
+ */
+func (a *UsageApiService) KeyInHeaderExecute(r ApiKeyInHeaderRequest) (map[string]interface{}, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
@@ -302,7 +319,7 @@ func (r apiKeyInHeaderRequest) Execute() (map[string]interface{}, *_nethttp.Resp
 		localVarReturnValue  map[string]interface{}
 	)
 
-	localBasePath, err := r.apiService.client.cfg.ServerURLWithContext(r.ctx, "UsageApiService.KeyInHeader")
+	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "UsageApiService.KeyInHeader")
 	if err != nil {
 		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
@@ -344,12 +361,12 @@ func (r apiKeyInHeaderRequest) Execute() (map[string]interface{}, *_nethttp.Resp
 			}
 		}
 	}
-	req, err := r.apiService.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
+	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return localVarReturnValue, nil, err
 	}
 
-	localVarHTTPResponse, err := r.apiService.client.callAPI(req)
+	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
@@ -368,7 +385,7 @@ func (r apiKeyInHeaderRequest) Execute() (map[string]interface{}, *_nethttp.Resp
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	err = r.apiService.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -379,29 +396,35 @@ func (r apiKeyInHeaderRequest) Execute() (map[string]interface{}, *_nethttp.Resp
 
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
-type apiKeyInQueryRequest struct {
+
+type ApiKeyInQueryRequest struct {
 	ctx _context.Context
-	apiService *UsageApiService
+	ApiService *UsageApiService
+}
+
+
+func (r ApiKeyInQueryRequest) Execute() (map[string]interface{}, *_nethttp.Response, error) {
+	return r.ApiService.KeyInQueryExecute(r)
 }
 
 /*
-KeyInQuery Use API key in query
-Use API key in query
+ * KeyInQuery Use API key in query
+ * Use API key in query
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-@return apiKeyInQueryRequest
-*/
-func (a *UsageApiService) KeyInQuery(ctx _context.Context) apiKeyInQueryRequest {
-	return apiKeyInQueryRequest{
-		apiService: a,
+ * @return ApiKeyInQueryRequest
+ */
+func (a *UsageApiService) KeyInQuery(ctx _context.Context) ApiKeyInQueryRequest {
+	return ApiKeyInQueryRequest{
+		ApiService: a,
 		ctx: ctx,
 	}
 }
 
 /*
-Execute executes the request
-@return map[string]interface{}
-*/
-func (r apiKeyInQueryRequest) Execute() (map[string]interface{}, *_nethttp.Response, error) {
+ * Execute executes the request
+ * @return map[string]interface{}
+ */
+func (a *UsageApiService) KeyInQueryExecute(r ApiKeyInQueryRequest) (map[string]interface{}, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
@@ -411,7 +434,7 @@ func (r apiKeyInQueryRequest) Execute() (map[string]interface{}, *_nethttp.Respo
 		localVarReturnValue  map[string]interface{}
 	)
 
-	localBasePath, err := r.apiService.client.cfg.ServerURLWithContext(r.ctx, "UsageApiService.KeyInQuery")
+	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "UsageApiService.KeyInQuery")
 	if err != nil {
 		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
@@ -453,12 +476,12 @@ func (r apiKeyInQueryRequest) Execute() (map[string]interface{}, *_nethttp.Respo
 			}
 		}
 	}
-	req, err := r.apiService.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
+	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return localVarReturnValue, nil, err
 	}
 
-	localVarHTTPResponse, err := r.apiService.client.callAPI(req)
+	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
@@ -477,7 +500,7 @@ func (r apiKeyInQueryRequest) Execute() (map[string]interface{}, *_nethttp.Respo
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	err = r.apiService.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/api_another_fake.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/api_another_fake.go
@@ -53,7 +53,7 @@ func (r ApiCall123TestSpecialTagsRequest) Client(client Client) ApiCall123TestSp
 }
 
 func (r ApiCall123TestSpecialTagsRequest) Execute() (Client, *_nethttp.Response, error) {
-    return r.ApiService.Call123TestSpecialTagsExecute(r)
+	return r.ApiService.Call123TestSpecialTagsExecute(r)
 }
 
 /*

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/api_default.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/api_default.go
@@ -47,7 +47,7 @@ type ApiFooGetRequest struct {
 
 
 func (r ApiFooGetRequest) Execute() (InlineResponseDefault, *_nethttp.Response, error) {
-    return r.ApiService.FooGetExecute(r)
+	return r.ApiService.FooGetExecute(r)
 }
 
 /*

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/api_fake.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/api_fake.go
@@ -225,7 +225,7 @@ type ApiFakeHealthGetRequest struct {
 
 
 func (r ApiFakeHealthGetRequest) Execute() (HealthCheckResult, *_nethttp.Response, error) {
-    return r.ApiService.FakeHealthGetExecute(r)
+	return r.ApiService.FakeHealthGetExecute(r)
 }
 
 /*
@@ -330,7 +330,7 @@ func (r ApiFakeOuterBooleanSerializeRequest) Body(body bool) ApiFakeOuterBoolean
 }
 
 func (r ApiFakeOuterBooleanSerializeRequest) Execute() (bool, *_nethttp.Response, error) {
-    return r.ApiService.FakeOuterBooleanSerializeExecute(r)
+	return r.ApiService.FakeOuterBooleanSerializeExecute(r)
 }
 
 /*
@@ -438,7 +438,7 @@ func (r ApiFakeOuterCompositeSerializeRequest) OuterComposite(outerComposite Out
 }
 
 func (r ApiFakeOuterCompositeSerializeRequest) Execute() (OuterComposite, *_nethttp.Response, error) {
-    return r.ApiService.FakeOuterCompositeSerializeExecute(r)
+	return r.ApiService.FakeOuterCompositeSerializeExecute(r)
 }
 
 /*
@@ -546,7 +546,7 @@ func (r ApiFakeOuterNumberSerializeRequest) Body(body float32) ApiFakeOuterNumbe
 }
 
 func (r ApiFakeOuterNumberSerializeRequest) Execute() (float32, *_nethttp.Response, error) {
-    return r.ApiService.FakeOuterNumberSerializeExecute(r)
+	return r.ApiService.FakeOuterNumberSerializeExecute(r)
 }
 
 /*
@@ -654,7 +654,7 @@ func (r ApiFakeOuterStringSerializeRequest) Body(body string) ApiFakeOuterString
 }
 
 func (r ApiFakeOuterStringSerializeRequest) Execute() (string, *_nethttp.Response, error) {
-    return r.ApiService.FakeOuterStringSerializeExecute(r)
+	return r.ApiService.FakeOuterStringSerializeExecute(r)
 }
 
 /*
@@ -762,7 +762,7 @@ func (r ApiTestBodyWithFileSchemaRequest) FileSchemaTestClass(fileSchemaTestClas
 }
 
 func (r ApiTestBodyWithFileSchemaRequest) Execute() (*_nethttp.Response, error) {
-    return r.ApiService.TestBodyWithFileSchemaExecute(r)
+	return r.ApiService.TestBodyWithFileSchemaExecute(r)
 }
 
 /*
@@ -867,7 +867,7 @@ func (r ApiTestBodyWithQueryParamsRequest) User(user User) ApiTestBodyWithQueryP
 }
 
 func (r ApiTestBodyWithQueryParamsRequest) Execute() (*_nethttp.Response, error) {
-    return r.ApiService.TestBodyWithQueryParamsExecute(r)
+	return r.ApiService.TestBodyWithQueryParamsExecute(r)
 }
 
 /*
@@ -970,7 +970,7 @@ func (r ApiTestClientModelRequest) Client(client Client) ApiTestClientModelReque
 }
 
 func (r ApiTestClientModelRequest) Execute() (Client, *_nethttp.Response, error) {
-    return r.ApiService.TestClientModelExecute(r)
+	return r.ApiService.TestClientModelExecute(r)
 }
 
 /*
@@ -1146,7 +1146,7 @@ func (r ApiTestEndpointParametersRequest) Callback(callback string) ApiTestEndpo
 }
 
 func (r ApiTestEndpointParametersRequest) Execute() (*_nethttp.Response, error) {
-    return r.ApiService.TestEndpointParametersExecute(r)
+	return r.ApiService.TestEndpointParametersExecute(r)
 }
 
 /*
@@ -1346,7 +1346,7 @@ func (r ApiTestEnumParametersRequest) EnumFormString(enumFormString string) ApiT
 }
 
 func (r ApiTestEnumParametersRequest) Execute() (*_nethttp.Response, error) {
-    return r.ApiService.TestEnumParametersExecute(r)
+	return r.ApiService.TestEnumParametersExecute(r)
 }
 
 /*
@@ -1498,7 +1498,7 @@ func (r ApiTestGroupParametersRequest) Int64Group(int64Group int64) ApiTestGroup
 }
 
 func (r ApiTestGroupParametersRequest) Execute() (*_nethttp.Response, error) {
-    return r.ApiService.TestGroupParametersExecute(r)
+	return r.ApiService.TestGroupParametersExecute(r)
 }
 
 /*
@@ -1614,7 +1614,7 @@ func (r ApiTestInlineAdditionalPropertiesRequest) RequestBody(requestBody map[st
 }
 
 func (r ApiTestInlineAdditionalPropertiesRequest) Execute() (*_nethttp.Response, error) {
-    return r.ApiService.TestInlineAdditionalPropertiesExecute(r)
+	return r.ApiService.TestInlineAdditionalPropertiesExecute(r)
 }
 
 /*
@@ -1718,7 +1718,7 @@ func (r ApiTestJsonFormDataRequest) Param2(param2 string) ApiTestJsonFormDataReq
 }
 
 func (r ApiTestJsonFormDataRequest) Execute() (*_nethttp.Response, error) {
-    return r.ApiService.TestJsonFormDataExecute(r)
+	return r.ApiService.TestJsonFormDataExecute(r)
 }
 
 /*
@@ -1840,7 +1840,7 @@ func (r ApiTestQueryParameterCollectionFormatRequest) Context(context []string) 
 }
 
 func (r ApiTestQueryParameterCollectionFormatRequest) Execute() (*_nethttp.Response, error) {
-    return r.ApiService.TestQueryParameterCollectionFormatExecute(r)
+	return r.ApiService.TestQueryParameterCollectionFormatExecute(r)
 }
 
 /*

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/api_fake_classname_tags123.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/api_fake_classname_tags123.go
@@ -53,7 +53,7 @@ func (r ApiTestClassnameRequest) Client(client Client) ApiTestClassnameRequest {
 }
 
 func (r ApiTestClassnameRequest) Execute() (Client, *_nethttp.Response, error) {
-    return r.ApiService.TestClassnameExecute(r)
+	return r.ApiService.TestClassnameExecute(r)
 }
 
 /*

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/api_pet.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/api_pet.go
@@ -162,7 +162,7 @@ func (r ApiAddPetRequest) Pet(pet Pet) ApiAddPetRequest {
 }
 
 func (r ApiAddPetRequest) Execute() (*_nethttp.Response, error) {
-    return r.ApiService.AddPetExecute(r)
+	return r.ApiService.AddPetExecute(r)
 }
 
 /*
@@ -262,7 +262,7 @@ func (r ApiDeletePetRequest) ApiKey(apiKey string) ApiDeletePetRequest {
 }
 
 func (r ApiDeletePetRequest) Execute() (*_nethttp.Response, error) {
-    return r.ApiService.DeletePetExecute(r)
+	return r.ApiService.DeletePetExecute(r)
 }
 
 /*
@@ -362,7 +362,7 @@ func (r ApiFindPetsByStatusRequest) Status(status []string) ApiFindPetsByStatusR
 }
 
 func (r ApiFindPetsByStatusRequest) Execute() ([]Pet, *_nethttp.Response, error) {
-    return r.ApiService.FindPetsByStatusExecute(r)
+	return r.ApiService.FindPetsByStatusExecute(r)
 }
 
 /*
@@ -472,7 +472,7 @@ func (r ApiFindPetsByTagsRequest) Tags(tags []string) ApiFindPetsByTagsRequest {
 }
 
 func (r ApiFindPetsByTagsRequest) Execute() ([]Pet, *_nethttp.Response, error) {
-    return r.ApiService.FindPetsByTagsExecute(r)
+	return r.ApiService.FindPetsByTagsExecute(r)
 }
 
 /*
@@ -578,7 +578,7 @@ type ApiGetPetByIdRequest struct {
 
 
 func (r ApiGetPetByIdRequest) Execute() (Pet, *_nethttp.Response, error) {
-    return r.ApiService.GetPetByIdExecute(r)
+	return r.ApiService.GetPetByIdExecute(r)
 }
 
 /*
@@ -701,7 +701,7 @@ func (r ApiUpdatePetRequest) Pet(pet Pet) ApiUpdatePetRequest {
 }
 
 func (r ApiUpdatePetRequest) Execute() (*_nethttp.Response, error) {
-    return r.ApiService.UpdatePetExecute(r)
+	return r.ApiService.UpdatePetExecute(r)
 }
 
 /*
@@ -806,7 +806,7 @@ func (r ApiUpdatePetWithFormRequest) Status(status string) ApiUpdatePetWithFormR
 }
 
 func (r ApiUpdatePetWithFormRequest) Execute() (*_nethttp.Response, error) {
-    return r.ApiService.UpdatePetWithFormExecute(r)
+	return r.ApiService.UpdatePetWithFormExecute(r)
 }
 
 /*
@@ -915,7 +915,7 @@ func (r ApiUploadFileRequest) File(file *os.File) ApiUploadFileRequest {
 }
 
 func (r ApiUploadFileRequest) Execute() (ApiResponse, *_nethttp.Response, error) {
-    return r.ApiService.UploadFileExecute(r)
+	return r.ApiService.UploadFileExecute(r)
 }
 
 /*
@@ -1043,7 +1043,7 @@ func (r ApiUploadFileWithRequiredFileRequest) AdditionalMetadata(additionalMetad
 }
 
 func (r ApiUploadFileWithRequiredFileRequest) Execute() (ApiResponse, *_nethttp.Response, error) {
-    return r.ApiService.UploadFileWithRequiredFileExecute(r)
+	return r.ApiService.UploadFileWithRequiredFileExecute(r)
 }
 
 /*

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/api_store.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/api_store.go
@@ -92,7 +92,7 @@ type ApiDeleteOrderRequest struct {
 
 
 func (r ApiDeleteOrderRequest) Execute() (*_nethttp.Response, error) {
-    return r.ApiService.DeleteOrderExecute(r)
+	return r.ApiService.DeleteOrderExecute(r)
 }
 
 /*
@@ -185,7 +185,7 @@ type ApiGetInventoryRequest struct {
 
 
 func (r ApiGetInventoryRequest) Execute() (map[string]int32, *_nethttp.Response, error) {
-    return r.ApiService.GetInventoryExecute(r)
+	return r.ApiService.GetInventoryExecute(r)
 }
 
 /*
@@ -301,7 +301,7 @@ type ApiGetOrderByIdRequest struct {
 
 
 func (r ApiGetOrderByIdRequest) Execute() (Order, *_nethttp.Response, error) {
-    return r.ApiService.GetOrderByIdExecute(r)
+	return r.ApiService.GetOrderByIdExecute(r)
 }
 
 /*
@@ -416,7 +416,7 @@ func (r ApiPlaceOrderRequest) Order(order Order) ApiPlaceOrderRequest {
 }
 
 func (r ApiPlaceOrderRequest) Execute() (Order, *_nethttp.Response, error) {
-    return r.ApiService.PlaceOrderExecute(r)
+	return r.ApiService.PlaceOrderExecute(r)
 }
 
 /*

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/api_user.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/api_user.go
@@ -144,7 +144,7 @@ func (r ApiCreateUserRequest) User(user User) ApiCreateUserRequest {
 }
 
 func (r ApiCreateUserRequest) Execute() (*_nethttp.Response, error) {
-    return r.ApiService.CreateUserExecute(r)
+	return r.ApiService.CreateUserExecute(r)
 }
 
 /*
@@ -244,7 +244,7 @@ func (r ApiCreateUsersWithArrayInputRequest) User(user []User) ApiCreateUsersWit
 }
 
 func (r ApiCreateUsersWithArrayInputRequest) Execute() (*_nethttp.Response, error) {
-    return r.ApiService.CreateUsersWithArrayInputExecute(r)
+	return r.ApiService.CreateUsersWithArrayInputExecute(r)
 }
 
 /*
@@ -343,7 +343,7 @@ func (r ApiCreateUsersWithListInputRequest) User(user []User) ApiCreateUsersWith
 }
 
 func (r ApiCreateUsersWithListInputRequest) Execute() (*_nethttp.Response, error) {
-    return r.ApiService.CreateUsersWithListInputExecute(r)
+	return r.ApiService.CreateUsersWithListInputExecute(r)
 }
 
 /*
@@ -438,7 +438,7 @@ type ApiDeleteUserRequest struct {
 
 
 func (r ApiDeleteUserRequest) Execute() (*_nethttp.Response, error) {
-    return r.ApiService.DeleteUserExecute(r)
+	return r.ApiService.DeleteUserExecute(r)
 }
 
 /*
@@ -532,7 +532,7 @@ type ApiGetUserByNameRequest struct {
 
 
 func (r ApiGetUserByNameRequest) Execute() (User, *_nethttp.Response, error) {
-    return r.ApiService.GetUserByNameExecute(r)
+	return r.ApiService.GetUserByNameExecute(r)
 }
 
 /*
@@ -645,7 +645,7 @@ func (r ApiLoginUserRequest) Password(password string) ApiLoginUserRequest {
 }
 
 func (r ApiLoginUserRequest) Execute() (string, *_nethttp.Response, error) {
-    return r.ApiService.LoginUserExecute(r)
+	return r.ApiService.LoginUserExecute(r)
 }
 
 /*
@@ -753,7 +753,7 @@ type ApiLogoutUserRequest struct {
 
 
 func (r ApiLogoutUserRequest) Execute() (*_nethttp.Response, error) {
-    return r.ApiService.LogoutUserExecute(r)
+	return r.ApiService.LogoutUserExecute(r)
 }
 
 /*
@@ -848,7 +848,7 @@ func (r ApiUpdateUserRequest) User(user User) ApiUpdateUserRequest {
 }
 
 func (r ApiUpdateUserRequest) Execute() (*_nethttp.Response, error) {
-    return r.ApiService.UpdateUserExecute(r)
+	return r.ApiService.UpdateUserExecute(r)
 }
 
 /*


### PR DESCRIPTION
- Add `structPrefix` support to go-experimental

cc @antihax (2017/11) @grokify (2018/07) @kemokemo (2018/09) @bkabrda (2019/07)


<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
