### PR TITLE
Adds cookie auth support to ApiKeyAuth in dart2 templates

### DIFF
--- a/modules/openapi-generator/src/main/resources/dart2/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/dart2/api_client.mustache
@@ -31,7 +31,7 @@ class ApiClient {
   {{/isBasicBearer}}
   {{/isBasic}}
   {{#isApiKey}}
-    _authentications['{{name}}'] = ApiKeyAuth({{#isKeyInHeader}}"header"{{/isKeyInHeader}}{{^isKeyInHeader}}"query"{{/isKeyInHeader}}, "{{keyParamName}}");
+    _authentications['{{name}}'] = ApiKeyAuth({{#isKeyInCookie}}"cookie"{{/isKeyInCookie}}{{^isKeyInCookie}}{{#isKeyInHeader}}"header"{{/isKeyInHeader}}{{^isKeyInHeader}}"query"{{/isKeyInHeader}}{{/isKeyInCookie}}, "{{keyParamName}}");
   {{/isApiKey}}
   {{#isOAuth}}
     _authentications['{{name}}'] = OAuth();

--- a/modules/openapi-generator/src/main/resources/dart2/auth/api_key_auth.mustache
+++ b/modules/openapi-generator/src/main/resources/dart2/auth/api_key_auth.mustache
@@ -24,6 +24,10 @@ class ApiKeyAuth implements Authentication {
       queryParams.add(QueryParam(paramName, value));
     } else if (location == 'header' && value != null) {
       headerParams[paramName] = value;
+    } else if (location == 'cookie' && value != null) {
+      headerParams.update('Cookie', (String existingCookie) {
+        return "$existingCookie; $paramName=$value";
+      }, ifAbsent: () => '$paramName=$value');
     }
   }
 }

--- a/samples/client/petstore/dart2/petstore_client_lib/lib/auth/api_key_auth.dart
+++ b/samples/client/petstore/dart2/petstore_client_lib/lib/auth/api_key_auth.dart
@@ -24,6 +24,10 @@ class ApiKeyAuth implements Authentication {
       queryParams.add(QueryParam(paramName, value));
     } else if (location == 'header' && value != null) {
       headerParams[paramName] = value;
+    } else if (location == 'cookie' && value != null) {
+      headerParams.update('Cookie', (String existingCookie) {
+        return "$existingCookie; $paramName=$value";
+      }, ifAbsent: () => '$paramName=$value');
     }
   }
 }


### PR DESCRIPTION
Issue #7344

This modifies `api_client.mustache` and `api_key_auth.mustache` to allow an option of `cookie` for location of apiKey.  To test, you can create a security schema such as:

```yaml
securitySchemes:
  ExampleCookieAuth:
    type: apiKey
    in: cookie
    name: session
```

This should send a `Cookie` header up to server with semi-colon separated auth keys/values e.g.:

`Cookie: session=12345; otherAuthKey=abcdef`



<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language. (@ircecho @swipesight @jaumard @athornz @amondnet )