### PR TITLE
Adds fix for issue7262 and a test of it

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -2826,9 +2826,8 @@ public class DefaultCodegen implements CodegenConfig {
                             if (ref == null) {
                                 // for schemas with no ref, it is not possible to build the discriminator map
                                 // because ref is how we get the model name
-                                // we only hit this use case for a schema with inline composed schemas, and one of those
-                                // schemas also has inline composed schemas
-                                throw new RuntimeException("Invalid inline schema defined in allOf in '" + childName + "'. Per the OpenApi spec, for this case when a composed schema defines a discriminator, the allOf schemas must use $ref. Change this inline definition to a $ref definition");
+                                // we hit this use case when an allOf composed schema contains an inline schema
+                                continue;
                             }
                             String parentName = ModelUtils.getSimpleRef(ref);
                             if (parentName.equals(currentSchemaName)) {

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
@@ -2251,5 +2251,6 @@ public class DefaultCodegenTest {
         final Set<String> expectedAllOf = new HashSet<>(Arrays.asList("UserTimeBase"));
         assertEquals(cm.allOf, expectedAllOf);
         assertEquals(openAPI.getComponents().getSchemas().size(), 2);
+        assertNull(cm.getDiscriminator());
     }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
@@ -2248,8 +2248,8 @@ public class DefaultCodegenTest {
         modelName = "UserSleep";
         sc = openAPI.getComponents().getSchemas().get(modelName);
         cm = codegen.fromModel(modelName, sc);
-        final Set<String> expectedAllOf = new HashSet<>(Arrays.asList("UserTimeBase", "UserSleepAllOf"));
+        final Set<String> expectedAllOf = new HashSet<>(Arrays.asList("UserTimeBase"));
         assertEquals(cm.allOf, expectedAllOf);
-        assertEquals(openAPI.getComponents().getSchemas().size(), 3);
+        assertEquals(openAPI.getComponents().getSchemas().size(), 2);
     }
 }

--- a/modules/openapi-generator/src/test/resources/3_0/issue7262.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/issue7262.yaml
@@ -1,0 +1,42 @@
+openapi: "3.0.1"
+info:
+  version: 1.0.0
+  title: allOf discriminator issue
+paths:
+  /sleep:
+    patch:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UserSleep'
+      responses:
+        '200':
+          description: Updated
+components:
+  schemas:
+    UserSleep:
+      allOf:
+        - $ref: '#/components/schemas/UserTimeBase'
+        - type: object
+          properties:
+            break:
+              type: string
+              nullable: true
+          additionalProperties: true
+    UserTimeBase:
+      required:
+        - "$type"
+      type: object
+      properties:
+        "$type":
+          type: string
+        start:
+          type: string
+          nullable: true
+        end:
+          type: string
+          nullable: true
+      additionalProperties: true
+      discriminator:
+        propertyName: "$type"

--- a/modules/openapi-generator/src/test/resources/3_0/issue7262.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/issue7262.yaml
@@ -19,10 +19,6 @@ components:
       allOf:
         - $ref: '#/components/schemas/UserTimeBase'
         - type: object
-#          properties:
-#            break:
-#              type: string
-#              nullable: true
           additionalProperties: true
     UserTimeBase:
       required:

--- a/modules/openapi-generator/src/test/resources/3_0/issue7262.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/issue7262.yaml
@@ -19,10 +19,10 @@ components:
       allOf:
         - $ref: '#/components/schemas/UserTimeBase'
         - type: object
-          properties:
-            break:
-              type: string
-              nullable: true
+#          properties:
+#            break:
+#              type: string
+#              nullable: true
           additionalProperties: true
     UserTimeBase:
       required:


### PR DESCRIPTION
We have an open issue where an allOf composed schema with an inline definition makes the openapi codegen throw an exception.
This PR updates our code to skip over those inline schemas
So now the exception is not thrown
Fixes https://github.com/OpenAPITools/openapi-generator/issues/7262

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [ ] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [X] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

Core Team:
@wing328 (2015/07)
@jimschubert (2016/05)
@cbornet (2016/05)
@ackintosh (2018/02)
@jmini (2018/04)
@etherealjoy (2019/06)
@spacether (2020/05)