### PR TITLE
[sonar] Java 11, use -nsu, exclude maven/online projects

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -22,4 +22,4 @@ jobs:
     - name: Jacoco Aggregate
       run: mvn jacoco:report-aggregate
     - name: Publish to Sonar
-      run: mvn -B -q sonar:sonar -Dsonar.projectKey=OpenAPITools_openapi-generator -Dsonar.organization=openapitools -Dsonar.host.url=https://sonarcloud.io -Dsonar.login=${{ secrets.SONAR_LOGIN }}
+      run: mvn -B -q sonar:sonar -Dsonar.projectKey=OpenAPITools_openapi-generator -Dsonar.organization=openapitools -Dsonar.host.url=https://sonarcloud.io -Dsonar.login=${{ secrets.SONAR_LOGIN }} -Dsonar.branch.name=master

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-    - name: Set up JDK 1.8
+    - name: Set up JDK 11
       uses: actions/setup-java@v1
       with:
-        java-version: 1.8
+        java-version: 11
     - name: Compile with Maven
       run: mvn clean package jacoco:report
     - name: Jacoco Aggregate

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -22,4 +22,4 @@ jobs:
     - name: Jacoco Aggregate
       run: mvn jacoco:report-aggregate
     - name: Publish to Sonar
-      run: mvn -B -q sonar:sonar -Dsonar.projectKey=OpenAPITools_openapi-generator -Dsonar.organization=openapitools -Dsonar.host.url=https://sonarcloud.io -Dsonar.login=${{ secrets.SONAR_LOGIN }} -Dsonar.branch.name=${GITHUB_REF##*/}
+      run: mvn -B -q sonar:sonar -Dsonar.projectKey=OpenAPITools_openapi-generator -Dsonar.organization=openapitools -Dsonar.host.url=https://sonarcloud.io -Dsonar.login=${{ secrets.SONAR_LOGIN }}

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -18,7 +18,7 @@ jobs:
       with:
         java-version: 11
     - name: Compile with Maven
-      run: mvn -B -q clean package jacoco:report
+      run: mvn -B -q clean install jacoco:report
     - name: Jacoco Aggregate
       run: mvn jacoco:report-aggregate
     - name: Publish to Sonar

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -18,8 +18,8 @@ jobs:
       with:
         java-version: 11
     - name: Compile with Maven
-      run: mvn clean package jacoco:report
+      run: mvn -B -q clean package jacoco:report
     - name: Jacoco Aggregate
       run: mvn jacoco:report-aggregate
     - name: Publish to Sonar
-      run: mvn -B -q sonar:sonar -Dsonar.projectKey=OpenAPITools_openapi-generator -Dsonar.organization=openapitools -Dsonar.host.url=https://sonarcloud.io -Dsonar.login=${{ secrets.SONAR_LOGIN }} -Dsonar.branch.name=master
+      run: mvn -B -q -nsu sonar:sonar -Dsonar.projectKey=OpenAPITools_openapi-generator -Dsonar.organization=openapitools -Dsonar.host.url=https://sonarcloud.io -Dsonar.login=${{ secrets.SONAR_LOGIN }} -Dsonar.branch.name=${GITHUB_REF##*/}

--- a/modules/openapi-generator-cli/src/main/java/org/openapitools/codegen/cmd/ConfigHelp.java
+++ b/modules/openapi-generator-cli/src/main/java/org/openapitools/codegen/cmd/ConfigHelp.java
@@ -39,15 +39,16 @@ import java.util.stream.Collectors;
 import static org.apache.commons.lang3.StringEscapeUtils.escapeHtml4;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 
-@SuppressWarnings({"unused","java:S106"})
+@SuppressWarnings({"unused","java:S106", "java:S1192"})
 @Command(name = "config-help", description = "Config help for chosen lang")
 public class ConfigHelp extends OpenApiGeneratorCommand {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(Generate.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ConfigHelp.class);
 
     private static final String FORMAT_TEXT = "text";
     private static final String FORMAT_MARKDOWN = "markdown";
     private static final String FORMAT_YAMLSAMPLE = "yamlsample";
+    private static final int FEATURE_SET_DISPLAY_WIDTH= 20;
 
     @Option(name = {"-g",
             "--generator-name"}, title = "generator name", description = "generator to get config help for")
@@ -147,7 +148,7 @@ public class ConfigHelp extends OpenApiGeneratorCommand {
             LOGGER.error("[error] Check the spelling of the generator's name and try again.");
             System.exit(1);
         } catch (IOException e) {
-            e.printStackTrace();
+            LOGGER.error("Unexpected error", e);
         }
     }
 
@@ -396,7 +397,7 @@ public class ConfigHelp extends OpenApiGeneratorCommand {
             String definedByKey = "Defined By";
             int maxNameLength = flattened.stream().map(FeatureSet.FeatureSetFlattened::getFeatureName).mapToInt(String::length).max().orElse(nameKey.length());
             int maxSupportedLength = supportedKey.length();
-            int definedInLength = 20;
+            int definedInLength = FEATURE_SET_DISPLAY_WIDTH;
             String format = "%-" + maxNameLength + "s\t%-" + maxSupportedLength + "s\t%-" + definedInLength + "s";
 
             flattened.forEach(featureSet -> {

--- a/modules/openapi-generator-maven-plugin/pom.xml
+++ b/modules/openapi-generator-maven-plugin/pom.xml
@@ -15,7 +15,7 @@
     <description>maven plugin to build modules from OpenAPI Generator</description>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <sonar.exclusions>org/openapitools/codegen/plugin/**/*</sonar.exclusions>
+        <sonar.exclusions>**/src/main/java/org/openapitools/codegen/plugin/**/*</sonar.exclusions>
     </properties>
     <dependencies>
         <dependency>

--- a/modules/openapi-generator-maven-plugin/pom.xml
+++ b/modules/openapi-generator-maven-plugin/pom.xml
@@ -15,6 +15,7 @@
     <description>maven plugin to build modules from OpenAPI Generator</description>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <sonar.exclusions>org/openapitools/codegen/plugin/**/*</sonar.exclusions>
     </properties>
     <dependencies>
         <dependency>

--- a/modules/openapi-generator-online/pom.xml
+++ b/modules/openapi-generator-online/pom.xml
@@ -19,6 +19,7 @@
         <springfox-version>3.0.0</springfox-version>
         <junit-version>4.13</junit-version>
         <jackson-version>2.10.2</jackson-version>
+        <sonar.exclusions>org/openapitools/codegen/online/**/*</sonar.exclusions>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/modules/openapi-generator-online/pom.xml
+++ b/modules/openapi-generator-online/pom.xml
@@ -19,7 +19,7 @@
         <springfox-version>3.0.0</springfox-version>
         <junit-version>4.13</junit-version>
         <jackson-version>2.10.2</jackson-version>
-        <sonar.exclusions>org/openapitools/codegen/online/**/*</sonar.exclusions>
+        <sonar.exclusions>**/org/openapitools/codegen/online/**/*</sonar.exclusions>
     </properties>
     <dependencyManagement>
         <dependencies>


### PR DESCRIPTION
Minor adjustments to sonar scanning…

* Exclude maven plugin from test coverage reporting
* Exclude online project from test coverage reporting
* Use `-nsu` to prevent scanner from pulling the `-SNAPSHOT` artifact from last master build, and use jars published locally
* Update to use Java 11 as Sonar will stop supporting publishing reports built via Java 8 soon

cc @OpenAPITools/generator-core-team as fyi

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [ ] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
