### PR TITLE
[python-experimental] implement `in` operator for model classes

### DIFF
--- a/modules/openapi-generator/src/main/resources/python/python-experimental/model_templates/methods_setattr_getattr_composed.mustache
+++ b/modules/openapi-generator/src/main/resources/python/python-experimental/model_templates/methods_setattr_getattr_composed.mustache
@@ -69,3 +69,19 @@
                 "the same".format(name, type(self).__name__),
                 path_to_item
             )
+
+    def __contains__(self, name):
+        """this allows us to use `in` operator: `'attr' in instance`"""
+
+        if name in self.required_properties:
+            return name in self.__dict__
+
+        model_instances = self._var_name_to_model_instances.get(
+            name, self._additional_properties_model_instances)
+
+        if model_instances:
+            for model_instance in model_instances:
+                if name in model_instance._data_store:
+                    return True
+
+        return False

--- a/modules/openapi-generator/src/main/resources/python/python-experimental/model_templates/methods_setattr_getattr_normal.mustache
+++ b/modules/openapi-generator/src/main/resources/python/python-experimental/model_templates/methods_setattr_getattr_normal.mustache
@@ -23,3 +23,10 @@
                 type(self).__name__, name),
             [name]
         )
+
+    def __contains__(self, name):
+        """this allows us to use `in` operator: `'attr' in instance`"""
+        if name in self.required_properties:
+            return name in self.__dict__
+
+        return name in self.__dict__['_data_store']

--- a/samples/client/petstore/python-experimental/petstore_api/model_utils.py
+++ b/samples/client/petstore/python-experimental/petstore_api/model_utils.py
@@ -316,6 +316,14 @@ class ModelSimple(OpenApiModel):
             [name]
         )
 
+    def __contains__(self, name):
+        """this allows us to use `in` operator: `'attr' in instance`"""
+        if name in self.required_properties:
+            return name in self.__dict__
+
+        return name in self.__dict__['_data_store']
+
+
     def to_str(self):
         """Returns the string representation of the model"""
         return str(self.value)
@@ -363,6 +371,14 @@ class ModelNormal(OpenApiModel):
                 type(self).__name__, name),
             [name]
         )
+
+    def __contains__(self, name):
+        """this allows us to use `in` operator: `'attr' in instance`"""
+        if name in self.required_properties:
+            return name in self.__dict__
+
+        return name in self.__dict__['_data_store']
+
 
     def to_dict(self):
         """Returns the model properties as a dict"""
@@ -487,6 +503,23 @@ class ModelComposed(OpenApiModel):
                 "the same".format(name, type(self).__name__),
                 path_to_item
             )
+
+    def __contains__(self, name):
+        """this allows us to use `in` operator: `'attr' in instance`"""
+
+        if name in self.required_properties:
+            return name in self.__dict__
+
+        model_instances = self._var_name_to_model_instances.get(
+            name, self._additional_properties_model_instances)
+
+        if model_instances:
+            for model_instance in model_instances:
+                if name in model_instance._data_store:
+                    return True
+
+        return False
+
 
     def to_dict(self):
         """Returns the model properties as a dict"""

--- a/samples/openapi3/client/extensions/x-auth-id-alias/python-experimental/x_auth_id_alias/model_utils.py
+++ b/samples/openapi3/client/extensions/x-auth-id-alias/python-experimental/x_auth_id_alias/model_utils.py
@@ -316,6 +316,14 @@ class ModelSimple(OpenApiModel):
             [name]
         )
 
+    def __contains__(self, name):
+        """this allows us to use `in` operator: `'attr' in instance`"""
+        if name in self.required_properties:
+            return name in self.__dict__
+
+        return name in self.__dict__['_data_store']
+
+
     def to_str(self):
         """Returns the string representation of the model"""
         return str(self.value)
@@ -363,6 +371,14 @@ class ModelNormal(OpenApiModel):
                 type(self).__name__, name),
             [name]
         )
+
+    def __contains__(self, name):
+        """this allows us to use `in` operator: `'attr' in instance`"""
+        if name in self.required_properties:
+            return name in self.__dict__
+
+        return name in self.__dict__['_data_store']
+
 
     def to_dict(self):
         """Returns the model properties as a dict"""
@@ -487,6 +503,23 @@ class ModelComposed(OpenApiModel):
                 "the same".format(name, type(self).__name__),
                 path_to_item
             )
+
+    def __contains__(self, name):
+        """this allows us to use `in` operator: `'attr' in instance`"""
+
+        if name in self.required_properties:
+            return name in self.__dict__
+
+        model_instances = self._var_name_to_model_instances.get(
+            name, self._additional_properties_model_instances)
+
+        if model_instances:
+            for model_instance in model_instances:
+                if name in model_instance._data_store:
+                    return True
+
+        return False
+
 
     def to_dict(self):
         """Returns the model properties as a dict"""

--- a/samples/openapi3/client/features/dynamic-servers/python-experimental/dynamic_servers/model_utils.py
+++ b/samples/openapi3/client/features/dynamic-servers/python-experimental/dynamic_servers/model_utils.py
@@ -316,6 +316,14 @@ class ModelSimple(OpenApiModel):
             [name]
         )
 
+    def __contains__(self, name):
+        """this allows us to use `in` operator: `'attr' in instance`"""
+        if name in self.required_properties:
+            return name in self.__dict__
+
+        return name in self.__dict__['_data_store']
+
+
     def to_str(self):
         """Returns the string representation of the model"""
         return str(self.value)
@@ -363,6 +371,14 @@ class ModelNormal(OpenApiModel):
                 type(self).__name__, name),
             [name]
         )
+
+    def __contains__(self, name):
+        """this allows us to use `in` operator: `'attr' in instance`"""
+        if name in self.required_properties:
+            return name in self.__dict__
+
+        return name in self.__dict__['_data_store']
+
 
     def to_dict(self):
         """Returns the model properties as a dict"""
@@ -487,6 +503,23 @@ class ModelComposed(OpenApiModel):
                 "the same".format(name, type(self).__name__),
                 path_to_item
             )
+
+    def __contains__(self, name):
+        """this allows us to use `in` operator: `'attr' in instance`"""
+
+        if name in self.required_properties:
+            return name in self.__dict__
+
+        model_instances = self._var_name_to_model_instances.get(
+            name, self._additional_properties_model_instances)
+
+        if model_instances:
+            for model_instance in model_instances:
+                if name in model_instance._data_store:
+                    return True
+
+        return False
+
 
     def to_dict(self):
         """Returns the model properties as a dict"""

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/model_utils.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/model_utils.py
@@ -316,6 +316,14 @@ class ModelSimple(OpenApiModel):
             [name]
         )
 
+    def __contains__(self, name):
+        """this allows us to use `in` operator: `'attr' in instance`"""
+        if name in self.required_properties:
+            return name in self.__dict__
+
+        return name in self.__dict__['_data_store']
+
+
     def to_str(self):
         """Returns the string representation of the model"""
         return str(self.value)
@@ -363,6 +371,14 @@ class ModelNormal(OpenApiModel):
                 type(self).__name__, name),
             [name]
         )
+
+    def __contains__(self, name):
+        """this allows us to use `in` operator: `'attr' in instance`"""
+        if name in self.required_properties:
+            return name in self.__dict__
+
+        return name in self.__dict__['_data_store']
+
 
     def to_dict(self):
         """Returns the model properties as a dict"""
@@ -487,6 +503,23 @@ class ModelComposed(OpenApiModel):
                 "the same".format(name, type(self).__name__),
                 path_to_item
             )
+
+    def __contains__(self, name):
+        """this allows us to use `in` operator: `'attr' in instance`"""
+
+        if name in self.required_properties:
+            return name in self.__dict__
+
+        model_instances = self._var_name_to_model_instances.get(
+            name, self._additional_properties_model_instances)
+
+        if model_instances:
+            for model_instance in model_instances:
+                if name in model_instance._data_store:
+                    return True
+
+        return False
+
 
     def to_dict(self):
         """Returns the model properties as a dict"""


### PR DESCRIPTION
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [X] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

Allow to check for attribute presence in model using `in` operator.

Unless I'm missing something, right now the only way to correctly get an attribute which may not be present is this:

    try:
        attr_value = instance.attr_name
    except ApiAttributeError:
        attr_value = None

which is quite cumbersome.

@spacether 