### PR TITLE
[java][groovy] Fix mangled src paths in some outputs on Windows

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
@@ -85,7 +85,8 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
     protected String licenseUrl = "http://unlicense.org";
     protected String projectFolder = "src/main";
     protected String projectTestFolder = "src/test";
-    protected String sourceFolder = projectFolder + File.separator + "java";
+    // this must not be OS-specific
+    protected String sourceFolder = projectFolder + "/java";
     protected String testFolder = projectTestFolder + "/java";
     protected boolean fullJavaUtil;
     protected boolean discriminatorCaseSensitive = true; // True if the discriminator value lookup should be case-sensitive.

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/GroovyClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/GroovyClientCodegen.java
@@ -60,7 +60,8 @@ public class GroovyClientCodegen extends AbstractJavaCodegen {
         languageSpecificPrimitives.add("File");
         languageSpecificPrimitives.add("Map");
 
-        sourceFolder = projectFolder + File.separator +"groovy";
+        // this must not be OS-specific
+        sourceFolder = projectFolder + "/groovy";
         outputFolder = "generated-code/groovy";
         modelTemplateFiles.put("model.mustache", ".groovy");
         apiTemplateFiles.put("api.mustache", ".groovy");

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/AbstractJavaCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/AbstractJavaCodegenTest.java
@@ -42,27 +42,27 @@ public class AbstractJavaCodegenTest {
 
     @Test
     public void toEnumVarNameShouldNotShortenUnderScore() throws Exception {
-        Assert.assertEquals("UNDERSCORE", fakeJavaCodegen.toEnumVarName("_", "String"));
-        Assert.assertEquals("__", fakeJavaCodegen.toEnumVarName("__", "String"));
-        Assert.assertEquals("__", fakeJavaCodegen.toEnumVarName("_,.", "String"));
+        Assert.assertEquals(fakeJavaCodegen.toEnumVarName("_", "String"), "UNDERSCORE");
+        Assert.assertEquals(fakeJavaCodegen.toEnumVarName("__", "String"), "__");
+        Assert.assertEquals(fakeJavaCodegen.toEnumVarName("_,.", "String"), "__");
     }
 
     @Test
     public void toVarNameShouldAvoidOverloadingGetClassMethod() throws Exception {
-        Assert.assertEquals("propertyClass", fakeJavaCodegen.toVarName("class"));
-        Assert.assertEquals("propertyClass", fakeJavaCodegen.toVarName("_class"));
-        Assert.assertEquals("propertyClass", fakeJavaCodegen.toVarName("__class"));
+        Assert.assertEquals(fakeJavaCodegen.toVarName("class"), "propertyClass");
+        Assert.assertEquals(fakeJavaCodegen.toVarName("_class"), "propertyClass");
+        Assert.assertEquals(fakeJavaCodegen.toVarName("__class"), "propertyClass");
     }
 
     @Test
     public void toModelNameShouldUseProvidedMapping() throws Exception {
         fakeJavaCodegen.importMapping().put("json_myclass", "com.test.MyClass");
-        Assert.assertEquals("com.test.MyClass", fakeJavaCodegen.toModelName("json_myclass"));
+        Assert.assertEquals(fakeJavaCodegen.toModelName("json_myclass"), "com.test.MyClass");
     }
 
     @Test
     public void toModelNameUsesPascalCase() throws Exception {
-        Assert.assertEquals("JsonAnotherclass", fakeJavaCodegen.toModelName("json_anotherclass"));
+        Assert.assertEquals(fakeJavaCodegen.toModelName("json_anotherclass"), "JsonAnotherclass");
     }
 
     @Test
@@ -600,6 +600,20 @@ public class AbstractJavaCodegenTest {
 
         String defaultValue = codegen.toDefaultValue(schema);
         Assert.assertEquals(defaultValue, "new HashMap<String, ComplexModel>()", "Expected string-ref map aliased model to default to new HashMap<String, ComplexModel>()");
+    }
+
+    @Test
+    public void srcMainFolderShouldNotBeOperatingSystemSpecificPaths() {
+        // it's not responsibility of the generator to fix OS-specific paths. This is left to template manager.
+        // This path must be non-OS-specific for expectations in source outputs (e.g. gradle build files)
+        Assert.assertEquals(fakeJavaCodegen.getSourceFolder(), "src/main/java");
+    }
+
+    @Test
+    public void srcTestFolderShouldNotBeOperatingSystemSpecificPaths() {
+        // it's not responsibility of the generator to fix OS-specific paths. This is left to template manager.
+        // This path must be non-OS-specific for expectations in source outputs (e.g. gradle build files)
+        Assert.assertEquals(fakeJavaCodegen.getTestFolder(), "src/test/java");
     }
 
     private static Schema<?> createObjectSchemaWithMinItems() {


### PR DESCRIPTION
Fixes #7434 

When generating on Windows, some outputs may look like:

```
 main.java.srcDirs = ['src/main\java']
```

That's wrong and this fixes the issue. Common strings like `src/main/java` shouldn't be treated like a path; if it's used to write files then it's the responsibility of the template manager, if it's used in Gradle outputs then it's Gradle's responsibility to normalize the path for the given OS.

cc @OpenAPITools/generator-core-team 

cc java technical committee
@bbdouglas @sreeshas @jfiala @lukoyanov @cbornet @jeff9finger @karismann @Zomzog @lwlee2608 @bkabrda 

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
