### PR TITLE
[doc] Update new-generator steps (new.sh)

### DIFF
--- a/docs/new-generator.md
+++ b/docs/new-generator.md
@@ -23,7 +23,7 @@ The minimum set of files required to create a new generator are:
   - Should include a README explaining usage
   - Must include an `api.mustache`
   - Exists under `modules/openapi-generator/src/main/resources/` (plus `embeddedTemplate` dir value, see below)
-* Sample scripts under `./bin`
+* Config file under `./bin/configs`
   - Gives users a "real life" example of generated output
   - Samples are used by CI to verify generators and test for regressions in some cases
   
@@ -43,6 +43,8 @@ Usage:
     -c  Create a client generator
     -s  Create a server generator
     -d  Create a documentation generator
+    -H  Create a schema generator
+    -f  Create a config generator
     -t  When specified, creates test file(s) for the generator.
     -h  Display help.
 
@@ -55,8 +57,7 @@ Examples:
     modules/openapi-generator/src/main/resources/kotlin-server/README.mustache
     modules/openapi-generator/src/main/resources/kotlin-server/model.mustache
     modules/openapi-generator/src/main/resources/kotlin-server/api.mustache
-    bin/windows/kotlin-server-petstore.bat
-    bin/kotlin-server-petstore.sh
+    bin/configs/kotlin-server-petstore-new.yaml
 
   Create a generic C# server generator:
   ./new.sh -n csharp -s -t
@@ -65,8 +66,7 @@ Examples:
     modules/openapi-generator/src/main/resources/csharp-server/README.mustache
     modules/openapi-generator/src/main/resources/csharp-server/model.mustache
     modules/openapi-generator/src/main/resources/csharp-server/api.mustache
-    bin/windows/csharp-server-petstore.bat
-    bin/csharp-server-petstore.sh
+    bin/configs/csharp-server-petstore-new.yaml
     modules/openapi-generator/src/test/java/org/openapitools/codegen/csharp/CsharpServerCodegenTest.java
     modules/openapi-generator/src/test/java/org/openapitools/codegen/csharp/CsharpServerCodegenModelTest.java
     modules/openapi-generator/src/test/java/org/openapitools/codegen/csharp/CsharpServerCodegenOptionsTest.java
@@ -88,8 +88,7 @@ Creating modules/openapi-generator/src/main/java/org/openapitools/codegen/langua
 Creating modules/openapi-generator/src/main/resources/common-mark-documentation/README.mustache
 Creating modules/openapi-generator/src/main/resources/common-mark-documentation/model.mustache
 Creating modules/openapi-generator/src/main/resources/common-mark-documentation/api.mustache
-Creating bin/windows/common-mark-documentation-petstore.bat
-Creating bin/common-mark-documentation-petstore.sh
+Creating bin/configs/common-mark-documentation-petstore-new.yaml
 Finished.
 ```
 
@@ -151,7 +150,7 @@ The `templateDir` variable refers to the "current" template directory setting, a
 Both of these variables exist because the generator will fallback to files under `embeddedTemplateDir` if they are not defined in the user's custom template directory.
 
 ```java
-apiPackage = File.separator + "Apis";
+apiPackage = "Apis";
 ```
 
 This sets the "package" location for anything considered an API document. You might want to change this setting if, for instance, your language doesn't support uppercase letters in the path. We don't need to worry about that here.
@@ -159,7 +158,7 @@ This sets the "package" location for anything considered an API document. You mi
 Every templated output from `api.mustache` (registered via `apiTemplateFiles` above) will end up in the directory defined by `apiPackage` here.
 
 ```java
-modelPackage = File.separator + "Models";
+modelPackage = "Models";
 ```
 
 Similarly, this sets the package for `Models`.
@@ -330,60 +329,28 @@ To compile quickly to test this out, you can run `mvn clean package -DskipTests`
 
 ### Compile Sample
 
-The `new.sh` script created `bin/common-mark-documentation-petstore.sh`:
+The `new.sh` script created the generation config file `bin/configs/common-mark-documentation-petstore-new.yaml`:
 
 ```bash
-#!/bin/sh
-
-SCRIPT="$0"
-
-while [ -h "$SCRIPT" ] ; do
-  ls=$(ls -ld "$SCRIPT")
-  link=$(expr "$ls" : '.*-> \(.*\)$')
-  if expr "$link" : '/.*' > /dev/null; then
-    SCRIPT="$link"
-  else
-    SCRIPT=$(dirname "$SCRIPT")/"$link"
-  fi
-done
-
-if [ ! -d "${APP_DIR}" ]; then
-  APP_DIR=$(dirname "$SCRIPT")/..
-  APP_DIR=$(cd "${APP_DIR}"; pwd)
-fi
-
-executable="./modules/openapi-generator-cli/target/openapi-generator-cli.jar"
-
-if [ ! -f "$executable" ]
-then
-  mvn clean package
-fi
-
-# if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g common-mark -o samples/documentation/petstore/common/mark"
-
-java ${JAVA_OPTS} -jar ${executable} ${ags}
+generatorName: common-mark
+outputDir: samples/documentation/petstore/common/mark
+inputSpec: modules/openapi-generator/src/test/resources/2_0/petstore.yaml
+templateDir: modules/openapi-generator/src/main/resources/common-mark
+additionalProperties:
+  hideGenerationTimestamp: "true"
 ```
 
-This script is often used to apply default options for generation. A common option in most of these script is to define the template directory as the generator's directory under `resources`. This allows template maintainers to modify and test out template changes which don't require recompilation of the entire project. You'd still need to recompile the project in full if you add or modify behaviors to the generator (such as adding a `CliOption`).
+This configuration file is passed to the generator's CLI tool during continuous integration builds, and many outputs are compiled and tested as a regression test on every build. Contributors are also asked to run `./bin/utils/ensure-up-to-date` before opening a pull request to regenerate all samples defined under `./bin/configs`. This allows maintainers to quickly verify whether changes impact other generators.
 
-Add `-t modules/openapi-generator/src/main/resources/common-mark-documentation` to `ags` line to simplify the evaluation of template-only modifications:
+Configuration based examples allow us to test the same samples in each tooling option (CLI, Gradle Plugin, Maven Plugin, etc.). 
 
-```diff
-diff --git a/bin/markdown-documentation-petstore.sh b/bin/markdown-documentation-petstore.sh
-index d816771478..94b4ce6d12 100644
---- a/bin/markdown-documentation-petstore.sh
-+++ b/bin/markdown-documentation-petstore.sh
-@@ -26,6 +26,6 @@ fi
+You can compile your generator by running:
 
- # if you've executed sbt assembly previously it will use that instead.
- export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
--ags="$@ generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g common-mark -o samples/documentation/petstore/common-mark"
-+ags="$@ generate -t modules/openapi-generator/src/main/resources/common-mark-documentation -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g common-mark -o samples/documentation/petstore/common/markdown"
-
- java ${JAVA_OPTS} -jar ${executable} ${ags}
+```bash
+./bin/generate-samples.sh bin/configs/common-mark-documentation-petstore-new.yaml
 ```
+
+This configuration file can be used to demonstrate the default options for generation. A common option in most of these configs is to define the template directory as the generator's directory under `resources`. This allows template maintainers to modify and test out template changes which don't require recompilation of the entire project. You'd still need to recompile the project in full if you add or modify behaviors to the generator (such as adding a `CliOption`).
 
 ### Verify output
 

--- a/modules/openapi-generator/src/main/resources/META-INF/services/org.openapitools.codegen.CodegenConfig
+++ b/modules/openapi-generator/src/main/resources/META-INF/services/org.openapitools.codegen.CodegenConfig
@@ -127,3 +127,5 @@ org.openapitools.codegen.languages.TypeScriptJqueryClientCodegen
 org.openapitools.codegen.languages.TypeScriptNodeClientCodegen
 org.openapitools.codegen.languages.TypeScriptReduxQueryClientCodegen
 org.openapitools.codegen.languages.TypeScriptRxjsClientCodegen
+
+org.openapitools.codegen.languages.CommonMarkDocumentationCodegen

--- a/new.sh
+++ b/new.sh
@@ -179,8 +179,8 @@ public class ${lang_classname} extends DefaultCodegen implements CodegenConfig {
         modelTemplateFiles.put("model.mustache", ".zz");
         apiTemplateFiles.put("api.mustache", ".zz");
         embeddedTemplateDir = templateDir = "${gen_name_camel}-${gen_type}";
-        apiPackage = File.separator + "Apis";
-        modelPackage = File.separator + "Models";
+        apiPackage = "Apis";
+        modelPackage = "Models";
         supportingFiles.add(new SupportingFile("README.mustache", "", "README.md"));
         // TODO: Fill this out.
     }

--- a/new.sh
+++ b/new.sh
@@ -10,7 +10,7 @@ Stubs out files for new generators
 Usage:
 $0 [options]
     Options:
-$(grep "[[:space:]].)\ #" $0 | tr -d "#" | sed -E 's/( \| \*)//' | sed -E 's/([a-z])\)/-\1/')
+$(grep "[[:space:]].)\ #" $0 | tr -d "#" | sed -E 's/( \| \*)//' | sed -E 's/([a-zA-Z])\)/-\1/')
 
 Examples:
   Create a server generator for ktor:
@@ -21,8 +21,7 @@ Examples:
     modules/openapi-generator/src/main/resources/kotlin-server/README.mustache
     modules/openapi-generator/src/main/resources/kotlin-server/model.mustache
     modules/openapi-generator/src/main/resources/kotlin-server/api.mustache
-    bin/windows/kotlin-server-petstore.bat
-    bin/kotlin-server-petstore.sh
+    bin/configs/kotlin-server-petstore-new.yaml
 
   Create a generic C# server generator:
   $0 -n csharp -s -t
@@ -31,8 +30,7 @@ Examples:
     modules/openapi-generator/src/main/resources/csharp-server/README.mustache
     modules/openapi-generator/src/main/resources/csharp-server/model.mustache
     modules/openapi-generator/src/main/resources/csharp-server/api.mustache
-    bin/windows/csharp-server-petstore.bat
-    bin/csharp-server-petstore.sh
+    bin/configs/csharp-server-petstore-new.yaml
     modules/openapi-generator/src/test/java/org/openapitools/codegen/csharp/CsharpServerCodegenTest.java
     modules/openapi-generator/src/test/java/org/openapitools/codegen/csharp/CsharpServerCodegenModelTest.java
     modules/openapi-generator/src/test/java/org/openapitools/codegen/csharp/CsharpServerCodegenOptionsTest.java
@@ -56,7 +54,7 @@ checkPreviousGenType() {
 }
 
 [ $# -eq 0 ] && usage
-while getopts ":hcsdtn:" arg; do
+while getopts ":hcsdtfHn:" arg; do
   case ${arg} in
     n) # Required. Specify generator name, should be kebab-cased.
       gen_name=${OPTARG}
@@ -73,7 +71,7 @@ while getopts ":hcsdtn:" arg; do
         checkPreviousGenType
         gen_type=documentation
         ;;
-    h) # Create a schema generator
+    H) # Create a schema generator
         checkPreviousGenType
         gen_type=schema
         ;;
@@ -201,60 +199,16 @@ echo "Creating modules/openapi-generator/src/main/resources/${gen_name_camel}-${
 echo "Creating modules/openapi-generator/src/main/resources/${gen_name_camel}-${gen_type}/api.mustache" && \
     touch "${root}/modules/openapi-generator/src/main/resources/${gen_name_camel}-${gen_type}/api.mustache"
 
-# Step 4: Create bash/batch scripts
-
-## Windows batch file
-echo "Creating bin/windows/${gen_name_camel}-${gen_type}-petstore.bat"
-cat > "${root}/bin/windows/${gen_name_camel}-${gen_type}-petstore.bat"<<EOF
-set executable=.\modules\openapi-generator-cli\target\openapi-generator-cli.jar
-
-If Not Exist %executable% (
-  mvn clean package
-)
-
-REM set JAVA_OPTS=%JAVA_OPTS% -Xmx1024M -DloggerPath=conf/log4j.properties
-set ags=generate  --artifact-id "${gen_name_camel}-petstore-${gen_type}" -i modules\openapi-generator\src\test\resources\2_0\petstore.yaml -g ${gen_name_camel} -o samples\\${gen_type}\petstore\\${gen_name_camel_pathwin}
-
-java %JAVA_OPTS% -jar %executable% %ags%
+# Step 4: Create generation config scripts
+echo "Creating bin/configs/${gen_name_camel}-${gen_type}-petstore-new.yaml"
+cat > "${root}/bin/configs/${gen_name_camel}-${gen_type}-petstore-new.yaml"<<EOF
+generatorName: ${gen_name_camel}
+outputDir: samples/${gen_type}/petstore/${gen_name_camel_path}
+inputSpec: modules/openapi-generator/src/test/resources/2_0/petstore.yaml
+templateDir: modules/openapi-generator/src/main/resources/${gen_name_camel}
+additionalProperties:
+  hideGenerationTimestamp: "true"
 EOF
-
-## Bash file
-echo "Creating bin/${gen_name_camel}-${gen_type}-petstore.sh"
-cat > "${root}/bin/${gen_name_camel}-${gen_type}-petstore.sh"<<EOF
-#!/bin/sh
-
-SCRIPT="\$0"
-
-while [ -h "\$SCRIPT" ] ; do
-  ls=\$(ls -ld "\$SCRIPT")
-  link=\$(expr "\$ls" : '.*-> \(.*\)$')
-  if expr "\$link" : '/.*' > /dev/null; then
-    SCRIPT="\$link"
-  else
-    SCRIPT=\$(dirname "\$SCRIPT")/"\$link"
-  fi
-done
-
-if [ ! -d "\${APP_DIR}" ]; then
-  APP_DIR=\$(dirname "\$SCRIPT")/..
-  APP_DIR=\$(cd "\${APP_DIR}"; pwd)
-fi
-
-executable="./modules/openapi-generator-cli/target/openapi-generator-cli.jar"
-
-if [ ! -f "\$executable" ]
-then
-  mvn clean package
-fi
-
-# if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="\${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="\$@ generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g ${gen_name_camel} -o samples/${gen_type}/petstore/${gen_name_camel_path}"
-
-java \${JAVA_OPTS} -jar \${executable} \${ags}
-EOF
-
-chmod u+x "${root}/bin/${gen_name_camel}-${gen_type}-petstore.sh"
 
 # Step 5: (optional) Create OpenAPI Generator test files
 if [ "1" -eq "${tests}" ]; then


### PR DESCRIPTION
We've moved away from script based iterative generation to config based generation. This allowed us to move away from the "ensure script" process taking 30+ minutes for contributors to taking as few as 1-2 minutes. It also allows us to reuse the configurations for golden samples in the plugins for easier testing of outputs.

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

cc @OpenAPITools/openapi-generator-core-team 