### PR TITLE
[JS] Allow auth.accessToken to be either function or string

### DIFF
--- a/modules/openapi-generator/src/main/resources/Javascript/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Javascript/ApiClient.mustache
@@ -338,7 +338,10 @@
           break;
         case 'bearer':
           if (auth.accessToken) {
-            request.set({'Authorization': 'Bearer ' + auth.accessToken});
+            var localVarBearerToken = typeof auth.accessToken === 'function'
+              ? auth.accessToken()
+              : auth.accessToken
+            request.set({'Authorization': 'Bearer ' + localVarBearerToken});
           }
           break;
         case 'apiKey':

--- a/modules/openapi-generator/src/main/resources/Javascript/es6/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Javascript/es6/ApiClient.mustache
@@ -304,7 +304,10 @@ class ApiClient {
                     break;
                 case 'bearer':
                     if (auth.accessToken) {
-                        request.set({'Authorization': 'Bearer ' + auth.accessToken});
+                        var localVarBearerToken = typeof auth.accessToken === 'function'
+                          ? auth.accessToken()
+                          : auth.accessToken
+                        request.set({'Authorization': 'Bearer ' + localVarBearerToken});
                     }
 
                     break;

--- a/samples/client/petstore/javascript-es6/src/ApiClient.js
+++ b/samples/client/petstore/javascript-es6/src/ApiClient.js
@@ -302,7 +302,10 @@ class ApiClient {
                     break;
                 case 'bearer':
                     if (auth.accessToken) {
-                        request.set({'Authorization': 'Bearer ' + auth.accessToken});
+                        var localVarBearerToken = typeof auth.accessToken === 'function'
+                          ? auth.accessToken()
+                          : auth.accessToken
+                        request.set({'Authorization': 'Bearer ' + localVarBearerToken});
                     }
 
                     break;

--- a/samples/client/petstore/javascript-promise-es6/src/ApiClient.js
+++ b/samples/client/petstore/javascript-promise-es6/src/ApiClient.js
@@ -302,7 +302,10 @@ class ApiClient {
                     break;
                 case 'bearer':
                     if (auth.accessToken) {
-                        request.set({'Authorization': 'Bearer ' + auth.accessToken});
+                        var localVarBearerToken = typeof auth.accessToken === 'function'
+                          ? auth.accessToken()
+                          : auth.accessToken
+                        request.set({'Authorization': 'Bearer ' + localVarBearerToken});
                     }
 
                     break;


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

I am using "custom" auth method (basically I need to generate new JWT every request). The easiest way to do it is to use custom accessToken function instead of string. My idea for solving this problem came from similiar code in typescript-axios client:

https://github.com/OpenAPITools/openapi-generator/blob/8c78f13a4180d7e49b63afe61bb35627260bee4e/samples/client/petstore/typescript-axios/builds/es6-target/api.ts#L281-L286

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@CodeNinjai (2017/07) @frol (2017/07) @cliffano (2017/07)
