### PR TITLE
[Java][Resteasy] Remove duplicate jackson-datatype-jsr310 dependency

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/resteasy/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/resteasy/pom.mustache
@@ -243,13 +243,6 @@
         </dependency>
 
         {{/withXml}}
-        {{#java8}}
-        <dependency>
-            <groupId>com.fasterxml.jackson.datatype</groupId>
-            <artifactId>jackson-datatype-jsr310</artifactId>
-            <version>${jackson-version}</version>
-        </dependency>
-        {{/java8}}
         {{^java8}}
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>


### PR DESCRIPTION
The jackson-datatype-jsr310 dependency is imported twice when the java8 option is enabled. As the dependency is also imported unconditionally I removed the conditional one.

<!-- Please check the completed items below -->
### PR checklist
 
- [x ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x ] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [ x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@bbdouglas @sreeshas @jfiala @lukoyanov @cbornet @jeff9finger @karismann @Zomzog @lwlee2608 @bkabrda