### PR TITLE
[typescript] Fix generation of enum models

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript/model/ObjectSerializer.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/model/ObjectSerializer.mustache
@@ -31,10 +31,13 @@ const supportedMediaTypes: { [mediaType: string]: number } = {
 let enumsMap: Set<string> = new Set<string>([
     {{#models}}
         {{#model}}
+            {{#isEnum}}
+    "{{classname}}{{enumName}}",
+            {{/isEnum}}
             {{#hasEnums}}
                 {{#vars}}
                     {{#isEnum}}
-					"{{classname}}{{enumName}}",
+    "{{classname}}{{enumName}}",
                     {{/isEnum}}
                 {{/vars}}
             {{/hasEnums}}
@@ -45,7 +48,9 @@ let enumsMap: Set<string> = new Set<string>([
 let typeMap: {[index: string]: any} = {
     {{#models}}
         {{#model}}
+            {{^isEnum}}
     "{{classname}}": {{classname}},
+            {{/isEnum}}
         {{/model}}
     {{/models}}
 }

--- a/modules/openapi-generator/src/main/resources/typescript/model/model.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/model/model.mustache
@@ -11,6 +11,7 @@ import { HttpFile } from '../http/http{{extensionForDeno}}';
 * {{{description}}}
 */
 {{/description}}
+{{^isEnum}}
 export class {{classname}} {{#parent}}extends {{{parent}}} {{/parent}}{
 {{#vars}}
 {{#description}}
@@ -75,5 +76,9 @@ export type {{classname}}{{enumName}} ={{#allowableValues}}{{#values}} "{{.}}" {
 {{/vars}}
 
 {{/hasEnums}}
+{{/isEnum}}
+{{#isEnum}}
+export type {{classname}} ={{#allowableValues}}{{#values}} "{{.}}" {{^-last}}|{{/-last}}{{/values}}{{/allowableValues}};
+{{/isEnum}}
 {{/model}}
 {{/models}}

--- a/samples/openapi3/client/petstore/typescript/builds/default/models/ObjectSerializer.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/default/models/ObjectSerializer.ts
@@ -35,8 +35,8 @@ const supportedMediaTypes: { [mediaType: string]: number } = {
 
                  
 let enumsMap: Set<string> = new Set<string>([
-					"OrderStatusEnum",
-					"PetStatusEnum",
+    "OrderStatusEnum",
+    "PetStatusEnum",
 ]);
 
 let typeMap: {[index: string]: any} = {

--- a/samples/openapi3/client/petstore/typescript/builds/deno/models/ObjectSerializer.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/deno/models/ObjectSerializer.ts
@@ -35,8 +35,8 @@ const supportedMediaTypes: { [mediaType: string]: number } = {
 
                  
 let enumsMap: Set<string> = new Set<string>([
-					"OrderStatusEnum",
-					"PetStatusEnum",
+    "OrderStatusEnum",
+    "PetStatusEnum",
 ]);
 
 let typeMap: {[index: string]: any} = {

--- a/samples/openapi3/client/petstore/typescript/builds/inversify/models/ObjectSerializer.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/inversify/models/ObjectSerializer.ts
@@ -35,8 +35,8 @@ const supportedMediaTypes: { [mediaType: string]: number } = {
 
                  
 let enumsMap: Set<string> = new Set<string>([
-					"OrderStatusEnum",
-					"PetStatusEnum",
+    "OrderStatusEnum",
+    "PetStatusEnum",
 ]);
 
 let typeMap: {[index: string]: any} = {

--- a/samples/openapi3/client/petstore/typescript/builds/jquery/models/ObjectSerializer.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/jquery/models/ObjectSerializer.ts
@@ -35,8 +35,8 @@ const supportedMediaTypes: { [mediaType: string]: number } = {
 
                  
 let enumsMap: Set<string> = new Set<string>([
-					"OrderStatusEnum",
-					"PetStatusEnum",
+    "OrderStatusEnum",
+    "PetStatusEnum",
 ]);
 
 let typeMap: {[index: string]: any} = {

--- a/samples/openapi3/client/petstore/typescript/builds/object_params/models/ObjectSerializer.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/object_params/models/ObjectSerializer.ts
@@ -35,8 +35,8 @@ const supportedMediaTypes: { [mediaType: string]: number } = {
 
                  
 let enumsMap: Set<string> = new Set<string>([
-					"OrderStatusEnum",
-					"PetStatusEnum",
+    "OrderStatusEnum",
+    "PetStatusEnum",
 ]);
 
 let typeMap: {[index: string]: any} = {


### PR DESCRIPTION
Due to the fact that the consolidated typescript template was forked from master so long ago, there are still some bugs left that where fixed for other typescript generators in the meantime. This is one of them.

This fixes #665 for the consolidated typescript generator. (With [sample definition](https://github.com/OpenAPITools/openapi-generator/issues/665#issuecomment-408769117))
The issue there is, that top-level enum schemas, which are not nested as attributes of other schemas are just generated as normal object schemas, which is not suited to represent the different allowed values.

Original fix for typescript-node was in PR #2266, merged as 8417c5bed0e23764dc841816c2322cf7dc4e9b0d in version 4.1.0.

CC: @TiFu (2017/07) @taxpon (2017/07) @sebastianhaas (2017/07) @kenisteward (2017/07) @Vrolijkx (2017/09) @macjohnny (2018/01) @topce (2018/10) @akehir (2019/07) @petejohansonxo (2019/11) @amakhrov (2020/02)

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [X] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
