### PR TITLE
[Spring] Use default jackson-databind 

### DIFF
--- a/modules/openapi-generator/src/main/resources/JavaSpring/libraries/spring-boot/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/libraries/spring-boot/pom.mustache
@@ -12,7 +12,6 @@
         {{#useSpringfox}}
         <springfox-version>2.9.2</springfox-version>
         {{/useSpringfox}}
-        <jackson-databind-version>2.9.8</jackson-databind-version>
     </properties>
 {{#parentOverridden}}
     <parent>
@@ -202,7 +201,6 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${jackson-databind-version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/samples/client/petstore/spring-stubs/pom.xml
+++ b/samples/client/petstore/spring-stubs/pom.xml
@@ -10,7 +10,6 @@
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <springfox-version>2.9.2</springfox-version>
-        <jackson-databind-version>2.9.8</jackson-databind-version>
     </properties>
     <parent>
         <groupId>org.springframework.boot</groupId>
@@ -62,7 +61,6 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${jackson-databind-version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/samples/server/petstore/springboot-beanvalidation-no-nullable/pom.xml
+++ b/samples/server/petstore/springboot-beanvalidation-no-nullable/pom.xml
@@ -10,7 +10,6 @@
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <springfox-version>2.9.2</springfox-version>
-        <jackson-databind-version>2.9.8</jackson-databind-version>
     </properties>
     <parent>
         <groupId>org.springframework.boot</groupId>
@@ -71,7 +70,6 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${jackson-databind-version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/samples/server/petstore/springboot-beanvalidation/pom.xml
+++ b/samples/server/petstore/springboot-beanvalidation/pom.xml
@@ -10,7 +10,6 @@
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <springfox-version>2.9.2</springfox-version>
-        <jackson-databind-version>2.9.8</jackson-databind-version>
     </properties>
     <parent>
         <groupId>org.springframework.boot</groupId>
@@ -75,7 +74,6 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${jackson-databind-version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/samples/server/petstore/springboot-delegate-j8/pom.xml
+++ b/samples/server/petstore/springboot-delegate-j8/pom.xml
@@ -10,7 +10,6 @@
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <springfox-version>2.9.2</springfox-version>
-        <jackson-databind-version>2.9.8</jackson-databind-version>
     </properties>
     <parent>
         <groupId>org.springframework.boot</groupId>
@@ -75,7 +74,6 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${jackson-databind-version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/samples/server/petstore/springboot-delegate/pom.xml
+++ b/samples/server/petstore/springboot-delegate/pom.xml
@@ -10,7 +10,6 @@
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <springfox-version>2.9.2</springfox-version>
-        <jackson-databind-version>2.9.8</jackson-databind-version>
     </properties>
     <parent>
         <groupId>org.springframework.boot</groupId>
@@ -75,7 +74,6 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${jackson-databind-version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/samples/server/petstore/springboot-implicitHeaders/pom.xml
+++ b/samples/server/petstore/springboot-implicitHeaders/pom.xml
@@ -10,7 +10,6 @@
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <springfox-version>2.9.2</springfox-version>
-        <jackson-databind-version>2.9.8</jackson-databind-version>
     </properties>
     <parent>
         <groupId>org.springframework.boot</groupId>
@@ -75,7 +74,6 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${jackson-databind-version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/samples/server/petstore/springboot-reactive/pom.xml
+++ b/samples/server/petstore/springboot-reactive/pom.xml
@@ -9,7 +9,6 @@
         <java.version>1.8</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
-        <jackson-databind-version>2.9.8</jackson-databind-version>
     </properties>
     <parent>
         <groupId>org.springframework.boot</groupId>
@@ -83,7 +82,6 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${jackson-databind-version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/pom.xml
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/pom.xml
@@ -10,7 +10,6 @@
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <springfox-version>2.9.2</springfox-version>
-        <jackson-databind-version>2.9.8</jackson-databind-version>
     </properties>
     <parent>
         <groupId>org.springframework.boot</groupId>
@@ -76,7 +75,6 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${jackson-databind-version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern/pom.xml
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern/pom.xml
@@ -10,7 +10,6 @@
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <springfox-version>2.9.2</springfox-version>
-        <jackson-databind-version>2.9.8</jackson-databind-version>
     </properties>
     <parent>
         <groupId>org.springframework.boot</groupId>
@@ -75,7 +74,6 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${jackson-databind-version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/samples/server/petstore/springboot-spring-pageable-without-j8/pom.xml
+++ b/samples/server/petstore/springboot-spring-pageable-without-j8/pom.xml
@@ -10,7 +10,6 @@
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <springfox-version>2.9.2</springfox-version>
-        <jackson-databind-version>2.9.8</jackson-databind-version>
     </properties>
     <parent>
         <groupId>org.springframework.boot</groupId>
@@ -76,7 +75,6 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${jackson-databind-version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/samples/server/petstore/springboot-spring-pageable/pom.xml
+++ b/samples/server/petstore/springboot-spring-pageable/pom.xml
@@ -10,7 +10,6 @@
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <springfox-version>2.9.2</springfox-version>
-        <jackson-databind-version>2.9.8</jackson-databind-version>
     </properties>
     <parent>
         <groupId>org.springframework.boot</groupId>
@@ -75,7 +74,6 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${jackson-databind-version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/samples/server/petstore/springboot-useoptional/pom.xml
+++ b/samples/server/petstore/springboot-useoptional/pom.xml
@@ -10,7 +10,6 @@
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <springfox-version>2.9.2</springfox-version>
-        <jackson-databind-version>2.9.8</jackson-databind-version>
     </properties>
     <parent>
         <groupId>org.springframework.boot</groupId>
@@ -75,7 +74,6 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${jackson-databind-version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/samples/server/petstore/springboot-virtualan/pom.xml
+++ b/samples/server/petstore/springboot-virtualan/pom.xml
@@ -10,7 +10,6 @@
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <springfox-version>2.9.2</springfox-version>
-        <jackson-databind-version>2.9.8</jackson-databind-version>
     </properties>
     <parent>
         <groupId>org.springframework.boot</groupId>
@@ -93,7 +92,6 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${jackson-databind-version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/samples/server/petstore/springboot/pom.xml
+++ b/samples/server/petstore/springboot/pom.xml
@@ -10,7 +10,6 @@
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <springfox-version>2.9.2</springfox-version>
-        <jackson-databind-version>2.9.8</jackson-databind-version>
     </properties>
     <parent>
         <groupId>org.springframework.boot</groupId>
@@ -75,7 +74,6 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${jackson-databind-version}</version>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
Use default jackson will fix #7743
<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04) @lwlee2608 (2019/10) @bkabrda (2020/01)