### PR TITLE
[core] Use canonical path for template dir

### DIFF
--- a/modules/openapi-generator-core/src/main/java/org/openapitools/codegen/config/WorkflowSettings.java
+++ b/modules/openapi-generator-core/src/main/java/org/openapitools/codegen/config/WorkflowSettings.java
@@ -442,7 +442,7 @@ public class WorkflowSettings {
                 // check to see if the folder exists
                 if (f.exists() && f.isDirectory()) {
                     uri = f.toURI();
-                    this.templateDir =  Paths.get(uri).toAbsolutePath().toString();
+                    this.templateDir =  Paths.get(uri).toAbsolutePath().normalize().toString();
                 } else {
                     URL url = this.getClass().getClassLoader().getResource(templateDir);
                     if (url != null) {

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/config/DynamicSettingsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/config/DynamicSettingsTest.java
@@ -68,7 +68,7 @@ public class DynamicSettingsTest {
         assertNotNull(workflowSettings);
 
         assertEquals(generatorSettings.getGeneratorName(), "none");
-        assertEquals(workflowSettings.getTemplateDir(), current.getAbsolutePath());
+        assertEquals(workflowSettings.getTemplateDir(), current.getCanonicalPath());
         assertNotEquals(workflowSettings.getTemplateDir(), input);
 
         assertEquals(generatorSettings.getAdditionalProperties().size(), 4);


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

Use the canonical path of `templateDir` instead of absolute path in order to get rid of `..` when specifying a relative templateDir like `-t ../../templates` in the command line, and avoid raising the new exception introduced in #6598: `IllegalArgumentException("Template location must be constrained to template directory.")`

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [ ] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [ ] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
