### PR TITLE
Go-server parse bool in query parameter

### DIFF
--- a/modules/openapi-generator/src/main/resources/go-server/controller-api.mustache
+++ b/modules/openapi-generator/src/main/resources/go-server/controller-api.mustache
@@ -64,8 +64,14 @@ func (c *{{classname}}Controller) {{nickname}}(w http.ResponseWriter, r *http.Re
 		w.WriteHeader(500)
 		return
 	}
-	{{/isInteger}}{{^isLong}}{{^isInteger}}
-	{{paramName}} := {{#isListContainer}}strings.Split({{/isListContainer}}query.Get("{{paramName}}"){{#isListContainer}}, ","){{/isListContainer}}{{/isInteger}}{{/isLong}}{{/isQueryParam}}{{#isFormParam}}{{#isFile}}
+	{{/isInteger}}{{#isBoolean}}
+	{{paramName}}, err := parseBoolParameter(query.Get("{{paramName}}"))
+	if err != nil {
+		w.WriteHeader(500)
+		return
+	}
+	{{/isBoolean}}{{^isLong}}{{^isInteger}}{{^isBoolean}}
+	{{paramName}} := {{#isListContainer}}strings.Split({{/isListContainer}}query.Get("{{paramName}}"){{#isListContainer}}, ","){{/isListContainer}}{{/isBoolean}}{{/isInteger}}{{/isLong}}{{/isQueryParam}}{{#isFormParam}}{{#isFile}}
 	{{paramName}}, err := ReadFormFileToTempFile(r, "{{paramName}}")
 	if err != nil {
 		w.WriteHeader(500)

--- a/modules/openapi-generator/src/main/resources/go-server/routers.mustache
+++ b/modules/openapi-generator/src/main/resources/go-server/routers.mustache
@@ -88,16 +88,25 @@ func ReadFormFileToTempFile(r *http.Request, key string) (*os.File, error) {
 	return file, nil
 }
 
-// parseInt64Parameter parses a sting parameter to an int64
+// parseInt64Parameter parses a string parameter to an int64
 func parseInt64Parameter(param string) (int64, error) {
 	return strconv.ParseInt(param, 10, 64)
 }
 
-// parseInt32Parameter parses a sting parameter to an int32
+// parseInt32Parameter parses a string parameter to an int32
 func parseInt32Parameter(param string) (int32, error) {
 	val, err := strconv.ParseInt(param, 10, 32)
 	if err != nil {
 		return -1, err
 	}
 	return int32(val), nil
+}
+
+// parseBoolParameter parses a string parameter to a bool
+func parseBoolParameter(param string) (bool, error) {
+	val, err := strconv.ParseBool(param)
+	if err != nil {
+		return false, err
+	}
+	return bool(val), nil
 }

--- a/modules/openapi-generator/src/test/resources/3_0/petstore.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/petstore.yaml
@@ -94,6 +94,14 @@ paths:
                 - pending
                 - sold
               default: available
+        - name: booltest
+          in: query
+          description: test for boolean parse generation
+          required: true
+          schema:
+            type: boolean
+            default: true
+            example: true
       responses:
         '200':
           description: successful operation

--- a/samples/server/petstore/go-api-server/api/openapi.yaml
+++ b/samples/server/petstore/go-api-server/api/openapi.yaml
@@ -91,6 +91,16 @@ paths:
             type: string
           type: array
         style: form
+      - description: test for boolean parse generation
+        explode: true
+        in: query
+        name: booltest
+        required: true
+        schema:
+          default: true
+          example: true
+          type: boolean
+        style: form
       responses:
         "200":
           content:

--- a/samples/server/petstore/go-api-server/go/api.go
+++ b/samples/server/petstore/go-api-server/go/api.go
@@ -61,7 +61,7 @@ type UserApiRouter interface {
 type PetApiServicer interface { 
 	AddPet(context.Context, Pet) (ImplResponse, error)
 	DeletePet(context.Context, int64, string) (ImplResponse, error)
-	FindPetsByStatus(context.Context, []string) (ImplResponse, error)
+	FindPetsByStatus(context.Context, []string, bool) (ImplResponse, error)
 	FindPetsByTags(context.Context, []string) (ImplResponse, error)
 	GetPetById(context.Context, int64) (ImplResponse, error)
 	UpdatePet(context.Context, Pet) (ImplResponse, error)

--- a/samples/server/petstore/go-api-server/go/api_pet.go
+++ b/samples/server/petstore/go-api-server/go/api_pet.go
@@ -124,7 +124,13 @@ func (c *PetApiController) DeletePet(w http.ResponseWriter, r *http.Request) {
 func (c *PetApiController) FindPetsByStatus(w http.ResponseWriter, r *http.Request) { 
 	query := r.URL.Query()
 	status := strings.Split(query.Get("status"), ",")
-	result, err := c.service.FindPetsByStatus(r.Context(), status)
+	booltest, err := parseBoolParameter(query.Get("booltest"))
+	if err != nil {
+		w.WriteHeader(500)
+		return
+	}
+	
+	result, err := c.service.FindPetsByStatus(r.Context(), status, booltest)
 	//If an error occured, encode the error with the status code
 	if err != nil {
 		EncodeJSONResponse(err.Error(), &result.Code, w)

--- a/samples/server/petstore/go-api-server/go/api_pet_service.go
+++ b/samples/server/petstore/go-api-server/go/api_pet_service.go
@@ -53,7 +53,7 @@ func (s *PetApiService) DeletePet(ctx context.Context, petId int64, apiKey strin
 }
 
 // FindPetsByStatus - Finds Pets by status
-func (s *PetApiService) FindPetsByStatus(ctx context.Context, status []string) (ImplResponse, error) {
+func (s *PetApiService) FindPetsByStatus(ctx context.Context, status []string, booltest bool) (ImplResponse, error) {
 	// TODO - update FindPetsByStatus with the required logic for this service method.
 	// Add api_pet_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
 

--- a/samples/server/petstore/go-api-server/go/routers.go
+++ b/samples/server/petstore/go-api-server/go/routers.go
@@ -90,16 +90,25 @@ func ReadFormFileToTempFile(r *http.Request, key string) (*os.File, error) {
 	return file, nil
 }
 
-// parseInt64Parameter parses a sting parameter to an int64
+// parseInt64Parameter parses a string parameter to an int64
 func parseInt64Parameter(param string) (int64, error) {
 	return strconv.ParseInt(param, 10, 64)
 }
 
-// parseInt32Parameter parses a sting parameter to an int32
+// parseInt32Parameter parses a string parameter to an int32
 func parseInt32Parameter(param string) (int32, error) {
 	val, err := strconv.ParseInt(param, 10, 32)
 	if err != nil {
 		return -1, err
 	}
 	return int32(val), nil
+}
+
+// parseBoolParameter parses a string parameter to a bool
+func parseBoolParameter(param string) (bool, error) {
+	val, err := strconv.ParseBool(param)
+	if err != nil {
+		return false, err
+	}
+	return bool(val), nil
 }


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

Hi, this PR allow support to boolean values in query parameters.
I change the petstore api example to generate a test case

The commits are pretty self explainatory, i added a function alongside parseInt32Parameter, and update the template in case of boolean value.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [ ] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
