### PR TITLE
Fix parameter uniqueness for form- and body-params

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -3839,10 +3839,20 @@ public class DefaultCodegen implements CodegenConfig {
         // add form/body parameter (if any) to the end of all parameter list
         if (!prependFormOrBodyParameters) {
             for (CodegenParameter cp : formParams) {
+                if (ensureUniqueParams) {
+                    if (!isParameterNameUnique(cp, allParams)) {
+                        cp.paramName = generateNextName(cp.paramName);
+                    }
+                }
                 allParams.add(cp.copy());
             }
 
             for (CodegenParameter cp : bodyParams) {
+                if (ensureUniqueParams) {
+                    if (!isParameterNameUnique(cp, allParams)) {
+                        cp.paramName = generateNextName(cp.paramName);
+                    }
+                }
                 allParams.add(cp.copy());
             }
         }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
@@ -412,6 +412,20 @@ public class DefaultCodegenTest {
     }
 
     @Test
+    public void testUniquenessRenameOfFormParameters() throws Exception {
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/form-duplicated-parameter.yaml");
+        DefaultCodegen codegen = new DefaultCodegen();
+        codegen.setOpenAPI(openAPI);
+        Operation operation = openAPI.getPaths().get("/form-param-poc/{id}").getPut();
+        CodegenOperation co = codegen.fromOperation("/form-param-poc/{id}", "put", operation, null);
+        Assert.assertEquals(co.path, "/form-param-poc/{id}");
+        Assert.assertEquals(co.allParams.size(), 2);
+        List<String> allParamsNames = co.allParams.stream().map(p -> p.paramName).collect(Collectors.toList());
+        Assert.assertTrue(allParamsNames.contains("id"));
+        Assert.assertTrue(allParamsNames.contains("id2"));
+    }
+
+    @Test
     public void testGetSchemaTypeWithComposedSchemaWithOneOf() {
         final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/composed-oneof.yaml");
         final DefaultCodegen codegen = new DefaultCodegen();

--- a/modules/openapi-generator/src/test/resources/3_0/form-duplicated-parameter.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/form-duplicated-parameter.yaml
@@ -1,0 +1,50 @@
+openapi: 3.0.1
+info:
+  title: FormData Test Api Documentation
+  description: Minimal OpenAPI spec file to showcase duplicated params for formData.
+  version: 0.0.1
+servers:
+  - url: /backend/rest
+tags:
+  - name: form-param-poc
+    description: File storage resource for Fiscalization France standard
+paths:
+  '/form-param-poc/{id}':
+    put:
+      tags:
+        - form-param-poc
+      summary: fullUpdate
+      operationId: form-param-poc_update
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/FormParameters'
+      responses:
+        '200':
+          description: OK.
+      security:
+        - oAuthConfig: []
+components:
+  schemas:
+    FormParameters:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+          readOnly: true
+  securitySchemes:
+    oAuthConfig:
+      type: oauth2
+      flows:
+        implicit:
+          authorizationUrl: ../backend/login/openid
+          scopes: {}


### PR DESCRIPTION
If a form-parameter had the same name as another (header-, query-,
path-, or cookie-)parameter, a conflict could be caused (for example
in the typescript generator). This fix executes the same uniqueness-
check and renaming for form- and body-parameters as it is done for
all other parameters.

Fixes #7575

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

### Technical committee
This fix has influence on all generators, however I was working with the TypeScript generator:
@TiFu (2017/07) @taxpon (2017/07) @sebastianhaas (2017/07) @kenisteward (2017/07) @Vrolijkx (2017/09) @macjohnny (2018/01) @topce (2018/10) @akehir (2019/07) @petejohansonxo (2019/11) @amakhrov (2020/02)

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
