### PR TITLE
[cpp-ue4] add support for empty response

### DIFF
--- a/modules/openapi-generator/src/main/resources/cpp-ue4/api-source.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-ue4/api-source.mustache
@@ -56,7 +56,11 @@ void {{classname}}::HandleResponse(FHttpResponsePtr HttpResponse, bool bSucceede
 		FString ContentType = HttpResponse->GetContentType();
 		FString Content;
 
-		if (ContentType == TEXT("application/json"))
+		if(ContentType.IsEmpty())
+		{
+			return; // Nothing to parse
+		}
+		else if (ContentType == TEXT("application/json"))
 		{
 			Content = HttpResponse->GetContentAsString();
 


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

Very simple change to the api template for cpp-ue4 to handle an API that respond without any content (for instance if it responds with a single 200 to indicate success).

Sadly, there are no test config for cpp-ue4 (yet?). I tested the change directly inside the UE4 project we have in which we are using openapi-generator (as it's a proprietary game I cannot share it obviously, but the resulting code did compîle well).

@ravinikam @etherealjoy @martindelille @muttleyxd @Kahncode

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [ ] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
