### PR TITLE
Add server URL without variables to the test spec

### DIFF
--- a/modules/openapi-generator/src/test/resources/3_0/java/petstore-with-fake-endpoints-models-for-testing-with-http-signature.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/java/petstore-with-fake-endpoints-models-for-testing-with-http-signature.yaml
@@ -1135,6 +1135,8 @@ servers:
           - 'v1'
           - 'v2'
         default: 'v2'
+  - url: https://127.0.0.1/no_variable
+    description: The local server without variables
 components:
   requestBodies:
     UserArray:

--- a/modules/openapi-generator/src/test/resources/3_0/petstore-with-fake-endpoints-models-for-testing-with-http-signature.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/petstore-with-fake-endpoints-models-for-testing-with-http-signature.yaml
@@ -1120,6 +1120,8 @@ servers:
           - 'v1'
           - 'v2'
         default: 'v2'
+  - url: https://127.0.0.1/no_variable
+    description: The local server without variables
 components:
   requestBodies:
     UserArray:

--- a/modules/openapi-generator/src/test/resources/3_0/petstore-with-fake-endpoints-models-for-testing.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/petstore-with-fake-endpoints-models-for-testing.yaml
@@ -1142,6 +1142,8 @@ servers:
           - 'v1'
           - 'v2'
         default: 'v2'
+  - url: https://127.0.0.1/no_varaible
+    description: The local server without variables
 components:
   requestBodies:
     UserArray:

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Client/Configuration.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Client/Configuration.cs
@@ -167,6 +167,12 @@ namespace Org.OpenAPITools.Client
                             }
                         }
                     }
+                },
+                {
+                    new Dictionary<string, object> {
+                        {"url", "https://127.0.0.1/no_variable"},
+                        {"description", "The local server without variables"},
+                    }
                 }
             };
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Client/Configuration.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Client/Configuration.cs
@@ -172,6 +172,12 @@ namespace Org.OpenAPITools.Client
                             }
                         }
                     }
+                },
+                {
+                    new Dictionary<string, object> {
+                        {"url", "https://127.0.0.1/no_variable"},
+                        {"description", "The local server without variables"},
+                    }
                 }
             };
 

--- a/samples/client/petstore/javascript-es6/src/ApiClient.js
+++ b/samples/client/petstore/javascript-es6/src/ApiClient.js
@@ -615,6 +615,10 @@ class ApiClient {
                     ]
                   }
                 }
+            },
+            {
+              'url': "https://127.0.0.1/no_varaible",
+              'description': "The local server without variables",
             }
       ];
     }

--- a/samples/client/petstore/javascript-promise-es6/src/ApiClient.js
+++ b/samples/client/petstore/javascript-promise-es6/src/ApiClient.js
@@ -616,6 +616,10 @@ class ApiClient {
                     ]
                   }
                 }
+            },
+            {
+              'url': "https://127.0.0.1/no_varaible",
+              'description': "The local server without variables",
             }
       ];
     }

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Configuration.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Configuration.php
@@ -471,6 +471,10 @@ class Configuration
                         ]
                     ]
                 ]
+            ],
+            [
+                "url" => "https://127.0.0.1/no_varaible",
+                "description" => "The local server without variables",
             ]
         ];
     }

--- a/samples/client/petstore/php/OpenAPIClient-php/tests/ConfigurationTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/tests/ConfigurationTest.php
@@ -47,9 +47,9 @@ class ConfigurationTest extends TestCase
     public function testInvalidIndex()
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Invalid index 2 when selecting the host. Must be less than 2');
+        $this->expectExceptionMessage('Invalid index 3 when selecting the host. Must be less than 3');
         $config = new Configuration();
-        $url = $config->getHostFromSettings(5);
+        $url = $config->getHostFromSettings(3);
     }
 
     /**

--- a/samples/client/petstore/php/OpenAPIClient-php/tests/ConfigurationTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/tests/ConfigurationTest.php
@@ -15,7 +15,7 @@ class ConfigurationTest extends TestCase
         $config = new Configuration();
         $servers = $config->getHostSettings();
 
-        $this->assertCount(2, $servers);
+        $this->assertCount(3, $servers);
         $this->assertSame("http://{server}.swagger.io:{port}/v2", $servers[0]["url"]);
         $this->assertSame("petstore", $servers[0]["variables"]["server"]["default_value"]);
         $this->assertSame("80", $servers[0]["variables"]["port"]["default_value"]);

--- a/samples/client/petstore/php/OpenAPIClient-php/tests/ConfigurationTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/tests/ConfigurationTest.php
@@ -49,11 +49,11 @@ class ConfigurationTest extends TestCase
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid index 2 when selecting the host. Must be less than 2');
         $config = new Configuration();
-        $url = $config->getHostFromSettings(2);
+        $url = $config->getHostFromSettings(5);
     }
 
     /**
-     * Test host settings with invalid vaues
+     * Test host settings with invalid values
      */
     public function testHostUrlWithInvalidValues()
     {

--- a/samples/client/petstore/ruby-faraday/lib/petstore/configuration.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/configuration.rb
@@ -286,6 +286,10 @@ module Petstore
                 ]
               }
             }
+        },
+        {
+          url: "https://127.0.0.1/no_varaible",
+          description: "The local server without variables",
         }
       ]
     end

--- a/samples/client/petstore/ruby/lib/petstore/configuration.rb
+++ b/samples/client/petstore/ruby/lib/petstore/configuration.rb
@@ -291,6 +291,10 @@ module Petstore
                 ]
               }
             }
+        },
+        {
+          url: "https://127.0.0.1/no_varaible",
+          description: "The local server without variables",
         }
       ]
     end

--- a/samples/openapi3/client/petstore/go/go-petstore/api/openapi.yaml
+++ b/samples/openapi3/client/petstore/go/go-petstore/api/openapi.yaml
@@ -31,6 +31,8 @@ servers:
       enum:
       - v1
       - v2
+- description: The local server without variables
+  url: https://127.0.0.1/no_variable
 tags:
 - description: Everything about your Pets
   name: pet

--- a/samples/openapi3/client/petstore/go/go-petstore/configuration.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/configuration.go
@@ -141,6 +141,10 @@ func NewConfiguration() *Configuration {
 					},
 				},
 			},
+			{
+				URL: "https://127.0.0.1/no_variable",
+				Description: "The local server without variables",
+			},
 		},
 		OperationServers: map[string]ServerConfigurations{
 			"PetApiService.AddPet": {

--- a/samples/openapi3/client/petstore/java/jersey2-java8/api/openapi.yaml
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/api/openapi.yaml
@@ -31,6 +31,8 @@ servers:
       enum:
       - v1
       - v2
+- description: The local server without variables
+  url: https://127.0.0.1/no_variable
 tags:
 - description: Everything about your Pets
   name: pet

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/ApiClient.java
@@ -116,6 +116,11 @@ public class ApiClient extends JavaTimeFormatter {
           )
         ));
       }}
+    ),
+    new ServerConfiguration(
+      "https://127.0.0.1/no_variable",
+      "The local server without variables",
+      new HashMap<String, ServerVariable>()
     )
   ));
   protected Integer serverIndex = 0;

--- a/samples/openapi3/client/petstore/python/petstore_api/configuration.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/configuration.py
@@ -556,6 +556,10 @@ conf = petstore_api.Configuration(
                         ]
                         }
                     }
+            },
+            {
+                'url': "https://127.0.0.1/no_varaible",
+                'description': "The local server without variables",
             }
         ]
 


### PR DESCRIPTION
- Add server URL without variables to the test spec to ensure the code works without variables defined.

FYI. @OpenAPITools/generator-core-team 

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
