### PR TITLE
Fix typos in Javascript test clients 'instane' to 'instance'

### DIFF
--- a/modules/openapi-generator/src/main/resources/Javascript-Apollo/model_test.mustache
+++ b/modules/openapi-generator/src/main/resources/Javascript-Apollo/model_test.mustache
@@ -44,7 +44,7 @@
   describe('{{classname}}', function() {
     it('should create an instance of {{classname}}', function() {
       // uncomment below and update the code to test {{classname}}
-      //var instane = new {{moduleName}}.{{classname}}();
+      //var instance = new {{moduleName}}.{{classname}}();
       //expect(instance).to.be.a({{moduleName}}.{{classname}});
     });
 

--- a/modules/openapi-generator/src/main/resources/Javascript/es6/model_test.mustache
+++ b/modules/openapi-generator/src/main/resources/Javascript/es6/model_test.mustache
@@ -53,7 +53,7 @@
 {{#vars}}
     it('should have the property {{name}} (base name: "{{baseName}}")', function() {
       // uncomment below and update the code to test the property {{name}}
-      //var instane = new {{moduleName}}.{{classname}}();
+      //var instance = new {{moduleName}}.{{classname}}();
       //expect(instance).to.be();
     });
 


### PR DESCRIPTION
Looks like this did not get propagated to these other JS clients from the original at 90859575ebfea800dde93a498e1439011963d6cf

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

CC: @CodeNinjai @frol  @cliffano 