### PR TITLE
Adds missing items property to Java classes which store Schema info

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenModel.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenModel.java
@@ -150,6 +150,7 @@ public class CodegenModel implements IJsonSchemaValidationProperties {
     private String pattern;
     private Number multipleOf;
     private CodegenProperty items;
+    private boolean isModel;
 
     public String getAdditionalPropertiesType() {
         return additionalPropertiesType;
@@ -561,6 +562,13 @@ public class CodegenModel implements IJsonSchemaValidationProperties {
         this.items = items;
     }
 
+    @Override
+    public boolean getIsModel() { return isModel; }
+
+    @Override
+    public void setIsModel(boolean isModel)  {
+        this.isModel = isModel;
+    }
 
     // indicates if the model component has validation on the root level schema
     // this will be true when minItems or minProperties is set

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenModel.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenModel.java
@@ -735,6 +735,7 @@ public class CodegenModel implements IJsonSchemaValidationProperties {
                 Objects.equals(getMaximum(), that.getMaximum()) &&
                 Objects.equals(getPattern(), that.getPattern()) &&
                 Objects.equals(getItems(), that.getItems()) &&
+                Objects.equals(getIsModel(), that.getIsModel()) &&
                 Objects.equals(getMultipleOf(), that.getMultipleOf());
     }
 
@@ -751,7 +752,7 @@ public class CodegenModel implements IJsonSchemaValidationProperties {
                 hasChildren, isMapModel, isDeprecated, hasOnlyReadOnly, getExternalDocumentation(), getVendorExtensions(),
                 getAdditionalPropertiesType(), getMaxProperties(), getMinProperties(), getUniqueItems(), getMaxItems(),
                 getMinItems(), getMaxLength(), getMinLength(), getExclusiveMinimum(), getExclusiveMaximum(), getMinimum(),
-                getMaximum(), getPattern(), getMultipleOf(), getItems());
+                getMaximum(), getPattern(), getMultipleOf(), getItems(), getIsModel());
     }
 
     @Override
@@ -831,6 +832,7 @@ public class CodegenModel implements IJsonSchemaValidationProperties {
         sb.append(", pattern='").append(pattern).append('\'');
         sb.append(", multipleOf='").append(multipleOf).append('\'');
         sb.append(", items='").append(items).append('\'');
+        sb.append(", isModel='").append(isModel).append('\'');
         sb.append('}');
         return sb.toString();
     }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenModel.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenModel.java
@@ -149,6 +149,7 @@ public class CodegenModel implements IJsonSchemaValidationProperties {
     private String maximum;
     private String pattern;
     private Number multipleOf;
+    private CodegenProperty items;
 
     public String getAdditionalPropertiesType() {
         return additionalPropertiesType;
@@ -550,6 +551,17 @@ public class CodegenModel implements IJsonSchemaValidationProperties {
         this.multipleOf = multipleOf;
     }
 
+    @Override
+    public CodegenProperty getItems() {
+        return items;
+    }
+
+    @Override
+    public void setItems(CodegenProperty items) {
+        this.items = items;
+    }
+
+
     // indicates if the model component has validation on the root level schema
     // this will be true when minItems or minProperties is set
     public boolean hasValidation() {
@@ -714,8 +726,8 @@ public class CodegenModel implements IJsonSchemaValidationProperties {
                 Objects.equals(getMinimum(), that.getMinimum()) &&
                 Objects.equals(getMaximum(), that.getMaximum()) &&
                 Objects.equals(getPattern(), that.getPattern()) &&
+                Objects.equals(getItems(), that.getItems()) &&
                 Objects.equals(getMultipleOf(), that.getMultipleOf());
-
     }
 
     @Override
@@ -731,7 +743,7 @@ public class CodegenModel implements IJsonSchemaValidationProperties {
                 hasChildren, isMapModel, isDeprecated, hasOnlyReadOnly, getExternalDocumentation(), getVendorExtensions(),
                 getAdditionalPropertiesType(), getMaxProperties(), getMinProperties(), getUniqueItems(), getMaxItems(),
                 getMinItems(), getMaxLength(), getMinLength(), getExclusiveMinimum(), getExclusiveMaximum(), getMinimum(),
-                getMaximum(), getPattern(), getMultipleOf());
+                getMaximum(), getPattern(), getMultipleOf(), getItems());
     }
 
     @Override
@@ -810,6 +822,7 @@ public class CodegenModel implements IJsonSchemaValidationProperties {
         sb.append(", maximum='").append(maximum).append('\'');
         sb.append(", pattern='").append(pattern).append('\'');
         sb.append(", multipleOf='").append(multipleOf).append('\'');
+        sb.append(", items='").append(items).append('\'');
         sb.append('}');
         return sb.toString();
     }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenParameter.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenParameter.java
@@ -487,5 +487,13 @@ public class CodegenParameter implements IJsonSchemaValidationProperties {
     public void setItems(CodegenProperty items) {
         this.items = items;
     }
+
+    @Override
+    public boolean getIsModel() { return isModel; }
+
+    @Override
+    public void setIsModel(boolean isModel)  {
+        this.isModel = isModel;
+    }
 }
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenParameter.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenParameter.java
@@ -478,5 +478,14 @@ public class CodegenParameter implements IJsonSchemaValidationProperties {
         this.multipleOf = multipleOf;
     }
 
+    @Override
+    public CodegenProperty getItems() {
+        return items;
+    }
+
+    @Override
+    public void setItems(CodegenProperty items) {
+        this.items = items;
+    }
 }
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenProperty.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenProperty.java
@@ -451,12 +451,22 @@ public class CodegenProperty implements Cloneable, IJsonSchemaValidationProperti
         this.allowableValues = allowableValues;
     }
 
+    @Override
     public CodegenProperty getItems() {
         return items;
     }
 
+    @Override
     public void setItems(CodegenProperty items) {
         this.items = items;
+    }
+
+    @Override
+    public boolean getIsModel() { return isModel; }
+
+    @Override
+    public void setIsModel(boolean isModel)  {
+        this.isModel = isModel;
     }
 
     public Map<String, Object> getVendorExtensions() {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenResponse.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenResponse.java
@@ -80,7 +80,7 @@ public class CodegenResponse implements IJsonSchemaValidationProperties {
         return Objects.hash(headers, code, message, hasMore, examples, dataType, baseType, containerType, hasHeaders,
                 isString, isNumeric, isInteger, isLong, isNumber, isFloat, isDouble, isByteArray, isBoolean, isDate,
                 isDateTime, isUuid, isEmail, isModel, isFreeFormObject, isAnyType, isDefault, simpleType, primitiveType,
-                isMapContainer, isListContainer, isBinary, isFile, schema, jsonSchema, vendorExtensions,
+                isMapContainer, isListContainer, isBinary, isFile, schema, jsonSchema, vendorExtensions, items,
                 getMaxProperties(), getMinProperties(), uniqueItems, getMaxItems(), getMinItems(), getMaxLength(),
                 getMinLength(), exclusiveMinimum, exclusiveMaximum, getMinimum(), getMaximum(), getPattern());
     }
@@ -115,6 +115,7 @@ public class CodegenResponse implements IJsonSchemaValidationProperties {
                 isListContainer == that.isListContainer &&
                 isBinary == that.isBinary &&
                 isFile == that.isFile &&
+                items == that.items &&
                 Objects.equals(headers, that.headers) &&
                 Objects.equals(code, that.code) &&
                 Objects.equals(message, that.message) &&
@@ -340,7 +341,7 @@ public class CodegenResponse implements IJsonSchemaValidationProperties {
         sb.append(", maximum='").append(maximum).append('\'');
         sb.append(", pattern='").append(pattern).append('\'');
         sb.append(", multipleOf='").append(multipleOf).append('\'');
-        sb.append(", isModel='").append(isModel).append('\'');
+        sb.append(", items='").append(items).append('\'');
         sb.append('}');
         return sb.toString();
     }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenResponse.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenResponse.java
@@ -73,6 +73,7 @@ public class CodegenResponse implements IJsonSchemaValidationProperties {
     private String maximum;
     public String pattern;
     public Number multipleOf;
+    private CodegenProperty items;
 
     @Override
     public int hashCode() {
@@ -268,6 +269,16 @@ public class CodegenResponse implements IJsonSchemaValidationProperties {
     @Override
     public void setMultipleOf(Number multipleOf) {
         this.multipleOf = multipleOf;
+    }
+
+    @Override
+    public CodegenProperty getItems() {
+        return items;
+    }
+
+    @Override
+    public void setItems(CodegenProperty items) {
+        this.items = items;
     }
 
     @Override

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenResponse.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenResponse.java
@@ -73,7 +73,7 @@ public class CodegenResponse implements IJsonSchemaValidationProperties {
     private String maximum;
     public String pattern;
     public Number multipleOf;
-    private CodegenProperty items;
+    public CodegenProperty items;
 
     @Override
     public int hashCode() {
@@ -282,6 +282,14 @@ public class CodegenResponse implements IJsonSchemaValidationProperties {
     }
 
     @Override
+    public boolean getIsModel() { return isModel; }
+
+    @Override
+    public void setIsModel(boolean isModel)  {
+        this.isModel = isModel;
+    }
+
+    @Override
     public String toString() {
         final StringBuilder sb = new StringBuilder("CodegenResponse{");
         sb.append("headers=").append(headers);
@@ -332,6 +340,7 @@ public class CodegenResponse implements IJsonSchemaValidationProperties {
         sb.append(", maximum='").append(maximum).append('\'');
         sb.append(", pattern='").append(pattern).append('\'');
         sb.append(", multipleOf='").append(multipleOf).append('\'');
+        sb.append(", isModel='").append(isModel).append('\'');
         sb.append('}');
         return sb.toString();
     }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -2314,7 +2314,9 @@ public class DefaultCodegen implements CodegenConfig {
         }
         if (ModelUtils.isArraySchema(schema)) {
             m.isArrayModel = true;
-            m.arrayModelType = fromProperty(name, schema).complexType;
+            CodegenProperty arrayProperty = fromProperty(name, schema);
+            m.setItems(arrayProperty.items);
+            m.arrayModelType = arrayProperty.complexType;
             addParentContainer(m, name, schema);
             ModelUtils.syncValidationProperties(schema, m);
         } else if (schema instanceof ComposedSchema) {
@@ -4002,8 +4004,10 @@ public class DefaultCodegen implements CodegenConfig {
 
             if (ModelUtils.isArraySchema(responseSchema)) {
                 ArraySchema as = (ArraySchema) responseSchema;
-                CodegenProperty innerProperty = fromProperty("response", getSchemaItems(as));
-                CodegenProperty innerCp = innerProperty;
+                CodegenProperty items = fromProperty("response", getSchemaItems(as));
+                r.setItems(items);
+                CodegenProperty innerCp = items;
+
                 while (innerCp != null) {
                     r.baseType = innerCp.baseType;
                     innerCp = innerCp.items;

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/IJsonSchemaValidationProperties.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/IJsonSchemaValidationProperties.java
@@ -56,4 +56,8 @@ public interface IJsonSchemaValidationProperties {
     CodegenProperty getItems();
 
     void setItems(CodegenProperty items);
+
+    boolean getIsModel();
+
+    void setIsModel(boolean isModel);
 }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/IJsonSchemaValidationProperties.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/IJsonSchemaValidationProperties.java
@@ -52,4 +52,8 @@ public interface IJsonSchemaValidationProperties {
     Number getMultipleOf();
 
     void setMultipleOf(Number multipleOf);
+
+    CodegenProperty getItems();
+
+    void setItems(CodegenProperty items);
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
@@ -2339,7 +2339,6 @@ public class DefaultCodegenTest {
         assertEquals(co.pathParams.get(0).getItems().getMaximum(), "7");
         assertEquals(co.bodyParams.get(0).getItems().getMaximum(), "7");
         assertEquals(co.responses.get(0).getItems().getMaximum(), "7");
-        // TODO add isModel as a property also
     }
 
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
@@ -2301,4 +2301,45 @@ public class DefaultCodegenTest {
         final List<String> flows = securities.stream().map(c -> c.flow).collect(Collectors.toList());
         assertTrue(flows.containsAll(Arrays.asList("password", "application")));
     }
+
+    @Test
+    public void testItemsPresent() {
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/issue_7613.yaml");
+        final DefaultCodegen codegen = new DefaultCodegen();
+        codegen.setOpenAPI(openAPI);
+
+        String modelName;
+        Schema sc;
+        CodegenModel cm;
+
+        modelName = "ArrayWithValidationsInItems";
+        sc = openAPI.getComponents().getSchemas().get(modelName);
+        cm = codegen.fromModel(modelName, sc);
+        assertEquals(cm.getItems().getMaximum(), "7");
+
+        modelName = "ObjectWithValidationsInArrayPropItems";
+        sc = openAPI.getComponents().getSchemas().get(modelName);
+        cm = codegen.fromModel(modelName, sc);
+        assertEquals(cm.getVars().get(0).getItems().getMaximum(), "7");
+
+        String path;
+        Operation operation;
+        CodegenOperation co;
+
+        path = "/ref_array_with_validations_in_items/{items}";
+        operation = openAPI.getPaths().get(path).getPost();
+        co = codegen.fromOperation(path, "POST", operation, null);
+        assertEquals(co.pathParams.get(0).getItems().getMaximum(), "7");
+        assertEquals(co.bodyParams.get(0).getItems().getMaximum(), "7");
+        assertEquals(co.responses.get(0).getItems().getMaximum(), "7");
+
+        path = "/array_with_validations_in_items/{items}";
+        operation = openAPI.getPaths().get(path).getPost();
+        co = codegen.fromOperation(path, "POST", operation, null);
+        assertEquals(co.pathParams.get(0).getItems().getMaximum(), "7");
+        assertEquals(co.bodyParams.get(0).getItems().getMaximum(), "7");
+        assertEquals(co.responses.get(0).getItems().getMaximum(), "7");
+        // TODO add isModel as a property also
+    }
+
 }

--- a/modules/openapi-generator/src/test/resources/3_0/issue_7613.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/issue_7613.yaml
@@ -69,11 +69,9 @@ paths:
               schema:
                 type: array
                 items:
-                  type: array
-                  items:
-                    type: integer
-                    format: int64
-                    maximum: 7
+                  type: integer
+                  format: int64
+                  maximum: 7
 components:
   schemas:
     ArrayWithValidationsInItems:

--- a/modules/openapi-generator/src/test/resources/3_0/issue_7613.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/issue_7613.yaml
@@ -48,22 +48,18 @@ paths:
           schema:
             type: array
             items:
-              type: array
-              items:
-                type: integer
-                format: int64
-                maximum: 7
+              type: integer
+              format: int64
+              maximum: 7
       requestBody:
         content:
           application/json:
             schema:
               type: array
               items:
-                type: array
-                items:
-                  type: integer
-                  format: int64
-                  maximum: 7
+                type: integer
+                format: int64
+                maximum: 7
         required: true
       responses:
         200:

--- a/modules/openapi-generator/src/test/resources/3_0/issue_7613.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/issue_7613.yaml
@@ -1,0 +1,119 @@
+openapi: 3.0.1
+info:
+  title: OpenAPI Petstore
+  description: "sample spec"
+  license:
+    name: Apache-2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0.html
+  version: 1.0.0
+servers:
+  - url: http://petstore.swagger.io:80/v2
+tags:
+  - name: items
+    description: Everything about your Pets
+paths:
+  /ref_array_with_validations_in_items/{items}:
+    post:
+      tags:
+        - items
+      operationId: refArrayWithValidationsInItems
+      parameters:
+        - name: items
+          in: path
+          required: true
+          schema:
+            $ref: '#/components/schemas/ArrayWithValidationsInItems'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ArrayWithValidationsInItems'
+        required: true
+      responses:
+        200:
+          description: success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ArrayWithValidationsInItems'
+  /array_with_validations_in_items/{items}:
+    post:
+      tags:
+        - items
+      operationId: arrayWithValidationsInItems
+      parameters:
+        - name: items
+          in: path
+          required: true
+          schema:
+            type: array
+            items:
+              type: array
+              items:
+                type: integer
+                format: int64
+                maximum: 7
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                type: array
+                items:
+                  type: integer
+                  format: int64
+                  maximum: 7
+        required: true
+      responses:
+        200:
+          description: success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: array
+                  items:
+                    type: integer
+                    format: int64
+                    maximum: 7
+components:
+  schemas:
+    ArrayWithValidationsInItems:
+      type: array
+      items:
+        type: integer
+        format: int64
+        maximum: 7
+    ObjectWithValidationsInArrayPropItems:
+      type: object
+      properties:
+        arrayProp:
+          type: array
+          items:
+            type: integer
+            format: int64
+            maximum: 7
+    ObjectWithValidationsInAdditionalProperties:
+      type: object
+      additionalProperties:
+        type: integer
+        format: int64
+        maximum: 7
+    ComposedOneOfInlineValidation:
+      oneOf:
+        - type: integer
+          format: int64
+          maximum: 7
+    ComposedAnyOfInlineValidation:
+      anyOf:
+        - type: integer
+          format: int64
+          maximum: 7
+    ComposedAllOfInlineValidation:
+      allOf:
+        - type: integer
+          format: int64
+          maximum: 7
+  securitySchemes: {}

--- a/samples/openapi3/client/petstore/python-experimental/.openapi-generator/VERSION
+++ b/samples/openapi3/client/petstore/python-experimental/.openapi-generator/VERSION
@@ -1,1 +1,1 @@
-5.0.0-SNAPSHOT
+unset

--- a/samples/openapi3/client/petstore/python-experimental/.openapi-generator/VERSION
+++ b/samples/openapi3/client/petstore/python-experimental/.openapi-generator/VERSION
@@ -1,1 +1,1 @@
-unset
+5.0.0-SNAPSHOT


### PR DESCRIPTION
Right now the master branch does not store the validations for array schema items for some classes
This PR fixes that issue, validations in items are now accessible on the CodegenProperty items instance.

This PR
- adds an items property to Java classes which store Schema info
  - the items property stores a CodegenProperty of the items of the current type Array schema
- adds an isModel property so the generator can tell if the schema is a model or not
  - the intention is to have isModel be true for codegenModels or Schemas that ref codegenModels
  - that way generators will know to stop moving through schemas and use that one if it is a refed model
If merged, this will be a partial fix for https://github.com/OpenAPITools/openapi-generator/issues/7613
  - it is up to the generators to set this property correctly

Tests have been added

### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [ ] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [X] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

Core Team:
@wing328 (2015/07) ❤️
@jimschubert (2016/05) ❤️
@cbornet (2016/05)
@ackintosh (2018/02) ❤️
@jmini (2018/04) ❤️
@etherealjoy (2019/06)
@spacether (2020/05)