### PR TITLE
[Ruby] fix port in the Ruby client

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
@@ -775,6 +775,7 @@ public class DefaultGenerator implements Generator {
         bundle.put("basePathWithoutHost", basePathWithoutHost);
         bundle.put("scheme", URLPathUtils.getScheme(url, config));
         bundle.put("host", url.getHost());
+        bundle.put("port", url.getPort());
         bundle.put("contextPath", contextPath);
         bundle.put("apiInfo", apis);
         bundle.put("models", allModels);

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
@@ -775,7 +775,9 @@ public class DefaultGenerator implements Generator {
         bundle.put("basePathWithoutHost", basePathWithoutHost);
         bundle.put("scheme", URLPathUtils.getScheme(url, config));
         bundle.put("host", url.getHost());
-        bundle.put("port", url.getPort());
+        if (url.getPort() != 80 ) {
+            bundle.put("serverPort", url.getPort());
+        }
         bundle.put("contextPath", contextPath);
         bundle.put("apiInfo", apis);
         bundle.put("models", allModels);

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
@@ -776,7 +776,7 @@ public class DefaultGenerator implements Generator {
         bundle.put("scheme", URLPathUtils.getScheme(url, config));
         bundle.put("host", url.getHost());
         if (url.getPort() != 80 ) {
-            bundle.put("serverPort", url.getPort());
+            bundle.put("port", url.getPort());
         }
         bundle.put("contextPath", contextPath);
         bundle.put("apiInfo", apis);

--- a/modules/openapi-generator/src/main/resources/ruby-client/configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/configuration.mustache
@@ -90,7 +90,7 @@ module {{moduleName}}
 
     def initialize
       @scheme = '{{scheme}}'
-      @host = '{{host}}'
+      @host = '{{host}}{{#port}}:{{{.}}}{{/port}}'
       @base_path = '{{contextPath}}'
       @api_key = {}
       @api_key_prefix = {}

--- a/modules/openapi-generator/src/main/resources/ruby-client/configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/configuration.mustache
@@ -90,7 +90,7 @@ module {{moduleName}}
 
     def initialize
       @scheme = '{{scheme}}'
-      @host = '{{host}}{{#port}}:{{{.}}}{{/port}}'
+      @host = '{{host}}{{#serverPort}}:{{{.}}}{{/serverPort}}'
       @base_path = '{{contextPath}}'
       @api_key = {}
       @api_key_prefix = {}

--- a/modules/openapi-generator/src/main/resources/ruby-client/configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/configuration.mustache
@@ -90,7 +90,7 @@ module {{moduleName}}
 
     def initialize
       @scheme = '{{scheme}}'
-      @host = '{{host}}{{#serverPort}}:{{{.}}}{{/serverPort}}'
+      @host = '{{host}}{{#port}}:{{{.}}}{{/port}}'
       @base_path = '{{contextPath}}'
       @api_key = {}
       @api_key_prefix = {}

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/docs/ChildCat.md
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/docs/ChildCat.md
@@ -4,7 +4,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Name** | **string** |  | [optional] 
-**PetType** | **string** |  | [optional] [default to PetTypeEnum.ChildCat]
+**PetType** | **string** |  | [default to PetTypeEnum.ChildCat]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/ChildCat.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/ChildCat.cs
@@ -49,7 +49,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets PetType
         /// </summary>
         [DataMember(Name = "pet_type", EmitDefaultValue = false)]
-        public PetTypeEnum? PetType { get; set; }
+        public PetTypeEnum PetType { get; set; }
         /// <summary>
         /// Initializes a new instance of the <see cref="ChildCat" /> class.
         /// </summary>
@@ -59,11 +59,11 @@ namespace Org.OpenAPITools.Model
         /// Initializes a new instance of the <see cref="ChildCat" /> class.
         /// </summary>
         /// <param name="name">name.</param>
-        /// <param name="petType">petType (default to PetTypeEnum.ChildCat).</param>
-        public ChildCat(string name = default(string), PetTypeEnum? petType = PetTypeEnum.ChildCat) : base()
+        /// <param name="petType">petType (required) (default to PetTypeEnum.ChildCat).</param>
+        public ChildCat(string name = default(string), PetTypeEnum petType = PetTypeEnum.ChildCat) : base()
         {
-            this.Name = name;
             this.PetType = petType;
+            this.Name = name;
         }
 
         /// <summary>

--- a/samples/openapi3/client/petstore/java/jersey2-java8/docs/ChildCat.md
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/docs/ChildCat.md
@@ -7,7 +7,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **name** | **String** |  |  [optional]
-**petType** | [**String**](#String) |  |  [optional]
+**petType** | [**String**](#String) |  | 
 
 
 

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ChildCat.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ChildCat.java
@@ -97,10 +97,9 @@ public class ChildCat extends ParentPet {
    * Get petType
    * @return petType
   **/
-  @javax.annotation.Nullable
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(required = true, value = "")
   @JsonProperty(JSON_PROPERTY_PET_TYPE)
-  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
   public String getPetType() {
     return petType;


### PR DESCRIPTION
- fix port in the Ruby client (e.g. https://localhost:3000 will result in the `:3000` omitted in the host in the Ruby client)

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

cc @cliffano (2017/07) @zlx (2017/09) @autopp (2019/02)
