### PR TITLE
[python][experimental] remove hardcoded PetApi

### DIFF
--- a/modules/openapi-generator/src/main/resources/python/python-experimental/__init__api.mustache
+++ b/modules/openapi-generator/src/main/resources/python/python-experimental/__init__api.mustache
@@ -1,3 +1,9 @@
+{{#apiInfo}}
+{{#apis}}
+{{#-first}}
 # do not import all apis into this module because that uses a lot of memory and stack frames
 # if you need the ability to import all apis from one package, import them with
-# from {{packageName}.apis import DefaultApi, PetApi
+# from {{packageName}}.apis import {{classname}}
+{{/-first}}
+{{/apis}}
+{{/apiInfo}}

--- a/modules/openapi-generator/src/main/resources/python/python-experimental/__init__apis.mustache
+++ b/modules/openapi-generator/src/main/resources/python/python-experimental/__init__apis.mustache
@@ -1,3 +1,6 @@
+{{#apiInfo}}
+{{#apis}}
+{{#-first}}
 # coding: utf-8
 
 # flake8: noqa
@@ -7,7 +10,7 @@
 # raise a `RecursionError`.
 # In order to avoid this, import only the API that you directly need like:
 #
-#   from {{packagename}}.api.pet_api import PetApi
+#   from {{packagename}}.api.{{classVarName}} import {{classname}}
 #
 # or import this package, but before doing it, use:
 #
@@ -15,8 +18,7 @@
 #   sys.setrecursionlimit(n)
 
 # Import APIs into API package:
-{{#apiInfo}}
-{{#apis}}
+{{/-first}}
 from {{apiPackage}}.{{classVarName}} import {{classname}}
 {{/apis}}
 {{/apiInfo}}

--- a/modules/openapi-generator/src/main/resources/python/python-experimental/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/python/python-experimental/api_client.mustache
@@ -750,11 +750,13 @@ class Endpoint(object):
     def __call__(self, *args, **kwargs):
         """ This method is invoked when endpoints are called
         Example:
-        pet_api = PetApi()
-        pet_api.add_pet  # this is an instance of the class Endpoint
-        pet_api.add_pet()  # this invokes pet_api.add_pet.__call__()
+{{#apiInfo}}{{#apis}}{{#-first}}{{#operations}}{{#operation}}{{#-first}}
+        api_instance = {{classname}}()
+        api_instance.{{operationId}}  # this is an instance of the class Endpoint
+        api_instance.{{operationId}}()  # this invokes api_instance.{{operationId}}.__call__()
         which then invokes the callable functions stored in that endpoint at
-        pet_api.add_pet.callable or self.callable in this class
+        api_instance.{{operationId}}.callable or self.callable in this class
+{{/-first}}{{/operation}}{{/operations}}{{/-first}}{{/apis}}{{/apiInfo}}
         """
         return self.callable(self, *args, **kwargs)
 

--- a/samples/client/petstore/python-experimental/petstore_api/api/__init__.py
+++ b/samples/client/petstore/python-experimental/petstore_api/api/__init__.py
@@ -1,3 +1,3 @@
 # do not import all apis into this module because that uses a lot of memory and stack frames
 # if you need the ability to import all apis from one package, import them with
-# from {{packageName}.apis import DefaultApi, PetApi
+# from petstore_api.apis import AnotherFakeApi

--- a/samples/client/petstore/python-experimental/petstore_api/api_client.py
+++ b/samples/client/petstore/python-experimental/petstore_api/api_client.py
@@ -729,11 +729,13 @@ class Endpoint(object):
     def __call__(self, *args, **kwargs):
         """ This method is invoked when endpoints are called
         Example:
-        pet_api = PetApi()
-        pet_api.add_pet  # this is an instance of the class Endpoint
-        pet_api.add_pet()  # this invokes pet_api.add_pet.__call__()
+
+        api_instance = AnotherFakeApi()
+        api_instance.call_123_test_special_tags  # this is an instance of the class Endpoint
+        api_instance.call_123_test_special_tags()  # this invokes api_instance.call_123_test_special_tags.__call__()
         which then invokes the callable functions stored in that endpoint at
-        pet_api.add_pet.callable or self.callable in this class
+        api_instance.call_123_test_special_tags.callable or self.callable in this class
+
         """
         return self.callable(self, *args, **kwargs)
 

--- a/samples/client/petstore/python-experimental/petstore_api/apis/__init__.py
+++ b/samples/client/petstore/python-experimental/petstore_api/apis/__init__.py
@@ -7,7 +7,7 @@
 # raise a `RecursionError`.
 # In order to avoid this, import only the API that you directly need like:
 #
-#   from .api.pet_api import PetApi
+#   from .api.another_fake_api import AnotherFakeApi
 #
 # or import this package, but before doing it, use:
 #

--- a/samples/openapi3/client/extensions/x-auth-id-alias/python-experimental/x_auth_id_alias/api/__init__.py
+++ b/samples/openapi3/client/extensions/x-auth-id-alias/python-experimental/x_auth_id_alias/api/__init__.py
@@ -1,3 +1,3 @@
 # do not import all apis into this module because that uses a lot of memory and stack frames
 # if you need the ability to import all apis from one package, import them with
-# from {{packageName}.apis import DefaultApi, PetApi
+# from x_auth_id_alias.apis import UsageApi

--- a/samples/openapi3/client/extensions/x-auth-id-alias/python-experimental/x_auth_id_alias/api_client.py
+++ b/samples/openapi3/client/extensions/x-auth-id-alias/python-experimental/x_auth_id_alias/api_client.py
@@ -729,11 +729,13 @@ class Endpoint(object):
     def __call__(self, *args, **kwargs):
         """ This method is invoked when endpoints are called
         Example:
-        pet_api = PetApi()
-        pet_api.add_pet  # this is an instance of the class Endpoint
-        pet_api.add_pet()  # this invokes pet_api.add_pet.__call__()
+
+        api_instance = UsageApi()
+        api_instance.any_key  # this is an instance of the class Endpoint
+        api_instance.any_key()  # this invokes api_instance.any_key.__call__()
         which then invokes the callable functions stored in that endpoint at
-        pet_api.add_pet.callable or self.callable in this class
+        api_instance.any_key.callable or self.callable in this class
+
         """
         return self.callable(self, *args, **kwargs)
 

--- a/samples/openapi3/client/extensions/x-auth-id-alias/python-experimental/x_auth_id_alias/apis/__init__.py
+++ b/samples/openapi3/client/extensions/x-auth-id-alias/python-experimental/x_auth_id_alias/apis/__init__.py
@@ -7,7 +7,7 @@
 # raise a `RecursionError`.
 # In order to avoid this, import only the API that you directly need like:
 #
-#   from .api.pet_api import PetApi
+#   from .api.usage_api import UsageApi
 #
 # or import this package, but before doing it, use:
 #

--- a/samples/openapi3/client/features/dynamic-servers/python-experimental/dynamic_servers/api/__init__.py
+++ b/samples/openapi3/client/features/dynamic-servers/python-experimental/dynamic_servers/api/__init__.py
@@ -1,3 +1,3 @@
 # do not import all apis into this module because that uses a lot of memory and stack frames
 # if you need the ability to import all apis from one package, import them with
-# from {{packageName}.apis import DefaultApi, PetApi
+# from dynamic_servers.apis import UsageApi

--- a/samples/openapi3/client/features/dynamic-servers/python-experimental/dynamic_servers/api_client.py
+++ b/samples/openapi3/client/features/dynamic-servers/python-experimental/dynamic_servers/api_client.py
@@ -729,11 +729,13 @@ class Endpoint(object):
     def __call__(self, *args, **kwargs):
         """ This method is invoked when endpoints are called
         Example:
-        pet_api = PetApi()
-        pet_api.add_pet  # this is an instance of the class Endpoint
-        pet_api.add_pet()  # this invokes pet_api.add_pet.__call__()
+
+        api_instance = UsageApi()
+        api_instance.custom_server  # this is an instance of the class Endpoint
+        api_instance.custom_server()  # this invokes api_instance.custom_server.__call__()
         which then invokes the callable functions stored in that endpoint at
-        pet_api.add_pet.callable or self.callable in this class
+        api_instance.custom_server.callable or self.callable in this class
+
         """
         return self.callable(self, *args, **kwargs)
 

--- a/samples/openapi3/client/features/dynamic-servers/python-experimental/dynamic_servers/apis/__init__.py
+++ b/samples/openapi3/client/features/dynamic-servers/python-experimental/dynamic_servers/apis/__init__.py
@@ -7,7 +7,7 @@
 # raise a `RecursionError`.
 # In order to avoid this, import only the API that you directly need like:
 #
-#   from .api.pet_api import PetApi
+#   from .api.usage_api import UsageApi
 #
 # or import this package, but before doing it, use:
 #

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/api/__init__.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/api/__init__.py
@@ -1,3 +1,3 @@
 # do not import all apis into this module because that uses a lot of memory and stack frames
 # if you need the ability to import all apis from one package, import them with
-# from {{packageName}.apis import DefaultApi, PetApi
+# from petstore_api.apis import AnotherFakeApi

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/api_client.py
@@ -736,11 +736,13 @@ class Endpoint(object):
     def __call__(self, *args, **kwargs):
         """ This method is invoked when endpoints are called
         Example:
-        pet_api = PetApi()
-        pet_api.add_pet  # this is an instance of the class Endpoint
-        pet_api.add_pet()  # this invokes pet_api.add_pet.__call__()
+
+        api_instance = AnotherFakeApi()
+        api_instance.call_123_test_special_tags  # this is an instance of the class Endpoint
+        api_instance.call_123_test_special_tags()  # this invokes api_instance.call_123_test_special_tags.__call__()
         which then invokes the callable functions stored in that endpoint at
-        pet_api.add_pet.callable or self.callable in this class
+        api_instance.call_123_test_special_tags.callable or self.callable in this class
+
         """
         return self.callable(self, *args, **kwargs)
 

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/apis/__init__.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/apis/__init__.py
@@ -7,7 +7,7 @@
 # raise a `RecursionError`.
 # In order to avoid this, import only the API that you directly need like:
 #
-#   from .api.pet_api import PetApi
+#   from .api.another_fake_api import AnotherFakeApi
 #
 # or import this package, but before doing it, use:
 #


### PR DESCRIPTION
- replaced hardcoded PetApi with actual values from the OpenAPI spec.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

cc @taxpon (2017/07) @frol (2017/07) @mbohlool (2017/07) @cbornet (2017/09) @kenjones-cisco (2017/11) @tomplus (2018/10) @Jyhess (2019/01) @arun-nalla (2019/11) @spacether (2019/11)


