### PR TITLE
[FIX][CLI] handle null result messages

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/config/CodegenConfigurator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/config/CodegenConfigurator.java
@@ -518,7 +518,7 @@ public class CodegenConfigurator {
         SwaggerParseResult result = new OpenAPIParser().readLocation(inputSpec, authorizationValues, options);
 
         // TODO: Move custom validations to a separate type as part of a "Workflow"
-        Set<String> validationMessages = new HashSet<>(result.getMessages());
+        Set<String> validationMessages = new HashSet<>(null != result.getMessages() ? result.getMessages() : new ArrayList<>());
         OpenAPI specification = result.getOpenAPI();
         // TODO: The line below could be removed when at least one of the issue below has been resolved.
         // https://github.com/swagger-api/swagger-parser/issues/1369


### PR DESCRIPTION

swagger-parser has the potential to return null
for messages which will throw NPE on
initialization of the  validationMessages hashset.
rather that allow this to happen we will assume
that a null message collection represents an empty
collection and continue.

Fixes #7453

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

This prevents a null pointer exception when the swagger-parser library returns a null on `getMessages()`. Rather than instantiate the validation HashSet with null, we will pass an empty list.

In my case I was experiencing this null pointer exception because swagger-parser has a bug which returns null for all fields when parameters are not passed in.

While this does not fix that issue, it allows a much more friendly run time exception to be thrown that states 

`Exception in thread "main" java.lang.RuntimeException: missing OpenAPI input!`

There seems to be a swagger-parser issue for this over here ==> https://github.com/swagger-api/swagger-parser/issues/1428

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [ ] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
