### PR TITLE
Fix issue7557 - allow body for DELETE requests

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-angular/api.service.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-angular/api.service.mustache
@@ -334,9 +334,10 @@ export class {{classname}} {
         }
 
     {{/isResponseFile}}
-        return this.httpClient.{{httpMethod}}{{^isResponseFile}}<{{#returnType}}{{{returnType}}}{{#isResponseTypeFile}}|undefined{{/isResponseTypeFile}}{{/returnType}}{{^returnType}}any{{/returnType}}>{{/isResponseFile}}(`${this.configuration.basePath}{{{path}}}`,{{#isBodyAllowed}}
-            {{#bodyParam}}{{paramName}}{{/bodyParam}}{{^bodyParam}}{{#hasFormParams}}convertFormParamsToString ? formParams.toString() : formParams{{/hasFormParams}}{{^hasFormParams}}null{{/hasFormParams}}{{/bodyParam}},{{/isBodyAllowed}}
+        return this.httpClient.request{{^isResponseFile}}<{{#returnType}}{{{returnType}}}{{#isResponseTypeFile}}|undefined{{/isResponseTypeFile}}{{/returnType}}{{^returnType}}any{{/returnType}}>{{/isResponseFile}}("{{httpMethod}}",
+            `${this.configuration.basePath}{{{path}}}`,
             {
+                body: {{#bodyParam}}{{paramName}}{{/bodyParam}}{{^bodyParam}}{{#hasFormParams}}convertFormParamsToString ? formParams.toString() : formParams{{/hasFormParams}}{{^hasFormParams}}null{{/hasFormParams}}{{/bodyParam}},
     {{#hasQueryParams}}
                 params: queryParameters,
     {{/hasQueryParams}}

--- a/modules/openapi-generator/src/main/resources/typescript-angular/api.service.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-angular/api.service.mustache
@@ -337,7 +337,14 @@ export class {{classname}} {
         return this.httpClient.request{{^isResponseFile}}<{{#returnType}}{{{returnType}}}{{#isResponseTypeFile}}|undefined{{/isResponseTypeFile}}{{/returnType}}{{^returnType}}any{{/returnType}}>{{/isResponseFile}}("{{httpMethod}}",
             `${this.configuration.basePath}{{{path}}}`,
             {
-                body: {{#bodyParam}}{{paramName}}{{/bodyParam}}{{^bodyParam}}{{#hasFormParams}}convertFormParamsToString ? formParams.toString() : formParams{{/hasFormParams}}{{^hasFormParams}}null{{/hasFormParams}}{{/bodyParam}},
+    {{#hasBodyParam}}
+                body: {{#bodyParam}}{{paramName}}{{/bodyParam}},
+    {{/hasBodyParam}}
+    {{^hasBodyParam}}
+      {{#hasFormParams}}
+                body: convertFormParamsToString ? formParams.toString() : formParams,
+      {{/hasFormParams}}
+    {{/hasBodyParam}}
     {{#hasQueryParams}}
                 params: queryParameters,
     {{/hasQueryParams}}

--- a/modules/openapi-generator/src/main/resources/typescript-angular/api.service.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-angular/api.service.mustache
@@ -334,7 +334,7 @@ export class {{classname}} {
         }
 
     {{/isResponseFile}}
-        return this.httpClient.request{{^isResponseFile}}<{{#returnType}}{{{returnType}}}{{#isResponseTypeFile}}|undefined{{/isResponseTypeFile}}{{/returnType}}{{^returnType}}any{{/returnType}}>{{/isResponseFile}}("{{httpMethod}}",
+        return this.httpClient.request{{^isResponseFile}}<{{#returnType}}{{{returnType}}}{{#isResponseTypeFile}}|undefined{{/isResponseTypeFile}}{{/returnType}}{{^returnType}}any{{/returnType}}>{{/isResponseFile}}('{{httpMethod}}',
             `${this.configuration.basePath}{{{path}}}`,
             {
     {{#hasBodyParam}}

--- a/samples/client/petstore/typescript-angular-v10-provided-in-root/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v10-provided-in-root/builds/default/api/pet.service.ts
@@ -148,7 +148,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("post",
+        return this.httpClient.request<any>('post',
             `${this.configuration.basePath}/pet`,
             {
                 body: body,
@@ -205,7 +205,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("delete",
+        return this.httpClient.request<any>('delete',
             `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
                 responseType: <any>responseType,
@@ -266,7 +266,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<Array<Pet>>("get",
+        return this.httpClient.request<Array<Pet>>('get',
             `${this.configuration.basePath}/pet/findByStatus`,
             {
                 params: queryParameters,
@@ -329,7 +329,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<Array<Pet>>("get",
+        return this.httpClient.request<Array<Pet>>('get',
             `${this.configuration.basePath}/pet/findByTags`,
             {
                 params: queryParameters,
@@ -385,7 +385,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<Pet>("get",
+        return this.httpClient.request<Pet>('get',
             `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
                 responseType: <any>responseType,
@@ -447,7 +447,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("put",
+        return this.httpClient.request<any>('put',
             `${this.configuration.basePath}/pet`,
             {
                 body: body,
@@ -524,7 +524,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("post",
+        return this.httpClient.request<any>('post',
             `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
                 body: convertFormParamsToString ? formParams.toString() : formParams,
@@ -605,7 +605,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<ApiResponse>("post",
+        return this.httpClient.request<ApiResponse>('post',
             `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}/uploadImage`,
             {
                 body: convertFormParamsToString ? formParams.toString() : formParams,

--- a/samples/client/petstore/typescript-angular-v10-provided-in-root/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v10-provided-in-root/builds/default/api/pet.service.ts
@@ -208,7 +208,6 @@ export class PetService {
         return this.httpClient.request<any>("delete",
             `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -270,7 +269,6 @@ export class PetService {
         return this.httpClient.request<Array<Pet>>("get",
             `${this.configuration.basePath}/pet/findByStatus`,
             {
-                body: null,
                 params: queryParameters,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
@@ -334,7 +332,6 @@ export class PetService {
         return this.httpClient.request<Array<Pet>>("get",
             `${this.configuration.basePath}/pet/findByTags`,
             {
-                body: null,
                 params: queryParameters,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
@@ -391,7 +388,6 @@ export class PetService {
         return this.httpClient.request<Pet>("get",
             `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,

--- a/samples/client/petstore/typescript-angular-v10-provided-in-root/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v10-provided-in-root/builds/default/api/pet.service.ts
@@ -148,9 +148,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.post<any>(`${this.configuration.basePath}/pet`,
-            body,
+        return this.httpClient.request<any>("post",
+            `${this.configuration.basePath}/pet`,
             {
+                body: body,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -204,8 +205,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.delete<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
+        return this.httpClient.request<any>("delete",
+            `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -264,8 +267,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByStatus`,
+        return this.httpClient.request<Array<Pet>>("get",
+            `${this.configuration.basePath}/pet/findByStatus`,
             {
+                body: null,
                 params: queryParameters,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
@@ -326,8 +331,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByTags`,
+        return this.httpClient.request<Array<Pet>>("get",
+            `${this.configuration.basePath}/pet/findByTags`,
             {
+                body: null,
                 params: queryParameters,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
@@ -381,8 +388,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<Pet>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
+        return this.httpClient.request<Pet>("get",
+            `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -442,9 +451,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.put<any>(`${this.configuration.basePath}/pet`,
-            body,
+        return this.httpClient.request<any>("put",
+            `${this.configuration.basePath}/pet`,
             {
+                body: body,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -518,9 +528,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.post<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
-            convertFormParamsToString ? formParams.toString() : formParams,
+        return this.httpClient.request<any>("post",
+            `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
+                body: convertFormParamsToString ? formParams.toString() : formParams,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -598,9 +609,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.post<ApiResponse>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}/uploadImage`,
-            convertFormParamsToString ? formParams.toString() : formParams,
+        return this.httpClient.request<ApiResponse>("post",
+            `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}/uploadImage`,
             {
+                body: convertFormParamsToString ? formParams.toString() : formParams,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,

--- a/samples/client/petstore/typescript-angular-v10-provided-in-root/builds/default/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v10-provided-in-root/builds/default/api/store.service.ts
@@ -121,7 +121,6 @@ export class StoreService {
         return this.httpClient.request<any>("delete",
             `${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -172,7 +171,6 @@ export class StoreService {
         return this.httpClient.request<{ [key: string]: number; }>("get",
             `${this.configuration.basePath}/store/inventory`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -221,7 +219,6 @@ export class StoreService {
         return this.httpClient.request<Order>("get",
             `${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,

--- a/samples/client/petstore/typescript-angular-v10-provided-in-root/builds/default/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v10-provided-in-root/builds/default/api/store.service.ts
@@ -118,8 +118,10 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.delete<any>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
+        return this.httpClient.request<any>("delete",
+            `${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -167,8 +169,10 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<{ [key: string]: number; }>(`${this.configuration.basePath}/store/inventory`,
+        return this.httpClient.request<{ [key: string]: number; }>("get",
+            `${this.configuration.basePath}/store/inventory`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -214,8 +218,10 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<Order>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
+        return this.httpClient.request<Order>("get",
+            `${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -268,9 +274,10 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.post<Order>(`${this.configuration.basePath}/store/order`,
-            body,
+        return this.httpClient.request<Order>("post",
+            `${this.configuration.basePath}/store/order`,
             {
+                body: body,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,

--- a/samples/client/petstore/typescript-angular-v10-provided-in-root/builds/default/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v10-provided-in-root/builds/default/api/store.service.ts
@@ -118,7 +118,7 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("delete",
+        return this.httpClient.request<any>('delete',
             `${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
             {
                 responseType: <any>responseType,
@@ -168,7 +168,7 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<{ [key: string]: number; }>("get",
+        return this.httpClient.request<{ [key: string]: number; }>('get',
             `${this.configuration.basePath}/store/inventory`,
             {
                 responseType: <any>responseType,
@@ -216,7 +216,7 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<Order>("get",
+        return this.httpClient.request<Order>('get',
             `${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
             {
                 responseType: <any>responseType,
@@ -271,7 +271,7 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<Order>("post",
+        return this.httpClient.request<Order>('post',
             `${this.configuration.basePath}/store/order`,
             {
                 body: body,

--- a/samples/client/petstore/typescript-angular-v10-provided-in-root/builds/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v10-provided-in-root/builds/default/api/user.service.ts
@@ -284,7 +284,6 @@ export class UserService {
         return this.httpClient.request<any>("delete",
             `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -332,7 +331,6 @@ export class UserService {
         return this.httpClient.request<User>("get",
             `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -394,7 +392,6 @@ export class UserService {
         return this.httpClient.request<string>("get",
             `${this.configuration.basePath}/user/login`,
             {
-                body: null,
                 params: queryParameters,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
@@ -437,7 +434,6 @@ export class UserService {
         return this.httpClient.request<any>("get",
             `${this.configuration.basePath}/user/logout`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,

--- a/samples/client/petstore/typescript-angular-v10-provided-in-root/builds/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v10-provided-in-root/builds/default/api/user.service.ts
@@ -126,9 +126,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.post<any>(`${this.configuration.basePath}/user`,
-            body,
+        return this.httpClient.request<any>("post",
+            `${this.configuration.basePath}/user`,
             {
+                body: body,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -179,9 +180,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.post<any>(`${this.configuration.basePath}/user/createWithArray`,
-            body,
+        return this.httpClient.request<any>("post",
+            `${this.configuration.basePath}/user/createWithArray`,
             {
+                body: body,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -232,9 +234,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.post<any>(`${this.configuration.basePath}/user/createWithList`,
-            body,
+        return this.httpClient.request<any>("post",
+            `${this.configuration.basePath}/user/createWithList`,
             {
+                body: body,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -278,8 +281,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.delete<any>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
+        return this.httpClient.request<any>("delete",
+            `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -324,8 +329,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<User>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
+        return this.httpClient.request<User>("get",
+            `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -384,8 +391,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<string>(`${this.configuration.basePath}/user/login`,
+        return this.httpClient.request<string>("get",
+            `${this.configuration.basePath}/user/login`,
             {
+                body: null,
                 params: queryParameters,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
@@ -425,8 +434,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<any>(`${this.configuration.basePath}/user/logout`,
+        return this.httpClient.request<any>("get",
+            `${this.configuration.basePath}/user/logout`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -482,9 +493,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.put<any>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
-            body,
+        return this.httpClient.request<any>("put",
+            `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
+                body: body,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,

--- a/samples/client/petstore/typescript-angular-v10-provided-in-root/builds/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v10-provided-in-root/builds/default/api/user.service.ts
@@ -126,7 +126,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("post",
+        return this.httpClient.request<any>('post',
             `${this.configuration.basePath}/user`,
             {
                 body: body,
@@ -180,7 +180,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("post",
+        return this.httpClient.request<any>('post',
             `${this.configuration.basePath}/user/createWithArray`,
             {
                 body: body,
@@ -234,7 +234,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("post",
+        return this.httpClient.request<any>('post',
             `${this.configuration.basePath}/user/createWithList`,
             {
                 body: body,
@@ -281,7 +281,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("delete",
+        return this.httpClient.request<any>('delete',
             `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
                 responseType: <any>responseType,
@@ -328,7 +328,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<User>("get",
+        return this.httpClient.request<User>('get',
             `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
                 responseType: <any>responseType,
@@ -389,7 +389,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<string>("get",
+        return this.httpClient.request<string>('get',
             `${this.configuration.basePath}/user/login`,
             {
                 params: queryParameters,
@@ -431,7 +431,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("get",
+        return this.httpClient.request<any>('get',
             `${this.configuration.basePath}/user/logout`,
             {
                 responseType: <any>responseType,
@@ -489,7 +489,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("put",
+        return this.httpClient.request<any>('put',
             `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
                 body: body,

--- a/samples/client/petstore/typescript-angular-v10-provided-in-root/builds/with-npm/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v10-provided-in-root/builds/with-npm/api/pet.service.ts
@@ -148,7 +148,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("post",
+        return this.httpClient.request<any>('post',
             `${this.configuration.basePath}/pet`,
             {
                 body: body,
@@ -205,7 +205,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("delete",
+        return this.httpClient.request<any>('delete',
             `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
                 responseType: <any>responseType,
@@ -266,7 +266,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<Array<Pet>>("get",
+        return this.httpClient.request<Array<Pet>>('get',
             `${this.configuration.basePath}/pet/findByStatus`,
             {
                 params: queryParameters,
@@ -329,7 +329,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<Array<Pet>>("get",
+        return this.httpClient.request<Array<Pet>>('get',
             `${this.configuration.basePath}/pet/findByTags`,
             {
                 params: queryParameters,
@@ -385,7 +385,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<Pet>("get",
+        return this.httpClient.request<Pet>('get',
             `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
                 responseType: <any>responseType,
@@ -447,7 +447,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("put",
+        return this.httpClient.request<any>('put',
             `${this.configuration.basePath}/pet`,
             {
                 body: body,
@@ -524,7 +524,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("post",
+        return this.httpClient.request<any>('post',
             `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
                 body: convertFormParamsToString ? formParams.toString() : formParams,
@@ -605,7 +605,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<ApiResponse>("post",
+        return this.httpClient.request<ApiResponse>('post',
             `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}/uploadImage`,
             {
                 body: convertFormParamsToString ? formParams.toString() : formParams,

--- a/samples/client/petstore/typescript-angular-v10-provided-in-root/builds/with-npm/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v10-provided-in-root/builds/with-npm/api/pet.service.ts
@@ -208,7 +208,6 @@ export class PetService {
         return this.httpClient.request<any>("delete",
             `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -270,7 +269,6 @@ export class PetService {
         return this.httpClient.request<Array<Pet>>("get",
             `${this.configuration.basePath}/pet/findByStatus`,
             {
-                body: null,
                 params: queryParameters,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
@@ -334,7 +332,6 @@ export class PetService {
         return this.httpClient.request<Array<Pet>>("get",
             `${this.configuration.basePath}/pet/findByTags`,
             {
-                body: null,
                 params: queryParameters,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
@@ -391,7 +388,6 @@ export class PetService {
         return this.httpClient.request<Pet>("get",
             `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,

--- a/samples/client/petstore/typescript-angular-v10-provided-in-root/builds/with-npm/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v10-provided-in-root/builds/with-npm/api/pet.service.ts
@@ -148,9 +148,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.post<any>(`${this.configuration.basePath}/pet`,
-            body,
+        return this.httpClient.request<any>("post",
+            `${this.configuration.basePath}/pet`,
             {
+                body: body,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -204,8 +205,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.delete<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
+        return this.httpClient.request<any>("delete",
+            `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -264,8 +267,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByStatus`,
+        return this.httpClient.request<Array<Pet>>("get",
+            `${this.configuration.basePath}/pet/findByStatus`,
             {
+                body: null,
                 params: queryParameters,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
@@ -326,8 +331,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByTags`,
+        return this.httpClient.request<Array<Pet>>("get",
+            `${this.configuration.basePath}/pet/findByTags`,
             {
+                body: null,
                 params: queryParameters,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
@@ -381,8 +388,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<Pet>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
+        return this.httpClient.request<Pet>("get",
+            `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -442,9 +451,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.put<any>(`${this.configuration.basePath}/pet`,
-            body,
+        return this.httpClient.request<any>("put",
+            `${this.configuration.basePath}/pet`,
             {
+                body: body,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -518,9 +528,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.post<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
-            convertFormParamsToString ? formParams.toString() : formParams,
+        return this.httpClient.request<any>("post",
+            `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
+                body: convertFormParamsToString ? formParams.toString() : formParams,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -598,9 +609,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.post<ApiResponse>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}/uploadImage`,
-            convertFormParamsToString ? formParams.toString() : formParams,
+        return this.httpClient.request<ApiResponse>("post",
+            `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}/uploadImage`,
             {
+                body: convertFormParamsToString ? formParams.toString() : formParams,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,

--- a/samples/client/petstore/typescript-angular-v10-provided-in-root/builds/with-npm/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v10-provided-in-root/builds/with-npm/api/store.service.ts
@@ -121,7 +121,6 @@ export class StoreService {
         return this.httpClient.request<any>("delete",
             `${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -172,7 +171,6 @@ export class StoreService {
         return this.httpClient.request<{ [key: string]: number; }>("get",
             `${this.configuration.basePath}/store/inventory`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -221,7 +219,6 @@ export class StoreService {
         return this.httpClient.request<Order>("get",
             `${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,

--- a/samples/client/petstore/typescript-angular-v10-provided-in-root/builds/with-npm/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v10-provided-in-root/builds/with-npm/api/store.service.ts
@@ -118,8 +118,10 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.delete<any>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
+        return this.httpClient.request<any>("delete",
+            `${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -167,8 +169,10 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<{ [key: string]: number; }>(`${this.configuration.basePath}/store/inventory`,
+        return this.httpClient.request<{ [key: string]: number; }>("get",
+            `${this.configuration.basePath}/store/inventory`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -214,8 +218,10 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<Order>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
+        return this.httpClient.request<Order>("get",
+            `${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -268,9 +274,10 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.post<Order>(`${this.configuration.basePath}/store/order`,
-            body,
+        return this.httpClient.request<Order>("post",
+            `${this.configuration.basePath}/store/order`,
             {
+                body: body,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,

--- a/samples/client/petstore/typescript-angular-v10-provided-in-root/builds/with-npm/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v10-provided-in-root/builds/with-npm/api/store.service.ts
@@ -118,7 +118,7 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("delete",
+        return this.httpClient.request<any>('delete',
             `${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
             {
                 responseType: <any>responseType,
@@ -168,7 +168,7 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<{ [key: string]: number; }>("get",
+        return this.httpClient.request<{ [key: string]: number; }>('get',
             `${this.configuration.basePath}/store/inventory`,
             {
                 responseType: <any>responseType,
@@ -216,7 +216,7 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<Order>("get",
+        return this.httpClient.request<Order>('get',
             `${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
             {
                 responseType: <any>responseType,
@@ -271,7 +271,7 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<Order>("post",
+        return this.httpClient.request<Order>('post',
             `${this.configuration.basePath}/store/order`,
             {
                 body: body,

--- a/samples/client/petstore/typescript-angular-v10-provided-in-root/builds/with-npm/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v10-provided-in-root/builds/with-npm/api/user.service.ts
@@ -284,7 +284,6 @@ export class UserService {
         return this.httpClient.request<any>("delete",
             `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -332,7 +331,6 @@ export class UserService {
         return this.httpClient.request<User>("get",
             `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -394,7 +392,6 @@ export class UserService {
         return this.httpClient.request<string>("get",
             `${this.configuration.basePath}/user/login`,
             {
-                body: null,
                 params: queryParameters,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
@@ -437,7 +434,6 @@ export class UserService {
         return this.httpClient.request<any>("get",
             `${this.configuration.basePath}/user/logout`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,

--- a/samples/client/petstore/typescript-angular-v10-provided-in-root/builds/with-npm/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v10-provided-in-root/builds/with-npm/api/user.service.ts
@@ -126,9 +126,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.post<any>(`${this.configuration.basePath}/user`,
-            body,
+        return this.httpClient.request<any>("post",
+            `${this.configuration.basePath}/user`,
             {
+                body: body,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -179,9 +180,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.post<any>(`${this.configuration.basePath}/user/createWithArray`,
-            body,
+        return this.httpClient.request<any>("post",
+            `${this.configuration.basePath}/user/createWithArray`,
             {
+                body: body,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -232,9 +234,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.post<any>(`${this.configuration.basePath}/user/createWithList`,
-            body,
+        return this.httpClient.request<any>("post",
+            `${this.configuration.basePath}/user/createWithList`,
             {
+                body: body,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -278,8 +281,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.delete<any>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
+        return this.httpClient.request<any>("delete",
+            `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -324,8 +329,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<User>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
+        return this.httpClient.request<User>("get",
+            `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -384,8 +391,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<string>(`${this.configuration.basePath}/user/login`,
+        return this.httpClient.request<string>("get",
+            `${this.configuration.basePath}/user/login`,
             {
+                body: null,
                 params: queryParameters,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
@@ -425,8 +434,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<any>(`${this.configuration.basePath}/user/logout`,
+        return this.httpClient.request<any>("get",
+            `${this.configuration.basePath}/user/logout`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -482,9 +493,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.put<any>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
-            body,
+        return this.httpClient.request<any>("put",
+            `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
+                body: body,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,

--- a/samples/client/petstore/typescript-angular-v10-provided-in-root/builds/with-npm/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v10-provided-in-root/builds/with-npm/api/user.service.ts
@@ -126,7 +126,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("post",
+        return this.httpClient.request<any>('post',
             `${this.configuration.basePath}/user`,
             {
                 body: body,
@@ -180,7 +180,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("post",
+        return this.httpClient.request<any>('post',
             `${this.configuration.basePath}/user/createWithArray`,
             {
                 body: body,
@@ -234,7 +234,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("post",
+        return this.httpClient.request<any>('post',
             `${this.configuration.basePath}/user/createWithList`,
             {
                 body: body,
@@ -281,7 +281,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("delete",
+        return this.httpClient.request<any>('delete',
             `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
                 responseType: <any>responseType,
@@ -328,7 +328,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<User>("get",
+        return this.httpClient.request<User>('get',
             `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
                 responseType: <any>responseType,
@@ -389,7 +389,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<string>("get",
+        return this.httpClient.request<string>('get',
             `${this.configuration.basePath}/user/login`,
             {
                 params: queryParameters,
@@ -431,7 +431,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("get",
+        return this.httpClient.request<any>('get',
             `${this.configuration.basePath}/user/logout`,
             {
                 responseType: <any>responseType,
@@ -489,7 +489,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("put",
+        return this.httpClient.request<any>('put',
             `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
                 body: body,

--- a/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/default/api/pet.service.ts
@@ -206,7 +206,6 @@ export class PetService {
         return this.httpClient.request<any>("delete",
             `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -268,7 +267,6 @@ export class PetService {
         return this.httpClient.request<Array<Pet>>("get",
             `${this.configuration.basePath}/pet/findByStatus`,
             {
-                body: null,
                 params: queryParameters,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
@@ -332,7 +330,6 @@ export class PetService {
         return this.httpClient.request<Array<Pet>>("get",
             `${this.configuration.basePath}/pet/findByTags`,
             {
-                body: null,
                 params: queryParameters,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
@@ -389,7 +386,6 @@ export class PetService {
         return this.httpClient.request<Pet>("get",
             `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,

--- a/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/default/api/pet.service.ts
@@ -146,7 +146,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("post",
+        return this.httpClient.request<any>('post',
             `${this.configuration.basePath}/pet`,
             {
                 body: body,
@@ -203,7 +203,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("delete",
+        return this.httpClient.request<any>('delete',
             `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
                 responseType: <any>responseType,
@@ -264,7 +264,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<Array<Pet>>("get",
+        return this.httpClient.request<Array<Pet>>('get',
             `${this.configuration.basePath}/pet/findByStatus`,
             {
                 params: queryParameters,
@@ -327,7 +327,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<Array<Pet>>("get",
+        return this.httpClient.request<Array<Pet>>('get',
             `${this.configuration.basePath}/pet/findByTags`,
             {
                 params: queryParameters,
@@ -383,7 +383,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<Pet>("get",
+        return this.httpClient.request<Pet>('get',
             `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
                 responseType: <any>responseType,
@@ -445,7 +445,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("put",
+        return this.httpClient.request<any>('put',
             `${this.configuration.basePath}/pet`,
             {
                 body: body,
@@ -522,7 +522,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("post",
+        return this.httpClient.request<any>('post',
             `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
                 body: convertFormParamsToString ? formParams.toString() : formParams,
@@ -603,7 +603,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<ApiResponse>("post",
+        return this.httpClient.request<ApiResponse>('post',
             `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}/uploadImage`,
             {
                 body: convertFormParamsToString ? formParams.toString() : formParams,

--- a/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/default/api/pet.service.ts
@@ -146,9 +146,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.post<any>(`${this.configuration.basePath}/pet`,
-            body,
+        return this.httpClient.request<any>("post",
+            `${this.configuration.basePath}/pet`,
             {
+                body: body,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -202,8 +203,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.delete<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
+        return this.httpClient.request<any>("delete",
+            `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -262,8 +265,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByStatus`,
+        return this.httpClient.request<Array<Pet>>("get",
+            `${this.configuration.basePath}/pet/findByStatus`,
             {
+                body: null,
                 params: queryParameters,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
@@ -324,8 +329,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByTags`,
+        return this.httpClient.request<Array<Pet>>("get",
+            `${this.configuration.basePath}/pet/findByTags`,
             {
+                body: null,
                 params: queryParameters,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
@@ -379,8 +386,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<Pet>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
+        return this.httpClient.request<Pet>("get",
+            `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -440,9 +449,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.put<any>(`${this.configuration.basePath}/pet`,
-            body,
+        return this.httpClient.request<any>("put",
+            `${this.configuration.basePath}/pet`,
             {
+                body: body,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -516,9 +526,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.post<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
-            convertFormParamsToString ? formParams.toString() : formParams,
+        return this.httpClient.request<any>("post",
+            `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
+                body: convertFormParamsToString ? formParams.toString() : formParams,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -596,9 +607,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.post<ApiResponse>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}/uploadImage`,
-            convertFormParamsToString ? formParams.toString() : formParams,
+        return this.httpClient.request<ApiResponse>("post",
+            `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}/uploadImage`,
             {
+                body: convertFormParamsToString ? formParams.toString() : formParams,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,

--- a/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/default/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/default/api/store.service.ts
@@ -116,8 +116,10 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.delete<any>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
+        return this.httpClient.request<any>("delete",
+            `${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -165,8 +167,10 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<{ [key: string]: number; }>(`${this.configuration.basePath}/store/inventory`,
+        return this.httpClient.request<{ [key: string]: number; }>("get",
+            `${this.configuration.basePath}/store/inventory`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -212,8 +216,10 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<Order>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
+        return this.httpClient.request<Order>("get",
+            `${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -266,9 +272,10 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.post<Order>(`${this.configuration.basePath}/store/order`,
-            body,
+        return this.httpClient.request<Order>("post",
+            `${this.configuration.basePath}/store/order`,
             {
+                body: body,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,

--- a/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/default/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/default/api/store.service.ts
@@ -119,7 +119,6 @@ export class StoreService {
         return this.httpClient.request<any>("delete",
             `${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -170,7 +169,6 @@ export class StoreService {
         return this.httpClient.request<{ [key: string]: number; }>("get",
             `${this.configuration.basePath}/store/inventory`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -219,7 +217,6 @@ export class StoreService {
         return this.httpClient.request<Order>("get",
             `${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,

--- a/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/default/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/default/api/store.service.ts
@@ -116,7 +116,7 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("delete",
+        return this.httpClient.request<any>('delete',
             `${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
             {
                 responseType: <any>responseType,
@@ -166,7 +166,7 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<{ [key: string]: number; }>("get",
+        return this.httpClient.request<{ [key: string]: number; }>('get',
             `${this.configuration.basePath}/store/inventory`,
             {
                 responseType: <any>responseType,
@@ -214,7 +214,7 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<Order>("get",
+        return this.httpClient.request<Order>('get',
             `${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
             {
                 responseType: <any>responseType,
@@ -269,7 +269,7 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<Order>("post",
+        return this.httpClient.request<Order>('post',
             `${this.configuration.basePath}/store/order`,
             {
                 body: body,

--- a/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/default/api/user.service.ts
@@ -282,7 +282,6 @@ export class UserService {
         return this.httpClient.request<any>("delete",
             `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -330,7 +329,6 @@ export class UserService {
         return this.httpClient.request<User>("get",
             `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -392,7 +390,6 @@ export class UserService {
         return this.httpClient.request<string>("get",
             `${this.configuration.basePath}/user/login`,
             {
-                body: null,
                 params: queryParameters,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
@@ -435,7 +432,6 @@ export class UserService {
         return this.httpClient.request<any>("get",
             `${this.configuration.basePath}/user/logout`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,

--- a/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/default/api/user.service.ts
@@ -124,9 +124,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.post<any>(`${this.configuration.basePath}/user`,
-            body,
+        return this.httpClient.request<any>("post",
+            `${this.configuration.basePath}/user`,
             {
+                body: body,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -177,9 +178,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.post<any>(`${this.configuration.basePath}/user/createWithArray`,
-            body,
+        return this.httpClient.request<any>("post",
+            `${this.configuration.basePath}/user/createWithArray`,
             {
+                body: body,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -230,9 +232,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.post<any>(`${this.configuration.basePath}/user/createWithList`,
-            body,
+        return this.httpClient.request<any>("post",
+            `${this.configuration.basePath}/user/createWithList`,
             {
+                body: body,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -276,8 +279,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.delete<any>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
+        return this.httpClient.request<any>("delete",
+            `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -322,8 +327,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<User>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
+        return this.httpClient.request<User>("get",
+            `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -382,8 +389,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<string>(`${this.configuration.basePath}/user/login`,
+        return this.httpClient.request<string>("get",
+            `${this.configuration.basePath}/user/login`,
             {
+                body: null,
                 params: queryParameters,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
@@ -423,8 +432,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<any>(`${this.configuration.basePath}/user/logout`,
+        return this.httpClient.request<any>("get",
+            `${this.configuration.basePath}/user/logout`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -480,9 +491,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.put<any>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
-            body,
+        return this.httpClient.request<any>("put",
+            `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
+                body: body,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,

--- a/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/default/api/user.service.ts
@@ -124,7 +124,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("post",
+        return this.httpClient.request<any>('post',
             `${this.configuration.basePath}/user`,
             {
                 body: body,
@@ -178,7 +178,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("post",
+        return this.httpClient.request<any>('post',
             `${this.configuration.basePath}/user/createWithArray`,
             {
                 body: body,
@@ -232,7 +232,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("post",
+        return this.httpClient.request<any>('post',
             `${this.configuration.basePath}/user/createWithList`,
             {
                 body: body,
@@ -279,7 +279,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("delete",
+        return this.httpClient.request<any>('delete',
             `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
                 responseType: <any>responseType,
@@ -326,7 +326,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<User>("get",
+        return this.httpClient.request<User>('get',
             `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
                 responseType: <any>responseType,
@@ -387,7 +387,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<string>("get",
+        return this.httpClient.request<string>('get',
             `${this.configuration.basePath}/user/login`,
             {
                 params: queryParameters,
@@ -429,7 +429,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("get",
+        return this.httpClient.request<any>('get',
             `${this.configuration.basePath}/user/logout`,
             {
                 responseType: <any>responseType,
@@ -487,7 +487,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("put",
+        return this.httpClient.request<any>('put',
             `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
                 body: body,

--- a/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/with-npm/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/with-npm/api/pet.service.ts
@@ -206,7 +206,6 @@ export class PetService {
         return this.httpClient.request<any>("delete",
             `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -268,7 +267,6 @@ export class PetService {
         return this.httpClient.request<Array<Pet>>("get",
             `${this.configuration.basePath}/pet/findByStatus`,
             {
-                body: null,
                 params: queryParameters,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
@@ -332,7 +330,6 @@ export class PetService {
         return this.httpClient.request<Array<Pet>>("get",
             `${this.configuration.basePath}/pet/findByTags`,
             {
-                body: null,
                 params: queryParameters,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
@@ -389,7 +386,6 @@ export class PetService {
         return this.httpClient.request<Pet>("get",
             `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,

--- a/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/with-npm/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/with-npm/api/pet.service.ts
@@ -146,7 +146,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("post",
+        return this.httpClient.request<any>('post',
             `${this.configuration.basePath}/pet`,
             {
                 body: body,
@@ -203,7 +203,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("delete",
+        return this.httpClient.request<any>('delete',
             `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
                 responseType: <any>responseType,
@@ -264,7 +264,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<Array<Pet>>("get",
+        return this.httpClient.request<Array<Pet>>('get',
             `${this.configuration.basePath}/pet/findByStatus`,
             {
                 params: queryParameters,
@@ -327,7 +327,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<Array<Pet>>("get",
+        return this.httpClient.request<Array<Pet>>('get',
             `${this.configuration.basePath}/pet/findByTags`,
             {
                 params: queryParameters,
@@ -383,7 +383,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<Pet>("get",
+        return this.httpClient.request<Pet>('get',
             `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
                 responseType: <any>responseType,
@@ -445,7 +445,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("put",
+        return this.httpClient.request<any>('put',
             `${this.configuration.basePath}/pet`,
             {
                 body: body,
@@ -522,7 +522,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("post",
+        return this.httpClient.request<any>('post',
             `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
                 body: convertFormParamsToString ? formParams.toString() : formParams,
@@ -603,7 +603,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<ApiResponse>("post",
+        return this.httpClient.request<ApiResponse>('post',
             `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}/uploadImage`,
             {
                 body: convertFormParamsToString ? formParams.toString() : formParams,

--- a/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/with-npm/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/with-npm/api/pet.service.ts
@@ -146,9 +146,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.post<any>(`${this.configuration.basePath}/pet`,
-            body,
+        return this.httpClient.request<any>("post",
+            `${this.configuration.basePath}/pet`,
             {
+                body: body,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -202,8 +203,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.delete<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
+        return this.httpClient.request<any>("delete",
+            `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -262,8 +265,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByStatus`,
+        return this.httpClient.request<Array<Pet>>("get",
+            `${this.configuration.basePath}/pet/findByStatus`,
             {
+                body: null,
                 params: queryParameters,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
@@ -324,8 +329,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByTags`,
+        return this.httpClient.request<Array<Pet>>("get",
+            `${this.configuration.basePath}/pet/findByTags`,
             {
+                body: null,
                 params: queryParameters,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
@@ -379,8 +386,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<Pet>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
+        return this.httpClient.request<Pet>("get",
+            `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -440,9 +449,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.put<any>(`${this.configuration.basePath}/pet`,
-            body,
+        return this.httpClient.request<any>("put",
+            `${this.configuration.basePath}/pet`,
             {
+                body: body,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -516,9 +526,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.post<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
-            convertFormParamsToString ? formParams.toString() : formParams,
+        return this.httpClient.request<any>("post",
+            `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
+                body: convertFormParamsToString ? formParams.toString() : formParams,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -596,9 +607,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.post<ApiResponse>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}/uploadImage`,
-            convertFormParamsToString ? formParams.toString() : formParams,
+        return this.httpClient.request<ApiResponse>("post",
+            `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}/uploadImage`,
             {
+                body: convertFormParamsToString ? formParams.toString() : formParams,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,

--- a/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/with-npm/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/with-npm/api/store.service.ts
@@ -116,8 +116,10 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.delete<any>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
+        return this.httpClient.request<any>("delete",
+            `${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -165,8 +167,10 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<{ [key: string]: number; }>(`${this.configuration.basePath}/store/inventory`,
+        return this.httpClient.request<{ [key: string]: number; }>("get",
+            `${this.configuration.basePath}/store/inventory`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -212,8 +216,10 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<Order>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
+        return this.httpClient.request<Order>("get",
+            `${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -266,9 +272,10 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.post<Order>(`${this.configuration.basePath}/store/order`,
-            body,
+        return this.httpClient.request<Order>("post",
+            `${this.configuration.basePath}/store/order`,
             {
+                body: body,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,

--- a/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/with-npm/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/with-npm/api/store.service.ts
@@ -119,7 +119,6 @@ export class StoreService {
         return this.httpClient.request<any>("delete",
             `${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -170,7 +169,6 @@ export class StoreService {
         return this.httpClient.request<{ [key: string]: number; }>("get",
             `${this.configuration.basePath}/store/inventory`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -219,7 +217,6 @@ export class StoreService {
         return this.httpClient.request<Order>("get",
             `${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,

--- a/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/with-npm/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/with-npm/api/store.service.ts
@@ -116,7 +116,7 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("delete",
+        return this.httpClient.request<any>('delete',
             `${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
             {
                 responseType: <any>responseType,
@@ -166,7 +166,7 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<{ [key: string]: number; }>("get",
+        return this.httpClient.request<{ [key: string]: number; }>('get',
             `${this.configuration.basePath}/store/inventory`,
             {
                 responseType: <any>responseType,
@@ -214,7 +214,7 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<Order>("get",
+        return this.httpClient.request<Order>('get',
             `${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
             {
                 responseType: <any>responseType,
@@ -269,7 +269,7 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<Order>("post",
+        return this.httpClient.request<Order>('post',
             `${this.configuration.basePath}/store/order`,
             {
                 body: body,

--- a/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/with-npm/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/with-npm/api/user.service.ts
@@ -282,7 +282,6 @@ export class UserService {
         return this.httpClient.request<any>("delete",
             `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -330,7 +329,6 @@ export class UserService {
         return this.httpClient.request<User>("get",
             `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -392,7 +390,6 @@ export class UserService {
         return this.httpClient.request<string>("get",
             `${this.configuration.basePath}/user/login`,
             {
-                body: null,
                 params: queryParameters,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
@@ -435,7 +432,6 @@ export class UserService {
         return this.httpClient.request<any>("get",
             `${this.configuration.basePath}/user/logout`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,

--- a/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/with-npm/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/with-npm/api/user.service.ts
@@ -124,9 +124,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.post<any>(`${this.configuration.basePath}/user`,
-            body,
+        return this.httpClient.request<any>("post",
+            `${this.configuration.basePath}/user`,
             {
+                body: body,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -177,9 +178,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.post<any>(`${this.configuration.basePath}/user/createWithArray`,
-            body,
+        return this.httpClient.request<any>("post",
+            `${this.configuration.basePath}/user/createWithArray`,
             {
+                body: body,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -230,9 +232,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.post<any>(`${this.configuration.basePath}/user/createWithList`,
-            body,
+        return this.httpClient.request<any>("post",
+            `${this.configuration.basePath}/user/createWithList`,
             {
+                body: body,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -276,8 +279,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.delete<any>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
+        return this.httpClient.request<any>("delete",
+            `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -322,8 +327,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<User>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
+        return this.httpClient.request<User>("get",
+            `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -382,8 +389,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<string>(`${this.configuration.basePath}/user/login`,
+        return this.httpClient.request<string>("get",
+            `${this.configuration.basePath}/user/login`,
             {
+                body: null,
                 params: queryParameters,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
@@ -423,8 +432,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<any>(`${this.configuration.basePath}/user/logout`,
+        return this.httpClient.request<any>("get",
+            `${this.configuration.basePath}/user/logout`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -480,9 +491,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.put<any>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
-            body,
+        return this.httpClient.request<any>("put",
+            `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
+                body: body,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,

--- a/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/with-npm/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/with-npm/api/user.service.ts
@@ -124,7 +124,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("post",
+        return this.httpClient.request<any>('post',
             `${this.configuration.basePath}/user`,
             {
                 body: body,
@@ -178,7 +178,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("post",
+        return this.httpClient.request<any>('post',
             `${this.configuration.basePath}/user/createWithArray`,
             {
                 body: body,
@@ -232,7 +232,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("post",
+        return this.httpClient.request<any>('post',
             `${this.configuration.basePath}/user/createWithList`,
             {
                 body: body,
@@ -279,7 +279,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("delete",
+        return this.httpClient.request<any>('delete',
             `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
                 responseType: <any>responseType,
@@ -326,7 +326,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<User>("get",
+        return this.httpClient.request<User>('get',
             `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
                 responseType: <any>responseType,
@@ -387,7 +387,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<string>("get",
+        return this.httpClient.request<string>('get',
             `${this.configuration.basePath}/user/login`,
             {
                 params: queryParameters,
@@ -429,7 +429,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("get",
+        return this.httpClient.request<any>('get',
             `${this.configuration.basePath}/user/logout`,
             {
                 responseType: <any>responseType,
@@ -487,7 +487,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("put",
+        return this.httpClient.request<any>('put',
             `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
                 body: body,

--- a/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/default/api/pet.service.ts
@@ -148,7 +148,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("post",
+        return this.httpClient.request<any>('post',
             `${this.configuration.basePath}/pet`,
             {
                 body: body,
@@ -205,7 +205,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("delete",
+        return this.httpClient.request<any>('delete',
             `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
                 responseType: <any>responseType,
@@ -266,7 +266,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<Array<Pet>>("get",
+        return this.httpClient.request<Array<Pet>>('get',
             `${this.configuration.basePath}/pet/findByStatus`,
             {
                 params: queryParameters,
@@ -329,7 +329,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<Array<Pet>>("get",
+        return this.httpClient.request<Array<Pet>>('get',
             `${this.configuration.basePath}/pet/findByTags`,
             {
                 params: queryParameters,
@@ -385,7 +385,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<Pet>("get",
+        return this.httpClient.request<Pet>('get',
             `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
                 responseType: <any>responseType,
@@ -447,7 +447,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("put",
+        return this.httpClient.request<any>('put',
             `${this.configuration.basePath}/pet`,
             {
                 body: body,
@@ -524,7 +524,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("post",
+        return this.httpClient.request<any>('post',
             `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
                 body: convertFormParamsToString ? formParams.toString() : formParams,
@@ -605,7 +605,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<ApiResponse>("post",
+        return this.httpClient.request<ApiResponse>('post',
             `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}/uploadImage`,
             {
                 body: convertFormParamsToString ? formParams.toString() : formParams,

--- a/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/default/api/pet.service.ts
@@ -208,7 +208,6 @@ export class PetService {
         return this.httpClient.request<any>("delete",
             `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -270,7 +269,6 @@ export class PetService {
         return this.httpClient.request<Array<Pet>>("get",
             `${this.configuration.basePath}/pet/findByStatus`,
             {
-                body: null,
                 params: queryParameters,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
@@ -334,7 +332,6 @@ export class PetService {
         return this.httpClient.request<Array<Pet>>("get",
             `${this.configuration.basePath}/pet/findByTags`,
             {
-                body: null,
                 params: queryParameters,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
@@ -391,7 +388,6 @@ export class PetService {
         return this.httpClient.request<Pet>("get",
             `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,

--- a/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/default/api/pet.service.ts
@@ -148,9 +148,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.post<any>(`${this.configuration.basePath}/pet`,
-            body,
+        return this.httpClient.request<any>("post",
+            `${this.configuration.basePath}/pet`,
             {
+                body: body,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -204,8 +205,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.delete<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
+        return this.httpClient.request<any>("delete",
+            `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -264,8 +267,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByStatus`,
+        return this.httpClient.request<Array<Pet>>("get",
+            `${this.configuration.basePath}/pet/findByStatus`,
             {
+                body: null,
                 params: queryParameters,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
@@ -326,8 +331,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByTags`,
+        return this.httpClient.request<Array<Pet>>("get",
+            `${this.configuration.basePath}/pet/findByTags`,
             {
+                body: null,
                 params: queryParameters,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
@@ -381,8 +388,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<Pet>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
+        return this.httpClient.request<Pet>("get",
+            `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -442,9 +451,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.put<any>(`${this.configuration.basePath}/pet`,
-            body,
+        return this.httpClient.request<any>("put",
+            `${this.configuration.basePath}/pet`,
             {
+                body: body,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -518,9 +528,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.post<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
-            convertFormParamsToString ? formParams.toString() : formParams,
+        return this.httpClient.request<any>("post",
+            `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
+                body: convertFormParamsToString ? formParams.toString() : formParams,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -598,9 +609,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.post<ApiResponse>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}/uploadImage`,
-            convertFormParamsToString ? formParams.toString() : formParams,
+        return this.httpClient.request<ApiResponse>("post",
+            `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}/uploadImage`,
             {
+                body: convertFormParamsToString ? formParams.toString() : formParams,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,

--- a/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/default/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/default/api/store.service.ts
@@ -121,7 +121,6 @@ export class StoreService {
         return this.httpClient.request<any>("delete",
             `${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -172,7 +171,6 @@ export class StoreService {
         return this.httpClient.request<{ [key: string]: number; }>("get",
             `${this.configuration.basePath}/store/inventory`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -221,7 +219,6 @@ export class StoreService {
         return this.httpClient.request<Order>("get",
             `${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,

--- a/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/default/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/default/api/store.service.ts
@@ -118,8 +118,10 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.delete<any>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
+        return this.httpClient.request<any>("delete",
+            `${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -167,8 +169,10 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<{ [key: string]: number; }>(`${this.configuration.basePath}/store/inventory`,
+        return this.httpClient.request<{ [key: string]: number; }>("get",
+            `${this.configuration.basePath}/store/inventory`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -214,8 +218,10 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<Order>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
+        return this.httpClient.request<Order>("get",
+            `${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -268,9 +274,10 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.post<Order>(`${this.configuration.basePath}/store/order`,
-            body,
+        return this.httpClient.request<Order>("post",
+            `${this.configuration.basePath}/store/order`,
             {
+                body: body,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,

--- a/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/default/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/default/api/store.service.ts
@@ -118,7 +118,7 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("delete",
+        return this.httpClient.request<any>('delete',
             `${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
             {
                 responseType: <any>responseType,
@@ -168,7 +168,7 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<{ [key: string]: number; }>("get",
+        return this.httpClient.request<{ [key: string]: number; }>('get',
             `${this.configuration.basePath}/store/inventory`,
             {
                 responseType: <any>responseType,
@@ -216,7 +216,7 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<Order>("get",
+        return this.httpClient.request<Order>('get',
             `${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
             {
                 responseType: <any>responseType,
@@ -271,7 +271,7 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<Order>("post",
+        return this.httpClient.request<Order>('post',
             `${this.configuration.basePath}/store/order`,
             {
                 body: body,

--- a/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/default/api/user.service.ts
@@ -284,7 +284,6 @@ export class UserService {
         return this.httpClient.request<any>("delete",
             `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -332,7 +331,6 @@ export class UserService {
         return this.httpClient.request<User>("get",
             `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -394,7 +392,6 @@ export class UserService {
         return this.httpClient.request<string>("get",
             `${this.configuration.basePath}/user/login`,
             {
-                body: null,
                 params: queryParameters,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
@@ -437,7 +434,6 @@ export class UserService {
         return this.httpClient.request<any>("get",
             `${this.configuration.basePath}/user/logout`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,

--- a/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/default/api/user.service.ts
@@ -126,9 +126,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.post<any>(`${this.configuration.basePath}/user`,
-            body,
+        return this.httpClient.request<any>("post",
+            `${this.configuration.basePath}/user`,
             {
+                body: body,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -179,9 +180,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.post<any>(`${this.configuration.basePath}/user/createWithArray`,
-            body,
+        return this.httpClient.request<any>("post",
+            `${this.configuration.basePath}/user/createWithArray`,
             {
+                body: body,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -232,9 +234,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.post<any>(`${this.configuration.basePath}/user/createWithList`,
-            body,
+        return this.httpClient.request<any>("post",
+            `${this.configuration.basePath}/user/createWithList`,
             {
+                body: body,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -278,8 +281,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.delete<any>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
+        return this.httpClient.request<any>("delete",
+            `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -324,8 +329,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<User>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
+        return this.httpClient.request<User>("get",
+            `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -384,8 +391,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<string>(`${this.configuration.basePath}/user/login`,
+        return this.httpClient.request<string>("get",
+            `${this.configuration.basePath}/user/login`,
             {
+                body: null,
                 params: queryParameters,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
@@ -425,8 +434,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<any>(`${this.configuration.basePath}/user/logout`,
+        return this.httpClient.request<any>("get",
+            `${this.configuration.basePath}/user/logout`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -482,9 +493,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.put<any>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
-            body,
+        return this.httpClient.request<any>("put",
+            `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
+                body: body,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,

--- a/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/default/api/user.service.ts
@@ -126,7 +126,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("post",
+        return this.httpClient.request<any>('post',
             `${this.configuration.basePath}/user`,
             {
                 body: body,
@@ -180,7 +180,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("post",
+        return this.httpClient.request<any>('post',
             `${this.configuration.basePath}/user/createWithArray`,
             {
                 body: body,
@@ -234,7 +234,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("post",
+        return this.httpClient.request<any>('post',
             `${this.configuration.basePath}/user/createWithList`,
             {
                 body: body,
@@ -281,7 +281,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("delete",
+        return this.httpClient.request<any>('delete',
             `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
                 responseType: <any>responseType,
@@ -328,7 +328,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<User>("get",
+        return this.httpClient.request<User>('get',
             `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
                 responseType: <any>responseType,
@@ -389,7 +389,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<string>("get",
+        return this.httpClient.request<string>('get',
             `${this.configuration.basePath}/user/login`,
             {
                 params: queryParameters,
@@ -431,7 +431,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("get",
+        return this.httpClient.request<any>('get',
             `${this.configuration.basePath}/user/logout`,
             {
                 responseType: <any>responseType,
@@ -489,7 +489,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("put",
+        return this.httpClient.request<any>('put',
             `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
                 body: body,

--- a/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/with-npm/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/with-npm/api/pet.service.ts
@@ -148,7 +148,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("post",
+        return this.httpClient.request<any>('post',
             `${this.configuration.basePath}/pet`,
             {
                 body: body,
@@ -205,7 +205,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("delete",
+        return this.httpClient.request<any>('delete',
             `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
                 responseType: <any>responseType,
@@ -266,7 +266,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<Array<Pet>>("get",
+        return this.httpClient.request<Array<Pet>>('get',
             `${this.configuration.basePath}/pet/findByStatus`,
             {
                 params: queryParameters,
@@ -329,7 +329,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<Array<Pet>>("get",
+        return this.httpClient.request<Array<Pet>>('get',
             `${this.configuration.basePath}/pet/findByTags`,
             {
                 params: queryParameters,
@@ -385,7 +385,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<Pet>("get",
+        return this.httpClient.request<Pet>('get',
             `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
                 responseType: <any>responseType,
@@ -447,7 +447,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("put",
+        return this.httpClient.request<any>('put',
             `${this.configuration.basePath}/pet`,
             {
                 body: body,
@@ -524,7 +524,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("post",
+        return this.httpClient.request<any>('post',
             `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
                 body: convertFormParamsToString ? formParams.toString() : formParams,
@@ -605,7 +605,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<ApiResponse>("post",
+        return this.httpClient.request<ApiResponse>('post',
             `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}/uploadImage`,
             {
                 body: convertFormParamsToString ? formParams.toString() : formParams,

--- a/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/with-npm/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/with-npm/api/pet.service.ts
@@ -208,7 +208,6 @@ export class PetService {
         return this.httpClient.request<any>("delete",
             `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -270,7 +269,6 @@ export class PetService {
         return this.httpClient.request<Array<Pet>>("get",
             `${this.configuration.basePath}/pet/findByStatus`,
             {
-                body: null,
                 params: queryParameters,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
@@ -334,7 +332,6 @@ export class PetService {
         return this.httpClient.request<Array<Pet>>("get",
             `${this.configuration.basePath}/pet/findByTags`,
             {
-                body: null,
                 params: queryParameters,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
@@ -391,7 +388,6 @@ export class PetService {
         return this.httpClient.request<Pet>("get",
             `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,

--- a/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/with-npm/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/with-npm/api/pet.service.ts
@@ -148,9 +148,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.post<any>(`${this.configuration.basePath}/pet`,
-            body,
+        return this.httpClient.request<any>("post",
+            `${this.configuration.basePath}/pet`,
             {
+                body: body,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -204,8 +205,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.delete<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
+        return this.httpClient.request<any>("delete",
+            `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -264,8 +267,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByStatus`,
+        return this.httpClient.request<Array<Pet>>("get",
+            `${this.configuration.basePath}/pet/findByStatus`,
             {
+                body: null,
                 params: queryParameters,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
@@ -326,8 +331,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByTags`,
+        return this.httpClient.request<Array<Pet>>("get",
+            `${this.configuration.basePath}/pet/findByTags`,
             {
+                body: null,
                 params: queryParameters,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
@@ -381,8 +388,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<Pet>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
+        return this.httpClient.request<Pet>("get",
+            `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -442,9 +451,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.put<any>(`${this.configuration.basePath}/pet`,
-            body,
+        return this.httpClient.request<any>("put",
+            `${this.configuration.basePath}/pet`,
             {
+                body: body,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -518,9 +528,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.post<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
-            convertFormParamsToString ? formParams.toString() : formParams,
+        return this.httpClient.request<any>("post",
+            `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
+                body: convertFormParamsToString ? formParams.toString() : formParams,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -598,9 +609,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.post<ApiResponse>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}/uploadImage`,
-            convertFormParamsToString ? formParams.toString() : formParams,
+        return this.httpClient.request<ApiResponse>("post",
+            `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}/uploadImage`,
             {
+                body: convertFormParamsToString ? formParams.toString() : formParams,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,

--- a/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/with-npm/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/with-npm/api/store.service.ts
@@ -121,7 +121,6 @@ export class StoreService {
         return this.httpClient.request<any>("delete",
             `${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -172,7 +171,6 @@ export class StoreService {
         return this.httpClient.request<{ [key: string]: number; }>("get",
             `${this.configuration.basePath}/store/inventory`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -221,7 +219,6 @@ export class StoreService {
         return this.httpClient.request<Order>("get",
             `${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,

--- a/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/with-npm/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/with-npm/api/store.service.ts
@@ -118,8 +118,10 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.delete<any>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
+        return this.httpClient.request<any>("delete",
+            `${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -167,8 +169,10 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<{ [key: string]: number; }>(`${this.configuration.basePath}/store/inventory`,
+        return this.httpClient.request<{ [key: string]: number; }>("get",
+            `${this.configuration.basePath}/store/inventory`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -214,8 +218,10 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<Order>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
+        return this.httpClient.request<Order>("get",
+            `${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -268,9 +274,10 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.post<Order>(`${this.configuration.basePath}/store/order`,
-            body,
+        return this.httpClient.request<Order>("post",
+            `${this.configuration.basePath}/store/order`,
             {
+                body: body,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,

--- a/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/with-npm/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/with-npm/api/store.service.ts
@@ -118,7 +118,7 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("delete",
+        return this.httpClient.request<any>('delete',
             `${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
             {
                 responseType: <any>responseType,
@@ -168,7 +168,7 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<{ [key: string]: number; }>("get",
+        return this.httpClient.request<{ [key: string]: number; }>('get',
             `${this.configuration.basePath}/store/inventory`,
             {
                 responseType: <any>responseType,
@@ -216,7 +216,7 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<Order>("get",
+        return this.httpClient.request<Order>('get',
             `${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
             {
                 responseType: <any>responseType,
@@ -271,7 +271,7 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<Order>("post",
+        return this.httpClient.request<Order>('post',
             `${this.configuration.basePath}/store/order`,
             {
                 body: body,

--- a/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/with-npm/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/with-npm/api/user.service.ts
@@ -284,7 +284,6 @@ export class UserService {
         return this.httpClient.request<any>("delete",
             `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -332,7 +331,6 @@ export class UserService {
         return this.httpClient.request<User>("get",
             `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -394,7 +392,6 @@ export class UserService {
         return this.httpClient.request<string>("get",
             `${this.configuration.basePath}/user/login`,
             {
-                body: null,
                 params: queryParameters,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
@@ -437,7 +434,6 @@ export class UserService {
         return this.httpClient.request<any>("get",
             `${this.configuration.basePath}/user/logout`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,

--- a/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/with-npm/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/with-npm/api/user.service.ts
@@ -126,9 +126,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.post<any>(`${this.configuration.basePath}/user`,
-            body,
+        return this.httpClient.request<any>("post",
+            `${this.configuration.basePath}/user`,
             {
+                body: body,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -179,9 +180,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.post<any>(`${this.configuration.basePath}/user/createWithArray`,
-            body,
+        return this.httpClient.request<any>("post",
+            `${this.configuration.basePath}/user/createWithArray`,
             {
+                body: body,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -232,9 +234,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.post<any>(`${this.configuration.basePath}/user/createWithList`,
-            body,
+        return this.httpClient.request<any>("post",
+            `${this.configuration.basePath}/user/createWithList`,
             {
+                body: body,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -278,8 +281,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.delete<any>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
+        return this.httpClient.request<any>("delete",
+            `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -324,8 +329,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<User>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
+        return this.httpClient.request<User>("get",
+            `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -384,8 +391,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<string>(`${this.configuration.basePath}/user/login`,
+        return this.httpClient.request<string>("get",
+            `${this.configuration.basePath}/user/login`,
             {
+                body: null,
                 params: queryParameters,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
@@ -425,8 +434,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<any>(`${this.configuration.basePath}/user/logout`,
+        return this.httpClient.request<any>("get",
+            `${this.configuration.basePath}/user/logout`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -482,9 +493,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.put<any>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
-            body,
+        return this.httpClient.request<any>("put",
+            `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
+                body: body,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,

--- a/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/with-npm/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/with-npm/api/user.service.ts
@@ -126,7 +126,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("post",
+        return this.httpClient.request<any>('post',
             `${this.configuration.basePath}/user`,
             {
                 body: body,
@@ -180,7 +180,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("post",
+        return this.httpClient.request<any>('post',
             `${this.configuration.basePath}/user/createWithArray`,
             {
                 body: body,
@@ -234,7 +234,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("post",
+        return this.httpClient.request<any>('post',
             `${this.configuration.basePath}/user/createWithList`,
             {
                 body: body,
@@ -281,7 +281,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("delete",
+        return this.httpClient.request<any>('delete',
             `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
                 responseType: <any>responseType,
@@ -328,7 +328,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<User>("get",
+        return this.httpClient.request<User>('get',
             `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
                 responseType: <any>responseType,
@@ -389,7 +389,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<string>("get",
+        return this.httpClient.request<string>('get',
             `${this.configuration.basePath}/user/login`,
             {
                 params: queryParameters,
@@ -431,7 +431,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("get",
+        return this.httpClient.request<any>('get',
             `${this.configuration.basePath}/user/logout`,
             {
                 responseType: <any>responseType,
@@ -489,7 +489,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("put",
+        return this.httpClient.request<any>('put',
             `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
                 body: body,

--- a/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/default/api/pet.service.ts
@@ -206,7 +206,6 @@ export class PetService {
         return this.httpClient.request<any>("delete",
             `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -268,7 +267,6 @@ export class PetService {
         return this.httpClient.request<Array<Pet>>("get",
             `${this.configuration.basePath}/pet/findByStatus`,
             {
-                body: null,
                 params: queryParameters,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
@@ -332,7 +330,6 @@ export class PetService {
         return this.httpClient.request<Array<Pet>>("get",
             `${this.configuration.basePath}/pet/findByTags`,
             {
-                body: null,
                 params: queryParameters,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
@@ -389,7 +386,6 @@ export class PetService {
         return this.httpClient.request<Pet>("get",
             `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,

--- a/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/default/api/pet.service.ts
@@ -146,7 +146,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("post",
+        return this.httpClient.request<any>('post',
             `${this.configuration.basePath}/pet`,
             {
                 body: body,
@@ -203,7 +203,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("delete",
+        return this.httpClient.request<any>('delete',
             `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
                 responseType: <any>responseType,
@@ -264,7 +264,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<Array<Pet>>("get",
+        return this.httpClient.request<Array<Pet>>('get',
             `${this.configuration.basePath}/pet/findByStatus`,
             {
                 params: queryParameters,
@@ -327,7 +327,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<Array<Pet>>("get",
+        return this.httpClient.request<Array<Pet>>('get',
             `${this.configuration.basePath}/pet/findByTags`,
             {
                 params: queryParameters,
@@ -383,7 +383,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<Pet>("get",
+        return this.httpClient.request<Pet>('get',
             `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
                 responseType: <any>responseType,
@@ -445,7 +445,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("put",
+        return this.httpClient.request<any>('put',
             `${this.configuration.basePath}/pet`,
             {
                 body: body,
@@ -522,7 +522,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("post",
+        return this.httpClient.request<any>('post',
             `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
                 body: convertFormParamsToString ? formParams.toString() : formParams,
@@ -603,7 +603,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<ApiResponse>("post",
+        return this.httpClient.request<ApiResponse>('post',
             `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}/uploadImage`,
             {
                 body: convertFormParamsToString ? formParams.toString() : formParams,

--- a/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/default/api/pet.service.ts
@@ -146,9 +146,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.post<any>(`${this.configuration.basePath}/pet`,
-            body,
+        return this.httpClient.request<any>("post",
+            `${this.configuration.basePath}/pet`,
             {
+                body: body,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -202,8 +203,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.delete<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
+        return this.httpClient.request<any>("delete",
+            `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -262,8 +265,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByStatus`,
+        return this.httpClient.request<Array<Pet>>("get",
+            `${this.configuration.basePath}/pet/findByStatus`,
             {
+                body: null,
                 params: queryParameters,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
@@ -324,8 +329,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByTags`,
+        return this.httpClient.request<Array<Pet>>("get",
+            `${this.configuration.basePath}/pet/findByTags`,
             {
+                body: null,
                 params: queryParameters,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
@@ -379,8 +386,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<Pet>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
+        return this.httpClient.request<Pet>("get",
+            `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -440,9 +449,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.put<any>(`${this.configuration.basePath}/pet`,
-            body,
+        return this.httpClient.request<any>("put",
+            `${this.configuration.basePath}/pet`,
             {
+                body: body,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -516,9 +526,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.post<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
-            convertFormParamsToString ? formParams.toString() : formParams,
+        return this.httpClient.request<any>("post",
+            `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
+                body: convertFormParamsToString ? formParams.toString() : formParams,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -596,9 +607,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.post<ApiResponse>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}/uploadImage`,
-            convertFormParamsToString ? formParams.toString() : formParams,
+        return this.httpClient.request<ApiResponse>("post",
+            `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}/uploadImage`,
             {
+                body: convertFormParamsToString ? formParams.toString() : formParams,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,

--- a/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/default/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/default/api/store.service.ts
@@ -116,8 +116,10 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.delete<any>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
+        return this.httpClient.request<any>("delete",
+            `${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -165,8 +167,10 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<{ [key: string]: number; }>(`${this.configuration.basePath}/store/inventory`,
+        return this.httpClient.request<{ [key: string]: number; }>("get",
+            `${this.configuration.basePath}/store/inventory`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -212,8 +216,10 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<Order>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
+        return this.httpClient.request<Order>("get",
+            `${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -266,9 +272,10 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.post<Order>(`${this.configuration.basePath}/store/order`,
-            body,
+        return this.httpClient.request<Order>("post",
+            `${this.configuration.basePath}/store/order`,
             {
+                body: body,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,

--- a/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/default/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/default/api/store.service.ts
@@ -119,7 +119,6 @@ export class StoreService {
         return this.httpClient.request<any>("delete",
             `${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -170,7 +169,6 @@ export class StoreService {
         return this.httpClient.request<{ [key: string]: number; }>("get",
             `${this.configuration.basePath}/store/inventory`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -219,7 +217,6 @@ export class StoreService {
         return this.httpClient.request<Order>("get",
             `${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,

--- a/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/default/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/default/api/store.service.ts
@@ -116,7 +116,7 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("delete",
+        return this.httpClient.request<any>('delete',
             `${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
             {
                 responseType: <any>responseType,
@@ -166,7 +166,7 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<{ [key: string]: number; }>("get",
+        return this.httpClient.request<{ [key: string]: number; }>('get',
             `${this.configuration.basePath}/store/inventory`,
             {
                 responseType: <any>responseType,
@@ -214,7 +214,7 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<Order>("get",
+        return this.httpClient.request<Order>('get',
             `${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
             {
                 responseType: <any>responseType,
@@ -269,7 +269,7 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<Order>("post",
+        return this.httpClient.request<Order>('post',
             `${this.configuration.basePath}/store/order`,
             {
                 body: body,

--- a/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/default/api/user.service.ts
@@ -282,7 +282,6 @@ export class UserService {
         return this.httpClient.request<any>("delete",
             `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -330,7 +329,6 @@ export class UserService {
         return this.httpClient.request<User>("get",
             `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -392,7 +390,6 @@ export class UserService {
         return this.httpClient.request<string>("get",
             `${this.configuration.basePath}/user/login`,
             {
-                body: null,
                 params: queryParameters,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
@@ -435,7 +432,6 @@ export class UserService {
         return this.httpClient.request<any>("get",
             `${this.configuration.basePath}/user/logout`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,

--- a/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/default/api/user.service.ts
@@ -124,9 +124,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.post<any>(`${this.configuration.basePath}/user`,
-            body,
+        return this.httpClient.request<any>("post",
+            `${this.configuration.basePath}/user`,
             {
+                body: body,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -177,9 +178,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.post<any>(`${this.configuration.basePath}/user/createWithArray`,
-            body,
+        return this.httpClient.request<any>("post",
+            `${this.configuration.basePath}/user/createWithArray`,
             {
+                body: body,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -230,9 +232,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.post<any>(`${this.configuration.basePath}/user/createWithList`,
-            body,
+        return this.httpClient.request<any>("post",
+            `${this.configuration.basePath}/user/createWithList`,
             {
+                body: body,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -276,8 +279,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.delete<any>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
+        return this.httpClient.request<any>("delete",
+            `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -322,8 +327,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<User>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
+        return this.httpClient.request<User>("get",
+            `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -382,8 +389,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<string>(`${this.configuration.basePath}/user/login`,
+        return this.httpClient.request<string>("get",
+            `${this.configuration.basePath}/user/login`,
             {
+                body: null,
                 params: queryParameters,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
@@ -423,8 +432,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<any>(`${this.configuration.basePath}/user/logout`,
+        return this.httpClient.request<any>("get",
+            `${this.configuration.basePath}/user/logout`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -480,9 +491,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.put<any>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
-            body,
+        return this.httpClient.request<any>("put",
+            `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
+                body: body,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,

--- a/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/default/api/user.service.ts
@@ -124,7 +124,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("post",
+        return this.httpClient.request<any>('post',
             `${this.configuration.basePath}/user`,
             {
                 body: body,
@@ -178,7 +178,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("post",
+        return this.httpClient.request<any>('post',
             `${this.configuration.basePath}/user/createWithArray`,
             {
                 body: body,
@@ -232,7 +232,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("post",
+        return this.httpClient.request<any>('post',
             `${this.configuration.basePath}/user/createWithList`,
             {
                 body: body,
@@ -279,7 +279,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("delete",
+        return this.httpClient.request<any>('delete',
             `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
                 responseType: <any>responseType,
@@ -326,7 +326,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<User>("get",
+        return this.httpClient.request<User>('get',
             `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
                 responseType: <any>responseType,
@@ -387,7 +387,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<string>("get",
+        return this.httpClient.request<string>('get',
             `${this.configuration.basePath}/user/login`,
             {
                 params: queryParameters,
@@ -429,7 +429,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("get",
+        return this.httpClient.request<any>('get',
             `${this.configuration.basePath}/user/logout`,
             {
                 responseType: <any>responseType,
@@ -487,7 +487,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("put",
+        return this.httpClient.request<any>('put',
             `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
                 body: body,

--- a/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/with-npm/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/with-npm/api/pet.service.ts
@@ -206,7 +206,6 @@ export class PetService {
         return this.httpClient.request<any>("delete",
             `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -268,7 +267,6 @@ export class PetService {
         return this.httpClient.request<Array<Pet>>("get",
             `${this.configuration.basePath}/pet/findByStatus`,
             {
-                body: null,
                 params: queryParameters,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
@@ -332,7 +330,6 @@ export class PetService {
         return this.httpClient.request<Array<Pet>>("get",
             `${this.configuration.basePath}/pet/findByTags`,
             {
-                body: null,
                 params: queryParameters,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
@@ -389,7 +386,6 @@ export class PetService {
         return this.httpClient.request<Pet>("get",
             `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,

--- a/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/with-npm/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/with-npm/api/pet.service.ts
@@ -146,7 +146,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("post",
+        return this.httpClient.request<any>('post',
             `${this.configuration.basePath}/pet`,
             {
                 body: body,
@@ -203,7 +203,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("delete",
+        return this.httpClient.request<any>('delete',
             `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
                 responseType: <any>responseType,
@@ -264,7 +264,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<Array<Pet>>("get",
+        return this.httpClient.request<Array<Pet>>('get',
             `${this.configuration.basePath}/pet/findByStatus`,
             {
                 params: queryParameters,
@@ -327,7 +327,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<Array<Pet>>("get",
+        return this.httpClient.request<Array<Pet>>('get',
             `${this.configuration.basePath}/pet/findByTags`,
             {
                 params: queryParameters,
@@ -383,7 +383,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<Pet>("get",
+        return this.httpClient.request<Pet>('get',
             `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
                 responseType: <any>responseType,
@@ -445,7 +445,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("put",
+        return this.httpClient.request<any>('put',
             `${this.configuration.basePath}/pet`,
             {
                 body: body,
@@ -522,7 +522,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("post",
+        return this.httpClient.request<any>('post',
             `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
                 body: convertFormParamsToString ? formParams.toString() : formParams,
@@ -603,7 +603,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<ApiResponse>("post",
+        return this.httpClient.request<ApiResponse>('post',
             `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}/uploadImage`,
             {
                 body: convertFormParamsToString ? formParams.toString() : formParams,

--- a/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/with-npm/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/with-npm/api/pet.service.ts
@@ -146,9 +146,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.post<any>(`${this.configuration.basePath}/pet`,
-            body,
+        return this.httpClient.request<any>("post",
+            `${this.configuration.basePath}/pet`,
             {
+                body: body,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -202,8 +203,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.delete<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
+        return this.httpClient.request<any>("delete",
+            `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -262,8 +265,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByStatus`,
+        return this.httpClient.request<Array<Pet>>("get",
+            `${this.configuration.basePath}/pet/findByStatus`,
             {
+                body: null,
                 params: queryParameters,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
@@ -324,8 +329,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByTags`,
+        return this.httpClient.request<Array<Pet>>("get",
+            `${this.configuration.basePath}/pet/findByTags`,
             {
+                body: null,
                 params: queryParameters,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
@@ -379,8 +386,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<Pet>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
+        return this.httpClient.request<Pet>("get",
+            `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -440,9 +449,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.put<any>(`${this.configuration.basePath}/pet`,
-            body,
+        return this.httpClient.request<any>("put",
+            `${this.configuration.basePath}/pet`,
             {
+                body: body,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -516,9 +526,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.post<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
-            convertFormParamsToString ? formParams.toString() : formParams,
+        return this.httpClient.request<any>("post",
+            `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
+                body: convertFormParamsToString ? formParams.toString() : formParams,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -596,9 +607,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.post<ApiResponse>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}/uploadImage`,
-            convertFormParamsToString ? formParams.toString() : formParams,
+        return this.httpClient.request<ApiResponse>("post",
+            `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}/uploadImage`,
             {
+                body: convertFormParamsToString ? formParams.toString() : formParams,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,

--- a/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/with-npm/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/with-npm/api/store.service.ts
@@ -116,8 +116,10 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.delete<any>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
+        return this.httpClient.request<any>("delete",
+            `${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -165,8 +167,10 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<{ [key: string]: number; }>(`${this.configuration.basePath}/store/inventory`,
+        return this.httpClient.request<{ [key: string]: number; }>("get",
+            `${this.configuration.basePath}/store/inventory`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -212,8 +216,10 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<Order>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
+        return this.httpClient.request<Order>("get",
+            `${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -266,9 +272,10 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.post<Order>(`${this.configuration.basePath}/store/order`,
-            body,
+        return this.httpClient.request<Order>("post",
+            `${this.configuration.basePath}/store/order`,
             {
+                body: body,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,

--- a/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/with-npm/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/with-npm/api/store.service.ts
@@ -119,7 +119,6 @@ export class StoreService {
         return this.httpClient.request<any>("delete",
             `${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -170,7 +169,6 @@ export class StoreService {
         return this.httpClient.request<{ [key: string]: number; }>("get",
             `${this.configuration.basePath}/store/inventory`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -219,7 +217,6 @@ export class StoreService {
         return this.httpClient.request<Order>("get",
             `${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,

--- a/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/with-npm/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/with-npm/api/store.service.ts
@@ -116,7 +116,7 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("delete",
+        return this.httpClient.request<any>('delete',
             `${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
             {
                 responseType: <any>responseType,
@@ -166,7 +166,7 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<{ [key: string]: number; }>("get",
+        return this.httpClient.request<{ [key: string]: number; }>('get',
             `${this.configuration.basePath}/store/inventory`,
             {
                 responseType: <any>responseType,
@@ -214,7 +214,7 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<Order>("get",
+        return this.httpClient.request<Order>('get',
             `${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
             {
                 responseType: <any>responseType,
@@ -269,7 +269,7 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<Order>("post",
+        return this.httpClient.request<Order>('post',
             `${this.configuration.basePath}/store/order`,
             {
                 body: body,

--- a/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/with-npm/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/with-npm/api/user.service.ts
@@ -282,7 +282,6 @@ export class UserService {
         return this.httpClient.request<any>("delete",
             `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -330,7 +329,6 @@ export class UserService {
         return this.httpClient.request<User>("get",
             `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -392,7 +390,6 @@ export class UserService {
         return this.httpClient.request<string>("get",
             `${this.configuration.basePath}/user/login`,
             {
-                body: null,
                 params: queryParameters,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
@@ -435,7 +432,6 @@ export class UserService {
         return this.httpClient.request<any>("get",
             `${this.configuration.basePath}/user/logout`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,

--- a/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/with-npm/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/with-npm/api/user.service.ts
@@ -124,9 +124,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.post<any>(`${this.configuration.basePath}/user`,
-            body,
+        return this.httpClient.request<any>("post",
+            `${this.configuration.basePath}/user`,
             {
+                body: body,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -177,9 +178,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.post<any>(`${this.configuration.basePath}/user/createWithArray`,
-            body,
+        return this.httpClient.request<any>("post",
+            `${this.configuration.basePath}/user/createWithArray`,
             {
+                body: body,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -230,9 +232,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.post<any>(`${this.configuration.basePath}/user/createWithList`,
-            body,
+        return this.httpClient.request<any>("post",
+            `${this.configuration.basePath}/user/createWithList`,
             {
+                body: body,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -276,8 +279,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.delete<any>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
+        return this.httpClient.request<any>("delete",
+            `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -322,8 +327,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<User>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
+        return this.httpClient.request<User>("get",
+            `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -382,8 +389,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<string>(`${this.configuration.basePath}/user/login`,
+        return this.httpClient.request<string>("get",
+            `${this.configuration.basePath}/user/login`,
             {
+                body: null,
                 params: queryParameters,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
@@ -423,8 +432,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<any>(`${this.configuration.basePath}/user/logout`,
+        return this.httpClient.request<any>("get",
+            `${this.configuration.basePath}/user/logout`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -480,9 +491,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.put<any>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
-            body,
+        return this.httpClient.request<any>("put",
+            `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
+                body: body,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,

--- a/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/with-npm/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/with-npm/api/user.service.ts
@@ -124,7 +124,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("post",
+        return this.httpClient.request<any>('post',
             `${this.configuration.basePath}/user`,
             {
                 body: body,
@@ -178,7 +178,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("post",
+        return this.httpClient.request<any>('post',
             `${this.configuration.basePath}/user/createWithArray`,
             {
                 body: body,
@@ -232,7 +232,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("post",
+        return this.httpClient.request<any>('post',
             `${this.configuration.basePath}/user/createWithList`,
             {
                 body: body,
@@ -279,7 +279,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("delete",
+        return this.httpClient.request<any>('delete',
             `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
                 responseType: <any>responseType,
@@ -326,7 +326,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<User>("get",
+        return this.httpClient.request<User>('get',
             `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
                 responseType: <any>responseType,
@@ -387,7 +387,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<string>("get",
+        return this.httpClient.request<string>('get',
             `${this.configuration.basePath}/user/login`,
             {
                 params: queryParameters,
@@ -429,7 +429,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("get",
+        return this.httpClient.request<any>('get',
             `${this.configuration.basePath}/user/logout`,
             {
                 responseType: <any>responseType,
@@ -487,7 +487,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("put",
+        return this.httpClient.request<any>('put',
             `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
                 body: body,

--- a/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/default/api/pet.service.ts
@@ -148,7 +148,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("post",
+        return this.httpClient.request<any>('post',
             `${this.configuration.basePath}/pet`,
             {
                 body: body,
@@ -205,7 +205,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("delete",
+        return this.httpClient.request<any>('delete',
             `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
                 responseType: <any>responseType,
@@ -266,7 +266,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<Array<Pet>>("get",
+        return this.httpClient.request<Array<Pet>>('get',
             `${this.configuration.basePath}/pet/findByStatus`,
             {
                 params: queryParameters,
@@ -329,7 +329,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<Array<Pet>>("get",
+        return this.httpClient.request<Array<Pet>>('get',
             `${this.configuration.basePath}/pet/findByTags`,
             {
                 params: queryParameters,
@@ -385,7 +385,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<Pet>("get",
+        return this.httpClient.request<Pet>('get',
             `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
                 responseType: <any>responseType,
@@ -447,7 +447,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("put",
+        return this.httpClient.request<any>('put',
             `${this.configuration.basePath}/pet`,
             {
                 body: body,
@@ -524,7 +524,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("post",
+        return this.httpClient.request<any>('post',
             `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
                 body: convertFormParamsToString ? formParams.toString() : formParams,
@@ -605,7 +605,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<ApiResponse>("post",
+        return this.httpClient.request<ApiResponse>('post',
             `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}/uploadImage`,
             {
                 body: convertFormParamsToString ? formParams.toString() : formParams,

--- a/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/default/api/pet.service.ts
@@ -208,7 +208,6 @@ export class PetService {
         return this.httpClient.request<any>("delete",
             `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -270,7 +269,6 @@ export class PetService {
         return this.httpClient.request<Array<Pet>>("get",
             `${this.configuration.basePath}/pet/findByStatus`,
             {
-                body: null,
                 params: queryParameters,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
@@ -334,7 +332,6 @@ export class PetService {
         return this.httpClient.request<Array<Pet>>("get",
             `${this.configuration.basePath}/pet/findByTags`,
             {
-                body: null,
                 params: queryParameters,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
@@ -391,7 +388,6 @@ export class PetService {
         return this.httpClient.request<Pet>("get",
             `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,

--- a/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/default/api/pet.service.ts
@@ -148,9 +148,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.post<any>(`${this.configuration.basePath}/pet`,
-            body,
+        return this.httpClient.request<any>("post",
+            `${this.configuration.basePath}/pet`,
             {
+                body: body,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -204,8 +205,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.delete<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
+        return this.httpClient.request<any>("delete",
+            `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -264,8 +267,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByStatus`,
+        return this.httpClient.request<Array<Pet>>("get",
+            `${this.configuration.basePath}/pet/findByStatus`,
             {
+                body: null,
                 params: queryParameters,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
@@ -326,8 +331,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByTags`,
+        return this.httpClient.request<Array<Pet>>("get",
+            `${this.configuration.basePath}/pet/findByTags`,
             {
+                body: null,
                 params: queryParameters,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
@@ -381,8 +388,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<Pet>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
+        return this.httpClient.request<Pet>("get",
+            `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -442,9 +451,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.put<any>(`${this.configuration.basePath}/pet`,
-            body,
+        return this.httpClient.request<any>("put",
+            `${this.configuration.basePath}/pet`,
             {
+                body: body,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -518,9 +528,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.post<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
-            convertFormParamsToString ? formParams.toString() : formParams,
+        return this.httpClient.request<any>("post",
+            `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
+                body: convertFormParamsToString ? formParams.toString() : formParams,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -598,9 +609,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.post<ApiResponse>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}/uploadImage`,
-            convertFormParamsToString ? formParams.toString() : formParams,
+        return this.httpClient.request<ApiResponse>("post",
+            `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}/uploadImage`,
             {
+                body: convertFormParamsToString ? formParams.toString() : formParams,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,

--- a/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/default/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/default/api/store.service.ts
@@ -121,7 +121,6 @@ export class StoreService {
         return this.httpClient.request<any>("delete",
             `${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -172,7 +171,6 @@ export class StoreService {
         return this.httpClient.request<{ [key: string]: number; }>("get",
             `${this.configuration.basePath}/store/inventory`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -221,7 +219,6 @@ export class StoreService {
         return this.httpClient.request<Order>("get",
             `${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,

--- a/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/default/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/default/api/store.service.ts
@@ -118,8 +118,10 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.delete<any>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
+        return this.httpClient.request<any>("delete",
+            `${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -167,8 +169,10 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<{ [key: string]: number; }>(`${this.configuration.basePath}/store/inventory`,
+        return this.httpClient.request<{ [key: string]: number; }>("get",
+            `${this.configuration.basePath}/store/inventory`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -214,8 +218,10 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<Order>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
+        return this.httpClient.request<Order>("get",
+            `${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -268,9 +274,10 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.post<Order>(`${this.configuration.basePath}/store/order`,
-            body,
+        return this.httpClient.request<Order>("post",
+            `${this.configuration.basePath}/store/order`,
             {
+                body: body,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,

--- a/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/default/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/default/api/store.service.ts
@@ -118,7 +118,7 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("delete",
+        return this.httpClient.request<any>('delete',
             `${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
             {
                 responseType: <any>responseType,
@@ -168,7 +168,7 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<{ [key: string]: number; }>("get",
+        return this.httpClient.request<{ [key: string]: number; }>('get',
             `${this.configuration.basePath}/store/inventory`,
             {
                 responseType: <any>responseType,
@@ -216,7 +216,7 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<Order>("get",
+        return this.httpClient.request<Order>('get',
             `${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
             {
                 responseType: <any>responseType,
@@ -271,7 +271,7 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<Order>("post",
+        return this.httpClient.request<Order>('post',
             `${this.configuration.basePath}/store/order`,
             {
                 body: body,

--- a/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/default/api/user.service.ts
@@ -284,7 +284,6 @@ export class UserService {
         return this.httpClient.request<any>("delete",
             `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -332,7 +331,6 @@ export class UserService {
         return this.httpClient.request<User>("get",
             `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -394,7 +392,6 @@ export class UserService {
         return this.httpClient.request<string>("get",
             `${this.configuration.basePath}/user/login`,
             {
-                body: null,
                 params: queryParameters,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
@@ -437,7 +434,6 @@ export class UserService {
         return this.httpClient.request<any>("get",
             `${this.configuration.basePath}/user/logout`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,

--- a/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/default/api/user.service.ts
@@ -126,9 +126,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.post<any>(`${this.configuration.basePath}/user`,
-            body,
+        return this.httpClient.request<any>("post",
+            `${this.configuration.basePath}/user`,
             {
+                body: body,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -179,9 +180,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.post<any>(`${this.configuration.basePath}/user/createWithArray`,
-            body,
+        return this.httpClient.request<any>("post",
+            `${this.configuration.basePath}/user/createWithArray`,
             {
+                body: body,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -232,9 +234,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.post<any>(`${this.configuration.basePath}/user/createWithList`,
-            body,
+        return this.httpClient.request<any>("post",
+            `${this.configuration.basePath}/user/createWithList`,
             {
+                body: body,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -278,8 +281,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.delete<any>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
+        return this.httpClient.request<any>("delete",
+            `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -324,8 +329,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<User>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
+        return this.httpClient.request<User>("get",
+            `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -384,8 +391,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<string>(`${this.configuration.basePath}/user/login`,
+        return this.httpClient.request<string>("get",
+            `${this.configuration.basePath}/user/login`,
             {
+                body: null,
                 params: queryParameters,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
@@ -425,8 +434,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<any>(`${this.configuration.basePath}/user/logout`,
+        return this.httpClient.request<any>("get",
+            `${this.configuration.basePath}/user/logout`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -482,9 +493,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.put<any>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
-            body,
+        return this.httpClient.request<any>("put",
+            `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
+                body: body,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,

--- a/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/default/api/user.service.ts
@@ -126,7 +126,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("post",
+        return this.httpClient.request<any>('post',
             `${this.configuration.basePath}/user`,
             {
                 body: body,
@@ -180,7 +180,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("post",
+        return this.httpClient.request<any>('post',
             `${this.configuration.basePath}/user/createWithArray`,
             {
                 body: body,
@@ -234,7 +234,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("post",
+        return this.httpClient.request<any>('post',
             `${this.configuration.basePath}/user/createWithList`,
             {
                 body: body,
@@ -281,7 +281,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("delete",
+        return this.httpClient.request<any>('delete',
             `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
                 responseType: <any>responseType,
@@ -328,7 +328,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<User>("get",
+        return this.httpClient.request<User>('get',
             `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
                 responseType: <any>responseType,
@@ -389,7 +389,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<string>("get",
+        return this.httpClient.request<string>('get',
             `${this.configuration.basePath}/user/login`,
             {
                 params: queryParameters,
@@ -431,7 +431,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("get",
+        return this.httpClient.request<any>('get',
             `${this.configuration.basePath}/user/logout`,
             {
                 responseType: <any>responseType,
@@ -489,7 +489,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("put",
+        return this.httpClient.request<any>('put',
             `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
                 body: body,

--- a/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/with-npm/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/with-npm/api/pet.service.ts
@@ -148,7 +148,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("post",
+        return this.httpClient.request<any>('post',
             `${this.configuration.basePath}/pet`,
             {
                 body: body,
@@ -205,7 +205,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("delete",
+        return this.httpClient.request<any>('delete',
             `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
                 responseType: <any>responseType,
@@ -266,7 +266,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<Array<Pet>>("get",
+        return this.httpClient.request<Array<Pet>>('get',
             `${this.configuration.basePath}/pet/findByStatus`,
             {
                 params: queryParameters,
@@ -329,7 +329,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<Array<Pet>>("get",
+        return this.httpClient.request<Array<Pet>>('get',
             `${this.configuration.basePath}/pet/findByTags`,
             {
                 params: queryParameters,
@@ -385,7 +385,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<Pet>("get",
+        return this.httpClient.request<Pet>('get',
             `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
                 responseType: <any>responseType,
@@ -447,7 +447,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("put",
+        return this.httpClient.request<any>('put',
             `${this.configuration.basePath}/pet`,
             {
                 body: body,
@@ -524,7 +524,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("post",
+        return this.httpClient.request<any>('post',
             `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
                 body: convertFormParamsToString ? formParams.toString() : formParams,
@@ -605,7 +605,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<ApiResponse>("post",
+        return this.httpClient.request<ApiResponse>('post',
             `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}/uploadImage`,
             {
                 body: convertFormParamsToString ? formParams.toString() : formParams,

--- a/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/with-npm/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/with-npm/api/pet.service.ts
@@ -208,7 +208,6 @@ export class PetService {
         return this.httpClient.request<any>("delete",
             `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -270,7 +269,6 @@ export class PetService {
         return this.httpClient.request<Array<Pet>>("get",
             `${this.configuration.basePath}/pet/findByStatus`,
             {
-                body: null,
                 params: queryParameters,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
@@ -334,7 +332,6 @@ export class PetService {
         return this.httpClient.request<Array<Pet>>("get",
             `${this.configuration.basePath}/pet/findByTags`,
             {
-                body: null,
                 params: queryParameters,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
@@ -391,7 +388,6 @@ export class PetService {
         return this.httpClient.request<Pet>("get",
             `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,

--- a/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/with-npm/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/with-npm/api/pet.service.ts
@@ -148,9 +148,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.post<any>(`${this.configuration.basePath}/pet`,
-            body,
+        return this.httpClient.request<any>("post",
+            `${this.configuration.basePath}/pet`,
             {
+                body: body,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -204,8 +205,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.delete<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
+        return this.httpClient.request<any>("delete",
+            `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -264,8 +267,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByStatus`,
+        return this.httpClient.request<Array<Pet>>("get",
+            `${this.configuration.basePath}/pet/findByStatus`,
             {
+                body: null,
                 params: queryParameters,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
@@ -326,8 +331,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByTags`,
+        return this.httpClient.request<Array<Pet>>("get",
+            `${this.configuration.basePath}/pet/findByTags`,
             {
+                body: null,
                 params: queryParameters,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
@@ -381,8 +388,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<Pet>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
+        return this.httpClient.request<Pet>("get",
+            `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -442,9 +451,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.put<any>(`${this.configuration.basePath}/pet`,
-            body,
+        return this.httpClient.request<any>("put",
+            `${this.configuration.basePath}/pet`,
             {
+                body: body,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -518,9 +528,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.post<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
-            convertFormParamsToString ? formParams.toString() : formParams,
+        return this.httpClient.request<any>("post",
+            `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
+                body: convertFormParamsToString ? formParams.toString() : formParams,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -598,9 +609,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.post<ApiResponse>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}/uploadImage`,
-            convertFormParamsToString ? formParams.toString() : formParams,
+        return this.httpClient.request<ApiResponse>("post",
+            `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}/uploadImage`,
             {
+                body: convertFormParamsToString ? formParams.toString() : formParams,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,

--- a/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/with-npm/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/with-npm/api/store.service.ts
@@ -121,7 +121,6 @@ export class StoreService {
         return this.httpClient.request<any>("delete",
             `${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -172,7 +171,6 @@ export class StoreService {
         return this.httpClient.request<{ [key: string]: number; }>("get",
             `${this.configuration.basePath}/store/inventory`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -221,7 +219,6 @@ export class StoreService {
         return this.httpClient.request<Order>("get",
             `${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,

--- a/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/with-npm/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/with-npm/api/store.service.ts
@@ -118,8 +118,10 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.delete<any>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
+        return this.httpClient.request<any>("delete",
+            `${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -167,8 +169,10 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<{ [key: string]: number; }>(`${this.configuration.basePath}/store/inventory`,
+        return this.httpClient.request<{ [key: string]: number; }>("get",
+            `${this.configuration.basePath}/store/inventory`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -214,8 +218,10 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<Order>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
+        return this.httpClient.request<Order>("get",
+            `${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -268,9 +274,10 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.post<Order>(`${this.configuration.basePath}/store/order`,
-            body,
+        return this.httpClient.request<Order>("post",
+            `${this.configuration.basePath}/store/order`,
             {
+                body: body,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,

--- a/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/with-npm/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/with-npm/api/store.service.ts
@@ -118,7 +118,7 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("delete",
+        return this.httpClient.request<any>('delete',
             `${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
             {
                 responseType: <any>responseType,
@@ -168,7 +168,7 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<{ [key: string]: number; }>("get",
+        return this.httpClient.request<{ [key: string]: number; }>('get',
             `${this.configuration.basePath}/store/inventory`,
             {
                 responseType: <any>responseType,
@@ -216,7 +216,7 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<Order>("get",
+        return this.httpClient.request<Order>('get',
             `${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
             {
                 responseType: <any>responseType,
@@ -271,7 +271,7 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<Order>("post",
+        return this.httpClient.request<Order>('post',
             `${this.configuration.basePath}/store/order`,
             {
                 body: body,

--- a/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/with-npm/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/with-npm/api/user.service.ts
@@ -284,7 +284,6 @@ export class UserService {
         return this.httpClient.request<any>("delete",
             `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -332,7 +331,6 @@ export class UserService {
         return this.httpClient.request<User>("get",
             `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -394,7 +392,6 @@ export class UserService {
         return this.httpClient.request<string>("get",
             `${this.configuration.basePath}/user/login`,
             {
-                body: null,
                 params: queryParameters,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
@@ -437,7 +434,6 @@ export class UserService {
         return this.httpClient.request<any>("get",
             `${this.configuration.basePath}/user/logout`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,

--- a/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/with-npm/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/with-npm/api/user.service.ts
@@ -126,9 +126,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.post<any>(`${this.configuration.basePath}/user`,
-            body,
+        return this.httpClient.request<any>("post",
+            `${this.configuration.basePath}/user`,
             {
+                body: body,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -179,9 +180,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.post<any>(`${this.configuration.basePath}/user/createWithArray`,
-            body,
+        return this.httpClient.request<any>("post",
+            `${this.configuration.basePath}/user/createWithArray`,
             {
+                body: body,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -232,9 +234,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.post<any>(`${this.configuration.basePath}/user/createWithList`,
-            body,
+        return this.httpClient.request<any>("post",
+            `${this.configuration.basePath}/user/createWithList`,
             {
+                body: body,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -278,8 +281,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.delete<any>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
+        return this.httpClient.request<any>("delete",
+            `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -324,8 +329,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<User>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
+        return this.httpClient.request<User>("get",
+            `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -384,8 +391,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<string>(`${this.configuration.basePath}/user/login`,
+        return this.httpClient.request<string>("get",
+            `${this.configuration.basePath}/user/login`,
             {
+                body: null,
                 params: queryParameters,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
@@ -425,8 +434,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<any>(`${this.configuration.basePath}/user/logout`,
+        return this.httpClient.request<any>("get",
+            `${this.configuration.basePath}/user/logout`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -482,9 +493,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.put<any>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
-            body,
+        return this.httpClient.request<any>("put",
+            `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
+                body: body,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,

--- a/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/with-npm/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/with-npm/api/user.service.ts
@@ -126,7 +126,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("post",
+        return this.httpClient.request<any>('post',
             `${this.configuration.basePath}/user`,
             {
                 body: body,
@@ -180,7 +180,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("post",
+        return this.httpClient.request<any>('post',
             `${this.configuration.basePath}/user/createWithArray`,
             {
                 body: body,
@@ -234,7 +234,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("post",
+        return this.httpClient.request<any>('post',
             `${this.configuration.basePath}/user/createWithList`,
             {
                 body: body,
@@ -281,7 +281,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("delete",
+        return this.httpClient.request<any>('delete',
             `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
                 responseType: <any>responseType,
@@ -328,7 +328,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<User>("get",
+        return this.httpClient.request<User>('get',
             `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
                 responseType: <any>responseType,
@@ -389,7 +389,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<string>("get",
+        return this.httpClient.request<string>('get',
             `${this.configuration.basePath}/user/login`,
             {
                 params: queryParameters,
@@ -431,7 +431,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("get",
+        return this.httpClient.request<any>('get',
             `${this.configuration.basePath}/user/logout`,
             {
                 responseType: <any>responseType,
@@ -489,7 +489,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("put",
+        return this.httpClient.request<any>('put',
             `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
                 body: body,

--- a/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/single-request-parameter/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/single-request-parameter/api/pet.service.ts
@@ -198,9 +198,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.post<any>(`${this.configuration.basePath}/pet`,
-            body,
+        return this.httpClient.request<any>("post",
+            `${this.configuration.basePath}/pet`,
             {
+                body: body,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -255,8 +256,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.delete<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
+        return this.httpClient.request<any>("delete",
+            `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -316,8 +319,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByStatus`,
+        return this.httpClient.request<Array<Pet>>("get",
+            `${this.configuration.basePath}/pet/findByStatus`,
             {
+                body: null,
                 params: queryParameters,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
@@ -379,8 +384,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByTags`,
+        return this.httpClient.request<Array<Pet>>("get",
+            `${this.configuration.basePath}/pet/findByTags`,
             {
+                body: null,
                 params: queryParameters,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
@@ -435,8 +442,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<Pet>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
+        return this.httpClient.request<Pet>("get",
+            `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -497,9 +506,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.put<any>(`${this.configuration.basePath}/pet`,
-            body,
+        return this.httpClient.request<any>("put",
+            `${this.configuration.basePath}/pet`,
             {
+                body: body,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -574,9 +584,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.post<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
-            convertFormParamsToString ? formParams.toString() : formParams,
+        return this.httpClient.request<any>("post",
+            `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
+                body: convertFormParamsToString ? formParams.toString() : formParams,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -655,9 +666,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.post<ApiResponse>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}/uploadImage`,
-            convertFormParamsToString ? formParams.toString() : formParams,
+        return this.httpClient.request<ApiResponse>("post",
+            `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}/uploadImage`,
             {
+                body: convertFormParamsToString ? formParams.toString() : formParams,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,

--- a/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/single-request-parameter/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/single-request-parameter/api/pet.service.ts
@@ -259,7 +259,6 @@ export class PetService {
         return this.httpClient.request<any>("delete",
             `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -322,7 +321,6 @@ export class PetService {
         return this.httpClient.request<Array<Pet>>("get",
             `${this.configuration.basePath}/pet/findByStatus`,
             {
-                body: null,
                 params: queryParameters,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
@@ -387,7 +385,6 @@ export class PetService {
         return this.httpClient.request<Array<Pet>>("get",
             `${this.configuration.basePath}/pet/findByTags`,
             {
-                body: null,
                 params: queryParameters,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
@@ -445,7 +442,6 @@ export class PetService {
         return this.httpClient.request<Pet>("get",
             `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,

--- a/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/single-request-parameter/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/single-request-parameter/api/pet.service.ts
@@ -198,7 +198,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("post",
+        return this.httpClient.request<any>('post',
             `${this.configuration.basePath}/pet`,
             {
                 body: body,
@@ -256,7 +256,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("delete",
+        return this.httpClient.request<any>('delete',
             `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
                 responseType: <any>responseType,
@@ -318,7 +318,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<Array<Pet>>("get",
+        return this.httpClient.request<Array<Pet>>('get',
             `${this.configuration.basePath}/pet/findByStatus`,
             {
                 params: queryParameters,
@@ -382,7 +382,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<Array<Pet>>("get",
+        return this.httpClient.request<Array<Pet>>('get',
             `${this.configuration.basePath}/pet/findByTags`,
             {
                 params: queryParameters,
@@ -439,7 +439,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<Pet>("get",
+        return this.httpClient.request<Pet>('get',
             `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
                 responseType: <any>responseType,
@@ -502,7 +502,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("put",
+        return this.httpClient.request<any>('put',
             `${this.configuration.basePath}/pet`,
             {
                 body: body,
@@ -580,7 +580,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("post",
+        return this.httpClient.request<any>('post',
             `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
                 body: convertFormParamsToString ? formParams.toString() : formParams,
@@ -662,7 +662,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<ApiResponse>("post",
+        return this.httpClient.request<ApiResponse>('post',
             `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}/uploadImage`,
             {
                 body: convertFormParamsToString ? formParams.toString() : formParams,

--- a/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/single-request-parameter/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/single-request-parameter/api/store.service.ts
@@ -137,7 +137,6 @@ export class StoreService {
         return this.httpClient.request<any>("delete",
             `${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -188,7 +187,6 @@ export class StoreService {
         return this.httpClient.request<{ [key: string]: number; }>("get",
             `${this.configuration.basePath}/store/inventory`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -238,7 +236,6 @@ export class StoreService {
         return this.httpClient.request<Order>("get",
             `${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,

--- a/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/single-request-parameter/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/single-request-parameter/api/store.service.ts
@@ -134,8 +134,10 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.delete<any>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
+        return this.httpClient.request<any>("delete",
+            `${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -183,8 +185,10 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<{ [key: string]: number; }>(`${this.configuration.basePath}/store/inventory`,
+        return this.httpClient.request<{ [key: string]: number; }>("get",
+            `${this.configuration.basePath}/store/inventory`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -231,8 +235,10 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<Order>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
+        return this.httpClient.request<Order>("get",
+            `${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -286,9 +292,10 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.post<Order>(`${this.configuration.basePath}/store/order`,
-            body,
+        return this.httpClient.request<Order>("post",
+            `${this.configuration.basePath}/store/order`,
             {
+                body: body,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,

--- a/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/single-request-parameter/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/single-request-parameter/api/store.service.ts
@@ -134,7 +134,7 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("delete",
+        return this.httpClient.request<any>('delete',
             `${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
             {
                 responseType: <any>responseType,
@@ -184,7 +184,7 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<{ [key: string]: number; }>("get",
+        return this.httpClient.request<{ [key: string]: number; }>('get',
             `${this.configuration.basePath}/store/inventory`,
             {
                 responseType: <any>responseType,
@@ -233,7 +233,7 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<Order>("get",
+        return this.httpClient.request<Order>('get',
             `${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
             {
                 responseType: <any>responseType,
@@ -289,7 +289,7 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<Order>("post",
+        return this.httpClient.request<Order>('post',
             `${this.configuration.basePath}/store/order`,
             {
                 body: body,

--- a/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/single-request-parameter/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/single-request-parameter/api/user.service.ts
@@ -166,7 +166,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("post",
+        return this.httpClient.request<any>('post',
             `${this.configuration.basePath}/user`,
             {
                 body: body,
@@ -221,7 +221,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("post",
+        return this.httpClient.request<any>('post',
             `${this.configuration.basePath}/user/createWithArray`,
             {
                 body: body,
@@ -276,7 +276,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("post",
+        return this.httpClient.request<any>('post',
             `${this.configuration.basePath}/user/createWithList`,
             {
                 body: body,
@@ -324,7 +324,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("delete",
+        return this.httpClient.request<any>('delete',
             `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
                 responseType: <any>responseType,
@@ -372,7 +372,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<User>("get",
+        return this.httpClient.request<User>('get',
             `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
                 responseType: <any>responseType,
@@ -434,7 +434,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<string>("get",
+        return this.httpClient.request<string>('get',
             `${this.configuration.basePath}/user/login`,
             {
                 params: queryParameters,
@@ -476,7 +476,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("get",
+        return this.httpClient.request<any>('get',
             `${this.configuration.basePath}/user/logout`,
             {
                 responseType: <any>responseType,
@@ -535,7 +535,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("put",
+        return this.httpClient.request<any>('put',
             `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
                 body: body,

--- a/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/single-request-parameter/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/single-request-parameter/api/user.service.ts
@@ -166,9 +166,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.post<any>(`${this.configuration.basePath}/user`,
-            body,
+        return this.httpClient.request<any>("post",
+            `${this.configuration.basePath}/user`,
             {
+                body: body,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -220,9 +221,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.post<any>(`${this.configuration.basePath}/user/createWithArray`,
-            body,
+        return this.httpClient.request<any>("post",
+            `${this.configuration.basePath}/user/createWithArray`,
             {
+                body: body,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -274,9 +276,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.post<any>(`${this.configuration.basePath}/user/createWithList`,
-            body,
+        return this.httpClient.request<any>("post",
+            `${this.configuration.basePath}/user/createWithList`,
             {
+                body: body,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -321,8 +324,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.delete<any>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
+        return this.httpClient.request<any>("delete",
+            `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -368,8 +373,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<User>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
+        return this.httpClient.request<User>("get",
+            `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -429,8 +436,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<string>(`${this.configuration.basePath}/user/login`,
+        return this.httpClient.request<string>("get",
+            `${this.configuration.basePath}/user/login`,
             {
+                body: null,
                 params: queryParameters,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
@@ -470,8 +479,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<any>(`${this.configuration.basePath}/user/logout`,
+        return this.httpClient.request<any>("get",
+            `${this.configuration.basePath}/user/logout`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -528,9 +539,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.put<any>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
-            body,
+        return this.httpClient.request<any>("put",
+            `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
+                body: body,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,

--- a/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/single-request-parameter/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/single-request-parameter/api/user.service.ts
@@ -327,7 +327,6 @@ export class UserService {
         return this.httpClient.request<any>("delete",
             `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -376,7 +375,6 @@ export class UserService {
         return this.httpClient.request<User>("get",
             `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -439,7 +437,6 @@ export class UserService {
         return this.httpClient.request<string>("get",
             `${this.configuration.basePath}/user/login`,
             {
-                body: null,
                 params: queryParameters,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
@@ -482,7 +479,6 @@ export class UserService {
         return this.httpClient.request<any>("get",
             `${this.configuration.basePath}/user/logout`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,

--- a/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/with-npm/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/with-npm/api/pet.service.ts
@@ -148,7 +148,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("post",
+        return this.httpClient.request<any>('post',
             `${this.configuration.basePath}/pet`,
             {
                 body: body,
@@ -205,7 +205,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("delete",
+        return this.httpClient.request<any>('delete',
             `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
                 responseType: <any>responseType,
@@ -266,7 +266,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<Array<Pet>>("get",
+        return this.httpClient.request<Array<Pet>>('get',
             `${this.configuration.basePath}/pet/findByStatus`,
             {
                 params: queryParameters,
@@ -329,7 +329,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<Array<Pet>>("get",
+        return this.httpClient.request<Array<Pet>>('get',
             `${this.configuration.basePath}/pet/findByTags`,
             {
                 params: queryParameters,
@@ -385,7 +385,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<Pet>("get",
+        return this.httpClient.request<Pet>('get',
             `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
                 responseType: <any>responseType,
@@ -447,7 +447,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("put",
+        return this.httpClient.request<any>('put',
             `${this.configuration.basePath}/pet`,
             {
                 body: body,
@@ -524,7 +524,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("post",
+        return this.httpClient.request<any>('post',
             `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
                 body: convertFormParamsToString ? formParams.toString() : formParams,
@@ -605,7 +605,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<ApiResponse>("post",
+        return this.httpClient.request<ApiResponse>('post',
             `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}/uploadImage`,
             {
                 body: convertFormParamsToString ? formParams.toString() : formParams,

--- a/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/with-npm/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/with-npm/api/pet.service.ts
@@ -208,7 +208,6 @@ export class PetService {
         return this.httpClient.request<any>("delete",
             `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -270,7 +269,6 @@ export class PetService {
         return this.httpClient.request<Array<Pet>>("get",
             `${this.configuration.basePath}/pet/findByStatus`,
             {
-                body: null,
                 params: queryParameters,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
@@ -334,7 +332,6 @@ export class PetService {
         return this.httpClient.request<Array<Pet>>("get",
             `${this.configuration.basePath}/pet/findByTags`,
             {
-                body: null,
                 params: queryParameters,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
@@ -391,7 +388,6 @@ export class PetService {
         return this.httpClient.request<Pet>("get",
             `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,

--- a/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/with-npm/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/with-npm/api/pet.service.ts
@@ -148,9 +148,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.post<any>(`${this.configuration.basePath}/pet`,
-            body,
+        return this.httpClient.request<any>("post",
+            `${this.configuration.basePath}/pet`,
             {
+                body: body,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -204,8 +205,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.delete<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
+        return this.httpClient.request<any>("delete",
+            `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -264,8 +267,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByStatus`,
+        return this.httpClient.request<Array<Pet>>("get",
+            `${this.configuration.basePath}/pet/findByStatus`,
             {
+                body: null,
                 params: queryParameters,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
@@ -326,8 +331,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByTags`,
+        return this.httpClient.request<Array<Pet>>("get",
+            `${this.configuration.basePath}/pet/findByTags`,
             {
+                body: null,
                 params: queryParameters,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
@@ -381,8 +388,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<Pet>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
+        return this.httpClient.request<Pet>("get",
+            `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -442,9 +451,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.put<any>(`${this.configuration.basePath}/pet`,
-            body,
+        return this.httpClient.request<any>("put",
+            `${this.configuration.basePath}/pet`,
             {
+                body: body,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -518,9 +528,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.post<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
-            convertFormParamsToString ? formParams.toString() : formParams,
+        return this.httpClient.request<any>("post",
+            `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
+                body: convertFormParamsToString ? formParams.toString() : formParams,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -598,9 +609,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.post<ApiResponse>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}/uploadImage`,
-            convertFormParamsToString ? formParams.toString() : formParams,
+        return this.httpClient.request<ApiResponse>("post",
+            `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}/uploadImage`,
             {
+                body: convertFormParamsToString ? formParams.toString() : formParams,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,

--- a/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/with-npm/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/with-npm/api/store.service.ts
@@ -121,7 +121,6 @@ export class StoreService {
         return this.httpClient.request<any>("delete",
             `${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -172,7 +171,6 @@ export class StoreService {
         return this.httpClient.request<{ [key: string]: number; }>("get",
             `${this.configuration.basePath}/store/inventory`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -221,7 +219,6 @@ export class StoreService {
         return this.httpClient.request<Order>("get",
             `${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,

--- a/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/with-npm/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/with-npm/api/store.service.ts
@@ -118,8 +118,10 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.delete<any>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
+        return this.httpClient.request<any>("delete",
+            `${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -167,8 +169,10 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<{ [key: string]: number; }>(`${this.configuration.basePath}/store/inventory`,
+        return this.httpClient.request<{ [key: string]: number; }>("get",
+            `${this.configuration.basePath}/store/inventory`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -214,8 +218,10 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<Order>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
+        return this.httpClient.request<Order>("get",
+            `${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -268,9 +274,10 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.post<Order>(`${this.configuration.basePath}/store/order`,
-            body,
+        return this.httpClient.request<Order>("post",
+            `${this.configuration.basePath}/store/order`,
             {
+                body: body,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,

--- a/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/with-npm/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/with-npm/api/store.service.ts
@@ -118,7 +118,7 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("delete",
+        return this.httpClient.request<any>('delete',
             `${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
             {
                 responseType: <any>responseType,
@@ -168,7 +168,7 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<{ [key: string]: number; }>("get",
+        return this.httpClient.request<{ [key: string]: number; }>('get',
             `${this.configuration.basePath}/store/inventory`,
             {
                 responseType: <any>responseType,
@@ -216,7 +216,7 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<Order>("get",
+        return this.httpClient.request<Order>('get',
             `${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
             {
                 responseType: <any>responseType,
@@ -271,7 +271,7 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<Order>("post",
+        return this.httpClient.request<Order>('post',
             `${this.configuration.basePath}/store/order`,
             {
                 body: body,

--- a/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/with-npm/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/with-npm/api/user.service.ts
@@ -284,7 +284,6 @@ export class UserService {
         return this.httpClient.request<any>("delete",
             `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -332,7 +331,6 @@ export class UserService {
         return this.httpClient.request<User>("get",
             `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -394,7 +392,6 @@ export class UserService {
         return this.httpClient.request<string>("get",
             `${this.configuration.basePath}/user/login`,
             {
-                body: null,
                 params: queryParameters,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
@@ -437,7 +434,6 @@ export class UserService {
         return this.httpClient.request<any>("get",
             `${this.configuration.basePath}/user/logout`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,

--- a/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/with-npm/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/with-npm/api/user.service.ts
@@ -126,9 +126,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.post<any>(`${this.configuration.basePath}/user`,
-            body,
+        return this.httpClient.request<any>("post",
+            `${this.configuration.basePath}/user`,
             {
+                body: body,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -179,9 +180,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.post<any>(`${this.configuration.basePath}/user/createWithArray`,
-            body,
+        return this.httpClient.request<any>("post",
+            `${this.configuration.basePath}/user/createWithArray`,
             {
+                body: body,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -232,9 +234,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.post<any>(`${this.configuration.basePath}/user/createWithList`,
-            body,
+        return this.httpClient.request<any>("post",
+            `${this.configuration.basePath}/user/createWithList`,
             {
+                body: body,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -278,8 +281,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.delete<any>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
+        return this.httpClient.request<any>("delete",
+            `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -324,8 +329,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<User>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
+        return this.httpClient.request<User>("get",
+            `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -384,8 +391,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<string>(`${this.configuration.basePath}/user/login`,
+        return this.httpClient.request<string>("get",
+            `${this.configuration.basePath}/user/login`,
             {
+                body: null,
                 params: queryParameters,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
@@ -425,8 +434,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<any>(`${this.configuration.basePath}/user/logout`,
+        return this.httpClient.request<any>("get",
+            `${this.configuration.basePath}/user/logout`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -482,9 +493,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.put<any>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
-            body,
+        return this.httpClient.request<any>("put",
+            `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
+                body: body,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,

--- a/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/with-npm/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/with-npm/api/user.service.ts
@@ -126,7 +126,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("post",
+        return this.httpClient.request<any>('post',
             `${this.configuration.basePath}/user`,
             {
                 body: body,
@@ -180,7 +180,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("post",
+        return this.httpClient.request<any>('post',
             `${this.configuration.basePath}/user/createWithArray`,
             {
                 body: body,
@@ -234,7 +234,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("post",
+        return this.httpClient.request<any>('post',
             `${this.configuration.basePath}/user/createWithList`,
             {
                 body: body,
@@ -281,7 +281,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("delete",
+        return this.httpClient.request<any>('delete',
             `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
                 responseType: <any>responseType,
@@ -328,7 +328,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<User>("get",
+        return this.httpClient.request<User>('get',
             `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
                 responseType: <any>responseType,
@@ -389,7 +389,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<string>("get",
+        return this.httpClient.request<string>('get',
             `${this.configuration.basePath}/user/login`,
             {
                 params: queryParameters,
@@ -431,7 +431,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("get",
+        return this.httpClient.request<any>('get',
             `${this.configuration.basePath}/user/logout`,
             {
                 responseType: <any>responseType,
@@ -489,7 +489,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("put",
+        return this.httpClient.request<any>('put',
             `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
                 body: body,

--- a/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/with-prefixed-module-name/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/with-prefixed-module-name/api/pet.service.ts
@@ -148,7 +148,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("post",
+        return this.httpClient.request<any>('post',
             `${this.configuration.basePath}/pet`,
             {
                 body: body,
@@ -205,7 +205,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("delete",
+        return this.httpClient.request<any>('delete',
             `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
                 responseType: <any>responseType,
@@ -266,7 +266,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<Array<Pet>>("get",
+        return this.httpClient.request<Array<Pet>>('get',
             `${this.configuration.basePath}/pet/findByStatus`,
             {
                 params: queryParameters,
@@ -329,7 +329,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<Array<Pet>>("get",
+        return this.httpClient.request<Array<Pet>>('get',
             `${this.configuration.basePath}/pet/findByTags`,
             {
                 params: queryParameters,
@@ -385,7 +385,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<Pet>("get",
+        return this.httpClient.request<Pet>('get',
             `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
                 responseType: <any>responseType,
@@ -447,7 +447,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("put",
+        return this.httpClient.request<any>('put',
             `${this.configuration.basePath}/pet`,
             {
                 body: body,
@@ -524,7 +524,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("post",
+        return this.httpClient.request<any>('post',
             `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
                 body: convertFormParamsToString ? formParams.toString() : formParams,
@@ -605,7 +605,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<ApiResponse>("post",
+        return this.httpClient.request<ApiResponse>('post',
             `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}/uploadImage`,
             {
                 body: convertFormParamsToString ? formParams.toString() : formParams,

--- a/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/with-prefixed-module-name/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/with-prefixed-module-name/api/pet.service.ts
@@ -208,7 +208,6 @@ export class PetService {
         return this.httpClient.request<any>("delete",
             `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -270,7 +269,6 @@ export class PetService {
         return this.httpClient.request<Array<Pet>>("get",
             `${this.configuration.basePath}/pet/findByStatus`,
             {
-                body: null,
                 params: queryParameters,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
@@ -334,7 +332,6 @@ export class PetService {
         return this.httpClient.request<Array<Pet>>("get",
             `${this.configuration.basePath}/pet/findByTags`,
             {
-                body: null,
                 params: queryParameters,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
@@ -391,7 +388,6 @@ export class PetService {
         return this.httpClient.request<Pet>("get",
             `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,

--- a/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/with-prefixed-module-name/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/with-prefixed-module-name/api/pet.service.ts
@@ -148,9 +148,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.post<any>(`${this.configuration.basePath}/pet`,
-            body,
+        return this.httpClient.request<any>("post",
+            `${this.configuration.basePath}/pet`,
             {
+                body: body,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -204,8 +205,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.delete<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
+        return this.httpClient.request<any>("delete",
+            `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -264,8 +267,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByStatus`,
+        return this.httpClient.request<Array<Pet>>("get",
+            `${this.configuration.basePath}/pet/findByStatus`,
             {
+                body: null,
                 params: queryParameters,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
@@ -326,8 +331,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByTags`,
+        return this.httpClient.request<Array<Pet>>("get",
+            `${this.configuration.basePath}/pet/findByTags`,
             {
+                body: null,
                 params: queryParameters,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
@@ -381,8 +388,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<Pet>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
+        return this.httpClient.request<Pet>("get",
+            `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -442,9 +451,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.put<any>(`${this.configuration.basePath}/pet`,
-            body,
+        return this.httpClient.request<any>("put",
+            `${this.configuration.basePath}/pet`,
             {
+                body: body,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -518,9 +528,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.post<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
-            convertFormParamsToString ? formParams.toString() : formParams,
+        return this.httpClient.request<any>("post",
+            `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
+                body: convertFormParamsToString ? formParams.toString() : formParams,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -598,9 +609,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.post<ApiResponse>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}/uploadImage`,
-            convertFormParamsToString ? formParams.toString() : formParams,
+        return this.httpClient.request<ApiResponse>("post",
+            `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}/uploadImage`,
             {
+                body: convertFormParamsToString ? formParams.toString() : formParams,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,

--- a/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/with-prefixed-module-name/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/with-prefixed-module-name/api/store.service.ts
@@ -121,7 +121,6 @@ export class StoreService {
         return this.httpClient.request<any>("delete",
             `${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -172,7 +171,6 @@ export class StoreService {
         return this.httpClient.request<{ [key: string]: number; }>("get",
             `${this.configuration.basePath}/store/inventory`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -221,7 +219,6 @@ export class StoreService {
         return this.httpClient.request<Order>("get",
             `${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,

--- a/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/with-prefixed-module-name/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/with-prefixed-module-name/api/store.service.ts
@@ -118,8 +118,10 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.delete<any>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
+        return this.httpClient.request<any>("delete",
+            `${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -167,8 +169,10 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<{ [key: string]: number; }>(`${this.configuration.basePath}/store/inventory`,
+        return this.httpClient.request<{ [key: string]: number; }>("get",
+            `${this.configuration.basePath}/store/inventory`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -214,8 +218,10 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<Order>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
+        return this.httpClient.request<Order>("get",
+            `${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -268,9 +274,10 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.post<Order>(`${this.configuration.basePath}/store/order`,
-            body,
+        return this.httpClient.request<Order>("post",
+            `${this.configuration.basePath}/store/order`,
             {
+                body: body,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,

--- a/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/with-prefixed-module-name/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/with-prefixed-module-name/api/store.service.ts
@@ -118,7 +118,7 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("delete",
+        return this.httpClient.request<any>('delete',
             `${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
             {
                 responseType: <any>responseType,
@@ -168,7 +168,7 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<{ [key: string]: number; }>("get",
+        return this.httpClient.request<{ [key: string]: number; }>('get',
             `${this.configuration.basePath}/store/inventory`,
             {
                 responseType: <any>responseType,
@@ -216,7 +216,7 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<Order>("get",
+        return this.httpClient.request<Order>('get',
             `${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
             {
                 responseType: <any>responseType,
@@ -271,7 +271,7 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<Order>("post",
+        return this.httpClient.request<Order>('post',
             `${this.configuration.basePath}/store/order`,
             {
                 body: body,

--- a/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/with-prefixed-module-name/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/with-prefixed-module-name/api/user.service.ts
@@ -284,7 +284,6 @@ export class UserService {
         return this.httpClient.request<any>("delete",
             `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -332,7 +331,6 @@ export class UserService {
         return this.httpClient.request<User>("get",
             `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -394,7 +392,6 @@ export class UserService {
         return this.httpClient.request<string>("get",
             `${this.configuration.basePath}/user/login`,
             {
-                body: null,
                 params: queryParameters,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
@@ -437,7 +434,6 @@ export class UserService {
         return this.httpClient.request<any>("get",
             `${this.configuration.basePath}/user/logout`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,

--- a/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/with-prefixed-module-name/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/with-prefixed-module-name/api/user.service.ts
@@ -126,9 +126,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.post<any>(`${this.configuration.basePath}/user`,
-            body,
+        return this.httpClient.request<any>("post",
+            `${this.configuration.basePath}/user`,
             {
+                body: body,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -179,9 +180,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.post<any>(`${this.configuration.basePath}/user/createWithArray`,
-            body,
+        return this.httpClient.request<any>("post",
+            `${this.configuration.basePath}/user/createWithArray`,
             {
+                body: body,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -232,9 +234,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.post<any>(`${this.configuration.basePath}/user/createWithList`,
-            body,
+        return this.httpClient.request<any>("post",
+            `${this.configuration.basePath}/user/createWithList`,
             {
+                body: body,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -278,8 +281,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.delete<any>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
+        return this.httpClient.request<any>("delete",
+            `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -324,8 +329,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<User>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
+        return this.httpClient.request<User>("get",
+            `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -384,8 +391,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<string>(`${this.configuration.basePath}/user/login`,
+        return this.httpClient.request<string>("get",
+            `${this.configuration.basePath}/user/login`,
             {
+                body: null,
                 params: queryParameters,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
@@ -425,8 +434,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<any>(`${this.configuration.basePath}/user/logout`,
+        return this.httpClient.request<any>("get",
+            `${this.configuration.basePath}/user/logout`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -482,9 +493,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.put<any>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
-            body,
+        return this.httpClient.request<any>("put",
+            `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
+                body: body,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,

--- a/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/with-prefixed-module-name/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/with-prefixed-module-name/api/user.service.ts
@@ -126,7 +126,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("post",
+        return this.httpClient.request<any>('post',
             `${this.configuration.basePath}/user`,
             {
                 body: body,
@@ -180,7 +180,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("post",
+        return this.httpClient.request<any>('post',
             `${this.configuration.basePath}/user/createWithArray`,
             {
                 body: body,
@@ -234,7 +234,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("post",
+        return this.httpClient.request<any>('post',
             `${this.configuration.basePath}/user/createWithList`,
             {
                 body: body,
@@ -281,7 +281,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("delete",
+        return this.httpClient.request<any>('delete',
             `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
                 responseType: <any>responseType,
@@ -328,7 +328,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<User>("get",
+        return this.httpClient.request<User>('get',
             `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
                 responseType: <any>responseType,
@@ -389,7 +389,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<string>("get",
+        return this.httpClient.request<string>('get',
             `${this.configuration.basePath}/user/login`,
             {
                 params: queryParameters,
@@ -431,7 +431,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("get",
+        return this.httpClient.request<any>('get',
             `${this.configuration.basePath}/user/logout`,
             {
                 responseType: <any>responseType,
@@ -489,7 +489,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("put",
+        return this.httpClient.request<any>('put',
             `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
                 body: body,

--- a/samples/client/petstore/typescript-angular-v9-provided-in-root/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v9-provided-in-root/builds/default/api/pet.service.ts
@@ -148,7 +148,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("post",
+        return this.httpClient.request<any>('post',
             `${this.configuration.basePath}/pet`,
             {
                 body: body,
@@ -205,7 +205,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("delete",
+        return this.httpClient.request<any>('delete',
             `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
                 responseType: <any>responseType,
@@ -266,7 +266,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<Array<Pet>>("get",
+        return this.httpClient.request<Array<Pet>>('get',
             `${this.configuration.basePath}/pet/findByStatus`,
             {
                 params: queryParameters,
@@ -329,7 +329,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<Array<Pet>>("get",
+        return this.httpClient.request<Array<Pet>>('get',
             `${this.configuration.basePath}/pet/findByTags`,
             {
                 params: queryParameters,
@@ -385,7 +385,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<Pet>("get",
+        return this.httpClient.request<Pet>('get',
             `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
                 responseType: <any>responseType,
@@ -447,7 +447,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("put",
+        return this.httpClient.request<any>('put',
             `${this.configuration.basePath}/pet`,
             {
                 body: body,
@@ -524,7 +524,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("post",
+        return this.httpClient.request<any>('post',
             `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
                 body: convertFormParamsToString ? formParams.toString() : formParams,
@@ -605,7 +605,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<ApiResponse>("post",
+        return this.httpClient.request<ApiResponse>('post',
             `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}/uploadImage`,
             {
                 body: convertFormParamsToString ? formParams.toString() : formParams,

--- a/samples/client/petstore/typescript-angular-v9-provided-in-root/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v9-provided-in-root/builds/default/api/pet.service.ts
@@ -208,7 +208,6 @@ export class PetService {
         return this.httpClient.request<any>("delete",
             `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -270,7 +269,6 @@ export class PetService {
         return this.httpClient.request<Array<Pet>>("get",
             `${this.configuration.basePath}/pet/findByStatus`,
             {
-                body: null,
                 params: queryParameters,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
@@ -334,7 +332,6 @@ export class PetService {
         return this.httpClient.request<Array<Pet>>("get",
             `${this.configuration.basePath}/pet/findByTags`,
             {
-                body: null,
                 params: queryParameters,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
@@ -391,7 +388,6 @@ export class PetService {
         return this.httpClient.request<Pet>("get",
             `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,

--- a/samples/client/petstore/typescript-angular-v9-provided-in-root/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v9-provided-in-root/builds/default/api/pet.service.ts
@@ -148,9 +148,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.post<any>(`${this.configuration.basePath}/pet`,
-            body,
+        return this.httpClient.request<any>("post",
+            `${this.configuration.basePath}/pet`,
             {
+                body: body,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -204,8 +205,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.delete<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
+        return this.httpClient.request<any>("delete",
+            `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -264,8 +267,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByStatus`,
+        return this.httpClient.request<Array<Pet>>("get",
+            `${this.configuration.basePath}/pet/findByStatus`,
             {
+                body: null,
                 params: queryParameters,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
@@ -326,8 +331,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByTags`,
+        return this.httpClient.request<Array<Pet>>("get",
+            `${this.configuration.basePath}/pet/findByTags`,
             {
+                body: null,
                 params: queryParameters,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
@@ -381,8 +388,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<Pet>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
+        return this.httpClient.request<Pet>("get",
+            `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -442,9 +451,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.put<any>(`${this.configuration.basePath}/pet`,
-            body,
+        return this.httpClient.request<any>("put",
+            `${this.configuration.basePath}/pet`,
             {
+                body: body,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -518,9 +528,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.post<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
-            convertFormParamsToString ? formParams.toString() : formParams,
+        return this.httpClient.request<any>("post",
+            `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
+                body: convertFormParamsToString ? formParams.toString() : formParams,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -598,9 +609,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.post<ApiResponse>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}/uploadImage`,
-            convertFormParamsToString ? formParams.toString() : formParams,
+        return this.httpClient.request<ApiResponse>("post",
+            `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}/uploadImage`,
             {
+                body: convertFormParamsToString ? formParams.toString() : formParams,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,

--- a/samples/client/petstore/typescript-angular-v9-provided-in-root/builds/default/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v9-provided-in-root/builds/default/api/store.service.ts
@@ -121,7 +121,6 @@ export class StoreService {
         return this.httpClient.request<any>("delete",
             `${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -172,7 +171,6 @@ export class StoreService {
         return this.httpClient.request<{ [key: string]: number; }>("get",
             `${this.configuration.basePath}/store/inventory`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -221,7 +219,6 @@ export class StoreService {
         return this.httpClient.request<Order>("get",
             `${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,

--- a/samples/client/petstore/typescript-angular-v9-provided-in-root/builds/default/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v9-provided-in-root/builds/default/api/store.service.ts
@@ -118,8 +118,10 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.delete<any>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
+        return this.httpClient.request<any>("delete",
+            `${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -167,8 +169,10 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<{ [key: string]: number; }>(`${this.configuration.basePath}/store/inventory`,
+        return this.httpClient.request<{ [key: string]: number; }>("get",
+            `${this.configuration.basePath}/store/inventory`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -214,8 +218,10 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<Order>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
+        return this.httpClient.request<Order>("get",
+            `${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -268,9 +274,10 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.post<Order>(`${this.configuration.basePath}/store/order`,
-            body,
+        return this.httpClient.request<Order>("post",
+            `${this.configuration.basePath}/store/order`,
             {
+                body: body,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,

--- a/samples/client/petstore/typescript-angular-v9-provided-in-root/builds/default/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v9-provided-in-root/builds/default/api/store.service.ts
@@ -118,7 +118,7 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("delete",
+        return this.httpClient.request<any>('delete',
             `${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
             {
                 responseType: <any>responseType,
@@ -168,7 +168,7 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<{ [key: string]: number; }>("get",
+        return this.httpClient.request<{ [key: string]: number; }>('get',
             `${this.configuration.basePath}/store/inventory`,
             {
                 responseType: <any>responseType,
@@ -216,7 +216,7 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<Order>("get",
+        return this.httpClient.request<Order>('get',
             `${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
             {
                 responseType: <any>responseType,
@@ -271,7 +271,7 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<Order>("post",
+        return this.httpClient.request<Order>('post',
             `${this.configuration.basePath}/store/order`,
             {
                 body: body,

--- a/samples/client/petstore/typescript-angular-v9-provided-in-root/builds/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v9-provided-in-root/builds/default/api/user.service.ts
@@ -284,7 +284,6 @@ export class UserService {
         return this.httpClient.request<any>("delete",
             `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -332,7 +331,6 @@ export class UserService {
         return this.httpClient.request<User>("get",
             `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -394,7 +392,6 @@ export class UserService {
         return this.httpClient.request<string>("get",
             `${this.configuration.basePath}/user/login`,
             {
-                body: null,
                 params: queryParameters,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
@@ -437,7 +434,6 @@ export class UserService {
         return this.httpClient.request<any>("get",
             `${this.configuration.basePath}/user/logout`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,

--- a/samples/client/petstore/typescript-angular-v9-provided-in-root/builds/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v9-provided-in-root/builds/default/api/user.service.ts
@@ -126,9 +126,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.post<any>(`${this.configuration.basePath}/user`,
-            body,
+        return this.httpClient.request<any>("post",
+            `${this.configuration.basePath}/user`,
             {
+                body: body,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -179,9 +180,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.post<any>(`${this.configuration.basePath}/user/createWithArray`,
-            body,
+        return this.httpClient.request<any>("post",
+            `${this.configuration.basePath}/user/createWithArray`,
             {
+                body: body,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -232,9 +234,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.post<any>(`${this.configuration.basePath}/user/createWithList`,
-            body,
+        return this.httpClient.request<any>("post",
+            `${this.configuration.basePath}/user/createWithList`,
             {
+                body: body,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -278,8 +281,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.delete<any>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
+        return this.httpClient.request<any>("delete",
+            `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -324,8 +329,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<User>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
+        return this.httpClient.request<User>("get",
+            `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -384,8 +391,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<string>(`${this.configuration.basePath}/user/login`,
+        return this.httpClient.request<string>("get",
+            `${this.configuration.basePath}/user/login`,
             {
+                body: null,
                 params: queryParameters,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
@@ -425,8 +434,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<any>(`${this.configuration.basePath}/user/logout`,
+        return this.httpClient.request<any>("get",
+            `${this.configuration.basePath}/user/logout`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -482,9 +493,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.put<any>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
-            body,
+        return this.httpClient.request<any>("put",
+            `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
+                body: body,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,

--- a/samples/client/petstore/typescript-angular-v9-provided-in-root/builds/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v9-provided-in-root/builds/default/api/user.service.ts
@@ -126,7 +126,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("post",
+        return this.httpClient.request<any>('post',
             `${this.configuration.basePath}/user`,
             {
                 body: body,
@@ -180,7 +180,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("post",
+        return this.httpClient.request<any>('post',
             `${this.configuration.basePath}/user/createWithArray`,
             {
                 body: body,
@@ -234,7 +234,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("post",
+        return this.httpClient.request<any>('post',
             `${this.configuration.basePath}/user/createWithList`,
             {
                 body: body,
@@ -281,7 +281,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("delete",
+        return this.httpClient.request<any>('delete',
             `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
                 responseType: <any>responseType,
@@ -328,7 +328,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<User>("get",
+        return this.httpClient.request<User>('get',
             `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
                 responseType: <any>responseType,
@@ -389,7 +389,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<string>("get",
+        return this.httpClient.request<string>('get',
             `${this.configuration.basePath}/user/login`,
             {
                 params: queryParameters,
@@ -431,7 +431,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("get",
+        return this.httpClient.request<any>('get',
             `${this.configuration.basePath}/user/logout`,
             {
                 responseType: <any>responseType,
@@ -489,7 +489,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("put",
+        return this.httpClient.request<any>('put',
             `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
                 body: body,

--- a/samples/client/petstore/typescript-angular-v9-provided-in-root/builds/with-npm/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v9-provided-in-root/builds/with-npm/api/pet.service.ts
@@ -148,7 +148,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("post",
+        return this.httpClient.request<any>('post',
             `${this.configuration.basePath}/pet`,
             {
                 body: body,
@@ -205,7 +205,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("delete",
+        return this.httpClient.request<any>('delete',
             `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
                 responseType: <any>responseType,
@@ -266,7 +266,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<Array<Pet>>("get",
+        return this.httpClient.request<Array<Pet>>('get',
             `${this.configuration.basePath}/pet/findByStatus`,
             {
                 params: queryParameters,
@@ -329,7 +329,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<Array<Pet>>("get",
+        return this.httpClient.request<Array<Pet>>('get',
             `${this.configuration.basePath}/pet/findByTags`,
             {
                 params: queryParameters,
@@ -385,7 +385,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<Pet>("get",
+        return this.httpClient.request<Pet>('get',
             `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
                 responseType: <any>responseType,
@@ -447,7 +447,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("put",
+        return this.httpClient.request<any>('put',
             `${this.configuration.basePath}/pet`,
             {
                 body: body,
@@ -524,7 +524,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("post",
+        return this.httpClient.request<any>('post',
             `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
                 body: convertFormParamsToString ? formParams.toString() : formParams,
@@ -605,7 +605,7 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<ApiResponse>("post",
+        return this.httpClient.request<ApiResponse>('post',
             `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}/uploadImage`,
             {
                 body: convertFormParamsToString ? formParams.toString() : formParams,

--- a/samples/client/petstore/typescript-angular-v9-provided-in-root/builds/with-npm/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v9-provided-in-root/builds/with-npm/api/pet.service.ts
@@ -208,7 +208,6 @@ export class PetService {
         return this.httpClient.request<any>("delete",
             `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -270,7 +269,6 @@ export class PetService {
         return this.httpClient.request<Array<Pet>>("get",
             `${this.configuration.basePath}/pet/findByStatus`,
             {
-                body: null,
                 params: queryParameters,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
@@ -334,7 +332,6 @@ export class PetService {
         return this.httpClient.request<Array<Pet>>("get",
             `${this.configuration.basePath}/pet/findByTags`,
             {
-                body: null,
                 params: queryParameters,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
@@ -391,7 +388,6 @@ export class PetService {
         return this.httpClient.request<Pet>("get",
             `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,

--- a/samples/client/petstore/typescript-angular-v9-provided-in-root/builds/with-npm/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v9-provided-in-root/builds/with-npm/api/pet.service.ts
@@ -148,9 +148,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.post<any>(`${this.configuration.basePath}/pet`,
-            body,
+        return this.httpClient.request<any>("post",
+            `${this.configuration.basePath}/pet`,
             {
+                body: body,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -204,8 +205,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.delete<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
+        return this.httpClient.request<any>("delete",
+            `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -264,8 +267,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByStatus`,
+        return this.httpClient.request<Array<Pet>>("get",
+            `${this.configuration.basePath}/pet/findByStatus`,
             {
+                body: null,
                 params: queryParameters,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
@@ -326,8 +331,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByTags`,
+        return this.httpClient.request<Array<Pet>>("get",
+            `${this.configuration.basePath}/pet/findByTags`,
             {
+                body: null,
                 params: queryParameters,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
@@ -381,8 +388,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<Pet>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
+        return this.httpClient.request<Pet>("get",
+            `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -442,9 +451,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.put<any>(`${this.configuration.basePath}/pet`,
-            body,
+        return this.httpClient.request<any>("put",
+            `${this.configuration.basePath}/pet`,
             {
+                body: body,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -518,9 +528,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.post<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
-            convertFormParamsToString ? formParams.toString() : formParams,
+        return this.httpClient.request<any>("post",
+            `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
+                body: convertFormParamsToString ? formParams.toString() : formParams,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -598,9 +609,10 @@ export class PetService {
             responseType = 'text';
         }
 
-        return this.httpClient.post<ApiResponse>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}/uploadImage`,
-            convertFormParamsToString ? formParams.toString() : formParams,
+        return this.httpClient.request<ApiResponse>("post",
+            `${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}/uploadImage`,
             {
+                body: convertFormParamsToString ? formParams.toString() : formParams,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,

--- a/samples/client/petstore/typescript-angular-v9-provided-in-root/builds/with-npm/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v9-provided-in-root/builds/with-npm/api/store.service.ts
@@ -121,7 +121,6 @@ export class StoreService {
         return this.httpClient.request<any>("delete",
             `${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -172,7 +171,6 @@ export class StoreService {
         return this.httpClient.request<{ [key: string]: number; }>("get",
             `${this.configuration.basePath}/store/inventory`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -221,7 +219,6 @@ export class StoreService {
         return this.httpClient.request<Order>("get",
             `${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,

--- a/samples/client/petstore/typescript-angular-v9-provided-in-root/builds/with-npm/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v9-provided-in-root/builds/with-npm/api/store.service.ts
@@ -118,8 +118,10 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.delete<any>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
+        return this.httpClient.request<any>("delete",
+            `${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -167,8 +169,10 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<{ [key: string]: number; }>(`${this.configuration.basePath}/store/inventory`,
+        return this.httpClient.request<{ [key: string]: number; }>("get",
+            `${this.configuration.basePath}/store/inventory`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -214,8 +218,10 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<Order>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
+        return this.httpClient.request<Order>("get",
+            `${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -268,9 +274,10 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.post<Order>(`${this.configuration.basePath}/store/order`,
-            body,
+        return this.httpClient.request<Order>("post",
+            `${this.configuration.basePath}/store/order`,
             {
+                body: body,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,

--- a/samples/client/petstore/typescript-angular-v9-provided-in-root/builds/with-npm/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v9-provided-in-root/builds/with-npm/api/store.service.ts
@@ -118,7 +118,7 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("delete",
+        return this.httpClient.request<any>('delete',
             `${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
             {
                 responseType: <any>responseType,
@@ -168,7 +168,7 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<{ [key: string]: number; }>("get",
+        return this.httpClient.request<{ [key: string]: number; }>('get',
             `${this.configuration.basePath}/store/inventory`,
             {
                 responseType: <any>responseType,
@@ -216,7 +216,7 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<Order>("get",
+        return this.httpClient.request<Order>('get',
             `${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
             {
                 responseType: <any>responseType,
@@ -271,7 +271,7 @@ export class StoreService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<Order>("post",
+        return this.httpClient.request<Order>('post',
             `${this.configuration.basePath}/store/order`,
             {
                 body: body,

--- a/samples/client/petstore/typescript-angular-v9-provided-in-root/builds/with-npm/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v9-provided-in-root/builds/with-npm/api/user.service.ts
@@ -284,7 +284,6 @@ export class UserService {
         return this.httpClient.request<any>("delete",
             `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -332,7 +331,6 @@ export class UserService {
         return this.httpClient.request<User>("get",
             `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -394,7 +392,6 @@ export class UserService {
         return this.httpClient.request<string>("get",
             `${this.configuration.basePath}/user/login`,
             {
-                body: null,
                 params: queryParameters,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
@@ -437,7 +434,6 @@ export class UserService {
         return this.httpClient.request<any>("get",
             `${this.configuration.basePath}/user/logout`,
             {
-                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,

--- a/samples/client/petstore/typescript-angular-v9-provided-in-root/builds/with-npm/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v9-provided-in-root/builds/with-npm/api/user.service.ts
@@ -126,9 +126,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.post<any>(`${this.configuration.basePath}/user`,
-            body,
+        return this.httpClient.request<any>("post",
+            `${this.configuration.basePath}/user`,
             {
+                body: body,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -179,9 +180,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.post<any>(`${this.configuration.basePath}/user/createWithArray`,
-            body,
+        return this.httpClient.request<any>("post",
+            `${this.configuration.basePath}/user/createWithArray`,
             {
+                body: body,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -232,9 +234,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.post<any>(`${this.configuration.basePath}/user/createWithList`,
-            body,
+        return this.httpClient.request<any>("post",
+            `${this.configuration.basePath}/user/createWithList`,
             {
+                body: body,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -278,8 +281,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.delete<any>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
+        return this.httpClient.request<any>("delete",
+            `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -324,8 +329,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<User>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
+        return this.httpClient.request<User>("get",
+            `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -384,8 +391,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<string>(`${this.configuration.basePath}/user/login`,
+        return this.httpClient.request<string>("get",
+            `${this.configuration.basePath}/user/login`,
             {
+                body: null,
                 params: queryParameters,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
@@ -425,8 +434,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.get<any>(`${this.configuration.basePath}/user/logout`,
+        return this.httpClient.request<any>("get",
+            `${this.configuration.basePath}/user/logout`,
             {
+                body: null,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
@@ -482,9 +493,10 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.put<any>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
-            body,
+        return this.httpClient.request<any>("put",
+            `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
+                body: body,
                 responseType: <any>responseType,
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,

--- a/samples/client/petstore/typescript-angular-v9-provided-in-root/builds/with-npm/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v9-provided-in-root/builds/with-npm/api/user.service.ts
@@ -126,7 +126,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("post",
+        return this.httpClient.request<any>('post',
             `${this.configuration.basePath}/user`,
             {
                 body: body,
@@ -180,7 +180,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("post",
+        return this.httpClient.request<any>('post',
             `${this.configuration.basePath}/user/createWithArray`,
             {
                 body: body,
@@ -234,7 +234,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("post",
+        return this.httpClient.request<any>('post',
             `${this.configuration.basePath}/user/createWithList`,
             {
                 body: body,
@@ -281,7 +281,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("delete",
+        return this.httpClient.request<any>('delete',
             `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
                 responseType: <any>responseType,
@@ -328,7 +328,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<User>("get",
+        return this.httpClient.request<User>('get',
             `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
                 responseType: <any>responseType,
@@ -389,7 +389,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<string>("get",
+        return this.httpClient.request<string>('get',
             `${this.configuration.basePath}/user/login`,
             {
                 params: queryParameters,
@@ -431,7 +431,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("get",
+        return this.httpClient.request<any>('get',
             `${this.configuration.basePath}/user/logout`,
             {
                 responseType: <any>responseType,
@@ -489,7 +489,7 @@ export class UserService {
             responseType = 'text';
         }
 
-        return this.httpClient.request<any>("put",
+        return this.httpClient.request<any>('put',
             `${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
                 body: body,


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
allow to have a body on a delete request.
DELETE requests support having a body per specification, therefore the openapi stubs should support this as well.

Instead of singling out the DELETE method, this PR uses the more generic `httpClient.request` that allows passing a 
body for any method.
Therefore it leaves the handling of a defined body on an unsupported method to the underlying implementation.
This is also the proposed solution by an angular developer, as the angular team is not willing to change the api of
`httpClient.delete` to support a body argument:
https://github.com/angular/angular/pull/37894

fixes issue: https://github.com/OpenAPITools/openapi-generator/issues/7557

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

technical committee:
@TiFu (2017/07) @taxpon (2017/07) @sebastianhaas (2017/07) @kenisteward (2017/07) @Vrolijkx (2017/09) @macjohnny (2018/01) @topce (2018/10) @akehir (2019/07) @petejohansonxo (2019/11) @amakhrov (2020/02)
