### PR TITLE
[Default] Generate referenced superclass even without properties

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -2857,8 +2857,8 @@ public class DefaultCodegen implements CodegenConfig {
     }
 
     protected List<MappedModel> getAllOfDescendants(String thisSchemaName, OpenAPI openAPI) {
-        ArrayList<String> queue = new ArrayList();
-        List<MappedModel> descendentSchemas = new ArrayList();
+        ArrayList<String> queue = new ArrayList<>();
+        List<MappedModel> descendentSchemas = new ArrayList<>();
         Map<String, Schema> schemas = ModelUtils.getSchemas(openAPI);
         String currentSchemaName = thisSchemaName;
         Set<String> keys = schemas.keySet();

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptAxiosClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptAxiosClientCodegen.java
@@ -166,7 +166,10 @@ public class TypeScriptAxiosClientCodegen extends AbstractTypeScriptClientCodege
 
     @Override
     protected void addAdditionPropertiesToCodeGenModel(CodegenModel codegenModel, Schema schema) {
-        codegenModel.additionalPropertiesType = getTypeDeclaration(getAdditionalProperties(schema));
+        Schema additionalProperties = getAdditionalProperties(schema);
+        if (null != additionalProperties) {
+            codegenModel.additionalPropertiesType = getTypeDeclaration(additionalProperties);
+        }
         addImport(codegenModel, codegenModel.additionalPropertiesType);
     }
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
@@ -1127,7 +1127,7 @@ public class ModelUtils {
 
     private static boolean hasDescendants(String simpleRef, OpenAPI openAPI) {
         for (Map.Entry<String, Schema> entry : getSchemas(openAPI).entrySet()) {
-            if (!isSameSchema(simpleRef, entry.getKey())) {
+            if (!simpleRef.equals(entry.getKey())) {
                 Schema schema = entry.getValue();
                 if (isComposedSchema(schema)) {
                     ComposedSchema composedChild = (ComposedSchema) schema;
@@ -1144,10 +1144,6 @@ public class ModelUtils {
             }
         }
         return false;
-    }
-
-    private static boolean isSameSchema(String simpleRef, String schema) {
-        return simpleRef.equals(schema);
     }
 
     /**

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
@@ -1132,7 +1132,9 @@ public class ModelUtils {
                 if (isComposedSchema(schema)) {
                     ComposedSchema composedChild = (ComposedSchema) schema;
                     boolean b = composedChild.getAllOf()
-                            .stream().map(Schema::get$ref)
+                            .stream()
+                            .map(Schema::get$ref)
+                            .filter(Objects::nonNull)
                             .map(ModelUtils::getSimpleRef)
                             .anyMatch(simpleRef::equals);
                     if (b) {

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
@@ -2282,8 +2282,8 @@ public class DefaultCodegenTest {
         DefaultGenerator generator = new DefaultGenerator();
         List<File> files = generator.opts(clientOptInput).generate();
 
-        TestUtils.ensureDoesNotContainsFile(files, output, "src/main/java/org/openapitools/client/model/FreeFormWithValidation.java");
-        TestUtils.ensureDoesNotContainsFile(files, output, "src/main/java/org/openapitools/client/model/FreeFormInterface.java");
+        TestUtils.ensureContainsFile(files, output, "src/main/java/org/openapitools/client/model/FreeFormWithValidation.java");
+        TestUtils.ensureContainsFile(files, output, "src/main/java/org/openapitools/client/model/FreeFormInterface.java");
         TestUtils.ensureDoesNotContainsFile(files, output, "src/main/java/org/openapitools/client/model/FreeForm.java");
         output.deleteOnExit();
     }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/utils/ModelUtilsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/utils/ModelUtilsTest.java
@@ -17,6 +17,7 @@
 
 package org.openapitools.codegen.utils;
 
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.media.*;
 import io.swagger.v3.oas.models.parameters.Parameter;
@@ -27,6 +28,10 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import java.util.*;
+
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonList;
+import static org.testng.Assert.assertEquals;
 
 public class ModelUtilsTest {
 
@@ -226,6 +231,19 @@ public class ModelUtilsTest {
 
         Assert.assertEquals(emailSchema, ModelUtils.unaliasSchema(openAPI, emailSchema, importMappings));
         Assert.assertEquals(stringSchema, ModelUtils.unaliasSchema(openAPI, emailSchema, new HashMap<>()));
+    }
+
+    @Test
+    public void unaliasSchemaWithRef() {
+        Schema pony = new Schema().$ref("#/components/schemas/Pony").type("object");
+        Schema unicorn = new ComposedSchema().allOf(singletonList(pony)).$ref("#/components/schemas/Unicorn");
+
+        OpenAPI openAPI = TestUtils.createOpenAPI();
+        openAPI.setComponents(new Components());
+        openAPI.getComponents().addSchemas("Pony", pony);
+        openAPI.getComponents().addSchemas("Unicorn", unicorn);
+
+        assertEquals(pony, ModelUtils.unaliasSchema(openAPI, pony, emptyMap()));
     }
 
     /**

--- a/modules/openapi-generator/src/test/resources/3_0/issue_7361.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/issue_7361.yaml
@@ -11,7 +11,7 @@ paths: {}
 components:
   schemas:
     FreeForm:
-      description: this will not be generated because a map will be used when othe componenets or endpoints ref this schema
+      description: this will not be generated because a map will be used when other componenets or endpoints ref this schema
       type: object
     FreeFormInterface:
       type: object

--- a/samples/client/petstore/typescript-axios/builds/composed-schemas/api.ts
+++ b/samples/client/petstore/typescript-axios/builds/composed-schemas/api.ts
@@ -135,6 +135,13 @@ export interface InlineObject {
 /**
  * 
  * @export
+ * @interface Pet
+ */
+export interface Pet {
+}
+/**
+ * 
+ * @export
  * @interface PetByAge
  */
 export interface PetByAge {


### PR DESCRIPTION
I've done the change on the default branch because I can reproduce with Java and Kotlin and I think it may be an issue on other languages. So I add the core team and not just the Java technical committee.

May fix #7638

@wing328
@jimschubert
@cbornet
@ackintosh
@jmini
@etherealjoy
@spacether

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
