### PR TITLE
Expose batch subcommand

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -12,7 +12,7 @@ codegen="${cli}/target/openapi-generator-cli.jar"
 # We code in a list of commands here as source processing is potentially buggy (requires undocumented conventional use of annotations).
 # A list of known commands helps us determine if we should compile CLI. There's an edge-case where a new command not added to this
 # list won't be considered a "real" command. We can get around that a bit by checking CLI completions beforehand if it exists.
-commands="config-help,generate,help,list,meta,validate,version"
+commands="config-help,generate,batch,help,list,meta,validate,version"
 
 if [ $# == 0 ]; then
 	echo "No command specified. Available commands:"

--- a/modules/openapi-generator-cli/src/main/java/org/openapitools/codegen/cmd/GenerateBatch.java
+++ b/modules/openapi-generator-cli/src/main/java/org/openapitools/codegen/cmd/GenerateBatch.java
@@ -61,7 +61,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 @SuppressWarnings({"unused", "MismatchedQueryAndUpdateOfCollection", "java:S106"})
-@Command(name = "batch", description = "Generate code in batch via external configs.", hidden = true)
+@Command(name = "batch", description = "Generate code in batch via external configs.")
 public class GenerateBatch extends OpenApiGeneratorCommand {
     private static AtomicInteger failures = new AtomicInteger(0);
     private static AtomicInteger successes = new AtomicInteger(0);


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
When you use the very usefull `batch` subcommand you can't use docker on npm wrapper.
https://openapi-generator.tech/docs/usage/#batch

NPM CLI Wrapper use `help` subcommand to validate possibles arguments https://github.com/OpenAPITools/openapi-generator-cli/blob/master/apps/generator-cli/src/app/services/pass-trough.service.ts#L21 so you get an error `error: unknown command 'batch'` when you use it.

In some cases, Docker image also could forbid usage of `batch`.

I will open a PR in https://github.com/OpenAPITools/openapi-generator-cli to propose usage of `completion` in place of `help` to check possible commands, but I think `batch` should no be hidden in help.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [ ] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [ ] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
