### PR TITLE
[Java][jaxrs-spec] add fromString() method to generated enums as required by JAX RS spec

### DIFF
--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/enumClass.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/enumClass.mustache
@@ -21,6 +21,21 @@ public enum {{datatypeWithEnum}} {
         return String.valueOf(value);
     }
 
+    /**
+     * Convert a String into {{dataType}}, as specified in the
+     * <a href="https://download.oracle.com/otndocs/jcp/jaxrs-2_0-fr-eval-spec/index.html">See JAX RS 2.0 Specification, section 3.2, p. 12</a>
+     */
+	public static {{datatypeWithEnum}} fromString(String s) {
+        for ({{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} b : {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}}.values()) {
+            // using Objects.toString() to be safe if value type non-object type
+            // because types like 'int' etc. will be auto-boxed
+            if (java.util.Objects.toString(b.value).equals(s)) {
+                return b;
+            }
+        }
+        {{#isNullable}}return null;{{/isNullable}}{{^isNullable}}throw new IllegalArgumentException("Unexpected string value '" + s + "'");{{/isNullable}}
+	}
+	
     @JsonCreator
     public static {{datatypeWithEnum}} fromValue({{dataType}} value) {
         for ({{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} b : {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}}.values()) {

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/enumOuterClass.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/enumOuterClass.mustache
@@ -25,6 +25,21 @@ public enum {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum
     this.value = value;
   }
 
+    /**
+     * Convert a String into {{dataType}}, as specified in the
+     * <a href="https://download.oracle.com/otndocs/jcp/jaxrs-2_0-fr-eval-spec/index.html">See JAX RS 2.0 Specification, section 3.2, p. 12</a>
+     */
+	public static {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} fromString(String s) {
+      for ({{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} b : {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}}.values()) {
+        // using Objects.toString() to be safe if value type non-object type
+        // because types like 'int' etc. will be auto-boxed
+        if (java.util.Objects.toString(b.value).equals(s)) {
+          return b;
+        }
+      }
+      {{#isNullable}}return null;{{/isNullable}}{{^isNullable}}throw new IllegalArgumentException("Unexpected string value '" + s + "'");{{/isNullable}}
+	}
+	
   @Override
   @JsonValue
   public String toString() {


### PR DESCRIPTION
I'd like to fix issue #3995 with this PR (see my comments there). 

The fix creates an additional static method `fromString()` as required by the JAX RS spec, so that compliant implementations can correctly parse enum arguments whoose wire string representation differs from the Java enum field name (e.g. MyEnum.FOO vs. "foo"). As it stands right now, a JAX RS implementation would expect "FOO" as a value passed as parameter, so parsing "foo" will fail.

I've coded this fix against v4.3.1, as I ran into other issues with 5.0.0 in my project and did use 4.3.1 there; however I assume this can be merged into both the 4.3.x and 5.0.x lines. I couldn't find a release branch for 4.3.x, so this PR is made against `master` in the hope that it will also be patched into the 4.3.x line if accepted.


<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [ ] **script does not exist in 4.3.1** Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
