### PR TITLE
Fix stringifying of ~= in enums

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -1558,6 +1558,7 @@ public class DefaultCodegen implements CodegenConfig {
         specialCharReplacements.put("<=", "Less_Than_Or_Equal_To");
         specialCharReplacements.put(">=", "Greater_Than_Or_Equal_To");
         specialCharReplacements.put("!=", "Not_Equal");
+        specialCharReplacements.put("~=", "Tilde_Equal");
     }
 
     /**


### PR DESCRIPTION
Fixes #4069

The jira openapi spec includes "~=" as a value of an enum. This change ensures it gets stringified correctly.

You can see the problem by performing Rust codegen on https://developer.atlassian.com/cloud/jira/platform/swagger.v3.json:

```
$ java -jar openapi-generator-cli.jar generate -i $jiraspecpath -o jira-openapi -g rust --library reqwest --additional-properties packageName=jira-openapi
$ grep -A100 'pub enum Operator' jira-openapi/src/models/field_value_clause.rs
pub enum Operator {
    #[serde(rename = "=")]
    Equal,
    #[serde(rename = "!=")]
    Not_Equal,
    #[serde(rename = ">")]
    Greater_Than,
    #[serde(rename = "<")]
    Less_Than,
    #[serde(rename = ">=")]
    Greater_Than_Or_Equal_To,
    #[serde(rename = "<=")]
    Less_Than_Or_Equal_To,
    #[serde(rename = "in")]
    _In,
    #[serde(rename = "not in")]
    Not_in,
    #[serde(rename = "~")]
    Tilde,
    #[serde(rename = "~=")]
    ,
    #[serde(rename = "is")]
    Is,
    #[serde(rename = "is not")]
    Is_not,
}
```

The `,` on a line by itself is not valid Rust. With this change, that line becomes `Tilde_Equal,`

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [X] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
