### PR TITLE
[bug][typescript] Fix node client generator import file paths

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptNodeClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptNodeClientCodegen.java
@@ -36,7 +36,8 @@ public class TypeScriptNodeClientCodegen extends AbstractTypeScriptClientCodegen
     private static final Logger LOGGER = LoggerFactory.getLogger(TypeScriptNodeClientCodegen.class);
 
     public static final String NPM_REPOSITORY = "npmRepository";
-    private static final String DEFAULT_IMPORT_PREFIX = "./";
+    private static final String DEFAULT_MODEL_FILENAME_DIRECTORY_PREFIX = "./";
+    private static final String DEFAULT_MODEL_IMPORT_DIRECTORY_PREFIX = "../";
 
     protected String npmRepository = null;
     protected String apiSuffix = "Api";
@@ -153,7 +154,7 @@ public class TypeScriptNodeClientCodegen extends AbstractTypeScriptClientCodegen
             return importMapping.get(name);
         }
 
-        return DEFAULT_IMPORT_PREFIX + camelize(toModelName(name), true);
+        return DEFAULT_MODEL_FILENAME_DIRECTORY_PREFIX + camelize(toModelName(name), true);
     }
 
     @Override
@@ -162,7 +163,7 @@ public class TypeScriptNodeClientCodegen extends AbstractTypeScriptClientCodegen
             return importMapping.get(name);
         }
 
-        return modelPackage() + "/" + camelize(toModelName(name), true);
+        return DEFAULT_MODEL_IMPORT_DIRECTORY_PREFIX + modelPackage() + "/" + camelize(toModelName(name), true);
     }
 
     @Override
@@ -222,8 +223,7 @@ public class TypeScriptNodeClientCodegen extends AbstractTypeScriptClientCodegen
         // Add additional filename information for model imports in the apis
         List<Map<String, Object>> imports = (List<Map<String, Object>>) operations.get("imports");
         for (Map<String, Object> im : imports) {
-            im.put("filename", im.get("import"));
-            im.put("classname", getModelnameFromModelFilename(im.get("filename").toString()));
+            im.put("filename", im.get("import").toString());
         }
 
         return operations;

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptNodeClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptNodeClientCodegen.java
@@ -309,10 +309,6 @@ public class TypeScriptNodeClientCodegen extends AbstractTypeScriptClientCodegen
         return toApiFilename(name);
     }
 
-    private String getModelnameFromModelFilename(String filename) {
-        String name = filename.substring((modelPackage() + File.separator).length());
-        return camelize(name);
-    }
 @Override
     protected void addAdditionPropertiesToCodeGenModel(CodegenModel codegenModel, Schema schema) {
         super.addAdditionPropertiesToCodeGenModel(codegenModel, schema);

--- a/modules/openapi-generator/src/main/resources/typescript-node/api-single.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-node/api-single.mustache
@@ -5,7 +5,7 @@ import http from 'http';
 
 /* tslint:disable:no-unused-locals */
 {{#imports}}
-import { {{classname}} } from '../{{filename}}';
+import { {{classname}} } from '{{filename}}';
 {{/imports}}
 
 import { ObjectSerializer, Authentication, VoidAuth, Interceptor } from '../model/models';

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/typescriptnode/TypeScriptNodeClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/typescriptnode/TypeScriptNodeClientCodegenTest.java
@@ -139,7 +139,7 @@ public class TypeScriptNodeClientCodegenTest {
     @Test(description = "correctly produces imports without import mapping")
     public void postProcessOperationsWithModelsTestWithoutImportMapping() {
         final String importName = "../model/pet";
-        Map<String, Object> operations = postProcessOperationsHelper(importName);
+        Map<String, Object> operations = createPostProcessOperationsMapWithImportName(importName);
 
         codegen.postProcessOperationsWithModels(operations, Collections.emptyList());
         List<Map<String, Object>> extractedImports = (List<Map<String, Object>>) operations.get("imports");
@@ -149,7 +149,7 @@ public class TypeScriptNodeClientCodegenTest {
     @Test(description = "correctly produces imports with import mapping")
     public void postProcessOperationsWithModelsTestWithImportMapping() {
         final String importName = "@namespace/dir/category";
-        Map<String, Object> operations = postProcessOperationsHelper(importName);
+        Map<String, Object> operations = createPostProcessOperationsMapWithImportName(importName);
 
         codegen.postProcessOperationsWithModels(operations, Collections.emptyList());
         List<Map<String, Object>> extractedImports = (List<Map<String, Object>>) operations.get("imports");
@@ -157,7 +157,7 @@ public class TypeScriptNodeClientCodegenTest {
         Assert.assertEquals(extractedImports.get(0).get("filename"), importName);
     }
 
-    private Map<String, Object> postProcessOperationsHelper(String importName) {
+    private Map<String, Object> createPostProcessOperationsMapWithImportName(String importName) {
         Map<String, Object> operations = new HashMap<String, Object>() {{
             put("operation", Collections.emptyList());
             put("classname", "Pet");

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/typescriptnode/TypeScriptNodeClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/typescriptnode/TypeScriptNodeClientCodegenTest.java
@@ -1,9 +1,6 @@
 package org.openapitools.codegen.typescript.typescriptnode;
 
-import com.google.common.collect.ImmutableMap;
 import io.swagger.v3.oas.models.OpenAPI;
-import org.jetbrains.annotations.NotNull;
-import org.openapitools.codegen.CodegenOperation;
 import org.openapitools.codegen.TestUtils;
 import org.openapitools.codegen.languages.TypeScriptNodeClientCodegen;
 import org.testng.Assert;
@@ -160,7 +157,6 @@ public class TypeScriptNodeClientCodegenTest {
         Assert.assertEquals(extractedImports.get(0).get("filename"), importName);
     }
 
-    @NotNull
     private Map<String, Object> postProcessOperationsHelper(String importName) {
         Map<String, Object> operations = new HashMap<String, Object>() {{
             put("operation", Collections.emptyList());


### PR DESCRIPTION
### Bug and Recap
Issue: Resolves https://github.com/OpenAPITools/openapi-generator/issues/7385
> For mapping such as:
> ```
>   "importMappings": {
>     "Pet": "../dataModel/petModel"
>   }
> ```
> **Actual**
> ```
> import { AModelPetModel } from '../../dataModel/petModel';
> ```
> **Expected**
> ```
> import { Pet } from '../dataModel/petModel';
> ```
> 
> For a mapping such as:
> ```
>   "importMappings": {
>     "Pet": "@company/prefix-zoo-store"
>   }
> ```
> 
> **Actual**
> ```
> import { NyPrefixZooStore } from '../@company/prefix-zoo-store';
> ```
> **Expected**
> ```
> import { Pet } from '@company/prefix-zoo-store';
> ```

### Method
Below is the map in `operations.get("imports")` based on the import location:

_Model is created by generator_
```
[{import=model/pet, classname=Pet}]
```

_BYOModel_
```
[{import=@company/prefix-zoo-store, classname=Pet}]
```

Therefore the logic was updated to a simpler version, assuming the mapping is created by prior areas.

```
for (Map<String, Object> im : imports) {
     im.put("filename", im.get("import").toString());
}
```

This resulted in the following import for:

_Created Model_
```
import { Pet } from '../model/pet';
```

_BYOModel_
```
import { Pet } from '../@company/prefix-zoo-store';
```

Per the above, this fixed the issue of the improper render which led to the bad `classname` i.e. what led to the following `NyPrefixZooStore`

The next issue was the extra `../` which is embedded as part of the template. See: https://github.com/OpenAPITools/openapi-generator/blob/master/modules/openapi-generator/src/main/resources/typescript-node/api-single.mustache#L8

For this purpose, the extra directory listing was remove from the template and added into the `Codegen` itself, where the `../` is appended by default _ONLY_ when the model is derived from an auto generated file. 

After this change here are the mappings in `operations.get("imports")`

_Model is created by generator_
```
[{import=../model/pet, classname=Pet}]
```

_BYOModel_
```
[{import=@company/prefix-zoo-store, classname=Pet}]
```

This resulted in the following import for:

_Created Model_
```
import { Pet } from '../model/pet';
```

_BYOModel_
```
import { Pet } from '@company/prefix-zoo-store';
```


### Testing

#### Unit
1. Updated tests for `defaultModelImportTest` 
2. Added tests for `postProcessOperationsWithModels`

#### Manual
1. Ran the above expected v/s actual output comparisons to ensure the values provided are accurate

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
