### PR TITLE
[typescript] Fix incorrect enum literal case

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractTypeScriptClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractTypeScriptClientCodegen.java
@@ -690,33 +690,16 @@ public abstract class AbstractTypeScriptClientCodegen extends DefaultCodegen imp
             case original:
                 return name;
             case camelCase:
-                return camelize(prepareEnumString(name), true);
+                return camelize(underscore(name), true);
             case PascalCase:
-                return camelize(prepareEnumString(name));
+                return camelize(underscore(name));
             case snake_case:
                 return underscore(name);
             case UPPERCASE:
-                return prepareEnumString(name).toUpperCase(Locale.ROOT);
+                return underscore(name).toUpperCase(Locale.ROOT);
             default:
                 throw new IllegalArgumentException("Unsupported enum property naming: '" + name);
         }
-    }
-
-    private String prepareEnumString(String name) {
-        if (name == null || name.isEmpty()) {
-            return name;
-        }
-
-        StringBuilder stringBuilder = new StringBuilder();
-        stringBuilder.append(name.charAt(0));
-        for (int i = 1; i < name.length(); i++) {
-            if (Character.isLowerCase(name.charAt(i - 1)) && Character.isUpperCase(name.charAt(i))) {
-                stringBuilder.append('_').append(name.charAt(i));
-            } else {
-                stringBuilder.append(name.charAt(i));
-            }
-        }
-        return StringUtils.lowerCase(stringBuilder.toString());
     }
 
     @Override

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractTypeScriptClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractTypeScriptClientCodegen.java
@@ -716,7 +716,7 @@ public abstract class AbstractTypeScriptClientCodegen extends DefaultCodegen imp
                 stringBuilder.append(name.charAt(i));
             }
         }
-        return stringBuilder.toString().toLowerCase();
+        return StringUtils.lowerCase(stringBuilder.toString());
     }
 
     @Override

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractTypeScriptClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractTypeScriptClientCodegen.java
@@ -690,16 +690,33 @@ public abstract class AbstractTypeScriptClientCodegen extends DefaultCodegen imp
             case original:
                 return name;
             case camelCase:
-                return camelize(name, true);
+                return camelize(prepareEnumString(name), true);
             case PascalCase:
-                return camelize(name);
+                return camelize(prepareEnumString(name));
             case snake_case:
                 return underscore(name);
             case UPPERCASE:
-                return name.toUpperCase(Locale.ROOT);
+                return prepareEnumString(name).toUpperCase(Locale.ROOT);
             default:
                 throw new IllegalArgumentException("Unsupported enum property naming: '" + name);
         }
+    }
+
+    private String prepareEnumString(String name) {
+        if (name == null || name.isEmpty()) {
+            return name;
+        }
+
+        StringBuilder stringBuilder = new StringBuilder();
+        stringBuilder.append(name.charAt(0));
+        for (int i = 1; i < name.length(); i++) {
+            if (Character.isLowerCase(name.charAt(i - 1)) && Character.isUpperCase(name.charAt(i))) {
+                stringBuilder.append('_').append(name.charAt(i));
+            } else {
+                stringBuilder.append(name.charAt(i));
+            }
+        }
+        return stringBuilder.toString().toLowerCase();
     }
 
     @Override

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/TypeScriptAxiosClientCodegenTestTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/TypeScriptAxiosClientCodegenTestTest.java
@@ -1,0 +1,81 @@
+package org.openapitools.codegen.typescript;
+
+import org.openapitools.codegen.CodegenConstants;
+import org.openapitools.codegen.languages.TypeScriptAxiosClientCodegen;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+public class TypeScriptAxiosClientCodegenTestTest {
+
+    TypeScriptAxiosClientCodegen codegen = new TypeScriptAxiosClientCodegen();
+
+    @Test
+    public void testToEnumVarNameOriginalNamingType() {
+        codegen.additionalProperties().put(CodegenConstants.ENUM_PROPERTY_NAMING, CodegenConstants.ENUM_PROPERTY_NAMING_TYPE.original.name());
+        codegen.processOpts();
+        assertEquals(codegen.toEnumVarName("SCIENCE", "string"), "SCIENCE");
+        assertEquals(codegen.toEnumVarName("SCIENCE_FICTION", "string"), "SCIENCE_FICTION");
+        assertEquals(codegen.toEnumVarName("science", "string"), "science");
+        assertEquals(codegen.toEnumVarName("science_fiction", "string"), "science_fiction");
+        assertEquals(codegen.toEnumVarName("scienceFiction", "string"), "scienceFiction");
+        assertEquals(codegen.toEnumVarName("ScienceFiction", "string"), "ScienceFiction");
+        assertEquals(codegen.toEnumVarName("A", "string"), "A");
+        assertEquals(codegen.toEnumVarName("b", "string"), "b");
+    }
+
+    @Test
+    public void testToEnumVarNameCamelCaseNamingType() {
+        codegen.additionalProperties().put(CodegenConstants.ENUM_PROPERTY_NAMING, CodegenConstants.ENUM_PROPERTY_NAMING_TYPE.camelCase.name());
+        codegen.processOpts();
+        assertEquals(codegen.toEnumVarName("SCIENCE", "string"), "science");
+        assertEquals(codegen.toEnumVarName("SCIENCE_FICTION", "string"), "scienceFiction");
+        assertEquals(codegen.toEnumVarName("science", "string"), "science");
+        assertEquals(codegen.toEnumVarName("science_fiction", "string"), "scienceFiction");
+        assertEquals(codegen.toEnumVarName("scienceFiction", "string"), "scienceFiction");
+        assertEquals(codegen.toEnumVarName("ScienceFiction", "string"), "scienceFiction");
+    }
+
+    @Test
+    public void testToEnumVarNamePascalCaseNamingType() {
+        codegen.additionalProperties().put(CodegenConstants.ENUM_PROPERTY_NAMING, CodegenConstants.ENUM_PROPERTY_NAMING_TYPE.PascalCase.name());
+        codegen.processOpts();
+        assertEquals(codegen.toEnumVarName("SCIENCE", "string"), "Science");
+        assertEquals(codegen.toEnumVarName("SCIENCE_FICTION", "string"), "ScienceFiction");
+        assertEquals(codegen.toEnumVarName("science", "string"), "Science");
+        assertEquals(codegen.toEnumVarName("science_fiction", "string"), "ScienceFiction");
+        assertEquals(codegen.toEnumVarName("scienceFiction", "string"), "ScienceFiction");
+        assertEquals(codegen.toEnumVarName("ScienceFiction", "string"), "ScienceFiction");
+        assertEquals(codegen.toEnumVarName("A", "string"), "A");
+        assertEquals(codegen.toEnumVarName("b", "string"), "B");
+    }
+
+    @Test
+    public void testToEnumVarNameSnakeCaseNamingType() {
+        codegen.additionalProperties().put(CodegenConstants.ENUM_PROPERTY_NAMING, CodegenConstants.ENUM_PROPERTY_NAMING_TYPE.snake_case.name());
+        codegen.processOpts();
+        assertEquals(codegen.toEnumVarName("SCIENCE", "string"), "science");
+        assertEquals(codegen.toEnumVarName("SCIENCE_FICTION", "string"), "science_fiction");
+        assertEquals(codegen.toEnumVarName("science", "string"), "science");
+        assertEquals(codegen.toEnumVarName("science_fiction", "string"), "science_fiction");
+        assertEquals(codegen.toEnumVarName("scienceFiction", "string"), "science_fiction");
+        assertEquals(codegen.toEnumVarName("ScienceFiction", "string"), "science_fiction");
+        assertEquals(codegen.toEnumVarName("A", "string"), "a");
+        assertEquals(codegen.toEnumVarName("b", "string"), "b");
+    }
+
+    @Test
+    public void testToEnumVarNameUpperCaseNamingType() {
+        codegen.additionalProperties().put(CodegenConstants.ENUM_PROPERTY_NAMING, CodegenConstants.ENUM_PROPERTY_NAMING_TYPE.UPPERCASE.name());
+        codegen.processOpts();
+        assertEquals(codegen.toEnumVarName("SCIENCE", "string"), "SCIENCE");
+        assertEquals(codegen.toEnumVarName("SCIENCE_FICTION", "string"), "SCIENCE_FICTION");
+        assertEquals(codegen.toEnumVarName("science", "string"), "SCIENCE");
+        assertEquals(codegen.toEnumVarName("science_fiction", "string"), "SCIENCE_FICTION");
+        assertEquals(codegen.toEnumVarName("scienceFiction", "string"), "SCIENCE_FICTION");
+        assertEquals(codegen.toEnumVarName("ScienceFiction", "string"), "SCIENCE_FICTION");
+        assertEquals(codegen.toEnumVarName("A", "string"), "A");
+        assertEquals(codegen.toEnumVarName("b", "string"), "B");
+    }
+
+}


### PR DESCRIPTION
fixes #7369
Enum values are generated incorrectly for PascalCase enum property naming type when the source enum values are in uppercase with underscores.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
