### PR TITLE
[C#][netcore] Fix warnings in HTTPSigningConfiguration

### DIFF
--- a/modules/openapi-generator/src/main/resources/csharp-netcore/HTTPSigningConfiguration.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/HTTPSigningConfiguration.mustache
@@ -78,9 +78,10 @@ namespace {{packageName}}.Client
         /// <summary>
         /// Gets the Headers for HTTpSIgning
         /// </summary>
-        /// <param name="method"></param>
-        /// <param name="path"></param>
-        /// <param name="requestOptions"></param>
+        /// <param name="basePath">Base path</param>
+        /// <param name="method">HTTP method</param>
+        /// <param name="path">Path</param>
+        /// <param name="requestOptions">Request options</param>
         /// <returns></returns>
         internal Dictionary<string, string> GetHttpSignedHeader(string basePath,string method, string path, RequestOptions requestOptions)
         {
@@ -313,16 +314,16 @@ namespace {{packageName}}.Client
             var ecKeyBase64String = keyStr.Replace(ecKeyHeader, "").Replace(ecKeyFooter, "").Trim();
             var keyBytes = System.Convert.FromBase64String(ecKeyBase64String);
             var ecdsa = ECDsa.Create();
-            var bytCount = 0;
 
 #if (NETCOREAPP3_0 || NETCOREAPP3_1 || NET5_0)
+            var byteCount = 0;
             if (configuration.KeyPassPhrase != null)
             {
-                ecdsa.ImportEncryptedPkcs8PrivateKey(keyPassPhrase, keyBytes, out bytCount);
+                ecdsa.ImportEncryptedPkcs8PrivateKey(keyPassPhrase, keyBytes, out byteCount);
             }
             else
             {
-                ecdsa.ImportPkcs8PrivateKey(keyBytes, out bytCount);
+                ecdsa.ImportPkcs8PrivateKey(keyBytes, out byteCount);
             }
             var signedBytes = ecdsa.SignHash(dataToSign);
             var derBytes = ConvertToECDSAANS1Format(signedBytes);
@@ -687,7 +688,6 @@ namespace {{packageName}}.Client
             else if (key[0].ToString().Contains(ecPrivateKeyHeader) &&
                 key[key.Length - 1].ToString().Contains(ecPrivateKeyFooter))
             {
-
                 /*this type of key can hold many type different types of private key, but here due lack of pem header
                 Considering this as EC key
                 */

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Client/HTTPSigningConfiguration.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Client/HTTPSigningConfiguration.cs
@@ -78,9 +78,10 @@ namespace Org.OpenAPITools.Client
         /// <summary>
         /// Gets the Headers for HTTpSIgning
         /// </summary>
-        /// <param name="method"></param>
-        /// <param name="path"></param>
-        /// <param name="requestOptions"></param>
+        /// <param name="basePath">Base path</param>
+        /// <param name="method">HTTP method</param>
+        /// <param name="path">Path</param>
+        /// <param name="requestOptions">Request options</param>
         /// <returns></returns>
         internal Dictionary<string, string> GetHttpSignedHeader(string basePath,string method, string path, RequestOptions requestOptions)
         {
@@ -313,16 +314,16 @@ namespace Org.OpenAPITools.Client
             var ecKeyBase64String = keyStr.Replace(ecKeyHeader, "").Replace(ecKeyFooter, "").Trim();
             var keyBytes = System.Convert.FromBase64String(ecKeyBase64String);
             var ecdsa = ECDsa.Create();
-            var bytCount = 0;
 
 #if (NETCOREAPP3_0 || NETCOREAPP3_1 || NET5_0)
+            var byteCount = 0;
             if (configuration.KeyPassPhrase != null)
             {
-                ecdsa.ImportEncryptedPkcs8PrivateKey(keyPassPhrase, keyBytes, out bytCount);
+                ecdsa.ImportEncryptedPkcs8PrivateKey(keyPassPhrase, keyBytes, out byteCount);
             }
             else
             {
-                ecdsa.ImportPkcs8PrivateKey(keyBytes, out bytCount);
+                ecdsa.ImportPkcs8PrivateKey(keyBytes, out byteCount);
             }
             var signedBytes = ecdsa.SignHash(dataToSign);
             var derBytes = ConvertToECDSAANS1Format(signedBytes);
@@ -687,7 +688,6 @@ namespace Org.OpenAPITools.Client
             else if (key[0].ToString().Contains(ecPrivateKeyHeader) &&
                 key[key.Length - 1].ToString().Contains(ecPrivateKeyFooter))
             {
-
                 /*this type of key can hold many type different types of private key, but here due lack of pem header
                 Considering this as EC key
                 */

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Client/HTTPSigningConfiguration.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Client/HTTPSigningConfiguration.cs
@@ -78,9 +78,10 @@ namespace Org.OpenAPITools.Client
         /// <summary>
         /// Gets the Headers for HTTpSIgning
         /// </summary>
-        /// <param name="method"></param>
-        /// <param name="path"></param>
-        /// <param name="requestOptions"></param>
+        /// <param name="basePath">Base path</param>
+        /// <param name="method">HTTP method</param>
+        /// <param name="path">Path</param>
+        /// <param name="requestOptions">Request options</param>
         /// <returns></returns>
         internal Dictionary<string, string> GetHttpSignedHeader(string basePath,string method, string path, RequestOptions requestOptions)
         {
@@ -313,16 +314,16 @@ namespace Org.OpenAPITools.Client
             var ecKeyBase64String = keyStr.Replace(ecKeyHeader, "").Replace(ecKeyFooter, "").Trim();
             var keyBytes = System.Convert.FromBase64String(ecKeyBase64String);
             var ecdsa = ECDsa.Create();
-            var bytCount = 0;
 
 #if (NETCOREAPP3_0 || NETCOREAPP3_1 || NET5_0)
+            var byteCount = 0;
             if (configuration.KeyPassPhrase != null)
             {
-                ecdsa.ImportEncryptedPkcs8PrivateKey(keyPassPhrase, keyBytes, out bytCount);
+                ecdsa.ImportEncryptedPkcs8PrivateKey(keyPassPhrase, keyBytes, out byteCount);
             }
             else
             {
-                ecdsa.ImportPkcs8PrivateKey(keyBytes, out bytCount);
+                ecdsa.ImportPkcs8PrivateKey(keyBytes, out byteCount);
             }
             var signedBytes = ecdsa.SignHash(dataToSign);
             var derBytes = ConvertToECDSAANS1Format(signedBytes);
@@ -687,7 +688,6 @@ namespace Org.OpenAPITools.Client
             else if (key[0].ToString().Contains(ecPrivateKeyHeader) &&
                 key[key.Length - 1].ToString().Contains(ecPrivateKeyFooter))
             {
-
                 /*this type of key can hold many type different types of private key, but here due lack of pem header
                 Considering this as EC key
                 */


### PR DESCRIPTION
Fix warnings in HTTPSigningConfiguration class

<!-- Please check the completed items below -->


### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

FYI. @mandrean (2017/08) @frankyjuang (2019/09) @shibayan (2020/02)



