### PR TITLE
[Apex] better handling of different content-type in the response

### DIFF
--- a/modules/openapi-generator/src/main/resources/apex/OAS.cls
+++ b/modules/openapi-generator/src/main/resources/apex/OAS.cls
@@ -183,7 +183,7 @@ public class OAS {
 
         @TestVisible
         protected virtual Object toReturnValue(String body, Type returnType, String contentType) {
-            if (contentType == 'application/json') {
+            if (contentType.contains('application/json')) {
                 Object o = returnType.newInstance();
                 if (o instanceof MappedProperties) {
                     Map<String, String> propertyMappings = ((MappedProperties) o).getPropertyMappings();

--- a/samples/client/petstore/apex/force-app/main/default/classes/OAS.cls
+++ b/samples/client/petstore/apex/force-app/main/default/classes/OAS.cls
@@ -183,7 +183,7 @@ public class OAS {
 
         @TestVisible
         protected virtual Object toReturnValue(String body, Type returnType, String contentType) {
-            if (contentType == 'application/json') {
+            if (contentType.contains('application/json')) {
                 Object o = returnType.newInstance();
                 if (o instanceof MappedProperties) {
                     Map<String, String> propertyMappings = ((MappedProperties) o).getPropertyMappings();


### PR DESCRIPTION
openapi-generator/modules/openapi-generator/src/main/resources/apex/OAS.cls

If you send a response that contains anything in addition to "application/json" nothing is returned.

Set the toReturnValue to validate for more than just application/json e.g. UTF-8 within the Content Type.

To fix #7500 