### PR TITLE
[Elixir] Fixes optional body mapping

### DIFF
--- a/modules/openapi-generator/src/main/resources/elixir/api.mustache
+++ b/modules/openapi-generator/src/main/resources/elixir/api.mustache
@@ -26,7 +26,12 @@ defmodule {{moduleName}}.Api.{{classname}} do
 {{/requiredParams}}
   - opts (KeywordList): [optional] Optional parameters
 {{#optionalParams}}
+{{#isBodyParam}}
+    - :body ({{dataType}}): {{&description}}
+{{/isBodyParam}}
+{{^isBodyParam}}
     - {{#underscored}}:{{paramName}}{{/underscored}} ({{dataType}}): {{&description}}
+{{/isBodyParam}}
 {{/optionalParams}}
   ## Returns
 
@@ -39,7 +44,12 @@ defmodule {{moduleName}}.Api.{{classname}} do
 {{#-first}}
     optional_params = %{
 {{/-first}}
-      :"{{baseName}}" => {{#isBodyParam}}:body{{/isBodyParam}}{{#isFormParam}}:form{{/isFormParam}}{{#isQueryParam}}:query{{/isQueryParam}}{{#isHeaderParam}}:headers{{/isHeaderParam}}{{#hasMore}},{{/hasMore}}
+{{#isBodyParam}}
+      :body => :body
+{{/isBodyParam}}
+{{^isBodyParam}}
+      :"{{baseName}}" => {{#isFormParam}}:form{{/isFormParam}}{{#isQueryParam}}:query{{/isQueryParam}}{{#isHeaderParam}}:headers{{/isHeaderParam}}{{#hasMore}},{{/hasMore}}
+{{/isBodyParam}}
 {{#-last}}
     }
 {{/-last}}

--- a/samples/client/petstore/elixir/lib/openapi_petstore/api/fake.ex
+++ b/samples/client/petstore/elixir/lib/openapi_petstore/api/fake.ex
@@ -54,7 +54,7 @@ defmodule OpenapiPetstore.Api.Fake do
   @spec fake_outer_boolean_serialize(Tesla.Env.client, keyword()) :: {:ok, Boolean.t} | {:error, Tesla.Env.t}
   def fake_outer_boolean_serialize(connection, opts \\ []) do
     optional_params = %{
-      :"body" => :body
+      :body => :body
     }
     %{}
     |> method(:post)
@@ -83,7 +83,7 @@ defmodule OpenapiPetstore.Api.Fake do
   @spec fake_outer_composite_serialize(Tesla.Env.client, keyword()) :: {:ok, OpenapiPetstore.Model.OuterComposite.t} | {:error, Tesla.Env.t}
   def fake_outer_composite_serialize(connection, opts \\ []) do
     optional_params = %{
-      :"body" => :body
+      :body => :body
     }
     %{}
     |> method(:post)
@@ -112,7 +112,7 @@ defmodule OpenapiPetstore.Api.Fake do
   @spec fake_outer_number_serialize(Tesla.Env.client, keyword()) :: {:ok, Float.t} | {:error, Tesla.Env.t}
   def fake_outer_number_serialize(connection, opts \\ []) do
     optional_params = %{
-      :"body" => :body
+      :body => :body
     }
     %{}
     |> method(:post)
@@ -141,7 +141,7 @@ defmodule OpenapiPetstore.Api.Fake do
   @spec fake_outer_string_serialize(Tesla.Env.client, keyword()) :: {:ok, String.t} | {:error, Tesla.Env.t}
   def fake_outer_string_serialize(connection, opts \\ []) do
     optional_params = %{
-      :"body" => :body
+      :body => :body
     }
     %{}
     |> method(:post)


### PR DESCRIPTION
Closes #5234 

This PR will map an optional body param, given by the static key `body` to the request body. This makes it relatively transparent to read what actually happens, instead of "mapping the title" in the optional param. This is also the default behavior for primitiv types.

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
cc: @wing328 I'm sorry it's you again :see_no_evil: 
