### PR TITLE
[ruby] fix default value for referenced schemas and enums

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractRubyCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractRubyCodegen.java
@@ -140,6 +140,7 @@ abstract public class AbstractRubyCodegen extends DefaultCodegen implements Code
 
     @Override
     public String toDefaultValue(Schema p) {
+        p = ModelUtils.getReferencedSchema(this.openAPI, p);
         if (ModelUtils.isIntegerSchema(p) || ModelUtils.isNumberSchema(p) || ModelUtils.isBooleanSchema(p)) {
             if (p.getDefault() != null) {
                 return p.getDefault().toString();
@@ -151,6 +152,11 @@ abstract public class AbstractRubyCodegen extends DefaultCodegen implements Code
         }
 
         return null;
+    }
+
+    @Override
+    public String toEnumDefaultValue(String value, String datatype) {
+        return datatype + "::" + value;
     }
 
     @Override

--- a/samples/client/petstore/ruby-faraday/docs/EnumTest.md
+++ b/samples/client/petstore/ruby-faraday/docs/EnumTest.md
@@ -10,8 +10,8 @@ Name | Type | Description | Notes
 **enum_number** | **Float** |  | [optional] 
 **outer_enum** | [**OuterEnum**](OuterEnum.md) |  | [optional] 
 **outer_enum_integer** | [**OuterEnumInteger**](OuterEnumInteger.md) |  | [optional] 
-**outer_enum_default_value** | [**OuterEnumDefaultValue**](OuterEnumDefaultValue.md) |  | [optional] 
-**outer_enum_integer_default_value** | [**OuterEnumIntegerDefaultValue**](OuterEnumIntegerDefaultValue.md) |  | [optional] 
+**outer_enum_default_value** | [**OuterEnumDefaultValue**](OuterEnumDefaultValue.md) |  | [optional] [default to &#39;placed&#39;]
+**outer_enum_integer_default_value** | [**OuterEnumIntegerDefaultValue**](OuterEnumIntegerDefaultValue.md) |  | [optional] [default to OuterEnumIntegerDefaultValue::N0]
 
 ## Code Sample
 

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/enum_test.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/enum_test.rb
@@ -128,10 +128,14 @@ module Petstore
 
       if attributes.key?(:'outer_enum_default_value')
         self.outer_enum_default_value = attributes[:'outer_enum_default_value']
+      else
+        self.outer_enum_default_value = 'placed'
       end
 
       if attributes.key?(:'outer_enum_integer_default_value')
         self.outer_enum_integer_default_value = attributes[:'outer_enum_integer_default_value']
+      else
+        self.outer_enum_integer_default_value = OuterEnumIntegerDefaultValue::N0
       end
     end
 

--- a/samples/client/petstore/ruby/docs/EnumTest.md
+++ b/samples/client/petstore/ruby/docs/EnumTest.md
@@ -10,8 +10,8 @@ Name | Type | Description | Notes
 **enum_number** | **Float** |  | [optional] 
 **outer_enum** | [**OuterEnum**](OuterEnum.md) |  | [optional] 
 **outer_enum_integer** | [**OuterEnumInteger**](OuterEnumInteger.md) |  | [optional] 
-**outer_enum_default_value** | [**OuterEnumDefaultValue**](OuterEnumDefaultValue.md) |  | [optional] 
-**outer_enum_integer_default_value** | [**OuterEnumIntegerDefaultValue**](OuterEnumIntegerDefaultValue.md) |  | [optional] 
+**outer_enum_default_value** | [**OuterEnumDefaultValue**](OuterEnumDefaultValue.md) |  | [optional] [default to &#39;placed&#39;]
+**outer_enum_integer_default_value** | [**OuterEnumIntegerDefaultValue**](OuterEnumIntegerDefaultValue.md) |  | [optional] [default to OuterEnumIntegerDefaultValue::N0]
 
 ## Code Sample
 

--- a/samples/client/petstore/ruby/lib/petstore/models/enum_test.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/enum_test.rb
@@ -128,10 +128,14 @@ module Petstore
 
       if attributes.key?(:'outer_enum_default_value')
         self.outer_enum_default_value = attributes[:'outer_enum_default_value']
+      else
+        self.outer_enum_default_value = 'placed'
       end
 
       if attributes.key?(:'outer_enum_integer_default_value')
         self.outer_enum_integer_default_value = attributes[:'outer_enum_integer_default_value']
+      else
+        self.outer_enum_integer_default_value = OuterEnumIntegerDefaultValue::N0
       end
     end
 


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
Default values for referenced schemas weren't being set. This fixes it. Also uses the constant definition for enum default values instead of the plain value

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

cc @cliffano (2017/07) @zlx (2017/09) @autopp (2019/02) @jimschubert @wing328 
