### PR TITLE
[typescript-fetch] serialize complex type in multipart/form-data as JSON

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-fetch/apis.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/apis.mustache
@@ -238,7 +238,12 @@ export class {{classname}} extends runtime.BaseAPI {
         {{/isListContainer}}
         {{^isListContainer}}
         if (requestParameters.{{paramName}} !== undefined) {
+            {{#isPrimitiveType}}
             formParams.append('{{baseName}}', requestParameters.{{paramName}} as any);
+            {{/isPrimitiveType}}
+            {{^isPrimitiveType}}
+            formParams.append('{{baseName}}', new Blob([JSON.stringify({{{dataType}}}ToJSON(requestParameters.{{paramName}}))], { type: "application/json", }));
+            {{/isPrimitiveType}}
         }
 
         {{/isListContainer}}


### PR DESCRIPTION
Complex types need to be serialized as JSON to avoid FormData.append()
from converting them into strings through .toString().

Fixes #7658

Tested locally by running the generator against the following schema:
```
---
openapi: "3.0.0"
info:
  title: Bug test case
  version: "1.0"
paths:
  /example:
    post:
      operationId: exampleOperation
      requestBody:
        content:
          multipart/form-data:
            schema:
              properties:
                simpleValue:
                  type: string
                fileValue:
                  format: binary
                  type: string
                complexvalue:
                  properties:
                    value1:
                      type: number
                    value2:
                      type: string
                  type: object
                complexvalue_with_underscores:
                  properties:
                    value_1:
                      type: string
                    value_2:
                      type: number
                  type: object
              type: object
      responses:
        "201":
          description: Created
```

This resulted in the following serialization code:
```
export interface ExampleOperationRequest {
    simpleValue?: string;
    fileValue?: Blob;
    complexvalue?: ExampleComplexvalue;
    complexvalueWithUnderscores?: ExampleComplexvalueWithUnderscores;
}
```
```
export interface ExampleComplexvalue {
    /**
     * 
     * @type {number}
     * @memberof ExampleComplexvalue
     */
    value1?: number;
    /**
     * 
     * @type {string}
     * @memberof ExampleComplexvalue
     */
    value2?: string;
}
```
```
export function ExampleComplexvalueToJSON(value?: ExampleComplexvalue | null): any {
    if (value === undefined) {
        return undefined;
    }
    if (value === null) {
        return null;
    }
    return {
        
        'value1': value.value1,
        'value2': value.value2,
    };
}
```
```
export interface ExampleComplexvalueWithUnderscores {
    /**
     * 
     * @type {string}
     * @memberof ExampleComplexvalueWithUnderscores
     */
    value1?: string;
    /**
     * 
     * @type {number}
     * @memberof ExampleComplexvalueWithUnderscores
     */
    value2?: number;
}
```
```
export function ExampleComplexvalueWithUnderscoresToJSON(value?: ExampleComplexvalueWithUnderscores | null): any {
    if (value === undefined) {
        return undefined;
    }
    if (value === null) {
        return null;
    }
    return {
        
        'value_1': value.value1,
        'value_2': value.value2,
    };
}
```
```
        if (requestParameters.simpleValue !== undefined) {
            formParams.append('simpleValue', requestParameters.simpleValue as any);
        }

        if (requestParameters.fileValue !== undefined) {
            formParams.append('fileValue', requestParameters.fileValue as any);
        }

        if (requestParameters.complexvalue !== undefined) {
            formParams.append('complexvalue', new Blob([JSON.stringify(ExampleComplexvalueToJSON(requestParameters.complexvalue))], { type: "application/json", }));
        }

        if (requestParameters.complexvalueWithUnderscores !== undefined) {
            formParams.append('complexvalue_with_underscores', new Blob([JSON.stringify(ExampleComplexvalueWithUnderscoresToJSON(requestParameters.complexvalueWithUnderscores))], { type: "application/json", }));
        }
```

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [X] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [X] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@TiFu (2017/07) @taxpon (2017/07) @sebastianhaas (2017/07) @kenisteward (2017/07) @Vrolijkx (2017/09) @macjohnny (2018/01) @topce (2018/10) @akehir (2019/07) @petejohansonxo (2019/11) @amakhrov (2020/02)