### PR TITLE
Adds isDateTime to CodegenModel

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenModel.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenModel.java
@@ -64,7 +64,7 @@ public class CodegenModel implements IJsonSchemaValidationProperties {
     public String defaultValue;
     public String arrayModelType;
     public boolean isAlias; // Is this effectively an alias of another simple type
-    public boolean isString, isInteger, isLong, isNumber, isNumeric, isFloat, isDouble, isDate;
+    public boolean isString, isInteger, isLong, isNumber, isNumeric, isFloat, isDouble, isDate, isDateTime;
     public List<CodegenProperty> vars = new ArrayList<CodegenProperty>(); // all properties (without parent's properties)
     public List<CodegenProperty> allVars = new ArrayList<CodegenProperty>(); // all properties (with parent's properties)
     public List<CodegenProperty> requiredVars = new ArrayList<CodegenProperty>(); // a list of required properties
@@ -578,6 +578,14 @@ public class CodegenModel implements IJsonSchemaValidationProperties {
         this.isDate = isDate;
     }
 
+    @Override
+    public boolean getIsDateTime() { return isDateTime; }
+
+    @Override
+    public void setIsDateTime(boolean isDateTime)   {
+        this.isDateTime = isDateTime;
+    }
+
     // indicates if the model component has validation on the root level schema
     // this will be true when minItems or minProperties is set
     public boolean hasValidation() {
@@ -679,6 +687,7 @@ public class CodegenModel implements IJsonSchemaValidationProperties {
                 isFloat == that.isFloat &&
                 isDouble == that.isDouble &&
                 isDate == that.isDate &&
+                isDateTime == that.isDateTime &&
                 hasVars == that.hasVars &&
                 emptyVars == that.emptyVars &&
                 hasMoreModels == that.hasMoreModels &&
@@ -755,7 +764,7 @@ public class CodegenModel implements IJsonSchemaValidationProperties {
                 getDescription(), getClassVarName(), getModelJson(), getDataType(), getXmlPrefix(), getXmlNamespace(),
                 getXmlName(), getClassFilename(), getUnescapedDescription(), getDiscriminator(), getDefaultValue(),
                 getArrayModelType(), isAlias, isString, isInteger, isLong, isNumber, isNumeric, isFloat, isDouble,
-                isDate,
+                isDate, isDateTime,
                 getVars(), getAllVars(), getRequiredVars(), getOptionalVars(), getReadOnlyVars(), getReadWriteVars(),
                 getParentVars(), getAllowableValues(), getMandatory(), getAllMandatory(), getImports(), hasVars,
                 isEmptyVars(), hasMoreModels, hasEnums, isEnum, isNullable, hasRequired, hasOptional, isArrayModel,
@@ -802,6 +811,7 @@ public class CodegenModel implements IJsonSchemaValidationProperties {
         sb.append(", isFloat=").append(isFloat);
         sb.append(", isDouble=").append(isDouble);
         sb.append(", isDate=").append(isDate);
+        sb.append(", isDateTime=").append(isDateTime);
         sb.append(", vars=").append(vars);
         sb.append(", allVars=").append(allVars);
         sb.append(", requiredVars=").append(requiredVars);

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenParameter.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenParameter.java
@@ -503,5 +503,13 @@ public class CodegenParameter implements IJsonSchemaValidationProperties {
     public void setIsDate(boolean isDate)   {
         this.isDate = isDate;
     }
+
+    @Override
+    public boolean getIsDateTime() { return isDateTime; }
+
+    @Override
+    public void setIsDateTime(boolean isDateTime)   {
+        this.isDateTime = isDateTime;
+    }
 }
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenProperty.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenProperty.java
@@ -477,6 +477,14 @@ public class CodegenProperty implements Cloneable, IJsonSchemaValidationProperti
         this.isDate = isDate;
     }
 
+    @Override
+    public boolean getIsDateTime() { return isDateTime; }
+
+    @Override
+    public void setIsDateTime(boolean isDateTime)   {
+        this.isDateTime = isDateTime;
+    }
+
     public Map<String, Object> getVendorExtensions() {
         return vendorExtensions;
     }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenResponse.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenResponse.java
@@ -299,6 +299,14 @@ public class CodegenResponse implements IJsonSchemaValidationProperties {
     }
 
     @Override
+    public boolean getIsDateTime() { return isDateTime; }
+
+    @Override
+    public void setIsDateTime(boolean isDateTime)   {
+        this.isDateTime = isDateTime;
+    }
+
+    @Override
     public String toString() {
         final StringBuilder sb = new StringBuilder("CodegenResponse{");
         sb.append("headers=").append(headers);

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -2520,6 +2520,11 @@ public class DefaultCodegen implements CodegenConfig {
                 } else { // int32 format
                     m.isInteger = Boolean.TRUE;
                 }
+            } else if (ModelUtils.isDateTimeSchema(schema)) {
+                // NOTE: DateTime schemas as CodegenModel is a rare use case and may be removed at a later date.
+                // Sync of properties is done for consistency with other data types like CodegenParameter/CodegenProperty.
+                ModelUtils.syncValidationProperties(schema, m);
+                m.isDateTime = Boolean.TRUE;
             } else if (ModelUtils.isDateSchema(schema)) {
                 // NOTE: Date schemas as CodegenModel is a rare use case and may be removed at a later date.
                 // Sync of properties is done for consistency with other data types like CodegenParameter/CodegenProperty.

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/IJsonSchemaValidationProperties.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/IJsonSchemaValidationProperties.java
@@ -64,4 +64,8 @@ public interface IJsonSchemaValidationProperties {
     boolean getIsDate();
 
     void setIsDate(boolean isDate);
+
+    boolean getIsDateTime();
+
+    void setIsDateTime(boolean isDateTime);
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
@@ -2386,5 +2386,37 @@ public class DefaultCodegenTest {
         assertEquals(co.bodyParams.get(0).isDate, true);
         assertEquals(co.responses.get(0).isString, false);
         assertEquals(co.responses.get(0).isDate, true);
+
+        modelName = "DateTimeWithValidation";
+        sc = openAPI.getComponents().getSchemas().get(modelName);
+        cm = codegen.fromModel(modelName, sc);
+        assertEquals(cm.isString, false);
+        assertEquals(cm.isDateTime, true);
+
+        modelName = "ObjectWithDateTimeWithValidation";
+        sc = openAPI.getComponents().getSchemas().get(modelName);
+        cm = codegen.fromModel(modelName, sc);
+        assertEquals(cm.getVars().get(0).isString, false);
+        assertEquals(cm.getVars().get(0).isDateTime, true);
+
+        path = "/ref_date_time_with_validation/{dateTime}";
+        operation = openAPI.getPaths().get(path).getPost();
+        co = codegen.fromOperation(path, "POST", operation, null);
+        assertEquals(co.pathParams.get(0).isString, false);
+        assertEquals(co.pathParams.get(0).isDateTime, true);
+        assertEquals(co.bodyParams.get(0).isString, false);
+        assertEquals(co.bodyParams.get(0).isDateTime, true);
+        assertEquals(co.responses.get(0).isString, false);
+        assertEquals(co.responses.get(0).isDateTime, true);
+
+        path = "/date_time_with_validation/{dateTime}";
+        operation = openAPI.getPaths().get(path).getPost();
+        co = codegen.fromOperation(path, "POST", operation, null);
+        assertEquals(co.pathParams.get(0).isString, false);
+        assertEquals(co.pathParams.get(0).isDateTime, true);
+        assertEquals(co.bodyParams.get(0).isString, false);
+        assertEquals(co.bodyParams.get(0).isDateTime, true);
+        assertEquals(co.responses.get(0).isString, false);
+        assertEquals(co.responses.get(0).isDateTime, true);
     }
 }

--- a/modules/openapi-generator/src/test/resources/3_0/issue_7651.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/issue_7651.yaml
@@ -66,6 +66,60 @@ paths:
                 type: string
                 format: date
                 pattern: '^2020.*'
+  /ref_date_time_with_validation/{dateTime}:
+    post:
+      tags:
+        - isX
+      operationId: refDateTimeWithValidation
+      parameters:
+        - name: dateTime
+          in: path
+          required: true
+          schema:
+            $ref: '#/components/schemas/DateTimeWithValidation'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DateTimeWithValidation'
+        required: true
+      responses:
+        200:
+          description: success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DateTimeWithValidation'
+  /date_time_with_validation/{dateTime}:
+    post:
+      tags:
+        - isX
+      operationId: dateTimeWithValidation
+      parameters:
+        - name: dateTime
+          in: path
+          required: true
+          schema:
+            type: string
+            format: date-time
+            pattern: '^2020.*'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: string
+              format: date-time
+              pattern: '^2020.*'
+        required: true
+      responses:
+        200:
+          description: success
+          content:
+            application/json:
+              schema:
+                type: string
+                format: date-time
+                pattern: '^2020.*'
 components:
   schemas:
     DateWithValidation:
@@ -78,5 +132,16 @@ components:
         dateWithValidation:
           type: string
           format: date
+          pattern: '^2020.*'
+    DateTimeWithValidation:
+      type: string
+      format: date-time
+      pattern: '^2020.*'
+    ObjectWithDateTimeWithValidation:
+      type: object
+      properties:
+        dateWithValidation:
+          type: string
+          format: date-time
           pattern: '^2020.*'
   securitySchemes: {}


### PR DESCRIPTION
This PR:

Adds isDateTme to CodegenModel
adds isDateTime getter and setter to IJsonSchemaValidationProperties
Adds a test to ensure that isDateTime has the correct values on on implementing java classes
is a feature break out for #7651
Note: this is potentially a breaking change because if one is generating a model for a date-time schema, the current master branch sets isString in that CodegenModel to true. After this PR, isString will be False and isDateTime will be true, which is consistent with how date schemas are handled in these classes:

CodegenProperty
CodegenParameter
CodegenResponse
Setting isString and isDateTime for date schemas should be consistent in these 4 classes.

### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [ ] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [X] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.


Core Team Members
@wing328 (2015/07) ❤️
@jimschubert (2016/05) ❤️
@cbornet (2016/05)
@ackintosh (2018/02) ❤️
@jmini (2018/04) ❤️
@etherealjoy (2019/06)
@spacether (2020/05)