### PR TITLE
Fixes #7635: typescript-inversify generator wrongly handles array typ…

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-inversify/api.service.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-inversify/api.service.mustache
@@ -73,7 +73,7 @@ export class {{classname}} {
         if ({{paramName}}) {
         {{#isCollectionFormatMulti}}
             {{paramName}}.forEach((element) => {
-                queryParameters.push('{{paramName}}='+encodeURIComponent(String({{paramName}})));
+                queryParameters.push('{{paramName}}='+encodeURIComponent(String(element)));
             })
         {{/isCollectionFormatMulti}}
         {{^isCollectionFormatMulti}}


### PR DESCRIPTION
Wrong variable is used in loop generating array type url parameters
