### PR TITLE
Fixes isFreeFormObject detection

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
@@ -781,7 +781,7 @@ public class ModelUtils {
                         }
                     } else if (addlProps instanceof Schema) {
                         // additionalProperties defined as {}
-                        if (addlProps.getType() == null && (addlProps.getProperties() == null || addlProps.getProperties().isEmpty())) {
+                        if (addlProps.getType() == null && addlProps.get$ref() == null && (addlProps.getProperties() == null || addlProps.getProperties().isEmpty())) {
                             return true;
                         }
                     }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/python/PythonClientExperimentalTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/python/PythonClientExperimentalTest.java
@@ -21,9 +21,15 @@ import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.media.*;
 import io.swagger.v3.parser.util.SchemaTypeUtil;
+
+import java.io.File;
 import java.math.BigDecimal;
+import java.nio.file.Files;
 import java.util.Arrays;
+import java.util.List;
+
 import org.openapitools.codegen.*;
+import org.openapitools.codegen.config.CodegenConfigurator;
 import org.openapitools.codegen.languages.PythonClientExperimentalCodegen;
 import org.openapitools.codegen.utils.ModelUtils;
 import org.testng.Assert;
@@ -374,5 +380,23 @@ public class PythonClientExperimentalTest {
         final CodegenModel noDefaultEumLengthOneModel = codegen.fromModel("noDefaultEumLengthOneModel", noDefaultEumLengthOne);
         Assert.assertEquals(noDefaultEumLengthOneModel.defaultValue, "15.0");
         Assert.assertEquals(noDefaultEumLengthOneModel.hasRequired, false);
+    }
+
+    @Test
+    public void testObjectModelWithRefedAdditionalPropertiesIsGenerated() throws Exception {
+        File output = Files.createTempDirectory("test").toFile();
+
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName("python-experimental")
+                .setInputSpec("src/test/resources/3_0/issue_7372.yaml")
+                .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
+
+        final ClientOptInput clientOptInput = configurator.toClientOptInput();
+        DefaultGenerator generator = new DefaultGenerator();
+        List<File> files = generator.opts(clientOptInput).generate();
+
+        TestUtils.ensureContainsFile(files, output, "openapi_client/model/a.py");
+        TestUtils.ensureContainsFile(files, output, "openapi_client/model/b.py");
+        output.deleteOnExit();
     }
 }

--- a/modules/openapi-generator/src/test/resources/3_0/issue_7372.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/issue_7372.yaml
@@ -1,0 +1,15 @@
+openapi: 3.0.0
+info:
+  title: foo
+  version: 1.0.0
+components:
+  schemas:
+    A:
+      type: object
+      additionalProperties:
+        $ref: '#/components/schemas/B'
+    B:
+      type: array
+      items:
+        type: object
+paths: {}


### PR DESCRIPTION
We have a bug in master branch where this schema:
```
    A:
      type: object
      additionalProperties:
        $ref: '#/components/schemas/B'
```
Is incorrectly interpreted as FreeFormObject when it should be a MapSchema
Per our java documentation a schema is FreeForm if:
```
A free form object is an object (i.e. 'type: object' in a OAS document) that:
1) Does not define properties, and
2) Is not a composed schema (no anyOf, oneOf, allOf), and
3) additionalproperties is not defined, or additionalproperties: true, or additionalproperties: {}.
```
Schema A does not satisfy requirement 3. Requirement 3 only allows additionalproperties  values of null, true, and empty object {}. We have {$ref: '#/components/schemas/B'} which is different.

This PR fixes that bug by making sure that when we are in isFreeFormObject we check to see that a ref does not exist in additionalProperties.
- A test has been added demonstrating that the above model is generated with our updated code
- If merged, this PR will fix https://github.com/OpenAPITools/openapi-generator/issues/7372#issuecomment-689776396
 

- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [ ] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [ ] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
