### PR TITLE
[Swift5][URLSession] Fix handling of customHeaders between retries

### DIFF
--- a/modules/openapi-generator/src/main/resources/swift5/libraries/urlsession/URLSessionImplementations.mustache
+++ b/modules/openapi-generator/src/main/resources/swift5/libraries/urlsession/URLSessionImplementations.mustache
@@ -87,11 +87,11 @@ private var urlSessionStore = SynchronizedDictionary<String, URLSession>()
         
         originalRequest.httpMethod = method.rawValue
         
-        buildHeaders().forEach { key, value in
+        headers.forEach { key, value in
             originalRequest.setValue(value, forHTTPHeaderField: key)
         }
         
-        headers.forEach { key, value in
+        buildHeaders().forEach { key, value in
             originalRequest.setValue(value, forHTTPHeaderField: key)
         }
         
@@ -244,8 +244,11 @@ private var urlSessionStore = SynchronizedDictionary<String, URLSession>()
     }
 
     {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}open{{/nonPublicApi}} func buildHeaders() -> [String: String] {
-        var httpHeaders = {{projectName}}API.customHeaders
+        var httpHeaders: [String : String] = [:]
         for (key, value) in self.headers {
+            httpHeaders[key] = value
+        }
+        for (key, value) in {{projectName}}API.customHeaders {
             httpHeaders[key] = value
         }
         return httpHeaders

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
@@ -87,11 +87,11 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T> {
 
         originalRequest.httpMethod = method.rawValue
 
-        buildHeaders().forEach { key, value in
+        headers.forEach { key, value in
             originalRequest.setValue(value, forHTTPHeaderField: key)
         }
 
-        headers.forEach { key, value in
+        buildHeaders().forEach { key, value in
             originalRequest.setValue(value, forHTTPHeaderField: key)
         }
 
@@ -244,9 +244,12 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T> {
     }
 
     open func buildHeaders() -> [String: String] {
-        var httpHeaders = PetstoreClientAPI.customHeaders
+        var httpHeaders: [String : String] = [:]
         for (key, value) in self.headers {
             httpHeaders[key] = value
+        }
+        for (key, value) in PetstoreClientAPI.customHeaders {
+            httpHeaders[key] = value    
         }
         return httpHeaders
     }

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
@@ -87,11 +87,11 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T> {
 
         originalRequest.httpMethod = method.rawValue
 
-        buildHeaders().forEach { key, value in
+        headers.forEach { key, value in
             originalRequest.setValue(value, forHTTPHeaderField: key)
         }
 
-        headers.forEach { key, value in
+        buildHeaders().forEach { key, value in
             originalRequest.setValue(value, forHTTPHeaderField: key)
         }
 
@@ -244,9 +244,12 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T> {
     }
 
     open func buildHeaders() -> [String: String] {
-        var httpHeaders = PetstoreClientAPI.customHeaders
+        var httpHeaders: [String : String] = [:]
         for (key, value) in self.headers {
             httpHeaders[key] = value
+        }
+        for (key, value) in PetstoreClientAPI.customHeaders {
+            httpHeaders[key] = value    
         }
         return httpHeaders
     }

--- a/samples/client/petstore/swift5/deprecated/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
+++ b/samples/client/petstore/swift5/deprecated/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
@@ -87,11 +87,11 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T> {
 
         originalRequest.httpMethod = method.rawValue
 
-        buildHeaders().forEach { key, value in
+        headers.forEach { key, value in
             originalRequest.setValue(value, forHTTPHeaderField: key)
         }
 
-        headers.forEach { key, value in
+        buildHeaders().forEach { key, value in
             originalRequest.setValue(value, forHTTPHeaderField: key)
         }
 
@@ -244,9 +244,12 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T> {
     }
 
     open func buildHeaders() -> [String: String] {
-        var httpHeaders = PetstoreClientAPI.customHeaders
+        var httpHeaders: [String : String] = [:]
         for (key, value) in self.headers {
             httpHeaders[key] = value
+        }
+        for (key, value) in PetstoreClientAPI.customHeaders {
+            httpHeaders[key] = value    
         }
         return httpHeaders
     }

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
@@ -87,11 +87,11 @@ internal class URLSessionRequestBuilder<T>: RequestBuilder<T> {
 
         originalRequest.httpMethod = method.rawValue
 
-        buildHeaders().forEach { key, value in
+        headers.forEach { key, value in
             originalRequest.setValue(value, forHTTPHeaderField: key)
         }
 
-        headers.forEach { key, value in
+        buildHeaders().forEach { key, value in
             originalRequest.setValue(value, forHTTPHeaderField: key)
         }
 
@@ -244,9 +244,12 @@ internal class URLSessionRequestBuilder<T>: RequestBuilder<T> {
     }
 
     internal func buildHeaders() -> [String: String] {
-        var httpHeaders = PetstoreClientAPI.customHeaders
+        var httpHeaders: [String : String] = [:]
         for (key, value) in self.headers {
             httpHeaders[key] = value
+        }
+        for (key, value) in PetstoreClientAPI.customHeaders {
+            httpHeaders[key] = value    
         }
         return httpHeaders
     }

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
@@ -87,11 +87,11 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T> {
 
         originalRequest.httpMethod = method.rawValue
 
-        buildHeaders().forEach { key, value in
+        headers.forEach { key, value in
             originalRequest.setValue(value, forHTTPHeaderField: key)
         }
 
-        headers.forEach { key, value in
+        buildHeaders().forEach { key, value in
             originalRequest.setValue(value, forHTTPHeaderField: key)
         }
 
@@ -244,9 +244,12 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T> {
     }
 
     open func buildHeaders() -> [String: String] {
-        var httpHeaders = PetstoreClientAPI.customHeaders
+        var httpHeaders: [String : String] = [:]
         for (key, value) in self.headers {
             httpHeaders[key] = value
+        }
+        for (key, value) in PetstoreClientAPI.customHeaders {
+            httpHeaders[key] = value    
         }
         return httpHeaders
     }

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
@@ -87,11 +87,11 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T> {
 
         originalRequest.httpMethod = method.rawValue
 
-        buildHeaders().forEach { key, value in
+        headers.forEach { key, value in
             originalRequest.setValue(value, forHTTPHeaderField: key)
         }
 
-        headers.forEach { key, value in
+        buildHeaders().forEach { key, value in
             originalRequest.setValue(value, forHTTPHeaderField: key)
         }
 
@@ -244,9 +244,12 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T> {
     }
 
     open func buildHeaders() -> [String: String] {
-        var httpHeaders = PetstoreClientAPI.customHeaders
+        var httpHeaders: [String : String] = [:]
         for (key, value) in self.headers {
             httpHeaders[key] = value
+        }
+        for (key, value) in PetstoreClientAPI.customHeaders {
+            httpHeaders[key] = value    
         }
         return httpHeaders
     }

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
@@ -87,11 +87,11 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T> {
 
         originalRequest.httpMethod = method.rawValue
 
-        buildHeaders().forEach { key, value in
+        headers.forEach { key, value in
             originalRequest.setValue(value, forHTTPHeaderField: key)
         }
 
-        headers.forEach { key, value in
+        buildHeaders().forEach { key, value in
             originalRequest.setValue(value, forHTTPHeaderField: key)
         }
 
@@ -244,9 +244,12 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T> {
     }
 
     open func buildHeaders() -> [String: String] {
-        var httpHeaders = PetstoreClientAPI.customHeaders
+        var httpHeaders: [String : String] = [:]
         for (key, value) in self.headers {
             httpHeaders[key] = value
+        }
+        for (key, value) in PetstoreClientAPI.customHeaders {
+            httpHeaders[key] = value    
         }
         return httpHeaders
     }

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
@@ -87,11 +87,11 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T> {
 
         originalRequest.httpMethod = method.rawValue
 
-        buildHeaders().forEach { key, value in
+        headers.forEach { key, value in
             originalRequest.setValue(value, forHTTPHeaderField: key)
         }
 
-        headers.forEach { key, value in
+        buildHeaders().forEach { key, value in
             originalRequest.setValue(value, forHTTPHeaderField: key)
         }
 
@@ -244,9 +244,12 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T> {
     }
 
     open func buildHeaders() -> [String: String] {
-        var httpHeaders = PetstoreClientAPI.customHeaders
+        var httpHeaders: [String : String] = [:]
         for (key, value) in self.headers {
             httpHeaders[key] = value
+        }
+        for (key, value) in PetstoreClientAPI.customHeaders {
+            httpHeaders[key] = value    
         }
         return httpHeaders
     }

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
@@ -87,11 +87,11 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T> {
 
         originalRequest.httpMethod = method.rawValue
 
-        buildHeaders().forEach { key, value in
+        headers.forEach { key, value in
             originalRequest.setValue(value, forHTTPHeaderField: key)
         }
 
-        headers.forEach { key, value in
+        buildHeaders().forEach { key, value in
             originalRequest.setValue(value, forHTTPHeaderField: key)
         }
 
@@ -244,9 +244,12 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T> {
     }
 
     open func buildHeaders() -> [String: String] {
-        var httpHeaders = PetstoreClientAPI.customHeaders
+        var httpHeaders: [String : String] = [:]
         for (key, value) in self.headers {
             httpHeaders[key] = value
+        }
+        for (key, value) in PetstoreClientAPI.customHeaders {
+            httpHeaders[key] = value    
         }
         return httpHeaders
     }

--- a/samples/client/petstore/swift5/urlsessionLibrary/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
@@ -87,11 +87,11 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T> {
 
         originalRequest.httpMethod = method.rawValue
 
-        buildHeaders().forEach { key, value in
+        headers.forEach { key, value in
             originalRequest.setValue(value, forHTTPHeaderField: key)
         }
 
-        headers.forEach { key, value in
+        buildHeaders().forEach { key, value in
             originalRequest.setValue(value, forHTTPHeaderField: key)
         }
 
@@ -244,9 +244,12 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T> {
     }
 
     open func buildHeaders() -> [String: String] {
-        var httpHeaders = PetstoreClientAPI.customHeaders
+        var httpHeaders: [String : String] = [:]
         for (key, value) in self.headers {
             httpHeaders[key] = value
+        }
+        for (key, value) in PetstoreClientAPI.customHeaders {
+            httpHeaders[key] = value    
         }
         return httpHeaders
     }


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
While trying to implement @4brunu suggestion for token refresh ( https://github.com/OpenAPITools/openapi-generator/issues/5462#issuecomment-592417371 ), with an access token configured in customHeaders with key "Authorization", I noticed that after changing the value in the customHeaders in the TokenRefresher, and then calling `shouldRetry(true)`, the following call would still use the old access token value. 
Looking into the issue I noticed that the new value (set via `MyAPI.customHeaders.updateValue(accessToken, forKey: "Authorization")` before calling `shouldRetry(true)` was being overwritten with the old one stored in self.headers in the `createURLRequest` function defined in URLSessionImplementations.swift.
The proposed change creates the new headers for the modifiedRequest by adding the customHeaders last, so that they can overwrite the keys stored in self.headers, thus fixing the problem. 

<!-- Please check the completed items below -->
### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [X] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [X] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@jgavris @ehyche @Edubits @jaz-ah @4brunu