### PR TITLE
[PowerShell] Fixed the empty string issue when server returns null

### DIFF
--- a/modules/openapi-generator/src/main/resources/powershell/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/powershell/api_client.mustache
@@ -185,7 +185,7 @@ function DeserializeResponse {
         [string[]]$ContentTypes
     )
 
-    If ([string]::IsNullOrEmpty($ReturnType)) { # void response
+    If ([string]::IsNullOrEmpty($ReturnType) -and $ContentTypes.Count -eq 0) { # void response
         return $Response
     } Elseif ($ReturnType -match '\[\]$') { # array
         return ConvertFrom-Json $Response

--- a/samples/client/petstore/powershell/src/PSPetstore/Private/PSApiClient.ps1
+++ b/samples/client/petstore/powershell/src/PSPetstore/Private/PSApiClient.ps1
@@ -172,7 +172,7 @@ function DeserializeResponse {
         [string[]]$ContentTypes
     )
 
-    If ([string]::IsNullOrEmpty($ReturnType)) { # void response
+    If ([string]::IsNullOrEmpty($ReturnType) -and $ContentTypes.Count -eq 0) { # void response
         return $Response
     } Elseif ($ReturnType -match '\[\]$') { # array
         return ConvertFrom-Json $Response


### PR DESCRIPTION
When the server send null in response PowerShell cmdlet return as Empty string not the $null which was misleading. 
Example before fix
```powershell
PS C:\> $result = Remove-NtpPolicy  -id xxxxxxxxxxxxxx  # the cmdlet removed the resource based on id and does not return anything

#$result is string.empty not null which is not as per the value returned from the server.
PS C:\> $result -eq $null
False
$result -eq ""
True
```

Example after fix
```powershell
PS C:\> $result = Remove-NtpPolicy  -id xxxxxxxxxxxxxx  # the cmdlet removed the resource based on id and does not return anything

PS C:\> $result -eq $null
True
```
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [ ] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
@wing328 