### PR TITLE
CHORE[CORE]: replace deprecated methods

### DIFF
--- a/modules/openapi-generator-online/src/main/java/org/openapitools/codegen/online/service/Generator.java
+++ b/modules/openapi-generator-online/src/main/java/org/openapitools/codegen/online/service/Generator.java
@@ -147,7 +147,7 @@ public class Generator {
 
         codegenConfig.setOutputDir(outputFolder);
 
-        clientOptInput.setConfig(codegenConfig);
+        clientOptInput.config(codegenConfig);
 
         try {
             List<File> files = new DefaultGenerator().opts(clientOptInput).generate();

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultGeneratorTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultGeneratorTest.java
@@ -345,10 +345,10 @@ public class DefaultGeneratorTest {
         openAPI.getPaths().addPathItem("path2/", new PathItem().get(new Operation().operationId("op2").addParametersItem(new QueryParameter().name("p1").schema(new StringSchema())).responses(new ApiResponses().addApiResponse("201", new ApiResponse().description("OK")))));
 
         ClientOptInput opts = new ClientOptInput();
-        opts.setOpenAPI(openAPI);
+        opts.openAPI(openAPI);
         CodegenConfig config = new DefaultCodegen();
         config.setStrictSpecBehavior(false);
-        opts.setConfig(config);
+        opts.config(config);
 
         DefaultGenerator generator = new DefaultGenerator();
         generator.opts(opts);
@@ -372,8 +372,8 @@ public class DefaultGeneratorTest {
         openAPI.getPaths().addPathItem("/path4", new PathItem().addParametersItem(new QueryParameter().name("p1").schema(new StringSchema())).get(new Operation().operationId("op4").responses(new ApiResponses().addApiResponse("201", new ApiResponse().description("OK")))));
 
         ClientOptInput opts = new ClientOptInput();
-        opts.setOpenAPI(openAPI);
-        opts.setConfig(new DefaultCodegen());
+        opts.openAPI(openAPI);
+        opts.config(new DefaultCodegen());
 
         DefaultGenerator generator = new DefaultGenerator();
         generator.opts(opts);
@@ -395,10 +395,10 @@ public class DefaultGeneratorTest {
     public void testRefModelValidationProperties() {
         OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/2_0/refAliasedPrimitiveWithValidation.yml");
         ClientOptInput opts = new ClientOptInput();
-        opts.setOpenAPI(openAPI);
+        opts.openAPI(openAPI);
         DefaultCodegen config = new DefaultCodegen();
         config.setStrictSpecBehavior(false);
-        opts.setConfig(config);
+        opts.config(config);
 
         DefaultGenerator generator = new DefaultGenerator();
         generator.opts(opts);

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/haskellservant/HaskellServantCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/haskellservant/HaskellServantCodegenTest.java
@@ -53,8 +53,8 @@ public class HaskellServantCodegenTest {
                 .getOpenAPI();
 
         ClientOptInput input = new ClientOptInput();
-        input.setOpenAPI(openAPI);
-        input.setConfig(codegen);
+        input.openAPI(openAPI);
+        input.config(codegen);
 
         // when
         DefaultGenerator generator = new DefaultGenerator();

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
@@ -485,8 +485,8 @@ public class JavaClientCodegenTest {
         final DefaultGenerator defaultGenerator = new DefaultGenerator();
 
         final ClientOptInput clientOptInput = new ClientOptInput();
-        clientOptInput.setOpenAPI(openAPI);
-        clientOptInput.setConfig(new JavaClientCodegen());
+        clientOptInput.openAPI(openAPI);
+        clientOptInput.config(new JavaClientCodegen());
 
         defaultGenerator.opts(clientOptInput);
         final List<CodegenOperation> codegenOperations = defaultGenerator.processPaths(openAPI.getPaths()).get("Pet");
@@ -541,8 +541,8 @@ public class JavaClientCodegenTest {
         final DefaultGenerator defaultGenerator = new DefaultGenerator();
 
         final ClientOptInput clientOptInput = new ClientOptInput();
-        clientOptInput.setOpenAPI(openAPI);
-        clientOptInput.setConfig(new JavaClientCodegen());
+        clientOptInput.openAPI(openAPI);
+        clientOptInput.config(new JavaClientCodegen());
 
         defaultGenerator.opts(clientOptInput);
         final List<CodegenOperation> codegenOperations = defaultGenerator.processPaths(openAPI.getPaths()).get("Pet");

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaModelTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaModelTest.java
@@ -1331,8 +1331,8 @@ public class JavaModelTest {
         final OpenAPI openAPI = TestUtils.parseFlattenSpec(inputSpec);
 
         final ClientOptInput opts = new ClientOptInput();
-        opts.setConfig(config);
-        opts.setOpenAPI(openAPI);
+        opts.config(config);
+        opts.openAPI(openAPI);
         new DefaultGenerator().opts(opts).generate();
 
         File orderFile = new File(output, "src/main/java/org/openapitools/client/api/DefaultApi.java");

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/jaxrs/JavaJAXRSCXFExtServerCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/jaxrs/JavaJAXRSCXFExtServerCodegenTest.java
@@ -381,8 +381,8 @@ public class JavaJAXRSCXFExtServerCodegenTest extends JavaJaxrsBaseTest {
         codegen.additionalProperties().put(CXFExtServerFeatures.GENERATE_OPERATION_BODY, "true");
 
         ClientOptInput input = new ClientOptInput();
-        input.setOpenAPI(openAPI);
-        input.setConfig(codegen);
+        input.openAPI(openAPI);
+        input.config(codegen);
 
         DefaultGenerator generator = new DefaultGenerator();
         generator.opts(input).generate();
@@ -426,8 +426,8 @@ public class JavaJAXRSCXFExtServerCodegenTest extends JavaJaxrsBaseTest {
         codegen.additionalProperties().put(CXFServerFeatures.LOAD_TEST_DATA_FROM_FILE, "true");
 
         ClientOptInput input = new ClientOptInput();
-        input.setOpenAPI(openAPI);
-        input.setConfig(codegen);
+        input.openAPI(openAPI);
+        input.config(codegen);
 
         DefaultGenerator generator = new DefaultGenerator();
         generator.opts(input).generate();

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
@@ -171,8 +171,8 @@ public class SpringCodegenTest {
         codegen.additionalProperties().put(CXFServerFeatures.LOAD_TEST_DATA_FROM_FILE, "true");
 
         ClientOptInput input = new ClientOptInput();
-        input.setOpenAPI(openAPI);
-        input.setConfig(codegen);
+        input.openAPI(openAPI);
+        input.config(codegen);
 
         DefaultGenerator generator = new DefaultGenerator();
 
@@ -255,8 +255,8 @@ public class SpringCodegenTest {
         codegen.additionalProperties().put(CXFServerFeatures.LOAD_TEST_DATA_FROM_FILE, "true");
 
         ClientOptInput input = new ClientOptInput();
-        input.setOpenAPI(openAPI);
-        input.setConfig(codegen);
+        input.openAPI(openAPI);
+        input.config(codegen);
 
         DefaultGenerator generator = new DefaultGenerator();
 
@@ -287,8 +287,8 @@ public class SpringCodegenTest {
         codegen.additionalProperties().put(CXFServerFeatures.LOAD_TEST_DATA_FROM_FILE, "true");
 
         ClientOptInput input = new ClientOptInput();
-        input.setOpenAPI(openAPI);
-        input.setConfig(codegen);
+        input.openAPI(openAPI);
+        input.config(codegen);
 
         DefaultGenerator generator = new DefaultGenerator();
 
@@ -426,8 +426,8 @@ public class SpringCodegenTest {
         codegen.additionalProperties().put(CXFServerFeatures.LOAD_TEST_DATA_FROM_FILE, "true");
 
         ClientOptInput input = new ClientOptInput();
-        input.setOpenAPI(openAPI);
-        input.setConfig(codegen);
+        input.openAPI(openAPI);
+        input.config(codegen);
 
         DefaultGenerator generator = new DefaultGenerator();
 


### PR DESCRIPTION
replace setConfig and setOpenApi with the
non-deprecated config / openAPI methods

Fixes N/A

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

Replace usages of `setOpenAPI` and `setConfig` with non-deprecated usages `config` / `openAPI`.

There also seem to be a bunch of unused deprecated methods in this package. Are these used by some third party or can these be pruned if unused?

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [ ] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [ ] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
