### PR TITLE
Update of Objective-C model-body.mustache to support discriminator.mappedModels

### DIFF
--- a/modules/openapi-generator/src/main/resources/objc/model-body.mustache
+++ b/modules/openapi-generator/src/main/resources/objc/model-body.mustache
@@ -27,9 +27,19 @@
     if(discriminatedClassName == nil ){
          return [super initWithDictionary:dict error:err];
     }
-    Class class = NSClassFromString([@"{{classPrefix}}" stringByAppendingString:discriminatedClassName]);
-    if(!class) {
-        class = NSClassFromString([@"{{classPrefix}}" stringByAppendingString:[discriminatedClassName capitalizedString]]);
+
+    Class class = nil;
+{{#discriminator.mappedModels}}
+    if ([discriminatedClassName isEqualToString:@"{{^vendorExtensions.x-discriminator-value}}{{mappingName}}{{/vendorExtensions.x-discriminator-value}}{{#vendorExtensions.x-discriminator-value}}{{{vendorExtensions.x-discriminator-value}}}{{/vendorExtensions.x-discriminator-value}}"]) {
+        class = NSClassFromString(@"{{modelName}}");
+    }
+    else
+{{/discriminator.mappedModels}}
+    {
+        class = NSClassFromString([@"{{classPrefix}}" stringByAppendingString:discriminatedClassName]);
+        if(!class) {
+            class = NSClassFromString([@"{{classPrefix}}" stringByAppendingString:[discriminatedClassName capitalizedString]]);
+        }
     }
     if([self class ] == class) {
         return [super initWithDictionary:dict error:err];


### PR DESCRIPTION
This fixes https://github.com/OpenAPITools/openapi-generator/issues/6587.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
--> `openapi-generator-gradle-plugin (maven wrapper) .... FAILURE` on Mac OS, is this supposed to work from Maven? Surely this is not related to the changes made.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
--> Did not cause any changes.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
--> There is no technical committee responsible for Objective-C.