### PR TITLE
Update default ruby, faraday versions

### DIFF
--- a/modules/openapi-generator/src/main/resources/ruby-client/gemspec.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/gemspec.mustache
@@ -16,16 +16,11 @@ Gem::Specification.new do |s|
   s.homepage    = "{{gemHomepage}}{{^gemHomepage}}https://openapi-generator.tech{{/gemHomepage}}"
   s.summary     = "{{gemSummary}}{{^gemSummary}}{{{appName}}} Ruby Gem{{/gemSummary}}"
   s.description = "{{gemDescription}}{{^gemDescription}}{{{appDescription}}}{{^appDescription}}{{{appName}}} Ruby Gem{{/appDescription}}{{/gemDescription}}"
-  {{#gemLicense}}
-  s.license     = '{{{gemLicense}}}'
-  {{/gemLicense}}
-  {{^gemLicense}}
-  s.license     = "Unlicense"
-  {{/gemLicense}}
-  s.required_ruby_version = "{{{gemRequiredRubyVersion}}}{{^gemRequiredRubyVersion}}>= 1.9{{/gemRequiredRubyVersion}}"
+  s.license     = "{{{gemLicense}}}{{^gemLicense}}Unlicense{{/gemLicense}}"
+  s.required_ruby_version = "{{{gemRequiredRubyVersion}}}{{^gemRequiredRubyVersion}}>= 2.4{{/gemRequiredRubyVersion}}"
 
   {{#isFaraday}}
-  s.add_runtime_dependency 'faraday', '>= 0.14.0'
+  s.add_runtime_dependency 'faraday', '~> 1.0', '>= 1.0.1'
   {{/isFaraday}}
   {{^isFaraday}}
   s.add_runtime_dependency 'typhoeus', '~> 1.0', '>= 1.0.1'

--- a/samples/client/petstore/ruby-faraday/petstore.gemspec
+++ b/samples/client/petstore/ruby-faraday/petstore.gemspec
@@ -25,9 +25,9 @@ Gem::Specification.new do |s|
   s.summary     = "OpenAPI Petstore Ruby Gem"
   s.description = "This spec is mainly for testing Petstore server and contains fake endpoints, models. Please do not use this for any other purpose. Special characters: \" \\"
   s.license     = "Unlicense"
-  s.required_ruby_version = ">= 1.9"
+  s.required_ruby_version = ">= 2.4"
 
-  s.add_runtime_dependency 'faraday', '>= 0.14.0'
+  s.add_runtime_dependency 'faraday', '~> 1.0', '>= 1.0.1'
 
   s.add_development_dependency 'rspec', '~> 3.6', '>= 3.6.0'
 

--- a/samples/client/petstore/ruby/petstore.gemspec
+++ b/samples/client/petstore/ruby/petstore.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.summary     = "OpenAPI Petstore Ruby Gem"
   s.description = "This spec is mainly for testing Petstore server and contains fake endpoints, models. Please do not use this for any other purpose. Special characters: \" \\"
   s.license     = "Unlicense"
-  s.required_ruby_version = ">= 1.9"
+  s.required_ruby_version = ">= 2.4"
 
   s.add_runtime_dependency 'typhoeus', '~> 1.0', '>= 1.0.1'
 

--- a/samples/openapi3/client/features/dynamic-servers/ruby/dynamic_servers.gemspec
+++ b/samples/openapi3/client/features/dynamic-servers/ruby/dynamic_servers.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.summary     = "OpenAPI Extension with dynamic servers Ruby Gem"
   s.description = "This specification shows how to use dynamic servers."
   s.license     = "Unlicense"
-  s.required_ruby_version = ">= 1.9"
+  s.required_ruby_version = ">= 2.4"
 
   s.add_runtime_dependency 'typhoeus', '~> 1.0', '>= 1.0.1'
 

--- a/samples/openapi3/client/features/generate-alias-as-model/ruby-client/petstore.gemspec
+++ b/samples/openapi3/client/features/generate-alias-as-model/ruby-client/petstore.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.summary     = "OpenAPI Extension generating aliases to maps and arrays as models Ruby Gem"
   s.description = "This specification shows how to generate aliases to maps and arrays as models."
   s.license     = "Unlicense"
-  s.required_ruby_version = ">= 1.9"
+  s.required_ruby_version = ">= 2.4"
 
   s.add_runtime_dependency 'typhoeus', '~> 1.0', '>= 1.0.1'
 


### PR DESCRIPTION
- Set default Ruby version to 2.4
- Set faraday version to 1.0.1

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

cc @cliffano (2017/07) @zlx (2017/09) @autopp (2019/02)



