### PR TITLE
Expose JsonSerializerSettings in ApiClient

### DIFF
--- a/modules/openapi-generator/src/main/resources/csharp-netcore/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/ApiClient.mustache
@@ -160,6 +160,10 @@ namespace {{packageName}}.Client
     {
         private readonly String _baseUrl;
 
+        /// <summary>
+        /// Specifies the settings on a <see cref="JsonSerializer" /> object. 
+        /// These settings can be adjusted to accomodate custom serialization rules.
+        /// </summary>
         public JsonSerializerSettings SerializerSettings { get; set; } = new JsonSerializerSettings
         {
             // OpenAPI generated types generally hide default constructors.
@@ -168,7 +172,7 @@ namespace {{packageName}}.Client
             {
                 NamingStrategy = new CamelCaseNamingStrategy
                 {
-                    OverrideSpecifiedNames = true
+                    OverrideSpecifiedNames = false
                 }
             }
         };

--- a/modules/openapi-generator/src/main/resources/csharp-netcore/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/ApiClient.mustache
@@ -160,6 +160,19 @@ namespace {{packageName}}.Client
     {
         private readonly String _baseUrl;
 
+        public JsonSerializerSettings SerializerSettings { get; set; } = new JsonSerializerSettings
+        {
+            // OpenAPI generated types generally hide default constructors.
+            ConstructorHandling = ConstructorHandling.AllowNonPublicDefaultConstructor,
+            ContractResolver = new DefaultContractResolver
+            {
+                NamingStrategy = new CamelCaseNamingStrategy
+                {
+                    OverrideSpecifiedNames = true
+                }
+            }
+        };
+
         /// <summary>
         /// Allows for extending request processing for <see cref="ApiClient"/> generated code.
         /// </summary>
@@ -258,7 +271,7 @@ namespace {{packageName}}.Client
             RestRequest request = new RestRequest(Method(method))
             {
                 Resource = path,
-                JsonSerializer = new CustomJsonCodec(configuration)
+                JsonSerializer = new CustomJsonCodec(SerializerSettings, configuration)
             };
 
             if (options.PathParameters != null)
@@ -406,7 +419,7 @@ namespace {{packageName}}.Client
             }
             else
             {
-                var customDeserializer = new CustomJsonCodec(configuration);
+                var customDeserializer = new CustomJsonCodec(SerializerSettings, configuration);
                 client.AddHandler("application/json", () => customDeserializer);
                 client.AddHandler("text/json", () => customDeserializer);
                 client.AddHandler("text/x-json", () => customDeserializer);
@@ -435,7 +448,7 @@ namespace {{packageName}}.Client
             InterceptRequest(req);
 
             IRestResponse<T> response;
-            if (RetryConfiguration.RetryPolicy != null)	
+            if (RetryConfiguration.RetryPolicy != null)
             {
                 var policy = RetryConfiguration.RetryPolicy;
                 var policyResult = policy.ExecuteAndCapture(() => client.Execute(req));
@@ -513,7 +526,7 @@ namespace {{packageName}}.Client
             }
             else
             {
-                var customDeserializer = new CustomJsonCodec(configuration);
+                var customDeserializer = new CustomJsonCodec(SerializerSettings, configuration);
                 client.AddHandler("application/json", () => customDeserializer);
                 client.AddHandler("text/json", () => customDeserializer);
                 client.AddHandler("text/x-json", () => customDeserializer);

--- a/modules/openapi-generator/src/main/resources/csharp/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp/ApiClient.mustache
@@ -30,7 +30,7 @@ namespace {{packageName}}.Client
     /// </summary>
     {{>visibility}} partial class ApiClient
     {
-        private JsonSerializerSettings serializerSettings = new JsonSerializerSettings
+        public JsonSerializerSettings serializerSettings = new JsonSerializerSettings
         {
             ConstructorHandling = ConstructorHandling.AllowNonPublicDefaultConstructor
         };

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools.Test/ApiClientTests.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools.Test/ApiClientTests.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.IO;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Reflection;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+using RestSharp;
+using Xunit;
+
+using Org.OpenAPITools.Client;
+using Org.OpenAPITools.Api;
+using Org.OpenAPITools.Model;
+
+namespace Org.OpenAPITools.Test
+{
+    /// <summary>
+    /// Class for testing ApiClient
+    /// </summary>
+    public class ApiClientTests
+    {
+        public ApiClientTests()
+        {
+        }
+
+        /// <summary>
+        /// Test GetSerializerSettingsTest
+        /// </summary>
+        [Fact]
+        public void GetSerializerSettingsTest()
+        {
+            ApiClient apiClient = new ApiClient();
+
+            var serializerSettingsPropertyInfo = typeof(ApiClient).GetProperty(nameof(ApiClient.SerializerSettings));
+
+            // Validate that we can the set the SerializerSettings (public visibility)
+            Assert.NotNull(serializerSettingsPropertyInfo?.GetSetMethod());
+
+            // Validate default serializer settings
+            Assert.NotNull(apiClient.SerializerSettings);
+            Assert.Equal(ConstructorHandling.AllowNonPublicDefaultConstructor, apiClient.SerializerSettings.ConstructorHandling);
+            Assert.False(((DefaultContractResolver)apiClient.SerializerSettings.ContractResolver).NamingStrategy.OverrideSpecifiedNames);
+        }
+    }
+}

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -164,6 +164,10 @@ namespace Org.OpenAPITools.Client
     {
         private readonly String _baseUrl;
 
+        /// <summary>
+        /// Specifies the settings on a <see cref="JsonSerializer" /> object. 
+        /// These settings can be adjusted to accomodate custom serialization rules.
+        /// </summary>
         public JsonSerializerSettings SerializerSettings { get; set; } = new JsonSerializerSettings
         {
             // OpenAPI generated types generally hide default constructors.
@@ -172,7 +176,7 @@ namespace Org.OpenAPITools.Client
             {
                 NamingStrategy = new CamelCaseNamingStrategy
                 {
-                    OverrideSpecifiedNames = true
+                    OverrideSpecifiedNames = false
                 }
             }
         };

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -164,6 +164,19 @@ namespace Org.OpenAPITools.Client
     {
         private readonly String _baseUrl;
 
+        public JsonSerializerSettings SerializerSettings { get; set; } = new JsonSerializerSettings
+        {
+            // OpenAPI generated types generally hide default constructors.
+            ConstructorHandling = ConstructorHandling.AllowNonPublicDefaultConstructor,
+            ContractResolver = new DefaultContractResolver
+            {
+                NamingStrategy = new CamelCaseNamingStrategy
+                {
+                    OverrideSpecifiedNames = true
+                }
+            }
+        };
+
         /// <summary>
         /// Allows for extending request processing for <see cref="ApiClient"/> generated code.
         /// </summary>
@@ -262,7 +275,7 @@ namespace Org.OpenAPITools.Client
             RestRequest request = new RestRequest(Method(method))
             {
                 Resource = path,
-                JsonSerializer = new CustomJsonCodec(configuration)
+                JsonSerializer = new CustomJsonCodec(SerializerSettings, configuration)
             };
 
             if (options.PathParameters != null)
@@ -410,7 +423,7 @@ namespace Org.OpenAPITools.Client
             }
             else
             {
-                var customDeserializer = new CustomJsonCodec(configuration);
+                var customDeserializer = new CustomJsonCodec(SerializerSettings, configuration);
                 client.AddHandler("application/json", () => customDeserializer);
                 client.AddHandler("text/json", () => customDeserializer);
                 client.AddHandler("text/x-json", () => customDeserializer);
@@ -439,7 +452,7 @@ namespace Org.OpenAPITools.Client
             InterceptRequest(req);
 
             IRestResponse<T> response;
-            if (RetryConfiguration.RetryPolicy != null)	
+            if (RetryConfiguration.RetryPolicy != null)
             {
                 var policy = RetryConfiguration.RetryPolicy;
                 var policyResult = policy.ExecuteAndCapture(() => client.Execute(req));
@@ -516,7 +529,7 @@ namespace Org.OpenAPITools.Client
             }
             else
             {
-                var customDeserializer = new CustomJsonCodec(configuration);
+                var customDeserializer = new CustomJsonCodec(SerializerSettings, configuration);
                 client.AddHandler("application/json", () => customDeserializer);
                 client.AddHandler("text/json", () => customDeserializer);
                 client.AddHandler("text/x-json", () => customDeserializer);

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -165,6 +165,19 @@ namespace Org.OpenAPITools.Client
     {
         private readonly String _baseUrl;
 
+        public JsonSerializerSettings SerializerSettings { get; set; } = new JsonSerializerSettings
+        {
+            // OpenAPI generated types generally hide default constructors.
+            ConstructorHandling = ConstructorHandling.AllowNonPublicDefaultConstructor,
+            ContractResolver = new DefaultContractResolver
+            {
+                NamingStrategy = new CamelCaseNamingStrategy
+                {
+                    OverrideSpecifiedNames = true
+                }
+            }
+        };
+
         /// <summary>
         /// Allows for extending request processing for <see cref="ApiClient"/> generated code.
         /// </summary>
@@ -263,7 +276,7 @@ namespace Org.OpenAPITools.Client
             RestRequest request = new RestRequest(Method(method))
             {
                 Resource = path,
-                JsonSerializer = new CustomJsonCodec(configuration)
+                JsonSerializer = new CustomJsonCodec(SerializerSettings, configuration)
             };
 
             if (options.PathParameters != null)
@@ -411,7 +424,7 @@ namespace Org.OpenAPITools.Client
             }
             else
             {
-                var customDeserializer = new CustomJsonCodec(configuration);
+                var customDeserializer = new CustomJsonCodec(SerializerSettings, configuration);
                 client.AddHandler("application/json", () => customDeserializer);
                 client.AddHandler("text/json", () => customDeserializer);
                 client.AddHandler("text/x-json", () => customDeserializer);
@@ -440,7 +453,7 @@ namespace Org.OpenAPITools.Client
             InterceptRequest(req);
 
             IRestResponse<T> response;
-            if (RetryConfiguration.RetryPolicy != null)	
+            if (RetryConfiguration.RetryPolicy != null)
             {
                 var policy = RetryConfiguration.RetryPolicy;
                 var policyResult = policy.ExecuteAndCapture(() => client.Execute(req));
@@ -517,7 +530,7 @@ namespace Org.OpenAPITools.Client
             }
             else
             {
-                var customDeserializer = new CustomJsonCodec(configuration);
+                var customDeserializer = new CustomJsonCodec(SerializerSettings, configuration);
                 client.AddHandler("application/json", () => customDeserializer);
                 client.AddHandler("text/json", () => customDeserializer);
                 client.AddHandler("text/x-json", () => customDeserializer);

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -165,6 +165,10 @@ namespace Org.OpenAPITools.Client
     {
         private readonly String _baseUrl;
 
+        /// <summary>
+        /// Specifies the settings on a <see cref="JsonSerializer" /> object. 
+        /// These settings can be adjusted to accomodate custom serialization rules.
+        /// </summary>
         public JsonSerializerSettings SerializerSettings { get; set; } = new JsonSerializerSettings
         {
             // OpenAPI generated types generally hide default constructors.
@@ -173,7 +177,7 @@ namespace Org.OpenAPITools.Client
             {
                 NamingStrategy = new CamelCaseNamingStrategy
                 {
-                    OverrideSpecifiedNames = true
+                    OverrideSpecifiedNames = false
                 }
             }
         };

--- a/samples/client/petstore/csharp/OpenAPIClient/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Client
     /// </summary>
     public partial class ApiClient
     {
-        private JsonSerializerSettings serializerSettings = new JsonSerializerSettings
+        public JsonSerializerSettings serializerSettings = new JsonSerializerSettings
         {
             ConstructorHandling = ConstructorHandling.AllowNonPublicDefaultConstructor
         };

--- a/samples/client/petstore/csharp/OpenAPIClientNetStandard/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp/OpenAPIClientNetStandard/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Client
     /// </summary>
     public partial class ApiClient
     {
-        private JsonSerializerSettings serializerSettings = new JsonSerializerSettings
+        public JsonSerializerSettings serializerSettings = new JsonSerializerSettings
         {
             ConstructorHandling = ConstructorHandling.AllowNonPublicDefaultConstructor
         };


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
In this PR, I expose the JsonSerializerSettings in the ApiClient so that serialization customizations can be done. For example, in my specific use-case, I wanted to add additional Converters to change the way JSON was being deserialized back into the csharp classes.

Fixes #4241

I reviewed the comments made on this related PR #4466 and incorporated the feedback into this PR.

@mandrean (2017/08) @frankyjuang (2019/09) @shibayan (2020/02)

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
