### PR TITLE
[BUG][Python] init access token for python client configuration

### DIFF
--- a/modules/openapi-generator/src/main/resources/python/configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/python/configuration.mustache
@@ -222,18 +222,6 @@ conf = {{{packageName}}}.Configuration(
         """The HTTP signing configuration
         """
 {{/hasHttpSignatureMethods}}
-{{#hasOAuthMethods}}
-        self.access_token = None
-        """access token for OAuth/Bearer
-        """
-{{/hasOAuthMethods}}
-{{^hasOAuthMethods}}
-{{#hasBearerMethods}}
-        self.access_token = None
-        """access token for OAuth/Bearer
-        """
-{{/hasBearerMethods}}
-{{/hasOAuthMethods}}
         self.logger = {}
         """Logging Settings
         """

--- a/modules/openapi-generator/src/main/resources/python/configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/python/configuration.mustache
@@ -166,6 +166,7 @@ conf = {{{packageName}}}.Configuration(
 
     def __init__(self, host=None,
                  api_key=None, api_key_prefix=None,
+                 access_token=None,
                  username=None, password=None,
                  discard_unknown_keys=False,
                  disabled_client_side_validations="",
@@ -192,6 +193,7 @@ conf = {{{packageName}}}.Configuration(
         """Temp file folder for downloading files
         """
         # Authentication Settings
+        self.access_token = access_token
         self.api_key = {}
         if api_key:
             self.api_key = api_key

--- a/samples/client/petstore/python-asyncio/petstore_api/configuration.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/configuration.py
@@ -120,6 +120,7 @@ conf = petstore_api.Configuration(
 
     def __init__(self, host=None,
                  api_key=None, api_key_prefix=None,
+                 access_token=None,
                  username=None, password=None,
                  discard_unknown_keys=False,
                  disabled_client_side_validations="",
@@ -143,6 +144,7 @@ conf = petstore_api.Configuration(
         """Temp file folder for downloading files
         """
         # Authentication Settings
+        self.access_token = access_token
         self.api_key = {}
         if api_key:
             self.api_key = api_key
@@ -164,9 +166,6 @@ conf = petstore_api.Configuration(
         """
         self.discard_unknown_keys = discard_unknown_keys
         self.disabled_client_side_validations = disabled_client_side_validations
-        self.access_token = None
-        """access token for OAuth/Bearer
-        """
         self.logger = {}
         """Logging Settings
         """

--- a/samples/client/petstore/python-tornado/petstore_api/configuration.py
+++ b/samples/client/petstore/python-tornado/petstore_api/configuration.py
@@ -121,6 +121,7 @@ conf = petstore_api.Configuration(
 
     def __init__(self, host=None,
                  api_key=None, api_key_prefix=None,
+                 access_token=None,
                  username=None, password=None,
                  discard_unknown_keys=False,
                  disabled_client_side_validations="",
@@ -144,6 +145,7 @@ conf = petstore_api.Configuration(
         """Temp file folder for downloading files
         """
         # Authentication Settings
+        self.access_token = access_token
         self.api_key = {}
         if api_key:
             self.api_key = api_key
@@ -165,9 +167,6 @@ conf = petstore_api.Configuration(
         """
         self.discard_unknown_keys = discard_unknown_keys
         self.disabled_client_side_validations = disabled_client_side_validations
-        self.access_token = None
-        """access token for OAuth/Bearer
-        """
         self.logger = {}
         """Logging Settings
         """

--- a/samples/client/petstore/python/petstore_api/configuration.py
+++ b/samples/client/petstore/python/petstore_api/configuration.py
@@ -121,6 +121,7 @@ conf = petstore_api.Configuration(
 
     def __init__(self, host=None,
                  api_key=None, api_key_prefix=None,
+                 access_token=None,
                  username=None, password=None,
                  discard_unknown_keys=False,
                  disabled_client_side_validations="",
@@ -144,6 +145,7 @@ conf = petstore_api.Configuration(
         """Temp file folder for downloading files
         """
         # Authentication Settings
+        self.access_token = access_token
         self.api_key = {}
         if api_key:
             self.api_key = api_key
@@ -165,9 +167,6 @@ conf = petstore_api.Configuration(
         """
         self.discard_unknown_keys = discard_unknown_keys
         self.disabled_client_side_validations = disabled_client_side_validations
-        self.access_token = None
-        """access token for OAuth/Bearer
-        """
         self.logger = {}
         """Logging Settings
         """

--- a/samples/openapi3/client/petstore/python/petstore_api/configuration.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/configuration.py
@@ -162,6 +162,7 @@ conf = petstore_api.Configuration(
 
     def __init__(self, host=None,
                  api_key=None, api_key_prefix=None,
+                 access_token=None,
                  username=None, password=None,
                  discard_unknown_keys=False,
                  disabled_client_side_validations="",
@@ -186,6 +187,7 @@ conf = petstore_api.Configuration(
         """Temp file folder for downloading files
         """
         # Authentication Settings
+        self.access_token = access_token
         self.api_key = {}
         if api_key:
             self.api_key = api_key
@@ -211,9 +213,6 @@ conf = petstore_api.Configuration(
             signing_info.host = host
         self.signing_info = signing_info
         """The HTTP signing configuration
-        """
-        self.access_token = None
-        """access token for OAuth/Bearer
         """
         self.logger = {}
         """Logging Settings


### PR DESCRIPTION
Generating Python client for my OpenAPI and it is outputting invalid Python code, it generates a Configuration class, which is trying to use self.access_token which is not initialised to any default value.

closes #7468 

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@spacether  @arun-nalla @taxpon @cbornet 