### PR TITLE
Fix body parameter in the Ruby client

### DIFF
--- a/modules/openapi-generator/src/main/resources/ruby-client/api.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/api.mustache
@@ -171,10 +171,12 @@ module {{moduleName}}
       form_params['{{baseName}}'] = {{#collectionFormat}}@api_client.build_collection_param(opts[:'{{{paramName}}}'], :{{{collectionFormat}}}){{/collectionFormat}}{{^collectionFormat}}opts[:'{{{paramName}}}']{{/collectionFormat}} if !opts[:'{{paramName}}'].nil?
       {{/required}}
       {{/formParams}}
+      {{#bodyParam}}
 
       # http body (model)
-      post_body = opts[:body] {{#bodyParam}}|| @api_client.object_to_http_body({{#required}}{{{paramName}}}{{/required}}{{^required}}opts[:'{{{paramName}}}']{{/required}}) {{/bodyParam}}
+      post_body = @api_client.object_to_http_body({{#required}}{{{paramName}}}{{/required}}{{^required}}opts[:'{{{paramName}}}']{{/required}})
 
+      {{/bodyParam}}
       # return_type
       return_type = opts[:return_type] {{#returnType}}|| '{{{returnType}}}' {{/returnType}}
 
@@ -185,7 +187,7 @@ module {{moduleName}}
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
-        :body => post_body,
+        :body => {{#bodyParam}}post_body{{/bodyParam}}{{^bodyParam}}nil{{/bodyParam}},
         :auth_names => auth_names,
         :return_type => return_type
       )

--- a/samples/client/petstore/ruby-faraday/lib/petstore/api/another_fake_api.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/api/another_fake_api.rb
@@ -59,7 +59,7 @@ module Petstore
       form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = opts[:body] || @api_client.object_to_http_body(client) 
+      post_body = @api_client.object_to_http_body(client)
 
       # return_type
       return_type = opts[:return_type] || 'Client' 

--- a/samples/client/petstore/ruby-faraday/lib/petstore/api/default_api.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/api/default_api.rb
@@ -45,10 +45,6 @@ module Petstore
 
       # form parameters
       form_params = opts[:form_params] || {}
-
-      # http body (model)
-      post_body = opts[:body] 
-
       # return_type
       return_type = opts[:return_type] || 'InlineResponseDefault' 
 
@@ -59,7 +55,7 @@ module Petstore
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
-        :body => post_body,
+        :body => nil,
         :auth_names => auth_names,
         :return_type => return_type
       )

--- a/samples/client/petstore/ruby-faraday/lib/petstore/api/fake_api.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/api/fake_api.rb
@@ -47,10 +47,6 @@ module Petstore
 
       # form parameters
       form_params = opts[:form_params] || {}
-
-      # http body (model)
-      post_body = opts[:body] 
-
       # return_type
       return_type = opts[:return_type] || 'HealthCheckResult' 
 
@@ -61,7 +57,7 @@ module Petstore
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
-        :body => post_body,
+        :body => nil,
         :auth_names => auth_names,
         :return_type => return_type
       )
@@ -115,7 +111,7 @@ module Petstore
       form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = opts[:body] || @api_client.object_to_http_body(pet) 
+      post_body = @api_client.object_to_http_body(pet)
 
       # return_type
       return_type = opts[:return_type] 
@@ -173,7 +169,7 @@ module Petstore
       form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = opts[:body] || @api_client.object_to_http_body(opts[:'body']) 
+      post_body = @api_client.object_to_http_body(opts[:'body'])
 
       # return_type
       return_type = opts[:return_type] || 'Boolean' 
@@ -231,7 +227,7 @@ module Petstore
       form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = opts[:body] || @api_client.object_to_http_body(opts[:'outer_composite']) 
+      post_body = @api_client.object_to_http_body(opts[:'outer_composite'])
 
       # return_type
       return_type = opts[:return_type] || 'OuterComposite' 
@@ -289,7 +285,7 @@ module Petstore
       form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = opts[:body] || @api_client.object_to_http_body(opts[:'body']) 
+      post_body = @api_client.object_to_http_body(opts[:'body'])
 
       # return_type
       return_type = opts[:return_type] || 'Float' 
@@ -347,7 +343,7 @@ module Petstore
       form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = opts[:body] || @api_client.object_to_http_body(opts[:'body']) 
+      post_body = @api_client.object_to_http_body(opts[:'body'])
 
       # return_type
       return_type = opts[:return_type] || 'String' 
@@ -407,7 +403,7 @@ module Petstore
       form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = opts[:body] || @api_client.object_to_http_body(file_schema_test_class) 
+      post_body = @api_client.object_to_http_body(file_schema_test_class)
 
       # return_type
       return_type = opts[:return_type] 
@@ -472,7 +468,7 @@ module Petstore
       form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = opts[:body] || @api_client.object_to_http_body(user) 
+      post_body = @api_client.object_to_http_body(user)
 
       # return_type
       return_type = opts[:return_type] 
@@ -536,7 +532,7 @@ module Petstore
       form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = opts[:body] || @api_client.object_to_http_body(client) 
+      post_body = @api_client.object_to_http_body(client)
 
       # return_type
       return_type = opts[:return_type] || 'Client' 
@@ -702,10 +698,6 @@ module Petstore
       form_params['dateTime'] = opts[:'date_time'] if !opts[:'date_time'].nil?
       form_params['password'] = opts[:'password'] if !opts[:'password'].nil?
       form_params['callback'] = opts[:'callback'] if !opts[:'callback'].nil?
-
-      # http body (model)
-      post_body = opts[:body] 
-
       # return_type
       return_type = opts[:return_type] 
 
@@ -716,7 +708,7 @@ module Petstore
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
-        :body => post_body,
+        :body => nil,
         :auth_names => auth_names,
         :return_type => return_type
       )
@@ -814,10 +806,6 @@ module Petstore
       form_params = opts[:form_params] || {}
       form_params['enum_form_string_array'] = @api_client.build_collection_param(opts[:'enum_form_string_array'], :csv) if !opts[:'enum_form_string_array'].nil?
       form_params['enum_form_string'] = opts[:'enum_form_string'] if !opts[:'enum_form_string'].nil?
-
-      # http body (model)
-      post_body = opts[:body] 
-
       # return_type
       return_type = opts[:return_type] 
 
@@ -828,7 +816,7 @@ module Petstore
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
-        :body => post_body,
+        :body => nil,
         :auth_names => auth_names,
         :return_type => return_type
       )
@@ -898,10 +886,6 @@ module Petstore
 
       # form parameters
       form_params = opts[:form_params] || {}
-
-      # http body (model)
-      post_body = opts[:body] 
-
       # return_type
       return_type = opts[:return_type] 
 
@@ -912,7 +896,7 @@ module Petstore
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
-        :body => post_body,
+        :body => nil,
         :auth_names => auth_names,
         :return_type => return_type
       )
@@ -960,7 +944,7 @@ module Petstore
       form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = opts[:body] || @api_client.object_to_http_body(request_body) 
+      post_body = @api_client.object_to_http_body(request_body)
 
       # return_type
       return_type = opts[:return_type] 
@@ -1026,10 +1010,6 @@ module Petstore
       form_params = opts[:form_params] || {}
       form_params['param'] = param
       form_params['param2'] = param2
-
-      # http body (model)
-      post_body = opts[:body] 
-
       # return_type
       return_type = opts[:return_type] 
 
@@ -1040,7 +1020,7 @@ module Petstore
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
-        :body => post_body,
+        :body => nil,
         :auth_names => auth_names,
         :return_type => return_type
       )
@@ -1113,10 +1093,6 @@ module Petstore
 
       # form parameters
       form_params = opts[:form_params] || {}
-
-      # http body (model)
-      post_body = opts[:body] 
-
       # return_type
       return_type = opts[:return_type] 
 
@@ -1127,7 +1103,7 @@ module Petstore
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
-        :body => post_body,
+        :body => nil,
         :auth_names => auth_names,
         :return_type => return_type
       )

--- a/samples/client/petstore/ruby-faraday/lib/petstore/api/fake_classname_tags123_api.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/api/fake_classname_tags123_api.rb
@@ -59,7 +59,7 @@ module Petstore
       form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = opts[:body] || @api_client.object_to_http_body(client) 
+      post_body = @api_client.object_to_http_body(client)
 
       # return_type
       return_type = opts[:return_type] || 'Client' 

--- a/samples/client/petstore/ruby-faraday/lib/petstore/api/pet_api.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/api/pet_api.rb
@@ -55,7 +55,7 @@ module Petstore
       form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = opts[:body] || @api_client.object_to_http_body(pet) 
+      post_body = @api_client.object_to_http_body(pet)
 
       # return_type
       return_type = opts[:return_type] 
@@ -114,10 +114,6 @@ module Petstore
 
       # form parameters
       form_params = opts[:form_params] || {}
-
-      # http body (model)
-      post_body = opts[:body] 
-
       # return_type
       return_type = opts[:return_type] 
 
@@ -128,7 +124,7 @@ module Petstore
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
-        :body => post_body,
+        :body => nil,
         :auth_names => auth_names,
         :return_type => return_type
       )
@@ -177,10 +173,6 @@ module Petstore
 
       # form parameters
       form_params = opts[:form_params] || {}
-
-      # http body (model)
-      post_body = opts[:body] 
-
       # return_type
       return_type = opts[:return_type] || 'Array<Pet>' 
 
@@ -191,7 +183,7 @@ module Petstore
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
-        :body => post_body,
+        :body => nil,
         :auth_names => auth_names,
         :return_type => return_type
       )
@@ -240,10 +232,6 @@ module Petstore
 
       # form parameters
       form_params = opts[:form_params] || {}
-
-      # http body (model)
-      post_body = opts[:body] 
-
       # return_type
       return_type = opts[:return_type] || 'Array<Pet>' 
 
@@ -254,7 +242,7 @@ module Petstore
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
-        :body => post_body,
+        :body => nil,
         :auth_names => auth_names,
         :return_type => return_type
       )
@@ -302,10 +290,6 @@ module Petstore
 
       # form parameters
       form_params = opts[:form_params] || {}
-
-      # http body (model)
-      post_body = opts[:body] 
-
       # return_type
       return_type = opts[:return_type] || 'Pet' 
 
@@ -316,7 +300,7 @@ module Petstore
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
-        :body => post_body,
+        :body => nil,
         :auth_names => auth_names,
         :return_type => return_type
       )
@@ -364,7 +348,7 @@ module Petstore
       form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = opts[:body] || @api_client.object_to_http_body(pet) 
+      post_body = @api_client.object_to_http_body(pet)
 
       # return_type
       return_type = opts[:return_type] 
@@ -428,10 +412,6 @@ module Petstore
       form_params = opts[:form_params] || {}
       form_params['name'] = opts[:'name'] if !opts[:'name'].nil?
       form_params['status'] = opts[:'status'] if !opts[:'status'].nil?
-
-      # http body (model)
-      post_body = opts[:body] 
-
       # return_type
       return_type = opts[:return_type] 
 
@@ -442,7 +422,7 @@ module Petstore
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
-        :body => post_body,
+        :body => nil,
         :auth_names => auth_names,
         :return_type => return_type
       )
@@ -496,10 +476,6 @@ module Petstore
       form_params = opts[:form_params] || {}
       form_params['additionalMetadata'] = opts[:'additional_metadata'] if !opts[:'additional_metadata'].nil?
       form_params['file'] = opts[:'file'] if !opts[:'file'].nil?
-
-      # http body (model)
-      post_body = opts[:body] 
-
       # return_type
       return_type = opts[:return_type] || 'ApiResponse' 
 
@@ -510,7 +486,7 @@ module Petstore
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
-        :body => post_body,
+        :body => nil,
         :auth_names => auth_names,
         :return_type => return_type
       )
@@ -568,10 +544,6 @@ module Petstore
       form_params = opts[:form_params] || {}
       form_params['requiredFile'] = required_file
       form_params['additionalMetadata'] = opts[:'additional_metadata'] if !opts[:'additional_metadata'].nil?
-
-      # http body (model)
-      post_body = opts[:body] 
-
       # return_type
       return_type = opts[:return_type] || 'ApiResponse' 
 
@@ -582,7 +554,7 @@ module Petstore
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
-        :body => post_body,
+        :body => nil,
         :auth_names => auth_names,
         :return_type => return_type
       )

--- a/samples/client/petstore/ruby-faraday/lib/petstore/api/store_api.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/api/store_api.rb
@@ -53,10 +53,6 @@ module Petstore
 
       # form parameters
       form_params = opts[:form_params] || {}
-
-      # http body (model)
-      post_body = opts[:body] 
-
       # return_type
       return_type = opts[:return_type] 
 
@@ -67,7 +63,7 @@ module Petstore
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
-        :body => post_body,
+        :body => nil,
         :auth_names => auth_names,
         :return_type => return_type
       )
@@ -109,10 +105,6 @@ module Petstore
 
       # form parameters
       form_params = opts[:form_params] || {}
-
-      # http body (model)
-      post_body = opts[:body] 
-
       # return_type
       return_type = opts[:return_type] || 'Hash<String, Integer>' 
 
@@ -123,7 +115,7 @@ module Petstore
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
-        :body => post_body,
+        :body => nil,
         :auth_names => auth_names,
         :return_type => return_type
       )
@@ -179,10 +171,6 @@ module Petstore
 
       # form parameters
       form_params = opts[:form_params] || {}
-
-      # http body (model)
-      post_body = opts[:body] 
-
       # return_type
       return_type = opts[:return_type] || 'Order' 
 
@@ -193,7 +181,7 @@ module Petstore
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
-        :body => post_body,
+        :body => nil,
         :auth_names => auth_names,
         :return_type => return_type
       )
@@ -243,7 +231,7 @@ module Petstore
       form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = opts[:body] || @api_client.object_to_http_body(order) 
+      post_body = @api_client.object_to_http_body(order)
 
       # return_type
       return_type = opts[:return_type] || 'Order' 

--- a/samples/client/petstore/ruby-faraday/lib/petstore/api/user_api.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/api/user_api.rb
@@ -57,7 +57,7 @@ module Petstore
       form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = opts[:body] || @api_client.object_to_http_body(user) 
+      post_body = @api_client.object_to_http_body(user)
 
       # return_type
       return_type = opts[:return_type] 
@@ -117,7 +117,7 @@ module Petstore
       form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = opts[:body] || @api_client.object_to_http_body(user) 
+      post_body = @api_client.object_to_http_body(user)
 
       # return_type
       return_type = opts[:return_type] 
@@ -177,7 +177,7 @@ module Petstore
       form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = opts[:body] || @api_client.object_to_http_body(user) 
+      post_body = @api_client.object_to_http_body(user)
 
       # return_type
       return_type = opts[:return_type] 
@@ -235,10 +235,6 @@ module Petstore
 
       # form parameters
       form_params = opts[:form_params] || {}
-
-      # http body (model)
-      post_body = opts[:body] 
-
       # return_type
       return_type = opts[:return_type] 
 
@@ -249,7 +245,7 @@ module Petstore
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
-        :body => post_body,
+        :body => nil,
         :auth_names => auth_names,
         :return_type => return_type
       )
@@ -295,10 +291,6 @@ module Petstore
 
       # form parameters
       form_params = opts[:form_params] || {}
-
-      # http body (model)
-      post_body = opts[:body] 
-
       # return_type
       return_type = opts[:return_type] || 'User' 
 
@@ -309,7 +301,7 @@ module Petstore
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
-        :body => post_body,
+        :body => nil,
         :auth_names => auth_names,
         :return_type => return_type
       )
@@ -363,10 +355,6 @@ module Petstore
 
       # form parameters
       form_params = opts[:form_params] || {}
-
-      # http body (model)
-      post_body = opts[:body] 
-
       # return_type
       return_type = opts[:return_type] || 'String' 
 
@@ -377,7 +365,7 @@ module Petstore
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
-        :body => post_body,
+        :body => nil,
         :auth_names => auth_names,
         :return_type => return_type
       )
@@ -415,10 +403,6 @@ module Petstore
 
       # form parameters
       form_params = opts[:form_params] || {}
-
-      # http body (model)
-      post_body = opts[:body] 
-
       # return_type
       return_type = opts[:return_type] 
 
@@ -429,7 +413,7 @@ module Petstore
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
-        :body => post_body,
+        :body => nil,
         :auth_names => auth_names,
         :return_type => return_type
       )
@@ -485,7 +469,7 @@ module Petstore
       form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = opts[:body] || @api_client.object_to_http_body(user) 
+      post_body = @api_client.object_to_http_body(user)
 
       # return_type
       return_type = opts[:return_type] 

--- a/samples/client/petstore/ruby/lib/petstore/api/another_fake_api.rb
+++ b/samples/client/petstore/ruby/lib/petstore/api/another_fake_api.rb
@@ -59,7 +59,7 @@ module Petstore
       form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = opts[:body] || @api_client.object_to_http_body(client) 
+      post_body = @api_client.object_to_http_body(client)
 
       # return_type
       return_type = opts[:return_type] || 'Client' 

--- a/samples/client/petstore/ruby/lib/petstore/api/default_api.rb
+++ b/samples/client/petstore/ruby/lib/petstore/api/default_api.rb
@@ -45,10 +45,6 @@ module Petstore
 
       # form parameters
       form_params = opts[:form_params] || {}
-
-      # http body (model)
-      post_body = opts[:body] 
-
       # return_type
       return_type = opts[:return_type] || 'InlineResponseDefault' 
 
@@ -59,7 +55,7 @@ module Petstore
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
-        :body => post_body,
+        :body => nil,
         :auth_names => auth_names,
         :return_type => return_type
       )

--- a/samples/client/petstore/ruby/lib/petstore/api/fake_api.rb
+++ b/samples/client/petstore/ruby/lib/petstore/api/fake_api.rb
@@ -47,10 +47,6 @@ module Petstore
 
       # form parameters
       form_params = opts[:form_params] || {}
-
-      # http body (model)
-      post_body = opts[:body] 
-
       # return_type
       return_type = opts[:return_type] || 'HealthCheckResult' 
 
@@ -61,7 +57,7 @@ module Petstore
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
-        :body => post_body,
+        :body => nil,
         :auth_names => auth_names,
         :return_type => return_type
       )
@@ -115,7 +111,7 @@ module Petstore
       form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = opts[:body] || @api_client.object_to_http_body(pet) 
+      post_body = @api_client.object_to_http_body(pet)
 
       # return_type
       return_type = opts[:return_type] 
@@ -173,7 +169,7 @@ module Petstore
       form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = opts[:body] || @api_client.object_to_http_body(opts[:'body']) 
+      post_body = @api_client.object_to_http_body(opts[:'body'])
 
       # return_type
       return_type = opts[:return_type] || 'Boolean' 
@@ -231,7 +227,7 @@ module Petstore
       form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = opts[:body] || @api_client.object_to_http_body(opts[:'outer_composite']) 
+      post_body = @api_client.object_to_http_body(opts[:'outer_composite'])
 
       # return_type
       return_type = opts[:return_type] || 'OuterComposite' 
@@ -289,7 +285,7 @@ module Petstore
       form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = opts[:body] || @api_client.object_to_http_body(opts[:'body']) 
+      post_body = @api_client.object_to_http_body(opts[:'body'])
 
       # return_type
       return_type = opts[:return_type] || 'Float' 
@@ -347,7 +343,7 @@ module Petstore
       form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = opts[:body] || @api_client.object_to_http_body(opts[:'body']) 
+      post_body = @api_client.object_to_http_body(opts[:'body'])
 
       # return_type
       return_type = opts[:return_type] || 'String' 
@@ -407,7 +403,7 @@ module Petstore
       form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = opts[:body] || @api_client.object_to_http_body(file_schema_test_class) 
+      post_body = @api_client.object_to_http_body(file_schema_test_class)
 
       # return_type
       return_type = opts[:return_type] 
@@ -472,7 +468,7 @@ module Petstore
       form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = opts[:body] || @api_client.object_to_http_body(user) 
+      post_body = @api_client.object_to_http_body(user)
 
       # return_type
       return_type = opts[:return_type] 
@@ -536,7 +532,7 @@ module Petstore
       form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = opts[:body] || @api_client.object_to_http_body(client) 
+      post_body = @api_client.object_to_http_body(client)
 
       # return_type
       return_type = opts[:return_type] || 'Client' 
@@ -702,10 +698,6 @@ module Petstore
       form_params['dateTime'] = opts[:'date_time'] if !opts[:'date_time'].nil?
       form_params['password'] = opts[:'password'] if !opts[:'password'].nil?
       form_params['callback'] = opts[:'callback'] if !opts[:'callback'].nil?
-
-      # http body (model)
-      post_body = opts[:body] 
-
       # return_type
       return_type = opts[:return_type] 
 
@@ -716,7 +708,7 @@ module Petstore
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
-        :body => post_body,
+        :body => nil,
         :auth_names => auth_names,
         :return_type => return_type
       )
@@ -814,10 +806,6 @@ module Petstore
       form_params = opts[:form_params] || {}
       form_params['enum_form_string_array'] = @api_client.build_collection_param(opts[:'enum_form_string_array'], :csv) if !opts[:'enum_form_string_array'].nil?
       form_params['enum_form_string'] = opts[:'enum_form_string'] if !opts[:'enum_form_string'].nil?
-
-      # http body (model)
-      post_body = opts[:body] 
-
       # return_type
       return_type = opts[:return_type] 
 
@@ -828,7 +816,7 @@ module Petstore
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
-        :body => post_body,
+        :body => nil,
         :auth_names => auth_names,
         :return_type => return_type
       )
@@ -898,10 +886,6 @@ module Petstore
 
       # form parameters
       form_params = opts[:form_params] || {}
-
-      # http body (model)
-      post_body = opts[:body] 
-
       # return_type
       return_type = opts[:return_type] 
 
@@ -912,7 +896,7 @@ module Petstore
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
-        :body => post_body,
+        :body => nil,
         :auth_names => auth_names,
         :return_type => return_type
       )
@@ -960,7 +944,7 @@ module Petstore
       form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = opts[:body] || @api_client.object_to_http_body(request_body) 
+      post_body = @api_client.object_to_http_body(request_body)
 
       # return_type
       return_type = opts[:return_type] 
@@ -1026,10 +1010,6 @@ module Petstore
       form_params = opts[:form_params] || {}
       form_params['param'] = param
       form_params['param2'] = param2
-
-      # http body (model)
-      post_body = opts[:body] 
-
       # return_type
       return_type = opts[:return_type] 
 
@@ -1040,7 +1020,7 @@ module Petstore
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
-        :body => post_body,
+        :body => nil,
         :auth_names => auth_names,
         :return_type => return_type
       )
@@ -1113,10 +1093,6 @@ module Petstore
 
       # form parameters
       form_params = opts[:form_params] || {}
-
-      # http body (model)
-      post_body = opts[:body] 
-
       # return_type
       return_type = opts[:return_type] 
 
@@ -1127,7 +1103,7 @@ module Petstore
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
-        :body => post_body,
+        :body => nil,
         :auth_names => auth_names,
         :return_type => return_type
       )

--- a/samples/client/petstore/ruby/lib/petstore/api/fake_classname_tags123_api.rb
+++ b/samples/client/petstore/ruby/lib/petstore/api/fake_classname_tags123_api.rb
@@ -59,7 +59,7 @@ module Petstore
       form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = opts[:body] || @api_client.object_to_http_body(client) 
+      post_body = @api_client.object_to_http_body(client)
 
       # return_type
       return_type = opts[:return_type] || 'Client' 

--- a/samples/client/petstore/ruby/lib/petstore/api/pet_api.rb
+++ b/samples/client/petstore/ruby/lib/petstore/api/pet_api.rb
@@ -55,7 +55,7 @@ module Petstore
       form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = opts[:body] || @api_client.object_to_http_body(pet) 
+      post_body = @api_client.object_to_http_body(pet)
 
       # return_type
       return_type = opts[:return_type] 
@@ -114,10 +114,6 @@ module Petstore
 
       # form parameters
       form_params = opts[:form_params] || {}
-
-      # http body (model)
-      post_body = opts[:body] 
-
       # return_type
       return_type = opts[:return_type] 
 
@@ -128,7 +124,7 @@ module Petstore
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
-        :body => post_body,
+        :body => nil,
         :auth_names => auth_names,
         :return_type => return_type
       )
@@ -177,10 +173,6 @@ module Petstore
 
       # form parameters
       form_params = opts[:form_params] || {}
-
-      # http body (model)
-      post_body = opts[:body] 
-
       # return_type
       return_type = opts[:return_type] || 'Array<Pet>' 
 
@@ -191,7 +183,7 @@ module Petstore
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
-        :body => post_body,
+        :body => nil,
         :auth_names => auth_names,
         :return_type => return_type
       )
@@ -240,10 +232,6 @@ module Petstore
 
       # form parameters
       form_params = opts[:form_params] || {}
-
-      # http body (model)
-      post_body = opts[:body] 
-
       # return_type
       return_type = opts[:return_type] || 'Array<Pet>' 
 
@@ -254,7 +242,7 @@ module Petstore
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
-        :body => post_body,
+        :body => nil,
         :auth_names => auth_names,
         :return_type => return_type
       )
@@ -302,10 +290,6 @@ module Petstore
 
       # form parameters
       form_params = opts[:form_params] || {}
-
-      # http body (model)
-      post_body = opts[:body] 
-
       # return_type
       return_type = opts[:return_type] || 'Pet' 
 
@@ -316,7 +300,7 @@ module Petstore
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
-        :body => post_body,
+        :body => nil,
         :auth_names => auth_names,
         :return_type => return_type
       )
@@ -364,7 +348,7 @@ module Petstore
       form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = opts[:body] || @api_client.object_to_http_body(pet) 
+      post_body = @api_client.object_to_http_body(pet)
 
       # return_type
       return_type = opts[:return_type] 
@@ -428,10 +412,6 @@ module Petstore
       form_params = opts[:form_params] || {}
       form_params['name'] = opts[:'name'] if !opts[:'name'].nil?
       form_params['status'] = opts[:'status'] if !opts[:'status'].nil?
-
-      # http body (model)
-      post_body = opts[:body] 
-
       # return_type
       return_type = opts[:return_type] 
 
@@ -442,7 +422,7 @@ module Petstore
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
-        :body => post_body,
+        :body => nil,
         :auth_names => auth_names,
         :return_type => return_type
       )
@@ -496,10 +476,6 @@ module Petstore
       form_params = opts[:form_params] || {}
       form_params['additionalMetadata'] = opts[:'additional_metadata'] if !opts[:'additional_metadata'].nil?
       form_params['file'] = opts[:'file'] if !opts[:'file'].nil?
-
-      # http body (model)
-      post_body = opts[:body] 
-
       # return_type
       return_type = opts[:return_type] || 'ApiResponse' 
 
@@ -510,7 +486,7 @@ module Petstore
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
-        :body => post_body,
+        :body => nil,
         :auth_names => auth_names,
         :return_type => return_type
       )
@@ -568,10 +544,6 @@ module Petstore
       form_params = opts[:form_params] || {}
       form_params['requiredFile'] = required_file
       form_params['additionalMetadata'] = opts[:'additional_metadata'] if !opts[:'additional_metadata'].nil?
-
-      # http body (model)
-      post_body = opts[:body] 
-
       # return_type
       return_type = opts[:return_type] || 'ApiResponse' 
 
@@ -582,7 +554,7 @@ module Petstore
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
-        :body => post_body,
+        :body => nil,
         :auth_names => auth_names,
         :return_type => return_type
       )

--- a/samples/client/petstore/ruby/lib/petstore/api/store_api.rb
+++ b/samples/client/petstore/ruby/lib/petstore/api/store_api.rb
@@ -53,10 +53,6 @@ module Petstore
 
       # form parameters
       form_params = opts[:form_params] || {}
-
-      # http body (model)
-      post_body = opts[:body] 
-
       # return_type
       return_type = opts[:return_type] 
 
@@ -67,7 +63,7 @@ module Petstore
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
-        :body => post_body,
+        :body => nil,
         :auth_names => auth_names,
         :return_type => return_type
       )
@@ -109,10 +105,6 @@ module Petstore
 
       # form parameters
       form_params = opts[:form_params] || {}
-
-      # http body (model)
-      post_body = opts[:body] 
-
       # return_type
       return_type = opts[:return_type] || 'Hash<String, Integer>' 
 
@@ -123,7 +115,7 @@ module Petstore
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
-        :body => post_body,
+        :body => nil,
         :auth_names => auth_names,
         :return_type => return_type
       )
@@ -179,10 +171,6 @@ module Petstore
 
       # form parameters
       form_params = opts[:form_params] || {}
-
-      # http body (model)
-      post_body = opts[:body] 
-
       # return_type
       return_type = opts[:return_type] || 'Order' 
 
@@ -193,7 +181,7 @@ module Petstore
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
-        :body => post_body,
+        :body => nil,
         :auth_names => auth_names,
         :return_type => return_type
       )
@@ -243,7 +231,7 @@ module Petstore
       form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = opts[:body] || @api_client.object_to_http_body(order) 
+      post_body = @api_client.object_to_http_body(order)
 
       # return_type
       return_type = opts[:return_type] || 'Order' 

--- a/samples/client/petstore/ruby/lib/petstore/api/user_api.rb
+++ b/samples/client/petstore/ruby/lib/petstore/api/user_api.rb
@@ -57,7 +57,7 @@ module Petstore
       form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = opts[:body] || @api_client.object_to_http_body(user) 
+      post_body = @api_client.object_to_http_body(user)
 
       # return_type
       return_type = opts[:return_type] 
@@ -117,7 +117,7 @@ module Petstore
       form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = opts[:body] || @api_client.object_to_http_body(user) 
+      post_body = @api_client.object_to_http_body(user)
 
       # return_type
       return_type = opts[:return_type] 
@@ -177,7 +177,7 @@ module Petstore
       form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = opts[:body] || @api_client.object_to_http_body(user) 
+      post_body = @api_client.object_to_http_body(user)
 
       # return_type
       return_type = opts[:return_type] 
@@ -235,10 +235,6 @@ module Petstore
 
       # form parameters
       form_params = opts[:form_params] || {}
-
-      # http body (model)
-      post_body = opts[:body] 
-
       # return_type
       return_type = opts[:return_type] 
 
@@ -249,7 +245,7 @@ module Petstore
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
-        :body => post_body,
+        :body => nil,
         :auth_names => auth_names,
         :return_type => return_type
       )
@@ -295,10 +291,6 @@ module Petstore
 
       # form parameters
       form_params = opts[:form_params] || {}
-
-      # http body (model)
-      post_body = opts[:body] 
-
       # return_type
       return_type = opts[:return_type] || 'User' 
 
@@ -309,7 +301,7 @@ module Petstore
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
-        :body => post_body,
+        :body => nil,
         :auth_names => auth_names,
         :return_type => return_type
       )
@@ -363,10 +355,6 @@ module Petstore
 
       # form parameters
       form_params = opts[:form_params] || {}
-
-      # http body (model)
-      post_body = opts[:body] 
-
       # return_type
       return_type = opts[:return_type] || 'String' 
 
@@ -377,7 +365,7 @@ module Petstore
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
-        :body => post_body,
+        :body => nil,
         :auth_names => auth_names,
         :return_type => return_type
       )
@@ -415,10 +403,6 @@ module Petstore
 
       # form parameters
       form_params = opts[:form_params] || {}
-
-      # http body (model)
-      post_body = opts[:body] 
-
       # return_type
       return_type = opts[:return_type] 
 
@@ -429,7 +413,7 @@ module Petstore
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
-        :body => post_body,
+        :body => nil,
         :auth_names => auth_names,
         :return_type => return_type
       )
@@ -485,7 +469,7 @@ module Petstore
       form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = opts[:body] || @api_client.object_to_http_body(user) 
+      post_body = @api_client.object_to_http_body(user)
 
       # return_type
       return_type = opts[:return_type] 


### PR DESCRIPTION
- Fix body parameter in the Ruby client

To fix https://github.com/OpenAPITools/openapi-generator/issues/7412

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [ ] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [ ] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
