### PR TITLE
[Java][vertx] Use typeMapping instead of postProcessParameter

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaVertXWebServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaVertXWebServerCodegen.java
@@ -68,6 +68,9 @@ public class JavaVertXWebServerCodegen extends AbstractJavaCodegen {
 
         // Override type mapping
         typeMapping.put("file", "FileUpload");
+        typeMapping.put("UUID", "String");
+        typeMapping.put("date", "String");
+        typeMapping.put("DateTime", "String");
     }
 
     public CodegenType getTag() {
@@ -158,14 +161,6 @@ public class JavaVertXWebServerCodegen extends AbstractJavaCodegen {
             }
         }
         return newObjs;
-    }
-
-    @Override
-    public void postProcessParameter(CodegenParameter parameter) {
-        super.postProcessParameter(parameter);
-        if (parameter.isUuid || parameter.isDate || parameter.isDateTime) {
-            parameter.dataType = "String";
-        }
     }
 
     @Override


### PR DESCRIPTION
- Use typeMapping instead of postProcessParameter to map UUID, Date, DateTime into String

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

cc @bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04) @lwlee2608 (2019/10) @bkabrda (2020/01)

