### PR TITLE
[Ruby] rename debugging variables

### DIFF
--- a/modules/openapi-generator/src/main/resources/ruby-client/api.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/api.mustache
@@ -173,13 +173,13 @@ module {{moduleName}}
       {{/formParams}}
 
       # http body (model)
-      post_body = opts[:body] {{#bodyParam}}|| @api_client.object_to_http_body({{#required}}{{{paramName}}}{{/required}}{{^required}}opts[:'{{{paramName}}}']{{/required}}) {{/bodyParam}}
+      post_body = opts[:debug_body]{{#bodyParam}} || @api_client.object_to_http_body({{#required}}{{{paramName}}}{{/required}}{{^required}}opts[:'{{{paramName}}}']{{/required}}){{/bodyParam}}
 
       # return_type
-      return_type = opts[:return_type] {{#returnType}}|| '{{{returnType}}}' {{/returnType}}
+      return_type = opts[:debug_return_type]{{#returnType}} || '{{{returnType}}}'{{/returnType}}
 
       # auth_names
-      auth_names = opts[:auth_names] || [{{#authMethods}}'{{name}}'{{#hasMore}}, {{/hasMore}}{{/authMethods}}]
+      auth_names = opts[:debug_auth_names] || [{{#authMethods}}'{{name}}'{{#hasMore}}, {{/hasMore}}{{/authMethods}}]
 
       new_options = opts.merge(
         :header_params => header_params,

--- a/samples/client/petstore/ruby-faraday/lib/petstore/api/another_fake_api.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/api/another_fake_api.rb
@@ -59,13 +59,13 @@ module Petstore
       form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = opts[:body] || @api_client.object_to_http_body(client) 
+      post_body = opts[:debug_body] || @api_client.object_to_http_body(client)
 
       # return_type
-      return_type = opts[:return_type] || 'Client' 
+      return_type = opts[:debug_return_type] || 'Client'
 
       # auth_names
-      auth_names = opts[:auth_names] || []
+      auth_names = opts[:debug_auth_names] || []
 
       new_options = opts.merge(
         :header_params => header_params,

--- a/samples/client/petstore/ruby-faraday/lib/petstore/api/default_api.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/api/default_api.rb
@@ -47,13 +47,13 @@ module Petstore
       form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = opts[:body] 
+      post_body = opts[:debug_body]
 
       # return_type
-      return_type = opts[:return_type] || 'InlineResponseDefault' 
+      return_type = opts[:debug_return_type] || 'InlineResponseDefault'
 
       # auth_names
-      auth_names = opts[:auth_names] || []
+      auth_names = opts[:debug_auth_names] || []
 
       new_options = opts.merge(
         :header_params => header_params,

--- a/samples/client/petstore/ruby-faraday/lib/petstore/api/fake_api.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/api/fake_api.rb
@@ -49,13 +49,13 @@ module Petstore
       form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = opts[:body] 
+      post_body = opts[:debug_body]
 
       # return_type
-      return_type = opts[:return_type] || 'HealthCheckResult' 
+      return_type = opts[:debug_return_type] || 'HealthCheckResult'
 
       # auth_names
-      auth_names = opts[:auth_names] || []
+      auth_names = opts[:debug_auth_names] || []
 
       new_options = opts.merge(
         :header_params => header_params,
@@ -115,13 +115,13 @@ module Petstore
       form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = opts[:body] || @api_client.object_to_http_body(pet) 
+      post_body = opts[:debug_body] || @api_client.object_to_http_body(pet)
 
       # return_type
-      return_type = opts[:return_type] 
+      return_type = opts[:debug_return_type]
 
       # auth_names
-      auth_names = opts[:auth_names] || ['http_signature_test']
+      auth_names = opts[:debug_auth_names] || ['http_signature_test']
 
       new_options = opts.merge(
         :header_params => header_params,
@@ -173,13 +173,13 @@ module Petstore
       form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = opts[:body] || @api_client.object_to_http_body(opts[:'body']) 
+      post_body = opts[:debug_body] || @api_client.object_to_http_body(opts[:'body'])
 
       # return_type
-      return_type = opts[:return_type] || 'Boolean' 
+      return_type = opts[:debug_return_type] || 'Boolean'
 
       # auth_names
-      auth_names = opts[:auth_names] || []
+      auth_names = opts[:debug_auth_names] || []
 
       new_options = opts.merge(
         :header_params => header_params,
@@ -231,13 +231,13 @@ module Petstore
       form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = opts[:body] || @api_client.object_to_http_body(opts[:'outer_composite']) 
+      post_body = opts[:debug_body] || @api_client.object_to_http_body(opts[:'outer_composite'])
 
       # return_type
-      return_type = opts[:return_type] || 'OuterComposite' 
+      return_type = opts[:debug_return_type] || 'OuterComposite'
 
       # auth_names
-      auth_names = opts[:auth_names] || []
+      auth_names = opts[:debug_auth_names] || []
 
       new_options = opts.merge(
         :header_params => header_params,
@@ -289,13 +289,13 @@ module Petstore
       form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = opts[:body] || @api_client.object_to_http_body(opts[:'body']) 
+      post_body = opts[:debug_body] || @api_client.object_to_http_body(opts[:'body'])
 
       # return_type
-      return_type = opts[:return_type] || 'Float' 
+      return_type = opts[:debug_return_type] || 'Float'
 
       # auth_names
-      auth_names = opts[:auth_names] || []
+      auth_names = opts[:debug_auth_names] || []
 
       new_options = opts.merge(
         :header_params => header_params,
@@ -347,13 +347,13 @@ module Petstore
       form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = opts[:body] || @api_client.object_to_http_body(opts[:'body']) 
+      post_body = opts[:debug_body] || @api_client.object_to_http_body(opts[:'body'])
 
       # return_type
-      return_type = opts[:return_type] || 'String' 
+      return_type = opts[:debug_return_type] || 'String'
 
       # auth_names
-      auth_names = opts[:auth_names] || []
+      auth_names = opts[:debug_auth_names] || []
 
       new_options = opts.merge(
         :header_params => header_params,
@@ -407,13 +407,13 @@ module Petstore
       form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = opts[:body] || @api_client.object_to_http_body(file_schema_test_class) 
+      post_body = opts[:debug_body] || @api_client.object_to_http_body(file_schema_test_class)
 
       # return_type
-      return_type = opts[:return_type] 
+      return_type = opts[:debug_return_type]
 
       # auth_names
-      auth_names = opts[:auth_names] || []
+      auth_names = opts[:debug_auth_names] || []
 
       new_options = opts.merge(
         :header_params => header_params,
@@ -472,13 +472,13 @@ module Petstore
       form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = opts[:body] || @api_client.object_to_http_body(user) 
+      post_body = opts[:debug_body] || @api_client.object_to_http_body(user)
 
       # return_type
-      return_type = opts[:return_type] 
+      return_type = opts[:debug_return_type]
 
       # auth_names
-      auth_names = opts[:auth_names] || []
+      auth_names = opts[:debug_auth_names] || []
 
       new_options = opts.merge(
         :header_params => header_params,
@@ -536,13 +536,13 @@ module Petstore
       form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = opts[:body] || @api_client.object_to_http_body(client) 
+      post_body = opts[:debug_body] || @api_client.object_to_http_body(client)
 
       # return_type
-      return_type = opts[:return_type] || 'Client' 
+      return_type = opts[:debug_return_type] || 'Client'
 
       # auth_names
-      auth_names = opts[:auth_names] || []
+      auth_names = opts[:debug_auth_names] || []
 
       new_options = opts.merge(
         :header_params => header_params,
@@ -704,13 +704,13 @@ module Petstore
       form_params['callback'] = opts[:'callback'] if !opts[:'callback'].nil?
 
       # http body (model)
-      post_body = opts[:body] 
+      post_body = opts[:debug_body]
 
       # return_type
-      return_type = opts[:return_type] 
+      return_type = opts[:debug_return_type]
 
       # auth_names
-      auth_names = opts[:auth_names] || ['http_basic_test']
+      auth_names = opts[:debug_auth_names] || ['http_basic_test']
 
       new_options = opts.merge(
         :header_params => header_params,
@@ -816,13 +816,13 @@ module Petstore
       form_params['enum_form_string'] = opts[:'enum_form_string'] if !opts[:'enum_form_string'].nil?
 
       # http body (model)
-      post_body = opts[:body] 
+      post_body = opts[:debug_body]
 
       # return_type
-      return_type = opts[:return_type] 
+      return_type = opts[:debug_return_type]
 
       # auth_names
-      auth_names = opts[:auth_names] || []
+      auth_names = opts[:debug_auth_names] || []
 
       new_options = opts.merge(
         :header_params => header_params,
@@ -900,13 +900,13 @@ module Petstore
       form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = opts[:body] 
+      post_body = opts[:debug_body]
 
       # return_type
-      return_type = opts[:return_type] 
+      return_type = opts[:debug_return_type]
 
       # auth_names
-      auth_names = opts[:auth_names] || ['bearer_test']
+      auth_names = opts[:debug_auth_names] || ['bearer_test']
 
       new_options = opts.merge(
         :header_params => header_params,
@@ -960,13 +960,13 @@ module Petstore
       form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = opts[:body] || @api_client.object_to_http_body(request_body) 
+      post_body = opts[:debug_body] || @api_client.object_to_http_body(request_body)
 
       # return_type
-      return_type = opts[:return_type] 
+      return_type = opts[:debug_return_type]
 
       # auth_names
-      auth_names = opts[:auth_names] || []
+      auth_names = opts[:debug_auth_names] || []
 
       new_options = opts.merge(
         :header_params => header_params,
@@ -1028,13 +1028,13 @@ module Petstore
       form_params['param2'] = param2
 
       # http body (model)
-      post_body = opts[:body] 
+      post_body = opts[:debug_body]
 
       # return_type
-      return_type = opts[:return_type] 
+      return_type = opts[:debug_return_type]
 
       # auth_names
-      auth_names = opts[:auth_names] || []
+      auth_names = opts[:debug_auth_names] || []
 
       new_options = opts.merge(
         :header_params => header_params,
@@ -1115,13 +1115,13 @@ module Petstore
       form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = opts[:body] 
+      post_body = opts[:debug_body]
 
       # return_type
-      return_type = opts[:return_type] 
+      return_type = opts[:debug_return_type]
 
       # auth_names
-      auth_names = opts[:auth_names] || []
+      auth_names = opts[:debug_auth_names] || []
 
       new_options = opts.merge(
         :header_params => header_params,

--- a/samples/client/petstore/ruby-faraday/lib/petstore/api/fake_classname_tags123_api.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/api/fake_classname_tags123_api.rb
@@ -59,13 +59,13 @@ module Petstore
       form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = opts[:body] || @api_client.object_to_http_body(client) 
+      post_body = opts[:debug_body] || @api_client.object_to_http_body(client)
 
       # return_type
-      return_type = opts[:return_type] || 'Client' 
+      return_type = opts[:debug_return_type] || 'Client'
 
       # auth_names
-      auth_names = opts[:auth_names] || ['api_key_query']
+      auth_names = opts[:debug_auth_names] || ['api_key_query']
 
       new_options = opts.merge(
         :header_params => header_params,

--- a/samples/client/petstore/ruby-faraday/lib/petstore/api/pet_api.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/api/pet_api.rb
@@ -55,13 +55,13 @@ module Petstore
       form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = opts[:body] || @api_client.object_to_http_body(pet) 
+      post_body = opts[:debug_body] || @api_client.object_to_http_body(pet)
 
       # return_type
-      return_type = opts[:return_type] 
+      return_type = opts[:debug_return_type]
 
       # auth_names
-      auth_names = opts[:auth_names] || ['petstore_auth']
+      auth_names = opts[:debug_auth_names] || ['petstore_auth']
 
       new_options = opts.merge(
         :header_params => header_params,
@@ -116,13 +116,13 @@ module Petstore
       form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = opts[:body] 
+      post_body = opts[:debug_body]
 
       # return_type
-      return_type = opts[:return_type] 
+      return_type = opts[:debug_return_type]
 
       # auth_names
-      auth_names = opts[:auth_names] || ['petstore_auth']
+      auth_names = opts[:debug_auth_names] || ['petstore_auth']
 
       new_options = opts.merge(
         :header_params => header_params,
@@ -179,13 +179,13 @@ module Petstore
       form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = opts[:body] 
+      post_body = opts[:debug_body]
 
       # return_type
-      return_type = opts[:return_type] || 'Array<Pet>' 
+      return_type = opts[:debug_return_type] || 'Array<Pet>'
 
       # auth_names
-      auth_names = opts[:auth_names] || ['petstore_auth']
+      auth_names = opts[:debug_auth_names] || ['petstore_auth']
 
       new_options = opts.merge(
         :header_params => header_params,
@@ -242,13 +242,13 @@ module Petstore
       form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = opts[:body] 
+      post_body = opts[:debug_body]
 
       # return_type
-      return_type = opts[:return_type] || 'Array<Pet>' 
+      return_type = opts[:debug_return_type] || 'Array<Pet>'
 
       # auth_names
-      auth_names = opts[:auth_names] || ['petstore_auth']
+      auth_names = opts[:debug_auth_names] || ['petstore_auth']
 
       new_options = opts.merge(
         :header_params => header_params,
@@ -304,13 +304,13 @@ module Petstore
       form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = opts[:body] 
+      post_body = opts[:debug_body]
 
       # return_type
-      return_type = opts[:return_type] || 'Pet' 
+      return_type = opts[:debug_return_type] || 'Pet'
 
       # auth_names
-      auth_names = opts[:auth_names] || ['api_key']
+      auth_names = opts[:debug_auth_names] || ['api_key']
 
       new_options = opts.merge(
         :header_params => header_params,
@@ -364,13 +364,13 @@ module Petstore
       form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = opts[:body] || @api_client.object_to_http_body(pet) 
+      post_body = opts[:debug_body] || @api_client.object_to_http_body(pet)
 
       # return_type
-      return_type = opts[:return_type] 
+      return_type = opts[:debug_return_type]
 
       # auth_names
-      auth_names = opts[:auth_names] || ['petstore_auth']
+      auth_names = opts[:debug_auth_names] || ['petstore_auth']
 
       new_options = opts.merge(
         :header_params => header_params,
@@ -430,13 +430,13 @@ module Petstore
       form_params['status'] = opts[:'status'] if !opts[:'status'].nil?
 
       # http body (model)
-      post_body = opts[:body] 
+      post_body = opts[:debug_body]
 
       # return_type
-      return_type = opts[:return_type] 
+      return_type = opts[:debug_return_type]
 
       # auth_names
-      auth_names = opts[:auth_names] || ['petstore_auth']
+      auth_names = opts[:debug_auth_names] || ['petstore_auth']
 
       new_options = opts.merge(
         :header_params => header_params,
@@ -498,13 +498,13 @@ module Petstore
       form_params['file'] = opts[:'file'] if !opts[:'file'].nil?
 
       # http body (model)
-      post_body = opts[:body] 
+      post_body = opts[:debug_body]
 
       # return_type
-      return_type = opts[:return_type] || 'ApiResponse' 
+      return_type = opts[:debug_return_type] || 'ApiResponse'
 
       # auth_names
-      auth_names = opts[:auth_names] || ['petstore_auth']
+      auth_names = opts[:debug_auth_names] || ['petstore_auth']
 
       new_options = opts.merge(
         :header_params => header_params,
@@ -570,13 +570,13 @@ module Petstore
       form_params['additionalMetadata'] = opts[:'additional_metadata'] if !opts[:'additional_metadata'].nil?
 
       # http body (model)
-      post_body = opts[:body] 
+      post_body = opts[:debug_body]
 
       # return_type
-      return_type = opts[:return_type] || 'ApiResponse' 
+      return_type = opts[:debug_return_type] || 'ApiResponse'
 
       # auth_names
-      auth_names = opts[:auth_names] || ['petstore_auth']
+      auth_names = opts[:debug_auth_names] || ['petstore_auth']
 
       new_options = opts.merge(
         :header_params => header_params,

--- a/samples/client/petstore/ruby-faraday/lib/petstore/api/store_api.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/api/store_api.rb
@@ -55,13 +55,13 @@ module Petstore
       form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = opts[:body] 
+      post_body = opts[:debug_body]
 
       # return_type
-      return_type = opts[:return_type] 
+      return_type = opts[:debug_return_type]
 
       # auth_names
-      auth_names = opts[:auth_names] || []
+      auth_names = opts[:debug_auth_names] || []
 
       new_options = opts.merge(
         :header_params => header_params,
@@ -111,13 +111,13 @@ module Petstore
       form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = opts[:body] 
+      post_body = opts[:debug_body]
 
       # return_type
-      return_type = opts[:return_type] || 'Hash<String, Integer>' 
+      return_type = opts[:debug_return_type] || 'Hash<String, Integer>'
 
       # auth_names
-      auth_names = opts[:auth_names] || ['api_key']
+      auth_names = opts[:debug_auth_names] || ['api_key']
 
       new_options = opts.merge(
         :header_params => header_params,
@@ -181,13 +181,13 @@ module Petstore
       form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = opts[:body] 
+      post_body = opts[:debug_body]
 
       # return_type
-      return_type = opts[:return_type] || 'Order' 
+      return_type = opts[:debug_return_type] || 'Order'
 
       # auth_names
-      auth_names = opts[:auth_names] || []
+      auth_names = opts[:debug_auth_names] || []
 
       new_options = opts.merge(
         :header_params => header_params,
@@ -243,13 +243,13 @@ module Petstore
       form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = opts[:body] || @api_client.object_to_http_body(order) 
+      post_body = opts[:debug_body] || @api_client.object_to_http_body(order)
 
       # return_type
-      return_type = opts[:return_type] || 'Order' 
+      return_type = opts[:debug_return_type] || 'Order'
 
       # auth_names
-      auth_names = opts[:auth_names] || []
+      auth_names = opts[:debug_auth_names] || []
 
       new_options = opts.merge(
         :header_params => header_params,

--- a/samples/client/petstore/ruby-faraday/lib/petstore/api/user_api.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/api/user_api.rb
@@ -57,13 +57,13 @@ module Petstore
       form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = opts[:body] || @api_client.object_to_http_body(user) 
+      post_body = opts[:debug_body] || @api_client.object_to_http_body(user)
 
       # return_type
-      return_type = opts[:return_type] 
+      return_type = opts[:debug_return_type]
 
       # auth_names
-      auth_names = opts[:auth_names] || []
+      auth_names = opts[:debug_auth_names] || []
 
       new_options = opts.merge(
         :header_params => header_params,
@@ -117,13 +117,13 @@ module Petstore
       form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = opts[:body] || @api_client.object_to_http_body(user) 
+      post_body = opts[:debug_body] || @api_client.object_to_http_body(user)
 
       # return_type
-      return_type = opts[:return_type] 
+      return_type = opts[:debug_return_type]
 
       # auth_names
-      auth_names = opts[:auth_names] || []
+      auth_names = opts[:debug_auth_names] || []
 
       new_options = opts.merge(
         :header_params => header_params,
@@ -177,13 +177,13 @@ module Petstore
       form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = opts[:body] || @api_client.object_to_http_body(user) 
+      post_body = opts[:debug_body] || @api_client.object_to_http_body(user)
 
       # return_type
-      return_type = opts[:return_type] 
+      return_type = opts[:debug_return_type]
 
       # auth_names
-      auth_names = opts[:auth_names] || []
+      auth_names = opts[:debug_auth_names] || []
 
       new_options = opts.merge(
         :header_params => header_params,
@@ -237,13 +237,13 @@ module Petstore
       form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = opts[:body] 
+      post_body = opts[:debug_body]
 
       # return_type
-      return_type = opts[:return_type] 
+      return_type = opts[:debug_return_type]
 
       # auth_names
-      auth_names = opts[:auth_names] || []
+      auth_names = opts[:debug_auth_names] || []
 
       new_options = opts.merge(
         :header_params => header_params,
@@ -297,13 +297,13 @@ module Petstore
       form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = opts[:body] 
+      post_body = opts[:debug_body]
 
       # return_type
-      return_type = opts[:return_type] || 'User' 
+      return_type = opts[:debug_return_type] || 'User'
 
       # auth_names
-      auth_names = opts[:auth_names] || []
+      auth_names = opts[:debug_auth_names] || []
 
       new_options = opts.merge(
         :header_params => header_params,
@@ -365,13 +365,13 @@ module Petstore
       form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = opts[:body] 
+      post_body = opts[:debug_body]
 
       # return_type
-      return_type = opts[:return_type] || 'String' 
+      return_type = opts[:debug_return_type] || 'String'
 
       # auth_names
-      auth_names = opts[:auth_names] || []
+      auth_names = opts[:debug_auth_names] || []
 
       new_options = opts.merge(
         :header_params => header_params,
@@ -417,13 +417,13 @@ module Petstore
       form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = opts[:body] 
+      post_body = opts[:debug_body]
 
       # return_type
-      return_type = opts[:return_type] 
+      return_type = opts[:debug_return_type]
 
       # auth_names
-      auth_names = opts[:auth_names] || []
+      auth_names = opts[:debug_auth_names] || []
 
       new_options = opts.merge(
         :header_params => header_params,
@@ -485,13 +485,13 @@ module Petstore
       form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = opts[:body] || @api_client.object_to_http_body(user) 
+      post_body = opts[:debug_body] || @api_client.object_to_http_body(user)
 
       # return_type
-      return_type = opts[:return_type] 
+      return_type = opts[:debug_return_type]
 
       # auth_names
-      auth_names = opts[:auth_names] || []
+      auth_names = opts[:debug_auth_names] || []
 
       new_options = opts.merge(
         :header_params => header_params,

--- a/samples/client/petstore/ruby/lib/petstore/api/another_fake_api.rb
+++ b/samples/client/petstore/ruby/lib/petstore/api/another_fake_api.rb
@@ -59,13 +59,13 @@ module Petstore
       form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = opts[:body] || @api_client.object_to_http_body(client) 
+      post_body = opts[:debug_body] || @api_client.object_to_http_body(client)
 
       # return_type
-      return_type = opts[:return_type] || 'Client' 
+      return_type = opts[:debug_return_type] || 'Client'
 
       # auth_names
-      auth_names = opts[:auth_names] || []
+      auth_names = opts[:debug_auth_names] || []
 
       new_options = opts.merge(
         :header_params => header_params,

--- a/samples/client/petstore/ruby/lib/petstore/api/default_api.rb
+++ b/samples/client/petstore/ruby/lib/petstore/api/default_api.rb
@@ -47,13 +47,13 @@ module Petstore
       form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = opts[:body] 
+      post_body = opts[:debug_body]
 
       # return_type
-      return_type = opts[:return_type] || 'InlineResponseDefault' 
+      return_type = opts[:debug_return_type] || 'InlineResponseDefault'
 
       # auth_names
-      auth_names = opts[:auth_names] || []
+      auth_names = opts[:debug_auth_names] || []
 
       new_options = opts.merge(
         :header_params => header_params,

--- a/samples/client/petstore/ruby/lib/petstore/api/fake_api.rb
+++ b/samples/client/petstore/ruby/lib/petstore/api/fake_api.rb
@@ -49,13 +49,13 @@ module Petstore
       form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = opts[:body] 
+      post_body = opts[:debug_body]
 
       # return_type
-      return_type = opts[:return_type] || 'HealthCheckResult' 
+      return_type = opts[:debug_return_type] || 'HealthCheckResult'
 
       # auth_names
-      auth_names = opts[:auth_names] || []
+      auth_names = opts[:debug_auth_names] || []
 
       new_options = opts.merge(
         :header_params => header_params,
@@ -115,13 +115,13 @@ module Petstore
       form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = opts[:body] || @api_client.object_to_http_body(pet) 
+      post_body = opts[:debug_body] || @api_client.object_to_http_body(pet)
 
       # return_type
-      return_type = opts[:return_type] 
+      return_type = opts[:debug_return_type]
 
       # auth_names
-      auth_names = opts[:auth_names] || ['http_signature_test']
+      auth_names = opts[:debug_auth_names] || ['http_signature_test']
 
       new_options = opts.merge(
         :header_params => header_params,
@@ -173,13 +173,13 @@ module Petstore
       form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = opts[:body] || @api_client.object_to_http_body(opts[:'body']) 
+      post_body = opts[:debug_body] || @api_client.object_to_http_body(opts[:'body'])
 
       # return_type
-      return_type = opts[:return_type] || 'Boolean' 
+      return_type = opts[:debug_return_type] || 'Boolean'
 
       # auth_names
-      auth_names = opts[:auth_names] || []
+      auth_names = opts[:debug_auth_names] || []
 
       new_options = opts.merge(
         :header_params => header_params,
@@ -231,13 +231,13 @@ module Petstore
       form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = opts[:body] || @api_client.object_to_http_body(opts[:'outer_composite']) 
+      post_body = opts[:debug_body] || @api_client.object_to_http_body(opts[:'outer_composite'])
 
       # return_type
-      return_type = opts[:return_type] || 'OuterComposite' 
+      return_type = opts[:debug_return_type] || 'OuterComposite'
 
       # auth_names
-      auth_names = opts[:auth_names] || []
+      auth_names = opts[:debug_auth_names] || []
 
       new_options = opts.merge(
         :header_params => header_params,
@@ -289,13 +289,13 @@ module Petstore
       form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = opts[:body] || @api_client.object_to_http_body(opts[:'body']) 
+      post_body = opts[:debug_body] || @api_client.object_to_http_body(opts[:'body'])
 
       # return_type
-      return_type = opts[:return_type] || 'Float' 
+      return_type = opts[:debug_return_type] || 'Float'
 
       # auth_names
-      auth_names = opts[:auth_names] || []
+      auth_names = opts[:debug_auth_names] || []
 
       new_options = opts.merge(
         :header_params => header_params,
@@ -347,13 +347,13 @@ module Petstore
       form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = opts[:body] || @api_client.object_to_http_body(opts[:'body']) 
+      post_body = opts[:debug_body] || @api_client.object_to_http_body(opts[:'body'])
 
       # return_type
-      return_type = opts[:return_type] || 'String' 
+      return_type = opts[:debug_return_type] || 'String'
 
       # auth_names
-      auth_names = opts[:auth_names] || []
+      auth_names = opts[:debug_auth_names] || []
 
       new_options = opts.merge(
         :header_params => header_params,
@@ -407,13 +407,13 @@ module Petstore
       form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = opts[:body] || @api_client.object_to_http_body(file_schema_test_class) 
+      post_body = opts[:debug_body] || @api_client.object_to_http_body(file_schema_test_class)
 
       # return_type
-      return_type = opts[:return_type] 
+      return_type = opts[:debug_return_type]
 
       # auth_names
-      auth_names = opts[:auth_names] || []
+      auth_names = opts[:debug_auth_names] || []
 
       new_options = opts.merge(
         :header_params => header_params,
@@ -472,13 +472,13 @@ module Petstore
       form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = opts[:body] || @api_client.object_to_http_body(user) 
+      post_body = opts[:debug_body] || @api_client.object_to_http_body(user)
 
       # return_type
-      return_type = opts[:return_type] 
+      return_type = opts[:debug_return_type]
 
       # auth_names
-      auth_names = opts[:auth_names] || []
+      auth_names = opts[:debug_auth_names] || []
 
       new_options = opts.merge(
         :header_params => header_params,
@@ -536,13 +536,13 @@ module Petstore
       form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = opts[:body] || @api_client.object_to_http_body(client) 
+      post_body = opts[:debug_body] || @api_client.object_to_http_body(client)
 
       # return_type
-      return_type = opts[:return_type] || 'Client' 
+      return_type = opts[:debug_return_type] || 'Client'
 
       # auth_names
-      auth_names = opts[:auth_names] || []
+      auth_names = opts[:debug_auth_names] || []
 
       new_options = opts.merge(
         :header_params => header_params,
@@ -704,13 +704,13 @@ module Petstore
       form_params['callback'] = opts[:'callback'] if !opts[:'callback'].nil?
 
       # http body (model)
-      post_body = opts[:body] 
+      post_body = opts[:debug_body]
 
       # return_type
-      return_type = opts[:return_type] 
+      return_type = opts[:debug_return_type]
 
       # auth_names
-      auth_names = opts[:auth_names] || ['http_basic_test']
+      auth_names = opts[:debug_auth_names] || ['http_basic_test']
 
       new_options = opts.merge(
         :header_params => header_params,
@@ -816,13 +816,13 @@ module Petstore
       form_params['enum_form_string'] = opts[:'enum_form_string'] if !opts[:'enum_form_string'].nil?
 
       # http body (model)
-      post_body = opts[:body] 
+      post_body = opts[:debug_body]
 
       # return_type
-      return_type = opts[:return_type] 
+      return_type = opts[:debug_return_type]
 
       # auth_names
-      auth_names = opts[:auth_names] || []
+      auth_names = opts[:debug_auth_names] || []
 
       new_options = opts.merge(
         :header_params => header_params,
@@ -900,13 +900,13 @@ module Petstore
       form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = opts[:body] 
+      post_body = opts[:debug_body]
 
       # return_type
-      return_type = opts[:return_type] 
+      return_type = opts[:debug_return_type]
 
       # auth_names
-      auth_names = opts[:auth_names] || ['bearer_test']
+      auth_names = opts[:debug_auth_names] || ['bearer_test']
 
       new_options = opts.merge(
         :header_params => header_params,
@@ -960,13 +960,13 @@ module Petstore
       form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = opts[:body] || @api_client.object_to_http_body(request_body) 
+      post_body = opts[:debug_body] || @api_client.object_to_http_body(request_body)
 
       # return_type
-      return_type = opts[:return_type] 
+      return_type = opts[:debug_return_type]
 
       # auth_names
-      auth_names = opts[:auth_names] || []
+      auth_names = opts[:debug_auth_names] || []
 
       new_options = opts.merge(
         :header_params => header_params,
@@ -1028,13 +1028,13 @@ module Petstore
       form_params['param2'] = param2
 
       # http body (model)
-      post_body = opts[:body] 
+      post_body = opts[:debug_body]
 
       # return_type
-      return_type = opts[:return_type] 
+      return_type = opts[:debug_return_type]
 
       # auth_names
-      auth_names = opts[:auth_names] || []
+      auth_names = opts[:debug_auth_names] || []
 
       new_options = opts.merge(
         :header_params => header_params,
@@ -1115,13 +1115,13 @@ module Petstore
       form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = opts[:body] 
+      post_body = opts[:debug_body]
 
       # return_type
-      return_type = opts[:return_type] 
+      return_type = opts[:debug_return_type]
 
       # auth_names
-      auth_names = opts[:auth_names] || []
+      auth_names = opts[:debug_auth_names] || []
 
       new_options = opts.merge(
         :header_params => header_params,

--- a/samples/client/petstore/ruby/lib/petstore/api/fake_classname_tags123_api.rb
+++ b/samples/client/petstore/ruby/lib/petstore/api/fake_classname_tags123_api.rb
@@ -59,13 +59,13 @@ module Petstore
       form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = opts[:body] || @api_client.object_to_http_body(client) 
+      post_body = opts[:debug_body] || @api_client.object_to_http_body(client)
 
       # return_type
-      return_type = opts[:return_type] || 'Client' 
+      return_type = opts[:debug_return_type] || 'Client'
 
       # auth_names
-      auth_names = opts[:auth_names] || ['api_key_query']
+      auth_names = opts[:debug_auth_names] || ['api_key_query']
 
       new_options = opts.merge(
         :header_params => header_params,

--- a/samples/client/petstore/ruby/lib/petstore/api/pet_api.rb
+++ b/samples/client/petstore/ruby/lib/petstore/api/pet_api.rb
@@ -55,13 +55,13 @@ module Petstore
       form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = opts[:body] || @api_client.object_to_http_body(pet) 
+      post_body = opts[:debug_body] || @api_client.object_to_http_body(pet)
 
       # return_type
-      return_type = opts[:return_type] 
+      return_type = opts[:debug_return_type]
 
       # auth_names
-      auth_names = opts[:auth_names] || ['petstore_auth']
+      auth_names = opts[:debug_auth_names] || ['petstore_auth']
 
       new_options = opts.merge(
         :header_params => header_params,
@@ -116,13 +116,13 @@ module Petstore
       form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = opts[:body] 
+      post_body = opts[:debug_body]
 
       # return_type
-      return_type = opts[:return_type] 
+      return_type = opts[:debug_return_type]
 
       # auth_names
-      auth_names = opts[:auth_names] || ['petstore_auth']
+      auth_names = opts[:debug_auth_names] || ['petstore_auth']
 
       new_options = opts.merge(
         :header_params => header_params,
@@ -179,13 +179,13 @@ module Petstore
       form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = opts[:body] 
+      post_body = opts[:debug_body]
 
       # return_type
-      return_type = opts[:return_type] || 'Array<Pet>' 
+      return_type = opts[:debug_return_type] || 'Array<Pet>'
 
       # auth_names
-      auth_names = opts[:auth_names] || ['petstore_auth']
+      auth_names = opts[:debug_auth_names] || ['petstore_auth']
 
       new_options = opts.merge(
         :header_params => header_params,
@@ -242,13 +242,13 @@ module Petstore
       form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = opts[:body] 
+      post_body = opts[:debug_body]
 
       # return_type
-      return_type = opts[:return_type] || 'Array<Pet>' 
+      return_type = opts[:debug_return_type] || 'Array<Pet>'
 
       # auth_names
-      auth_names = opts[:auth_names] || ['petstore_auth']
+      auth_names = opts[:debug_auth_names] || ['petstore_auth']
 
       new_options = opts.merge(
         :header_params => header_params,
@@ -304,13 +304,13 @@ module Petstore
       form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = opts[:body] 
+      post_body = opts[:debug_body]
 
       # return_type
-      return_type = opts[:return_type] || 'Pet' 
+      return_type = opts[:debug_return_type] || 'Pet'
 
       # auth_names
-      auth_names = opts[:auth_names] || ['api_key']
+      auth_names = opts[:debug_auth_names] || ['api_key']
 
       new_options = opts.merge(
         :header_params => header_params,
@@ -364,13 +364,13 @@ module Petstore
       form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = opts[:body] || @api_client.object_to_http_body(pet) 
+      post_body = opts[:debug_body] || @api_client.object_to_http_body(pet)
 
       # return_type
-      return_type = opts[:return_type] 
+      return_type = opts[:debug_return_type]
 
       # auth_names
-      auth_names = opts[:auth_names] || ['petstore_auth']
+      auth_names = opts[:debug_auth_names] || ['petstore_auth']
 
       new_options = opts.merge(
         :header_params => header_params,
@@ -430,13 +430,13 @@ module Petstore
       form_params['status'] = opts[:'status'] if !opts[:'status'].nil?
 
       # http body (model)
-      post_body = opts[:body] 
+      post_body = opts[:debug_body]
 
       # return_type
-      return_type = opts[:return_type] 
+      return_type = opts[:debug_return_type]
 
       # auth_names
-      auth_names = opts[:auth_names] || ['petstore_auth']
+      auth_names = opts[:debug_auth_names] || ['petstore_auth']
 
       new_options = opts.merge(
         :header_params => header_params,
@@ -498,13 +498,13 @@ module Petstore
       form_params['file'] = opts[:'file'] if !opts[:'file'].nil?
 
       # http body (model)
-      post_body = opts[:body] 
+      post_body = opts[:debug_body]
 
       # return_type
-      return_type = opts[:return_type] || 'ApiResponse' 
+      return_type = opts[:debug_return_type] || 'ApiResponse'
 
       # auth_names
-      auth_names = opts[:auth_names] || ['petstore_auth']
+      auth_names = opts[:debug_auth_names] || ['petstore_auth']
 
       new_options = opts.merge(
         :header_params => header_params,
@@ -570,13 +570,13 @@ module Petstore
       form_params['additionalMetadata'] = opts[:'additional_metadata'] if !opts[:'additional_metadata'].nil?
 
       # http body (model)
-      post_body = opts[:body] 
+      post_body = opts[:debug_body]
 
       # return_type
-      return_type = opts[:return_type] || 'ApiResponse' 
+      return_type = opts[:debug_return_type] || 'ApiResponse'
 
       # auth_names
-      auth_names = opts[:auth_names] || ['petstore_auth']
+      auth_names = opts[:debug_auth_names] || ['petstore_auth']
 
       new_options = opts.merge(
         :header_params => header_params,

--- a/samples/client/petstore/ruby/lib/petstore/api/store_api.rb
+++ b/samples/client/petstore/ruby/lib/petstore/api/store_api.rb
@@ -55,13 +55,13 @@ module Petstore
       form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = opts[:body] 
+      post_body = opts[:debug_body]
 
       # return_type
-      return_type = opts[:return_type] 
+      return_type = opts[:debug_return_type]
 
       # auth_names
-      auth_names = opts[:auth_names] || []
+      auth_names = opts[:debug_auth_names] || []
 
       new_options = opts.merge(
         :header_params => header_params,
@@ -111,13 +111,13 @@ module Petstore
       form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = opts[:body] 
+      post_body = opts[:debug_body]
 
       # return_type
-      return_type = opts[:return_type] || 'Hash<String, Integer>' 
+      return_type = opts[:debug_return_type] || 'Hash<String, Integer>'
 
       # auth_names
-      auth_names = opts[:auth_names] || ['api_key']
+      auth_names = opts[:debug_auth_names] || ['api_key']
 
       new_options = opts.merge(
         :header_params => header_params,
@@ -181,13 +181,13 @@ module Petstore
       form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = opts[:body] 
+      post_body = opts[:debug_body]
 
       # return_type
-      return_type = opts[:return_type] || 'Order' 
+      return_type = opts[:debug_return_type] || 'Order'
 
       # auth_names
-      auth_names = opts[:auth_names] || []
+      auth_names = opts[:debug_auth_names] || []
 
       new_options = opts.merge(
         :header_params => header_params,
@@ -243,13 +243,13 @@ module Petstore
       form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = opts[:body] || @api_client.object_to_http_body(order) 
+      post_body = opts[:debug_body] || @api_client.object_to_http_body(order)
 
       # return_type
-      return_type = opts[:return_type] || 'Order' 
+      return_type = opts[:debug_return_type] || 'Order'
 
       # auth_names
-      auth_names = opts[:auth_names] || []
+      auth_names = opts[:debug_auth_names] || []
 
       new_options = opts.merge(
         :header_params => header_params,

--- a/samples/client/petstore/ruby/lib/petstore/api/user_api.rb
+++ b/samples/client/petstore/ruby/lib/petstore/api/user_api.rb
@@ -57,13 +57,13 @@ module Petstore
       form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = opts[:body] || @api_client.object_to_http_body(user) 
+      post_body = opts[:debug_body] || @api_client.object_to_http_body(user)
 
       # return_type
-      return_type = opts[:return_type] 
+      return_type = opts[:debug_return_type]
 
       # auth_names
-      auth_names = opts[:auth_names] || []
+      auth_names = opts[:debug_auth_names] || []
 
       new_options = opts.merge(
         :header_params => header_params,
@@ -117,13 +117,13 @@ module Petstore
       form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = opts[:body] || @api_client.object_to_http_body(user) 
+      post_body = opts[:debug_body] || @api_client.object_to_http_body(user)
 
       # return_type
-      return_type = opts[:return_type] 
+      return_type = opts[:debug_return_type]
 
       # auth_names
-      auth_names = opts[:auth_names] || []
+      auth_names = opts[:debug_auth_names] || []
 
       new_options = opts.merge(
         :header_params => header_params,
@@ -177,13 +177,13 @@ module Petstore
       form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = opts[:body] || @api_client.object_to_http_body(user) 
+      post_body = opts[:debug_body] || @api_client.object_to_http_body(user)
 
       # return_type
-      return_type = opts[:return_type] 
+      return_type = opts[:debug_return_type]
 
       # auth_names
-      auth_names = opts[:auth_names] || []
+      auth_names = opts[:debug_auth_names] || []
 
       new_options = opts.merge(
         :header_params => header_params,
@@ -237,13 +237,13 @@ module Petstore
       form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = opts[:body] 
+      post_body = opts[:debug_body]
 
       # return_type
-      return_type = opts[:return_type] 
+      return_type = opts[:debug_return_type]
 
       # auth_names
-      auth_names = opts[:auth_names] || []
+      auth_names = opts[:debug_auth_names] || []
 
       new_options = opts.merge(
         :header_params => header_params,
@@ -297,13 +297,13 @@ module Petstore
       form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = opts[:body] 
+      post_body = opts[:debug_body]
 
       # return_type
-      return_type = opts[:return_type] || 'User' 
+      return_type = opts[:debug_return_type] || 'User'
 
       # auth_names
-      auth_names = opts[:auth_names] || []
+      auth_names = opts[:debug_auth_names] || []
 
       new_options = opts.merge(
         :header_params => header_params,
@@ -365,13 +365,13 @@ module Petstore
       form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = opts[:body] 
+      post_body = opts[:debug_body]
 
       # return_type
-      return_type = opts[:return_type] || 'String' 
+      return_type = opts[:debug_return_type] || 'String'
 
       # auth_names
-      auth_names = opts[:auth_names] || []
+      auth_names = opts[:debug_auth_names] || []
 
       new_options = opts.merge(
         :header_params => header_params,
@@ -417,13 +417,13 @@ module Petstore
       form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = opts[:body] 
+      post_body = opts[:debug_body]
 
       # return_type
-      return_type = opts[:return_type] 
+      return_type = opts[:debug_return_type]
 
       # auth_names
-      auth_names = opts[:auth_names] || []
+      auth_names = opts[:debug_auth_names] || []
 
       new_options = opts.merge(
         :header_params => header_params,
@@ -485,13 +485,13 @@ module Petstore
       form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = opts[:body] || @api_client.object_to_http_body(user) 
+      post_body = opts[:debug_body] || @api_client.object_to_http_body(user)
 
       # return_type
-      return_type = opts[:return_type] 
+      return_type = opts[:debug_return_type]
 
       # auth_names
-      auth_names = opts[:auth_names] || []
+      auth_names = opts[:debug_auth_names] || []
 
       new_options = opts.merge(
         :header_params => header_params,


### PR DESCRIPTION
- rename debugging variables by adding the `debug_` prefix
- minor formatting fix to avoid trailing spaces

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

cc @cliffano (2017/07) @zlx (2017/09) @autopp (2019/02)


