### PR TITLE
[C#][netcore]Fixed the HTTPSigning to calculate the body diegest without CamelCase

### DIFF
--- a/modules/openapi-generator/src/main/resources/csharp-netcore/HttpSigningConfiguration.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/HttpSigningConfiguration.mustache
@@ -146,7 +146,6 @@ namespace {{packageName}}.Client
             if (requestOptions.Data != null)
             {
                 var serializerSettings = new JsonSerializerSettings();
-                serializerSettings.ContractResolver = new CamelCasePropertyNamesContractResolver();
                 requestBody = JsonConvert.SerializeObject(requestOptions.Data, serializerSettings);
             }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
@@ -146,7 +146,6 @@ namespace Org.OpenAPITools.Client
             if (requestOptions.Data != null)
             {
                 var serializerSettings = new JsonSerializerSettings();
-                serializerSettings.ContractResolver = new CamelCasePropertyNamesContractResolver();
                 requestBody = JsonConvert.SerializeObject(requestOptions.Data, serializerSettings);
             }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
@@ -146,7 +146,6 @@ namespace Org.OpenAPITools.Client
             if (requestOptions.Data != null)
             {
                 var serializerSettings = new JsonSerializerSettings();
-                serializerSettings.ContractResolver = new CamelCasePropertyNamesContractResolver();
                 requestBody = JsonConvert.SerializeObject(requestOptions.Data, serializerSettings);
             }
 


### PR DESCRIPTION
Fixed the HTTPSigning to calculate the request body digest without CamelCase.
This fix is done in context to the PR  
https://github.com/OpenAPITools/openapi-generator/pull/7583

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [ ] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
@wing328 