### PR TITLE
Fix incorrect enum values for typescript clients

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -11,8 +11,8 @@ assignees: ''
 
 - [ ] Have you provided a full/minimal spec to reproduce the issue?
 - [ ] Have you validated the input using an OpenAPI validator ([example](https://apidevtools.org/swagger-parser/online/))?
-- [ ] Have you [tested with the latest master](https://github.com/OpenAPITools/openapi-generator/wiki/FAQ#how-to-test-with-the-latest-master-of-openapi-generator) to confirm the issuue still exists?
-- [ ] Have you search for related issues/PRs?
+- [ ] Have you [tested with the latest master](https://github.com/OpenAPITools/openapi-generator/wiki/FAQ#how-to-test-with-the-latest-master-of-openapi-generator) to confirm the issue still exists?
+- [ ] Have you searched for related issues/PRs?
 - [ ] What's the actual output vs expected output?
 - [ ] [Optional] Sponsorship to speed up the bug fix or feature request ([example](https://github.com/OpenAPITools/openapi-generator/issues/6178))
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractKotlinCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractKotlinCodegen.java
@@ -771,7 +771,9 @@ public abstract class AbstractKotlinCodegen extends DefaultCodegen implements Co
     @Override
     protected boolean needToImport(String type) {
         // provides extra protection against improperly trying to import language primitives and java types
-        boolean imports = !type.startsWith("kotlin.") && !type.startsWith("java.") && !defaultIncludes.contains(type) && !languageSpecificPrimitives.contains(type);
+        boolean imports = !type.startsWith("kotlin.") && !type.startsWith("java.") &&
+                !defaultIncludes.contains(type) && !languageSpecificPrimitives.contains(type) &&
+                !type.contains(".");
         return imports;
     }
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractTypeScriptClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractTypeScriptClientCodegen.java
@@ -690,16 +690,33 @@ public abstract class AbstractTypeScriptClientCodegen extends DefaultCodegen imp
             case original:
                 return name;
             case camelCase:
-                return camelize(StringUtils.lowerCase(name), true);
+                return camelize(prepareEnumString(name), true);
             case PascalCase:
-                return camelize(StringUtils.lowerCase(name));
+                return camelize(prepareEnumString(name));
             case snake_case:
                 return underscore(name);
             case UPPERCASE:
-                return name.toUpperCase(Locale.ROOT);
+                return prepareEnumString(name).toUpperCase(Locale.ROOT);
             default:
                 throw new IllegalArgumentException("Unsupported enum property naming: '" + name);
         }
+    }
+
+    private String prepareEnumString(String name) {
+        if (name == null || name.isEmpty()) {
+            return name;
+        }
+
+        StringBuilder stringBuilder = new StringBuilder();
+        stringBuilder.append(name.charAt(0));
+        for (int i = 1; i < name.length(); i++) {
+            if (Character.isLowerCase(name.charAt(i - 1)) && Character.isUpperCase(name.charAt(i))) {
+                stringBuilder.append('_').append(name.charAt(i));
+            } else {
+                stringBuilder.append(name.charAt(i));
+            }
+        }
+        return stringBuilder.toString().toLowerCase();
     }
 
     @Override

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractTypeScriptClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractTypeScriptClientCodegen.java
@@ -690,9 +690,9 @@ public abstract class AbstractTypeScriptClientCodegen extends DefaultCodegen imp
             case original:
                 return name;
             case camelCase:
-                return camelize(name, true);
+                return camelize(StringUtils.lowerCase(name), true);
             case PascalCase:
-                return camelize(name);
+                return camelize(StringUtils.lowerCase(name));
             case snake_case:
                 return underscore(name);
             case UPPERCASE:

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/TypeScriptAxiosClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/TypeScriptAxiosClientCodegenTest.java
@@ -1,0 +1,63 @@
+package org.openapitools.codegen.typescript;
+
+import org.openapitools.codegen.CodegenConstants;
+import org.openapitools.codegen.languages.TypeScriptAxiosClientCodegen;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+public class TypeScriptAxiosClientCodegenTest {
+
+    TypeScriptAxiosClientCodegen codegen = new TypeScriptAxiosClientCodegen();
+
+    @Test
+    public void testToEnumVarNameOriginalNamingType() {
+        codegen.additionalProperties().put(CodegenConstants.ENUM_PROPERTY_NAMING, CodegenConstants.ENUM_PROPERTY_NAMING_TYPE.original.name());
+        codegen.processOpts();
+        assertEquals(codegen.toEnumVarName("SCIENCE", "string"), "SCIENCE");
+        assertEquals(codegen.toEnumVarName("SCIENCE_FICTION", "string"), "SCIENCE_FICTION");
+        assertEquals(codegen.toEnumVarName("science", "string"), "science");
+        assertEquals(codegen.toEnumVarName("science_fiction", "string"), "science_fiction");
+    }
+
+    @Test
+    public void testToEnumVarNameCamelCaseNamingType() {
+        codegen.additionalProperties().put(CodegenConstants.ENUM_PROPERTY_NAMING, CodegenConstants.ENUM_PROPERTY_NAMING_TYPE.camelCase.name());
+        codegen.processOpts();
+        assertEquals(codegen.toEnumVarName("SCIENCE", "string"), "science");
+        assertEquals(codegen.toEnumVarName("SCIENCE_FICTION", "string"), "scienceFiction");
+        assertEquals(codegen.toEnumVarName("science", "string"), "science");
+        assertEquals(codegen.toEnumVarName("science_fiction", "string"), "scienceFiction");
+    }
+
+    @Test
+    public void testToEnumVarNamePascalCaseNamingType() {
+        codegen.additionalProperties().put(CodegenConstants.ENUM_PROPERTY_NAMING, CodegenConstants.ENUM_PROPERTY_NAMING_TYPE.PascalCase.name());
+        codegen.processOpts();
+        assertEquals(codegen.toEnumVarName("SCIENCE", "string"), "Science");
+        assertEquals(codegen.toEnumVarName("SCIENCE_FICTION", "string"), "ScienceFiction");
+        assertEquals(codegen.toEnumVarName("science", "string"), "Science");
+        assertEquals(codegen.toEnumVarName("science_fiction", "string"), "ScienceFiction");
+    }
+
+    @Test
+    public void testToEnumVarNameSnakeCaseNamingType() {
+        codegen.additionalProperties().put(CodegenConstants.ENUM_PROPERTY_NAMING, CodegenConstants.ENUM_PROPERTY_NAMING_TYPE.snake_case.name());
+        codegen.processOpts();
+        assertEquals(codegen.toEnumVarName("SCIENCE", "string"), "science");
+        assertEquals(codegen.toEnumVarName("SCIENCE_FICTION", "string"), "science_fiction");
+        assertEquals(codegen.toEnumVarName("science", "string"), "science");
+        assertEquals(codegen.toEnumVarName("science_fiction", "string"), "science_fiction");
+    }
+
+    @Test
+    public void testToEnumVarNameUpperCaseNamingType() {
+        codegen.additionalProperties().put(CodegenConstants.ENUM_PROPERTY_NAMING, CodegenConstants.ENUM_PROPERTY_NAMING_TYPE.UPPERCASE.name());
+        codegen.processOpts();
+        assertEquals(codegen.toEnumVarName("SCIENCE", "string"), "SCIENCE");
+        assertEquals(codegen.toEnumVarName("SCIENCE_FICTION", "string"), "SCIENCE_FICTION");
+        assertEquals(codegen.toEnumVarName("science", "string"), "SCIENCE");
+        assertEquals(codegen.toEnumVarName("science_fiction", "string"), "SCIENCE_FICTION");
+    }
+
+}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/TypeScriptAxiosClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/TypeScriptAxiosClientCodegenTest.java
@@ -18,6 +18,10 @@ public class TypeScriptAxiosClientCodegenTest {
         assertEquals(codegen.toEnumVarName("SCIENCE_FICTION", "string"), "SCIENCE_FICTION");
         assertEquals(codegen.toEnumVarName("science", "string"), "science");
         assertEquals(codegen.toEnumVarName("science_fiction", "string"), "science_fiction");
+        assertEquals(codegen.toEnumVarName("scienceFiction", "string"), "scienceFiction");
+        assertEquals(codegen.toEnumVarName("ScienceFiction", "string"), "ScienceFiction");
+        assertEquals(codegen.toEnumVarName("A", "string"), "A");
+        assertEquals(codegen.toEnumVarName("b", "string"), "b");
     }
 
     @Test
@@ -28,6 +32,8 @@ public class TypeScriptAxiosClientCodegenTest {
         assertEquals(codegen.toEnumVarName("SCIENCE_FICTION", "string"), "scienceFiction");
         assertEquals(codegen.toEnumVarName("science", "string"), "science");
         assertEquals(codegen.toEnumVarName("science_fiction", "string"), "scienceFiction");
+        assertEquals(codegen.toEnumVarName("scienceFiction", "string"), "scienceFiction");
+        assertEquals(codegen.toEnumVarName("ScienceFiction", "string"), "scienceFiction");
     }
 
     @Test
@@ -38,6 +44,10 @@ public class TypeScriptAxiosClientCodegenTest {
         assertEquals(codegen.toEnumVarName("SCIENCE_FICTION", "string"), "ScienceFiction");
         assertEquals(codegen.toEnumVarName("science", "string"), "Science");
         assertEquals(codegen.toEnumVarName("science_fiction", "string"), "ScienceFiction");
+        assertEquals(codegen.toEnumVarName("scienceFiction", "string"), "ScienceFiction");
+        assertEquals(codegen.toEnumVarName("ScienceFiction", "string"), "ScienceFiction");
+        assertEquals(codegen.toEnumVarName("A", "string"), "A");
+        assertEquals(codegen.toEnumVarName("b", "string"), "B");
     }
 
     @Test
@@ -48,6 +58,10 @@ public class TypeScriptAxiosClientCodegenTest {
         assertEquals(codegen.toEnumVarName("SCIENCE_FICTION", "string"), "science_fiction");
         assertEquals(codegen.toEnumVarName("science", "string"), "science");
         assertEquals(codegen.toEnumVarName("science_fiction", "string"), "science_fiction");
+        assertEquals(codegen.toEnumVarName("scienceFiction", "string"), "science_fiction");
+        assertEquals(codegen.toEnumVarName("ScienceFiction", "string"), "science_fiction");
+        assertEquals(codegen.toEnumVarName("A", "string"), "a");
+        assertEquals(codegen.toEnumVarName("b", "string"), "b");
     }
 
     @Test
@@ -58,6 +72,10 @@ public class TypeScriptAxiosClientCodegenTest {
         assertEquals(codegen.toEnumVarName("SCIENCE_FICTION", "string"), "SCIENCE_FICTION");
         assertEquals(codegen.toEnumVarName("science", "string"), "SCIENCE");
         assertEquals(codegen.toEnumVarName("science_fiction", "string"), "SCIENCE_FICTION");
+        assertEquals(codegen.toEnumVarName("scienceFiction", "string"), "SCIENCE_FICTION");
+        assertEquals(codegen.toEnumVarName("ScienceFiction", "string"), "SCIENCE_FICTION");
+        assertEquals(codegen.toEnumVarName("A", "string"), "A");
+        assertEquals(codegen.toEnumVarName("b", "string"), "B");
     }
 
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/utils/ModelUtilsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/utils/ModelUtilsTest.java
@@ -280,4 +280,10 @@ public class ModelUtilsTest {
         ArraySchema as = null;
         Assert.assertFalse(ModelUtils.isSet(as));
     }
+
+    @Test
+    public void testSimpleRefDecoding() {
+        String decoded = ModelUtils.getSimpleRef("#/components/~01%20Hallo~1Welt");
+        Assert.assertEquals(decoded, "~1 Hallo/Welt");
+    }
 }

--- a/website/src/dynamic/users.yml
+++ b/website/src/dynamic/users.yml
@@ -399,7 +399,7 @@
   infoLink: "https://vouchery.io"
   pinned: false
 -
-  caption: wbt-solutions UG
+  caption: wbt-solutions
   image: "img/companies/wbt_solutions.png"
   infoLink: "https://www.wbt-solutions.de/"
   pinned: false


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
fixes #7369
Enum values are generated incorrectly for PascalCase enum property naming type when the source enum values are in uppercase with underscores.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
