### PR TITLE
Fix Rust codegen for AnyType

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustClientCodegen.java
@@ -162,6 +162,7 @@ public class RustClientCodegen extends DefaultCodegen implements CodegenConfig {
         typeMapping.put("binary", "crate::models::File");
         typeMapping.put("ByteArray", "String");
         typeMapping.put("object", "serde_json::Value");
+        typeMapping.put("AnyType", "serde_json::Value");
 
         // no need for rust
         //importMapping = new HashMap<String, String>();


### PR DESCRIPTION
Simply adds a type for AnyType for Rust codegen. I can see that this is present for other languages, so is really just filling a missing piece:

```
$ rg '"AnyType"'
modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
1451:        typeMapping.put("AnyType", "oas_any_type_not_mapped");
2082:            return "AnyType";

modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPhpCodegen.java
130:        typeMapping.put("AnyType", "mixed");

modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
178:        typeMapping.put("AnyType", "Object");

modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractTypeScriptClientCodegen.java
173:        typeMapping.put("AnyType", "any");
896:            ? schemas.stream().filter(schema -> !"AnyType".equals(super.getSchemaType(schema))).collect(Collectors.toList())

modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/DartDioClientCodegen.java
92:        typeMapping.put("AnyType", "Object");

modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractGoCodegen.java
133:        typeMapping.put("AnyType", "interface{}");

modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustServerCodegen.java
214:        typeMapping.put("AnyType", "serde_json::Value");

modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonClientCodegen.java
138:        typeMapping.put("AnyType", "object");

modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CSharpNetCoreClientCodegen.java
142:        typeMapping.put("AnyType", "Object");
```

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [X] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

cc @frol (2017/07) @farcaller (2017/08) @richardwhiuk (2019/07) @paladinzh (2020/05)


