### PR TITLE
[C][Client]Support data callback function

### DIFF
--- a/modules/openapi-generator/src/main/resources/C-libcurl/apiClient.c.mustache
+++ b/modules/openapi-generator/src/main/resources/C-libcurl/apiClient.c.mustache
@@ -13,6 +13,7 @@ apiClient_t *apiClient_create() {
     apiClient->sslConfig = NULL;
     apiClient->dataReceived = NULL;
     apiClient->dataReceivedLen = 0;
+    apiClient->data_callback_func = NULL;
     apiClient->response_code = 0;
     {{#hasAuthMethods}}
     {{#authMethods}}
@@ -58,6 +59,7 @@ apiClient_t *apiClient_create_with_base_path(const char *basePath
 
     apiClient->dataReceived = NULL;
     apiClient->dataReceivedLen = 0;
+    apiClient->data_callback_func = NULL;
     apiClient->response_code = 0;
     {{#hasAuthMethods}}
     {{#authMethods}}
@@ -91,6 +93,7 @@ void apiClient_free(apiClient_t *apiClient) {
     if(apiClient->basePath) {
         free(apiClient->basePath);
     }
+    apiClient->data_callback_func = NULL;
     {{#hasAuthMethods}}
     {{#authMethods}}
     {{#isBasic}}
@@ -558,6 +561,10 @@ size_t writeDataCallback(void *buffer, size_t size, size_t nmemb, void *userp) {
     apiClient->dataReceived = (char *)realloc( apiClient->dataReceived, apiClient->dataReceivedLen + size_this_time + 1);
     memcpy(apiClient->dataReceived + apiClient->dataReceivedLen, buffer, size_this_time);
     apiClient->dataReceivedLen += size_this_time;
+    ((char*)apiClient->dataReceived)[apiClient->dataReceivedLen] = '\0'; // the space size of (apiClient->dataReceived) = dataReceivedLen + 1
+    if (apiClient->data_callback_func) {
+        apiClient->data_callback_func(&apiClient->dataReceived, &apiClient->dataReceivedLen);
+    }
     return size_this_time;
 }
 

--- a/modules/openapi-generator/src/main/resources/C-libcurl/apiClient.h.mustache
+++ b/modules/openapi-generator/src/main/resources/C-libcurl/apiClient.h.mustache
@@ -23,6 +23,7 @@ typedef struct apiClient_t {
     sslConfig_t *sslConfig;
     void *dataReceived;
     long dataReceivedLen;
+    void (*data_callback_func)(void **, long *);
     long response_code;
     {{#hasAuthMethods}}
     {{#authMethods}}

--- a/modules/openapi-generator/src/main/resources/C-libcurl/list.c.mustache
+++ b/modules/openapi-generator/src/main/resources/C-libcurl/list.c.mustache
@@ -183,3 +183,18 @@ char* findStrInStrList(list_t *strList, const char *str)
 
     return NULL;
 }
+
+void clear_and_free_string_list(list_t *list)
+{
+    if (!list) {
+        return;
+    }
+
+    listEntry_t *listEntry = NULL;
+    list_ForEach(listEntry, list) {
+        char *list_item = listEntry->data;
+        free(list_item);
+        list_item = NULL;
+    }
+    list_free(list);
+}

--- a/modules/openapi-generator/src/main/resources/C-libcurl/list.h.mustache
+++ b/modules/openapi-generator/src/main/resources/C-libcurl/list.h.mustache
@@ -38,4 +38,5 @@ void listEntry_printAsInt(listEntry_t* listEntry, void *additionalData);
 void listEntry_free(listEntry_t *listEntry, void *additionalData);
 
 char* findStrInStrList(list_t* strList, const char* str);
+void clear_and_free_string_list(list_t * list);
 #endif // INCLUDE_LIST_H

--- a/samples/client/petstore/c/include/apiClient.h
+++ b/samples/client/petstore/c/include/apiClient.h
@@ -23,6 +23,7 @@ typedef struct apiClient_t {
     sslConfig_t *sslConfig;
     void *dataReceived;
     long dataReceivedLen;
+    void (*data_callback_func)(void **, long *);
     long response_code;
     list_t *apiKeys_api_key;
     char *accessToken;

--- a/samples/client/petstore/c/include/list.h
+++ b/samples/client/petstore/c/include/list.h
@@ -38,4 +38,5 @@ void listEntry_printAsInt(listEntry_t* listEntry, void *additionalData);
 void listEntry_free(listEntry_t *listEntry, void *additionalData);
 
 char* findStrInStrList(list_t* strList, const char* str);
+void clear_and_free_string_list(list_t * list);
 #endif // INCLUDE_LIST_H

--- a/samples/client/petstore/c/src/list.c
+++ b/samples/client/petstore/c/src/list.c
@@ -183,3 +183,18 @@ char* findStrInStrList(list_t *strList, const char *str)
 
     return NULL;
 }
+
+void clear_and_free_string_list(list_t *list)
+{
+    if (!list) {
+        return;
+    }
+
+    listEntry_t *listEntry = NULL;
+    list_ForEach(listEntry, list) {
+        char *list_item = listEntry->data;
+        free(list_item);
+        list_item = NULL;
+    }
+    list_free(list);
+}


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
There is a special API design: 
When the client issues a http request, http server will block the request ( does not return to client ), and write some data to stream to client continuously. 
e.g. 
In kubernetes, when client issues a ```watch``` request, kube-apiserver will block this request, but write the watch event data to the stream to client once there is new event such as pod creation/deletion. Client needs to read and handle these event data.

But for now, c generator does not support this mode because ```apiClient_invoke``` and ```writeDataCallback``` have no chance to access the raw data if the request is blocking.

This PR adds a ```data_callback_func``` to ```writeDataCallback```, if it is not NULL, it will be called to access the data received. By this means, user can inject a data_callback_func to handle when the request is blocking.
```c
size_t writeDataCallback(void *buffer, size_t size, size_t nmemb, void *userp) {
    ...
    if (apiClient->data_callback_func) {
        apiClient->data_callback_func(&apiClient->dataReceived, &apiClient->dataReceivedLen);
    }
    ...
}

```

This change does not impact current request logic because ```apiClient->data_callback_func = NULL``` by default.
 

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@wing328 @zhemant @michelealbano
