### PR TITLE
Resolve an exception situation when a remote server returns 204 with no body.

### DIFF
--- a/modules/openapi-generator/src/main/resources/dart2/api.mustache
+++ b/modules/openapi-generator/src/main/resources/dart2/api.mustache
@@ -165,7 +165,12 @@ class {{{classname}}} {
     if (response.statusCode >= 400) {
       throw ApiException(response.statusCode, _decodeBodyBytes(response));
     }
-    if (response.body != null) {
+
+    // When a remote server returns no body with a status of 204, we shall not decode it.
+    // At the time of writing this, `dart:convert` will throw an "Unexpected end of input"
+    // FormatException when trying to decode an empty string.
+    final responseBody = response.body;
+    if (responseBody != null && (responseBody.isNotEmpty || 204 != response.statusCode)) {
       {{#isListContainer}}
         {{#returnType}}
       return (apiClient.deserialize(_decodeBodyBytes(response), '{{{returnType}}}') as List)

--- a/modules/openapi-generator/src/main/resources/dart2/api_helper.mustache
+++ b/modules/openapi-generator/src/main/resources/dart2/api_helper.mustache
@@ -56,6 +56,6 @@ String parameterToString(dynamic value) {
 String _decodeBodyBytes(Response response) {
   final contentType = response.headers['content-type'];
   return contentType != null && contentType.contains('application/json')
-    ? utf8.decode(response.bodyBytes)
+    ? response.bodyBytes == null ? null : utf8.decode(response.bodyBytes)
     : response.body;
 }

--- a/samples/client/petstore/dart2/petstore_client_lib/lib/api/pet_api.dart
+++ b/samples/client/petstore/dart2/petstore_client_lib/lib/api/pet_api.dart
@@ -77,7 +77,12 @@ class PetApi {
     if (response.statusCode >= 400) {
       throw ApiException(response.statusCode, _decodeBodyBytes(response));
     }
-    if (response.body != null) {
+
+    // When a remote server returns no body with a status of 204, we shall not decode it.
+    // At the time of writing this, `dart:convert` will throw an "Unexpected end of input"
+    // FormatException when trying to decode an empty string.
+    final responseBody = response.body;
+    if (responseBody != null && (responseBody.isNotEmpty || 204 != response.statusCode)) {
     }
     return;
   }
@@ -149,7 +154,12 @@ class PetApi {
     if (response.statusCode >= 400) {
       throw ApiException(response.statusCode, _decodeBodyBytes(response));
     }
-    if (response.body != null) {
+
+    // When a remote server returns no body with a status of 204, we shall not decode it.
+    // At the time of writing this, `dart:convert` will throw an "Unexpected end of input"
+    // FormatException when trying to decode an empty string.
+    final responseBody = response.body;
+    if (responseBody != null && (responseBody.isNotEmpty || 204 != response.statusCode)) {
     }
     return;
   }
@@ -221,7 +231,12 @@ class PetApi {
     if (response.statusCode >= 400) {
       throw ApiException(response.statusCode, _decodeBodyBytes(response));
     }
-    if (response.body != null) {
+
+    // When a remote server returns no body with a status of 204, we shall not decode it.
+    // At the time of writing this, `dart:convert` will throw an "Unexpected end of input"
+    // FormatException when trying to decode an empty string.
+    final responseBody = response.body;
+    if (responseBody != null && (responseBody.isNotEmpty || 204 != response.statusCode)) {
       return (apiClient.deserialize(_decodeBodyBytes(response), 'List<Pet>') as List)
         .map((item) => item as Pet)
         .toList(growable: false);
@@ -296,7 +311,12 @@ class PetApi {
     if (response.statusCode >= 400) {
       throw ApiException(response.statusCode, _decodeBodyBytes(response));
     }
-    if (response.body != null) {
+
+    // When a remote server returns no body with a status of 204, we shall not decode it.
+    // At the time of writing this, `dart:convert` will throw an "Unexpected end of input"
+    // FormatException when trying to decode an empty string.
+    final responseBody = response.body;
+    if (responseBody != null && (responseBody.isNotEmpty || 204 != response.statusCode)) {
       return (apiClient.deserialize(_decodeBodyBytes(response), 'List<Pet>') as List)
         .map((item) => item as Pet)
         .toList(growable: false);
@@ -370,7 +390,12 @@ class PetApi {
     if (response.statusCode >= 400) {
       throw ApiException(response.statusCode, _decodeBodyBytes(response));
     }
-    if (response.body != null) {
+
+    // When a remote server returns no body with a status of 204, we shall not decode it.
+    // At the time of writing this, `dart:convert` will throw an "Unexpected end of input"
+    // FormatException when trying to decode an empty string.
+    final responseBody = response.body;
+    if (responseBody != null && (responseBody.isNotEmpty || 204 != response.statusCode)) {
       return apiClient.deserialize(_decodeBodyBytes(response), 'Pet') as Pet;
     }
     return null;
@@ -438,7 +463,12 @@ class PetApi {
     if (response.statusCode >= 400) {
       throw ApiException(response.statusCode, _decodeBodyBytes(response));
     }
-    if (response.body != null) {
+
+    // When a remote server returns no body with a status of 204, we shall not decode it.
+    // At the time of writing this, `dart:convert` will throw an "Unexpected end of input"
+    // FormatException when trying to decode an empty string.
+    final responseBody = response.body;
+    if (responseBody != null && (responseBody.isNotEmpty || 204 != response.statusCode)) {
     }
     return;
   }
@@ -531,7 +561,12 @@ class PetApi {
     if (response.statusCode >= 400) {
       throw ApiException(response.statusCode, _decodeBodyBytes(response));
     }
-    if (response.body != null) {
+
+    // When a remote server returns no body with a status of 204, we shall not decode it.
+    // At the time of writing this, `dart:convert` will throw an "Unexpected end of input"
+    // FormatException when trying to decode an empty string.
+    final responseBody = response.body;
+    if (responseBody != null && (responseBody.isNotEmpty || 204 != response.statusCode)) {
     }
     return;
   }
@@ -622,7 +657,12 @@ class PetApi {
     if (response.statusCode >= 400) {
       throw ApiException(response.statusCode, _decodeBodyBytes(response));
     }
-    if (response.body != null) {
+
+    // When a remote server returns no body with a status of 204, we shall not decode it.
+    // At the time of writing this, `dart:convert` will throw an "Unexpected end of input"
+    // FormatException when trying to decode an empty string.
+    final responseBody = response.body;
+    if (responseBody != null && (responseBody.isNotEmpty || 204 != response.statusCode)) {
       return apiClient.deserialize(_decodeBodyBytes(response), 'ApiResponse') as ApiResponse;
     }
     return null;

--- a/samples/client/petstore/dart2/petstore_client_lib/lib/api/store_api.dart
+++ b/samples/client/petstore/dart2/petstore_client_lib/lib/api/store_api.dart
@@ -81,7 +81,12 @@ class StoreApi {
     if (response.statusCode >= 400) {
       throw ApiException(response.statusCode, _decodeBodyBytes(response));
     }
-    if (response.body != null) {
+
+    // When a remote server returns no body with a status of 204, we shall not decode it.
+    // At the time of writing this, `dart:convert` will throw an "Unexpected end of input"
+    // FormatException when trying to decode an empty string.
+    final responseBody = response.body;
+    if (responseBody != null && (responseBody.isNotEmpty || 204 != response.statusCode)) {
     }
     return;
   }
@@ -139,7 +144,12 @@ class StoreApi {
     if (response.statusCode >= 400) {
       throw ApiException(response.statusCode, _decodeBodyBytes(response));
     }
-    if (response.body != null) {
+
+    // When a remote server returns no body with a status of 204, we shall not decode it.
+    // At the time of writing this, `dart:convert` will throw an "Unexpected end of input"
+    // FormatException when trying to decode an empty string.
+    final responseBody = response.body;
+    if (responseBody != null && (responseBody.isNotEmpty || 204 != response.statusCode)) {
       return Map<String, int>.from(apiClient.deserialize(_decodeBodyBytes(response), 'Map<String, int>'));
     }
     return null;
@@ -211,7 +221,12 @@ class StoreApi {
     if (response.statusCode >= 400) {
       throw ApiException(response.statusCode, _decodeBodyBytes(response));
     }
-    if (response.body != null) {
+
+    // When a remote server returns no body with a status of 204, we shall not decode it.
+    // At the time of writing this, `dart:convert` will throw an "Unexpected end of input"
+    // FormatException when trying to decode an empty string.
+    final responseBody = response.body;
+    if (responseBody != null && (responseBody.isNotEmpty || 204 != response.statusCode)) {
       return apiClient.deserialize(_decodeBodyBytes(response), 'Order') as Order;
     }
     return null;
@@ -279,7 +294,12 @@ class StoreApi {
     if (response.statusCode >= 400) {
       throw ApiException(response.statusCode, _decodeBodyBytes(response));
     }
-    if (response.body != null) {
+
+    // When a remote server returns no body with a status of 204, we shall not decode it.
+    // At the time of writing this, `dart:convert` will throw an "Unexpected end of input"
+    // FormatException when trying to decode an empty string.
+    final responseBody = response.body;
+    if (responseBody != null && (responseBody.isNotEmpty || 204 != response.statusCode)) {
       return apiClient.deserialize(_decodeBodyBytes(response), 'Order') as Order;
     }
     return null;

--- a/samples/client/petstore/dart2/petstore_client_lib/lib/api/user_api.dart
+++ b/samples/client/petstore/dart2/petstore_client_lib/lib/api/user_api.dart
@@ -81,7 +81,12 @@ class UserApi {
     if (response.statusCode >= 400) {
       throw ApiException(response.statusCode, _decodeBodyBytes(response));
     }
-    if (response.body != null) {
+
+    // When a remote server returns no body with a status of 204, we shall not decode it.
+    // At the time of writing this, `dart:convert` will throw an "Unexpected end of input"
+    // FormatException when trying to decode an empty string.
+    final responseBody = response.body;
+    if (responseBody != null && (responseBody.isNotEmpty || 204 != response.statusCode)) {
     }
     return;
   }
@@ -148,7 +153,12 @@ class UserApi {
     if (response.statusCode >= 400) {
       throw ApiException(response.statusCode, _decodeBodyBytes(response));
     }
-    if (response.body != null) {
+
+    // When a remote server returns no body with a status of 204, we shall not decode it.
+    // At the time of writing this, `dart:convert` will throw an "Unexpected end of input"
+    // FormatException when trying to decode an empty string.
+    final responseBody = response.body;
+    if (responseBody != null && (responseBody.isNotEmpty || 204 != response.statusCode)) {
     }
     return;
   }
@@ -215,7 +225,12 @@ class UserApi {
     if (response.statusCode >= 400) {
       throw ApiException(response.statusCode, _decodeBodyBytes(response));
     }
-    if (response.body != null) {
+
+    // When a remote server returns no body with a status of 204, we shall not decode it.
+    // At the time of writing this, `dart:convert` will throw an "Unexpected end of input"
+    // FormatException when trying to decode an empty string.
+    final responseBody = response.body;
+    if (responseBody != null && (responseBody.isNotEmpty || 204 != response.statusCode)) {
     }
     return;
   }
@@ -286,7 +301,12 @@ class UserApi {
     if (response.statusCode >= 400) {
       throw ApiException(response.statusCode, _decodeBodyBytes(response));
     }
-    if (response.body != null) {
+
+    // When a remote server returns no body with a status of 204, we shall not decode it.
+    // At the time of writing this, `dart:convert` will throw an "Unexpected end of input"
+    // FormatException when trying to decode an empty string.
+    final responseBody = response.body;
+    if (responseBody != null && (responseBody.isNotEmpty || 204 != response.statusCode)) {
     }
     return;
   }
@@ -353,7 +373,12 @@ class UserApi {
     if (response.statusCode >= 400) {
       throw ApiException(response.statusCode, _decodeBodyBytes(response));
     }
-    if (response.body != null) {
+
+    // When a remote server returns no body with a status of 204, we shall not decode it.
+    // At the time of writing this, `dart:convert` will throw an "Unexpected end of input"
+    // FormatException when trying to decode an empty string.
+    final responseBody = response.body;
+    if (responseBody != null && (responseBody.isNotEmpty || 204 != response.statusCode)) {
       return apiClient.deserialize(_decodeBodyBytes(response), 'User') as User;
     }
     return null;
@@ -432,7 +457,12 @@ class UserApi {
     if (response.statusCode >= 400) {
       throw ApiException(response.statusCode, _decodeBodyBytes(response));
     }
-    if (response.body != null) {
+
+    // When a remote server returns no body with a status of 204, we shall not decode it.
+    // At the time of writing this, `dart:convert` will throw an "Unexpected end of input"
+    // FormatException when trying to decode an empty string.
+    final responseBody = response.body;
+    if (responseBody != null && (responseBody.isNotEmpty || 204 != response.statusCode)) {
       return apiClient.deserialize(_decodeBodyBytes(response), 'String') as String;
     }
     return null;
@@ -487,7 +517,12 @@ class UserApi {
     if (response.statusCode >= 400) {
       throw ApiException(response.statusCode, _decodeBodyBytes(response));
     }
-    if (response.body != null) {
+
+    // When a remote server returns no body with a status of 204, we shall not decode it.
+    // At the time of writing this, `dart:convert` will throw an "Unexpected end of input"
+    // FormatException when trying to decode an empty string.
+    final responseBody = response.body;
+    if (responseBody != null && (responseBody.isNotEmpty || 204 != response.statusCode)) {
     }
     return;
   }
@@ -567,7 +602,12 @@ class UserApi {
     if (response.statusCode >= 400) {
       throw ApiException(response.statusCode, _decodeBodyBytes(response));
     }
-    if (response.body != null) {
+
+    // When a remote server returns no body with a status of 204, we shall not decode it.
+    // At the time of writing this, `dart:convert` will throw an "Unexpected end of input"
+    // FormatException when trying to decode an empty string.
+    final responseBody = response.body;
+    if (responseBody != null && (responseBody.isNotEmpty || 204 != response.statusCode)) {
     }
     return;
   }

--- a/samples/client/petstore/dart2/petstore_client_lib/lib/api_helper.dart
+++ b/samples/client/petstore/dart2/petstore_client_lib/lib/api_helper.dart
@@ -56,6 +56,6 @@ String parameterToString(dynamic value) {
 String _decodeBodyBytes(Response response) {
   final contentType = response.headers['content-type'];
   return contentType != null && contentType.contains('application/json')
-    ? utf8.decode(response.bodyBytes)
+    ? response.bodyBytes == null ? null : utf8.decode(response.bodyBytes)
     : response.body;
 }


### PR DESCRIPTION
This resolves a problem in API client when a remote server returns no body with a status code of 204 (default behavior according to the spec.)

@ircecho (2017/07) @swipesight (2018/09) @jaumard (2018/09) @athornz (2019/12) @amondnet (2019/12)

<!-- Please check the completed items below -->
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [X] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [X] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
