### PR TITLE
[C#][netcore] Add nullable support to oneOf models

### DIFF
--- a/modules/openapi-generator/src/main/resources/csharp-netcore/AbstractOpenAPISchema.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/AbstractOpenAPISchema.mustache
@@ -14,7 +14,7 @@ namespace {{packageName}}.{{modelPackage}}
         /// <summary>
         ///  Custom JSON serializer
         /// </summary>
-        protected readonly JsonSerializerSettings _serializerSettings = new JsonSerializerSettings
+        static public readonly JsonSerializerSettings SerializerSettings = new JsonSerializerSettings
         {
             // OpenAPI generated types generally hide default constructors.
             ConstructorHandling = ConstructorHandling.AllowNonPublicDefaultConstructor,

--- a/modules/openapi-generator/src/main/resources/csharp-netcore/modelOneOf.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/modelOneOf.mustache
@@ -87,7 +87,7 @@
         /// <returns>JSON string presentation of the object</returns>
         public override string ToJson()
         {
-            return JsonConvert.SerializeObject(this.ActualInstance, _serializerSettings);
+            return JsonConvert.SerializeObject(this.ActualInstance, {{classname}}.SerializerSettings);
         }
 
         /// <summary>
@@ -106,11 +106,11 @@
             {
                 {{#mappedModels}}
                 case "{{{mappingName}}}":
-                    new{{classname}} = new {{classname}}(JsonConvert.DeserializeObject<{{{modelName}}}>(jsonString, new{{classname}}._serializerSettings));
+                    new{{classname}} = new {{classname}}(JsonConvert.DeserializeObject<{{{modelName}}}>(jsonString, {{classname}}.SerializerSettings));
                     return new{{classname}};
                 {{/mappedModels}}
                 default:
-                    System.Diagnostics.Debug.WriteLine(String.Format("Failed to lookup discriminator value `%s` for {{classname}}. Possible values:{{#mappedModels}} {{{mappingName}}}{{/mappedModels}}", discriminatorValue));
+                    System.Diagnostics.Debug.WriteLine(String.Format("Failed to lookup discriminator value `{0}` for {{classname}}. Possible values:{{#mappedModels}} {{{mappingName}}}{{/mappedModels}}", discriminatorValue));
                     break;
             }
 
@@ -122,14 +122,14 @@
 
             try
             {
-                new{{classname}} = new {{classname}}(JsonConvert.DeserializeObject<{{{.}}}>(jsonString, new{{classname}}._serializerSettings));
+                new{{classname}} = new {{classname}}(JsonConvert.DeserializeObject<{{{.}}}>(jsonString, {{classname}}.SerializerSettings));
                 matchedTypes.Add("{{{.}}}");
                 match++;
             }
             catch (Exception exception)
             {
                 // deserialization failed, try the next one
-                System.Diagnostics.Debug.WriteLine(String.Format("Failed to deserialize `%s` into {{{.}}}: %s", jsonString, exception.ToString()));
+                System.Diagnostics.Debug.WriteLine(String.Format("Failed to deserialize `{0}` into {{{.}}}: {1}", jsonString, exception.ToString()));
             }
             {{/oneOf}}
 

--- a/modules/openapi-generator/src/main/resources/csharp-netcore/modelOneOf.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/modelOneOf.mustache
@@ -4,6 +4,7 @@
     [DataContract(Name = "{{{name}}}")]
     {{>visibility}} partial class {{classname}} : AbstractOpenAPISchema, {{#parent}}{{{parent}}}, {{/parent}}IEquatable<{{classname}}>{{#validatable}}, IValidatableObject{{/validatable}}
     {
+        {{#isNullable}}
         /// <summary>
         /// Initializes a new instance of the <see cref="{{classname}}" /> class.
         /// </summary>
@@ -13,6 +14,7 @@
             this.SchemaType= "oneOf";
         }
 
+        {{/isNullable}}
         {{#oneOf}}
         /// <summary>
         /// Initializes a new instance of the <see cref="{{classname}}" /> class
@@ -95,7 +97,7 @@
         /// <returns>An instance of {{classname}}</returns>
         public static {{classname}} FromJson(string jsonString)
         {
-            {{classname}} new{{classname}} = new {{classname}}();
+            {{classname}} new{{classname}} = null;
             {{#useOneOfDiscriminatorLookup}}
             {{#discriminator}}
 
@@ -104,7 +106,7 @@
             {
                 {{#mappedModels}}
                 case "{{{mappingName}}}":
-                    new{{classname}}.ActualInstance = JsonConvert.DeserializeObject<{{{modelName}}}>(jsonString, new{{classname}}._serializerSettings);
+                    new{{classname}} = new {{classname}}(JsonConvert.DeserializeObject<{{{modelName}}}>(jsonString, new{{classname}}._serializerSettings));
                     return new{{classname}};
                 {{/mappedModels}}
                 default:
@@ -120,7 +122,7 @@
 
             try
             {
-                new{{classname}}.ActualInstance = JsonConvert.DeserializeObject<{{{.}}}>(jsonString, new{{classname}}._serializerSettings);
+                new{{classname}} = new {{classname}}(JsonConvert.DeserializeObject<{{{.}}}>(jsonString, new{{classname}}._serializerSettings));
                 matchedTypes.Add("{{{.}}}");
                 match++;
             }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools.Test/JSONComposedSchemaTests.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools.Test/JSONComposedSchemaTests.cs
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Test
             t.Name = "Something";
 
             Fruit f1 = new Fruit(a);
-            Fruit f2 = new Fruit(a);
+            Fruit f2 = new Fruit(b);
 
             f1.ActualInstance = b;
             f2.ActualInstance = a;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/AbstractOpenAPISchema.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/AbstractOpenAPISchema.cs
@@ -22,7 +22,7 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         ///  Custom JSON serializer
         /// </summary>
-        protected readonly JsonSerializerSettings _serializerSettings = new JsonSerializerSettings
+        static public readonly JsonSerializerSettings SerializerSettings = new JsonSerializerSettings
         {
             // OpenAPI generated types generally hide default constructors.
             ConstructorHandling = ConstructorHandling.AllowNonPublicDefaultConstructor,

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Fruit.cs
@@ -124,7 +124,7 @@ namespace Org.OpenAPITools.Model
         /// <returns>JSON string presentation of the object</returns>
         public override string ToJson()
         {
-            return JsonConvert.SerializeObject(this.ActualInstance, _serializerSettings);
+            return JsonConvert.SerializeObject(this.ActualInstance, Fruit.SerializerSettings);
         }
 
         /// <summary>
@@ -140,26 +140,26 @@ namespace Org.OpenAPITools.Model
 
             try
             {
-                newFruit = new Fruit(JsonConvert.DeserializeObject<Apple>(jsonString, newFruit._serializerSettings));
+                newFruit = new Fruit(JsonConvert.DeserializeObject<Apple>(jsonString, Fruit.SerializerSettings));
                 matchedTypes.Add("Apple");
                 match++;
             }
             catch (Exception exception)
             {
                 // deserialization failed, try the next one
-                System.Diagnostics.Debug.WriteLine(String.Format("Failed to deserialize `%s` into Apple: %s", jsonString, exception.ToString()));
+                System.Diagnostics.Debug.WriteLine(String.Format("Failed to deserialize `{0}` into Apple: {1}", jsonString, exception.ToString()));
             }
 
             try
             {
-                newFruit = new Fruit(JsonConvert.DeserializeObject<Banana>(jsonString, newFruit._serializerSettings));
+                newFruit = new Fruit(JsonConvert.DeserializeObject<Banana>(jsonString, Fruit.SerializerSettings));
                 matchedTypes.Add("Banana");
                 match++;
             }
             catch (Exception exception)
             {
                 // deserialization failed, try the next one
-                System.Diagnostics.Debug.WriteLine(String.Format("Failed to deserialize `%s` into Banana: %s", jsonString, exception.ToString()));
+                System.Diagnostics.Debug.WriteLine(String.Format("Failed to deserialize `{0}` into Banana: {1}", jsonString, exception.ToString()));
             }
 
             if (match == 0)

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Fruit.cs
@@ -33,15 +33,6 @@ namespace Org.OpenAPITools.Model
     public partial class Fruit : AbstractOpenAPISchema, IEquatable<Fruit>, IValidatableObject
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="Fruit" /> class.
-        /// </summary>
-        public Fruit()
-        {
-            this.IsNullable = true;
-            this.SchemaType= "oneOf";
-        }
-
-        /// <summary>
         /// Initializes a new instance of the <see cref="Fruit" /> class
         /// with the <see cref="Apple" /> class
         /// </summary>
@@ -143,13 +134,13 @@ namespace Org.OpenAPITools.Model
         /// <returns>An instance of Fruit</returns>
         public static Fruit FromJson(string jsonString)
         {
-            Fruit newFruit = new Fruit();
+            Fruit newFruit = null;
             int match = 0;
             List<string> matchedTypes = new List<string>();
 
             try
             {
-                newFruit.ActualInstance = JsonConvert.DeserializeObject<Apple>(jsonString, newFruit._serializerSettings);
+                newFruit = new Fruit(JsonConvert.DeserializeObject<Apple>(jsonString, newFruit._serializerSettings));
                 matchedTypes.Add("Apple");
                 match++;
             }
@@ -161,7 +152,7 @@ namespace Org.OpenAPITools.Model
 
             try
             {
-                newFruit.ActualInstance = JsonConvert.DeserializeObject<Banana>(jsonString, newFruit._serializerSettings);
+                newFruit = new Fruit(JsonConvert.DeserializeObject<Banana>(jsonString, newFruit._serializerSettings));
                 matchedTypes.Add("Banana");
                 match++;
             }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/FruitReq.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/FruitReq.cs
@@ -133,7 +133,7 @@ namespace Org.OpenAPITools.Model
         /// <returns>JSON string presentation of the object</returns>
         public override string ToJson()
         {
-            return JsonConvert.SerializeObject(this.ActualInstance, _serializerSettings);
+            return JsonConvert.SerializeObject(this.ActualInstance, FruitReq.SerializerSettings);
         }
 
         /// <summary>
@@ -149,26 +149,26 @@ namespace Org.OpenAPITools.Model
 
             try
             {
-                newFruitReq = new FruitReq(JsonConvert.DeserializeObject<AppleReq>(jsonString, newFruitReq._serializerSettings));
+                newFruitReq = new FruitReq(JsonConvert.DeserializeObject<AppleReq>(jsonString, FruitReq.SerializerSettings));
                 matchedTypes.Add("AppleReq");
                 match++;
             }
             catch (Exception exception)
             {
                 // deserialization failed, try the next one
-                System.Diagnostics.Debug.WriteLine(String.Format("Failed to deserialize `%s` into AppleReq: %s", jsonString, exception.ToString()));
+                System.Diagnostics.Debug.WriteLine(String.Format("Failed to deserialize `{0}` into AppleReq: {1}", jsonString, exception.ToString()));
             }
 
             try
             {
-                newFruitReq = new FruitReq(JsonConvert.DeserializeObject<BananaReq>(jsonString, newFruitReq._serializerSettings));
+                newFruitReq = new FruitReq(JsonConvert.DeserializeObject<BananaReq>(jsonString, FruitReq.SerializerSettings));
                 matchedTypes.Add("BananaReq");
                 match++;
             }
             catch (Exception exception)
             {
                 // deserialization failed, try the next one
-                System.Diagnostics.Debug.WriteLine(String.Format("Failed to deserialize `%s` into BananaReq: %s", jsonString, exception.ToString()));
+                System.Diagnostics.Debug.WriteLine(String.Format("Failed to deserialize `{0}` into BananaReq: {1}", jsonString, exception.ToString()));
             }
 
             if (match == 0)

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/FruitReq.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/FruitReq.cs
@@ -143,13 +143,13 @@ namespace Org.OpenAPITools.Model
         /// <returns>An instance of FruitReq</returns>
         public static FruitReq FromJson(string jsonString)
         {
-            FruitReq newFruitReq = new FruitReq();
+            FruitReq newFruitReq = null;
             int match = 0;
             List<string> matchedTypes = new List<string>();
 
             try
             {
-                newFruitReq.ActualInstance = JsonConvert.DeserializeObject<AppleReq>(jsonString, newFruitReq._serializerSettings);
+                newFruitReq = new FruitReq(JsonConvert.DeserializeObject<AppleReq>(jsonString, newFruitReq._serializerSettings));
                 matchedTypes.Add("AppleReq");
                 match++;
             }
@@ -161,7 +161,7 @@ namespace Org.OpenAPITools.Model
 
             try
             {
-                newFruitReq.ActualInstance = JsonConvert.DeserializeObject<BananaReq>(jsonString, newFruitReq._serializerSettings);
+                newFruitReq = new FruitReq(JsonConvert.DeserializeObject<BananaReq>(jsonString, newFruitReq._serializerSettings));
                 matchedTypes.Add("BananaReq");
                 match++;
             }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Mammal.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Mammal.cs
@@ -34,15 +34,6 @@ namespace Org.OpenAPITools.Model
     public partial class Mammal : AbstractOpenAPISchema, IEquatable<Mammal>, IValidatableObject
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="Mammal" /> class.
-        /// </summary>
-        public Mammal()
-        {
-            this.IsNullable = true;
-            this.SchemaType= "oneOf";
-        }
-
-        /// <summary>
         /// Initializes a new instance of the <see cref="Mammal" /> class
         /// with the <see cref="Pig" /> class
         /// </summary>
@@ -170,19 +161,19 @@ namespace Org.OpenAPITools.Model
         /// <returns>An instance of Mammal</returns>
         public static Mammal FromJson(string jsonString)
         {
-            Mammal newMammal = new Mammal();
+            Mammal newMammal = null;
 
             string discriminatorValue = JObject.Parse(jsonString)["className"].ToString();
             switch (discriminatorValue)
             {
                 case "Pig":
-                    newMammal.ActualInstance = JsonConvert.DeserializeObject<Pig>(jsonString, newMammal._serializerSettings);
+                    newMammal = new Mammal(JsonConvert.DeserializeObject<Pig>(jsonString, newMammal._serializerSettings));
                     return newMammal;
                 case "whale":
-                    newMammal.ActualInstance = JsonConvert.DeserializeObject<Whale>(jsonString, newMammal._serializerSettings);
+                    newMammal = new Mammal(JsonConvert.DeserializeObject<Whale>(jsonString, newMammal._serializerSettings));
                     return newMammal;
                 case "zebra":
-                    newMammal.ActualInstance = JsonConvert.DeserializeObject<Zebra>(jsonString, newMammal._serializerSettings);
+                    newMammal = new Mammal(JsonConvert.DeserializeObject<Zebra>(jsonString, newMammal._serializerSettings));
                     return newMammal;
                 default:
                     System.Diagnostics.Debug.WriteLine(String.Format("Failed to lookup discriminator value `%s` for Mammal. Possible values: Pig whale zebra", discriminatorValue));
@@ -194,7 +185,7 @@ namespace Org.OpenAPITools.Model
 
             try
             {
-                newMammal.ActualInstance = JsonConvert.DeserializeObject<Pig>(jsonString, newMammal._serializerSettings);
+                newMammal = new Mammal(JsonConvert.DeserializeObject<Pig>(jsonString, newMammal._serializerSettings));
                 matchedTypes.Add("Pig");
                 match++;
             }
@@ -206,7 +197,7 @@ namespace Org.OpenAPITools.Model
 
             try
             {
-                newMammal.ActualInstance = JsonConvert.DeserializeObject<Whale>(jsonString, newMammal._serializerSettings);
+                newMammal = new Mammal(JsonConvert.DeserializeObject<Whale>(jsonString, newMammal._serializerSettings));
                 matchedTypes.Add("Whale");
                 match++;
             }
@@ -218,7 +209,7 @@ namespace Org.OpenAPITools.Model
 
             try
             {
-                newMammal.ActualInstance = JsonConvert.DeserializeObject<Zebra>(jsonString, newMammal._serializerSettings);
+                newMammal = new Mammal(JsonConvert.DeserializeObject<Zebra>(jsonString, newMammal._serializerSettings));
                 matchedTypes.Add("Zebra");
                 match++;
             }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Mammal.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Mammal.cs
@@ -151,7 +151,7 @@ namespace Org.OpenAPITools.Model
         /// <returns>JSON string presentation of the object</returns>
         public override string ToJson()
         {
-            return JsonConvert.SerializeObject(this.ActualInstance, _serializerSettings);
+            return JsonConvert.SerializeObject(this.ActualInstance, Mammal.SerializerSettings);
         }
 
         /// <summary>
@@ -167,16 +167,16 @@ namespace Org.OpenAPITools.Model
             switch (discriminatorValue)
             {
                 case "Pig":
-                    newMammal = new Mammal(JsonConvert.DeserializeObject<Pig>(jsonString, newMammal._serializerSettings));
+                    newMammal = new Mammal(JsonConvert.DeserializeObject<Pig>(jsonString, Mammal.SerializerSettings));
                     return newMammal;
                 case "whale":
-                    newMammal = new Mammal(JsonConvert.DeserializeObject<Whale>(jsonString, newMammal._serializerSettings));
+                    newMammal = new Mammal(JsonConvert.DeserializeObject<Whale>(jsonString, Mammal.SerializerSettings));
                     return newMammal;
                 case "zebra":
-                    newMammal = new Mammal(JsonConvert.DeserializeObject<Zebra>(jsonString, newMammal._serializerSettings));
+                    newMammal = new Mammal(JsonConvert.DeserializeObject<Zebra>(jsonString, Mammal.SerializerSettings));
                     return newMammal;
                 default:
-                    System.Diagnostics.Debug.WriteLine(String.Format("Failed to lookup discriminator value `%s` for Mammal. Possible values: Pig whale zebra", discriminatorValue));
+                    System.Diagnostics.Debug.WriteLine(String.Format("Failed to lookup discriminator value `{0}` for Mammal. Possible values: Pig whale zebra", discriminatorValue));
                     break;
             }
 
@@ -185,38 +185,38 @@ namespace Org.OpenAPITools.Model
 
             try
             {
-                newMammal = new Mammal(JsonConvert.DeserializeObject<Pig>(jsonString, newMammal._serializerSettings));
+                newMammal = new Mammal(JsonConvert.DeserializeObject<Pig>(jsonString, Mammal.SerializerSettings));
                 matchedTypes.Add("Pig");
                 match++;
             }
             catch (Exception exception)
             {
                 // deserialization failed, try the next one
-                System.Diagnostics.Debug.WriteLine(String.Format("Failed to deserialize `%s` into Pig: %s", jsonString, exception.ToString()));
+                System.Diagnostics.Debug.WriteLine(String.Format("Failed to deserialize `{0}` into Pig: {1}", jsonString, exception.ToString()));
             }
 
             try
             {
-                newMammal = new Mammal(JsonConvert.DeserializeObject<Whale>(jsonString, newMammal._serializerSettings));
+                newMammal = new Mammal(JsonConvert.DeserializeObject<Whale>(jsonString, Mammal.SerializerSettings));
                 matchedTypes.Add("Whale");
                 match++;
             }
             catch (Exception exception)
             {
                 // deserialization failed, try the next one
-                System.Diagnostics.Debug.WriteLine(String.Format("Failed to deserialize `%s` into Whale: %s", jsonString, exception.ToString()));
+                System.Diagnostics.Debug.WriteLine(String.Format("Failed to deserialize `{0}` into Whale: {1}", jsonString, exception.ToString()));
             }
 
             try
             {
-                newMammal = new Mammal(JsonConvert.DeserializeObject<Zebra>(jsonString, newMammal._serializerSettings));
+                newMammal = new Mammal(JsonConvert.DeserializeObject<Zebra>(jsonString, Mammal.SerializerSettings));
                 matchedTypes.Add("Zebra");
                 match++;
             }
             catch (Exception exception)
             {
                 // deserialization failed, try the next one
-                System.Diagnostics.Debug.WriteLine(String.Format("Failed to deserialize `%s` into Zebra: %s", jsonString, exception.ToString()));
+                System.Diagnostics.Debug.WriteLine(String.Format("Failed to deserialize `{0}` into Zebra: {1}", jsonString, exception.ToString()));
             }
 
             if (match == 0)

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/NullableShape.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/NullableShape.cs
@@ -144,16 +144,16 @@ namespace Org.OpenAPITools.Model
         /// <returns>An instance of NullableShape</returns>
         public static NullableShape FromJson(string jsonString)
         {
-            NullableShape newNullableShape = new NullableShape();
+            NullableShape newNullableShape = null;
 
             string discriminatorValue = JObject.Parse(jsonString)["shapeType"].ToString();
             switch (discriminatorValue)
             {
                 case "Quadrilateral":
-                    newNullableShape.ActualInstance = JsonConvert.DeserializeObject<Quadrilateral>(jsonString, newNullableShape._serializerSettings);
+                    newNullableShape = new NullableShape(JsonConvert.DeserializeObject<Quadrilateral>(jsonString, newNullableShape._serializerSettings));
                     return newNullableShape;
                 case "Triangle":
-                    newNullableShape.ActualInstance = JsonConvert.DeserializeObject<Triangle>(jsonString, newNullableShape._serializerSettings);
+                    newNullableShape = new NullableShape(JsonConvert.DeserializeObject<Triangle>(jsonString, newNullableShape._serializerSettings));
                     return newNullableShape;
                 default:
                     System.Diagnostics.Debug.WriteLine(String.Format("Failed to lookup discriminator value `%s` for NullableShape. Possible values: Quadrilateral Triangle", discriminatorValue));
@@ -165,7 +165,7 @@ namespace Org.OpenAPITools.Model
 
             try
             {
-                newNullableShape.ActualInstance = JsonConvert.DeserializeObject<Quadrilateral>(jsonString, newNullableShape._serializerSettings);
+                newNullableShape = new NullableShape(JsonConvert.DeserializeObject<Quadrilateral>(jsonString, newNullableShape._serializerSettings));
                 matchedTypes.Add("Quadrilateral");
                 match++;
             }
@@ -177,7 +177,7 @@ namespace Org.OpenAPITools.Model
 
             try
             {
-                newNullableShape.ActualInstance = JsonConvert.DeserializeObject<Triangle>(jsonString, newNullableShape._serializerSettings);
+                newNullableShape = new NullableShape(JsonConvert.DeserializeObject<Triangle>(jsonString, newNullableShape._serializerSettings));
                 matchedTypes.Add("Triangle");
                 match++;
             }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/NullableShape.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/NullableShape.cs
@@ -134,7 +134,7 @@ namespace Org.OpenAPITools.Model
         /// <returns>JSON string presentation of the object</returns>
         public override string ToJson()
         {
-            return JsonConvert.SerializeObject(this.ActualInstance, _serializerSettings);
+            return JsonConvert.SerializeObject(this.ActualInstance, NullableShape.SerializerSettings);
         }
 
         /// <summary>
@@ -150,13 +150,13 @@ namespace Org.OpenAPITools.Model
             switch (discriminatorValue)
             {
                 case "Quadrilateral":
-                    newNullableShape = new NullableShape(JsonConvert.DeserializeObject<Quadrilateral>(jsonString, newNullableShape._serializerSettings));
+                    newNullableShape = new NullableShape(JsonConvert.DeserializeObject<Quadrilateral>(jsonString, NullableShape.SerializerSettings));
                     return newNullableShape;
                 case "Triangle":
-                    newNullableShape = new NullableShape(JsonConvert.DeserializeObject<Triangle>(jsonString, newNullableShape._serializerSettings));
+                    newNullableShape = new NullableShape(JsonConvert.DeserializeObject<Triangle>(jsonString, NullableShape.SerializerSettings));
                     return newNullableShape;
                 default:
-                    System.Diagnostics.Debug.WriteLine(String.Format("Failed to lookup discriminator value `%s` for NullableShape. Possible values: Quadrilateral Triangle", discriminatorValue));
+                    System.Diagnostics.Debug.WriteLine(String.Format("Failed to lookup discriminator value `{0}` for NullableShape. Possible values: Quadrilateral Triangle", discriminatorValue));
                     break;
             }
 
@@ -165,26 +165,26 @@ namespace Org.OpenAPITools.Model
 
             try
             {
-                newNullableShape = new NullableShape(JsonConvert.DeserializeObject<Quadrilateral>(jsonString, newNullableShape._serializerSettings));
+                newNullableShape = new NullableShape(JsonConvert.DeserializeObject<Quadrilateral>(jsonString, NullableShape.SerializerSettings));
                 matchedTypes.Add("Quadrilateral");
                 match++;
             }
             catch (Exception exception)
             {
                 // deserialization failed, try the next one
-                System.Diagnostics.Debug.WriteLine(String.Format("Failed to deserialize `%s` into Quadrilateral: %s", jsonString, exception.ToString()));
+                System.Diagnostics.Debug.WriteLine(String.Format("Failed to deserialize `{0}` into Quadrilateral: {1}", jsonString, exception.ToString()));
             }
 
             try
             {
-                newNullableShape = new NullableShape(JsonConvert.DeserializeObject<Triangle>(jsonString, newNullableShape._serializerSettings));
+                newNullableShape = new NullableShape(JsonConvert.DeserializeObject<Triangle>(jsonString, NullableShape.SerializerSettings));
                 matchedTypes.Add("Triangle");
                 match++;
             }
             catch (Exception exception)
             {
                 // deserialization failed, try the next one
-                System.Diagnostics.Debug.WriteLine(String.Format("Failed to deserialize `%s` into Triangle: %s", jsonString, exception.ToString()));
+                System.Diagnostics.Debug.WriteLine(String.Format("Failed to deserialize `{0}` into Triangle: {1}", jsonString, exception.ToString()));
             }
 
             if (match == 0)

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Pig.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Pig.cs
@@ -34,15 +34,6 @@ namespace Org.OpenAPITools.Model
     public partial class Pig : AbstractOpenAPISchema, IEquatable<Pig>, IValidatableObject
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="Pig" /> class.
-        /// </summary>
-        public Pig()
-        {
-            this.IsNullable = true;
-            this.SchemaType= "oneOf";
-        }
-
-        /// <summary>
         /// Initializes a new instance of the <see cref="Pig" /> class
         /// with the <see cref="BasquePig" /> class
         /// </summary>
@@ -144,16 +135,16 @@ namespace Org.OpenAPITools.Model
         /// <returns>An instance of Pig</returns>
         public static Pig FromJson(string jsonString)
         {
-            Pig newPig = new Pig();
+            Pig newPig = null;
 
             string discriminatorValue = JObject.Parse(jsonString)["className"].ToString();
             switch (discriminatorValue)
             {
                 case "BasquePig":
-                    newPig.ActualInstance = JsonConvert.DeserializeObject<BasquePig>(jsonString, newPig._serializerSettings);
+                    newPig = new Pig(JsonConvert.DeserializeObject<BasquePig>(jsonString, newPig._serializerSettings));
                     return newPig;
                 case "DanishPig":
-                    newPig.ActualInstance = JsonConvert.DeserializeObject<DanishPig>(jsonString, newPig._serializerSettings);
+                    newPig = new Pig(JsonConvert.DeserializeObject<DanishPig>(jsonString, newPig._serializerSettings));
                     return newPig;
                 default:
                     System.Diagnostics.Debug.WriteLine(String.Format("Failed to lookup discriminator value `%s` for Pig. Possible values: BasquePig DanishPig", discriminatorValue));
@@ -165,7 +156,7 @@ namespace Org.OpenAPITools.Model
 
             try
             {
-                newPig.ActualInstance = JsonConvert.DeserializeObject<BasquePig>(jsonString, newPig._serializerSettings);
+                newPig = new Pig(JsonConvert.DeserializeObject<BasquePig>(jsonString, newPig._serializerSettings));
                 matchedTypes.Add("BasquePig");
                 match++;
             }
@@ -177,7 +168,7 @@ namespace Org.OpenAPITools.Model
 
             try
             {
-                newPig.ActualInstance = JsonConvert.DeserializeObject<DanishPig>(jsonString, newPig._serializerSettings);
+                newPig = new Pig(JsonConvert.DeserializeObject<DanishPig>(jsonString, newPig._serializerSettings));
                 matchedTypes.Add("DanishPig");
                 match++;
             }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Pig.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Pig.cs
@@ -125,7 +125,7 @@ namespace Org.OpenAPITools.Model
         /// <returns>JSON string presentation of the object</returns>
         public override string ToJson()
         {
-            return JsonConvert.SerializeObject(this.ActualInstance, _serializerSettings);
+            return JsonConvert.SerializeObject(this.ActualInstance, Pig.SerializerSettings);
         }
 
         /// <summary>
@@ -141,13 +141,13 @@ namespace Org.OpenAPITools.Model
             switch (discriminatorValue)
             {
                 case "BasquePig":
-                    newPig = new Pig(JsonConvert.DeserializeObject<BasquePig>(jsonString, newPig._serializerSettings));
+                    newPig = new Pig(JsonConvert.DeserializeObject<BasquePig>(jsonString, Pig.SerializerSettings));
                     return newPig;
                 case "DanishPig":
-                    newPig = new Pig(JsonConvert.DeserializeObject<DanishPig>(jsonString, newPig._serializerSettings));
+                    newPig = new Pig(JsonConvert.DeserializeObject<DanishPig>(jsonString, Pig.SerializerSettings));
                     return newPig;
                 default:
-                    System.Diagnostics.Debug.WriteLine(String.Format("Failed to lookup discriminator value `%s` for Pig. Possible values: BasquePig DanishPig", discriminatorValue));
+                    System.Diagnostics.Debug.WriteLine(String.Format("Failed to lookup discriminator value `{0}` for Pig. Possible values: BasquePig DanishPig", discriminatorValue));
                     break;
             }
 
@@ -156,26 +156,26 @@ namespace Org.OpenAPITools.Model
 
             try
             {
-                newPig = new Pig(JsonConvert.DeserializeObject<BasquePig>(jsonString, newPig._serializerSettings));
+                newPig = new Pig(JsonConvert.DeserializeObject<BasquePig>(jsonString, Pig.SerializerSettings));
                 matchedTypes.Add("BasquePig");
                 match++;
             }
             catch (Exception exception)
             {
                 // deserialization failed, try the next one
-                System.Diagnostics.Debug.WriteLine(String.Format("Failed to deserialize `%s` into BasquePig: %s", jsonString, exception.ToString()));
+                System.Diagnostics.Debug.WriteLine(String.Format("Failed to deserialize `{0}` into BasquePig: {1}", jsonString, exception.ToString()));
             }
 
             try
             {
-                newPig = new Pig(JsonConvert.DeserializeObject<DanishPig>(jsonString, newPig._serializerSettings));
+                newPig = new Pig(JsonConvert.DeserializeObject<DanishPig>(jsonString, Pig.SerializerSettings));
                 matchedTypes.Add("DanishPig");
                 match++;
             }
             catch (Exception exception)
             {
                 // deserialization failed, try the next one
-                System.Diagnostics.Debug.WriteLine(String.Format("Failed to deserialize `%s` into DanishPig: %s", jsonString, exception.ToString()));
+                System.Diagnostics.Debug.WriteLine(String.Format("Failed to deserialize `{0}` into DanishPig: {1}", jsonString, exception.ToString()));
             }
 
             if (match == 0)

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Quadrilateral.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Quadrilateral.cs
@@ -125,7 +125,7 @@ namespace Org.OpenAPITools.Model
         /// <returns>JSON string presentation of the object</returns>
         public override string ToJson()
         {
-            return JsonConvert.SerializeObject(this.ActualInstance, _serializerSettings);
+            return JsonConvert.SerializeObject(this.ActualInstance, Quadrilateral.SerializerSettings);
         }
 
         /// <summary>
@@ -141,13 +141,13 @@ namespace Org.OpenAPITools.Model
             switch (discriminatorValue)
             {
                 case "ComplexQuadrilateral":
-                    newQuadrilateral = new Quadrilateral(JsonConvert.DeserializeObject<ComplexQuadrilateral>(jsonString, newQuadrilateral._serializerSettings));
+                    newQuadrilateral = new Quadrilateral(JsonConvert.DeserializeObject<ComplexQuadrilateral>(jsonString, Quadrilateral.SerializerSettings));
                     return newQuadrilateral;
                 case "SimpleQuadrilateral":
-                    newQuadrilateral = new Quadrilateral(JsonConvert.DeserializeObject<SimpleQuadrilateral>(jsonString, newQuadrilateral._serializerSettings));
+                    newQuadrilateral = new Quadrilateral(JsonConvert.DeserializeObject<SimpleQuadrilateral>(jsonString, Quadrilateral.SerializerSettings));
                     return newQuadrilateral;
                 default:
-                    System.Diagnostics.Debug.WriteLine(String.Format("Failed to lookup discriminator value `%s` for Quadrilateral. Possible values: ComplexQuadrilateral SimpleQuadrilateral", discriminatorValue));
+                    System.Diagnostics.Debug.WriteLine(String.Format("Failed to lookup discriminator value `{0}` for Quadrilateral. Possible values: ComplexQuadrilateral SimpleQuadrilateral", discriminatorValue));
                     break;
             }
 
@@ -156,26 +156,26 @@ namespace Org.OpenAPITools.Model
 
             try
             {
-                newQuadrilateral = new Quadrilateral(JsonConvert.DeserializeObject<ComplexQuadrilateral>(jsonString, newQuadrilateral._serializerSettings));
+                newQuadrilateral = new Quadrilateral(JsonConvert.DeserializeObject<ComplexQuadrilateral>(jsonString, Quadrilateral.SerializerSettings));
                 matchedTypes.Add("ComplexQuadrilateral");
                 match++;
             }
             catch (Exception exception)
             {
                 // deserialization failed, try the next one
-                System.Diagnostics.Debug.WriteLine(String.Format("Failed to deserialize `%s` into ComplexQuadrilateral: %s", jsonString, exception.ToString()));
+                System.Diagnostics.Debug.WriteLine(String.Format("Failed to deserialize `{0}` into ComplexQuadrilateral: {1}", jsonString, exception.ToString()));
             }
 
             try
             {
-                newQuadrilateral = new Quadrilateral(JsonConvert.DeserializeObject<SimpleQuadrilateral>(jsonString, newQuadrilateral._serializerSettings));
+                newQuadrilateral = new Quadrilateral(JsonConvert.DeserializeObject<SimpleQuadrilateral>(jsonString, Quadrilateral.SerializerSettings));
                 matchedTypes.Add("SimpleQuadrilateral");
                 match++;
             }
             catch (Exception exception)
             {
                 // deserialization failed, try the next one
-                System.Diagnostics.Debug.WriteLine(String.Format("Failed to deserialize `%s` into SimpleQuadrilateral: %s", jsonString, exception.ToString()));
+                System.Diagnostics.Debug.WriteLine(String.Format("Failed to deserialize `{0}` into SimpleQuadrilateral: {1}", jsonString, exception.ToString()));
             }
 
             if (match == 0)

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Quadrilateral.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Quadrilateral.cs
@@ -34,15 +34,6 @@ namespace Org.OpenAPITools.Model
     public partial class Quadrilateral : AbstractOpenAPISchema, IEquatable<Quadrilateral>, IValidatableObject
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="Quadrilateral" /> class.
-        /// </summary>
-        public Quadrilateral()
-        {
-            this.IsNullable = true;
-            this.SchemaType= "oneOf";
-        }
-
-        /// <summary>
         /// Initializes a new instance of the <see cref="Quadrilateral" /> class
         /// with the <see cref="ComplexQuadrilateral" /> class
         /// </summary>
@@ -144,16 +135,16 @@ namespace Org.OpenAPITools.Model
         /// <returns>An instance of Quadrilateral</returns>
         public static Quadrilateral FromJson(string jsonString)
         {
-            Quadrilateral newQuadrilateral = new Quadrilateral();
+            Quadrilateral newQuadrilateral = null;
 
             string discriminatorValue = JObject.Parse(jsonString)["quadrilateralType"].ToString();
             switch (discriminatorValue)
             {
                 case "ComplexQuadrilateral":
-                    newQuadrilateral.ActualInstance = JsonConvert.DeserializeObject<ComplexQuadrilateral>(jsonString, newQuadrilateral._serializerSettings);
+                    newQuadrilateral = new Quadrilateral(JsonConvert.DeserializeObject<ComplexQuadrilateral>(jsonString, newQuadrilateral._serializerSettings));
                     return newQuadrilateral;
                 case "SimpleQuadrilateral":
-                    newQuadrilateral.ActualInstance = JsonConvert.DeserializeObject<SimpleQuadrilateral>(jsonString, newQuadrilateral._serializerSettings);
+                    newQuadrilateral = new Quadrilateral(JsonConvert.DeserializeObject<SimpleQuadrilateral>(jsonString, newQuadrilateral._serializerSettings));
                     return newQuadrilateral;
                 default:
                     System.Diagnostics.Debug.WriteLine(String.Format("Failed to lookup discriminator value `%s` for Quadrilateral. Possible values: ComplexQuadrilateral SimpleQuadrilateral", discriminatorValue));
@@ -165,7 +156,7 @@ namespace Org.OpenAPITools.Model
 
             try
             {
-                newQuadrilateral.ActualInstance = JsonConvert.DeserializeObject<ComplexQuadrilateral>(jsonString, newQuadrilateral._serializerSettings);
+                newQuadrilateral = new Quadrilateral(JsonConvert.DeserializeObject<ComplexQuadrilateral>(jsonString, newQuadrilateral._serializerSettings));
                 matchedTypes.Add("ComplexQuadrilateral");
                 match++;
             }
@@ -177,7 +168,7 @@ namespace Org.OpenAPITools.Model
 
             try
             {
-                newQuadrilateral.ActualInstance = JsonConvert.DeserializeObject<SimpleQuadrilateral>(jsonString, newQuadrilateral._serializerSettings);
+                newQuadrilateral = new Quadrilateral(JsonConvert.DeserializeObject<SimpleQuadrilateral>(jsonString, newQuadrilateral._serializerSettings));
                 matchedTypes.Add("SimpleQuadrilateral");
                 match++;
             }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Shape.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Shape.cs
@@ -34,15 +34,6 @@ namespace Org.OpenAPITools.Model
     public partial class Shape : AbstractOpenAPISchema, IEquatable<Shape>, IValidatableObject
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="Shape" /> class.
-        /// </summary>
-        public Shape()
-        {
-            this.IsNullable = true;
-            this.SchemaType= "oneOf";
-        }
-
-        /// <summary>
         /// Initializes a new instance of the <see cref="Shape" /> class
         /// with the <see cref="Quadrilateral" /> class
         /// </summary>
@@ -144,16 +135,16 @@ namespace Org.OpenAPITools.Model
         /// <returns>An instance of Shape</returns>
         public static Shape FromJson(string jsonString)
         {
-            Shape newShape = new Shape();
+            Shape newShape = null;
 
             string discriminatorValue = JObject.Parse(jsonString)["shapeType"].ToString();
             switch (discriminatorValue)
             {
                 case "Quadrilateral":
-                    newShape.ActualInstance = JsonConvert.DeserializeObject<Quadrilateral>(jsonString, newShape._serializerSettings);
+                    newShape = new Shape(JsonConvert.DeserializeObject<Quadrilateral>(jsonString, newShape._serializerSettings));
                     return newShape;
                 case "Triangle":
-                    newShape.ActualInstance = JsonConvert.DeserializeObject<Triangle>(jsonString, newShape._serializerSettings);
+                    newShape = new Shape(JsonConvert.DeserializeObject<Triangle>(jsonString, newShape._serializerSettings));
                     return newShape;
                 default:
                     System.Diagnostics.Debug.WriteLine(String.Format("Failed to lookup discriminator value `%s` for Shape. Possible values: Quadrilateral Triangle", discriminatorValue));
@@ -165,7 +156,7 @@ namespace Org.OpenAPITools.Model
 
             try
             {
-                newShape.ActualInstance = JsonConvert.DeserializeObject<Quadrilateral>(jsonString, newShape._serializerSettings);
+                newShape = new Shape(JsonConvert.DeserializeObject<Quadrilateral>(jsonString, newShape._serializerSettings));
                 matchedTypes.Add("Quadrilateral");
                 match++;
             }
@@ -177,7 +168,7 @@ namespace Org.OpenAPITools.Model
 
             try
             {
-                newShape.ActualInstance = JsonConvert.DeserializeObject<Triangle>(jsonString, newShape._serializerSettings);
+                newShape = new Shape(JsonConvert.DeserializeObject<Triangle>(jsonString, newShape._serializerSettings));
                 matchedTypes.Add("Triangle");
                 match++;
             }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Shape.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Shape.cs
@@ -125,7 +125,7 @@ namespace Org.OpenAPITools.Model
         /// <returns>JSON string presentation of the object</returns>
         public override string ToJson()
         {
-            return JsonConvert.SerializeObject(this.ActualInstance, _serializerSettings);
+            return JsonConvert.SerializeObject(this.ActualInstance, Shape.SerializerSettings);
         }
 
         /// <summary>
@@ -141,13 +141,13 @@ namespace Org.OpenAPITools.Model
             switch (discriminatorValue)
             {
                 case "Quadrilateral":
-                    newShape = new Shape(JsonConvert.DeserializeObject<Quadrilateral>(jsonString, newShape._serializerSettings));
+                    newShape = new Shape(JsonConvert.DeserializeObject<Quadrilateral>(jsonString, Shape.SerializerSettings));
                     return newShape;
                 case "Triangle":
-                    newShape = new Shape(JsonConvert.DeserializeObject<Triangle>(jsonString, newShape._serializerSettings));
+                    newShape = new Shape(JsonConvert.DeserializeObject<Triangle>(jsonString, Shape.SerializerSettings));
                     return newShape;
                 default:
-                    System.Diagnostics.Debug.WriteLine(String.Format("Failed to lookup discriminator value `%s` for Shape. Possible values: Quadrilateral Triangle", discriminatorValue));
+                    System.Diagnostics.Debug.WriteLine(String.Format("Failed to lookup discriminator value `{0}` for Shape. Possible values: Quadrilateral Triangle", discriminatorValue));
                     break;
             }
 
@@ -156,26 +156,26 @@ namespace Org.OpenAPITools.Model
 
             try
             {
-                newShape = new Shape(JsonConvert.DeserializeObject<Quadrilateral>(jsonString, newShape._serializerSettings));
+                newShape = new Shape(JsonConvert.DeserializeObject<Quadrilateral>(jsonString, Shape.SerializerSettings));
                 matchedTypes.Add("Quadrilateral");
                 match++;
             }
             catch (Exception exception)
             {
                 // deserialization failed, try the next one
-                System.Diagnostics.Debug.WriteLine(String.Format("Failed to deserialize `%s` into Quadrilateral: %s", jsonString, exception.ToString()));
+                System.Diagnostics.Debug.WriteLine(String.Format("Failed to deserialize `{0}` into Quadrilateral: {1}", jsonString, exception.ToString()));
             }
 
             try
             {
-                newShape = new Shape(JsonConvert.DeserializeObject<Triangle>(jsonString, newShape._serializerSettings));
+                newShape = new Shape(JsonConvert.DeserializeObject<Triangle>(jsonString, Shape.SerializerSettings));
                 matchedTypes.Add("Triangle");
                 match++;
             }
             catch (Exception exception)
             {
                 // deserialization failed, try the next one
-                System.Diagnostics.Debug.WriteLine(String.Format("Failed to deserialize `%s` into Triangle: %s", jsonString, exception.ToString()));
+                System.Diagnostics.Debug.WriteLine(String.Format("Failed to deserialize `{0}` into Triangle: {1}", jsonString, exception.ToString()));
             }
 
             if (match == 0)

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/ShapeOrNull.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/ShapeOrNull.cs
@@ -134,7 +134,7 @@ namespace Org.OpenAPITools.Model
         /// <returns>JSON string presentation of the object</returns>
         public override string ToJson()
         {
-            return JsonConvert.SerializeObject(this.ActualInstance, _serializerSettings);
+            return JsonConvert.SerializeObject(this.ActualInstance, ShapeOrNull.SerializerSettings);
         }
 
         /// <summary>
@@ -150,13 +150,13 @@ namespace Org.OpenAPITools.Model
             switch (discriminatorValue)
             {
                 case "Quadrilateral":
-                    newShapeOrNull = new ShapeOrNull(JsonConvert.DeserializeObject<Quadrilateral>(jsonString, newShapeOrNull._serializerSettings));
+                    newShapeOrNull = new ShapeOrNull(JsonConvert.DeserializeObject<Quadrilateral>(jsonString, ShapeOrNull.SerializerSettings));
                     return newShapeOrNull;
                 case "Triangle":
-                    newShapeOrNull = new ShapeOrNull(JsonConvert.DeserializeObject<Triangle>(jsonString, newShapeOrNull._serializerSettings));
+                    newShapeOrNull = new ShapeOrNull(JsonConvert.DeserializeObject<Triangle>(jsonString, ShapeOrNull.SerializerSettings));
                     return newShapeOrNull;
                 default:
-                    System.Diagnostics.Debug.WriteLine(String.Format("Failed to lookup discriminator value `%s` for ShapeOrNull. Possible values: Quadrilateral Triangle", discriminatorValue));
+                    System.Diagnostics.Debug.WriteLine(String.Format("Failed to lookup discriminator value `{0}` for ShapeOrNull. Possible values: Quadrilateral Triangle", discriminatorValue));
                     break;
             }
 
@@ -165,26 +165,26 @@ namespace Org.OpenAPITools.Model
 
             try
             {
-                newShapeOrNull = new ShapeOrNull(JsonConvert.DeserializeObject<Quadrilateral>(jsonString, newShapeOrNull._serializerSettings));
+                newShapeOrNull = new ShapeOrNull(JsonConvert.DeserializeObject<Quadrilateral>(jsonString, ShapeOrNull.SerializerSettings));
                 matchedTypes.Add("Quadrilateral");
                 match++;
             }
             catch (Exception exception)
             {
                 // deserialization failed, try the next one
-                System.Diagnostics.Debug.WriteLine(String.Format("Failed to deserialize `%s` into Quadrilateral: %s", jsonString, exception.ToString()));
+                System.Diagnostics.Debug.WriteLine(String.Format("Failed to deserialize `{0}` into Quadrilateral: {1}", jsonString, exception.ToString()));
             }
 
             try
             {
-                newShapeOrNull = new ShapeOrNull(JsonConvert.DeserializeObject<Triangle>(jsonString, newShapeOrNull._serializerSettings));
+                newShapeOrNull = new ShapeOrNull(JsonConvert.DeserializeObject<Triangle>(jsonString, ShapeOrNull.SerializerSettings));
                 matchedTypes.Add("Triangle");
                 match++;
             }
             catch (Exception exception)
             {
                 // deserialization failed, try the next one
-                System.Diagnostics.Debug.WriteLine(String.Format("Failed to deserialize `%s` into Triangle: %s", jsonString, exception.ToString()));
+                System.Diagnostics.Debug.WriteLine(String.Format("Failed to deserialize `{0}` into Triangle: {1}", jsonString, exception.ToString()));
             }
 
             if (match == 0)

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/ShapeOrNull.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/ShapeOrNull.cs
@@ -144,16 +144,16 @@ namespace Org.OpenAPITools.Model
         /// <returns>An instance of ShapeOrNull</returns>
         public static ShapeOrNull FromJson(string jsonString)
         {
-            ShapeOrNull newShapeOrNull = new ShapeOrNull();
+            ShapeOrNull newShapeOrNull = null;
 
             string discriminatorValue = JObject.Parse(jsonString)["shapeType"].ToString();
             switch (discriminatorValue)
             {
                 case "Quadrilateral":
-                    newShapeOrNull.ActualInstance = JsonConvert.DeserializeObject<Quadrilateral>(jsonString, newShapeOrNull._serializerSettings);
+                    newShapeOrNull = new ShapeOrNull(JsonConvert.DeserializeObject<Quadrilateral>(jsonString, newShapeOrNull._serializerSettings));
                     return newShapeOrNull;
                 case "Triangle":
-                    newShapeOrNull.ActualInstance = JsonConvert.DeserializeObject<Triangle>(jsonString, newShapeOrNull._serializerSettings);
+                    newShapeOrNull = new ShapeOrNull(JsonConvert.DeserializeObject<Triangle>(jsonString, newShapeOrNull._serializerSettings));
                     return newShapeOrNull;
                 default:
                     System.Diagnostics.Debug.WriteLine(String.Format("Failed to lookup discriminator value `%s` for ShapeOrNull. Possible values: Quadrilateral Triangle", discriminatorValue));
@@ -165,7 +165,7 @@ namespace Org.OpenAPITools.Model
 
             try
             {
-                newShapeOrNull.ActualInstance = JsonConvert.DeserializeObject<Quadrilateral>(jsonString, newShapeOrNull._serializerSettings);
+                newShapeOrNull = new ShapeOrNull(JsonConvert.DeserializeObject<Quadrilateral>(jsonString, newShapeOrNull._serializerSettings));
                 matchedTypes.Add("Quadrilateral");
                 match++;
             }
@@ -177,7 +177,7 @@ namespace Org.OpenAPITools.Model
 
             try
             {
-                newShapeOrNull.ActualInstance = JsonConvert.DeserializeObject<Triangle>(jsonString, newShapeOrNull._serializerSettings);
+                newShapeOrNull = new ShapeOrNull(JsonConvert.DeserializeObject<Triangle>(jsonString, newShapeOrNull._serializerSettings));
                 matchedTypes.Add("Triangle");
                 match++;
             }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Triangle.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Triangle.cs
@@ -151,7 +151,7 @@ namespace Org.OpenAPITools.Model
         /// <returns>JSON string presentation of the object</returns>
         public override string ToJson()
         {
-            return JsonConvert.SerializeObject(this.ActualInstance, _serializerSettings);
+            return JsonConvert.SerializeObject(this.ActualInstance, Triangle.SerializerSettings);
         }
 
         /// <summary>
@@ -167,16 +167,16 @@ namespace Org.OpenAPITools.Model
             switch (discriminatorValue)
             {
                 case "EquilateralTriangle":
-                    newTriangle = new Triangle(JsonConvert.DeserializeObject<EquilateralTriangle>(jsonString, newTriangle._serializerSettings));
+                    newTriangle = new Triangle(JsonConvert.DeserializeObject<EquilateralTriangle>(jsonString, Triangle.SerializerSettings));
                     return newTriangle;
                 case "IsoscelesTriangle":
-                    newTriangle = new Triangle(JsonConvert.DeserializeObject<IsoscelesTriangle>(jsonString, newTriangle._serializerSettings));
+                    newTriangle = new Triangle(JsonConvert.DeserializeObject<IsoscelesTriangle>(jsonString, Triangle.SerializerSettings));
                     return newTriangle;
                 case "ScaleneTriangle":
-                    newTriangle = new Triangle(JsonConvert.DeserializeObject<ScaleneTriangle>(jsonString, newTriangle._serializerSettings));
+                    newTriangle = new Triangle(JsonConvert.DeserializeObject<ScaleneTriangle>(jsonString, Triangle.SerializerSettings));
                     return newTriangle;
                 default:
-                    System.Diagnostics.Debug.WriteLine(String.Format("Failed to lookup discriminator value `%s` for Triangle. Possible values: EquilateralTriangle IsoscelesTriangle ScaleneTriangle", discriminatorValue));
+                    System.Diagnostics.Debug.WriteLine(String.Format("Failed to lookup discriminator value `{0}` for Triangle. Possible values: EquilateralTriangle IsoscelesTriangle ScaleneTriangle", discriminatorValue));
                     break;
             }
 
@@ -185,38 +185,38 @@ namespace Org.OpenAPITools.Model
 
             try
             {
-                newTriangle = new Triangle(JsonConvert.DeserializeObject<EquilateralTriangle>(jsonString, newTriangle._serializerSettings));
+                newTriangle = new Triangle(JsonConvert.DeserializeObject<EquilateralTriangle>(jsonString, Triangle.SerializerSettings));
                 matchedTypes.Add("EquilateralTriangle");
                 match++;
             }
             catch (Exception exception)
             {
                 // deserialization failed, try the next one
-                System.Diagnostics.Debug.WriteLine(String.Format("Failed to deserialize `%s` into EquilateralTriangle: %s", jsonString, exception.ToString()));
+                System.Diagnostics.Debug.WriteLine(String.Format("Failed to deserialize `{0}` into EquilateralTriangle: {1}", jsonString, exception.ToString()));
             }
 
             try
             {
-                newTriangle = new Triangle(JsonConvert.DeserializeObject<IsoscelesTriangle>(jsonString, newTriangle._serializerSettings));
+                newTriangle = new Triangle(JsonConvert.DeserializeObject<IsoscelesTriangle>(jsonString, Triangle.SerializerSettings));
                 matchedTypes.Add("IsoscelesTriangle");
                 match++;
             }
             catch (Exception exception)
             {
                 // deserialization failed, try the next one
-                System.Diagnostics.Debug.WriteLine(String.Format("Failed to deserialize `%s` into IsoscelesTriangle: %s", jsonString, exception.ToString()));
+                System.Diagnostics.Debug.WriteLine(String.Format("Failed to deserialize `{0}` into IsoscelesTriangle: {1}", jsonString, exception.ToString()));
             }
 
             try
             {
-                newTriangle = new Triangle(JsonConvert.DeserializeObject<ScaleneTriangle>(jsonString, newTriangle._serializerSettings));
+                newTriangle = new Triangle(JsonConvert.DeserializeObject<ScaleneTriangle>(jsonString, Triangle.SerializerSettings));
                 matchedTypes.Add("ScaleneTriangle");
                 match++;
             }
             catch (Exception exception)
             {
                 // deserialization failed, try the next one
-                System.Diagnostics.Debug.WriteLine(String.Format("Failed to deserialize `%s` into ScaleneTriangle: %s", jsonString, exception.ToString()));
+                System.Diagnostics.Debug.WriteLine(String.Format("Failed to deserialize `{0}` into ScaleneTriangle: {1}", jsonString, exception.ToString()));
             }
 
             if (match == 0)

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Triangle.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Triangle.cs
@@ -34,15 +34,6 @@ namespace Org.OpenAPITools.Model
     public partial class Triangle : AbstractOpenAPISchema, IEquatable<Triangle>, IValidatableObject
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="Triangle" /> class.
-        /// </summary>
-        public Triangle()
-        {
-            this.IsNullable = true;
-            this.SchemaType= "oneOf";
-        }
-
-        /// <summary>
         /// Initializes a new instance of the <see cref="Triangle" /> class
         /// with the <see cref="EquilateralTriangle" /> class
         /// </summary>
@@ -170,19 +161,19 @@ namespace Org.OpenAPITools.Model
         /// <returns>An instance of Triangle</returns>
         public static Triangle FromJson(string jsonString)
         {
-            Triangle newTriangle = new Triangle();
+            Triangle newTriangle = null;
 
             string discriminatorValue = JObject.Parse(jsonString)["triangleType"].ToString();
             switch (discriminatorValue)
             {
                 case "EquilateralTriangle":
-                    newTriangle.ActualInstance = JsonConvert.DeserializeObject<EquilateralTriangle>(jsonString, newTriangle._serializerSettings);
+                    newTriangle = new Triangle(JsonConvert.DeserializeObject<EquilateralTriangle>(jsonString, newTriangle._serializerSettings));
                     return newTriangle;
                 case "IsoscelesTriangle":
-                    newTriangle.ActualInstance = JsonConvert.DeserializeObject<IsoscelesTriangle>(jsonString, newTriangle._serializerSettings);
+                    newTriangle = new Triangle(JsonConvert.DeserializeObject<IsoscelesTriangle>(jsonString, newTriangle._serializerSettings));
                     return newTriangle;
                 case "ScaleneTriangle":
-                    newTriangle.ActualInstance = JsonConvert.DeserializeObject<ScaleneTriangle>(jsonString, newTriangle._serializerSettings);
+                    newTriangle = new Triangle(JsonConvert.DeserializeObject<ScaleneTriangle>(jsonString, newTriangle._serializerSettings));
                     return newTriangle;
                 default:
                     System.Diagnostics.Debug.WriteLine(String.Format("Failed to lookup discriminator value `%s` for Triangle. Possible values: EquilateralTriangle IsoscelesTriangle ScaleneTriangle", discriminatorValue));
@@ -194,7 +185,7 @@ namespace Org.OpenAPITools.Model
 
             try
             {
-                newTriangle.ActualInstance = JsonConvert.DeserializeObject<EquilateralTriangle>(jsonString, newTriangle._serializerSettings);
+                newTriangle = new Triangle(JsonConvert.DeserializeObject<EquilateralTriangle>(jsonString, newTriangle._serializerSettings));
                 matchedTypes.Add("EquilateralTriangle");
                 match++;
             }
@@ -206,7 +197,7 @@ namespace Org.OpenAPITools.Model
 
             try
             {
-                newTriangle.ActualInstance = JsonConvert.DeserializeObject<IsoscelesTriangle>(jsonString, newTriangle._serializerSettings);
+                newTriangle = new Triangle(JsonConvert.DeserializeObject<IsoscelesTriangle>(jsonString, newTriangle._serializerSettings));
                 matchedTypes.Add("IsoscelesTriangle");
                 match++;
             }
@@ -218,7 +209,7 @@ namespace Org.OpenAPITools.Model
 
             try
             {
-                newTriangle.ActualInstance = JsonConvert.DeserializeObject<ScaleneTriangle>(jsonString, newTriangle._serializerSettings);
+                newTriangle = new Triangle(JsonConvert.DeserializeObject<ScaleneTriangle>(jsonString, newTriangle._serializerSettings));
                 matchedTypes.Add("ScaleneTriangle");
                 match++;
             }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/AbstractOpenAPISchema.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/AbstractOpenAPISchema.cs
@@ -22,7 +22,7 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         ///  Custom JSON serializer
         /// </summary>
-        protected readonly JsonSerializerSettings _serializerSettings = new JsonSerializerSettings
+        static public readonly JsonSerializerSettings SerializerSettings = new JsonSerializerSettings
         {
             // OpenAPI generated types generally hide default constructors.
             ConstructorHandling = ConstructorHandling.AllowNonPublicDefaultConstructor,

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Fruit.cs
@@ -124,7 +124,7 @@ namespace Org.OpenAPITools.Model
         /// <returns>JSON string presentation of the object</returns>
         public override string ToJson()
         {
-            return JsonConvert.SerializeObject(this.ActualInstance, _serializerSettings);
+            return JsonConvert.SerializeObject(this.ActualInstance, Fruit.SerializerSettings);
         }
 
         /// <summary>
@@ -140,26 +140,26 @@ namespace Org.OpenAPITools.Model
 
             try
             {
-                newFruit = new Fruit(JsonConvert.DeserializeObject<Apple>(jsonString, newFruit._serializerSettings));
+                newFruit = new Fruit(JsonConvert.DeserializeObject<Apple>(jsonString, Fruit.SerializerSettings));
                 matchedTypes.Add("Apple");
                 match++;
             }
             catch (Exception exception)
             {
                 // deserialization failed, try the next one
-                System.Diagnostics.Debug.WriteLine(String.Format("Failed to deserialize `%s` into Apple: %s", jsonString, exception.ToString()));
+                System.Diagnostics.Debug.WriteLine(String.Format("Failed to deserialize `{0}` into Apple: {1}", jsonString, exception.ToString()));
             }
 
             try
             {
-                newFruit = new Fruit(JsonConvert.DeserializeObject<Banana>(jsonString, newFruit._serializerSettings));
+                newFruit = new Fruit(JsonConvert.DeserializeObject<Banana>(jsonString, Fruit.SerializerSettings));
                 matchedTypes.Add("Banana");
                 match++;
             }
             catch (Exception exception)
             {
                 // deserialization failed, try the next one
-                System.Diagnostics.Debug.WriteLine(String.Format("Failed to deserialize `%s` into Banana: %s", jsonString, exception.ToString()));
+                System.Diagnostics.Debug.WriteLine(String.Format("Failed to deserialize `{0}` into Banana: {1}", jsonString, exception.ToString()));
             }
 
             if (match == 0)

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Fruit.cs
@@ -33,15 +33,6 @@ namespace Org.OpenAPITools.Model
     public partial class Fruit : AbstractOpenAPISchema, IEquatable<Fruit>, IValidatableObject
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="Fruit" /> class.
-        /// </summary>
-        public Fruit()
-        {
-            this.IsNullable = true;
-            this.SchemaType= "oneOf";
-        }
-
-        /// <summary>
         /// Initializes a new instance of the <see cref="Fruit" /> class
         /// with the <see cref="Apple" /> class
         /// </summary>
@@ -143,13 +134,13 @@ namespace Org.OpenAPITools.Model
         /// <returns>An instance of Fruit</returns>
         public static Fruit FromJson(string jsonString)
         {
-            Fruit newFruit = new Fruit();
+            Fruit newFruit = null;
             int match = 0;
             List<string> matchedTypes = new List<string>();
 
             try
             {
-                newFruit.ActualInstance = JsonConvert.DeserializeObject<Apple>(jsonString, newFruit._serializerSettings);
+                newFruit = new Fruit(JsonConvert.DeserializeObject<Apple>(jsonString, newFruit._serializerSettings));
                 matchedTypes.Add("Apple");
                 match++;
             }
@@ -161,7 +152,7 @@ namespace Org.OpenAPITools.Model
 
             try
             {
-                newFruit.ActualInstance = JsonConvert.DeserializeObject<Banana>(jsonString, newFruit._serializerSettings);
+                newFruit = new Fruit(JsonConvert.DeserializeObject<Banana>(jsonString, newFruit._serializerSettings));
                 matchedTypes.Add("Banana");
                 match++;
             }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/FruitReq.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/FruitReq.cs
@@ -133,7 +133,7 @@ namespace Org.OpenAPITools.Model
         /// <returns>JSON string presentation of the object</returns>
         public override string ToJson()
         {
-            return JsonConvert.SerializeObject(this.ActualInstance, _serializerSettings);
+            return JsonConvert.SerializeObject(this.ActualInstance, FruitReq.SerializerSettings);
         }
 
         /// <summary>
@@ -149,26 +149,26 @@ namespace Org.OpenAPITools.Model
 
             try
             {
-                newFruitReq = new FruitReq(JsonConvert.DeserializeObject<AppleReq>(jsonString, newFruitReq._serializerSettings));
+                newFruitReq = new FruitReq(JsonConvert.DeserializeObject<AppleReq>(jsonString, FruitReq.SerializerSettings));
                 matchedTypes.Add("AppleReq");
                 match++;
             }
             catch (Exception exception)
             {
                 // deserialization failed, try the next one
-                System.Diagnostics.Debug.WriteLine(String.Format("Failed to deserialize `%s` into AppleReq: %s", jsonString, exception.ToString()));
+                System.Diagnostics.Debug.WriteLine(String.Format("Failed to deserialize `{0}` into AppleReq: {1}", jsonString, exception.ToString()));
             }
 
             try
             {
-                newFruitReq = new FruitReq(JsonConvert.DeserializeObject<BananaReq>(jsonString, newFruitReq._serializerSettings));
+                newFruitReq = new FruitReq(JsonConvert.DeserializeObject<BananaReq>(jsonString, FruitReq.SerializerSettings));
                 matchedTypes.Add("BananaReq");
                 match++;
             }
             catch (Exception exception)
             {
                 // deserialization failed, try the next one
-                System.Diagnostics.Debug.WriteLine(String.Format("Failed to deserialize `%s` into BananaReq: %s", jsonString, exception.ToString()));
+                System.Diagnostics.Debug.WriteLine(String.Format("Failed to deserialize `{0}` into BananaReq: {1}", jsonString, exception.ToString()));
             }
 
             if (match == 0)

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/FruitReq.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/FruitReq.cs
@@ -143,13 +143,13 @@ namespace Org.OpenAPITools.Model
         /// <returns>An instance of FruitReq</returns>
         public static FruitReq FromJson(string jsonString)
         {
-            FruitReq newFruitReq = new FruitReq();
+            FruitReq newFruitReq = null;
             int match = 0;
             List<string> matchedTypes = new List<string>();
 
             try
             {
-                newFruitReq.ActualInstance = JsonConvert.DeserializeObject<AppleReq>(jsonString, newFruitReq._serializerSettings);
+                newFruitReq = new FruitReq(JsonConvert.DeserializeObject<AppleReq>(jsonString, newFruitReq._serializerSettings));
                 matchedTypes.Add("AppleReq");
                 match++;
             }
@@ -161,7 +161,7 @@ namespace Org.OpenAPITools.Model
 
             try
             {
-                newFruitReq.ActualInstance = JsonConvert.DeserializeObject<BananaReq>(jsonString, newFruitReq._serializerSettings);
+                newFruitReq = new FruitReq(JsonConvert.DeserializeObject<BananaReq>(jsonString, newFruitReq._serializerSettings));
                 matchedTypes.Add("BananaReq");
                 match++;
             }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Mammal.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Mammal.cs
@@ -151,7 +151,7 @@ namespace Org.OpenAPITools.Model
         /// <returns>JSON string presentation of the object</returns>
         public override string ToJson()
         {
-            return JsonConvert.SerializeObject(this.ActualInstance, _serializerSettings);
+            return JsonConvert.SerializeObject(this.ActualInstance, Mammal.SerializerSettings);
         }
 
         /// <summary>
@@ -167,38 +167,38 @@ namespace Org.OpenAPITools.Model
 
             try
             {
-                newMammal = new Mammal(JsonConvert.DeserializeObject<Pig>(jsonString, newMammal._serializerSettings));
+                newMammal = new Mammal(JsonConvert.DeserializeObject<Pig>(jsonString, Mammal.SerializerSettings));
                 matchedTypes.Add("Pig");
                 match++;
             }
             catch (Exception exception)
             {
                 // deserialization failed, try the next one
-                System.Diagnostics.Debug.WriteLine(String.Format("Failed to deserialize `%s` into Pig: %s", jsonString, exception.ToString()));
+                System.Diagnostics.Debug.WriteLine(String.Format("Failed to deserialize `{0}` into Pig: {1}", jsonString, exception.ToString()));
             }
 
             try
             {
-                newMammal = new Mammal(JsonConvert.DeserializeObject<Whale>(jsonString, newMammal._serializerSettings));
+                newMammal = new Mammal(JsonConvert.DeserializeObject<Whale>(jsonString, Mammal.SerializerSettings));
                 matchedTypes.Add("Whale");
                 match++;
             }
             catch (Exception exception)
             {
                 // deserialization failed, try the next one
-                System.Diagnostics.Debug.WriteLine(String.Format("Failed to deserialize `%s` into Whale: %s", jsonString, exception.ToString()));
+                System.Diagnostics.Debug.WriteLine(String.Format("Failed to deserialize `{0}` into Whale: {1}", jsonString, exception.ToString()));
             }
 
             try
             {
-                newMammal = new Mammal(JsonConvert.DeserializeObject<Zebra>(jsonString, newMammal._serializerSettings));
+                newMammal = new Mammal(JsonConvert.DeserializeObject<Zebra>(jsonString, Mammal.SerializerSettings));
                 matchedTypes.Add("Zebra");
                 match++;
             }
             catch (Exception exception)
             {
                 // deserialization failed, try the next one
-                System.Diagnostics.Debug.WriteLine(String.Format("Failed to deserialize `%s` into Zebra: %s", jsonString, exception.ToString()));
+                System.Diagnostics.Debug.WriteLine(String.Format("Failed to deserialize `{0}` into Zebra: {1}", jsonString, exception.ToString()));
             }
 
             if (match == 0)

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Mammal.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Mammal.cs
@@ -34,15 +34,6 @@ namespace Org.OpenAPITools.Model
     public partial class Mammal : AbstractOpenAPISchema, IEquatable<Mammal>, IValidatableObject
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="Mammal" /> class.
-        /// </summary>
-        public Mammal()
-        {
-            this.IsNullable = true;
-            this.SchemaType= "oneOf";
-        }
-
-        /// <summary>
         /// Initializes a new instance of the <see cref="Mammal" /> class
         /// with the <see cref="Pig" /> class
         /// </summary>
@@ -170,13 +161,13 @@ namespace Org.OpenAPITools.Model
         /// <returns>An instance of Mammal</returns>
         public static Mammal FromJson(string jsonString)
         {
-            Mammal newMammal = new Mammal();
+            Mammal newMammal = null;
             int match = 0;
             List<string> matchedTypes = new List<string>();
 
             try
             {
-                newMammal.ActualInstance = JsonConvert.DeserializeObject<Pig>(jsonString, newMammal._serializerSettings);
+                newMammal = new Mammal(JsonConvert.DeserializeObject<Pig>(jsonString, newMammal._serializerSettings));
                 matchedTypes.Add("Pig");
                 match++;
             }
@@ -188,7 +179,7 @@ namespace Org.OpenAPITools.Model
 
             try
             {
-                newMammal.ActualInstance = JsonConvert.DeserializeObject<Whale>(jsonString, newMammal._serializerSettings);
+                newMammal = new Mammal(JsonConvert.DeserializeObject<Whale>(jsonString, newMammal._serializerSettings));
                 matchedTypes.Add("Whale");
                 match++;
             }
@@ -200,7 +191,7 @@ namespace Org.OpenAPITools.Model
 
             try
             {
-                newMammal.ActualInstance = JsonConvert.DeserializeObject<Zebra>(jsonString, newMammal._serializerSettings);
+                newMammal = new Mammal(JsonConvert.DeserializeObject<Zebra>(jsonString, newMammal._serializerSettings));
                 matchedTypes.Add("Zebra");
                 match++;
             }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/NullableShape.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/NullableShape.cs
@@ -134,7 +134,7 @@ namespace Org.OpenAPITools.Model
         /// <returns>JSON string presentation of the object</returns>
         public override string ToJson()
         {
-            return JsonConvert.SerializeObject(this.ActualInstance, _serializerSettings);
+            return JsonConvert.SerializeObject(this.ActualInstance, NullableShape.SerializerSettings);
         }
 
         /// <summary>
@@ -150,26 +150,26 @@ namespace Org.OpenAPITools.Model
 
             try
             {
-                newNullableShape = new NullableShape(JsonConvert.DeserializeObject<Quadrilateral>(jsonString, newNullableShape._serializerSettings));
+                newNullableShape = new NullableShape(JsonConvert.DeserializeObject<Quadrilateral>(jsonString, NullableShape.SerializerSettings));
                 matchedTypes.Add("Quadrilateral");
                 match++;
             }
             catch (Exception exception)
             {
                 // deserialization failed, try the next one
-                System.Diagnostics.Debug.WriteLine(String.Format("Failed to deserialize `%s` into Quadrilateral: %s", jsonString, exception.ToString()));
+                System.Diagnostics.Debug.WriteLine(String.Format("Failed to deserialize `{0}` into Quadrilateral: {1}", jsonString, exception.ToString()));
             }
 
             try
             {
-                newNullableShape = new NullableShape(JsonConvert.DeserializeObject<Triangle>(jsonString, newNullableShape._serializerSettings));
+                newNullableShape = new NullableShape(JsonConvert.DeserializeObject<Triangle>(jsonString, NullableShape.SerializerSettings));
                 matchedTypes.Add("Triangle");
                 match++;
             }
             catch (Exception exception)
             {
                 // deserialization failed, try the next one
-                System.Diagnostics.Debug.WriteLine(String.Format("Failed to deserialize `%s` into Triangle: %s", jsonString, exception.ToString()));
+                System.Diagnostics.Debug.WriteLine(String.Format("Failed to deserialize `{0}` into Triangle: {1}", jsonString, exception.ToString()));
             }
 
             if (match == 0)

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/NullableShape.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/NullableShape.cs
@@ -144,13 +144,13 @@ namespace Org.OpenAPITools.Model
         /// <returns>An instance of NullableShape</returns>
         public static NullableShape FromJson(string jsonString)
         {
-            NullableShape newNullableShape = new NullableShape();
+            NullableShape newNullableShape = null;
             int match = 0;
             List<string> matchedTypes = new List<string>();
 
             try
             {
-                newNullableShape.ActualInstance = JsonConvert.DeserializeObject<Quadrilateral>(jsonString, newNullableShape._serializerSettings);
+                newNullableShape = new NullableShape(JsonConvert.DeserializeObject<Quadrilateral>(jsonString, newNullableShape._serializerSettings));
                 matchedTypes.Add("Quadrilateral");
                 match++;
             }
@@ -162,7 +162,7 @@ namespace Org.OpenAPITools.Model
 
             try
             {
-                newNullableShape.ActualInstance = JsonConvert.DeserializeObject<Triangle>(jsonString, newNullableShape._serializerSettings);
+                newNullableShape = new NullableShape(JsonConvert.DeserializeObject<Triangle>(jsonString, newNullableShape._serializerSettings));
                 matchedTypes.Add("Triangle");
                 match++;
             }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Pig.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Pig.cs
@@ -125,7 +125,7 @@ namespace Org.OpenAPITools.Model
         /// <returns>JSON string presentation of the object</returns>
         public override string ToJson()
         {
-            return JsonConvert.SerializeObject(this.ActualInstance, _serializerSettings);
+            return JsonConvert.SerializeObject(this.ActualInstance, Pig.SerializerSettings);
         }
 
         /// <summary>
@@ -141,26 +141,26 @@ namespace Org.OpenAPITools.Model
 
             try
             {
-                newPig = new Pig(JsonConvert.DeserializeObject<BasquePig>(jsonString, newPig._serializerSettings));
+                newPig = new Pig(JsonConvert.DeserializeObject<BasquePig>(jsonString, Pig.SerializerSettings));
                 matchedTypes.Add("BasquePig");
                 match++;
             }
             catch (Exception exception)
             {
                 // deserialization failed, try the next one
-                System.Diagnostics.Debug.WriteLine(String.Format("Failed to deserialize `%s` into BasquePig: %s", jsonString, exception.ToString()));
+                System.Diagnostics.Debug.WriteLine(String.Format("Failed to deserialize `{0}` into BasquePig: {1}", jsonString, exception.ToString()));
             }
 
             try
             {
-                newPig = new Pig(JsonConvert.DeserializeObject<DanishPig>(jsonString, newPig._serializerSettings));
+                newPig = new Pig(JsonConvert.DeserializeObject<DanishPig>(jsonString, Pig.SerializerSettings));
                 matchedTypes.Add("DanishPig");
                 match++;
             }
             catch (Exception exception)
             {
                 // deserialization failed, try the next one
-                System.Diagnostics.Debug.WriteLine(String.Format("Failed to deserialize `%s` into DanishPig: %s", jsonString, exception.ToString()));
+                System.Diagnostics.Debug.WriteLine(String.Format("Failed to deserialize `{0}` into DanishPig: {1}", jsonString, exception.ToString()));
             }
 
             if (match == 0)

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Pig.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Pig.cs
@@ -34,15 +34,6 @@ namespace Org.OpenAPITools.Model
     public partial class Pig : AbstractOpenAPISchema, IEquatable<Pig>, IValidatableObject
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="Pig" /> class.
-        /// </summary>
-        public Pig()
-        {
-            this.IsNullable = true;
-            this.SchemaType= "oneOf";
-        }
-
-        /// <summary>
         /// Initializes a new instance of the <see cref="Pig" /> class
         /// with the <see cref="BasquePig" /> class
         /// </summary>
@@ -144,13 +135,13 @@ namespace Org.OpenAPITools.Model
         /// <returns>An instance of Pig</returns>
         public static Pig FromJson(string jsonString)
         {
-            Pig newPig = new Pig();
+            Pig newPig = null;
             int match = 0;
             List<string> matchedTypes = new List<string>();
 
             try
             {
-                newPig.ActualInstance = JsonConvert.DeserializeObject<BasquePig>(jsonString, newPig._serializerSettings);
+                newPig = new Pig(JsonConvert.DeserializeObject<BasquePig>(jsonString, newPig._serializerSettings));
                 matchedTypes.Add("BasquePig");
                 match++;
             }
@@ -162,7 +153,7 @@ namespace Org.OpenAPITools.Model
 
             try
             {
-                newPig.ActualInstance = JsonConvert.DeserializeObject<DanishPig>(jsonString, newPig._serializerSettings);
+                newPig = new Pig(JsonConvert.DeserializeObject<DanishPig>(jsonString, newPig._serializerSettings));
                 matchedTypes.Add("DanishPig");
                 match++;
             }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Quadrilateral.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Quadrilateral.cs
@@ -125,7 +125,7 @@ namespace Org.OpenAPITools.Model
         /// <returns>JSON string presentation of the object</returns>
         public override string ToJson()
         {
-            return JsonConvert.SerializeObject(this.ActualInstance, _serializerSettings);
+            return JsonConvert.SerializeObject(this.ActualInstance, Quadrilateral.SerializerSettings);
         }
 
         /// <summary>
@@ -141,26 +141,26 @@ namespace Org.OpenAPITools.Model
 
             try
             {
-                newQuadrilateral = new Quadrilateral(JsonConvert.DeserializeObject<ComplexQuadrilateral>(jsonString, newQuadrilateral._serializerSettings));
+                newQuadrilateral = new Quadrilateral(JsonConvert.DeserializeObject<ComplexQuadrilateral>(jsonString, Quadrilateral.SerializerSettings));
                 matchedTypes.Add("ComplexQuadrilateral");
                 match++;
             }
             catch (Exception exception)
             {
                 // deserialization failed, try the next one
-                System.Diagnostics.Debug.WriteLine(String.Format("Failed to deserialize `%s` into ComplexQuadrilateral: %s", jsonString, exception.ToString()));
+                System.Diagnostics.Debug.WriteLine(String.Format("Failed to deserialize `{0}` into ComplexQuadrilateral: {1}", jsonString, exception.ToString()));
             }
 
             try
             {
-                newQuadrilateral = new Quadrilateral(JsonConvert.DeserializeObject<SimpleQuadrilateral>(jsonString, newQuadrilateral._serializerSettings));
+                newQuadrilateral = new Quadrilateral(JsonConvert.DeserializeObject<SimpleQuadrilateral>(jsonString, Quadrilateral.SerializerSettings));
                 matchedTypes.Add("SimpleQuadrilateral");
                 match++;
             }
             catch (Exception exception)
             {
                 // deserialization failed, try the next one
-                System.Diagnostics.Debug.WriteLine(String.Format("Failed to deserialize `%s` into SimpleQuadrilateral: %s", jsonString, exception.ToString()));
+                System.Diagnostics.Debug.WriteLine(String.Format("Failed to deserialize `{0}` into SimpleQuadrilateral: {1}", jsonString, exception.ToString()));
             }
 
             if (match == 0)

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Quadrilateral.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Quadrilateral.cs
@@ -34,15 +34,6 @@ namespace Org.OpenAPITools.Model
     public partial class Quadrilateral : AbstractOpenAPISchema, IEquatable<Quadrilateral>, IValidatableObject
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="Quadrilateral" /> class.
-        /// </summary>
-        public Quadrilateral()
-        {
-            this.IsNullable = true;
-            this.SchemaType= "oneOf";
-        }
-
-        /// <summary>
         /// Initializes a new instance of the <see cref="Quadrilateral" /> class
         /// with the <see cref="ComplexQuadrilateral" /> class
         /// </summary>
@@ -144,13 +135,13 @@ namespace Org.OpenAPITools.Model
         /// <returns>An instance of Quadrilateral</returns>
         public static Quadrilateral FromJson(string jsonString)
         {
-            Quadrilateral newQuadrilateral = new Quadrilateral();
+            Quadrilateral newQuadrilateral = null;
             int match = 0;
             List<string> matchedTypes = new List<string>();
 
             try
             {
-                newQuadrilateral.ActualInstance = JsonConvert.DeserializeObject<ComplexQuadrilateral>(jsonString, newQuadrilateral._serializerSettings);
+                newQuadrilateral = new Quadrilateral(JsonConvert.DeserializeObject<ComplexQuadrilateral>(jsonString, newQuadrilateral._serializerSettings));
                 matchedTypes.Add("ComplexQuadrilateral");
                 match++;
             }
@@ -162,7 +153,7 @@ namespace Org.OpenAPITools.Model
 
             try
             {
-                newQuadrilateral.ActualInstance = JsonConvert.DeserializeObject<SimpleQuadrilateral>(jsonString, newQuadrilateral._serializerSettings);
+                newQuadrilateral = new Quadrilateral(JsonConvert.DeserializeObject<SimpleQuadrilateral>(jsonString, newQuadrilateral._serializerSettings));
                 matchedTypes.Add("SimpleQuadrilateral");
                 match++;
             }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Shape.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Shape.cs
@@ -125,7 +125,7 @@ namespace Org.OpenAPITools.Model
         /// <returns>JSON string presentation of the object</returns>
         public override string ToJson()
         {
-            return JsonConvert.SerializeObject(this.ActualInstance, _serializerSettings);
+            return JsonConvert.SerializeObject(this.ActualInstance, Shape.SerializerSettings);
         }
 
         /// <summary>
@@ -141,26 +141,26 @@ namespace Org.OpenAPITools.Model
 
             try
             {
-                newShape = new Shape(JsonConvert.DeserializeObject<Quadrilateral>(jsonString, newShape._serializerSettings));
+                newShape = new Shape(JsonConvert.DeserializeObject<Quadrilateral>(jsonString, Shape.SerializerSettings));
                 matchedTypes.Add("Quadrilateral");
                 match++;
             }
             catch (Exception exception)
             {
                 // deserialization failed, try the next one
-                System.Diagnostics.Debug.WriteLine(String.Format("Failed to deserialize `%s` into Quadrilateral: %s", jsonString, exception.ToString()));
+                System.Diagnostics.Debug.WriteLine(String.Format("Failed to deserialize `{0}` into Quadrilateral: {1}", jsonString, exception.ToString()));
             }
 
             try
             {
-                newShape = new Shape(JsonConvert.DeserializeObject<Triangle>(jsonString, newShape._serializerSettings));
+                newShape = new Shape(JsonConvert.DeserializeObject<Triangle>(jsonString, Shape.SerializerSettings));
                 matchedTypes.Add("Triangle");
                 match++;
             }
             catch (Exception exception)
             {
                 // deserialization failed, try the next one
-                System.Diagnostics.Debug.WriteLine(String.Format("Failed to deserialize `%s` into Triangle: %s", jsonString, exception.ToString()));
+                System.Diagnostics.Debug.WriteLine(String.Format("Failed to deserialize `{0}` into Triangle: {1}", jsonString, exception.ToString()));
             }
 
             if (match == 0)

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Shape.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Shape.cs
@@ -34,15 +34,6 @@ namespace Org.OpenAPITools.Model
     public partial class Shape : AbstractOpenAPISchema, IEquatable<Shape>, IValidatableObject
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="Shape" /> class.
-        /// </summary>
-        public Shape()
-        {
-            this.IsNullable = true;
-            this.SchemaType= "oneOf";
-        }
-
-        /// <summary>
         /// Initializes a new instance of the <see cref="Shape" /> class
         /// with the <see cref="Quadrilateral" /> class
         /// </summary>
@@ -144,13 +135,13 @@ namespace Org.OpenAPITools.Model
         /// <returns>An instance of Shape</returns>
         public static Shape FromJson(string jsonString)
         {
-            Shape newShape = new Shape();
+            Shape newShape = null;
             int match = 0;
             List<string> matchedTypes = new List<string>();
 
             try
             {
-                newShape.ActualInstance = JsonConvert.DeserializeObject<Quadrilateral>(jsonString, newShape._serializerSettings);
+                newShape = new Shape(JsonConvert.DeserializeObject<Quadrilateral>(jsonString, newShape._serializerSettings));
                 matchedTypes.Add("Quadrilateral");
                 match++;
             }
@@ -162,7 +153,7 @@ namespace Org.OpenAPITools.Model
 
             try
             {
-                newShape.ActualInstance = JsonConvert.DeserializeObject<Triangle>(jsonString, newShape._serializerSettings);
+                newShape = new Shape(JsonConvert.DeserializeObject<Triangle>(jsonString, newShape._serializerSettings));
                 matchedTypes.Add("Triangle");
                 match++;
             }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/ShapeOrNull.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/ShapeOrNull.cs
@@ -134,7 +134,7 @@ namespace Org.OpenAPITools.Model
         /// <returns>JSON string presentation of the object</returns>
         public override string ToJson()
         {
-            return JsonConvert.SerializeObject(this.ActualInstance, _serializerSettings);
+            return JsonConvert.SerializeObject(this.ActualInstance, ShapeOrNull.SerializerSettings);
         }
 
         /// <summary>
@@ -150,26 +150,26 @@ namespace Org.OpenAPITools.Model
 
             try
             {
-                newShapeOrNull = new ShapeOrNull(JsonConvert.DeserializeObject<Quadrilateral>(jsonString, newShapeOrNull._serializerSettings));
+                newShapeOrNull = new ShapeOrNull(JsonConvert.DeserializeObject<Quadrilateral>(jsonString, ShapeOrNull.SerializerSettings));
                 matchedTypes.Add("Quadrilateral");
                 match++;
             }
             catch (Exception exception)
             {
                 // deserialization failed, try the next one
-                System.Diagnostics.Debug.WriteLine(String.Format("Failed to deserialize `%s` into Quadrilateral: %s", jsonString, exception.ToString()));
+                System.Diagnostics.Debug.WriteLine(String.Format("Failed to deserialize `{0}` into Quadrilateral: {1}", jsonString, exception.ToString()));
             }
 
             try
             {
-                newShapeOrNull = new ShapeOrNull(JsonConvert.DeserializeObject<Triangle>(jsonString, newShapeOrNull._serializerSettings));
+                newShapeOrNull = new ShapeOrNull(JsonConvert.DeserializeObject<Triangle>(jsonString, ShapeOrNull.SerializerSettings));
                 matchedTypes.Add("Triangle");
                 match++;
             }
             catch (Exception exception)
             {
                 // deserialization failed, try the next one
-                System.Diagnostics.Debug.WriteLine(String.Format("Failed to deserialize `%s` into Triangle: %s", jsonString, exception.ToString()));
+                System.Diagnostics.Debug.WriteLine(String.Format("Failed to deserialize `{0}` into Triangle: {1}", jsonString, exception.ToString()));
             }
 
             if (match == 0)

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/ShapeOrNull.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/ShapeOrNull.cs
@@ -144,13 +144,13 @@ namespace Org.OpenAPITools.Model
         /// <returns>An instance of ShapeOrNull</returns>
         public static ShapeOrNull FromJson(string jsonString)
         {
-            ShapeOrNull newShapeOrNull = new ShapeOrNull();
+            ShapeOrNull newShapeOrNull = null;
             int match = 0;
             List<string> matchedTypes = new List<string>();
 
             try
             {
-                newShapeOrNull.ActualInstance = JsonConvert.DeserializeObject<Quadrilateral>(jsonString, newShapeOrNull._serializerSettings);
+                newShapeOrNull = new ShapeOrNull(JsonConvert.DeserializeObject<Quadrilateral>(jsonString, newShapeOrNull._serializerSettings));
                 matchedTypes.Add("Quadrilateral");
                 match++;
             }
@@ -162,7 +162,7 @@ namespace Org.OpenAPITools.Model
 
             try
             {
-                newShapeOrNull.ActualInstance = JsonConvert.DeserializeObject<Triangle>(jsonString, newShapeOrNull._serializerSettings);
+                newShapeOrNull = new ShapeOrNull(JsonConvert.DeserializeObject<Triangle>(jsonString, newShapeOrNull._serializerSettings));
                 matchedTypes.Add("Triangle");
                 match++;
             }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Triangle.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Triangle.cs
@@ -151,7 +151,7 @@ namespace Org.OpenAPITools.Model
         /// <returns>JSON string presentation of the object</returns>
         public override string ToJson()
         {
-            return JsonConvert.SerializeObject(this.ActualInstance, _serializerSettings);
+            return JsonConvert.SerializeObject(this.ActualInstance, Triangle.SerializerSettings);
         }
 
         /// <summary>
@@ -167,38 +167,38 @@ namespace Org.OpenAPITools.Model
 
             try
             {
-                newTriangle = new Triangle(JsonConvert.DeserializeObject<EquilateralTriangle>(jsonString, newTriangle._serializerSettings));
+                newTriangle = new Triangle(JsonConvert.DeserializeObject<EquilateralTriangle>(jsonString, Triangle.SerializerSettings));
                 matchedTypes.Add("EquilateralTriangle");
                 match++;
             }
             catch (Exception exception)
             {
                 // deserialization failed, try the next one
-                System.Diagnostics.Debug.WriteLine(String.Format("Failed to deserialize `%s` into EquilateralTriangle: %s", jsonString, exception.ToString()));
+                System.Diagnostics.Debug.WriteLine(String.Format("Failed to deserialize `{0}` into EquilateralTriangle: {1}", jsonString, exception.ToString()));
             }
 
             try
             {
-                newTriangle = new Triangle(JsonConvert.DeserializeObject<IsoscelesTriangle>(jsonString, newTriangle._serializerSettings));
+                newTriangle = new Triangle(JsonConvert.DeserializeObject<IsoscelesTriangle>(jsonString, Triangle.SerializerSettings));
                 matchedTypes.Add("IsoscelesTriangle");
                 match++;
             }
             catch (Exception exception)
             {
                 // deserialization failed, try the next one
-                System.Diagnostics.Debug.WriteLine(String.Format("Failed to deserialize `%s` into IsoscelesTriangle: %s", jsonString, exception.ToString()));
+                System.Diagnostics.Debug.WriteLine(String.Format("Failed to deserialize `{0}` into IsoscelesTriangle: {1}", jsonString, exception.ToString()));
             }
 
             try
             {
-                newTriangle = new Triangle(JsonConvert.DeserializeObject<ScaleneTriangle>(jsonString, newTriangle._serializerSettings));
+                newTriangle = new Triangle(JsonConvert.DeserializeObject<ScaleneTriangle>(jsonString, Triangle.SerializerSettings));
                 matchedTypes.Add("ScaleneTriangle");
                 match++;
             }
             catch (Exception exception)
             {
                 // deserialization failed, try the next one
-                System.Diagnostics.Debug.WriteLine(String.Format("Failed to deserialize `%s` into ScaleneTriangle: %s", jsonString, exception.ToString()));
+                System.Diagnostics.Debug.WriteLine(String.Format("Failed to deserialize `{0}` into ScaleneTriangle: {1}", jsonString, exception.ToString()));
             }
 
             if (match == 0)

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Triangle.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Triangle.cs
@@ -34,15 +34,6 @@ namespace Org.OpenAPITools.Model
     public partial class Triangle : AbstractOpenAPISchema, IEquatable<Triangle>, IValidatableObject
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="Triangle" /> class.
-        /// </summary>
-        public Triangle()
-        {
-            this.IsNullable = true;
-            this.SchemaType= "oneOf";
-        }
-
-        /// <summary>
         /// Initializes a new instance of the <see cref="Triangle" /> class
         /// with the <see cref="EquilateralTriangle" /> class
         /// </summary>
@@ -170,13 +161,13 @@ namespace Org.OpenAPITools.Model
         /// <returns>An instance of Triangle</returns>
         public static Triangle FromJson(string jsonString)
         {
-            Triangle newTriangle = new Triangle();
+            Triangle newTriangle = null;
             int match = 0;
             List<string> matchedTypes = new List<string>();
 
             try
             {
-                newTriangle.ActualInstance = JsonConvert.DeserializeObject<EquilateralTriangle>(jsonString, newTriangle._serializerSettings);
+                newTriangle = new Triangle(JsonConvert.DeserializeObject<EquilateralTriangle>(jsonString, newTriangle._serializerSettings));
                 matchedTypes.Add("EquilateralTriangle");
                 match++;
             }
@@ -188,7 +179,7 @@ namespace Org.OpenAPITools.Model
 
             try
             {
-                newTriangle.ActualInstance = JsonConvert.DeserializeObject<IsoscelesTriangle>(jsonString, newTriangle._serializerSettings);
+                newTriangle = new Triangle(JsonConvert.DeserializeObject<IsoscelesTriangle>(jsonString, newTriangle._serializerSettings));
                 matchedTypes.Add("IsoscelesTriangle");
                 match++;
             }
@@ -200,7 +191,7 @@ namespace Org.OpenAPITools.Model
 
             try
             {
-                newTriangle.ActualInstance = JsonConvert.DeserializeObject<ScaleneTriangle>(jsonString, newTriangle._serializerSettings);
+                newTriangle = new Triangle(JsonConvert.DeserializeObject<ScaleneTriangle>(jsonString, newTriangle._serializerSettings));
                 matchedTypes.Add("ScaleneTriangle");
                 match++;
             }


### PR DESCRIPTION
- Add nullable support to oneOf models

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

cc @mandrean (2017/08) @frankyjuang (2019/09) @shibayan (2020/02)


