### PR TITLE
Fix PHP test using a proper getter

### DIFF
--- a/samples/client/petstore/php/OpenAPIClient-php/tests/PetApiTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/tests/PetApiTest.php
@@ -114,7 +114,7 @@ class PetApiTest extends TestCase
         $this->assertSame($status_code, 200);
         $this->assertSame($response_headers['Content-Type'], ['application/json']);
     }
-/* comment out due to https://github.com/OpenAPITools/openapi-generator/pull/7376#issuecomment-699722244
+
     public function testFindPetByStatus()
     {
         $response = $this->api->findPetsByStatus('available');
@@ -122,13 +122,13 @@ class PetApiTest extends TestCase
 
         $this->assertSame(get_class($response[0]), Pet::class); // verify the object is Pet
         foreach ($response as $pet) {
-            $this->assertSame($pet['status'], 'available');
+            $this->assertSame($pet->getStatus(), 'available');
         }
 
         $response = $this->api->findPetsByStatus('unknown_and_incorrect_status');
         $this->assertCount(0, $response);
     }
- */
+
     public function testUpdatePet()
     {
         $petId = 10001;


### PR DESCRIPTION
Fix PHP test using a proper getter: `$pet->getStatus()`

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

cc @jebentier (2017/07), @dkarlovi (2017/07), @mandrean (2017/08), @jfastnacht (2017/09), @ackintosh (2017/09) ❤️, @ybelenko (2018/07), @renepardon (2018/12)

