### PR TITLE
[ci] Clarify wording in ensure script output

### DIFF
--- a/bin/utils/ensure-up-to-date
+++ b/bin/utils/ensure-up-to-date
@@ -53,7 +53,7 @@ if [ -n "$(git status --porcelain)" ]; then
     git --no-pager diff
     echo "Perform git status"
     git status
-    echo "This script runs in pull requests against the anticipated merge commit (as if the PR was merged now)."
+    echo -e "\nThis script runs in pull requests against the anticipated merge commit (as if the PR was merged now)."
     echo "When you see unexpected files here, it likely means that there are newer commits in master that you need to "
     echo -e "rebase or merge into your branch.\n"
     echo "Please run 'bin/utils/ensure-up-to-date' locally and commit changes (UNCOMMITTED CHANGES ERROR)"

--- a/bin/utils/ensure-up-to-date
+++ b/bin/utils/ensure-up-to-date
@@ -53,8 +53,9 @@ if [ -n "$(git status --porcelain)" ]; then
     git --no-pager diff
     echo "Perform git status"
     git status
-    echo "This runs in pull requests against the anticipated merge commit (as if the PR was merged now)."
-    echo "When you see unexpected files here, it likely means there are newer commits in master to pull into your branch."
+    echo "This script runs in pull requests against the anticipated merge commit (as if the PR was merged now)."
+    echo "When you see unexpected files here, it likely means that there are newer commits in master that you need to "
+    echo -e "rebase or merge into your branch.\n"
     echo "Please run 'bin/utils/ensure-up-to-date' locally and commit changes (UNCOMMITTED CHANGES ERROR)"
     exit 1
 else

--- a/bin/utils/ensure-up-to-date
+++ b/bin/utils/ensure-up-to-date
@@ -53,6 +53,8 @@ if [ -n "$(git status --porcelain)" ]; then
     git --no-pager diff
     echo "Perform git status"
     git status
+    echo "This runs in pull requests against the anticipated merge commit (as if the PR was merged now)."
+    echo "When you see unexpected files here, it likely means there are newer commits in master to pull into your branch."
     echo "Please run 'bin/utils/ensure-up-to-date' locally and commit changes (UNCOMMITTED CHANGES ERROR)"
     exit 1
 else


### PR DESCRIPTION
Based on discussions in slack, this clarifies in the script echo that we run against merge commits.
cc @spacether 

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
